### PR TITLE
ref(onboarding): Make packageName consistent with a full desc

### DIFF
--- a/static/app/gettingStartedDocs/bun/bun.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.tsx
@@ -148,7 +148,7 @@ const docs: Docs = {
   feedbackOnboardingJsLoader,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'bun',
-    sdkPackage: '@sentry/bun',
+    packageName: '@sentry/bun',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -557,7 +557,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'angular',
-  sdkPackage: '@sentry/angular',
+  packageName: '@sentry/angular',
 });
 
 const docs: Docs<PlatformOptions> = {

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -548,7 +548,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptFullStackOnboarding({
-  basePackage: '@sentry/astro',
+  packageName: '@sentry/astro',
   browserProfilingLink:
     'https://docs.sentry.io/platforms/javascript/guides/astro/profiling/browser-profiling/',
   nodeProfilingLink:
@@ -563,11 +563,11 @@ const docs: Docs = {
   featureFlagOnboarding,
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'astro',
-    sdkPackage: '@sentry/astro',
+    packageName: '@sentry/astro',
   }),
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'astro',
+    packageName: '@sentry/astro',
     configFileName: 'sentry.server.config.js',
   }),
 };

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -384,7 +384,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'ember',
-  sdkPackage: '@sentry/ember',
+  packageName: '@sentry/ember',
 });
 
 const docs: Docs = {

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -399,7 +399,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'gatsby',
-  sdkPackage: '@sentry/gatsby',
+  packageName: '@sentry/gatsby',
 });
 
 const docs: Docs = {

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -1023,7 +1023,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'javascript',
-  sdkPackage: '@sentry/browser',
+  packageName: '@sentry/browser',
 });
 
 export const featureFlagOnboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -543,7 +543,7 @@ Sentry.init({
 };
 
 const profilingOnboarding = getJavascriptFullStackOnboarding({
-  basePackage: '@sentry/nextjs',
+  packageName: '@sentry/nextjs',
   browserProfilingLink:
     'https://docs.sentry.io/platforms/javascript/guides/nextjs/profiling/browser-profiling/',
   nodeProfilingLink:
@@ -612,10 +612,10 @@ const docs: Docs = {
   profilingOnboarding,
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'nextjs',
-    sdkPackage: '@sentry/nextjs',
+    packageName: '@sentry/nextjs',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'nextjs',
+    packageName: '@sentry/nextjs',
     configFileName: 'sentry.server.config.ts',
   }),
 };

--- a/static/app/gettingStartedDocs/javascript/nuxt.tsx
+++ b/static/app/gettingStartedDocs/javascript/nuxt.tsx
@@ -290,10 +290,10 @@ const docs: Docs = {
   featureFlagOnboarding,
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'nuxt',
-    sdkPackage: '@sentry/nuxt',
+    packageName: '@sentry/nuxt',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'nuxt',
+    packageName: '@sentry/nuxt',
     configFileName: 'sentry.server.config.ts',
   }),
 };

