### PR TITLE
perf(query-builder): Use simpler logic for config merging

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-import merge from 'lodash/merge';
 import moment from 'moment-timezone';
 import type {LocationRange} from 'peggy';
 
@@ -1524,7 +1523,7 @@ export function parseSearch(
   additionalConfig?: Partial<SearchConfig>
 ): ParseResult | null {
   const config = additionalConfig
-    ? merge({...defaultConfig}, additionalConfig)
+    ? {...defaultConfig, ...additionalConfig}
     : defaultConfig;
 
   return tryParseSearch(query, {

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1523,7 +1523,7 @@ export function parseSearch(
   additionalConfig?: Partial<SearchConfig>
 ): ParseResult | null {
   const config = additionalConfig
-    ? {...defaultConfig, ...additionalConfig}
+    ? mergeSearchConfigOntoDefaults(defaultConfig, additionalConfig)
     : defaultConfig;
 
   return tryParseSearch(query, {
@@ -1532,6 +1532,28 @@ export function parseSearch(
     TermOperator,
     FilterType,
   });
+}
+
+/**
+ * Applies a partial search configuration onto the default config. This is very
+ * similar to a simple `{...a, ...b}`, but it ignores any `undefined` values of
+ * `b`. This is important because `{...{key: false}, ...{key: undefined}}`
+ * results in `{key: undefined}`, which is not what we want. We want the values
+ * of the search config to override the default _only_ if they're actually
+ * defined.
+ */
+function mergeSearchConfigOntoDefaults(
+  a: SearchConfig,
+  b: Partial<SearchConfig>
+): SearchConfig {
+  const newConfig: SearchConfig = {
+    ...a,
+    ...Object.fromEntries(
+      Object.entries(b).filter(([_key, value]) => value !== undefined)
+    ),
+  };
+
+  return newConfig;
 }
 
 /**

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1523,7 +1523,7 @@ export function parseSearch(
   additionalConfig?: Partial<SearchConfig>
 ): ParseResult | null {
   const config = additionalConfig
-    ? mergeSearchConfigOntoDefaults(defaultConfig, additionalConfig)
+    ? mergeSearchConfigWithDefaults(defaultConfig, additionalConfig)
     : defaultConfig;
 
   return tryParseSearch(query, {
@@ -1542,7 +1542,7 @@ export function parseSearch(
  * of the search config to override the default _only_ if they're actually
  * defined.
  */
-function mergeSearchConfigOntoDefaults(
+function mergeSearchConfigWithDefaults(
   a: SearchConfig,
   b: Partial<SearchConfig>
 ): SearchConfig {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -31,7 +31,7 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
-import {InvalidReason} from 'sentry/components/searchSyntax/parser';
+import {defaultConfig, InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {t, tct, tctCode} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
@@ -700,6 +700,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                           }
                           onChange={onChange}
                           invalidMessages={{
+                            ...defaultConfig.invalidMessages,
                             [InvalidReason.WILDCARD_NOT_ALLOWED]: t(
                               'The wildcard operator is not supported here.'
                             ),

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
-import {InvalidReason} from 'sentry/components/searchSyntax/parser';
+import {defaultConfig, InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
@@ -22,6 +22,7 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
 
 const invalidMessages = {
+  ...defaultConfig.invalidMessages,
   [InvalidReason.WILDCARD_NOT_ALLOWED]: t("Release queries don't support wildcards."),
   [InvalidReason.FREE_TEXT_NOT_ALLOWED]: t(
     "Release queries don't support free text search."

--- a/static/app/views/detectors/datasetConfig/components/releaseSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/releaseSearchBar.tsx
@@ -1,7 +1,7 @@
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
-import {InvalidReason} from 'sentry/components/searchSyntax/parser';
+import {defaultConfig, InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {SavedSearchType} from 'sentry/types/group';
@@ -26,6 +26,7 @@ const supportedTags = Object.values(SESSIONS_FILTER_TAGS).reduce<TagCollection>(
 );
 
 const invalidMessages = {
+  ...defaultConfig.invalidMessages,
   [InvalidReason.WILDCARD_NOT_ALLOWED]: t("Release queries don't support wildcards."),
   [InvalidReason.FREE_TEXT_NOT_ALLOWED]: t(
     "Release queries don't support free text search."


### PR DESCRIPTION
`SearchQueryBuilder` (and some other code) use the `parseQueryBuilderValue` to parse search strings. Under-the-hood, this uses the `parseSearch` function. That function, in turn needs to create a parser config, which it does via Lodash's `merge` function into a default configuration. Unfortunately, this is ruinously expensive if repeated. e.g.,

<img width="802" height="333" alt="Screenshot 2025-10-20 at 3 31 51 PM" src="https://github.com/user-attachments/assets/9db35e2e-693d-4f17-af2d-9e2d1da74d18" />

You can see that this takes ~90ms, all of which is `baseMergeDeep`. Looking at [the documentation](https://lodash.com/docs/4.17.15#merge), there's a major caveat:

> Array and plain object properties are merged recursively. Other objects and value types are overridden by assignment.

`SearchConfig` is almost exclusively made of `Set` and `boolean` items! There are only two mergeable properties: `supportedTags` and `invalidMessages`. The former is not in the `defaultConfig`, so there's nothing to merge. The latter is used in a few places, and I've added the merge there manually. This results in a pretty eye-watering speedup:

<img width="482" height="65" alt="Screenshot 2025-10-20 at 3 54 35 PM" src="https://github.com/user-attachments/assets/f2d45340-b2b3-46fd-9507-b79607298cf0" />

This creates a _slight_ footgun where users who supply custom messages will need to make sure to merge with the defaults to get them, but the speedup feels like it's worth it. Alternatively, I can probably add a little exception there and merge _just_ the messages?
