### PR TITLE
chore(search-bar): Move to op only for wildcard enabled attributes

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -785,14 +785,10 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('escapes values with spaces and reserved characters', async () => {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />, {
-        organization: {features: ['search-query-builder-input-flow-changes']},
-      });
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
 
-      await userEvent.keyboard('assigned:');
-      await userEvent.click(screen.getByRole('option', {name: 'is'}));
-      await userEvent.keyboard('some" value{enter}');
+      await userEvent.keyboard('assigned:some" value{enter}');
 
       // Value should be surrounded by quotes and escaped
       expect(
@@ -915,8 +911,7 @@ describe('SearchQueryBuilder', () => {
     it('can add an unsupported filter key and value', async () => {
       const mockOnChange = jest.fn();
       render(
-        <SearchQueryBuilder {...defaultProps} onChange={mockOnChange} initialQuery="" />,
-        {organization: {features: ['search-query-builder-input-flow-changes']}}
+        <SearchQueryBuilder {...defaultProps} onChange={mockOnChange} initialQuery="" />
       );
       await userEvent.click(getLastInput());
 
@@ -926,10 +921,7 @@ describe('SearchQueryBuilder', () => {
         'foo '
       );
 
-      await userEvent.keyboard('a:');
-      expect(await screen.findByRole('option', {name: 'is'})).toHaveFocus();
-      await userEvent.keyboard('{enter}');
-      await userEvent.keyboard('b{enter}');
+      await userEvent.keyboard('a:b{enter}');
 
       expect(await screen.findByRole('row', {name: 'foo'})).toBeInTheDocument();
       expect(await screen.findByRole('row', {name: 'a:b'})).toBeInTheDocument();

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -8,6 +8,7 @@ import type {KeyboardEvent, Node} from '@react-types/shared';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
+import {areWildcardOperatorsAllowed} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {useFilterKeyListBox} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox';
 import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import {useSortedFilterKeyItems} from 'sentry/components/searchQueryBuilder/tokens/useSortedFilterKeyItems';
@@ -138,7 +139,16 @@ function calculateNextFocusForFilter(
 ): FocusOverride {
   const numPreviousFilterItems = countPreviousItemsOfType({state, type: Token.FILTER});
 
-  let part: FocusOverride['part'] = hasInputChangeFlows ? 'op' : 'value';
+  const isNumericField =
+    definition?.kind === FieldKind.METRICS ||
+    definition?.kind === FieldKind.MEASUREMENT ||
+    definition?.kind === FieldKind.NUMERIC_METRICS;
+
+  let part: FocusOverride['part'] =
+    hasInputChangeFlows && (isNumericField || areWildcardOperatorsAllowed(definition))
+      ? 'op'
+      : 'value';
+
   if (
     definition &&
     definition.kind === FieldKind.FUNCTION &&

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -25,7 +25,7 @@ import DetectorsList from 'sentry/views/detectors/list';
 
 describe('DetectorsList', () => {
   const organization = OrganizationFixture({
-    features: ['workflow-engine-ui', 'search-query-builder-input-flow-changes'],
+    features: ['workflow-engine-ui'],
     access: ['org:write'],
   });
 
@@ -169,9 +169,6 @@ describe('DetectorsList', () => {
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(await screen.findByRole('option', {name: 'type'}));
 
-      const isOption = await screen.findByRole('option', {name: 'is'});
-      await userEvent.click(isOption);
-
       const options = await screen.findAllByRole('option');
       expect(options).toHaveLength(4);
       expect(options[0]).toHaveTextContent('error');
@@ -204,13 +201,7 @@ describe('DetectorsList', () => {
       const searchInput = await screen.findByRole('combobox', {
         name: 'Add a search term',
       });
-      await userEvent.type(searchInput, 'assignee:');
-
-      await userEvent.keyboard('{enter}');
-
-      await userEvent.keyboard('test@example.com');
-
-      await userEvent.keyboard('{enter}');
+      await userEvent.type(searchInput, 'assignee:test@example.com{enter}');
 
       await screen.findByText('Assigned Detector');
       expect(mockDetectorsRequestAssignee).toHaveBeenCalled();
@@ -500,10 +491,7 @@ describe('DetectorsList', () => {
       const searchInput = await screen.findByRole('combobox', {
         name: 'Add a search term',
       });
-      await userEvent.type(searchInput, 'assignee:');
-      await userEvent.keyboard('{enter}');
-      await userEvent.keyboard('test@example.com');
-      await userEvent.keyboard('{enter}');
+      await userEvent.type(searchInput, 'assignee:test@example.com{enter}');
 
       // Wait for filtered results to load
       await screen.findByText('Assigned Detector 1');

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -147,14 +147,11 @@ describe('IssueListSearchBar', () => {
         body: tagValueResponse,
       });
 
-      render(<IssueListSearchBar {...newDefaultProps} />, {
-        organization: {features: ['search-query-builder-input-flow-changes']},
-      });
+      render(<IssueListSearchBar {...newDefaultProps} />);
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.paste(tagKey, {delay: null});
       await userEvent.click(screen.getByRole('option', {name: tagKey}));
-      await userEvent.click(screen.getByRole('option', {name: 'is'}));
       expect(await screen.findByRole('option', {name: tagValue})).toBeInTheDocument();
 
       await waitFor(() => {

--- a/static/app/views/projectDetail/projectFilters.spec.tsx
+++ b/static/app/views/projectDetail/projectFilters.spec.tsx
@@ -27,8 +27,7 @@ describe('ProjectDetail > ProjectFilters', () => {
         onSearch={onSearch}
         tagValueLoader={tagValueLoader}
         relativeDateOptions={{}}
-      />,
-      {organization: {features: ['search-query-builder-input-flow-changes']}}
+      />
     );
 
     await userEvent.click(
@@ -43,7 +42,6 @@ describe('ProjectDetail > ProjectFilters', () => {
     expect(screen.getByRole('option', {name: 'release.version'})).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('option', {name: 'release.version'}));
-    await userEvent.click(screen.getByRole('option', {name: 'is'}));
 
     await screen.findByText('sentry@0.5.3');
   });

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -545,7 +545,6 @@ describe('ReleasesList', () => {
 
     await userEvent.clear(smartSearchBar);
     await userEvent.click(screen.getByRole('option', {name: 'release.version'}));
-    await userEvent.click(screen.getByRole('option', {name: 'is'}));
 
     expect(await screen.findByText('sentry@0.5.3')).toBeInTheDocument();
   });


### PR DESCRIPTION
This PR tightens up when we move to the operator dropdown when entering search filters into the search bar.

Ticket: EXP-550