### PR TITLE
chore(uptime): Remove uses of `uptime-eap-uptime-results-query` from `organization_uptime_stats`

### DIFF
--- a/src/sentry/uptime/endpoints/organization_uptime_summary.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_summary.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from datetime import datetime
 
 from drf_spectacular.utils import extend_schema
@@ -83,8 +84,17 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
         )
 
         try:
+            # XXX: We need to query these using hex, since we store them without dashes.
+            # We remove this once we remove the old uptime checks
+            if use_eap_results:
+                subscription_id_formatter = lambda sub_id: uuid.UUID(sub_id).hex
+            else:
+                subscription_id_formatter = lambda sub_id: str(uuid.UUID(sub_id))
+
             subscription_id_to_original_id, subscription_ids = (
-                authorize_and_map_uptime_detector_subscription_ids(uptime_detector_ids, projects)
+                authorize_and_map_uptime_detector_subscription_ids(
+                    uptime_detector_ids, projects, subscription_id_formatter
+                )
             )
 
         except ValueError:

--- a/src/sentry/uptime/endpoints/organization_uptime_summary.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_summary.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from datetime import datetime
 
 from drf_spectacular.utils import extend_schema
@@ -84,18 +83,10 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
         )
 
         try:
-            # XXX: We need to query these using hex, since we store them without dashes.
-            # We remove this once we remove the old uptime checks
-            if use_eap_results:
-                subscription_id_formatter = lambda sub_id: uuid.UUID(sub_id).hex
-            else:
-                subscription_id_formatter = lambda sub_id: str(uuid.UUID(sub_id))
-
             subscription_id_to_original_id, subscription_ids = (
-                authorize_and_map_uptime_detector_subscription_ids(
-                    uptime_detector_ids, projects, subscription_id_formatter
-                )
+                authorize_and_map_uptime_detector_subscription_ids(uptime_detector_ids, projects)
             )
+
         except ValueError:
             return self.respond("Invalid uptime detector ids provided", status=400)
 

--- a/src/sentry/uptime/endpoints/utils.py
+++ b/src/sentry/uptime/endpoints/utils.py
@@ -1,4 +1,5 @@
 import uuid
+from collections.abc import Callable
 
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
@@ -18,6 +19,7 @@ Maximum number of uptime subscription IDs that may be queried at once
 def authorize_and_map_uptime_detector_subscription_ids(
     detector_ids: list[str],
     projects: list[Project],
+    sub_id_formatter: Callable[[str], str] = lambda sub_id: uuid.UUID(sub_id).hex,
 ) -> tuple[dict[str, int], list[str]]:
     """
     Authorize the detector ids and return their corresponding subscription ids.
@@ -76,8 +78,6 @@ def authorize_and_map_uptime_detector_subscription_ids(
 
     if set(detector_ids_ints) != validated_detector_ids:
         raise ValueError("Invalid detector ids provided")
-
-    sub_id_formatter = lambda sub_id: uuid.UUID(sub_id).hex
 
     subscription_id_to_detector_id = {
         sub_id_formatter(detector_data[1]): detector_data[0]

--- a/src/sentry/uptime/endpoints/utils.py
+++ b/src/sentry/uptime/endpoints/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+import uuid
 
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
@@ -18,7 +18,6 @@ Maximum number of uptime subscription IDs that may be queried at once
 def authorize_and_map_uptime_detector_subscription_ids(
     detector_ids: list[str],
     projects: list[Project],
-    sub_id_formatter: Callable[[str], str],
 ) -> tuple[dict[str, int], list[str]]:
     """
     Authorize the detector ids and return their corresponding subscription ids.
@@ -28,7 +27,6 @@ def authorize_and_map_uptime_detector_subscription_ids(
     Args:
         detector_ids: List of Detector IDs as strings
         projects: List of Project objects the user has access to
-        sub_id_formatter: Function to format subscription IDs (e.g., hex vs string format)
 
     Returns:
         Tuple of:
@@ -78,6 +76,8 @@ def authorize_and_map_uptime_detector_subscription_ids(
 
     if set(detector_ids_ints) != validated_detector_ids:
         raise ValueError("Invalid detector ids provided")
+
+    sub_id_formatter = lambda sub_id: uuid.UUID(sub_id).hex
 
     subscription_id_to_detector_id = {
         sub_id_formatter(detector_data[1]): detector_data[0]

--- a/tests/sentry/uptime/endpoints/test_utils.py
+++ b/tests/sentry/uptime/endpoints/test_utils.py
@@ -16,15 +16,10 @@ class AuthorizeAndMapUptimeDetectorSubscriptionIdsTest(TestCase):
         detector = self.create_uptime_detector(
             uptime_subscription=subscription, project=self.project
         )
-
-        hex_formatter = lambda sub_id: uuid.UUID(sub_id).hex
-
         mapping, subscription_ids = authorize_and_map_uptime_detector_subscription_ids(
             detector_ids=[str(detector.id)],
             projects=[self.project],
-            sub_id_formatter=hex_formatter,
         )
-
         expected_hex_id = uuid.UUID(subscription_id).hex
         assert expected_hex_id in mapping
         assert mapping[expected_hex_id] == detector.id
@@ -39,7 +34,6 @@ class AuthorizeAndMapUptimeDetectorSubscriptionIdsTest(TestCase):
             authorize_and_map_uptime_detector_subscription_ids(
                 detector_ids=[invalid_id],
                 projects=[self.project],
-                sub_id_formatter=str,
             )
 
     def test_cross_project_access_denied(self) -> None:
@@ -58,7 +52,6 @@ class AuthorizeAndMapUptimeDetectorSubscriptionIdsTest(TestCase):
             authorize_and_map_uptime_detector_subscription_ids(
                 detector_ids=[str(other_detector.id)],
                 projects=[self.project],
-                sub_id_formatter=str,
             )
 
     def test_multiple_detectors(self) -> None:
@@ -72,28 +65,22 @@ class AuthorizeAndMapUptimeDetectorSubscriptionIdsTest(TestCase):
         subscription2 = self.create_uptime_subscription(
             url="https://example2.com", subscription_id=subscription_id2
         )
-
         detector1 = self.create_uptime_detector(
             uptime_subscription=subscription1, project=self.project
         )
         detector2 = self.create_uptime_detector(
             uptime_subscription=subscription2, project=self.project
         )
-
-        string_formatter = lambda sub_id: str(uuid.UUID(sub_id))
-
         mapping, subscription_ids = authorize_and_map_uptime_detector_subscription_ids(
             detector_ids=[str(detector1.id), str(detector2.id)],
             projects=[self.project],
-            sub_id_formatter=string_formatter,
         )
 
-        # Verify both detectors are mapped
         assert len(mapping) == 2
         assert len(subscription_ids) == 2
 
-        expected_str_id1 = str(uuid.UUID(subscription_id1))
-        expected_str_id2 = str(uuid.UUID(subscription_id2))
+        expected_str_id1 = uuid.UUID(subscription_id1).hex
+        expected_str_id2 = uuid.UUID(subscription_id2).hex
 
         assert expected_str_id1 in mapping
         assert expected_str_id2 in mapping


### PR DESCRIPTION
We've enabled this flag and are no longer using this path, so removing this flag. Splitting into separate prs to avoid one huge pr

<!-- Describe your PR here. -->