### PR TITLE
feat(trace-tree-node): BaseNode implementation changes to achieve feature parity

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/collapsedNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/collapsedNode.tsx
@@ -2,7 +2,6 @@ import {uuid4} from '@sentry/core';
 
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceCollapsedRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceCollapsedRow';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
@@ -45,10 +44,10 @@ export class CollapsedNode extends BaseNode<TraceTree.CollapsedNode> {
   renderWaterfallRow<NodeType extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<NodeType>
   ): React.ReactNode {
-    return <TraceCollapsedRow {...props} node={props.node} />;
+    return <TraceCollapsedRow {...props} node={this} />;
   }
 
-  renderDetails<NodeType extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<NodeType extends BaseNode>(
     _props: TraceTreeNodeDetailsProps<NodeType>
   ): React.ReactNode {
     return null;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/errorNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/errorNode.tsx
@@ -8,7 +8,6 @@ import {
   isTraceError,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceErrorRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceErrorRow';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
@@ -42,6 +41,10 @@ export class ErrorNode extends BaseNode<TraceTree.TraceErrorIssue> {
     this.parent?.children.push(this);
   }
 
+  get startTimestamp(): number {
+    return this.space[0];
+  }
+
   get description(): string | undefined {
     return isTraceError(this.value)
       ? this.value.title || this.value.message
@@ -73,22 +76,13 @@ export class ErrorNode extends BaseNode<TraceTree.TraceErrorIssue> {
   renderWaterfallRow<NodeType extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<NodeType>
   ): React.ReactNode {
-    return <TraceErrorRow {...props} node={props.node} />;
+    return <TraceErrorRow {...props} node={this} />;
   }
 
-  renderDetails<T extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<T extends BaseNode>(
     props: TraceTreeNodeDetailsProps<T>
   ): React.ReactNode {
-    return (
-      <ErrorNodeDetails
-        {...props}
-        node={
-          props.node as
-            | TraceTreeNode<TraceTree.TraceError>
-            | TraceTreeNode<TraceTree.EAPError>
-        }
-      />
-    );
+    return <ErrorNodeDetails {...props} node={this} />;
   }
 
   matchWithFreeText(query: string): boolean {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/noInstrumentationNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/noInstrumentationNode.tsx
@@ -4,9 +4,7 @@ import {uuid4} from '@sentry/core';
 import {t} from 'sentry/locale';
 import {MissingInstrumentationNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
-import type {MissingInstrumentationNode} from 'sentry/views/performance/newTraceDetails/traceModels/missingInstrumentationNode';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceMissingInstrumentationRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceMissingInstrumentationRow';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
@@ -66,19 +64,14 @@ export class NoInstrumentationNode extends BaseNode<TraceTree.MissingInstrumenta
   renderWaterfallRow<NodeType extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<NodeType>
   ): React.ReactNode {
-    return <TraceMissingInstrumentationRow {...props} node={props.node} />;
+    return <TraceMissingInstrumentationRow {...props} node={this} />;
   }
 
-  renderDetails<NodeType extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<NodeType extends BaseNode>(
     props: TraceTreeNodeDetailsProps<NodeType>
   ): React.ReactNode {
     // Won't need this cast once we use BaseNode type for props.node
-    return (
-      <MissingInstrumentationNodeDetails
-        {...props}
-        node={props.node as unknown as MissingInstrumentationNode}
-      />
-    );
+    return <MissingInstrumentationNodeDetails {...props} node={this} />;
   }
 
   matchById(id: string): boolean {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/noInstrumentationNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/noInstrumentationNode.tsx
@@ -70,7 +70,6 @@ export class NoInstrumentationNode extends BaseNode<TraceTree.MissingInstrumenta
   renderDetails<NodeType extends BaseNode>(
     props: TraceTreeNodeDetailsProps<NodeType>
   ): React.ReactNode {
-    // Won't need this cast once we use BaseNode type for props.node
     return <MissingInstrumentationNodeDetails {...props} node={this} />;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.tsx
@@ -3,9 +3,7 @@ import type {Theme} from '@emotion/react';
 import {t} from 'sentry/locale';
 import {AutogroupNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/autogroup';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
-import type {ParentAutogroupNode as LegacyParentAutogroupNode} from 'sentry/views/performance/newTraceDetails/traceModels/parentAutogroupNode';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceAutogroupedRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceAutogroupedRow';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
@@ -75,18 +73,13 @@ export class ParentAutogroupNode extends BaseNode<TraceTree.ChildrenAutogroup> {
   renderWaterfallRow<NodeType extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<NodeType>
   ): React.ReactNode {
-    return <TraceAutogroupedRow {...props} node={props.node} />;
+    return <TraceAutogroupedRow {...props} node={this} />;
   }
 
-  renderDetails<NodeType extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<NodeType extends BaseNode>(
     props: TraceTreeNodeDetailsProps<NodeType>
   ): React.ReactNode {
-    return (
-      <AutogroupNodeDetails
-        {...props}
-        node={props.node as unknown as LegacyParentAutogroupNode}
-      />
-    );
+    return <AutogroupNodeDetails {...props} node={this} />;
   }
 
   matchWithFreeText(query: string): boolean {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/rootNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/rootNode.tsx
@@ -3,7 +3,6 @@ import {uuid4} from '@sentry/core';
 import {t} from 'sentry/locale';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
 import {BaseNode} from './baseNode';
@@ -36,7 +35,7 @@ export class RootNode extends BaseNode<null> {
     return null;
   }
 
-  renderDetails<T extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<T extends BaseNode>(
     _props: TraceTreeNodeDetailsProps<T>
   ): React.ReactNode {
     return null;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/siblingAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/siblingAutogroupNode.tsx
@@ -5,7 +5,6 @@ import {t} from 'sentry/locale';
 import {AutogroupNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/autogroup';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceAutogroupedRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceAutogroupedRow';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
@@ -75,13 +74,13 @@ export class SiblingAutogroupNode extends BaseNode<TraceTree.SiblingAutogroup> {
   renderWaterfallRow<NodeType extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<NodeType>
   ): React.ReactNode {
-    return <TraceAutogroupedRow {...props} node={props.node} />;
+    return <TraceAutogroupedRow {...props} node={this} />;
   }
 
-  renderDetails<NodeType extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<NodeType extends BaseNode>(
     props: TraceTreeNodeDetailsProps<NodeType>
   ): React.ReactNode {
-    return <AutogroupNodeDetails {...props} node={props.node} />;
+    return <AutogroupNodeDetails {...props} node={this} />;
   }
 
   matchById(_id: string): boolean {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
@@ -44,16 +44,8 @@ export class SpanNode extends BaseNode<TraceTree.Span> {
     );
   }
 
-  get description(): string | undefined {
-    return this.value.description;
-  }
-
   get endTimestamp(): number {
     return this.value.timestamp;
-  }
-
-  get startTimestamp(): number {
-    return this.value.start_timestamp;
   }
 
   get drawerTabsTitle(): string {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
@@ -6,7 +6,6 @@ import type {EventTransaction} from 'sentry/types/event';
 import {SpanNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 import {TraceSpanRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceSpanRow';
 
@@ -72,6 +71,12 @@ export class SpanNode extends BaseNode<TraceTree.Span> {
     return this.event?.sdk?.name ?? undefined;
   }
 
+  get projectSlug(): string {
+    // The span value does not have a project slug, so we need to find a parent that has one.
+    // If we don't find one, we return the default project slug.
+    return this.findParent(p => !!p.projectSlug)?.projectSlug ?? 'default';
+  }
+
   makeBarColor(theme: Theme): string {
     return pickBarColor(this.op, theme);
   }
@@ -94,15 +99,13 @@ export class SpanNode extends BaseNode<TraceTree.Span> {
   renderWaterfallRow<T extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<T>
   ): React.ReactNode {
-    return <TraceSpanRow {...props} node={props.node} />;
+    return <TraceSpanRow {...props} node={this} />;
   }
 
-  renderDetails<T extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<T extends BaseNode>(
     props: TraceTreeNodeDetailsProps<T>
   ): React.ReactNode {
-    return (
-      <SpanNodeDetails {...props} node={props.node as TraceTreeNode<TraceTree.Span>} />
-    );
+    return <SpanNodeDetails {...props} node={this} />;
   }
 
   matchWithFreeText(query: string): boolean {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/traceNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/traceNode.tsx
@@ -1,7 +1,6 @@
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import {isTraceSplitResult} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {TraceRootRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceRootNode';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
@@ -53,10 +52,10 @@ export class TraceNode extends BaseNode<TraceTree.Trace> {
   renderWaterfallRow<T extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<T>
   ): React.ReactNode {
-    return <TraceRootRow {...props} node={props.node} />;
+    return <TraceRootRow {...props} node={this} />;
   }
 
-  renderDetails<T extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<T extends BaseNode>(
     _props: TraceTreeNodeDetailsProps<T>
   ): React.ReactNode {
     return null;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
@@ -233,9 +233,7 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
    * Returns the bounds of the added subtree as [start, end] timestamps.
    */
   appendSpans(spans: TraceTree.Span[], event: EventTransaction | null): [number, number] {
-    const txnChildren = this.findAllChildren(c =>
-      isTransactionNode(c)
-    ) as TransactionNode[];
+    const txnChildren = this.findAllChildren(c => isTransactionNode(c));
 
     // Clear children of root node as we are recreating the sub tree
     this.children = [];
@@ -287,7 +285,7 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
 
     // Reparent transactions under children spans
     for (const transaction of txnChildren) {
-      const parent = spanIdToNode.get(transaction.value.parent_span_id!);
+      const parent = spanIdToNode.get(transaction.value.parent_span_id);
       // If the parent span does not exist in the span tree, the transaction will remain under the current node
       if (!parent) {
         if (transaction.parent?.children.indexOf(transaction) === -1) {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
@@ -307,13 +307,11 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
 
       parent.children.push(transaction);
       transaction.parent = parent;
-
-      // Invalidating the node and its children to ensure the tree is rebuilt correctly,
-      // after we have potentially done some re-parenting.
-      this.invalidate();
-      this.forEachChild(child => child.invalidate());
     }
 
+    // Invalidating the node and its children to ensure the tree is rebuilt correctly,
+    // after we have potentially done some re-parenting.
+    this.invalidate();
     this.children.sort(traceChronologicalSort);
     this.forEachChild(c => {
       c.invalidate();

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
@@ -200,13 +200,7 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
   renderDetails<T extends BaseNode>(
     props: TraceTreeNodeDetailsProps<T>
   ): React.ReactNode {
-    return (
-      <TransactionNodeDetails
-        {...props}
-        // Won't need this cast once we use BaseNode type for props.node
-        node={this}
-      />
-    );
+    return <TransactionNodeDetails {...props} node={this} />;
   }
 
   printNode(): string {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode.tsx
@@ -6,7 +6,6 @@ import {uniqueId} from 'sentry/utils/guid';
 import {UptimeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptime';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 import {TraceSpanRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceSpanRow';
 
@@ -141,18 +140,13 @@ export class UptimeCheckNode extends BaseNode<TraceTree.UptimeCheck> {
   renderWaterfallRow<NodeType extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<NodeType>
   ): React.ReactNode {
-    return <TraceSpanRow {...props} node={props.node} />;
+    return <TraceSpanRow {...props} node={this} />;
   }
 
-  renderDetails<NodeType extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<NodeType extends BaseNode>(
     props: TraceTreeNodeDetailsProps<NodeType>
   ): React.ReactNode {
-    return (
-      <UptimeNodeDetails
-        {...props}
-        node={props.node as TraceTreeNode<TraceTree.UptimeCheck>}
-      />
-    );
+    return <UptimeNodeDetails {...props} node={this} />;
   }
 
   matchWithFreeText(query: string): boolean {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckTimingNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckTimingNode.tsx
@@ -4,7 +4,6 @@ import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {UptimeTimingDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptime/timing';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 import {TraceSpanRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceSpanRow';
 
@@ -37,12 +36,12 @@ export class UptimeCheckTimingNode extends BaseNode<TraceTree.UptimeCheckTiming>
       <TraceSpanRow
         {...props}
         // Won't need this cast once we use BaseNode type for props.node
-        node={this as unknown as TraceTreeNode<TraceTree.UptimeCheckTiming>}
+        node={this}
       />
     );
   }
 
-  renderDetails<NodeType extends TraceTreeNode<TraceTree.NodeValue>>(
+  renderDetails<NodeType extends BaseNode>(
     props: TraceTreeNodeDetailsProps<NodeType>
   ): React.ReactNode {
     return <UptimeTimingDetails {...props} node={this} />;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckTimingNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckTimingNode.tsx
@@ -32,13 +32,7 @@ export class UptimeCheckTimingNode extends BaseNode<TraceTree.UptimeCheckTiming>
   renderWaterfallRow<NodeType extends TraceTree.Node = TraceTree.Node>(
     props: TraceRowProps<NodeType>
   ): React.ReactNode {
-    return (
-      <TraceSpanRow
-        {...props}
-        // Won't need this cast once we use BaseNode type for props.node
-        node={this}
-      />
-    );
+    return <TraceSpanRow {...props} node={this} />;
   }
 
   renderDetails<NodeType extends BaseNode>(


### PR DESCRIPTION
- This PR includes the changes required in BaseNode and it's subclasses to achieve feature parity as we replace `TraceTreeNode` with `BaseNode` in the stacked PR: https://github.com/getsentry/sentry/pull/101874

- Added tests for new BaseNode methods

- Got rid of all typescript errors form BaseNode and its subclasses

- Added in line PR comments for blocks that aren't trivial
