### PR TITLE
feat(dashboards): render dashboards link if available

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -55,6 +55,8 @@ import toPercent from 'sentry/utils/number/toPercent';
 import Projects from 'sentry/utils/projects';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {isUrl} from 'sentry/utils/string/isUrl';
+import {hasDrillDownFlowsFeature} from 'sentry/views/dashboards/hooks/useHasDrillDownFlows';
+import type {LinkedDashboard} from 'sentry/views/dashboards/types';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
 import type {TraceItemDetailsMeta} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -1326,6 +1328,16 @@ const StyledTooltip = styled(Tooltip)`
   ${p => p.theme.overflowEllipsis}
 `;
 
+export function getFieldRenderer(
+  field: string,
+  meta: MetaType,
+  isAlias = true,
+  dashboardLink: LinkedDashboard | undefined = undefined
+): FieldFormatterRenderFunctionPartial {
+  const baseRenderer = getFieldRendererBase(field, meta, isAlias);
+  return wrapFieldRendererInDashboardLink(baseRenderer, dashboardLink);
+}
+
 /**
  * Get the field renderer for the named field and metadata
  *
@@ -1334,7 +1346,7 @@ const StyledTooltip = styled(Tooltip)`
  * @param {boolean} isAlias convert the name with getAggregateAlias
  * @returns {Function}
  */
-export function getFieldRenderer(
+function getFieldRendererBase(
   field: string,
   meta: MetaType,
   isAlias = true
@@ -1363,4 +1375,19 @@ export function getFieldRenderer(
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);
   }
   return partial(FIELD_FORMATTERS.string.renderFunc, fieldName);
+}
+
+function wrapFieldRendererInDashboardLink(
+  renderer: FieldFormatterRenderFunctionPartial,
+  dashboardLink: LinkedDashboard | undefined
+): FieldFormatterRenderFunctionPartial {
+  return function (data, baggage) {
+    const {organization} = baggage;
+    if (hasDrillDownFlowsFeature(organization) && dashboardLink) {
+      // TODO: Add filters from the current dashboard to the url
+      const dashboardUrl = `/organizations/${organization.slug}/dashboard/${dashboardLink.dashboardId}/`;
+      return <Link to={dashboardUrl}>{renderer(data, baggage)}</Link>;
+    }
+    return renderer(data, baggage);
+  };
 }

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1377,6 +1377,7 @@ function getFieldRendererBase(
   return partial(FIELD_FORMATTERS.string.renderFunc, fieldName);
 }
 
+// TODO: Need to handle cases where a field already has a link in it's renderer
 function wrapFieldRendererInDashboardLink(
   renderer: FieldFormatterRenderFunctionPartial,
   dashboardLink: LinkedDashboard | undefined

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -231,7 +231,12 @@ export const SpansConfig: DatasetConfig<
     if (field === 'trace') {
       return renderTraceAsLinkable(widget);
     }
-    return getFieldRenderer(field, meta, false);
+    // Dashboard links are applicable to tables, which should only have one query hence the `queries[0]`
+    const dashboardLink = widget?.queries[0]?.linkedDashboards?.find(
+      linkedDashboard => linkedDashboard.field === field
+    );
+
+    return getFieldRenderer(field, meta, false, dashboardLink);
   },
 };
 

--- a/static/app/views/dashboards/hooks/useHasDrillDownFlows.tsx
+++ b/static/app/views/dashboards/hooks/useHasDrillDownFlows.tsx
@@ -1,6 +1,11 @@
+import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export function useHasDrillDownFlows() {
   const organization = useOrganization();
+  return hasDrillDownFlowsFeature(organization);
+}
+
+export function hasDrillDownFlowsFeature(organization: Organization) {
   return organization.features.includes('dashboards-drilldown-flow');
 }


### PR DESCRIPTION
If a dashboard link is available and the drill down flow flag is available for a field it will be rendered and accessible view `open link`
<img width="345" height="322" alt="image" src="https://github.com/user-attachments/assets/86fdbcb1-ad66-44e0-990d-d71888f3bd89" />
This is only done in the spans dataset config for now, we can expand to more datasets as we go. In a future PR i'll also ensure dashboard filters are applied