--- a/static/app/gettingStartedDocs/javascript/react-router.tsx
+++ b/static/app/gettingStartedDocs/javascript/react-router.tsx
@@ -536,7 +536,7 @@ const performanceOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptFullStackOnboarding({
-  basePackage: '@sentry/react-router',
+  packageName: '@sentry/react-router',
   browserProfilingLink:
     'https://docs.sentry.io/platforms/javascript/guides/react-router/profiling/browser-profiling/',
   nodeProfilingLink:
@@ -551,12 +551,12 @@ const docs: Docs = {
   performanceOnboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'react-router',
+    packageName: '@sentry/react-router',
     configFileName: 'instrument.server.mjs',
   }),
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'react-router',
-    sdkPackage: '@sentry/react-router',
+    packageName: '@sentry/react-router',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -652,7 +652,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'react',
-  sdkPackage: '@sentry/react',
+  packageName: '@sentry/react',
 });
 
 const docs: Docs = {

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -274,7 +274,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptFullStackOnboarding({
-  basePackage: '@sentry/remix',
+  packageName: '@sentry/remix',
   browserProfilingLink:
     'https://docs.sentry.io/platforms/javascript/guides/remix/profiling/browser-profiling/',
   nodeProfilingLink:
@@ -289,12 +289,12 @@ const docs: Docs = {
   featureFlagOnboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'remix',
+    packageName: '@sentry/remix',
     configFileName: 'instrument.server.mjs',
   }),
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'remix',
-    sdkPackage: '@sentry/remix',
+    packageName: '@sentry/remix',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -409,7 +409,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'solid',
-  sdkPackage: '@sentry/solid',
+  packageName: '@sentry/solid',
 });
 
 const docs: Docs = {

--- a/static/app/gettingStartedDocs/javascript/solidstart.tsx
+++ b/static/app/gettingStartedDocs/javascript/solidstart.tsx
@@ -573,12 +573,12 @@ const docs: Docs = {
   featureFlagOnboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'solidstart',
+    packageName: '@sentry/solidstart',
     configFileName: 'instrument.server.mjs',
   }),
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'solidstart',
-    sdkPackage: '@sentry/solidstart',
+    packageName: '@sentry/solidstart',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -412,7 +412,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'svelte',
-  sdkPackage: '@sentry/svelte',
+  packageName: '@sentry/svelte',
 });
 
 const docs: Docs = {

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -247,7 +247,7 @@ const crashReportOnboarding: OnboardingConfig = {
 };
 
 const profilingOnboarding = getJavascriptFullStackOnboarding({
-  basePackage: '@sentry/sveltekit',
+  packageName: '@sentry/sveltekit',
   browserProfilingLink:
     'https://docs.sentry.io/platforms/javascript/guides/sveltekit/profiling/browser-profiling/',
   nodeProfilingLink:
@@ -262,12 +262,12 @@ const docs: Docs = {
   featureFlagOnboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'sveltekit',
+    packageName: '@sentry/sveltekit',
     configFileName: 'instrumentation.server.js',
   }),
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'sveltekit',
-    sdkPackage: '@sentry/sveltekit',
+    packageName: '@sentry/sveltekit',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
+++ b/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
@@ -487,7 +487,7 @@ export const APIRoute = createAPIFileRoute("/api/sentry-example-api")({
 };
 
 const profilingOnboarding = getJavascriptFullStackOnboarding({
-  basePackage: '@sentry/tanstackstart-react',
+  packageName: '@sentry/tanstackstart-react',
   browserProfilingLink:
     'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/profiling/browser-profiling/',
   nodeProfilingLink:
@@ -498,12 +498,12 @@ const docs: Docs = {
   onboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'tanstackstart-react',
+    packageName: '@sentry/tanstackstart-react',
     configFileName: 'app/ssr.tsx',
   }),
   logsOnboarding: getJavascriptLogsFullStackOnboarding({
     docsPlatform: 'tanstackstart-react',
-    sdkPackage: '@sentry/tanstackstart-react',
+    packageName: '@sentry/tanstackstart-react',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -434,7 +434,7 @@ const profilingOnboarding = getJavascriptProfilingOnboarding({
 const logsOnboarding: OnboardingConfig = getJavascriptLogsOnboarding({
   installSnippetBlock,
   docsPlatform: 'vue',
-  sdkPackage: '@sentry/vue',
+  packageName: '@sentry/vue',
 });
 
 const docs: Docs<PlatformOptions> = {

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -166,7 +166,7 @@ const installationMethodOnboarding: Record<
             text: t('Add the Sentry AWS Serverless SDK as a dependency'),
           },
           getInstallCodeBlock(params, {
-            basePackage: '@sentry/aws-serverless',
+            packageName: '@sentry/aws-serverless',
           }),
         ],
       },
@@ -218,17 +218,17 @@ const docs: Docs<PlatformOptions> = {
   onboarding,
   crashReportOnboarding,
   profilingOnboarding: getNodeProfilingOnboarding({
-    basePackage: '@sentry/aws-serverless',
+    packageName: '@sentry/aws-serverless',
   }),
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'aws-lambda',
-    sdkPackage: '@sentry/aws-serverless',
+    packageName: '@sentry/aws-serverless',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'aws-serverless',
+    packageName: '@sentry/aws-serverless',
   }),
   mcpOnboarding: getNodeMcpOnboarding({
-    basePackage: 'aws-serverless',
+    packageName: '@sentry/aws-serverless',
   }),
   platformOptions,
 };

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -136,7 +136,7 @@ const docs: Docs = {
   profilingOnboarding: getNodeProfilingOnboarding(),
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'azure-functions',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),
   mcpOnboarding: getNodeMcpOnboarding(),

--- a/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
@@ -94,7 +94,7 @@ const onboarding: OnboardingConfig = {
           type: 'text',
           text: t('Add the Sentry Cloudflare SDK as a dependency:'),
         },
-        getInstallCodeBlock(params, {basePackage: '@sentry/cloudflare'}),
+        getInstallCodeBlock(params, {packageName: '@sentry/cloudflare'}),
       ],
     },
   ],
@@ -235,11 +235,11 @@ const docs: Docs = {
   crashReportOnboarding,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'cloudflare',
-    sdkPackage: '@sentry/cloudflare',
-    generateConfigureSnippet: (params, sdkPackage) => ({
+    packageName: '@sentry/cloudflare',
+    generateConfigureSnippet: (params, packageName) => ({
       type: 'code',
       language: 'javascript',
-      code: `import * as Sentry from "${sdkPackage}";
+      code: `import * as Sentry from "${packageName}";
 
 export const onRequest = [
   // Make sure Sentry is the first middleware
@@ -257,10 +257,10 @@ export const onRequest = [
     }),
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'cloudflare',
+    packageName: '@sentry/cloudflare',
   }),
   mcpOnboarding: getNodeMcpOnboarding({
-    basePackage: 'cloudflare',
+    packageName: '@sentry/cloudflare',
   }),
 };
 

--- a/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
@@ -93,7 +93,7 @@ const onboarding: OnboardingConfig = {
           type: 'text',
           text: t('Add the Sentry Cloudflare SDK as a dependency:'),
         },
-        getInstallCodeBlock(params, {basePackage: '@sentry/cloudflare'}),
+        getInstallCodeBlock(params, {packageName: '@sentry/cloudflare'}),
       ],
     },
   ],
