### PR TITLE
fix(explorer): Fix repo definition RPC

### DIFF
--- a/src/sentry/seer/constants.py
+++ b/src/sentry/seer/constants.py
@@ -1,0 +1,13 @@
+"""
+Constants shared across Seer modules.
+"""
+
+from sentry.integrations.types import IntegrationProviderSlug
+
+# Supported repository providers for Seer features
+SEER_SUPPORTED_SCM_PROVIDERS = [
+    "integrations:github",
+    "integrations:github_enterprise",
+    IntegrationProviderSlug.GITHUB.value,
+    IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+]

--- a/src/sentry/seer/constants.py
+++ b/src/sentry/seer/constants.py
@@ -1,7 +1,3 @@
-"""
-Constants shared across Seer modules.
-"""
-
 from sentry.integrations.types import IntegrationProviderSlug
 
 # Supported repository providers for Seer features

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -20,6 +20,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
+from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
 from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -72,13 +73,7 @@ def get_repos_and_access(project: Project, group_id: int) -> list[dict]:
     for repo in repos:
         # We only support github and github enterprise for now.
         provider = repo.get("provider")
-        allowed_providers = [
-            "integrations:github",
-            "integrations:github_enterprise",
-            IntegrationProviderSlug.GITHUB.value,
-            IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
-        ]
-        if provider not in allowed_providers:
+        if provider not in SEER_SUPPORTED_SCM_PROVIDERS:
             continue
 
         body = orjson.dumps(


### PR DESCRIPTION
Some fixes for the query for fetching repo definitions by name:
- filter to only supported SCM providers
- if there are multiple integrations available, don't error, and just return the first one (this is rare but possible)