### PR TITLE
feat(aci): Make delayed scheduling min age an option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3194,6 +3194,12 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "workflow_engine.schedule.min_cohort_scheduling_age_seconds",
+    type=Int,
+    default=50,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -88,10 +88,13 @@ class ProjectChooser:
     ProjectChooser assists in determining which projects to process based on the cohort updates.
     """
 
-    def __init__(self, buffer_client: DelayedWorkflowClient, num_cohorts: int):
+    def __init__(
+        self, buffer_client: DelayedWorkflowClient, num_cohorts: int, min_scheduling_age: timedelta
+    ):
         self.client = buffer_client
         assert num_cohorts > 0 and num_cohorts <= 255
         self.num_cohorts = num_cohorts
+        self.min_scheduling_age = min_scheduling_age
 
     def _project_id_to_cohort(self, project_id: int) -> int:
         return hashlib.sha256(project_id.to_bytes(8)).digest()[0] % self.num_cohorts
@@ -108,7 +111,7 @@ class ProjectChooser:
         cohort_to_elapsed = dict[int, timedelta]()
         long_ago = now - 1000
         target_max_age = timedelta(minutes=1)  # must run
-        min_scheduling_age = timedelta(seconds=50)  # can run
+        min_scheduling_age = self.min_scheduling_age  # can run
         # The cohort choice algorithm is essentially:
         # 1. Any cohort that hasn't been run recently enough (based on target_max_age)
         #   must be run.
@@ -119,6 +122,22 @@ class ProjectChooser:
         # With this, we distribute cohorts across runs, but ensure we don't process them
         # too frequently or too late, while not being too dependent on number of cohorts or
         # frequency of scheduling.
+        if len(cohort_updates.values) != self.num_cohorts:
+            logger.info(
+                "%s cohort_updates.values, but num_cohorts is %s. Resetting.",
+                len(cohort_updates.values),
+                self.num_cohorts,
+                extra={"cohort_updates": cohort_updates.values},
+            )
+            # When cohort counts change, we accept that we'll be potentially running some
+            # projects a bit too early. Previous cohorts are no longer valid, so the timestamps
+            # associated with them are only accurate for setting bounds on the whole project space.
+            # But, we can still use that to avoid running projects too early by giving them all the
+            # eldest timestamp.
+            eldest = min(cohort_updates.values.values(), default=long_ago)
+            # This also ensures that if we downsize cohorts, we don't let data from now-dead cohorts
+            # linger.
+            cohort_updates.values = {co: eldest for co in range(self.num_cohorts)}
         for co in range(self.num_cohorts):
             last_run = cohort_updates.values.get(co)
             if last_run is None:
@@ -202,7 +221,15 @@ def process_buffered_workflows(buffer_client: DelayedWorkflowClient) -> None:
         # Check if cohort-based selection is enabled (defaults to True for safety)
         use_cohort_selection = options.get("workflow_engine.use_cohort_selection", True)
         project_chooser = (
-            ProjectChooser(buffer_client, num_cohorts=options.get("workflow_engine.num_cohorts", 1))
+            ProjectChooser(
+                buffer_client,
+                num_cohorts=options.get("workflow_engine.num_cohorts", 1),
+                min_scheduling_age=timedelta(
+                    seconds=options.get(
+                        "workflow_engine.schedule.min_cohort_scheduling_age_seconds", 50
+                    )
+                ),
+            )
             if use_cohort_selection
             else None
         )

--- a/tests/sentry/workflow_engine/processors/test_schedule.py
+++ b/tests/sentry/workflow_engine/processors/test_schedule.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
@@ -239,7 +239,7 @@ class TestProjectChooser:
 
     @pytest.fixture
     def project_chooser(self, mock_buffer):
-        return ProjectChooser(mock_buffer, num_cohorts=6)
+        return ProjectChooser(mock_buffer, num_cohorts=6, min_scheduling_age=timedelta(seconds=50))
 
     def _find_projects_for_cohorts(self, chooser: ProjectChooser, num_cohorts: int) -> list[int]:
         """Helper method to find project IDs that map to each cohort to ensure even distribution."""
@@ -300,8 +300,8 @@ class TestProjectChooser:
         fetch_time = 1000.0
         cohort_updates = CohortUpdates(
             values={
-                0: 995.0,  # 5 seconds ago - may process (older)
-                1: 998.0,  # 2 seconds ago - may process (newer)
+                0: 945.0,  # 55 seconds ago - may process (older)
+                1: 948.0,  # 52 seconds ago - may process (newer)
                 2: 999.0,  # 1 second ago - no process
             }
         )
@@ -411,7 +411,9 @@ class TestProjectChooser:
         This demonstrates that all projects are processed together every minute.
         """
         # Create ProjectChooser with cohort count = 1 (production default)
-        chooser = ProjectChooser(mock_buffer, num_cohorts=1)
+        chooser = ProjectChooser(
+            mock_buffer, num_cohorts=1, min_scheduling_age=timedelta(seconds=50)
+        )
         all_project_ids = self._find_projects_for_cohorts(chooser, 1)
 
         # Add more projects to demonstrate they all map to cohort 0
@@ -444,6 +446,32 @@ class TestProjectChooser:
                 f"Run {minute}: Expected all {len(all_project_ids)} projects to be processed, "
                 f"but got {len(processed_projects)}: {sorted(processed_projects)}"
             )
+
+    def test_cohort_count_change_uses_eldest_freshness(self, mock_buffer) -> None:
+        """
+        Test that when num_cohorts changes, all new cohorts use the eldest stored cohort freshness,
+        then cohorts that need processing are scheduled and updated to current time.
+        """
+        # Start with 3 cohorts at different ages
+        cohort_updates = CohortUpdates(
+            values={
+                0: 100.0,  # eldest
+                1: 200.0,
+                2: 300.0,  # newest
+            }
+        )
+
+        # Change to 6 cohorts - since all cohorts will be reset to 100.0 (900 seconds old),
+        # they will all exceed the target_max_age of 60 seconds and be scheduled to run
+        new_chooser = ProjectChooser(
+            mock_buffer, num_cohorts=6, min_scheduling_age=timedelta(seconds=50)
+        )
+        new_chooser.project_ids_to_process(1000.0, cohort_updates, [])
+
+        # All 6 cohorts should exist and be set to current time since they were all very old
+        assert len(cohort_updates.values) == 6
+        for cohort_id in range(6):
+            assert cohort_updates.values[cohort_id] == 1000.0
 
 
 class TestChosenProjects:


### PR DESCRIPTION
Since min age is something we want to tune with frequency, make it an option.
While here, also refines the cohort change logic to log, ensure no stale data, and to use min known rather than assuming no knowledge; not a big behavioral impact, but marginal improvement in some corner cases.