### PR TITLE
chore(uptime): Remove remaining uses of `uptime-eap-uptime-results-query`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -462,8 +462,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:unlimited-auto-triggered-autofix-runs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables view hierarchy attachment scrubbing
     manager.add("organizations:view-hierarchy-scrubbing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable querying uptime data from EAP uptime_results instead of uptime_checks
-    manager.add("organizations:uptime-eap-uptime-results-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable email notifications when auto-detected uptime monitors graduate from onboarding
     manager.add("organizations:uptime-auto-detected-monitor-emails", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/uptime/endpoints/organization_uptime_summary.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_summary.py
@@ -33,7 +33,6 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -79,10 +78,6 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
                 status=400,
             )
 
-        use_eap_results = features.has(
-            "organizations:uptime-eap-uptime-results-query", organization, actor=request.user
-        )
-
         try:
             # XXX: We need to query these using hex, since we store them without dashes.
             # We remove this once we remove the old uptime checks
@@ -101,31 +96,14 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
             return self.respond("Invalid uptime detector ids provided", status=400)
 
         try:
-            if use_eap_results:
-                eap_response = self._make_eap_request(
-                    organization,
-                    projects,
-                    subscription_ids,
-                    start,
-                    end,
-                    TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
-                    "subscription_id",
-                    include_avg_duration=True,
-                )
-            else:
-                eap_response = self._make_eap_request(
-                    organization,
-                    projects,
-                    subscription_ids,
-                    start,
-                    end,
-                    TraceItemType.TRACE_ITEM_TYPE_UPTIME_CHECK,
-                    "uptime_subscription_id",
-                    include_avg_duration=False,
-                )
-            formatted_response = self._format_response(
-                eap_response, include_avg_duration=use_eap_results
+            eap_response = self._make_eap_request(
+                organization,
+                projects,
+                subscription_ids,
+                start,
+                end,
             )
+            formatted_response = self._format_response(eap_response)
         except Exception:
             logger.exception("Error making EAP RPC request for uptime check summary")
             return self.respond("error making request", status=400)
@@ -150,9 +128,6 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
         subscription_ids: list[str],
         start: datetime,
         end: datetime,
-        trace_item_type: TraceItemType.ValueType,
-        subscription_key: str,
-        include_avg_duration: bool = False,
     ) -> TraceItemTableResponse:
         start_timestamp = Timestamp()
         start_timestamp.FromDatetime(start)
@@ -160,7 +135,7 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
         end_timestamp.FromDatetime(end)
 
         subscription_attribute_key = AttributeKey(
-            name=subscription_key,
+            name="subscription_id",
             type=AttributeKey.Type.TYPE_STRING,
         )
 
@@ -233,24 +208,22 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
             ),
         ]
 
