### PR TITLE
fix(releases): Make commit file change query accept a list of commit ids instead of joining

### DIFF
--- a/src/sentry/releases/endpoints/organization_release_meta.py
+++ b/src/sentry/releases/endpoints/organization_release_meta.py
@@ -57,8 +57,10 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
 
         commit_files_changed = (
             CommitFileChange.objects.filter(
-                commit_id__in=ReleaseCommit.objects.filter(release=release).values_list(
-                    "commit_id", flat=True
+                commit_id__in=list(
+                    ReleaseCommit.objects.filter(release=release).values_list(
+                        "commit_id", flat=True
+                    )
                 )
             )
             .values("filename")


### PR DESCRIPTION
We moved `CommitFileChange` to a separate database, and so this query should fail. It's working because we copied (but didn't replicate) the `ReleaseCommit` table. Explicitly making the query to `ReleaseCommit` evaluate so that it routes to the right place.