### PR TITLE
chore(eco): sentry app install deletion outbox

### DIFF
--- a/src/sentry/deletions/defaults/sentry_app_installation.py
+++ b/src/sentry/deletions/defaults/sentry_app_installation.py
@@ -1,11 +1,8 @@
 from collections.abc import Sequence
 
-from sentry.constants import ObjectStatus
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.deletions.defaults.apigrant import ModelApiGrantDeletionTask
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
-from sentry.types.region import RegionMappingNotFound
-from sentry.workflow_engine.service.action import action_service
 
 
 class SentryAppInstallationDeletionTask(ModelDeletionTask[SentryAppInstallation]):
@@ -28,15 +25,3 @@ class SentryAppInstallationDeletionTask(ModelDeletionTask[SentryAppInstallation]
 
     def mark_deletion_in_progress(self, instance_list: Sequence[SentryAppInstallation]) -> None:
         pass
-
-    def delete_instance(self, instance: SentryAppInstallation) -> None:
-        try:
-            action_service.update_action_status_for_sentry_app_via_uuid(
-                organization_id=instance.organization_id,
-                status=ObjectStatus.DISABLED,
-                sentry_app_install_uuid=instance.uuid,
-            )
-        except RegionMappingNotFound:
-            pass
-
-        return super().delete_instance(instance)

--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -62,6 +62,7 @@ class OutboxCategory(IntEnum):
 
     SERVICE_HOOK_UPDATE = 40
     SENTRY_APP_DELETE = 41
+    SENTRY_APP_INSTALLATION_DELETE = 42
 
     @classmethod
     def as_choices(cls) -> Sequence[tuple[int, int]]:
@@ -304,6 +305,7 @@ class OutboxScope(IntEnum):
             OutboxCategory.SENTRY_APP_UPDATE,
             OutboxCategory.SERVICE_HOOK_UPDATE,
             OutboxCategory.SENTRY_APP_DELETE,
+            OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
         },
     )
     # No longer in use

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -83,6 +83,31 @@ def process_sentry_app_deletes(
         # TODO: also update webhook actions using object identifier (sentry app slug)
 
 
+@receiver(process_control_outbox, sender=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE)
+def process_sentry_app_installation_deletes(
+    shard_identifier: int,
+    object_identifier: int,
+    region_name: str,
+    payload: Mapping[str, Any],
+    **kwds: Any,
+):
+    # This function should only be used when the sentry app is being deleted.
+    # Currently this receiver is only used for deletion.
+    if options.get("workflow_engine.sentry-app-actions-outbox"):
+        logger.info(
+            "sentry_app_installation_delete.update_action_status",
+            extra={
+                "region_name": region_name,
+                "sentry_app_install_uuid": payload["uuid"],
+            },
+        )
+        action_service.update_action_status_for_sentry_app_via_uuid__region(
+            region_name=region_name,
+            status=ObjectStatus.DISABLED,
+            sentry_app_install_uuid=payload["uuid"],
+        )
+
+
 @receiver(process_control_outbox, sender=OutboxCategory.API_APPLICATION_UPDATE)
 def process_api_application_updates(object_identifier: int, region_name: str, **kwds: Any):
     if (

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -241,8 +241,8 @@ class SentryApp(ParanoidModel, HasApiScopes, Model):
             for outbox in self.outboxes_for_delete():
                 outbox.save()
 
-        SentryAppAvatar.objects.filter(sentry_app=self).delete()
-        return super().delete(*args, **kwargs)
+            SentryAppAvatar.objects.filter(sentry_app=self).delete()
+            return super().delete(*args, **kwargs)
 
     def _disable(self):
         self.events = []

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -128,7 +128,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         with outbox_context(transaction.atomic(using=router.db_for_write(SentryAppInstallation))):
             for outbox in self.outboxes_for_delete():
                 outbox.save()
-        return super().delete(*args, **kwargs)
+            return super().delete(*args, **kwargs)
 
     @property
     def api_application_id(self) -> int | None:

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -16,9 +16,9 @@ from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, co
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.models.paranoia import ParanoidManager, ParanoidModel
-from sentry.hybridcloud.models.outbox import ControlOutboxBase, outbox_context
+from sentry.hybridcloud.models.outbox import ControlOutbox, ControlOutboxBase, outbox_context
 from sentry.hybridcloud.outbox.base import ReplicatedControlModel
-from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
 from sentry.projects.services.project import RpcProject
 from sentry.sentry_apps.services.app.model import RpcSentryAppComponent, RpcSentryAppInstallation
 from sentry.sentry_apps.utils.errors import (
@@ -26,7 +26,7 @@ from sentry.sentry_apps.utils.errors import (
     SentryAppIntegratorError,
     SentryAppSentryError,
 )
-from sentry.types.region import find_regions_for_orgs
+from sentry.types.region import find_all_region_names, find_regions_for_orgs
 
 if TYPE_CHECKING:
     from sentry.models.project import Project
@@ -140,6 +140,19 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         # Use 0 in case of bad relations from api_applicaiton_id -- the replication ordering for
         # these isn't so important in that case.
         return super().outboxes_for_update(shard_identifier=self.api_application_id or 0)
+
+    def outboxes_for_delete(self) -> list[ControlOutbox]:
+        return [
+            ControlOutbox(
+                shard_scope=OutboxScope.APP_SCOPE,
+                shard_identifier=self.id,
+                object_identifier=self.id,
+                category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
+                region_name=region_name,
+                payload={"uuid": self.uuid},
+            )
+            for region_name in find_all_region_names()
+        ]
 
     def prepare_ui_component(
         self,

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -151,7 +151,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
         return [
             ControlOutbox(
                 shard_scope=OutboxScope.APP_SCOPE,
-                shard_identifier=self.id,
+                shard_identifier=self.api_application_id or 0,
                 object_identifier=self.id,
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -8,16 +8,21 @@ from sentry.analytics.events.sentry_app_installation_updated import (
     SentryAppInstallationUpdatedEvent,
 )
 from sentry.analytics.events.sentry_app_uninstalled import SentryAppUninstalledEvent
-from sentry.constants import SentryAppInstallationStatus
+from sentry.constants import ObjectStatus, SentryAppInstallationStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions_control
 from sentry.models.auditlogentry import AuditLogEntry
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.token_exchange.grant_exchanger import GrantExchanger
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
+from sentry.workflow_engine.models.action import Action
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 class SentryAppInstallationDetailsTest(APITestCase):
@@ -103,6 +108,7 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
 class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
     @responses.activate
     @patch("sentry.analytics.record")
+    @override_options({"workflow_engine.sentry-app-actions-outbox": True})
     def test_delete_install(self, record: MagicMock) -> None:
         responses.add(url="https://example.com/webhook", method=responses.POST, body=b"")
         self.login_as(user=self.user)
@@ -122,8 +128,23 @@ class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
             ),
         )
 
+        action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": self.installation2.uuid,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+
         with self.tasks():
             run_scheduled_deletions_control()
+
+        with outbox_runner():
+            pass
+
+        action.refresh_from_db()
+        assert action.status == ObjectStatus.DISABLED
 
         assert not SentryAppInstallation.objects.filter(id=self.installation2.id).exists()
 


### PR DESCRIPTION
Add an outbox to update actions statuses when a sentry app installation is deleted. This will be eventually consistent.