### PR TITLE
fix(aci): When building chart, specify allow_eap

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -237,7 +237,12 @@ def build_metric_alert_chart(
         organization,
         actor=user,
     )
-    aggregate = translate_aggregate_field(snuba_query.aggregate, reverse=True, allow_mri=allow_mri)
+    aggregate = translate_aggregate_field(
+        snuba_query.aggregate,
+        reverse=True,
+        allow_mri=allow_mri,
+        allow_eap=dataset == Dataset.EventsAnalyticsPlatform,
+    )
     # If we allow alerts to be across multiple orgs this will break
     # TODO: determine whether this validation is necessary
     first_subscription_or_none = snuba_query.subscriptions.first()

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -89,7 +89,9 @@ class BuildMetricAlertChartTest(TestCase):
     def test_eap_alert(self, mock_client_get: MagicMock, mock_generate_chart: MagicMock) -> None:
         mock_client_get.return_value.data = {"data": []}
         alert_rule = self.create_alert_rule(
-            query="span.op:pageload", dataset=Dataset.EventsAnalyticsPlatform
+            query="span.op:pageload",
+            dataset=Dataset.EventsAnalyticsPlatform,
+            aggregate="apdex(span.duration, 8000)",
         )
         incident = self.create_incident(
             status=2,


### PR DESCRIPTION
The validation criteria for EAP are slightly different, so passing along whether we're using EAP makes our validation more accurate.
This also makes this callsite of translate_aggregate_field consistent with others.


Fixes SENTRY-5AN1.