### PR TITLE
chore(preprod): Add better UX for admins trying to download builds

### DIFF
--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -95,6 +95,16 @@ export function useBuildDetailsActions({
           if (errorJson.detail) {
             if (typeof errorJson.detail === 'string') {
               errorMessage = errorJson.detail;
+            } else if (errorJson.detail.code === 'staff-required') {
+              addErrorMessage(
+                t(
+                  'Re-authenticate as staff first and then return to this page and try again. Redirecting...'
+                )
+              );
+              setTimeout(() => {
+                window.location.href = 'https://sentry.sentry.io/_admin/';
+              }, 2000);
+              return;
             } else if (errorJson.detail.message) {
               errorMessage = errorJson.detail.message;
             } else if (errorJson.detail.code) {

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -102,7 +102,7 @@ export function useBuildDetailsActions({
                 )
               );
               setTimeout(() => {
-                window.location.href = 'https://sentry.sentry.io/_admin/';
+                window.location.href = '/_admin/';
               }, 2000);
               return;
             } else if (errorJson.detail.message) {


### PR DESCRIPTION
Closes EME-439

Before you'd just get this cryptic "You need to re-authenticate for staff" message but it wasn't clear what you needed to do. Now the messaging is more clear and will even do the redirect for you