### PR TITLE
feat(replay): add more mobile breadcrumb log messages

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -133,6 +133,10 @@ class EventType(Enum):
     DEVICE_BATTERY = 25
     DEVICE_ORIENTATION = 26
     DEVICE_CONNECTIVITY = 27
+    SCROLL = 28
+    SWIPE = 29
+    BACKGROUND = 30
+    FOREGROUND = 31
 
 
 def which(event: dict[str, Any]) -> EventType:
@@ -204,6 +208,14 @@ def which(event: dict[str, Any]) -> EventType:
                     return EventType.DEVICE_ORIENTATION
                 elif category == "device.connectivity":
                     return EventType.DEVICE_CONNECTIVITY
+                elif category == "ui.scroll":
+                    return EventType.SCROLL
+                elif category == "ui.swipe":
+                    return EventType.SWIPE
+                elif category == "app.background":
+                    return EventType.BACKGROUND
+                elif category == "app.foreground":
+                    return EventType.FOREGROUND
                 else:
                     return EventType.UNKNOWN
             elif event["data"]["tag"] == "performanceSpan":
@@ -288,6 +300,10 @@ def get_timestamp_unit(event_type: EventType) -> Literal["s", "ms"]:
             | EventType.DEVICE_BATTERY
             | EventType.DEVICE_ORIENTATION
             | EventType.DEVICE_CONNECTIVITY
+            | EventType.SCROLL
+            | EventType.SWIPE
+            | EventType.BACKGROUND
+            | EventType.FOREGROUND
         ):
             return "ms"
 
@@ -609,6 +625,14 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
         case EventType.DEVICE_ORIENTATION:
             return None
         case EventType.DEVICE_CONNECTIVITY:
+            return None
+        case EventType.SCROLL:
+            return None
+        case EventType.SWIPE:
+            return None
+        case EventType.BACKGROUND:
+            return None
+        case EventType.FOREGROUND:
             return None
 
 

--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -411,6 +411,18 @@ def as_log_message(event: dict[str, Any]) -> str | None:
             case EventType.DEVICE_CONNECTIVITY:
                 state = event["data"]["payload"]["data"]["state"]
                 return f"Device connectivity was changed to {state} at {timestamp}"
+            case EventType.SCROLL:
+                view_id = event["data"]["payload"]["data"].get("view.id")
+                direction = event["data"]["payload"]["data"].get("direction", "")
+                return f"User scrolled {view_id} {direction} at {timestamp}"
+            case EventType.SWIPE:
+                view_id = event["data"]["payload"]["data"].get("view.id")
+                direction = event["data"]["payload"]["data"].get("direction", "")
+                return f"User swiped {view_id} {direction} at {timestamp}"
+            case EventType.BACKGROUND:
+                return f"User moved the app to the background at {timestamp}"
+            case EventType.FOREGROUND:
+                return f"User moved the app to the foreground at {timestamp}"
             case EventType.MUTATIONS:
                 return None
             case EventType.UNKNOWN:

--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -412,11 +412,11 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 state = event["data"]["payload"]["data"]["state"]
                 return f"Device connectivity was changed to {state} at {timestamp}"
             case EventType.SCROLL:
-                view_id = event["data"]["payload"]["data"].get("view.id")
+                view_id = event["data"]["payload"]["data"].get("view.id", "")
                 direction = event["data"]["payload"]["data"].get("direction", "")
                 return f"User scrolled {view_id} {direction} at {timestamp}"
             case EventType.SWIPE:
-                view_id = event["data"]["payload"]["data"].get("view.id")
+                view_id = event["data"]["payload"]["data"].get("view.id", "")
                 direction = event["data"]["payload"]["data"].get("direction", "")
                 return f"User swiped {view_id} {direction} at {timestamp}"
             case EventType.BACKGROUND:

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -1039,6 +1039,76 @@ def test_which() -> None:
     }
     assert which(event) == EventType.DEVICE_CONNECTIVITY
 
