### PR TITLE
fix(seer-ghe): send & validate ghe ids in repos

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -148,7 +148,9 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
         if len(repo_name_sections) > 1 and repo.provider:
             repo_dict = {
                 "organization_id": repo.organization_id,
-                "integration_id": str(repo.integration_id) if repo.integration_id else None,
+                "integration_id": (
+                    str(repo.integration_id) if repo.integration_id is not None else None
+                ),
                 "provider": repo.provider,
                 "owner": repo_name_sections[0],
                 "name": "/".join(repo_name_sections[1:]),

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -147,6 +147,8 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
         # We expect a repository name to be in the format of "owner/name" for now.
         if len(repo_name_sections) > 1 and repo.provider:
             repo_dict = {
+                "organization_id": repo.organization_id,
+                "integration_id": str(repo.integration_id) if repo.integration_id else None,
                 "provider": repo.provider,
                 "owner": repo_name_sections[0],
                 "name": "/".join(repo_name_sections[1:]),

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -25,18 +25,29 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 logger = logging.getLogger(__name__)
 
 
-class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):
-    repositories = serializers.ListField(required=True)
-    automated_run_stopping_point = serializers.CharField(required=False, allow_null=True)
+class BranchOverrideSerializer(CamelSnakeSerializer):
+    tag_name = serializers.CharField(required=True)
+    tag_value = serializers.CharField(required=True)
+    branch_name = serializers.CharField(required=True)
 
-    def validate_repositories(self, value):
-        """Ensure all repositories have organization_id and integration_id set."""
-        for repo in value:
-            if not repo.get("organization_id") or not repo.get("integration_id"):
-                raise serializers.ValidationError(
-                    "All repositories must have organization_id and integration_id set"
-                )
-        return value
+
+class RepositorySerializer(CamelSnakeSerializer):
+    organization_id = serializers.IntegerField(required=True)
+    integration_id = serializers.CharField(required=True)
+    provider = serializers.CharField(required=True)
+    owner = serializers.CharField(required=True)
+    name = serializers.CharField(required=True)
+    external_id = serializers.CharField(required=True)
+    branch_name = serializers.CharField(required=False, allow_null=True)
+    branch_overrides = BranchOverrideSerializer(many=True, required=False)
+    instructions = serializers.CharField(required=False, allow_null=True)
+    base_commit_sha = serializers.CharField(required=False, allow_null=True)
+    provider_raw = serializers.CharField(required=False, allow_null=True)
+
+
+class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):
+    repositories = RepositorySerializer(many=True, required=True)
+    automated_run_stopping_point = serializers.CharField(required=False, allow_null=True)
 
 
 class SeerProjectPreference(BaseModel):

--- a/src/sentry/seer/models.py
+++ b/src/sentry/seer/models.py
@@ -27,7 +27,8 @@ class SummarizeIssueResponse(BaseModel):
 
 
 class SeerRepoDefinition(BaseModel):
-    integration_id: str | None = None  # TODO(jianyuan): Make this required
+    organization_id: int | None = None
+    integration_id: str | None = None
     provider: str
     owner: str
     name: str

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -28,11 +28,15 @@ class TestGetRepoFromCodeMappings(TestCase):
 
     def test_get_repos_from_project_code_mappings_with_data(self) -> None:
         project = self.create_project()
