### PR TITLE
feat(seer-explorer): Add RPC to get repo definition

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -76,6 +76,7 @@ from sentry.seer.explorer.tools import (
     execute_trace_query_chart,
     execute_trace_query_table,
     get_issue_details,
+    get_repository_definition,
     rpc_get_trace_waterfall,
 )
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
@@ -1025,6 +1026,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "get_issue_details": get_issue_details,
     "execute_trace_query_chart": execute_trace_query_chart,
     "execute_trace_query_table": execute_trace_query_table,
+    "get_repository_definition": get_repository_definition,
     #
     # Replays
     "get_replay_summary_logs": rpc_get_replay_summary_logs,

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -13,6 +13,7 @@ from sentry.models.apikey import ApiKey
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.repository import Repository
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.seer.autofix.autofix import get_all_tags_overview
@@ -272,6 +273,51 @@ def get_trace_waterfall(trace_id: str, organization_id: int) -> EAPTrace | None:
 def rpc_get_trace_waterfall(trace_id: str, organization_id: int) -> dict[str, Any]:
     trace = get_trace_waterfall(trace_id, organization_id)
     return trace.dict() if trace else {}
+
+
+def get_repository_definition(*, organization_id: int, repo_full_name: str) -> dict | None:
+    """
+    Look up a repository by full name (owner/repo-name) that the org has access to.
+    Returns full RepoDefinition if found and accessible via code mappings, None otherwise.
+
+    Args:
+        organization_id: The ID of the organization
+        repo_full_name: Full repository name in format "owner/repo-name" (e.g., "getsentry/seer")
+
+    Returns:
+        dict with RepoDefinition fields if found, None otherwise
+    """
+    parts = repo_full_name.split("/")
+    if len(parts) != 2:
+        logger.warning(
+            "seer.rpc.invalid_repo_name_format",
+            extra={"repo_full_name": repo_full_name},
+        )
+        return None
+
+    owner, name = parts
+
+    try:
+        repo = Repository.objects.get(
+            organization_id=organization_id,
+            name=repo_full_name,
+            status=ObjectStatus.ACTIVE,
+        )
+    except Repository.DoesNotExist:
+        logger.info(
+            "seer.rpc.repository_not_found",
+            extra={"organization_id": organization_id, "repo_full_name": repo_full_name},
+        )
+        return None
+
+    return {
+        "organization_id": organization_id,
+        "integration_id": str(repo.integration_id) if repo.integration_id else None,
+        "provider": repo.provider,
+        "owner": owner,
+        "name": name,
+        "external_id": repo.external_id,
+    }
 
 
 def get_issue_details(

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -5,11 +5,14 @@ from unittest.mock import patch
 import pytest
 from pydantic import BaseModel
 
+from sentry.constants import ObjectStatus
 from sentry.models.group import Group
+from sentry.models.repository import Repository
 from sentry.seer.explorer.tools import (
     execute_trace_query_chart,
     execute_trace_query_table,
     get_issue_details,
+    get_repository_definition,
     get_trace_waterfall,
 )
 from sentry.seer.sentry_data_models import EAPTrace
@@ -777,3 +780,104 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
         assert isinstance(result.get("project_id"), int)
         assert isinstance(result.get("issue"), dict)
         _ExplorerIssue.parse_obj(result.get("issue", {}))
+
+
+@pytest.mark.django_db(databases=["default", "control"])
+class TestGetRepositoryDefinition(APITransactionTestCase):
+    def test_get_repository_definition_success(self):
+        """Test successful repository lookup"""
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/seer",
+            provider="integrations:github",
+            external_id="12345678",
+            integration_id=123,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        result = get_repository_definition(
+            organization_id=self.organization.id,
+            repo_full_name="getsentry/seer",
+        )
+
+        assert result is not None
+        assert result["organization_id"] == self.organization.id
+        assert result["integration_id"] == "123"
+        assert result["provider"] == "integrations:github"
+        assert result["owner"] == "getsentry"
+        assert result["name"] == "seer"
+        assert result["external_id"] == "12345678"
+
+    def test_get_repository_definition_invalid_format(self):
+        """Test that invalid repo name format returns None"""
+        result = get_repository_definition(
+            organization_id=self.organization.id,
+            repo_full_name="invalid-format",
+        )
+
+        assert result is None
+
+    def test_get_repository_definition_not_found(self):
+        """Test that nonexistent repository returns None"""
+        result = get_repository_definition(
+            organization_id=self.organization.id,
+            repo_full_name="nonexistent/repo",
+        )
+
+        assert result is None
+
+    def test_get_repository_definition_wrong_org(self):
+        """Test that repository from different org returns None"""
+        other_org = self.create_organization()
+        Repository.objects.create(
+            organization_id=other_org.id,
+            name="getsentry/seer",
+            provider="integrations:github",
+            external_id="12345678",
+            integration_id=123,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        result = get_repository_definition(
+            organization_id=self.organization.id,
+            repo_full_name="getsentry/seer",
+        )
+
+        assert result is None
+
+    def test_get_repository_definition_inactive_repo(self):
+        """Test that inactive repository returns None"""
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/seer",
+            provider="integrations:github",
+            external_id="12345678",
+            integration_id=123,
+            status=ObjectStatus.DISABLED,
+        )
+
+        result = get_repository_definition(
+            organization_id=self.organization.id,
+            repo_full_name="getsentry/seer",
+        )
+
+        assert result is None
+
+    def test_get_repository_definition_no_integration_id(self):
+        """Test repository without integration_id"""
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/seer",
+            provider="integrations:github",
+            external_id="12345678",
+            integration_id=None,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        result = get_repository_definition(
+            organization_id=self.organization.id,
+            repo_full_name="getsentry/seer",
+        )
+
+        assert result is not None
+        assert result["integration_id"] is None


### PR DESCRIPTION
Adds an RPC endpoint for Seer to get a full repo definition given the name of a repository. This will be used so the agent can dynamically access repos on the fly without having to send a list of repos in the initial session request (since explorer can act on any repo and any project at any time). 

This RPC is used here: https://github.com/getsentry/seer/pull/3730