### PR TITLE
ref(integration): Update channel-validation from get to post

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_channel_validate.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_channel_validate.py
@@ -29,27 +29,28 @@ from sentry.shared_integrations.exceptions import ApiError
 
 @control_silo_endpoint
 class OrganizationIntegrationChannelValidateEndpoint(OrganizationIntegrationBaseEndpoint):
-    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     class ChannelValidateSerializer(serializers.Serializer):
         channel = serializers.CharField(required=True, allow_blank=False)
 
-    def get(
+    def post(
         self,
         request: Request,
         organization_context: Any,
         integration_id: int,
         **kwargs: Any,
     ) -> Response:
-        """Validate whether a channel exists for the given integration."""
-        serializer = self.ChannelValidateSerializer(data=request.GET)
+        """
+        Validate whether a channel exists for the given integration
+        """
+        serializer = self.ChannelValidateSerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         channel = serializer.validated_data["channel"].strip()
         integration = self.get_integration(organization_context.organization.id, integration_id)
-
         provider = integration.provider
 
         try:

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
@@ -18,9 +18,7 @@ class BaseChannelValidateTest(APITestCase):
         self.login_as(self.user)
 
     def _get_response(self, integration_id, channel):
-        return self.get_success_response(
-            self.organization.slug, integration_id, **{"channel": channel}
-        )
+        return self.get_success_response(self.organization.slug, integration_id, channel=channel)
 
 
 @control_silo_test

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
@@ -139,9 +139,7 @@ class ChannelValidateErrorCasesTest(BaseChannelValidateTest):
         assert "channel" in resp.data
 
     def test_integration_not_found(self):
-        resp = self.get_error_response(
-            self.organization.slug, 99999, status_code=404, **{"channel": "#x"}
-        )
+        resp = self.get_error_response(self.organization.slug, 99999, status_code=404, channel="#x")
         assert resp.status_code == 404
 
     def test_unsupported_provider(self):
@@ -149,7 +147,7 @@ class ChannelValidateErrorCasesTest(BaseChannelValidateTest):
             organization=self.organization, provider="github", name="GitHub", external_id="github:1"
         )
         resp = self.get_error_response(
-            self.organization.slug, integration.id, status_code=400, **{"channel": "#x"}
+            self.organization.slug, integration.id, status_code=400, channel="#x"
         )
         assert resp.data["valid"] is False
         assert "Unsupported provider" in resp.data.get("detail", "")

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
@@ -11,14 +11,16 @@ from sentry.testutils.silo import control_silo_test
 
 class BaseChannelValidateTest(APITestCase):
     endpoint = "sentry-api-0-organization-integration-channel-validate"
-    method = "get"
+    method = "post"
 
     def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
 
     def _get_response(self, integration_id, channel):
-        return self.get_success_response(self.organization.slug, integration_id, channel=channel)
+        return self.get_success_response(
+            self.organization.slug, integration_id, **{"channel": channel}
+        )
 
 
 @control_silo_test
@@ -137,7 +139,9 @@ class ChannelValidateErrorCasesTest(BaseChannelValidateTest):
         assert "channel" in resp.data
 
     def test_integration_not_found(self):
-        resp = self.get_error_response(self.organization.slug, 99999, status_code=404, channel="#x")
+        resp = self.get_error_response(
+            self.organization.slug, 99999, status_code=404, **{"channel": "#x"}
+        )
         assert resp.status_code == 404
 
     def test_unsupported_provider(self):
@@ -145,7 +149,7 @@ class ChannelValidateErrorCasesTest(BaseChannelValidateTest):
             organization=self.organization, provider="github", name="GitHub", external_id="github:1"
         )
         resp = self.get_error_response(
-            self.organization.slug, integration.id, status_code=400, channel="#x"
+            self.organization.slug, integration.id, status_code=400, **{"channel": "#x"}
         )
         assert resp.data["valid"] is False
         assert "Unsupported provider" in resp.data.get("detail", "")


### PR DESCRIPTION
`post` fits better than `get`

Contributes to https://linear.app/getsentry/issue/TET-1229/implement-dropdown-or-validation-for-slack-field