### PR TITLE
auth: preserve session redirect URL through 2FA flow

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -186,6 +186,8 @@ def _get_login_redirect(request: HttpRequest, default: str | None = None) -> str
     if after_2fa is not None:
         return after_2fa
 
+    # Only pop _next from session after 2FA is complete to preserve
+    # invitation/redirect URLs across the 2FA flow
     login_url = request.session.pop("_next", None)
     if not login_url:
         return default

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -139,7 +139,10 @@ class AuthLoginView(BaseView):
         """
         Returns the next URI a user should visit in their authentication flow.
         """
-        next_uri_fallback = request.session.pop("_next", None)
+        # Don't pop _next here - it needs to persist through the entire auth flow
+        # including 2FA. It will be popped later by get_login_redirect() after
+        # all authentication steps complete.
+        next_uri_fallback = request.session.get("_next", None)
         return request.GET.get(REDIRECT_FIELD_NAME, next_uri_fallback)
 
     def redirect_authenticated_user(self, request: HttpRequest, next_uri: str) -> HttpResponseBase:


### PR DESCRIPTION
Fixes #101794

## Problem

When users with 2FA enabled accept organization invites while logged out, they get stuck in a login loop. The redirect URL (`_next` session variable) was being prematurely removed during the initial login GET request. After completing 2FA, the system had no redirect target, causing the loop.

## Root Cause

`get_next_uri()` in `auth_login.py` was using `session.pop()` to read the redirect URL, removing it before the authentication flow completed. When 2FA was required, the URL was already gone by the time 2FA finished.

## Solution

Changed `get_next_uri()` to use `session.get()` instead of `session.pop()`, allowing `_next` to persist through the entire authentication flow including 2FA. The session cleanup now correctly happens in `get_login_redirect()` after all authentication steps complete.

## Session Lifecycle
```
initiate_login() -> get_next_uri() [READ] -> 2FA -> get_login_redirect() [CLEANUP]
```

## Changes

- `auth_login.py:145`: Changed `.pop("_next")` to `.get("_next")`  
- `auth.py:189-190`: Added clarifying comment about cleanup timing

## Testing

Manual testing confirms:
- 2FA users accepting invites no longer loop
- Non-2FA flows continue to work
- Session variables properly cleaned up after auth