### PR TITLE
fix(prevent): Convert github org id to str for prevent ai

### DIFF
--- a/src/sentry/prevent/endpoints/organization_github_repos.py
+++ b/src/sentry/prevent/endpoints/organization_github_repos.py
@@ -131,8 +131,9 @@ class OrganizationPreventGitHubReposEndpoint(OrganizationEndpoint):
                 )
 
             if repos:
+                account_id = integration.metadata.get("account_id")
                 github_org_data = {
-                    "githubOrganizationId": integration.metadata.get("account_id"),
+                    "githubOrganizationId": str(account_id) if account_id is not None else None,
                     "name": integration.name,
                     "repos": repos,
                 }


### PR DESCRIPTION
Convert github org id to a string as it appears it is saved as int. This will be used downstream by frontend as string

<img width="395" height="230" alt="Screenshot 2025-10-20 at 8 59 56 AM" src="https://github.com/user-attachments/assets/d8337a66-6761-4eb3-8e7c-d21364684c95" />
