### PR TITLE
chore(aci): update webhook actions when sentry app install is deleted

### DIFF
--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -40,6 +40,10 @@ class DatabaseBackedActionService(ActionService):
             config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
             config__target_identifier=sentry_app_install_uuid,
         ).update(status=status)
+        Action.objects.filter(
+            type=Action.Type.WEBHOOK,
+            config__target_identifier=sentry_app_install_uuid,
+        ).update(status=status)
 
     def update_action_status_for_sentry_app_via_uuid__region(
         self,
@@ -51,6 +55,10 @@ class DatabaseBackedActionService(ActionService):
         Action.objects.filter(
             type=Action.Type.SENTRY_APP,
             config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            config__target_identifier=sentry_app_install_uuid,
+        ).update(status=status)
+        Action.objects.filter(
+            type=Action.Type.WEBHOOK,
             config__target_identifier=sentry_app_install_uuid,
         ).update(status=status)
 

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -263,6 +263,12 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        webhook_action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={
+                "target_identifier": sentry_app_installation.uuid,
+            },
+        )
 
         action_service.update_action_status_for_sentry_app_via_uuid(
             organization_id=self.organization.id,
@@ -273,6 +279,9 @@ class TestActionService(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
+
+            webhook_action.refresh_from_db()
+            assert webhook_action.status == ObjectStatus.DISABLED
 
     def test_update_action_status_for_sentry_app__installation_uuid__region(self) -> None:
         sentry_app_installation = self.create_sentry_app_installation(
@@ -287,6 +296,12 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
+        webhook_action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={
+                "target_identifier": sentry_app_installation.uuid,
+            },
+        )
         action_service.update_action_status_for_sentry_app_via_uuid__region(
             region_name="us",
             sentry_app_install_uuid=sentry_app_installation.uuid,
@@ -295,6 +310,9 @@ class TestActionService(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
+
+            webhook_action.refresh_from_db()
+            assert webhook_action.status == ObjectStatus.DISABLED
 
     def test_update_action_status_for_sentry_app__via_sentry_app_id(self) -> None:
         action = self.create_action(


### PR DESCRIPTION
We recently changed some sentry app actions to be saved as webhook actions. This PR makes sure we also update the webhook action statuses when the corresponding sentry app installation is deleted.

Some requests will be stale and not update all the data we want (sentry app actions + webhook actions) but that's ok. We'll likely have to do a backfill anyway to disable the webhook actions that are already invalid because the sentry app UUID doesn't exist anymore.