+    event = {
+        "type": 5,
+        "timestamp": 1760948639388,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1760948639.388,
+                "category": "ui.scroll",
+                "level": "info",
+                "data": {
+                    "view.class": "androidx.recyclerview.widget.RecyclerView",
+                    "view.id": "recycler_view",
+                    "direction": "up",
+                },
+            },
+        },
+    }
+    assert which(event) == EventType.SCROLL
+
+    event = {
+        "type": 5,
+        "timestamp": 1760948640299,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1760948640.299,
+                "category": "ui.swipe",
+                "level": "info",
+                "data": {
+                    "view.class": "androidx.recyclerview.widget.RecyclerView",
+                    "view.id": "recycler_view",
+                    "direction": "up",
+                },
+            },
+        },
+    }
+    assert which(event) == EventType.SWIPE
+
+    event = {
+        "type": 5,
+        "timestamp": 1758735184405,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1758735184.405,
+                "category": "app.background",
+                "data": {},
+            },
+        },
+    }
+    assert which(event) == EventType.BACKGROUND
+
+    event = {
+        "type": 5,
+        "timestamp": 1758733250461,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1758733250.461,
+                "category": "app.foreground",
+                "data": {},
+            },
+        },
+    }
+    assert which(event) == EventType.FOREGROUND
+
     assert which({}) == EventType.UNKNOWN
 
 

--- a/tests/sentry/replays/usecases/test_summarize.py
+++ b/tests/sentry/replays/usecases/test_summarize.py
@@ -914,6 +914,88 @@ def test_as_log_message_device_connectivity() -> None:
     assert get_timestamp_unit(which(event)) == "ms"
 
 
+def test_as_log_message_scroll() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1760948639388,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1760948639.388,
+                "category": "ui.scroll",
+                "level": "info",
+                "data": {
+                    "view.class": "androidx.recyclerview.widget.RecyclerView",
+                    "view.id": "recycler_view",
+                    "direction": "up",
+                },
+            },
+        },
+    }
+    assert as_log_message(event) == "User scrolled recycler_view up at 1760948639388.0"
+    assert get_timestamp_unit(which(event)) == "ms"
+
+
+def test_as_log_message_swipe() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1760948640299,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1760948640.299,
+                "category": "ui.swipe",
+                "level": "info",
+                "data": {
+                    "view.class": "androidx.recyclerview.widget.RecyclerView",
+                    "view.id": "recycler_view",
+                    "direction": "up",
+                },
+            },
+        },
+    }
+    assert as_log_message(event) == "User swiped recycler_view up at 1760948640299.0"
+    assert get_timestamp_unit(which(event)) == "ms"
+
+
+def test_as_log_message_background() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1758735184405,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1758735184.405,
+                "category": "app.background",
+                "data": {},
+            },
+        },
+    }
+    assert as_log_message(event) == "User moved the app to the background at 1758735184405.0"
+    assert get_timestamp_unit(which(event)) == "ms"
+
+
+def test_as_log_message_foreground() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1758733250461,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1758733250.461,
+                "category": "app.foreground",
+                "data": {},
+            },
+        },
+    }
+    assert as_log_message(event) == "User moved the app to the foreground at 1758733250461.0"
+    assert get_timestamp_unit(which(event)) == "ms"
+
+
 def test_parse_iso_timestamp_to_ms() -> None:
     # Without timezone
     assert _parse_iso_timestamp_to_ms("2023-01-01T12:00:00") == 1672574400000


### PR DESCRIPTION
- follow up to https://github.com/getsentry/sentry/pull/101764
- add swipe, scroll, app foreground, & app background breadcrumb logs so that we can get replay AI summaries for mobile replays.
- relates to https://linear.app/getsentry/issue/REPLAY-662/mobile-summaries

mobile-specific crumbs:
 - [x] tap
 - [x] device battery level
 - [x] device orientation
 - [x] device connectivity
 - [x] app background
 - [x] app foreground
 - [x] swipe
 - [x] scroll
 - [ ] navigation --> TODO
