### PR TITLE
task(preprod): Add helpful local info modals for two image insights

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -482,9 +482,9 @@ export type InsightInfoModalOptions = {
 };
 
 export async function openInsightInfoModal(options: InsightInfoModalOptions) {
-  const {InsightInfoModal, modalCss} = await import(
+  const {InsightInfoModal} = await import(
     'sentry/views/preprod/buildDetails/main/insights/insightInfoModal'
   );
 
-  openModal(deps => <InsightInfoModal {...deps} {...options} />, {modalCss});
+  openModal(deps => <InsightInfoModal {...deps} {...options} />);
 }

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -475,3 +475,16 @@ export async function openPrivateGamingSdkAccessModal(
 
   openModal(deps => <PrivateGamingSdkAccessModal {...deps} {...options} />);
 }
+
+export type InsightInfoModalOptions = {
+  children: React.ReactNode;
+  title: string;
+};
+
+export async function openInsightInfoModal(options: InsightInfoModalOptions) {
+  const {InsightInfoModal, modalCss} = await import(
+    'sentry/views/preprod/buildDetails/main/insights/insightInfoModal'
+  );
+
+  openModal(deps => <InsightInfoModal {...deps} {...options} />, {modalCss});
+}

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -28,6 +28,7 @@ import {
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import {processInsights} from 'sentry/views/preprod/utils/insightProcessing';
+import {validatedPlatform} from 'sentry/views/preprod/utils/sharedTypesUtils';
 import {filterTreemapElement} from 'sentry/views/preprod/utils/treemapFiltering';
 
 interface LoadingContentProps {
@@ -315,7 +316,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
       {processedInsights.length > 0 && (
         <AppSizeInsights
           processedInsights={processedInsights}
-          platform={buildDetailsData?.app_info?.platform ?? undefined}
+          platform={validatedPlatform(buildDetailsData?.app_info?.platform)}
         />
       )}
     </Flex>

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -313,7 +313,10 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
       )}
       <ChartContainer>{visualizationContent}</ChartContainer>
       {processedInsights.length > 0 && (
-        <AppSizeInsights processedInsights={processedInsights} />
+        <AppSizeInsights
+          processedInsights={processedInsights}
+          platform={buildDetailsData?.app_info?.platform ?? undefined}
+        />
       )}
     </Flex>
   );

--- a/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
@@ -1,0 +1,161 @@
+import {useState} from 'react';
+
+import {Alert} from 'sentry/components/core/alert';
+import {CodeBlock} from 'sentry/components/core/code';
+import {Container, Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Heading} from 'sentry/components/core/text/heading';
+import RadioGroup from 'sentry/components/forms/controls/radioGroup';
+import {t} from 'sentry/locale';
+import {
+  Code,
+  CodeBlockWrapper,
+  InsightInfoModal,
+  OrderedList,
+} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
+
+interface AlternativeIconsInsightInfoModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const HEIC_SCRIPT = `#!/bin/bash
+#
+# Icon Optimizer for iOS Apps (HEIC)
+# Reduces alternate icon file sizes by resizing to homescreen quality (180px → 1024px) and converts to HEIC format
+#
+# Usage:  optimize_icon MyIcon.png
+
+optimize_icon() {
+    local input="$1"
+    local output="$(basename "$input" | sed 's/\\.[^.]*$//')_optimized.heic"
+
+    [ ! -f "$input" ] && echo "❌ File not found: $input" && return 1
+
+    echo "🔄 Optimizing $(basename "$input")..."
+
+    # Resize: original → 180px → 1024px (simulates homescreen quality)
+    sips --resampleWidth 180 "$input" --out /tmp/icon.png >/dev/null 2>&1 || return 1
+    sips --resampleWidth 1024 /tmp/icon.png -s format heic -s formatOptions 85 --out "$output" >/dev/null 2>&1
+
+    rm /tmp/icon.png
+
+    if [ -f "$output" ]; then
+        local saved=$(( ($(stat -f%z "$input") - $(stat -f%z "$output")) / 1024 ))
+        echo "✅ Saved \${saved}KB → $output"
+    else
+        echo "❌ Optimization failed"
+        return 1
+    fi
+}`;
+
+const PNG_SCRIPT = `#!/bin/bash
+#
+# Icon Optimizer for iOS Apps (PNG)
+# Reduces alternate icon file sizes by resizing to homescreen quality (180px → 1024px)
+#
+# Usage:  optimize_icon MyIcon.png
+
+optimize_icon() {
+    local input="$1"
+    local output="$(basename "$input" | sed 's/\\.[^.]*$//')_optimized.png"
+
+    [ ! -f "$input" ] && echo "❌ File not found: $input" && return 1
+
+    echo "🔄 Optimizing $(basename "$input")..."
+
+    # Resize: original → 180px → 1024px (simulates homescreen quality)
+    sips --resampleWidth 180 "$input" --out /tmp/icon.png >/dev/null 2>&1 || return 1
+    sips --resampleWidth 1024 /tmp/icon.png --out "$output" >/dev/null 2>&1
+
+    rm /tmp/icon.png
+
+    if [ -f "$output" ]; then
+        local saved=$(( ($(stat -f%z "$input") - $(stat -f%z "$output")) / 1024 ))
+        echo "✅ Saved \${saved}KB → $output"
+    else
+        echo "❌ Optimization failed"
+        return 1
+    fi
+}`;
+
+type OutputFormat = 'heic' | 'png';
+
+export function AlternativeIconsInsightInfoModal({
+  isOpen,
+  onClose,
+}: AlternativeIconsInsightInfoModalProps) {
+  const [outputFormat, setOutputFormat] = useState<OutputFormat>('heic');
+
+  const currentScript = outputFormat === 'heic' ? HEIC_SCRIPT : PNG_SCRIPT;
+  const exampleCommand = 'optimize_icon YourImage.png';
+
+  const description =
+    outputFormat === 'heic'
+      ? t(
+          'Use this script to optimize your images locally. It reduces file sizes by simulating homescreen quality (180px → 1024px) and converts to HEIC format.'
+        )
+      : t(
+          'Use this script to optimize your images locally. It reduces file sizes by simulating homescreen quality (180px → 1024px) and keeps them as PNG files.'
+        );
+
+  return (
+    <InsightInfoModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('Optimize alternate app icons')}
+    >
+      <Text>{description}</Text>
+
+      <Container padding="md 0">
+        <RadioGroup
+          label={t('Output format')}
+          value={outputFormat}
+          choices={[
+            ['heic', t('Convert to HEIC')],
+            ['png', t('Optimize PNG')],
+          ]}
+          onChange={(value: string) => setOutputFormat(value as OutputFormat)}
+          orientInline
+        />
+      </Container>
+
+      {outputFormat === 'heic' && (
+        <Alert type="warning">
+          {t(
+            "Reminder: If you convert your image to HEIC, make sure to update the reference in your app's project to use this new filepath!"
+          )}
+        </Alert>
+      )}
+
+      <CodeBlockWrapper>
+        <CodeBlock language="bash" filename="optimize.sh">
+          {currentScript}
+        </CodeBlock>
+      </CodeBlockWrapper>
+
+      <Flex direction="column" gap="sm">
+        <Heading as="h3" size="md">
+          {t('How to use:')}
+        </Heading>
+        <OrderedList>
+          <li>
+            <Text>
+              {t('Save the script as')} <Code>optimize.sh</Code>
+            </Text>
+          </li>
+          <li>
+            <Text>
+              {t('Run:')} <Code>source optimize.sh</Code>
+            </Text>
+          </li>
+          <li>
+            <Text>
+              {t('Optimize your images:')} <Code>{exampleCommand}</Code>
+            </Text>
+          </li>
+        </OrderedList>
+      </Flex>
+    </InsightInfoModal>
+  );
+}

