### PR TITLE
core: override theme colors from base.less

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -138,6 +138,24 @@ const styles = (theme: Theme, isDark: boolean) => css`
     background: ${theme.backgroundSecondary};
   }
 
+  body.theme-dark {
+    background: ${theme.tokens.background.primary};
+
+    .loading .loading-indicator {
+      background: ${theme.tokens.background.primary};
+    }
+  }
+
+  body.theme-system {
+    @media (prefers-color-scheme: dark) {
+      background: ${theme.tokens.background.primary};
+    }
+
+    .loading .loading-indicator {
+      background: ${theme.tokens.background.primary};
+    }
+  }
+
   abbr {
     ${theme.tooltipUnderline()};
   }


### PR DESCRIPTION
Override base.less styles that are set by the django theme so that they match the UI version