-        repo = self.create_repo(name="getsentry/sentry", provider="github", external_id="123")
+        repo = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
         self.create_code_mapping(project=project, repo=repo)
         repos = get_autofix_repos_from_project_code_mappings(project)
         expected_repos = [
             {
+                "integration_id": str(repo.integration_id),
+                "organization_id": project.organization.id,
                 "provider": repo.provider,
                 "owner": "getsentry",
                 "name": "sentry",

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -135,6 +135,8 @@ class BaseOrganizationCodingAgentsTest(APITestCase):
         if repos is None:
             repos = [
                 SeerRepoDefinition(
+                    organization_id=self.organization.id,
+                    integration_id=str(self.integration.id),
                     owner="test",
                     name="repo",
                     external_id="123",
@@ -702,12 +704,16 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
 
         multi_repo_list = [
             SeerRepoDefinition(
+                organization_id=self.organization.id,
+                integration_id=str(self.integration.id),
                 owner="owner1",
                 name="repo1",
                 external_id="123",
                 provider="github",
             ),
             SeerRepoDefinition(
+                organization_id=self.organization.id,
+                integration_id=str(self.integration.id),
                 owner="owner2",
                 name="repo2",
                 external_id="456",
@@ -779,12 +785,16 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
 
         multi_repo_list = [
             SeerRepoDefinition(
+                organization_id=self.organization.id,
+                integration_id=str(self.integration.id),
                 owner="owner1",
                 name="repo1",
                 external_id="123",
                 provider="github",
             ),
             SeerRepoDefinition(
+                organization_id=self.organization.id,
+                integration_id=str(self.integration.id),
                 owner="owner2",
                 name="repo2",
                 external_id="456",
@@ -848,8 +858,22 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
 
         # Create multi-repo autofix state
         multi_repo_list = [
-            SeerRepoDefinition(owner="owner1", name="repo1", external_id="123", provider="github"),
-            SeerRepoDefinition(owner="owner2", name="repo2", external_id="456", provider="github"),
+            SeerRepoDefinition(
+                organization_id=self.organization.id,
+                integration_id=str(self.integration.id),
+                owner="owner1",
+                name="repo1",
+                external_id="123",
+                provider="github",
+            ),
+            SeerRepoDefinition(
+                organization_id=self.organization.id,
+                integration_id=str(self.integration.id),
+                owner="owner2",
+                name="repo2",
+                external_id="456",
+                provider="github",
+            ),
         ]
         mock_autofix_state = self._create_mock_autofix_state(repos=multi_repo_list)
         mock_autofix_state.steps = [
@@ -988,10 +1012,20 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         mock_autofix_state = self._create_mock_autofix_state(
             repos=[
                 SeerRepoDefinition(
-                    owner="owner1", name="repo1", external_id="123", provider="github"
+                    organization_id=self.organization.id,
+                    integration_id=str(self.integration.id),
+                    owner="owner1",
+                    name="repo1",
+                    external_id="123",
+                    provider="github",
                 ),
                 SeerRepoDefinition(
-                    owner="owner2", name="repo2", external_id="456", provider="github"
+                    organization_id=self.organization.id,
+                    integration_id=str(self.integration.id),
+                    owner="owner2",
+                    name="repo2",
+                    external_id="456",
+                    provider="github",
                 ),
             ]
         )
@@ -1053,7 +1087,12 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         mock_autofix_state = self._create_mock_autofix_state(
             repos=[
                 SeerRepoDefinition(
-                    owner="owner1", name="repo1", external_id="123", provider="github"
+                    organization_id=self.organization.id,
+                    integration_id=str(self.integration.id),
+                    owner="owner1",
+                    name="repo1",
+                    external_id="123",
+                    provider="github",
                 ),
             ]
         )

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -375,13 +375,16 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert call_kwargs["group"].id == group.id  # Check that the group object matches
 
         # Check that the repos parameter contains the expected data
-        expected_repo = {
+        expected_repo_fields = {
             "provider": "integrations:github",
             "owner": "getsentry",
             "name": "sentry",
             "external_id": "123",
         }
-        assert expected_repo in call_kwargs["repos"]
+        assert any(
+            all(repo.get(key) == value for key, value in expected_repo_fields.items())
+            for repo in call_kwargs["repos"]
+        )
 
         # Check that the instruction was passed correctly
         assert call_kwargs["instruction"] == "Yes"
@@ -527,13 +530,16 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert call_kwargs["group"].id == group.id  # Check that the group object matches
 
         # Check that the repos parameter contains the expected data
-        expected_repo = {
+        expected_repo_fields = {
             "provider": "integrations:github",
             "owner": "getsentry",
             "name": "sentry",
             "external_id": "123",
         }
-        assert expected_repo in call_kwargs["repos"]
+        assert any(
+            all(repo.get(key) == value for key, value in expected_repo_fields.items())
+            for repo in call_kwargs["repos"]
+        )
 
         # Check that the instruction was passed correctly
         assert call_kwargs["instruction"] == "Yes"
@@ -609,13 +615,16 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert call_kwargs["group"].id == group.id  # Check that the group object matches
 
         # Check that the repos parameter contains the expected data
-        expected_repo = {
+        expected_repo_fields = {
             "provider": "integrations:github",
             "owner": "getsentry",
             "name": "sentry",
             "external_id": "123",
         }
-        assert expected_repo in call_kwargs["repos"]
+        assert any(
+            all(repo.get(key) == value for key, value in expected_repo_fields.items())
+            for repo in call_kwargs["repos"]
+        )
 
         # Check that the instruction was passed correctly
         assert call_kwargs["instruction"] == "Yes"

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -100,6 +100,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         request_data = {
             "repositories": [
                 {
+                    "organization_id": self.org.id,
                     "integration_id": "111",
                     "provider": "github",
                     "owner": "getsentry",
@@ -175,7 +176,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         request_data = {
             "repositories": [
                 {
-                    # Missing required 'provider' field
+                    # Missing required 'provider' and 'integration_id' fields
                     "owner": "getsentry",
                     "name": "sentry",
                 }
@@ -185,11 +186,11 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         # Make the request
         response = self.client.post(self.url, data=request_data)
 
-        # Should fail with a 500 error according to actual behavior
-        assert response.status_code == 500
+        # Should fail with a 400 error for invalid request data
+        assert response.status_code == 400
 
-        # We don't assert mock_post.assert_not_called() here since the error happens
-        # during validation which triggers a 500 error rather than a 400
+        # The post to Seer should not be called since validation fails
+        mock_post.assert_not_called()
 
     @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
     def test_api_error_status_code(self, mock_post: MagicMock) -> None:


### PR DESCRIPTION
adds a request serializer for the seer preferences POST endpoint to ensure all repos that get sent through there have these values set

we've merged #101860 first, which will ensure we always send these fields in the POST.

also fixes a bug when we use repos from code mappings & don't send it