--- a/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
@@ -9,8 +9,8 @@ import {Heading} from 'sentry/components/core/text/heading';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import {t} from 'sentry/locale';
 import {
-  Code,
   CodeBlockWrapper,
+  InlineCode,
   OrderedList,
 } from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
 
@@ -129,17 +129,17 @@ function AlternativeIconsContent() {
         <OrderedList>
           <li>
             <Text>
-              {t('Save the script as')} <Code>optimize.sh</Code>
+              {t('Save the script as')} <InlineCode>optimize.sh</InlineCode>
             </Text>
           </li>
           <li>
             <Text>
-              {t('Run:')} <Code>source optimize.sh</Code>
+              {t('Run:')} <InlineCode>source optimize.sh</InlineCode>
             </Text>
           </li>
           <li>
             <Text>
-              {t('Optimize your images:')} <Code>{exampleCommand}</Code>
+              {t('Optimize your images:')} <InlineCode>{exampleCommand}</InlineCode>
             </Text>
           </li>
         </OrderedList>

--- a/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
@@ -1,5 +1,6 @@
-import {useState} from 'react';
+import {Fragment, useState} from 'react';
 
+import {openInsightInfoModal} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
 import {CodeBlock} from 'sentry/components/core/code';
 import {Container, Flex} from 'sentry/components/core/layout';
@@ -10,14 +11,8 @@ import {t} from 'sentry/locale';
 import {
   Code,
   CodeBlockWrapper,
-  InsightInfoModal,
   OrderedList,
 } from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
-
-interface AlternativeIconsInsightInfoModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
 
 const HEIC_SCRIPT = `#!/bin/bash
 #
@@ -81,10 +76,7 @@ optimize_icon() {
 
 type OutputFormat = 'heic' | 'png';
 
-export function AlternativeIconsInsightInfoModal({
-  isOpen,
-  onClose,
-}: AlternativeIconsInsightInfoModalProps) {
+function AlternativeIconsContent() {
   const [outputFormat, setOutputFormat] = useState<OutputFormat>('heic');
 
   const currentScript = outputFormat === 'heic' ? HEIC_SCRIPT : PNG_SCRIPT;
@@ -100,11 +92,7 @@ export function AlternativeIconsInsightInfoModal({
         );
 
   return (
-    <InsightInfoModal
-      isOpen={isOpen}
-      onClose={onClose}
-      title={t('Optimize alternate app icons')}
-    >
+    <Fragment>
       <Text>{description}</Text>
 
       <Container padding="md 0">
@@ -156,6 +144,13 @@ export function AlternativeIconsInsightInfoModal({
           </li>
         </OrderedList>
       </Flex>
-    </InsightInfoModal>
+    </Fragment>
   );
+}
+
+export function openAlternativeIconsInsightModal() {
+  openInsightInfoModal({
+    title: t('Optimize alternate app icons'),
+    children: <AlternativeIconsContent />,
+  });
 }

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -15,9 +15,10 @@ import {type ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessin
 
 interface AppSizeInsightsProps {
   processedInsights: ProcessedInsight[];
+  platform?: string;
 }
 
-export function AppSizeInsights({processedInsights}: AppSizeInsightsProps) {
+export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const isSidebarOpen = searchParams.get('insights') === 'open';
 
@@ -63,7 +64,7 @@ export function AppSizeInsights({processedInsights}: AppSizeInsightsProps) {
       >
         {topInsights.map(insight => (
           <Flex
-            key={insight.name}
+            key={insight.key}
             align="center"
             justify="between"
             radius="md"
@@ -95,6 +96,7 @@ export function AppSizeInsights({processedInsights}: AppSizeInsightsProps) {
         processedInsights={processedInsights}
         isOpen={isSidebarOpen}
         onClose={closeSidebar}
+        platform={platform}
       />
     </Container>
   );

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -11,11 +11,12 @@ import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {AppSizeInsightsSidebar} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar';
 import {formatUpside} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import {type ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 
 interface AppSizeInsightsProps {
   processedInsights: ProcessedInsight[];
-  platform?: string;
+  platform?: Platform;
 }
 
 export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsProps) {

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -16,12 +16,14 @@ interface AppSizeInsightsSidebarProps {
   isOpen: boolean;
   onClose: () => void;
   processedInsights: ProcessedInsight[];
+  platform?: string;
 }
 
 export function AppSizeInsightsSidebar({
   processedInsights,
   isOpen,
   onClose,
+  platform,
 }: AppSizeInsightsSidebarProps) {
   const [expandedInsights, setExpandedInsights] = useState<Set<string>>(new Set());
 
@@ -38,12 +40,12 @@ export function AppSizeInsightsSidebar({
     sizeStorageKey: 'app-size-insights-sidebar-width',
   });
 
-  const toggleExpanded = (insightName: string) => {
+  const toggleExpanded = (insightKey: string) => {
     const newExpanded = new Set(expandedInsights);
-    if (newExpanded.has(insightName)) {
-      newExpanded.delete(insightName);
+    if (newExpanded.has(insightKey)) {
+      newExpanded.delete(insightKey);
     } else {
-      newExpanded.add(insightName);
+      newExpanded.add(insightKey);
     }
     setExpandedInsights(newExpanded);
   };
@@ -98,10 +100,11 @@ export function AppSizeInsightsSidebar({
               <Flex direction="column" gap="xl" width="100%">
                 {processedInsights.map(insight => (
                   <AppSizeInsightsSidebarRow
-                    key={insight.name}
+                    key={insight.key}
                     insight={insight}
-                    isExpanded={expandedInsights.has(insight.name)}
-                    onToggleExpanded={() => toggleExpanded(insight.name)}
+                    isExpanded={expandedInsights.has(insight.key)}
+                    onToggleExpanded={() => toggleExpanded(insight.key)}
+                    platform={platform}
                   />
                 ))}
               </Flex>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -10,13 +10,14 @@ import {IconClose, IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {AppSizeInsightsSidebarRow} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 
 interface AppSizeInsightsSidebarProps {
   isOpen: boolean;
   onClose: () => void;
   processedInsights: ProcessedInsight[];
-  platform?: string;
+  platform?: Platform;
 }
 
 export function AppSizeInsightsSidebar({

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -10,8 +9,8 @@ import {IconChevron} from 'sentry/icons/iconChevron';
 import {t, tn} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
-import {AlternativeIconsInsightInfoModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
-import {OptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
+import {openAlternativeIconsInsightModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
+import {openOptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
 import type {OptimizableImageFile} from 'sentry/views/preprod/types/appSizeTypes';
 import type {
   ProcessedInsight,
@@ -46,8 +45,15 @@ export function AppSizeInsightsSidebarRow({
   platform?: string;
 }) {
   const theme = useTheme();
-  const [isFixModalOpen, setIsFixModalOpen] = useState(false);
   const shouldShowTooltip = INSIGHTS_WITH_MORE_INFO_MODAL.includes(insight.key);
+
+  const handleOpenModal = () => {
+    if (insight.key === 'alternate_icons_optimization') {
+      openAlternativeIconsInsightModal();
+    } else if (insight.key === 'image_optimization') {
+      openOptimizeImagesModal(platform);
+    }
+  };
 
   return (
     <Flex border="muted" radius="md" padding="xl" direction="column" gap="md">
@@ -78,7 +84,7 @@ export function AppSizeInsightsSidebarRow({
           {insight.description}
         </Text>
         {shouldShowTooltip && (
-          <LinkText onClick={() => setIsFixModalOpen(true)}>
+          <LinkText onClick={handleOpenModal}>
             {t('See how to fix this locally →')}
           </LinkText>
         )}
@@ -122,21 +128,6 @@ export function AppSizeInsightsSidebarRow({
           </Container>
         )}
       </Container>
-
-      {insight.key === 'alternate_icons_optimization' && (
-        <AlternativeIconsInsightInfoModal
-          isOpen={isFixModalOpen}
-          onClose={() => setIsFixModalOpen(false)}
-        />
-      )}
-
-      {insight.key === 'image_optimization' && (
-        <OptimizeImagesModal
-          isOpen={isFixModalOpen}
-          onClose={() => setIsFixModalOpen(false)}
-          platform={platform}
-        />
-      )}
     </Flex>
   );
 }

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -12,6 +12,7 @@ import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {openAlternativeIconsInsightModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
 import {openOptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
 import type {OptimizableImageFile} from 'sentry/views/preprod/types/appSizeTypes';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import type {
   ProcessedInsight,
   ProcessedInsightFile,
@@ -42,7 +43,7 @@ export function AppSizeInsightsSidebarRow({
   insight: ProcessedInsight;
   isExpanded: boolean;
   onToggleExpanded: () => void;
-  platform?: string;
+  platform?: Platform;
 }) {
   const theme = useTheme();
   const shouldShowTooltip = INSIGHTS_WITH_MORE_INFO_MODAL.includes(insight.key);

--- a/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
@@ -1,0 +1,129 @@
+import {Fragment, type ReactNode} from 'react';
+import styled from '@emotion/styled';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
+import {Heading} from 'sentry/components/core/text/heading';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+interface InsightInfoModalProps {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+}
+
+export function InsightInfoModal({
+  isOpen,
+  onClose,
+  title,
+  children,
+}: InsightInfoModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <AnimatePresence>
+        {isOpen && (
+          <Fragment>
+            <Backdrop
+              key="insight-modal-backdrop"
+              initial={{opacity: 0}}
+              animate={{opacity: 1}}
+              exit={{opacity: 0}}
+              transition={{duration: 0.2}}
+              onClick={onClose}
+            />
+            <ModalContainer
+              key="insight-modal-content"
+              initial={{opacity: 0, scale: 0.95, x: '-50%', y: '-50%'}}
+              animate={{opacity: 1, scale: 1, x: '-50%', y: '-50%'}}
+              exit={{opacity: 0, scale: 0.95, x: '-50%', y: '-50%'}}
+              transition={{duration: 0.2}}
+              onClick={e => e.stopPropagation()}
+            >
+              <Flex direction="column" gap="lg" style={{width: '100%', minWidth: 0}}>
+                <Flex justify="between" align="center">
+                  <Heading as="h2" size="lg">
+                    {title}
+                  </Heading>
+                  <Button
+                    size="sm"
+                    icon={<IconClose />}
+                    aria-label={t('Close modal')}
+                    onClick={onClose}
+                  />
+                </Flex>
+
+                <Flex direction="column" gap="md" style={{minWidth: 0}}>
+                  {children}
+                </Flex>
+              </Flex>
+            </ModalContainer>
+          </Fragment>
+        )}
+      </AnimatePresence>
+    </Fragment>
+  );
+}
+
+const Backdrop = styled(motion.div)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10000;
+  pointer-events: auto;
+`;
+
+const ModalContainer = styled(motion.div)`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 90%;
+  max-width: 700px;
+  height: auto;
+  background: ${p => p.theme.background};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${p => p.theme.space.xl};
+  z-index: 10001;
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  display: flex;
+  overflow: hidden;
+`;
+
+export const CodeBlockWrapper = styled('div')`
+  max-height: 300px;
+  overflow: auto;
+  min-width: 0;
+  width: 100%;
+  padding: ${p => p.theme.space.sm} 0;
+`;
+
+export const Code = styled('code')`
+  background: ${p => p.theme.backgroundSecondary};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  border-radius: ${p => p.theme.borderRadius};
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSize.sm};
+  color: ${p => p.theme.purple300};
+`;
+
+export const OrderedList = styled('ol')`
+  margin: 0;
+  padding-left: ${p => p.theme.space.xl};
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+
+  li {
+    color: ${p => p.theme.textColor};
+  }
+`;

--- a/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
@@ -1,5 +1,4 @@
 import {Fragment, type ReactNode} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -32,11 +31,6 @@ const ContentWrapper = styled('div')`
   min-width: 0;
 `;
 
-export const modalCss = css`
-  width: 90%;
-  max-width: 700px;
-`;
-
 export const CodeBlockWrapper = styled('div')`
   max-height: 300px;
   overflow: auto;
@@ -45,7 +39,7 @@ export const CodeBlockWrapper = styled('div')`
   padding: ${p => p.theme.space.sm} 0;
 `;
 
-export const Code = styled('code')`
+export const InlineCode = styled('code')`
   background: ${p => p.theme.backgroundSecondary};
   padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
   border-radius: ${p => p.theme.borderRadius};

--- a/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
@@ -1,102 +1,40 @@
 import {Fragment, type ReactNode} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import {AnimatePresence, motion} from 'framer-motion';
 
-import {Button} from 'sentry/components/core/button';
-import {Flex} from 'sentry/components/core/layout';
-import {Heading} from 'sentry/components/core/text/heading';
-import {IconClose} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {space} from 'sentry/styles/space';
 
-interface InsightInfoModalProps {
+type InsightInfoModalOptions = {
   children: ReactNode;
-  isOpen: boolean;
-  onClose: () => void;
   title: string;
-}
+};
 
-export function InsightInfoModal({
-  isOpen,
-  onClose,
-  title,
-  children,
-}: InsightInfoModalProps) {
-  if (!isOpen) {
-    return null;
-  }
+type Props = ModalRenderProps & InsightInfoModalOptions;
 
+export function InsightInfoModal({Header, Body, title, children}: Props) {
   return (
     <Fragment>
-      <AnimatePresence>
-        {isOpen && (
-          <Fragment>
-            <Backdrop
-              key="insight-modal-backdrop"
-              initial={{opacity: 0}}
-              animate={{opacity: 1}}
-              exit={{opacity: 0}}
-              transition={{duration: 0.2}}
-              onClick={onClose}
-            />
-            <ModalContainer
-              key="insight-modal-content"
-              initial={{opacity: 0, scale: 0.95, x: '-50%', y: '-50%'}}
-              animate={{opacity: 1, scale: 1, x: '-50%', y: '-50%'}}
-              exit={{opacity: 0, scale: 0.95, x: '-50%', y: '-50%'}}
-              transition={{duration: 0.2}}
-              onClick={e => e.stopPropagation()}
-            >
-              <Flex direction="column" gap="lg" style={{width: '100%', minWidth: 0}}>
-                <Flex justify="between" align="center">
-                  <Heading as="h2" size="lg">
-                    {title}
-                  </Heading>
-                  <Button
-                    size="sm"
-                    icon={<IconClose />}
-                    aria-label={t('Close modal')}
-                    onClick={onClose}
-                  />
-                </Flex>
-
-                <Flex direction="column" gap="md" style={{minWidth: 0}}>
-                  {children}
-                </Flex>
-              </Flex>
-            </ModalContainer>
-          </Fragment>
-        )}
-      </AnimatePresence>
+      <Header closeButton>
+        <h3>{title}</h3>
+      </Header>
+      <Body>
+        <ContentWrapper>{children}</ContentWrapper>
+      </Body>
     </Fragment>
   );
 }
 
-const Backdrop = styled(motion.div)`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 10000;
-  pointer-events: auto;
+const ContentWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(3)};
+  min-width: 0;
 `;
 
-const ModalContainer = styled(motion.div)`
-  position: fixed;
-  top: 50%;
-  left: 50%;
+export const modalCss = css`
   width: 90%;
   max-width: 700px;
-  height: auto;
-  background: ${p => p.theme.background};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-  padding: ${p => p.theme.space.xl};
-  z-index: 10001;
-  box-shadow: ${p => p.theme.dropShadowHeavy};
-  display: flex;
-  overflow: hidden;
 `;
 
 export const CodeBlockWrapper = styled('div')`

--- a/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
@@ -1,0 +1,135 @@
+import {CodeBlock} from 'sentry/components/core/code';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Heading} from 'sentry/components/core/text/heading';
+import {t} from 'sentry/locale';
+import {
+  CodeBlockWrapper,
+  InsightInfoModal,
+} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
+
+interface OptimizeImagesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  platform?: string;
+}
+
+const IOS_IMAGEMIN_SCRIPT = `# Install imagemin-cli
+npm install -g imagemin-cli
+
+# Optimize PNG with quality 85
+imagemin input.png --plugin=pngquant --plugin.quality=[0.85,0.85] > output.png
+
+# Optimize JPEG with quality 85
+imagemin input.jpg --plugin=mozjpeg --plugin.quality=85 > output.jpg`;
+
+const ANDROID_CWEBP_SCRIPT = `# Install cwebp (on Mac)
+brew install webp
+
+# Convert PNG to lossless WebP
+cwebp -lossless input.png -o output.webp
+
+# Convert JPEG to lossless WebP
+cwebp -lossless input.jpg -o output.webp`;
+
+export function OptimizeImagesModal({
+  isOpen,
+  onClose,
+  platform: rawPlatform,
+}: OptimizeImagesModalProps) {
+  const platform = rawPlatform?.toLowerCase();
+
+  const title =
+    platform === 'ios'
+      ? t('Optimize Images (iOS)')
+      : platform === 'android'
+        ? t('Optimize Images (Android)')
+        : t('Optimize Images');
+
+  return (
+    <InsightInfoModal isOpen={isOpen} onClose={onClose} title={title}>
+      {platform === 'ios' ? (
+        <Flex direction="column" gap="2xl">
+          <Text>
+            {t(
+              'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We will show an optimized image insight for any image whose size can be reduced by more than 4KB through lossy compression or converted to HEIC format (for apps targeting iOS 12 or later).'
+            )}
+          </Text>
+
+          <Flex direction="column" gap="xl">
+            <Flex direction="column" gap="sm">
+              <Heading as="h3" size="md">
+                {t('Option 1: Use Imagemin (Command-line)')}
+              </Heading>
+              <CodeBlockWrapper>
+                <CodeBlock language="bash" filename="optimize.sh">
+                  {IOS_IMAGEMIN_SCRIPT}
+                </CodeBlock>
+              </CodeBlockWrapper>
+            </Flex>
+
+            <Flex direction="column" gap="sm">
+              <Heading as="h3" size="md">
+                {t('Option 2: Use ImageOptim (GUI)')}
+              </Heading>
+              <Text>
+                {t(
+                  'Download ImageOptim for Mac, drag and drop your images to compress them with lossy compression.'
+                )}
+              </Text>
+            </Flex>
+
+            <Flex direction="column" gap="sm">
+              <Heading as="h3" size="md">
+                {t('Option 3: Convert to HEIC')}
+              </Heading>
+              <Text>
+                {t(
+                  'Open the image in Preview, choose File → Export, then select HEIC from the format dropdown.'
+                )}
+              </Text>
+            </Flex>
+          </Flex>
+        </Flex>
+      ) : (
+        <Flex direction="column" gap="2xl">
+          <Text>
+            {t(
+              'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We find all PNG or JPEG files in your resources or assets directory and compare them to lossless WebP versions. If there is a size reduction, we will recommend using WebP.'
+            )}
+          </Text>
+
+          <Flex direction="column" gap="xl">
+            <Flex direction="column" gap="sm">
+              <Heading as="h3" size="md">
+                {t('Option 1: Use Android Studio')}
+              </Heading>
+              <Text>
+                {t(
+                  'Right-click an image in Android Studio, select "Convert to WebP", and choose lossless conversion.'
+                )}
+              </Text>
+            </Flex>
+
+            <Flex direction="column" gap="sm">
+              <Heading as="h3" size="md">
+                {t('Option 2: Use cwebp (Command-line)')}
+              </Heading>
+              <CodeBlockWrapper>
+                <CodeBlock language="bash" filename="convert-webp.sh">
+                  {ANDROID_CWEBP_SCRIPT}
+                </CodeBlock>
+              </CodeBlockWrapper>
+            </Flex>
+
+            <Text variant="muted" size="sm">
+              {t(
+                'Note: Based on minSdkVersion >= 18, lossless WebP is recommended. For versions < 18, assets with alpha channels are skipped.'
+              )}
+            </Text>
+          </Flex>
+        </Flex>
+      )}
+    </InsightInfoModal>
+  );
+}

--- a/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
@@ -7,6 +7,7 @@ import {Text} from 'sentry/components/core/text';
 import {Heading} from 'sentry/components/core/text/heading';
 import {t} from 'sentry/locale';
 import {CodeBlockWrapper} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 
 const IOS_IMAGEMIN_SCRIPT = `# Install imagemin-cli
 npm install -g imagemin-cli
