### PR TITLE
perf(widget-builder): Lazily calculate field dropdown options

### DIFF
--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -71,7 +71,7 @@ export type MenuListItemProps = {
    * not very visible - if possible, add additional text via the `details`
    * prop instead.
    */
-  tooltip?: React.ReactNode;
+  tooltip?: EdgeItems;
   /**
    * Additional props to be passed into <Tooltip />.
    */
@@ -130,7 +130,15 @@ function BaseMenuListItem({
       ref={mergeRefs(ref, itemRef)}
       {...props}
     >
-      <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
+      <Tooltip
+        skipWrapper
+        title={
+          typeof tooltip === 'function'
+            ? tooltip({disabled, isFocused, isSelected})
+            : tooltip
+        }
+        {...tooltipOptions}
+      >
         <InnerWrap
           isFocused={isFocused}
           disabled={disabled}

--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -24,9 +24,11 @@ import type {FormSize} from 'sentry/utils/theme';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 
 /**
- * Leading/trailing items to be rendered alongside the main text label.
+ * A renderable item. Either a React node, or a function that accepts properties
+ * of the item, and returns a React node. The function version is useful for
+ * lazily rendering supplementary content like training items and tooltips.
  */
-type EdgeItems =
+type ExtraContent =
   | React.ReactNode
   | ((state: {
       disabled: boolean;
@@ -53,7 +55,7 @@ export type MenuListItemProps = {
   /**
    * Items to be added to the left of the label
    */
-  leadingItems?: EdgeItems;
+  leadingItems?: ExtraContent;
   /**
    * Accented text and background (on hover) colors.
    */
@@ -71,7 +73,7 @@ export type MenuListItemProps = {
    * not very visible - if possible, add additional text via the `details`
    * prop instead.
    */
-  tooltip?: EdgeItems;
+  tooltip?: ExtraContent;
   /**
    * Additional props to be passed into <Tooltip />.
    */
@@ -79,7 +81,7 @@ export type MenuListItemProps = {
   /**
    * Items to be added to the right of the label.
    */
-  trailingItems?: EdgeItems;
+  trailingItems?: ExtraContent;
 };
 
 interface OtherProps {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -90,21 +90,24 @@ function formatColumnOptions(
             ? prettifyTagKey(option.value.meta.name)
             : option.value.meta.name,
 
-        trailingItems: renderTag(
-          option.value.kind,
-          option.value.meta.name,
-          option.value.kind !== FieldValueKind.FUNCTION &&
-            option.value.kind !== FieldValueKind.EQUATION
-            ? option.value.meta.dataType
-            : undefined
-        ),
+        trailingItems: () => {
+          return renderTag(
+            option.value.kind,
+            option.value.meta.name,
+            option.value.kind !== FieldValueKind.FUNCTION &&
+              option.value.kind !== FieldValueKind.EQUATION
+              ? option.value.meta.dataType
+              : undefined
+          );
+        },
         disabled: !supported,
-        tooltip:
-          !supported && field.kind === FieldValueKind.FUNCTION
+        tooltip: ({disabled}: {disabled: boolean}) => {
+          return disabled && field.kind === FieldValueKind.FUNCTION
             ? tct('This field is not available for the [aggregate] function', {
                 aggregate: <strong>{field.function[0]}</strong>,
               })
-            : undefined,
+            : undefined;
+        },
       };
     });
 }


### PR DESCRIPTION
There have been a few complaints about the performance of the Widget Builder component. Many changes are needed, but this is a quick win. The major reason for slowness is the `Visualize` component, which runs the `formatColumnOptions` function. This function can take ~300ms to run if there are >1,000 options for the field (which can be the case if many projects are selected).

The reason for the slowness is the `tooltip` and `trailingItems` props on each option. They both render React components, which, yes, slow. The good news is that `CompactSelect` supports evaluating `trailingItems` (and `leadingItems`) at render-time, inside the component, by passing a _function_ that returns a React node, rather than a React node. In this PR, I added the same functionality to `tooltip`, and switched `Visualize` to use those options. The win is pretty major, from ~200-300ms to render `Visualize` to ~10ms-25ms to render `Visualize`.

This punts the rendering work to `CompactSelect`, but this kind of amortization is still net good IMO, since `CompactSelect` can be virtualized or improved in other ways.

**Before:**
<img width="304" height="58" alt="Screenshot 2025-10-20 at 3 24 26 PM" src="https://github.com/user-attachments/assets/1df273ea-bf35-42b8-a2ee-e19f8edae002" />

**After:**
<img width="434" height="179" alt="Screenshot 2025-10-20 at 3 17 17 PM" src="https://github.com/user-attachments/assets/9b079082-d891-42d9-975e-d5c679ceef2d" />

Many other improvements are needed, but this is very helpful already. We'll continue to reap the benefits of this if we end up virtualizing the contents of `CompactSelect` 👍🏻 

@getsentry/design-engineering any objections to this? Seems pretty natural to me, especially since `leadingItems` and `trailingItems` already support this pattern