### PR TITLE
fix(aci): filter out non-alertable and broken sentry apps in available actions endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/action_handler_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_handler_serializer.py
@@ -73,10 +73,11 @@ class ActionHandlerSerializer(Serializer):
                 "installationId": str(installation.id),
                 "installationUuid": str(installation.uuid),
                 "status": installation.sentry_app.status,
-                "settings": component.app_schema.get("settings", {}) if component else None,
             }
-            if component.app_schema.get("title"):
-                sentry_app["title"] = component.app_schema.get("title")
+            if component:
+                sentry_app["settings"] = component.app_schema.get("settings", {})
+                if component.app_schema.get("title"):
+                    sentry_app["title"] = component.app_schema.get("title")
             result["sentryApp"] = sentry_app
 
         services = kwargs.get("services")

--- a/src/sentry/workflow_engine/endpoints/serializers/action_handler_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_handler_serializer.py
@@ -3,7 +3,6 @@ from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.rules.actions.notify_event_service import PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS
-from sentry.sentry_apps.models.sentry_app_installation import prepare_ui_component
 from sentry.workflow_engine.types import ActionHandler
 
 
@@ -74,18 +73,10 @@ class ActionHandlerSerializer(Serializer):
                 "installationId": str(installation.id),
                 "installationUuid": str(installation.uuid),
                 "status": installation.sentry_app.status,
+                "settings": component.app_schema.get("settings", {}) if component else None,
             }
-            if component:
-                prepared_component = prepare_ui_component(
-                    installation=installation,
-                    component=component,
-                    project_slug=None,
-                    values=None,
-                )
-                if prepared_component:
-                    sentry_app["settings"] = prepared_component.app_schema.get("settings", {})
-                    if prepared_component.app_schema.get("title"):
-                        sentry_app["title"] = prepared_component.app_schema.get("title")
+            if component.app_schema.get("title"):
+                sentry_app["title"] = component.app_schema.get("title")
             result["sentryApp"] = sentry_app
 
         services = kwargs.get("services")


### PR DESCRIPTION
fixes 2 bugs that were causing the available actions endpoint to return more results than expected:
- we weren't filtering all sentry apps by `is_alertable`, causing the webhook action to return extra SentryAppServices that are not alertable
- we weren't calling `prepare_ui_component` on the sentry app components, causing us to return broken sentry apps that fail component preparation (see below) https://github.com/getsentry/sentry/blob/da98041d2de6f134a8ebd92c7f39306aab0ac7cd/src/sentry/sentry_apps/models/sentry_app_installation.py#L255-L256