@@ -26,10 +27,46 @@ cwebp -lossless input.png -o output.webp
 # Convert JPEG to lossless WebP
 cwebp -lossless input.jpg -o output.webp`;
 
-function getOptimizeImagesContent(platform?: string): ReactNode {
-  const normalizedPlatform = platform?.toLowerCase();
+function getOptimizeImagesContent(platform?: Platform): ReactNode {
+  return platform === 'android' ? (
+    <Flex direction="column" gap="2xl">
+      <Text>
+        {t(
+          'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We find all PNG or JPEG files in your resources or assets directory and compare them to lossless WebP versions. If there is a size reduction, we will recommend using WebP.'
+        )}
+      </Text>
 
-  return normalizedPlatform === 'ios' ? (
+      <Flex direction="column" gap="xl">
+        <Flex direction="column" gap="sm">
+          <Heading as="h3" size="md">
+            {t('Option 1: Use Android Studio')}
+          </Heading>
+          <Text>
+            {t(
+              'Right-click an image in Android Studio, select "Convert to WebP", and choose lossless conversion.'
+            )}
+          </Text>
+        </Flex>
+
+        <Flex direction="column" gap="sm">
+          <Heading as="h3" size="md">
+            {t('Option 2: Use cwebp (Command-line)')}
+          </Heading>
+          <CodeBlockWrapper>
+            <CodeBlock language="bash" filename="convert-webp.sh">
+              {ANDROID_CWEBP_SCRIPT}
+            </CodeBlock>
+          </CodeBlockWrapper>
+        </Flex>
+
+        <Text variant="muted" size="sm">
+          {t(
+            'Note: Based on minSdkVersion >= 18, lossless WebP is recommended. For versions < 18, assets with alpha channels are skipped.'
+          )}
+        </Text>
+      </Flex>
+    </Flex>
+  ) : (
     <Flex direction="column" gap="2xl">
       <Text>
         {t(
@@ -72,54 +109,15 @@ function getOptimizeImagesContent(platform?: string): ReactNode {
         </Flex>
       </Flex>
     </Flex>
-  ) : (
-    <Flex direction="column" gap="2xl">
-      <Text>
-        {t(
-          'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We find all PNG or JPEG files in your resources or assets directory and compare them to lossless WebP versions. If there is a size reduction, we will recommend using WebP.'
-        )}
-      </Text>
-
-      <Flex direction="column" gap="xl">
-        <Flex direction="column" gap="sm">
-          <Heading as="h3" size="md">
-            {t('Option 1: Use Android Studio')}
-          </Heading>
-          <Text>
-            {t(
-              'Right-click an image in Android Studio, select "Convert to WebP", and choose lossless conversion.'
-            )}
-          </Text>
-        </Flex>
-
-        <Flex direction="column" gap="sm">
-          <Heading as="h3" size="md">
-            {t('Option 2: Use cwebp (Command-line)')}
-          </Heading>
-          <CodeBlockWrapper>
-            <CodeBlock language="bash" filename="convert-webp.sh">
-              {ANDROID_CWEBP_SCRIPT}
-            </CodeBlock>
-          </CodeBlockWrapper>
-        </Flex>
-
-        <Text variant="muted" size="sm">
-          {t(
-            'Note: Based on minSdkVersion >= 18, lossless WebP is recommended. For versions < 18, assets with alpha channels are skipped.'
-          )}
-        </Text>
-      </Flex>
-    </Flex>
   );
 }
 
-export function openOptimizeImagesModal(platform?: string) {
-  const normalizedPlatform = platform?.toLowerCase();
+export function openOptimizeImagesModal(platform?: Platform) {
   const title =
-    normalizedPlatform === 'ios'
-      ? t('Optimize Images (iOS)')
-      : normalizedPlatform === 'android'
-        ? t('Optimize Images (Android)')
+    platform === 'android'
+      ? t('Optimize Images (Android)')
+      : platform === 'ios'
+        ? t('Optimize Images (iOS)')
         : t('Optimize Images');
 
   openInsightInfoModal({

--- a/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
@@ -1,18 +1,12 @@
+import type {ReactNode} from 'react';
+
+import {openInsightInfoModal} from 'sentry/actionCreators/modal';
 import {CodeBlock} from 'sentry/components/core/code';
 import {Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {Heading} from 'sentry/components/core/text/heading';
 import {t} from 'sentry/locale';
-import {
-  CodeBlockWrapper,
-  InsightInfoModal,
-} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
-
-interface OptimizeImagesModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  platform?: string;
-}
+import {CodeBlockWrapper} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
 
 const IOS_IMAGEMIN_SCRIPT = `# Install imagemin-cli
 npm install -g imagemin-cli
