### PR TITLE
fix(eco): Updates GH routing to work based on event type rather than property values

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -24,6 +24,7 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.identity.services.identity.service import identity_service
 from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.pipeline import ensure_integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
@@ -676,10 +677,10 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
     }
 
     _handlers: dict[str, type[GitHubWebhook]] = {
-        "push": PushEventWebhook,
-        "pull_request": PullRequestEventWebhook,
-        "installation": InstallationEventWebhook,
-        "issues": IssuesEventWebhook,
+        GithubWebhookType.PUSH: PushEventWebhook,
+        GithubWebhookType.PULL_REQUEST: PullRequestEventWebhook,
+        GithubWebhookType.INSTALLATION: InstallationEventWebhook,
+        GithubWebhookType.ISSUE: IssuesEventWebhook,
     }
 
     def get_handler(self, event_type: str) -> type[GitHubWebhook] | None:

--- a/src/sentry/integrations/github/webhook_types.py
+++ b/src/sentry/integrations/github/webhook_types.py
@@ -1,0 +1,10 @@
+from enum import StrEnum
+
+GITHUB_WEBHOOK_TYPE_HEADER = "HTTP_X_GITHUB_EVENT"
+
+
+class GithubWebhookType(StrEnum):
+    INSTALLATION = "installation"
+    ISSUE = "issues"
+    PULL_REQUEST = "pull_request"
+    PUSH = "push"

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import orjson
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 
 import sentry.options as options
@@ -14,6 +14,7 @@ from sentry.integrations.github.webhook import (
     GitHubIntegrationsWebhookEndpoint,
     get_github_external_id,
 )
+from sentry.integrations.github.webhook_types import GITHUB_WEBHOOK_TYPE_HEADER, GithubWebhookType
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.types import IntegrationProviderSlug
@@ -32,6 +33,18 @@ class GithubRequestParser(BaseRequestParser):
     def _get_external_id(self, event: Mapping[str, Any]) -> str | None:
         """Overridden in GithubEnterpriseRequestParser"""
         return get_github_external_id(event)
+
+    def should_route_to_control_silo(
+        self, parsed_event: Mapping[str, Any], request: HttpRequest
+    ) -> bool:
+        if options.get("github.webhook-type-routing.enabled"):
+            return request.META.get(GITHUB_WEBHOOK_TYPE_HEADER) == GithubWebhookType.INSTALLATION
+
+        return (
+            parsed_event.get("installation")
+            and not parsed_event.get("issue")
+            and parsed_event.get("action") in {"created", "deleted"}
+        )
 
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:
@@ -61,11 +74,7 @@ class GithubRequestParser(BaseRequestParser):
         except orjson.JSONDecodeError:
             return HttpResponse(status=400)
 
-        if (
-            event.get("installation")
-            and not event.get("issue")
-            and event.get("action") in {"created", "deleted"}
-        ):
+        if self.should_route_to_control_silo(parsed_event=event, request=self.request):
             self.try_forward_to_codecov(event=event)
             return self.get_response_from_control_silo()
 

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -40,7 +40,7 @@ class GithubRequestParser(BaseRequestParser):
         if options.get("github.webhook-type-routing.enabled"):
             return request.META.get(GITHUB_WEBHOOK_TYPE_HEADER) == GithubWebhookType.INSTALLATION
 
-        return (
+        return bool(
             parsed_event.get("installation")
             and not parsed_event.get("issue")
             and parsed_event.get("action") in {"created", "deleted"}

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3603,3 +3603,11 @@ register(
     },
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Enables or disables Github webhook routing based on the type of webhook
+register(
+    "github.webhook-type-routing.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -8,6 +8,7 @@ from rest_framework import status
 
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.hybridcloud.models.webhookpayload import DestinationType
+from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.middleware.integrations.parsers.github import GithubRequestParser
@@ -49,7 +50,7 @@ class GithubRequestParserTest(TestCase):
             self.path,
             data=b"invalid-data",
             content_type="application/x-www-form-urlencoded",
-            headers={"X-GITHUB-EVENT": "installation"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
         response = parser.get_response()
@@ -68,7 +69,7 @@ class GithubRequestParserTest(TestCase):
             self.path,
             data={"installation": {"id": "1"}},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "issue"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.ISSUE.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -87,7 +88,7 @@ class GithubRequestParserTest(TestCase):
             self.path,
             data={},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "issue"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.ISSUE.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -112,7 +113,7 @@ class GithubRequestParserTest(TestCase):
             path,
             data={"installation": {"id": "1"}},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "installation"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -130,7 +131,7 @@ class GithubRequestParserTest(TestCase):
             self.path,
             data={"installation": {"id": "1"}},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "installation"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
         result = parser.get_integration_from_request()
@@ -144,7 +145,7 @@ class GithubRequestParserTest(TestCase):
             self.path,
             data={"installation": {"id": "1"}},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "issue"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.ISSUE.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -169,7 +170,7 @@ class GithubRequestParserTest(TestCase):
             self.path,
             data={"installation": {"id": "1"}},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "push"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -201,7 +202,7 @@ class GithubRequestParserTest(TestCase):
             self.path,
             data={"installation": {"id": "1"}},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "push"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -235,7 +236,7 @@ class GithubRequestParserTest(TestCase):
             reverse("sentry-integration-github-webhook"),
             data={"installation": {"id": "1"}, "action": "created"},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "installation"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -251,7 +252,7 @@ class GithubRequestParserTest(TestCase):
             reverse("sentry-integration-github-webhook"),
             data={"installation": {"id": "1"}, "action": "deleted"},
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "installation"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
@@ -276,7 +277,7 @@ class GithubRequestParserTest(TestCase):
                 "repository": {"id": "1"},
             },
             content_type="application/json",
-            headers={"X-GITHUB-EVENT": "issue"},
+            headers={"X-GITHUB-EVENT": GithubWebhookType.ISSUE.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 


### PR DESCRIPTION
This PR refactors the fix in #101810, which redirects issue webhooks to regions rather than Control Silo.

The previous fix was fragile, assuming that the existence of an `issue` property means a webhook should be routed to regions. Instead, this change uses the `X-Github-Event` header passed to us by Github to differentiate based on _domain_ rather than payload structure.


