### PR TITLE
chore(uptime): Remove uses of `uptime-eap-uptime-results-query` from `project_uptime_alert_checks_index`

### DIFF
--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -32,7 +32,7 @@ from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
-from sentry.uptime.eap_utils import get_columns_for_uptime_trace_item_type
+from sentry.uptime.eap_utils import get_columns_for_uptime_result
 from sentry.utils.numbers import base32_encode
 from sentry.utils.snuba_rpc import table_rpc
 
@@ -354,7 +354,7 @@ def _uptime_results_query(
                 mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
             ),
         ),
-        columns=get_columns_for_uptime_trace_item_type(TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT),
+        columns=get_columns_for_uptime_result(),
         filter=TraceItemFilter(
             comparison_filter=ComparisonFilter(
                 key=AttributeKey(

--- a/src/sentry/uptime/eap_utils.py
+++ b/src/sentry/uptime/eap_utils.py
@@ -1,72 +1,11 @@
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from sentry.search.eap.uptime_results.attributes import UPTIME_ATTRIBUTE_DEFINITIONS
 
 
-def get_columns_for_uptime_trace_item_type(
-    trace_item_type: TraceItemType.ValueType = TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
-) -> list[Column]:
-    if trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT:
-        renames = {"status_reason_type": "check_status_reason"}
-        return [
-            Column(
-                label=renames.get(col.internal_name, col.internal_name), key=col.proto_definition
-            )
-            for col in UPTIME_ATTRIBUTE_DEFINITIONS.values()
-        ]
-    else:
-        return [
-            Column(
-                label="environment",
-                key=AttributeKey(name="environment", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="region",
-                key=AttributeKey(name="region", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="check_status",
-                key=AttributeKey(name="check_status", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="http_status_code",
-                key=AttributeKey(name="http_status_code", type=AttributeKey.Type.TYPE_INT),
-            ),
-            Column(
-                label="incident_status",
-                key=AttributeKey(name="incident_status", type=AttributeKey.Type.TYPE_INT),
-            ),
-            Column(
-                label="trace_id",
-                key=AttributeKey(name="trace_id", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="timestamp",
-                key=AttributeKey(
-                    name="timestamp",
-                    type=AttributeKey.Type.TYPE_DOUBLE,
-                ),
-            ),
-            Column(
-                label="uptime_subscription_id",
-                key=AttributeKey(name="uptime_subscription_id", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="uptime_check_id",
-                key=AttributeKey(name="uptime_check_id", type=AttributeKey.Type.TYPE_STRING),
-            ),
-            Column(
-                label="scheduled_check_time",
-                key=AttributeKey(name="scheduled_check_time", type=AttributeKey.Type.TYPE_DOUBLE),
-            ),
-            Column(
-                label="duration_ms",
-                key=AttributeKey(name="duration_ms", type=AttributeKey.Type.TYPE_INT),
-            ),
-            Column(
-                label="check_status_reason",
-                key=AttributeKey(name="check_status_reason", type=AttributeKey.Type.TYPE_STRING),
-            ),
-        ]
+def get_columns_for_uptime_result() -> list[Column]:
+    renames = {"status_reason_type": "check_status_reason"}
+    return [
+        Column(label=renames.get(col.internal_name, col.internal_name), key=col.proto_definition)
+        for col in UPTIME_ATTRIBUTE_DEFINITIONS.values()
+    ]

--- a/src/sentry/uptime/eap_utils.py
+++ b/src/sentry/uptime/eap_utils.py
@@ -1,4 +1,5 @@
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.search.eap.uptime_results.attributes import UPTIME_ATTRIBUTE_DEFINITIONS
 
@@ -9,3 +10,10 @@ def get_columns_for_uptime_result() -> list[Column]:
         Column(label=renames.get(col.internal_name, col.internal_name), key=col.proto_definition)
         for col in UPTIME_ATTRIBUTE_DEFINITIONS.values()
     ]
+
+
+# XXX: Backwards compat for this function
+def get_columns_for_uptime_trace_item_type(
+    trace_item_type: TraceItemType.ValueType = TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
+) -> list[Column]:
+    return get_columns_for_uptime_result()

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -2,7 +2,7 @@ import uuid
 from abc import abstractmethod
 from datetime import datetime, timedelta, timezone
 
-from sentry.testutils.cases import UptimeCheckSnubaTestCase, UptimeResultEAPTestCase
+from sentry.testutils.cases import UptimeResultEAPTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
@@ -193,48 +193,13 @@ class ProjectUptimeAlertCheckIndexBaseTest(UptimeAlertBaseEndpointTest):
 
 @region_silo_test
 @freeze_time(MOCK_DATETIME)
-class ProjectUptimeAlertCheckIndexEndpoint(
-    ProjectUptimeAlertCheckIndexBaseTest, UptimeCheckSnubaTestCase
-):
-    __test__ = True
-    features = {
-        "organizations:uptime-eap-enabled": False,
-        "organizations:uptime-eap-uptime-results-query": False,
-    }
-
-    def store_uptime_data(
-        self,
-        subscription_id,
-        check_status,
-        incident_status=IncidentStatus.NO_INCIDENT,
-        scheduled_check_time=None,
-        http_status=None,
-    ):
-        # if scheduled_check_time is None:
-        #     scheduled_check_time = datetime.now(timezone.utc) - timedelta(hours=12)
-        #
-        self.store_snuba_uptime_check(
-            subscription_id=subscription_id,
-            check_status=check_status,
-            incident_status=incident_status,
-            scheduled_check_time=scheduled_check_time,
-            http_status=http_status,
-            region="default",
-        )
-
-
-@region_silo_test
-@freeze_time(MOCK_DATETIME)
 class ProjectUptimeAlertCheckIndexEndpointWithEAPTests(
     ProjectUptimeAlertCheckIndexBaseTest, UptimeResultEAPTestCase
 ):
     __test__ = True
 
     def setUp(self) -> None:
-        self.features = {
-            "organizations:uptime-eap-enabled": True,
-            "organizations:uptime-eap-uptime-results-query": True,
-        }
+        self.features = {"organizations:uptime-eap-enabled": True}
         super().setUp()
 
     def store_uptime_data(


### PR DESCRIPTION
We've enabled this flag and are no longer using this path, so removing this flag. Splitting into separate prs to avoid one huge pr
