### PR TITLE
feat(dashboards) update frontend to pass through linkedDashboards 

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -72,7 +72,7 @@ interface WidgetQueryOnDemand {
 
 export type LinkedDashboard = {
   dashboardId: string;
-  fieldId: string;
+  field: string;
 };
 
 /**

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -70,6 +70,11 @@ interface WidgetQueryOnDemand {
   extractionState: OnDemandExtractionState;
 }
 
+export type LinkedDashboard = {
+  dashboardId: string;
+  fieldId: string;
+};
+
 /**
  * A widget query is one or more aggregates and a single filter string (conditions.)
  * Widgets can have multiple widget queries, and they all combine into a unified timeseries view (for example)
@@ -88,6 +93,7 @@ export type WidgetQuery = {
   // widgets.
   fields?: string[];
   isHidden?: boolean | null;
+  linkedDashboards?: LinkedDashboard[];
   // Contains the on-demand entries for the widget query.
   onDemand?: WidgetQueryOnDemand[];
   // Aggregate selected for the Big Number widget builder

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -811,7 +811,7 @@ function Visualize({error, setError}: VisualizeProps) {
                                         fields[index]?.field
                                       ) {
                                         return (
-                                          linkedDashboard.fieldId === fields[index].field
+                                          linkedDashboard.field === fields[index].field
                                         );
                                       }
                                       return false;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -324,6 +324,7 @@ function Visualize({error, setError}: VisualizeProps) {
   const datasetConfig = useMemo(() => getDatasetConfig(state.dataset), [state.dataset]);
 
   const fields = isChartWidget ? state.yAxis : state.fields;
+  const linkedDashboards = state.linkedDashboards || [];
   const updateAction = isChartWidget
     ? BuilderStateAction.SET_Y_AXIS
     : BuilderStateAction.SET_FIELDS;
@@ -788,6 +789,34 @@ function Visualize({error, setError}: VisualizeProps) {
                               size="zero"
                               onClick={() => {
                                 openLinkToDashboardModal({
+                                  onLink: dashboardId => {
+                                    if (
+                                      fields[index]?.kind === FieldValueKind.FIELD &&
+                                      fields[index]?.field
+                                    ) {
+                                      const newLinkedDashboards = [
+                                        ...linkedDashboards,
+                                        {dashboardId, fieldId: fields[index].field},
+                                      ];
+                                      dispatch({
+                                        type: BuilderStateAction.SET_LINKED_DASHBOARDS,
+                                        payload: newLinkedDashboards,
+                                      });
+                                    }
+                                  },
+                                  currentLinkedDashboard: linkedDashboards.find(
+                                    linkedDashboard => {
+                                      if (
+                                        fields[index]?.kind === FieldValueKind.FIELD &&
+                                        fields[index]?.field
+                                      ) {
+                                        return (
+                                          linkedDashboard.fieldId === fields[index].field
+                                        );
+                                      }
+                                      return false;
+                                    }
+                                  ),
                                   source,
                                 });
                               }}

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -36,7 +36,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {useHasDrillDownFlows} from 'sentry/views/dashboards/hooks/useHasDrillDownFlows';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DisplayType,
+  WidgetType,
+  type LinkedDashboard,
+} from 'sentry/views/dashboards/types';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import SortableVisualizeFieldWrapper from 'sentry/views/dashboards/widgetBuilder/components/common/sortableFieldWrapper';
 import {ExploreArithmeticBuilder} from 'sentry/views/dashboards/widgetBuilder/components/exploreArithmeticBuilder';
@@ -794,9 +798,9 @@ function Visualize({error, setError}: VisualizeProps) {
                                       fields[index]?.kind === FieldValueKind.FIELD &&
                                       fields[index]?.field
                                     ) {
-                                      const newLinkedDashboards = [
+                                      const newLinkedDashboards: LinkedDashboard[] = [
                                         ...linkedDashboards,
-                                        {dashboardId, fieldId: fields[index].field},
+                                        {dashboardId, field: fields[index].field},
                                       ];
                                       dispatch({
                                         type: BuilderStateAction.SET_LINKED_DASHBOARDS,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -663,8 +663,8 @@ function serializeLinkedDashboards(linkedDashboards: LinkedDashboard[] = []): st
   return linkedDashboards.map(linkedDashboard => {
     return JSON.stringify({
       dashboardId: linkedDashboard.dashboardId,
-      fieldId: linkedDashboard.fieldId,
-    });
+      field: linkedDashboard.field,
+    } satisfies LinkedDashboard);
   });
 }
 
@@ -672,11 +672,11 @@ function deserializeLinkedDashboards(linkedDashboards: string[]): LinkedDashboar
   return linkedDashboards
     .map(linkedDashboard => {
       const maybeLinkedDashboard = JSON.parse(linkedDashboard);
-      if (maybeLinkedDashboard.dashboardId && maybeLinkedDashboard.fieldId) {
+      if (maybeLinkedDashboard.dashboardId && maybeLinkedDashboard.field) {
         return {
           dashboardId: maybeLinkedDashboard.dashboardId,
-          fieldId: maybeLinkedDashboard.fieldId,
-        };
+          field: maybeLinkedDashboard.field,
+        } satisfies LinkedDashboard;
       }
       return undefined;
     })

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -32,6 +32,7 @@ describe('convertBuilderStateToWidget', () => {
           columns: ['geo.country'],
           conditions: '',
           name: '',
+          linkedDashboards: [],
           orderby: 'geo.country',
           selectedAggregate: undefined,
         },

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -63,7 +63,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       fieldAliases: fieldAliases ?? [],
       name: legendAlias[index] ?? '',
       selectedAggregate: state.selectedAggregate,
-
+      linkedDashboards: state.linkedDashboards ?? [],
       // Big number widgets don't support sorting, so always ignore the sort state
       orderby: state.displayType === DisplayType.BIG_NUMBER ? '' : sort,
     };


### PR DESCRIPTION
1. When you save a widget, the `linkedDashboards` are now passed through to the backend
2. Some misc changes to the link a dashboard model such as adding a spinner while the dashboard list is loading