@@ -231,11 +231,11 @@ const docs: Docs = {
   crashReportOnboarding,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'cloudflare',
-    sdkPackage: '@sentry/cloudflare',
-    generateConfigureSnippet: (params, sdkPackage) => ({
+    packageName: '@sentry/cloudflare',
+    generateConfigureSnippet: (params, packageName) => ({
       type: 'code',
       language: 'javascript',
-      code: `import * as Sentry from "${sdkPackage}";
+      code: `import * as Sentry from "${packageName}";
 
 export default Sentry.withSentry(
   env => ({
@@ -257,10 +257,10 @@ export default Sentry.withSentry(
     }),
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'cloudflare',
+    packageName: '@sentry/cloudflare',
   }),
   mcpOnboarding: getNodeMcpOnboarding({
-    basePackage: 'cloudflare',
+    packageName: '@sentry/cloudflare',
   }),
 };
 

--- a/static/app/gettingStartedDocs/node/connect.tsx
+++ b/static/app/gettingStartedDocs/node/connect.tsx
@@ -29,7 +29,7 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet()}
 
 // All other imports below
-${getSentryImportSnippet('node')}
+${getSentryImportSnippet('@sentry/node')}
 const connect = require("connect");
 
 const app = connect();
@@ -192,7 +192,7 @@ const docs: Docs = {
   profilingOnboarding: getNodeProfilingOnboarding(),
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'connect',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),
   mcpOnboarding: getNodeMcpOnboarding(),

--- a/static/app/gettingStartedDocs/node/express.tsx
+++ b/static/app/gettingStartedDocs/node/express.tsx
@@ -33,7 +33,7 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet()}
 
 // All other imports below
-${getSentryImportSnippet('node')}
+${getSentryImportSnippet('@sentry/node')}
 const express = require("express");
 
 const app = express();
@@ -211,7 +211,7 @@ const docs: Docs = {
   feedbackOnboardingJsLoader,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'express',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   profilingOnboarding: getNodeProfilingOnboarding(),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),

--- a/static/app/gettingStartedDocs/node/fastify.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.tsx
@@ -33,7 +33,7 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet()}
 
 // All other imports below
-${getSentryImportSnippet('node')}
+${getSentryImportSnippet('@sentry/node')}
 const Fastify = require('fastify')
 
 const app = Fastify();
@@ -198,7 +198,7 @@ const docs: Docs = {
   profilingOnboarding: getNodeProfilingOnboarding(),
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'fastify',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),
   mcpOnboarding: getNodeMcpOnboarding(),

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -76,7 +76,7 @@ const onboarding: OnboardingConfig = {
           ),
         },
         getInstallCodeBlock(params, {
-          basePackage: '@sentry/google-cloud-serverless',
+          packageName: '@sentry/google-cloud-serverless',
         }),
       ],
     },
