### PR TITLE
fix(seer-ghe): send org id and integration id

### DIFF
--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -306,6 +306,8 @@ export interface SeerRepoDefinition {
   branch_name?: string;
   branch_overrides?: BranchOverride[];
   instructions?: string;
+  integration_id?: string;
+  organization_id?: number;
   provider_raw?: string;
 }
 

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -122,6 +122,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         }
 
         return {
+          organization_id: parseInt(organization.id, 10),
           integration_id: repo.integrationId,
           provider,
           owner: owner || '',
@@ -139,6 +140,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
       setShowSaveNotice(true);
     },
     [
+      organization.id,
       repositories,
       selectedRepoIds,
       repoSettings,

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -161,6 +161,7 @@ describe('ProjectSeer', () => {
             automated_run_stopping_point: 'root_cause',
             repositories: [
               {
+                organization_id: 3,
                 branch_name: '',
                 external_id: '101',
                 instructions: '',
@@ -171,6 +172,7 @@ describe('ProjectSeer', () => {
                 branch_overrides: [],
               },
               {
+                organization_id: 3,
                 branch_name: '',
                 external_id: '102',
                 instructions: '',
@@ -221,6 +223,7 @@ describe('ProjectSeer', () => {
             automated_run_stopping_point: 'root_cause',
             repositories: [
               {
+                organization_id: 3,
                 external_id: '101',
                 name: 'sentry',
                 owner: 'getsentry',


### PR DESCRIPTION
make sure we set `integration_id` and `organization_id` when we send seer repo definitions from the frontend.

not making the fields required in the type because only GitHub Enterprise actually requires these fields, and backfilling all existing repos will be a big task.

however, from now on we'll just send all new repos with these fields.
