### PR TITLE
ref(uptime): Avg Duration is always available

### DIFF
--- a/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
@@ -35,30 +35,25 @@ export function UptimeDetailsSidebar({
         <SectionHeading>{t('Checked URL')}</SectionHeading>
         <CodeBlock hideCopyButton>{`${uptimeSub.method} ${uptimeSub.url}`}</CodeBlock>
       </MonitorUrlContainer>
-      <Grid
-        columns={summary && summary.avgDurationUs !== null ? '2fr 1fr 1fr' : '1fr 1fr'}
-        gap="2xl"
-      >
+      <Grid columns="2fr 1fr 1fr" gap="2xl">
         <UptimeContainer>
           <SectionHeading>{t('Legend')}</SectionHeading>
           <DetailsTimelineLegend showMissedLegend={showMissedLegend} />
         </UptimeContainer>
-        {summary && summary.avgDurationUs !== null && (
-          <div>
-            <SectionHeading>{t('Duration')}</SectionHeading>
-            <UptimeContainer>
-              {summary === undefined ? (
-                <Text size="xl">
-                  <Placeholder width="60px" height="1lh" />
-                </Text>
-              ) : summary === null ? (
-                '-'
-              ) : (
-                <UptimeDuration size="xl" summary={summary} />
-              )}
-            </UptimeContainer>
-          </div>
-        )}
+        <div>
+          <SectionHeading>{t('Duration')}</SectionHeading>
+          <UptimeContainer>
+            {summary === undefined ? (
+              <Text size="xl">
+                <Placeholder width="60px" height="1lh" />
+              </Text>
+            ) : summary === null ? (
+              '-'
+            ) : (
+              <UptimeDuration size="xl" summary={summary} />
+            )}
+          </UptimeContainer>
+        </div>
         <div>
           <SectionHeading>{t('Uptime')}</SectionHeading>
           <UptimeContainer>

--- a/static/app/views/alerts/rules/uptime/types.tsx
+++ b/static/app/views/alerts/rules/uptime/types.tsx
@@ -47,10 +47,7 @@ export interface UptimeCheck {
 }
 
 export interface UptimeSummary {
-  // TODO(epurkhiser): In the future this will always be set once all customers
-  // are querying the EAP uptime results trace item set, and we can get rid of
-  // various conditionals when the null type is removed.
-  avgDurationUs: number | null;
+  avgDurationUs: number;
   downtimeChecks: number;
   failedChecks: number;
   missedWindowChecks: number;

--- a/static/app/views/insights/uptime/components/duration.spec.tsx
+++ b/static/app/views/insights/uptime/components/duration.spec.tsx
@@ -5,17 +5,12 @@ import {UptimeDuration} from 'sentry/views/insights/uptime/components/duration';
 
 describe('UptimeDuration', () => {
   const baseSummary: UptimeSummary = {
-    avgDurationUs: null,
+    avgDurationUs: 50_000,
     downtimeChecks: 0,
     failedChecks: 0,
     missedWindowChecks: 0,
     totalChecks: 100,
   };
-
-  it('renders nothing when avgDurationUs is null', () => {
-    const {container} = render(<UptimeDuration summary={baseSummary} />);
-    expect(container).toBeEmptyDOMElement();
-  });
 
   it('renders millisecond durations correctly', () => {
     const summary = {...baseSummary, avgDurationUs: 350_000};

--- a/static/app/views/insights/uptime/components/duration.tsx
+++ b/static/app/views/insights/uptime/components/duration.tsx
@@ -9,10 +9,6 @@ type UptimeDurationProps = {
 };
 
 export function UptimeDuration({summary, size}: UptimeDurationProps) {
-  if (summary.avgDurationUs === null) {
-    return null;
-  }
-
   const avgDurationSeconds = summary.avgDurationUs / 1000000;
   const avgDurationMs = summary.avgDurationUs / 1000;
 

--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -103,12 +103,10 @@ export function OverviewRow({summary, uptimeDetector, timeWindowConfig, single}:
                   )}
                 />
               </Flex>
-              {summary.avgDurationUs !== null && (
-                <Flex gap="xs" align="center">
-                  <IconClock />
-                  <UptimeDuration size="xs" summary={summary} />
-                </Flex>
-              )}
+              <Flex gap="xs" align="center">
+                <IconClock />
+                <UptimeDuration size="xs" summary={summary} />
+              </Flex>
             </Fragment>
           )}
         </DetailsLine>


### PR DESCRIPTION
Once we've removed the legacy uptime checks storage backend, and only
rely on uptime EAP Items, we will always have this property