@@ -165,14 +165,14 @@ const docs: Docs = {
   onboarding,
   crashReportOnboarding,
   profilingOnboarding: getNodeProfilingOnboarding({
-    basePackage: '@sentry/google-cloud-serverless',
+    packageName: '@sentry/google-cloud-serverless',
   }),
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'gcp-functions',
-    sdkPackage: '@sentry/google-cloud-serverless',
+    packageName: '@sentry/google-cloud-serverless',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'google-cloud-serverless',
+    packageName: '@sentry/google-cloud-serverless',
   }),
   mcpOnboarding: getNodeMcpOnboarding(),
 };

--- a/static/app/gettingStartedDocs/node/hapi.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.tsx
@@ -31,7 +31,7 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet()}
 
 // All other imports below
-${getSentryImportSnippet('node')}
+${getSentryImportSnippet('@sentry/node')}
 const Hapi = require('@hapi/hapi');
 
 const init = async () => {
@@ -244,7 +244,7 @@ const docs: Docs = {
   crashReportOnboarding,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'hapi',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   profilingOnboarding: getNodeProfilingOnboarding(),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),

--- a/static/app/gettingStartedDocs/node/hono.tsx
+++ b/static/app/gettingStartedDocs/node/hono.tsx
@@ -43,7 +43,7 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet()}
 
 // All other imports below
-${getSentryImportSnippet('node')}
+${getSentryImportSnippet('@sentry/node')}
 const { Hono } = require("hono");
 const { HTTPException } = require("hono/http-exception");
 
@@ -277,7 +277,7 @@ const docs: Docs = {
   crashReportOnboarding,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'hono',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   profilingOnboarding: getNodeProfilingOnboarding(),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -31,7 +31,7 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet()}
 
 // All other imports below
-${getSentryImportSnippet('node')}
+${getSentryImportSnippet('@sentry/node')}
 const Koa = require("koa");
 
 const app = new Koa();
@@ -238,7 +238,7 @@ const docs: Docs = {
   crashReportOnboarding,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'koa',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   profilingOnboarding: getNodeProfilingOnboarding(),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -116,7 +116,7 @@ const onboarding: OnboardingConfig = {
           text: t('Add the Sentry NestJS SDK as a dependency:'),
         },
         getInstallCodeBlock(params, {
-          basePackage: '@sentry/nestjs',
+          packageName: '@sentry/nestjs',
         }),
       ],
     },