@@ -32,104 +26,104 @@ cwebp -lossless input.png -o output.webp
 # Convert JPEG to lossless WebP
 cwebp -lossless input.jpg -o output.webp`;
 
-export function OptimizeImagesModal({
-  isOpen,
-  onClose,
-  platform: rawPlatform,
-}: OptimizeImagesModalProps) {
-  const platform = rawPlatform?.toLowerCase();
+function getOptimizeImagesContent(platform?: string): ReactNode {
+  const normalizedPlatform = platform?.toLowerCase();
 
+  return normalizedPlatform === 'ios' ? (
+    <Flex direction="column" gap="2xl">
+      <Text>
+        {t(
+          'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We will show an optimized image insight for any image whose size can be reduced by more than 4KB through lossy compression or converted to HEIC format (for apps targeting iOS 12 or later).'
+        )}
+      </Text>
+
+      <Flex direction="column" gap="xl">
+        <Flex direction="column" gap="sm">
+          <Heading as="h3" size="md">
+            {t('Option 1: Use Imagemin (Command-line)')}
+          </Heading>
+          <CodeBlockWrapper>
+            <CodeBlock language="bash" filename="optimize.sh">
+              {IOS_IMAGEMIN_SCRIPT}
+            </CodeBlock>
+          </CodeBlockWrapper>
+        </Flex>
+
+        <Flex direction="column" gap="sm">
+          <Heading as="h3" size="md">
+            {t('Option 2: Use ImageOptim (GUI)')}
+          </Heading>
+          <Text>
+            {t(
+              'Download ImageOptim for Mac, drag and drop your images to compress them with lossy compression.'
+            )}
+          </Text>
+        </Flex>
+
+        <Flex direction="column" gap="sm">
+          <Heading as="h3" size="md">
+            {t('Option 3: Convert to HEIC')}
+          </Heading>
+          <Text>
+            {t(
+              'Open the image in Preview, choose File → Export, then select HEIC from the format dropdown.'
+            )}
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  ) : (
+    <Flex direction="column" gap="2xl">
+      <Text>
+        {t(
+          'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We find all PNG or JPEG files in your resources or assets directory and compare them to lossless WebP versions. If there is a size reduction, we will recommend using WebP.'
+        )}
+      </Text>
+
+      <Flex direction="column" gap="xl">
+        <Flex direction="column" gap="sm">
+          <Heading as="h3" size="md">
+            {t('Option 1: Use Android Studio')}
+          </Heading>
+          <Text>
+            {t(
+              'Right-click an image in Android Studio, select "Convert to WebP", and choose lossless conversion.'
+            )}
+          </Text>
+        </Flex>
+
+        <Flex direction="column" gap="sm">
+          <Heading as="h3" size="md">
+            {t('Option 2: Use cwebp (Command-line)')}
+          </Heading>
+          <CodeBlockWrapper>
+            <CodeBlock language="bash" filename="convert-webp.sh">
+              {ANDROID_CWEBP_SCRIPT}
+            </CodeBlock>
+          </CodeBlockWrapper>
+        </Flex>
+
+        <Text variant="muted" size="sm">
+          {t(
+            'Note: Based on minSdkVersion >= 18, lossless WebP is recommended. For versions < 18, assets with alpha channels are skipped.'
+          )}
+        </Text>
+      </Flex>
+    </Flex>
+  );
+}
+
+export function openOptimizeImagesModal(platform?: string) {
+  const normalizedPlatform = platform?.toLowerCase();
   const title =
-    platform === 'ios'
+    normalizedPlatform === 'ios'
       ? t('Optimize Images (iOS)')
-      : platform === 'android'
+      : normalizedPlatform === 'android'
         ? t('Optimize Images (Android)')
         : t('Optimize Images');
 
-  return (
-    <InsightInfoModal isOpen={isOpen} onClose={onClose} title={title}>
-      {platform === 'ios' ? (
-        <Flex direction="column" gap="2xl">
-          <Text>
-            {t(
-              'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We will show an optimized image insight for any image whose size can be reduced by more than 4KB through lossy compression or converted to HEIC format (for apps targeting iOS 12 or later).'
-            )}
-          </Text>
-
-          <Flex direction="column" gap="xl">
-            <Flex direction="column" gap="sm">
-              <Heading as="h3" size="md">
-                {t('Option 1: Use Imagemin (Command-line)')}
-              </Heading>
-              <CodeBlockWrapper>
-                <CodeBlock language="bash" filename="optimize.sh">
-                  {IOS_IMAGEMIN_SCRIPT}
-                </CodeBlock>
-              </CodeBlockWrapper>
-            </Flex>
-
-            <Flex direction="column" gap="sm">
-              <Heading as="h3" size="md">
-                {t('Option 2: Use ImageOptim (GUI)')}
-              </Heading>
-              <Text>
-                {t(
-                  'Download ImageOptim for Mac, drag and drop your images to compress them with lossy compression.'
-                )}
-              </Text>
-            </Flex>
-
-            <Flex direction="column" gap="sm">
-              <Heading as="h3" size="md">
-                {t('Option 3: Convert to HEIC')}
-              </Heading>
-              <Text>
-                {t(
-                  'Open the image in Preview, choose File → Export, then select HEIC from the format dropdown.'
-                )}
-              </Text>
-            </Flex>
-          </Flex>
-        </Flex>
-      ) : (
-        <Flex direction="column" gap="2xl">
-          <Text>
-            {t(
-              'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We find all PNG or JPEG files in your resources or assets directory and compare them to lossless WebP versions. If there is a size reduction, we will recommend using WebP.'
-            )}
-          </Text>
-
-          <Flex direction="column" gap="xl">
-            <Flex direction="column" gap="sm">
-              <Heading as="h3" size="md">
-                {t('Option 1: Use Android Studio')}
-              </Heading>
-              <Text>
-                {t(
-                  'Right-click an image in Android Studio, select "Convert to WebP", and choose lossless conversion.'
-                )}
-              </Text>
-            </Flex>
-
-            <Flex direction="column" gap="sm">
-              <Heading as="h3" size="md">
-                {t('Option 2: Use cwebp (Command-line)')}
-              </Heading>
-              <CodeBlockWrapper>
-                <CodeBlock language="bash" filename="convert-webp.sh">
-                  {ANDROID_CWEBP_SCRIPT}
-                </CodeBlock>
-              </CodeBlockWrapper>
-            </Flex>
-
-            <Text variant="muted" size="sm">
-              {t(
-                'Note: Based on minSdkVersion >= 18, lossless WebP is recommended. For versions < 18, assets with alpha channels are skipped.'
-              )}
-            </Text>
-          </Flex>
-        </Flex>
-      )}
-    </InsightInfoModal>
-  );
+  openInsightInfoModal({
+    title,
+    children: getOptimizeImagesContent(platform),
+  });
 }

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -28,6 +28,7 @@ export interface ProcessedInsightFile {
 export interface ProcessedInsight {
   description: string;
   files: ProcessedInsightFile[];
+  key: string;
   name: string;
   percentage: number;
   totalSavings: number;
@@ -144,6 +145,7 @@ export function processInsights(
         : [];
 
       processedInsights.push({
+        key: config.key,
         name: config.name,
         description: config.description,
         totalSavings: insight.total_savings,
@@ -178,6 +180,7 @@ export function processInsights(
         : [];
 
       processedInsights.push({
+        key: config.key,
         name: config.name,
         description: config.description,
         totalSavings: insight.total_savings,
@@ -210,6 +213,7 @@ export function processInsights(
       const groups = Array.isArray(insight.groups) ? insight.groups : [];
 
       processedInsights.push({
+        key: config.key,
         name: config.name,
         description: config.description,
         totalSavings: insight.total_savings,
@@ -237,6 +241,7 @@ export function processInsights(
       const files = Array.isArray(insight.files) ? insight.files : [];
 
       processedInsights.push({
+        key: config.key,
         name: config.name,
         description: config.description,
         totalSavings: insight.total_savings,
@@ -261,6 +266,7 @@ export function processInsights(
       const groups = Array.isArray(insight.groups) ? insight.groups : [];
 
       processedInsights.push({
+        key: config.key,
         name: config.name,
         description: config.description,
         totalSavings: insight.total_savings,
@@ -302,6 +308,7 @@ export function processInsights(
       if (config) {
         const files = Array.isArray(insight.files) ? insight.files : [];
         processedInsights.push({
+          key: config.key,
           name: config.name,
           description: config.description,
           totalSavings: insight.total_savings,

--- a/static/app/views/preprod/utils/sharedTypesUtils.ts
+++ b/static/app/views/preprod/utils/sharedTypesUtils.ts
@@ -1,0 +1,8 @@
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
+
+export function validatedPlatform(platform: unknown): Platform | undefined {
+  if (platform === 'ios' || platform === 'android' || platform === 'macos') {
+    return platform;
+  }
+  return undefined;
+}

--- a/tests/js/fixtures/preProdAppSize.ts
+++ b/tests/js/fixtures/preProdAppSize.ts
@@ -8,6 +8,7 @@ export function ProcessedInsightFixture(
   params: Partial<ProcessedInsight> = {}
 ): ProcessedInsight {
   return {
+    key: 'duplicate_files',
     name: 'Duplicate files',
     description: 'You have files that are duplicated across your app',
     totalSavings: 1024000,


### PR DESCRIPTION
Closes EME-315

Since we will no longer provide the user with the optimized images to just straight download, lets provide them helpful info so they can address it themselves

<img width="1513" height="1155" alt="image" src="https://github.com/user-attachments/assets/3eb1b2db-1586-4c27-a9d6-af14e1d83f5c" />

<img width="1511" height="1157" alt="image" src="https://github.com/user-attachments/assets/4fc2f21b-aa8c-4936-9997-3ec2a06c81d1" />

<img width="1511" height="1155" alt="image" src="https://github.com/user-attachments/assets/1e74b2e6-854e-46ba-86db-e1d6279c9cc8" />

