### PR TITLE
fix(replay): set default option to true for rage clicks and hydration errors

### DIFF
--- a/src/sentry/replays/usecases/ingest/cache.py
+++ b/src/sentry/replays/usecases/ingest/cache.py
@@ -17,8 +17,8 @@ def _has_replays_lookup(project_id: int) -> bool:
 
 def _option_lookup(project_id: int) -> tuple[bool, bool]:
     default_options = {
-        "sentry:replay_hydration_error_issues": False,
-        "sentry:replay_rage_click_issues": False,
+        "sentry:replay_hydration_error_issues": True,
+        "sentry:replay_rage_click_issues": True,
     }
 
     # We're intentionally manually looking up the options. We're avoided the project-options local

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -411,6 +411,7 @@ def _should_report_hydration_error_issue(project_id: int, context: ProcessorCont
         return ProjectOption.objects.get_value(
             project_id,
             "sentry:replay_hydration_error_issues",
+            default=True,
         )
 
 
@@ -425,6 +426,7 @@ def _should_report_rage_click_issue(project_id: int, context: ProcessorContext) 
         return ProjectOption.objects.get_value(
             project_id,
             "sentry:replay_rage_click_issues",
+            default=True,
         )
 
 

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -411,7 +411,7 @@ def _should_report_hydration_error_issue(project_id: int, context: ProcessorCont
         return ProjectOption.objects.get_value(
             project_id,
             "sentry:replay_hydration_error_issues",
-            default=False,
+            default=True,
         )
 
 
@@ -426,7 +426,7 @@ def _should_report_rage_click_issue(project_id: int, context: ProcessorContext) 
         return ProjectOption.objects.get_value(
             project_id,
             "sentry:replay_rage_click_issues",
-            default=False,
+            default=True,
         )
 
 

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -411,7 +411,6 @@ def _should_report_hydration_error_issue(project_id: int, context: ProcessorCont
         return ProjectOption.objects.get_value(
             project_id,
             "sentry:replay_hydration_error_issues",
-            default=True,
         )
 
 
@@ -426,7 +425,6 @@ def _should_report_rage_click_issue(project_id: int, context: ProcessorContext) 
         return ProjectOption.objects.get_value(
             project_id,
             "sentry:replay_rage_click_issues",
-            default=True,
         )
 
 

--- a/tests/sentry/replays/integration/test_ingest_cache.py
+++ b/tests/sentry/replays/integration/test_ingest_cache.py
@@ -41,14 +41,14 @@ def test_options_cache(default_project: Project) -> None:
     options_cache = make_options_cache()
 
     ProjectOption.objects.set_value(
-        project=default_project, key="sentry:replay_hydration_error_issues", value=True
+        project=default_project, key="sentry:replay_hydration_error_issues", value=False
     )
     ProjectOption.objects.set_value(
-        project=default_project, key="sentry:replay_rage_click_issues", value=True
+        project=default_project, key="sentry:replay_rage_click_issues", value=False
     )
 
-    assert options_cache[default_project.id][0] is True
-    assert options_cache[default_project.id][1] is True
+    assert options_cache[default_project.id][0] is False
+    assert options_cache[default_project.id][1] is False
 
 
 @django_db_all
@@ -56,19 +56,7 @@ def test_options_cache_hydration(default_project: Project) -> None:
     options_cache = make_options_cache()
 
     ProjectOption.objects.set_value(
-        project=default_project, key="sentry:replay_hydration_error_issues", value=True
-    )
-
-    assert options_cache[default_project.id][0] is True
-    assert options_cache[default_project.id][1] is False
-
-
-@django_db_all
-def test_options_cache_rage(default_project: Project) -> None:
-    options_cache = make_options_cache()
-
-    ProjectOption.objects.set_value(
-        project=default_project, key="sentry:replay_rage_click_issues", value=True
+        project=default_project, key="sentry:replay_hydration_error_issues", value=False
     )
 
     assert options_cache[default_project.id][0] is False
@@ -76,11 +64,23 @@ def test_options_cache_rage(default_project: Project) -> None:
 
 
 @django_db_all
+def test_options_cache_rage(default_project: Project) -> None:
+    options_cache = make_options_cache()
+
+    ProjectOption.objects.set_value(
+        project=default_project, key="sentry:replay_rage_click_issues", value=False
+    )
+
+    assert options_cache[default_project.id][0] is True
+    assert options_cache[default_project.id][1] is False
+
+
+@django_db_all
 def test_options_cache_missing(default_project: Project) -> None:
     options_cache = make_options_cache()
 
-    assert options_cache[default_project.id][0] is False
-    assert options_cache[default_project.id][1] is False
+    assert options_cache[default_project.id][0] is True
+    assert options_cache[default_project.id][1] is True
 
-    assert options_cache[2346326722][0] is False
-    assert options_cache[2346326722][1] is False
+    assert options_cache[2346326722][0] is True
+    assert options_cache[2346326722][1] is True

--- a/tests/sentry/replays/integration/test_ingest_options.py
+++ b/tests/sentry/replays/integration/test_ingest_options.py
@@ -12,7 +12,7 @@ def test_should_report_hydration_error_issue_no_value(default_project: Project) 
     result = _should_report_hydration_error_issue(
         default_project.id, {"options_cache": None, "has_sent_replays_cache": None}
     )
-    assert result is False
+    assert result is True
 
 
 @django_db_all
@@ -32,7 +32,7 @@ def test_should_report_hydration_error_issue_no_project() -> None:
     result = _should_report_hydration_error_issue(
         210492104914, {"options_cache": None, "has_sent_replays_cache": None}
     )
-    assert result is False
+    assert result is True
 
 
 @django_db_all
@@ -40,7 +40,7 @@ def test_should_report_rage_click_issue_no_value(default_project: Project) -> No
     result = _should_report_rage_click_issue(
         default_project.id, {"options_cache": None, "has_sent_replays_cache": None}
     )
-    assert result is False
+    assert result is True
 
 
 @django_db_all
@@ -48,7 +48,7 @@ def test_should_report_rage_click_issue_no_project() -> None:
     result = _should_report_rage_click_issue(
         210492104914, {"options_cache": None, "has_sent_replays_cache": None}
     )
-    assert result is False
+    assert result is True
 
 
 @django_db_all


### PR DESCRIPTION
Set default to True in project options lookup for options `sentry:replay_hydration_error_issues` and `sentry:replay_rage_click_issues`. Default should already be True in 

https://github.com/getsentry/sentry/blob/59968dbfdbcd74221f29b9f62b0a904a67443558/src/sentry/projectoptions/defaults.py#L126-L129

https://github.com/getsentry/sentry/blob/59968dbfdbcd74221f29b9f62b0a904a67443558/src/sentry/projectoptions/defaults.py#L121-L124

Should resolve inc 1461.