### PR TITLE
chore(aci): RPC function to update sentry app webhook action via slug

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -58,7 +58,9 @@ def process_sentry_app_updates(object_identifier: int, region_name: str, **kwds:
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.SENTRY_APP_DELETE)
-def process_sentry_app_deletes(object_identifier: int, region_name: str, **kwds: Any):
+def process_sentry_app_deletes(
+    shard_identifier: int, object_identifier: str, region_name: str, **kwds: Any
+):
     # This function should only be used when the sentry app is being deleted.
     # Currently this receiver is only used for deletion.
     if options.get("workflow_engine.sentry-app-actions-outbox"):
@@ -66,15 +68,15 @@ def process_sentry_app_deletes(object_identifier: int, region_name: str, **kwds:
             "sentry_app_update.update_action_status",
             extra={
                 "region_name": region_name,
-                "sentry_app_id": object_identifier,
+                "sentry_app_id": shard_identifier,
             },
         )
         action_service.update_action_status_for_sentry_app_via_sentry_app_id(
             region_name=region_name,
             status=ObjectStatus.DISABLED,
-            sentry_app_id=object_identifier,
+            sentry_app_id=shard_identifier,
         )
-        # TODO: also update webhook actions
+        # TODO: also update webhook actions using object identifier (sentry app slug)
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.API_APPLICATION_UPDATE)

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -74,6 +74,7 @@ def process_sentry_app_deletes(object_identifier: int, region_name: str, **kwds:
             status=ObjectStatus.DISABLED,
             sentry_app_id=object_identifier,
         )
+        # TODO: also update webhook actions
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.API_APPLICATION_UPDATE)

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -59,7 +59,11 @@ def process_sentry_app_updates(object_identifier: int, region_name: str, **kwds:
 
 @receiver(process_control_outbox, sender=OutboxCategory.SENTRY_APP_DELETE)
 def process_sentry_app_deletes(
-    shard_identifier: int, object_identifier: str, region_name: str, **kwds: Any
+    shard_identifier: int,
+    object_identifier: str,
+    region_name: str,
+    payload: Mapping[str, Any],
+    **kwds: Any,
 ):
     # This function should only be used when the sentry app is being deleted.
     # Currently this receiver is only used for deletion.
@@ -68,13 +72,13 @@ def process_sentry_app_deletes(
             "sentry_app_update.update_action_status",
             extra={
                 "region_name": region_name,
-                "sentry_app_id": shard_identifier,
+                "sentry_app_id": object_identifier,
             },
         )
         action_service.update_action_status_for_sentry_app_via_sentry_app_id(
             region_name=region_name,
             status=ObjectStatus.DISABLED,
-            sentry_app_id=shard_identifier,
+            sentry_app_id=object_identifier,
         )
         # TODO: also update webhook actions using object identifier (sentry app slug)
 

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -60,7 +60,7 @@ def process_sentry_app_updates(object_identifier: int, region_name: str, **kwds:
 @receiver(process_control_outbox, sender=OutboxCategory.SENTRY_APP_DELETE)
 def process_sentry_app_deletes(
     shard_identifier: int,
-    object_identifier: str,
+    object_identifier: int,
     region_name: str,
     payload: Mapping[str, Any],
     **kwds: Any,

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -220,9 +220,10 @@ class SentryApp(ParanoidModel, HasApiScopes, Model):
             ControlOutbox(
                 shard_scope=OutboxScope.APP_SCOPE,
                 shard_identifier=self.id,
-                object_identifier=self.slug,
+                object_identifier=self.id,
                 category=OutboxCategory.SENTRY_APP_DELETE,
                 region_name=region_name,
+                payload={"slug": self.slug},
             )
             for region_name in find_all_region_names()
         ]

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -220,7 +220,7 @@ class SentryApp(ParanoidModel, HasApiScopes, Model):
             ControlOutbox(
                 shard_scope=OutboxScope.APP_SCOPE,
                 shard_identifier=self.id,
-                object_identifier=self.id,  # TODO: use slug instead of id
+                object_identifier=self.slug,
                 category=OutboxCategory.SENTRY_APP_DELETE,
                 region_name=region_name,
             )

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -220,7 +220,7 @@ class SentryApp(ParanoidModel, HasApiScopes, Model):
             ControlOutbox(
                 shard_scope=OutboxScope.APP_SCOPE,
                 shard_identifier=self.id,
-                object_identifier=self.id,
+                object_identifier=self.id,  # TODO: use slug instead of id
                 category=OutboxCategory.SENTRY_APP_DELETE,
                 region_name=region_name,
             )

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -66,3 +66,15 @@ class DatabaseBackedActionService(ActionService):
             config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_ID,
             config__target_identifier=str(sentry_app_id),
         ).update(status=status)
+
+    def update_action_status_for_webhook_via_sentry_app_slug(
+        self,
+        *,
+        region_name: str,
+        status: int,
+        sentry_app_slug: str,
+    ) -> None:
+        Action.objects.filter(
+            type=Action.Type.WEBHOOK,
+            config__target_identifier=sentry_app_slug,
+        ).update(status=status)

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -67,5 +67,16 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
+    @regional_rpc_method(resolve=ByRegionName())
+    @abc.abstractmethod
+    def update_action_status_for_webhook_via_sentry_app_slug(
+        self,
+        *,
+        region_name: str,
+        status: int,
+        sentry_app_slug: str,
+    ) -> None:
+        pass
+
 
 action_service = ActionService.create_delegation()

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -314,3 +314,20 @@ class TestActionService(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
+
+    def test_update_action_status_for_webhook_via_sentry_app_slug(self) -> None:
+        action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={
+                "target_identifier": self.sentry_app.slug,
+            },
+        )
+        action_service.update_action_status_for_webhook_via_sentry_app_slug(
+            region_name="us",
+            sentry_app_slug=self.sentry_app.slug,
+            status=ObjectStatus.DISABLED,
+        )
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            action.refresh_from_db()
+            assert action.status == ObjectStatus.DISABLED


### PR DESCRIPTION
We recently changed some sentry app actions to be saved as webhook actions. This means we'll also need to update statuses for these webhook actions when the corresponding sentry app is deleted, using the sentry app slug to find related webhook actions.

This PR also prepares the control outbox receiver to process both since sentry app actions use sentry app id and the webhook actions use sentry app slug.