@@ -332,17 +332,17 @@ const docs: Docs = {
   feedbackOnboardingCrashApi: feedbackOnboardingNode,
   crashReportOnboarding,
   profilingOnboarding: getNodeProfilingOnboarding({
-    basePackage: '@sentry/nestjs',
+    packageName: '@sentry/nestjs',
   }),
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'nestjs',
-    sdkPackage: '@sentry/nestjs',
+    packageName: '@sentry/nestjs',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: 'nestjs',
+    packageName: '@sentry/nestjs',
   }),
   mcpOnboarding: getNodeMcpOnboarding({
-    basePackage: 'nestjs',
+    packageName: '@sentry/nestjs',
   }),
 };
 

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -451,7 +451,7 @@ const docs: Docs = {
   }),
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'node',
-    sdkPackage: '@sentry/node',
+    packageName: '@sentry/node',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding(),
   mcpOnboarding: getNodeMcpOnboarding(),

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -169,12 +169,12 @@ export const getJavascriptLogsOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({
   docsPlatform,
-  sdkPackage,
+  packageName,
   installSnippetBlock,
 }: {
   docsPlatform: string;
   installSnippetBlock: ContentBlock;
-  sdkPackage: `@sentry/${string}`;
+  packageName: `@sentry/${string}`;
 }): OnboardingConfig<PlatformOptions> => ({
   install: () => [
     {
@@ -183,10 +183,10 @@ export const getJavascriptLogsOnboarding = <
         {
           type: 'text',
           text: tct(
-            'Add the Sentry SDK as a dependency. The minimum version of [sdkPackage] that supports logs is [code:9.41.0].',
+            'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports logs is [code:9.41.0].',
             {
               code: <code />,
-              sdkPackage: <code>{sdkPackage}</code>,
+              packageName: <code>{packageName}</code>,
             }
           ),
         },
@@ -222,7 +222,7 @@ export const getJavascriptLogsOnboarding = <
           type: 'code',
           language: 'javascript',
           code: `
-import * as Sentry from "${sdkPackage}";
+import * as Sentry from "${packageName}";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -259,7 +259,7 @@ Sentry.init({
         {
           type: 'code',
           language: 'jsx',
-          code: `import * as Sentry from "${sdkPackage}";
+          code: `import * as Sentry from "${packageName}";
 
 Sentry.logger.info('User triggered test log', { log_source: 'sentry_test' })`,
         },
@@ -272,10 +272,10 @@ export const getJavascriptLogsFullStackOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({
   docsPlatform,
-  sdkPackage,
+  packageName,
 }: {
   docsPlatform: string;
-  sdkPackage: `@sentry/${string}`;
+  packageName: `@sentry/${string}`;
 }): OnboardingConfig<PlatformOptions> => ({
   install: () => [
     {
@@ -284,10 +284,10 @@ export const getJavascriptLogsFullStackOnboarding = <
         {
           type: 'text',
           text: tct(
-            'To add logs make sure [sdkPackage] is up-to-date. The minimum version of [sdkPackage] that supports logs is [code:9.41.0].',
+            'To add logs make sure [packageName] is up-to-date. The minimum version of [packageName] that supports logs is [code:9.41.0].',
             {
               code: <code />,
-              sdkPackage: <code>{sdkPackage}</code>,
+              packageName: <code>{packageName}</code>,
             }
           ),
         },
@@ -299,19 +299,19 @@ export const getJavascriptLogsFullStackOnboarding = <
               label: 'npm',
               value: 'npm',
               language: 'bash',
-              code: `npm install ${sdkPackage} --save`,
+              code: `npm install ${packageName} --save`,
             },
             {
               label: 'yarn',
               value: 'yarn',
               language: 'bash',
-              code: `yarn add ${sdkPackage}`,
+              code: `yarn add ${packageName}`,
             },
             {
               label: 'pnpm',
               value: 'pnpm',
               language: 'bash',
-              code: `pnpm add ${sdkPackage}`,
+              code: `pnpm add ${packageName}`,
             },
           ],
         },
@@ -346,7 +346,7 @@ export const getJavascriptLogsFullStackOnboarding = <
           type: 'code',
           language: 'javascript',
           code: `
-import * as Sentry from "${sdkPackage}";
+import * as Sentry from "${packageName}";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -385,7 +385,7 @@ Sentry.init({
         {
           type: 'code',
           language: 'jsx',
-          code: `import * as Sentry from "${sdkPackage}";
+          code: `import * as Sentry from "${packageName}";
 
 Sentry.logger.info('User triggered test log', { log_source: 'sentry_test' })`,
         },
@@ -397,14 +397,14 @@ Sentry.logger.info('User triggered test log', { log_source: 'sentry_test' })`,
 export const getJavascriptFullStackOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({
-  basePackage,
+  packageName,
   browserProfilingLink,
   nodeProfilingLink,
   getProfilingHeaderContent = getDefaultProfilingHeaderContent,
 }: {
-  basePackage: string;
   browserProfilingLink: string;
   nodeProfilingLink: string;
+  packageName: `@sentry/${string}`;
   getProfilingHeaderContent?: (params: DocsParams) => ContentBlock[];
 }): OnboardingConfig<PlatformOptions> => ({
   install: () => [
@@ -414,10 +414,10 @@ export const getJavascriptFullStackOnboarding = <
         {
           type: 'text',
           text: tct(
-            'To enable profiling, add [code:@sentry/profiling-node] to your imports and make sure [packageCode] is up-to-date. The minimum version of [packageCode] that supports node and browser profiling is [code:7.60.0].',
+            'To enable profiling, add [code:@sentry/profiling-node] to your imports and make sure [packageName] is up-to-date. The minimum version of [packageName] that supports node and browser profiling is [code:7.60.0].',
             {
               code: <code />,
-              packageCode: <code>{basePackage}</code>,
+              packageName: <code>{packageName}</code>,
             }
           ),
         },
@@ -427,17 +427,17 @@ export const getJavascriptFullStackOnboarding = <
             {
               label: 'npm',
               language: 'bash',
-              code: `npm install ${basePackage} @sentry/profiling-node --save`,
+              code: `npm install ${packageName} @sentry/profiling-node --save`,
             },
             {
               label: 'yarn',
               language: 'bash',
-              code: `yarn add ${basePackage} @sentry/profiling-node`,
+              code: `yarn add ${packageName} @sentry/profiling-node`,
             },
             {
               label: 'pnpm',
               language: 'bash',
-              code: `pnpm add ${basePackage} @sentry/profiling-node`,
+              code: `pnpm add ${packageName} @sentry/profiling-node`,
             },
           ],
         },

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -13,14 +13,14 @@ function getInstallSnippet({
   params,
   packageManager,
   additionalPackages = [],
-  basePackage = '@sentry/node',
+  packageName = '@sentry/node',
 }: {
   packageManager: 'npm' | 'yarn' | 'pnpm';
   params: DocsParams;
-  additionalPackages?: string[];
-  basePackage?: string;
+  additionalPackages?: Array<`@sentry/${string}`>;
+  packageName?: `@sentry/${string}`;
 }) {
-  let packages = [basePackage];
+  let packages = [packageName];
   if (params.isProfilingSelected) {
     packages.push('@sentry/profiling-node');
   }
@@ -40,11 +40,11 @@ function getInstallSnippet({
 export function getInstallCodeBlock(
   params: DocsParams,
   {
-    basePackage = '@sentry/node',
+    packageName = '@sentry/node',
     additionalPackages,
   }: {
-    additionalPackages?: string[];
-    basePackage?: string;
+    additionalPackages?: Array<`@sentry/${string}`>;
+    packageName?: `@sentry/${string}`;
   } = {}
 ): ContentBlock {
   return {
@@ -57,7 +57,7 @@ export function getInstallCodeBlock(
           params,
           additionalPackages,
           packageManager: 'npm',
-          basePackage,
+          packageName,
         }),
       },
       {
@@ -67,7 +67,7 @@ export function getInstallCodeBlock(
           params,
           additionalPackages,
           packageManager: 'yarn',
-          basePackage,
+          packageName,
         }),
       },
       {
@@ -77,7 +77,7 @@ export function getInstallCodeBlock(
           params,
           additionalPackages,
           packageManager: 'pnpm',
-          basePackage,
+          packageName,
         }),
       },
     ],
@@ -85,17 +85,17 @@ export function getInstallCodeBlock(
 }
 
 function getImport(
-  sdkPackage: 'node' | 'google-cloud-serverless' | 'aws-serverless' | 'nestjs',
+  packageName: `@sentry/${string}`,
   defaultMode?: 'esm' | 'cjs'
 ): string[] {
   return defaultMode === 'esm'
     ? [
-        `// Import with \`const Sentry = require("@sentry/${sdkPackage}");\` if you are using CJS`,
-        `import * as Sentry from "@sentry/${sdkPackage}"`,
+        `// Import with \`const Sentry = require("${packageName}");\` if you are using CJS`,
+        `import * as Sentry from "${packageName}"`,
       ]
     : [
-        `// Import with \`import * as Sentry from "@sentry/${sdkPackage}"\` if you are using ESM`,
-        `const Sentry = require("@sentry/${sdkPackage}");`,
+        `// Import with \`import * as Sentry from "${packageName}"\` if you are using ESM`,
+        `const Sentry = require("${packageName}");`,
       ];
 }
 
@@ -109,10 +109,10 @@ function getProfilingImport(defaultMode?: 'esm' | 'cjs'): string {
  * Import Snippet for the Node and Serverless SDKs without other packages (like profiling).
  */
 export function getSentryImportSnippet(
-  sdkPackage: 'node' | 'google-cloud-serverless' | 'aws-serverless' | 'nestjs',
+  packageName: `@sentry/${string}`,
   defaultMode?: 'esm' | 'cjs'
 ): string {
-  return getImport(sdkPackage, defaultMode).join('\n');
+  return getImport(packageName, defaultMode).join('\n');
 }
 
 export function getImportInstrumentSnippet(
@@ -131,10 +131,10 @@ require("./${filename}");`;
 }
 
 const libraryMap = {
-  node: 'node',
-  aws: 'aws-serverless',
-  gpc: 'google-cloud-serverless',
-  nestjs: 'nestjs',
+  node: '@sentry/node',
+  aws: '@sentry/aws-serverless',
+  gpc: '@sentry/google-cloud-serverless',
+  nestjs: '@sentry/nestjs',
 } as const;
 
 function getDefaultNodeImports({
@@ -222,10 +222,10 @@ Sentry.startSpan({
   }`;
 
 export const getNodeProfilingOnboarding = ({
-  basePackage = '@sentry/node',
+  packageName = '@sentry/node',
   profilingLifecycle = 'trace',
 }: {
-  basePackage?: string;
+  packageName?: `@sentry/${string}`;
   profilingLifecycle?: 'trace' | 'manual';
 } = {}): OnboardingConfig => ({
   install: params => [
@@ -242,7 +242,7 @@ export const getNodeProfilingOnboarding = ({
           ),
         },
         getInstallCodeBlock(params, {
-          basePackage,
+          packageName,
         }),
       ],
     },
@@ -374,11 +374,11 @@ Sentry.profiler.stopProfiler();
 });
 
 export const getNodeAgentMonitoringOnboarding = ({
-  basePackage = 'node',
+  packageName = '@sentry/node',
   configFileName,
 }: {
-  basePackage?: string;
   configFileName?: string;
+  packageName?: `@sentry/${string}`;
 } = {}): OnboardingConfig => ({
   install: params => [
     {
@@ -394,7 +394,7 @@ export const getNodeAgentMonitoringOnboarding = ({
           ),
         },
         getInstallCodeBlock(params, {
-          basePackage: `@sentry/${basePackage}`,
+          packageName,
         }),
       ],
     },
@@ -419,7 +419,7 @@ export const getNodeAgentMonitoringOnboarding = ({
           {
             label: configFileName ? configFileName : 'JavaScript',
             language: 'javascript',
-            code: `${getImport(basePackage === '@sentry/node' ? 'node' : (basePackage as any)).join('\n')}
+            code: `${getImport(packageName).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -486,7 +486,7 @@ const result = await generateText({
           {
             label: 'JavaScript',
             language: 'javascript',
-            code: `${getImport(basePackage === '@sentry/node' ? 'node' : (basePackage as any)).join('\n')}
+            code: `${getImport(packageName).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -520,7 +520,7 @@ Sentry.init({
           {
             label: 'JavaScript',
             language: 'javascript',
-            code: `${getImport(basePackage === '@sentry/node' ? 'node' : (basePackage as any)).join('\n')}
+            code: `${getImport(packageName).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -554,7 +554,7 @@ Sentry.init({
           {
             label: 'JavaScript',
             language: 'javascript',
-            code: `${getImport(basePackage === '@sentry/node' ? 'node' : (basePackage as any)).join('\n')}
+            code: `${getImport(packageName).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -592,7 +592,7 @@ Sentry.init({
           {
             label: 'JavaScript',
             language: 'javascript',
-            code: `${getImport(basePackage === '@sentry/node' ? 'node' : (basePackage as any)).join('\n')}
+            code: `${getImport(packageName).join('\n')}
 
 // Create a span around your AI call
 await Sentry.startSpan({
@@ -713,9 +713,9 @@ const response = await ai.models.generateContent({
 });
 
 export const getNodeMcpOnboarding = ({
-  basePackage = 'node',
+  packageName = '@sentry/node',
 }: {
-  basePackage?: string;
+  packageName?: `@sentry/${string}`;
 } = {}): OnboardingConfig => ({
   introduction: () => (
     <Alert type="info" showIcon={false}>
@@ -743,7 +743,7 @@ export const getNodeMcpOnboarding = ({
           ),
         },
         getInstallCodeBlock(params, {
-          basePackage: `@sentry/${basePackage}`,
+          packageName,
         }),
       ],
     },
@@ -765,7 +765,7 @@ export const getNodeMcpOnboarding = ({
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              code: `${getImport(basePackage === '@sentry/node' ? 'node' : (basePackage as any)).join('\n')}
+              code: `${getImport(packageName).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -810,13 +810,13 @@ const server = Sentry.wrapMcpServerWithSentry(new McpServer({
 
 function getNodeLogsConfigureSnippet(
   params: DocsParams,
-  sdkPackage: `@sentry/${string}`
+  packageName: `@sentry/${string}`
 ): ContentBlock {
   return {
     type: 'code',
     language: 'javascript',
     code: `
-import * as Sentry from "${sdkPackage}";
+import * as Sentry from "${packageName}";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -834,11 +834,11 @@ export const getNodeLogsOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 >({
   docsPlatform,
-  sdkPackage,
+  packageName,
   generateConfigureSnippet = getNodeLogsConfigureSnippet,
 }: {
   docsPlatform: string;
-  sdkPackage: `@sentry/${string}`;
+  packageName: `@sentry/${string}`;
   generateConfigureSnippet?: typeof getNodeLogsConfigureSnippet;
 }): OnboardingConfig<PlatformOptions> => ({
   install: (params: DocsParams) => [
@@ -848,16 +848,14 @@ export const getNodeLogsOnboarding = <
         {
           type: 'text',
           text: tct(
-            'Add the Sentry SDK as a dependency. The minimum version of [sdkPackage] that supports logs is [code:9.41.0].',
+            'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports logs is [code:9.41.0].',
             {
               code: <code />,
-              sdkPackage: <code>{sdkPackage}</code>,
+              packageName: <code>{packageName}</code>,
             }
           ),
         },
-        getInstallCodeBlock(params, {
-          basePackage: sdkPackage,
-        }),
+        getInstallCodeBlock(params, {packageName}),
         {
           type: 'text',
           text: tct(
@@ -885,7 +883,7 @@ export const getNodeLogsOnboarding = <
             {code: <code />}
           ),
         },
-        generateConfigureSnippet(params, sdkPackage),
+        generateConfigureSnippet(params, packageName),
         {
           type: 'text',
           text: tct('For more detailed information, see the [link:logs documentation].', {
@@ -910,7 +908,7 @@ export const getNodeLogsOnboarding = <
         {
           type: 'code',
           language: 'javascript',
-          code: `import * as Sentry from "${sdkPackage}";
+          code: `import * as Sentry from "${packageName}";
 
 Sentry.logger.info('User triggered test log', { action: 'test_log' })`,
         },


### PR DESCRIPTION
- All functions now consistently use the `packageName` parameter, replacing older variations such as `sdkPackage` and `packageCode.
- TypeScript type definitions now enforce the `@sentry/${string}` pattern
- Full package names are used consistently across all JavaScript/Bun and Node files

We probably can improve the function `getSdkInitSnippet` to get the full package name too, but that I will leave for a follow-up.

closes https://linear.app/getsentry/issue/TET-742/cleanup-js-node-onboarding-snippets-basepackage-inconsistency