### PR TITLE
chore(uptime): Remove code that writes to old EAP table. Also fixes bug with writing misses to the new table

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2551,7 +2551,6 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
     "monitors-clock-tasks": "default",
     "monitors-incident-occurrences": "default",
     "uptime-results": "default",
-    "snuba-uptime-results": "default",
     "generic-events": "default",
     "snuba-generic-events-commit-log": "default",
     "group-attributes": "default",

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -58,7 +58,6 @@ class Topic(Enum):
     MONITORS_CLOCK_TASKS = "monitors-clock-tasks"
     MONITORS_INCIDENT_OCCURRENCES = "monitors-incident-occurrences"
     UPTIME_RESULTS = "uptime-results"
-    SNUBA_UPTIME_RESULTS = "snuba-uptime-results"
     EVENTSTREAM_GENERIC = "generic-events"
     GENERIC_EVENTS_COMMIT_LOG = "snuba-generic-events-commit-log"
     GROUP_ATTRIBUTES = "group-attributes"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3234,13 +3234,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "uptime.snuba_uptime_results.enabled",
-    type=Bool,
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Controls whether uptime monitoring creates issues via the issue platform.
 register(
     "uptime.create-issues",

--- a/src/sentry/uptime/consumers/eap_converter.py
+++ b/src/sentry/uptime/consumers/eap_converter.py
@@ -158,11 +158,10 @@ def convert_uptime_result_to_trace_items(
     """
     trace_items = []
 
-    request_info_list = result.get("request_info_list", [])  # Optional field
+    request_info_list: list[RequestInfo | None] = result.get("request_info_list", [])
     if not request_info_list:
         request_info = result["request_info"]
-        if request_info is not None:
-            request_info_list = [request_info]
+        request_info_list = [request_info]
 
     for sequence, request_info in enumerate(request_info_list):
         if sequence == 0:

--- a/src/sentry/uptime/consumers/eap_converter.py
+++ b/src/sentry/uptime/consumers/eap_converter.py
@@ -9,7 +9,7 @@ all requests in a redirect chain.
 
 import logging
 import uuid
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Sequence
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
@@ -158,7 +158,7 @@ def convert_uptime_result_to_trace_items(
     """
     trace_items = []
 
-    request_info_list: list[RequestInfo | None] = result.get("request_info_list", [])
+    request_info_list: Sequence[RequestInfo | None] = result.get("request_info_list", [])
     if not request_info_list:
         request_info = result["request_info"]
         request_info_list = [request_info]

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -6,18 +6,14 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
-from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload
-from sentry_kafka_schemas.codecs import Codec
-from sentry_kafka_schemas.schema_types.snuba_uptime_results_v1 import SnubaUptimeResult
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CHECKSTATUS_DISALLOWED_BY_ROBOTS,
     CHECKSTATUS_MISSED_WINDOW,
     CheckResult,
 )
 
-from sentry import features, options
-from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry import features
+from sentry.conf.types.kafka_definition import Topic
 from sentry.remote_subscriptions.consumers.result_consumer import (
     ResultProcessor,
     ResultsStrategyFactory,
@@ -42,10 +38,8 @@ from sentry.uptime.subscriptions.tasks import (
     send_uptime_config_deletion,
     update_remote_uptime_subscription,
 )
-from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils import metrics
-from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.kafka_config import get_topic_definition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.processors.detector import process_detectors
@@ -61,21 +55,8 @@ ACTIVE_THRESHOLD_REDIS_TTL = timedelta(seconds=max(UptimeSubscription.IntervalSe
     minutes=60
 )
 
-SNUBA_UPTIME_RESULTS_CODEC: Codec[SnubaUptimeResult] = get_topic_codec(Topic.SNUBA_UPTIME_RESULTS)
-
 # We want to limit cardinality for provider tags. This controls how many tags we should include
 TOTAL_PROVIDERS_TO_INCLUDE_AS_TAGS = 30
-
-
-def _get_snuba_uptime_checks_producer():
-    return get_arroyo_producer(
-        "sentry.uptime.consumers.results_consumer",
-        Topic.SNUBA_UPTIME_RESULTS,
-        exclude_config_keys=["compression.type", "message.max.bytes"],
-    )
-
-
-_snuba_uptime_checks_producer = SingletonProducer(_get_snuba_uptime_checks_producer)
 
 
 def build_last_update_key(detector: Detector) -> str:
@@ -135,61 +116,6 @@ def try_check_and_update_regions(
     # regions for this subscription so that they all get an update set of currently active regions.
     subscription.update(status=UptimeSubscription.Status.UPDATING.value)
     update_remote_uptime_subscription.delay(subscription.id)
-
-
-def produce_snuba_uptime_result(
-    detector: Detector,
-    result: CheckResult,
-    metric_tags: dict[str, str],
-) -> None:
-    """
-    Produces a message to Snuba's Kafka topic for uptime check results.
-    """
-    try:
-        detector_state = detector.detectorstate_set.first()
-        if detector_state and detector_state.is_triggered:
-            incident_status = IncidentStatus.IN_INCIDENT
-        else:
-            incident_status = IncidentStatus.NO_INCIDENT
-
-        snuba_message: SnubaUptimeResult = {
-            # Copy over fields from original result
-            "guid": result["guid"],
-            "subscription_id": result["subscription_id"],
-            "status": result["status"],
-            "status_reason": result["status_reason"],
-            "trace_id": result["trace_id"],
-            "span_id": result["span_id"],
-            "scheduled_check_time_ms": result["scheduled_check_time_ms"],
-            "actual_check_time_ms": result["actual_check_time_ms"],
-            "duration_ms": result["duration_ms"],
-            "request_info": result["request_info"],
-            # Add required Snuba-specific fields
-            "organization_id": detector.project.organization_id,
-            "project_id": detector.project.id,
-            "retention_days": 90,
-            "incident_status": incident_status.value,
-            "region": result["region"],
-        }
-
-        topic = get_topic_definition(Topic.SNUBA_UPTIME_RESULTS)["real_topic_name"]
-        payload = KafkaPayload(None, SNUBA_UPTIME_RESULTS_CODEC.encode(snuba_message), [])
-
-        _snuba_uptime_checks_producer.produce(ArroyoTopic(topic), payload)
-
-        metrics.incr(
-            "uptime.result_processor.snuba_message_produced",
-            sample_rate=1.0,
-            tags=metric_tags,
-        )
-
-    except Exception:
-        logger.exception("Failed to produce Snuba message for uptime result")
-        metrics.incr(
-            "uptime.result_processor.snuba_message_failed",
-            sample_rate=1.0,
-            tags=metric_tags,
-        )
 
 
 def is_shadow_region_result(result: CheckResult, regions: list[UptimeSubscriptionRegion]) -> bool:
@@ -443,14 +369,6 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                         "duration_ms": 0,
                         "request_info": None,
                     }
-
-                    if options.get("uptime.snuba_uptime_results.enabled"):
-                        produce_snuba_uptime_result(
-                            detector,
-                            missed_result,
-                            synthetic_metric_tags.copy(),
-                        )
-
                     produce_eap_uptime_result(
                         detector,
                         missed_result,
@@ -492,11 +410,8 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         except Exception:
             logger.exception("Failed to process result for uptime project subscription")
 
-        # Snuba production _must_ happen after handling the result, since we
+        # EAP production _must_ happen after handling the result, since we
         # may mutate the UptimeSubscription when we determine we're in an incident
-        if options.get("uptime.snuba_uptime_results.enabled"):
-            produce_snuba_uptime_result(detector, result, metric_tags.copy())
-
         produce_eap_uptime_result(detector, result, metric_tags.copy())
 
         # Track the last update date to allow deduplication

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -20,6 +20,7 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CHECKSTATUSREASONTYPE_TIMEOUT,
     CheckResult,
 )
+from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry.conf.types import kafka_definition
 from sentry.conf.types.kafka_definition import Topic as KafkaTopic
@@ -51,7 +52,6 @@ from sentry.uptime.subscriptions.subscriptions import (
     build_detector_fingerprint_component,
 )
 from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
-from sentry.utils import json
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.uptime.subscriptions.test_tasks import ConfigPusherTestMixin
 
@@ -99,6 +99,11 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 consumer = factory.create_with_partitions(commit, {self.partition: 0})
 
             consumer.submit(message)
+
+    def decode_trace_item(self, payload_value: bytes) -> TraceItem:
+        """Helper to decode a TraceItem from the produced Kafka payload."""
+        codec = get_topic_codec(KafkaTopic.SNUBA_ITEMS)
+        return codec.decode(payload_value)
 
     def test(self) -> None:
         fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
@@ -326,7 +331,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 extra={**result},
             )
 
-    @override_options({"uptime.snuba_uptime_results.enabled": False})
     def test_missed_check_updated_interval(self) -> None:
         result = self.create_uptime_result(self.subscription.subscription_id)
 
@@ -367,8 +371,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 extra={"num_missed_checks": 1, **result},
             )
 
-    @mock.patch("sentry.uptime.consumers.results_consumer._snuba_uptime_checks_producer.produce")
-    @override_options({"uptime.snuba_uptime_results.enabled": True})
+    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
     def test_missed_check_true_positive(self, mock_produce: MagicMock) -> None:
         result = self.create_uptime_result(self.subscription.subscription_id)
 
@@ -393,16 +396,22 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
 
             assert mock_produce.call_count == 3
 
-            synth_1 = json.loads(mock_produce.call_args_list[0].args[1].value)
-            synth_2 = json.loads(mock_produce.call_args_list[1].args[1].value)
-            synth_3 = json.loads(mock_produce.call_args_list[2].args[1].value)
+            synth_1 = self.decode_trace_item(mock_produce.call_args_list[0].args[1].value)
+            synth_2 = self.decode_trace_item(mock_produce.call_args_list[1].args[1].value)
+            synth_3 = self.decode_trace_item(mock_produce.call_args_list[2].args[1].value)
 
-            assert synth_1["status"] == "missed_window"
-            assert synth_2["status"] == "missed_window"
-            assert synth_3["status"] == "failure"
+            assert synth_1.attributes["check_status"].string_value == "missed_window"
+            assert synth_2.attributes["check_status"].string_value == "missed_window"
+            assert synth_3.attributes["check_status"].string_value == "failure"
 
-            assert synth_1["scheduled_check_time_ms"] == last_update_time + 300 * 1000
-            assert synth_2["scheduled_check_time_ms"] == last_update_time + 600 * 1000
+            assert (
+                synth_1.attributes["scheduled_check_time_us"].int_value
+                == (last_update_time + 300 * 1000) * 1000
+            )
+            assert (
+                synth_2.attributes["scheduled_check_time_us"].int_value
+                == (last_update_time + 600 * 1000) * 1000
+            )
 
             logger.info.assert_any_call(
                 "uptime.result_processor.num_missing_check",
@@ -490,7 +499,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
-    @override_options({"uptime.snuba_uptime_results.enabled": False})
     def test_missed(self) -> None:
         features = [
             "organizations:uptime",
@@ -524,7 +532,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
-    @override_options({"uptime.snuba_uptime_results.enabled": False})
     def test_disallowed(self) -> None:
         features = [
             "organizations:uptime",
@@ -970,7 +977,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         assert group_1 == [result_1, result_2]
         assert group_2 == [result_3]
 
-    @override_options({"uptime.snuba_uptime_results.enabled": False})
     def test_provider_stats(self) -> None:
         features = [
             "organizations:uptime",
@@ -1033,8 +1039,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
 
-    @mock.patch("sentry.uptime.consumers.results_consumer._snuba_uptime_checks_producer.produce")
-    @override_options({"uptime.snuba_uptime_results.enabled": True})
+    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
     def test_produces_snuba_uptime_results(self, mock_produce: MagicMock) -> None:
         """
         Validates that the consumer produces a message to Snuba's Kafka topic for uptime check results
@@ -1047,16 +1052,15 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.send_result(result)
         mock_produce.assert_called_once()
 
-        assert mock_produce.call_args.args[0].name == "snuba-uptime-results"
+        assert mock_produce.call_args.args[0].name == "snuba-items"
 
-        parsed_value = json.loads(mock_produce.call_args.args[1].value)
-        assert parsed_value["organization_id"] == self.project.organization_id
-        assert parsed_value["project_id"] == self.project.id
-        assert parsed_value["incident_status"] == 0
-        assert parsed_value["retention_days"] == 90
+        trace_item = self.decode_trace_item(mock_produce.call_args.args[1].value)
+        assert trace_item.organization_id == self.project.organization_id
+        assert trace_item.project_id == self.project.id
+        assert trace_item.attributes["incident_status"].int_value == 0
+        assert trace_item.retention_days == 90
 
-    @override_options({"uptime.snuba_uptime_results.enabled": True})
-    @mock.patch("sentry.uptime.consumers.results_consumer._snuba_uptime_checks_producer.produce")
+    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
     def test_produces_snuba_uptime_results_in_incident(self, mock_produce: MagicMock) -> None:
         """
         Validates that the consumer produces a message to Snuba's Kafka topic for uptime check results
@@ -1071,10 +1075,10 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.send_result(result)
         mock_produce.assert_called_once()
 
-        assert mock_produce.call_args.args[0].name == "snuba-uptime-results"
+        assert mock_produce.call_args.args[0].name == "snuba-items"
 
-        parsed_value = json.loads(mock_produce.call_args.args[1].value)
-        assert parsed_value["incident_status"] == 1
+        trace_item = self.decode_trace_item(mock_produce.call_args.args[1].value)
+        assert trace_item.attributes["incident_status"].int_value == 1
 
     @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
     def test_produces_eap_uptime_results(self, mock_produce: MagicMock) -> None:


### PR DESCRIPTION
This is a cleanup where we remove the old writing code. As part of tidying up the tests, I noticed a bug with us not writing misses to the new EAP system.

I think that we can roll forward here without waiting for another 90 days to backfill, since misses are not too common in general.