-        # We're only recording duraitons in the uptime_results table
-        if include_avg_duration:
-            columns.append(
-                Column(
-                    label="avg_duration_us",
-                    aggregation=AttributeAggregation(
-                        aggregate=Function.FUNCTION_AVG,
-                        key=AttributeKey(name="check_duration_us", type=AttributeKey.Type.TYPE_INT),
-                        label="avg(check_duration_us)",
-                    ),
-                )
+        columns.append(
+            Column(
+                label="avg_duration_us",
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_AVG,
+                    key=AttributeKey(name="check_duration_us", type=AttributeKey.Type.TYPE_INT),
+                    label="avg(check_duration_us)",
+                ),
             )
+        )
 
         request = TraceItemTableRequest(
             meta=RequestMeta(
                 organization_id=organization.id,
                 project_ids=[project.id for project in projects],
-                trace_item_type=trace_item_type,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_UPTIME_RESULT,
                 start_timestamp=start_timestamp,
                 end_timestamp=end_timestamp,
                 downsampled_storage_config=DownsampledStorageConfig(
@@ -265,9 +238,7 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
         assert len(responses) == 1
         return responses[0]
 
-    def _format_response(
-        self, response: TraceItemTableResponse, include_avg_duration: bool = False
-    ) -> dict[str, UptimeSummary]:
+    def _format_response(self, response: TraceItemTableResponse) -> dict[str, UptimeSummary]:
         """
         Formats the response from the EAP RPC request into a dictionary mapping
         subscription ids to UptimeSummary
@@ -287,7 +258,7 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
 
             # Get avg_duration_us if available, otherwise set to None
             avg_duration_us = None
-            if include_avg_duration and "avg_duration_us" in row_dict:
+            if "avg_duration_us" in row_dict:
                 avg_duration_us = row_dict["avg_duration_us"].val_double
 
             summary_stats = UptimeSummary(

--- a/src/sentry/uptime/endpoints/organization_uptime_summary.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_summary.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from datetime import datetime
 
 from drf_spectacular.utils import extend_schema
@@ -79,19 +78,9 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
             )
 
         try:
-            # XXX: We need to query these using hex, since we store them without dashes.
-            # We remove this once we remove the old uptime checks
-            if use_eap_results:
-                subscription_id_formatter = lambda sub_id: uuid.UUID(sub_id).hex
-            else:
-                subscription_id_formatter = lambda sub_id: str(uuid.UUID(sub_id))
-
             subscription_id_to_original_id, subscription_ids = (
-                authorize_and_map_uptime_detector_subscription_ids(
-                    uptime_detector_ids, projects, subscription_id_formatter
-                )
+                authorize_and_map_uptime_detector_subscription_ids(uptime_detector_ids, projects)
             )
-
         except ValueError:
             return self.respond("Invalid uptime detector ids provided", status=400)
 

--- a/src/sentry/uptime/endpoints/organization_uptime_summary.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_summary.py
@@ -245,17 +245,12 @@ class OrganizationUptimeSummaryEndpoint(OrganizationEndpoint):
                 for col_idx, col_name in enumerate(column_names)
             }
 
-            # Get avg_duration_us if available, otherwise set to None
-            avg_duration_us = None
-            if "avg_duration_us" in row_dict:
-                avg_duration_us = row_dict["avg_duration_us"].val_double
-
             summary_stats = UptimeSummary(
                 total_checks=int(row_dict["total_checks"].val_double),
                 failed_checks=int(row_dict["failed_checks"].val_double),
                 downtime_checks=int(row_dict["downtime_checks"].val_double),
                 missed_window_checks=int(row_dict["missed_window_checks"].val_double),
-                avg_duration_us=avg_duration_us,
+                avg_duration_us=row_dict["avg_duration_us"].val_double,
             )
 
             subscription_id = row_dict["uptime_subscription_id"].val_str

--- a/src/sentry/uptime/endpoints/utils.py
+++ b/src/sentry/uptime/endpoints/utils.py
@@ -1,5 +1,4 @@
 import uuid
-from collections.abc import Callable
 
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
@@ -19,7 +18,6 @@ Maximum number of uptime subscription IDs that may be queried at once
 def authorize_and_map_uptime_detector_subscription_ids(
     detector_ids: list[str],
     projects: list[Project],
-    sub_id_formatter: Callable[[str], str] = lambda sub_id: uuid.UUID(sub_id).hex,
 ) -> tuple[dict[str, int], list[str]]:
     """
     Authorize the detector ids and return their corresponding subscription ids.
@@ -78,6 +76,8 @@ def authorize_and_map_uptime_detector_subscription_ids(
 
     if set(detector_ids_ints) != validated_detector_ids:
         raise ValueError("Invalid detector ids provided")
+
+    sub_id_formatter = lambda sub_id: uuid.UUID(sub_id).hex
 
     subscription_id_to_detector_id = {
         sub_id_formatter(detector_data[1]): detector_data[0]

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -144,8 +144,7 @@ class UptimeSummary:
     failed_checks: int
     downtime_checks: int
     missed_window_checks: int
-    # TODO(epurkhiser): Remove None option once we're only using the uptime results table
-    avg_duration_us: float | None
+    avg_duration_us: float
 
 
 class UptimeMonitorMode(enum.IntEnum):

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -586,10 +586,7 @@ class OrganizationEventsTraceEndpointTest(
         """Test that uptime results are included when include_uptime=1"""
         self.load_trace(is_eap=True)
 
-        features = self.FEATURES + [
-            "organizations:uptime-eap-enabled",
-            "organizations:uptime-eap-uptime-results-query",
-        ]
+        features = self.FEATURES + ["organizations:uptime-eap-enabled"]
         redirect_result = self._create_uptime_result_with_original_url(
             organization=self.organization,
             project=self.project,
@@ -701,10 +698,7 @@ class OrganizationEventsTraceEndpointTest(
             scheduled_check_time=self.day_ago,
         )
 
-        features = self.FEATURES + [
-            "organizations:uptime-eap-enabled",
-            "organizations:uptime-eap-uptime-results-query",
-        ]
+        features = self.FEATURES + ["organizations:uptime-eap-enabled"]
 
         self.store_uptime_results([redirect_result, final_result])
 
@@ -739,10 +733,7 @@ class OrganizationEventsTraceEndpointTest(
             check_duration_us=200000,
         )
 
-        features = self.FEATURES + [
-            "organizations:uptime-eap-enabled",
-            "organizations:uptime-eap-uptime-results-query",
-        ]
+        features = self.FEATURES + ["organizations:uptime-eap-enabled"]
 
         self.store_uptime_results([uptime_result])
 


### PR DESCRIPTION
This removes the final paths that use this feature flag, and also the flag itself
