### PR TITLE
feat(aci): Display loading errors on metric monitor chart

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.spec.tsx
@@ -1,8 +1,4 @@
-import {
-  MetricDetectorFixture,
-  SnubaQueryDataSourceFixture,
-} from 'sentry-fixture/detectors';
-import {OrganizationFixture} from 'sentry-fixture/organization';
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/views/detectors/components/details/metric/chart.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.spec.tsx
@@ -1,0 +1,37 @@
+import {
+  MetricDetectorFixture,
+  SnubaQueryDataSourceFixture,
+} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
+
+describe('MetricDetectorDetailsChart', () => {
+  const detector = MetricDetectorFixture();
+  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [],
+    });
+  });
+
+  it('displays error alert and error panel when API request fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-stats/`,
+      body: {
+        detail: 'Invalid query: xyz',
+      },
+      statusCode: 400,
+    });
+
+    render(<MetricDetectorDetailsChart detector={detector} snubaQuery={snubaQuery} />);
+
+    expect(await screen.findByText('Invalid query: xyz')).toBeInTheDocument();
+    expect(screen.getByText('Error loading chart data')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/detectors/hooks/useMetricDetectorSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorSeries.tsx
@@ -74,6 +74,14 @@ export function useMetricDetectorSeries({
   >(seriesQueryOptions, {
     // 5 minutes
     staleTime: 5 * 60 * 1000,
+    retry: (failureCount, apiError: RequestError) => {
+      // Disable retries for 400 status code
+      if (apiError?.status === 400) {
+        return false;
+      }
+
+      return failureCount < 2;
+    },
     ...options,
   });
 


### PR DESCRIPTION
Displays the error message and stops retrying on 400 bad request which for event-stats is usually never going to load.

<img width="1010" height="393" alt="image" src="https://github.com/user-attachments/assets/31ee6b09-64fc-4a8d-aaf2-35f1f8d76185" />
