### PR TITLE
feat(aci): Display all ongoing issues on error monitor page

### DIFF
--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -1,280 +1,44 @@
-import {Fragment, useCallback} from 'react';
-import styled from '@emotion/styled';
-
-import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
-import {Text} from 'sentry/components/core/text';
-import {DateTime} from 'sentry/components/dateTime';
-import Duration from 'sentry/components/duration';
-import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
-import {
-  AssigneeSelector,
-  useHandleAssigneeChange,
-} from 'sentry/components/group/assigneeSelector';
-import {GroupStatusTag} from 'sentry/components/group/inboxBadges/groupStatusTag';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
-import Placeholder from 'sentry/components/placeholder';
-import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
+import GroupList from 'sentry/components/issues/groupList';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t, tn} from 'sentry/locale';
-import type {Group} from 'sentry/types/group';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
+import {getUtcDateString} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  buildDetectorZoomQuery,
-  computeZoomRangeMs,
-} from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
-import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
-import {useGroup} from 'sentry/views/issueDetails/useGroup';
+import usePageFilters from 'sentry/utils/usePageFilters';
 
-interface OpenPeriodsSubTableProps {
-  groupId: string;
-  onZoom: (start: Date, end?: Date) => void;
-}
-
-function OpenPeriodsSubTable({groupId, onZoom}: OpenPeriodsSubTableProps) {
-  const location = useLocation();
-  const start = location.query?.start as string | undefined;
-  const end = location.query?.end as string | undefined;
-  const statsPeriod = location.query?.statsPeriod as string | undefined;
-  const dateParams = {start, end, statsPeriod};
-  const {
-    data: openPeriods,
-    isPending: isOpenPeriodsPending,
-    isError: isOpenPeriodsError,
-  } = useOpenPeriods({groupId, ...dateParams});
-
-  if (isOpenPeriodsPending) {
-    return <OpenPeriodsSubTableSkeleton />;
-  }
-
-  if (isOpenPeriodsError) {
-    return (
-      <SubTable>
-        <SmallEmptyState>{t('Failed to load open periods.')}</SmallEmptyState>
-      </SubTable>
-    );
-  }
-
-  if (!openPeriods?.length) {
-    return (
-      <SubTable>
-        <SmallEmptyState>
-          {t('No open periods within current date range.')}
-        </SmallEmptyState>
-      </SubTable>
-    );
-  }
-
-  return (
-    <SubTable>
-      {openPeriods.map((period, idx) => {
-        const openPeriodStart = new Date(period.start);
-        const openPeriodEnd = period.end ? new Date(period.end) : undefined;
-        const diffMs =
-          (openPeriodEnd ?? new Date()).getTime() - openPeriodStart.getTime();
-        const seconds = diffMs / 1000;
-        return (
-          <SimpleTable.Row key={`${period.start}-${idx}`}>
-            <SimpleTable.RowCell>
-              {/* TODO: Status Color */}
-              <Text tabular>#{period.id}</Text>
-            </SimpleTable.RowCell>
-            <SimpleTable.RowCell>
-              <Text>
-                {t('Started')} <DateTime date={openPeriodStart} />
-              </Text>
-            </SimpleTable.RowCell>
-            <SimpleTable.RowCell>
-              <Text>
-                {openPeriodEnd ? (
-                  <Fragment>
-                    {t('Ended')} {openPeriodEnd ? <DateTime date={openPeriodEnd} /> : '—'}
-                  </Fragment>
-                ) : (
-                  t('Ongoing')
-                )}
-              </Text>
-            </SimpleTable.RowCell>
-            <SimpleTable.RowCell>
-              <Duration seconds={seconds} abbreviation />
-            </SimpleTable.RowCell>
-            <SimpleTable.RowCell justify="flex-end">
-              <Button size="xs" onClick={() => onZoom(openPeriodStart, openPeriodEnd)}>
-                {t('Zoom')}
-              </Button>
-            </SimpleTable.RowCell>
-          </SimpleTable.Row>
-        );
-      })}
-    </SubTable>
-  );
-}
-
-function OpenPeriodsSubTableSkeleton() {
-  return (
-    <SubTable>
-      {[0, 1, 2].map(i => (
-        <SimpleTable.Row key={i}>
-          <SimpleTable.RowCell>
-            <Placeholder height="20px" width="24px" />
-          </SimpleTable.RowCell>
-          <SimpleTable.RowCell>
-            <Placeholder height="20px" width="60%" />
-          </SimpleTable.RowCell>
-          <SimpleTable.RowCell>
-            <Placeholder height="20px" width="40%" />
-          </SimpleTable.RowCell>
-          <SimpleTable.RowCell>
-            <Placeholder height="20px" width="50%" />
-          </SimpleTable.RowCell>
-          <SimpleTable.RowCell justify="flex-end">
-            <Placeholder height="24px" width="48px" />
-          </SimpleTable.RowCell>
-        </SimpleTable.Row>
-      ))}
-    </SubTable>
-  );
-}
-
-function LatestGroupWithOpenPeriods({
-  groupId,
-  intervalSeconds,
-}: {
+type DetectorDetailsOngoingIssuesProps = {
   detector: Detector;
-  groupId: string;
-  intervalSeconds?: number;
-}) {
-  const {data: group, isPending, isError} = useGroup({groupId});
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const zoomToRange = useCallback(
-    (start: Date, end?: Date) => {
-      const startMs = start.getTime();
-      const endMs = (end ?? new Date()).getTime();
-      const {start: zoomStart, end: zoomEnd} = computeZoomRangeMs({
-        startMs,
-        endMs,
-        intervalSeconds,
-      });
-      navigate({
-        pathname: location.pathname,
-        query: buildDetectorZoomQuery(location.query, zoomStart, zoomEnd),
-      });
-    },
-    [location.pathname, location.query, navigate, intervalSeconds]
-  );
-
-  if (isPending) {
-    return <LoadingIndicator />;
-  }
-
-  if (!group || isError) {
-    return (
-      <SimpleTable>
-        <SimpleTable.Empty>
-          <EmptyStateWarning small>
-            {t('Failed to load the latest issue')}
-          </EmptyStateWarning>
-        </SimpleTable.Empty>
-      </SimpleTable>
-    );
-  }
-
-  return (
-    <StyledTable>
-      <SimpleTable.Header>
-        <SimpleTable.HeaderCell>{t('Issue')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Last Seen')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>{t('Assignee')}</SimpleTable.HeaderCell>
-      </SimpleTable.Header>
-
-      <SimpleTable.Row>
-        <EventOrGroupCell>
-          <EventOrGroupHeader data={group} />
-        </EventOrGroupCell>
-        <SimpleTable.RowCell>
-          <GroupStatusTag fontSize="md">{group.substatus ?? group.status}</GroupStatusTag>
-        </SimpleTable.RowCell>
-        <SimpleTable.RowCell>
-          <TimeAgoCell date={group.lastSeen} />
-        </SimpleTable.RowCell>
-        <SimpleTable.RowCell>
-          <IssueAssigneeSelector group={group} />
-        </SimpleTable.RowCell>
-      </SimpleTable.Row>
-
-      <SimpleTable.Row>
-        <div style={{gridColumn: '1 / -1', paddingTop: 0}}>
-          <OpenPeriodsSubTable groupId={group.id} onZoom={zoomToRange} />
-        </div>
-      </SimpleTable.Row>
-    </StyledTable>
-  );
-}
-
-function IssueAssigneeSelector({group}: {group: Group}) {
-  const organization = useOrganization();
-  const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
-    organization,
-    group,
-  });
-
-  return (
-    <AssigneeSelector
-      group={group}
-      assigneeLoading={assigneeLoading}
-      handleAssigneeChange={handleAssigneeChange}
-      showLabel
-    />
-  );
-}
-
-interface OngoingIssueProps {
-  detector: Detector;
-  /**
-   * Helps the zoom function add padding on left and right of the open period.
-   * If intervalSeconds is 24 hours, we would want a lot more padding than if it's 1 minute.
-   */
-  intervalSeconds?: number;
-}
+};
 
 export function DetectorDetailsOngoingIssues({
   detector,
-  intervalSeconds,
-}: OngoingIssueProps) {
+}: DetectorDetailsOngoingIssuesProps) {
   const organization = useOrganization();
-  const location = useLocation();
-  // TODO: We'll probably need to make a query to get all linked issues
-  const latestGroupId = detector.latestGroup?.id;
-  const numIssues = latestGroupId ? 1 : 0;
-
-  const issueSearchQueryParams = {
-    query: `is:unresolved detector:${detector.id}`,
-    limit: 5,
-    start: location.query.start,
-    end: location.query.end,
-    statsPeriod: location.query.statsPeriod,
+  const query = `is:unresolved detector:${detector.id}`;
+  const {selection} = usePageFilters();
+  const queryParams = {
+    query,
+    project: detector.projectId,
+    start: selection.datetime.start
+      ? getUtcDateString(selection.datetime.start)
+      : undefined,
+    end: selection.datetime.end ? getUtcDateString(selection.datetime.end) : undefined,
+    statsPeriod: selection.datetime.period,
   };
 
   return (
     <Section
       title={
         <Flex justify="between" align="center">
-          {tn('Ongoing Issue', 'Ongoing Issues', numIssues)}
+          {t('Ongoing Issues')}
           <LinkButton
             size="xs"
             to={{
               pathname: `/organizations/${organization.slug}/issues/`,
-              query: issueSearchQueryParams,
+              query: queryParams,
             }}
           >
             {t('View All')}
@@ -283,42 +47,10 @@ export function DetectorDetailsOngoingIssues({
       }
     >
       <ErrorBoundary mini>
-        {latestGroupId ? (
-          <LatestGroupWithOpenPeriods
-            detector={detector}
-            groupId={latestGroupId}
-            intervalSeconds={intervalSeconds}
-          />
-        ) : (
-          <SimpleTable>
-            <SimpleTable.Empty>
-              <EmptyStateWarning small withIcon={false}>
-                {t('No ongoing issue found for this monitor')}
-              </EmptyStateWarning>
-            </SimpleTable.Empty>
-          </SimpleTable>
-        )}
+        <div>
+          <GroupList numPlaceholderRows={5} queryParams={{...queryParams, limit: 5}} />
+        </div>
       </ErrorBoundary>
     </Section>
   );
 }
-
-const EventOrGroupCell = styled(SimpleTable.RowCell)`
-  & > div {
-    overflow: hidden;
-  }
-`;
-
-const StyledTable = styled(SimpleTable)`
-  grid-template-columns: 1fr min-content auto min-content;
-`;
-
-const SubTable = styled(SimpleTable)`
-  background-color: ${p => p.theme.backgroundSecondary};
-  grid-template-columns: min-content 1fr 1fr 0.5fr min-content;
-  border: 0;
-`;
-
-const SmallEmptyState = styled(SimpleTable.Empty)`
-  min-height: unset;
-`;

--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -3,7 +3,7 @@ import {Flex} from 'sentry/components/core/layout';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import GroupList from 'sentry/components/issues/groupList';
 import Section from 'sentry/components/workflowEngine/ui/section';
-import {t, tn} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {getUtcDateString} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';

--- a/static/app/views/detectors/components/details/common/openPeriodIssues.spec.tsx
+++ b/static/app/views/detectors/components/details/common/openPeriodIssues.spec.tsx
@@ -7,9 +7,9 @@ import {SimpleGroupFixture} from 'sentry-fixture/group';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
-import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 
-describe('DetectorDetailsOngoingIssues', () => {
+describe('DetectorDetailsOpenPeriodIssues', () => {
   it('renders latest issue with one open period', async () => {
     const detector = MetricDetectorFixture({
       latestGroup: SimpleGroupFixture({
@@ -52,7 +52,7 @@ describe('DetectorDetailsOngoingIssues', () => {
       ],
     });
 
-    render(<DetectorDetailsOngoingIssues detector={detector} />);
+    render(<DetectorDetailsOpenPeriodIssues detector={detector} />);
 
     expect(await screen.findByTestId('event-issue-header')).toBeInTheDocument();
 

--- a/static/app/views/detectors/components/details/common/openPeriodIssues.tsx
+++ b/static/app/views/detectors/components/details/common/openPeriodIssues.tsx
@@ -1,0 +1,327 @@
+import {Fragment, useCallback} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {DateTime} from 'sentry/components/dateTime';
+import Duration from 'sentry/components/duration';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
+import {
+  AssigneeSelector,
+  useHandleAssigneeChange,
+} from 'sentry/components/group/assigneeSelector';
+import {GroupStatusTag} from 'sentry/components/group/inboxBadges/groupStatusTag';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Placeholder from 'sentry/components/placeholder';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t, tn} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  buildDetectorZoomQuery,
+  computeZoomRangeMs,
+} from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
+import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
+
+interface OpenPeriodsSubTableProps {
+  groupId: string;
+  onZoom: (start: Date, end?: Date) => void;
+}
+
+function OpenPeriodsSubTable({groupId, onZoom}: OpenPeriodsSubTableProps) {
+  const location = useLocation();
+  const start = location.query?.start as string | undefined;
+  const end = location.query?.end as string | undefined;
+  const statsPeriod = location.query?.statsPeriod as string | undefined;
+  const dateParams = {start, end, statsPeriod};
+  const {
+    data: openPeriods,
+    isPending: isOpenPeriodsPending,
+    isError: isOpenPeriodsError,
+  } = useOpenPeriods({groupId, ...dateParams});
+
+  if (isOpenPeriodsPending) {
+    return <OpenPeriodsSubTableSkeleton />;
+  }
+
+  if (isOpenPeriodsError) {
+    return (
+      <SubTable>
+        <SmallEmptyState>{t('Failed to load open periods.')}</SmallEmptyState>
+      </SubTable>
+    );
+  }
+
+  if (!openPeriods?.length) {
+    return (
+      <SubTable>
+        <SmallEmptyState>
+          {t('No open periods within current date range.')}
+        </SmallEmptyState>
+      </SubTable>
+    );
+  }
+
+  return (
+    <SubTable>
+      {openPeriods.map((period, idx) => {
+        const openPeriodStart = new Date(period.start);
+        const openPeriodEnd = period.end ? new Date(period.end) : undefined;
+        const diffMs =
+          (openPeriodEnd ?? new Date()).getTime() - openPeriodStart.getTime();
+        const seconds = diffMs / 1000;
+        return (
+          <SimpleTable.Row key={`${period.start}-${idx}`}>
+            <SimpleTable.RowCell>
+              {/* TODO: Status Color */}
+              <Text tabular>#{period.id}</Text>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <Text>
+                {t('Started')} <DateTime date={openPeriodStart} />
+              </Text>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <Text>
+                {openPeriodEnd ? (
+                  <Fragment>
+                    {t('Ended')} {openPeriodEnd ? <DateTime date={openPeriodEnd} /> : '—'}
+                  </Fragment>
+                ) : (
+                  t('Ongoing')
+                )}
+              </Text>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <Duration seconds={seconds} abbreviation />
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell justify="flex-end">
+              <Button size="xs" onClick={() => onZoom(openPeriodStart, openPeriodEnd)}>
+                {t('Zoom')}
+              </Button>
+            </SimpleTable.RowCell>
+          </SimpleTable.Row>
+        );
+      })}
+    </SubTable>
+  );
+}
+
+function OpenPeriodsSubTableSkeleton() {
+  return (
+    <SubTable>
+      {[0, 1, 2].map(i => (
+        <SimpleTable.Row key={i}>
+          <SimpleTable.RowCell>
+            <Placeholder height="20px" width="24px" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell>
+            <Placeholder height="20px" width="60%" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell>
+            <Placeholder height="20px" width="40%" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell>
+            <Placeholder height="20px" width="50%" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell justify="flex-end">
+            <Placeholder height="24px" width="48px" />
+          </SimpleTable.RowCell>
+        </SimpleTable.Row>
+      ))}
+    </SubTable>
+  );
+}
+
+function LatestGroupWithOpenPeriods({
+  groupId,
+  intervalSeconds,
+}: {
+  detector: Detector;
+  groupId: string;
+  intervalSeconds?: number;
+}) {
+  const {data: group, isPending, isError} = useGroup({groupId});
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const zoomToRange = useCallback(
+    (start: Date, end?: Date) => {
+      const startMs = start.getTime();
+      const endMs = (end ?? new Date()).getTime();
+      const {start: zoomStart, end: zoomEnd} = computeZoomRangeMs({
+        startMs,
+        endMs,
+        intervalSeconds,
+      });
+      navigate({
+        pathname: location.pathname,
+        query: buildDetectorZoomQuery(location.query, zoomStart, zoomEnd),
+      });
+    },
+    [location.pathname, location.query, navigate, intervalSeconds]
+  );
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (!group || isError) {
+    return (
+      <SimpleTable>
+        <SimpleTable.Empty>
+          <EmptyStateWarning small>
+            {t('Failed to load the latest issue')}
+          </EmptyStateWarning>
+        </SimpleTable.Empty>
+      </SimpleTable>
+    );
+  }
+
+  return (
+    <StyledTable>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell>{t('Issue')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Last Seen')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Assignee')}</SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+
+      <SimpleTable.Row>
+        <EventOrGroupCell>
+          <EventOrGroupHeader data={group} />
+        </EventOrGroupCell>
+        <SimpleTable.RowCell>
+          <GroupStatusTag fontSize="md">{group.substatus ?? group.status}</GroupStatusTag>
+        </SimpleTable.RowCell>
+        <SimpleTable.RowCell>
+          <TimeAgoCell date={group.lastSeen} />
+        </SimpleTable.RowCell>
+        <SimpleTable.RowCell>
+          <IssueAssigneeSelector group={group} />
+        </SimpleTable.RowCell>
+      </SimpleTable.Row>
+
+      <SimpleTable.Row>
+        <div style={{gridColumn: '1 / -1', paddingTop: 0}}>
+          <OpenPeriodsSubTable groupId={group.id} onZoom={zoomToRange} />
+        </div>
+      </SimpleTable.Row>
+    </StyledTable>
+  );
+}
+
+function IssueAssigneeSelector({group}: {group: Group}) {
+  const organization = useOrganization();
+  const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
+    organization,
+    group,
+  });
+
+  return (
+    <AssigneeSelector
+      group={group}
+      assigneeLoading={assigneeLoading}
+      handleAssigneeChange={handleAssigneeChange}
+      showLabel
+    />
+  );
+}
+
+interface OngoingIssueProps {
+  detector: Detector;
+  /**
+   * Helps the zoom function add padding on left and right of the open period.
+   * If intervalSeconds is 24 hours, we would want a lot more padding than if it's 1 minute.
+   */
+  intervalSeconds?: number;
+}
+
+/**
+ * Use this to display the list of issues for detectors which have open periods.
+ */
+export function DetectorDetailsOpenPeriodIssues({
+  detector,
+  intervalSeconds,
+}: OngoingIssueProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  // TODO: We'll probably need to make a query to get all linked issues
+  const latestGroupId = detector.latestGroup?.id;
+  const numIssues = latestGroupId ? 1 : 0;
+
+  const issueSearchQueryParams = {
+    query: `is:unresolved detector:${detector.id}`,
+    limit: 5,
+    start: location.query.start,
+    end: location.query.end,
+    statsPeriod: location.query.statsPeriod,
+  };
+
+  return (
+    <Section
+      title={
+        <Flex justify="between" align="center">
+          {tn('Ongoing Issue', 'Ongoing Issues', numIssues)}
+          <LinkButton
+            size="xs"
+            to={{
+              pathname: `/organizations/${organization.slug}/issues/`,
+              query: issueSearchQueryParams,
+            }}
+          >
+            {t('View All')}
+          </LinkButton>
+        </Flex>
+      }
+    >
+      <ErrorBoundary mini>
+        {latestGroupId ? (
+          <LatestGroupWithOpenPeriods
+            detector={detector}
+            groupId={latestGroupId}
+            intervalSeconds={intervalSeconds}
+          />
+        ) : (
+          <SimpleTable>
+            <SimpleTable.Empty>
+              <EmptyStateWarning small withIcon={false}>
+                {t('No ongoing issue found for this monitor')}
+              </EmptyStateWarning>
+            </SimpleTable.Empty>
+          </SimpleTable>
+        )}
+      </ErrorBoundary>
+    </Section>
+  );
+}
+
+const EventOrGroupCell = styled(SimpleTable.RowCell)`
+  & > div {
+    overflow: hidden;
+  }
+`;
+
+const StyledTable = styled(SimpleTable)`
+  grid-template-columns: 1fr min-content auto min-content;
+`;
+
+const SubTable = styled(SimpleTable)`
+  background-color: ${p => p.theme.backgroundSecondary};
+  grid-template-columns: min-content 1fr 1fr 0.5fr min-content;
+  border: 0;
+`;
+
+const SmallEmptyState = styled(SimpleTable.Empty)`
+  min-height: unset;
+`;

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -32,7 +32,7 @@ import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
-import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 import {DetailsTimeline} from 'sentry/views/insights/crons/components/detailsTimeline';
 import {DetailsTimelineLegend} from 'sentry/views/insights/crons/components/detailsTimelineLegend';
@@ -170,7 +170,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
                   onStatsLoaded={checkHasUnknown}
                 />
                 <ErrorBoundary mini>
-                  <DetectorDetailsOngoingIssues
+                  <DetectorDetailsOpenPeriodIssues
                     detector={detector}
                     intervalSeconds={intervalSeconds}
                   />

--- a/static/app/views/detectors/components/details/error/index.spec.tsx
+++ b/static/app/views/detectors/components/details/error/index.spec.tsx
@@ -25,7 +25,7 @@ describe('ErrorDetectorDetails', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/?limit=5&query=is%3Aunresolved%20detector%3A2&statsPeriod=14d',
+      url: '/organizations/org-slug/issues/?limit=5&project=1&query=is%3Aunresolved%20detector%3A2&statsPeriod=14d',
       method: 'GET',
       body: [GroupFixture()],
     });
@@ -39,7 +39,7 @@ describe('ErrorDetectorDetails', () => {
       body: GroupFixture(),
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/open-periods/`,
+      url: `/organizations/org-slug/issues/`,
       body: [],
     });
   });

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -1,6 +1,5 @@
 import {ExternalLink, Link} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import Placeholder from 'sentry/components/placeholder';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
@@ -14,7 +13,6 @@ import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/deta
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
-import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 
 type ErrorDetectorDetailsProps = {
   detector: Detector;

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -14,6 +14,7 @@ import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/deta
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 
 type ErrorDetectorDetailsProps = {
   detector: Detector;
@@ -72,9 +73,7 @@ export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsPr
       <DetailLayout.Body>
         <DetailLayout.Main>
           <DatePageFilter />
-          <ErrorBoundary mini>
-            <DetectorDetailsOngoingIssues detector={detector} />
-          </ErrorBoundary>
+          <DetectorDetailsOngoingIssues detector={detector} />
           <DetectorDetailsAutomations detector={detector} />
         </DetailLayout.Main>
         <DetailLayout.Sidebar>

--- a/static/app/views/detectors/components/details/fallback.tsx
+++ b/static/app/views/detectors/components/details/fallback.tsx
@@ -6,7 +6,7 @@ import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
-import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 
 type FallbackDetectorDetailsProps = {
   detector: Detector;
@@ -23,7 +23,7 @@ export function FallbackDetectorDetails({
       <DetailLayout.Body>
         <DetailLayout.Main>
           <ErrorBoundary mini>
-            <DetectorDetailsOngoingIssues detector={detector} />
+            <DetectorDetailsOpenPeriodIssues detector={detector} />
           </ErrorBoundary>
           <DetectorDetailsAutomations detector={detector} />
         </DetailLayout.Main>

--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -5,7 +5,7 @@ import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
-import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
 import {MetricDetectorDetailsSidebar} from 'sentry/views/detectors/components/details/metric/sidebar';
 import {MetricTimePeriodSelect} from 'sentry/views/detectors/components/details/metric/timePeriodSelect';
@@ -42,7 +42,7 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
             <MetricDetectorDetailsChart detector={detector} snubaQuery={snubaQuery} />
           )}
           <ErrorBoundary mini>
-            <DetectorDetailsOngoingIssues
+            <DetectorDetailsOpenPeriodIssues
               detector={detector}
               intervalSeconds={intervalSeconds}
             />


### PR DESCRIPTION
The error monitor does not have open periods, so it should just display the normal list of issues.

- Renamed `ongoingIssues` -> `openPeriodIssues`
- Added new `ongoingIssues` component that renders GroupList

Before:

<img width="1108" height="406" alt="CleanShot 2025-10-21 at 14 44 11" src="https://github.com/user-attachments/assets/33a1d6cb-82d4-4980-85ab-13bcd0e730c7" />

After:

<img width="1114" height="754" alt="CleanShot 2025-10-21 at 14 42 30" src="https://github.com/user-attachments/assets/4931f259-0c58-4a85-a7d6-b93b9f1f80bb" />
