### PR TITLE
chore(aci): rename automations to alerts

### DIFF
--- a/static/app/components/workflowEngine/gridCell/index.stories.tsx
+++ b/static/app/components/workflowEngine/gridCell/index.stories.tsx
@@ -103,7 +103,7 @@ export default Storybook.story('Grid Cell Components', story => {
   ];
 
   const linkedGroupsTable: Array<GridColumnOrder<keyof ExampleAutomation>> = [
-    {key: 'linkedItems', name: 'Connected Monitors/Automations', width: 200},
+    {key: 'linkedItems', name: 'Connected Monitors/Alerts', width: 200},
   ];
 
   const openIssuesTable: Array<GridColumnOrder<keyof ExampleAutomation>> = [

--- a/static/app/components/workflowEngine/layout/detail.tsx
+++ b/static/app/components/workflowEngine/layout/detail.tsx
@@ -17,7 +17,7 @@ interface WorkflowEngineDetailLayoutProps {
 }
 
 /**
- * Precomposed 67/33 layout for Automations / Monitors detail pages.
+ * Precomposed 67/33 layout for Monitors / Alerts detail pages.
  */
 function DetailLayout({children}: WorkflowEngineDetailLayoutProps) {
   return <StyledPage>{children}</StyledPage>;

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -20,7 +20,7 @@ interface WorkflowEngineEditLayoutProps {
 }
 
 /**
- * Precomposed layout for Automations / Monitors edit pages with form handling.
+ * Precomposed layout for Monitors / Alerts edit pages with form handling.
  */
 function EditLayout({children, formProps}: WorkflowEngineEditLayoutProps) {
   return (

--- a/static/app/views/automations/components/automationFeedbackButton.tsx
+++ b/static/app/views/automations/components/automationFeedbackButton.tsx
@@ -16,7 +16,7 @@ export function AutomationFeedbackButton() {
       size="sm"
       onClick={() =>
         openForm({
-          messagePlaceholder: t('How can we improve the automation experience?'),
+          messagePlaceholder: t('How can we improve the alerts experience?'),
           tags: {
             ['feedback.source']: 'automations',
             ['feedback.owner']: 'aci',

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -61,7 +61,7 @@ export default function AutomationForm({model}: {model: FormModel}) {
       </Card>
       <Card>
         <Heading as="h2" size="lg">
-          {t('Automation Builder')}
+          {t('Alert Builder')}
         </Heading>
         <AutomationBuilder />
       </Card>

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -109,7 +109,7 @@ export function validateAutomationBuilderState(state: AutomationBuilderState) {
     }
     // validate action filter actions
     if (actionFilter.actions?.length === 0) {
-      errors[actionFilter.id] = t('You must add an action for this automation to run.');
+      errors[actionFilter.id] = t('You must add an action for this alert to run.');
       continue;
     }
     for (const action of actionFilter.actions || []) {

--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -193,18 +193,18 @@ export function AutomationsTableActions({
         <FullWidthAlert type="warning" showIcon={false}>
           <Flex justify="center" wrap="wrap" gap="md">
             {allInQuerySelected ? (
-              tct('Selected all [count] automations that match this search query.', {
+              tct('Selected all [count] alerts that match this search query.', {
                 count: queryCount,
               })
             ) : (
               <Fragment>
                 {tn(
-                  '%s automation on this page selected.',
-                  '%s automations on this page selected.',
+                  '%s alert on this page selected.',
+                  '%s alerts on this page selected.',
                   selected.size
                 )}
                 <Button priority="link" onClick={() => setAllInQuerySelected(true)}>
-                  {tct('Select all [count] automations that match this search query.', {
+                  {tct('Select all [count] alerts that match this search query.', {
                     count: queryCount,
                   })}
                 </Button>

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -170,9 +170,9 @@ function AutomationListTable({
         />
       )}
       {isSuccess && automations.length === 0 && (
-        <SimpleTable.Empty>{t('No automations found')}</SimpleTable.Empty>
+        <SimpleTable.Empty>{t('No alerts found')}</SimpleTable.Empty>
       )}
-      {isError && <LoadingError message={t('Error loading automations')} />}
+      {isError && <LoadingError message={t('Error loading alerts')} />}
       {isPending && <LoadingSkeletons />}
       {isSuccess &&
         automations.map(automation => (

--- a/static/app/views/automations/components/automationListTable/search.tsx
+++ b/static/app/views/automations/components/automationListTable/search.tsx
@@ -49,7 +49,7 @@ export function AutomationSearch({initialQuery, onSearch}: AutomationSearchProps
   return (
     <SearchQueryBuilder
       initialQuery={initialQuery}
-      placeholder={t('Search for automations')}
+      placeholder={t('Search for alerts')}
       onSearch={onSearch}
       filterKeys={FILTER_KEYS}
       getTagValues={() => Promise.resolve([])}

--- a/static/app/views/automations/components/automationStatsChart.tsx
+++ b/static/app/views/automations/components/automationStatsChart.tsx
@@ -54,7 +54,7 @@ export function AutomationStatsChart({
     <Panel>
       <StyledPanelBody withPadding>
         <ChartHeader>
-          <HeaderTitleLegend>{t('Automations Triggered')}</HeaderTitleLegend>
+          <HeaderTitleLegend>{t('Alerts Triggered')}</HeaderTitleLegend>
         </ChartHeader>
         {isPending && <Placeholder height="200px" />}
         {isError && <LoadingError />}
@@ -76,7 +76,7 @@ export function AutomationStatsChart({
                 }}
                 series={[
                   {
-                    seriesName: t('Automations Triggered'),
+                    seriesName: t('Alerts Triggered'),
                     data:
                       fireHistory?.map(automation => ({
                         name: automation.date,

--- a/static/app/views/automations/components/editAutomationActions.tsx
+++ b/static/app/views/automations/components/editAutomationActions.tsx
@@ -37,9 +37,7 @@ export function EditAutomationActions({automation}: EditAutomationActionsProps) 
       },
       {
         onSuccess: data => {
-          addSuccessMessage(
-            data.enabled ? t('Automation enabled') : t('Automation disabled')
-          );
+          addSuccessMessage(data.enabled ? t('Alert enabled') : t('Alert disabled'));
         },
       }
     );
@@ -47,7 +45,7 @@ export function EditAutomationActions({automation}: EditAutomationActionsProps) 
 
   const handleDelete = useCallback(() => {
     openConfirmModal({
-      message: t('Are you sure you want to delete this automation?'),
+      message: t('Are you sure you want to delete this alert?'),
       confirmText: t('Delete'),
       priority: 'danger',
       onConfirm: async () => {

--- a/static/app/views/automations/components/editableAutomationName.tsx
+++ b/static/app/views/automations/components/editableAutomationName.tsx
@@ -16,8 +16,8 @@ export function EditableAutomationName() {
               },
             });
           }}
-          errorMessage={t('Please set a name for your automation.')}
-          placeholder={t('New Automation')}
+          errorMessage={t('Please set a name for your alert.')}
+          placeholder={t('New Alert')}
         />
       )}
     </FormField>

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -64,8 +64,8 @@ describe('AutomationDetail', () => {
     render(<AutomationDetail />, {
       organization,
       initialRouterConfig: {
-        route: '/automations/:automationId/',
-        location: {pathname: '/automations/123/'},
+        route: '/alerts/:automationId/',
+        location: {pathname: '/alerts/123/'},
       },
     });
 
@@ -96,8 +96,8 @@ describe('AutomationDetail', () => {
     render(<AutomationDetail />, {
       organization,
       initialRouterConfig: {
-        route: '/automations/:automationId/',
-        location: {pathname: '/automations/123/'},
+        route: '/alerts/:automationId/',
+        location: {pathname: '/alerts/123/'},
       },
     });
 
@@ -121,7 +121,7 @@ describe('AutomationDetail', () => {
   });
 
   describe('Action warnings', () => {
-    it('displays warning when automation has no actions', async () => {
+    it('displays warning when alert has no actions', async () => {
       const automationWithWarning = AutomationFixture({
         ...automation,
         actionFilters: [ActionFilterFixture({actions: []})],
@@ -135,15 +135,15 @@ describe('AutomationDetail', () => {
       render(<AutomationDetail />, {
         organization,
         initialRouterConfig: {
-          route: '/automations/:automationId/',
-          location: {pathname: '/automations/123/'},
+          route: '/alerts/:automationId/',
+          location: {pathname: '/alerts/123/'},
         },
       });
 
       await screen.findByRole('heading', {name: 'Test Automation'});
 
       expect(
-        screen.getByText('You must add an action for this automation to run.')
+        screen.getByText('You must add an action for this alert to run.')
       ).toBeInTheDocument();
     });
 
@@ -165,8 +165,8 @@ describe('AutomationDetail', () => {
       render(<AutomationDetail />, {
         organization,
         initialRouterConfig: {
-          route: '/automations/:automationId/',
-          location: {pathname: '/automations/123/'},
+          route: '/alerts/:automationId/',
+          location: {pathname: '/alerts/123/'},
         },
       });
 
@@ -174,7 +174,7 @@ describe('AutomationDetail', () => {
 
       expect(
         screen.getByText(
-          'Automation is invalid because no actions can run. Actions need to be reconfigured.'
+          'Alert is invalid because no actions can run. Actions need to be reconfigured.'
         )
       ).toBeInTheDocument();
     });
@@ -197,8 +197,8 @@ describe('AutomationDetail', () => {
       render(<AutomationDetail />, {
         organization,
         initialRouterConfig: {
-          route: '/automations/:automationId/',
-          location: {pathname: '/automations/123/'},
+          route: '/alerts/:automationId/',
+          location: {pathname: '/alerts/123/'},
         },
       });
 

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -83,7 +83,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
             <Breadcrumbs
               crumbs={[
                 {
-                  label: t('Automations'),
+                  label: t('Alerts'),
                   to: makeAutomationBasePathname(
                     organization.slug,
                     automationsLinkPrefix
@@ -245,9 +245,7 @@ function Actions({automation}: {automation: Automation}) {
       },
       {
         onSuccess: () => {
-          addSuccessMessage(
-            newEnabled ? t('Automation enabled') : t('Automation disabled')
-          );
+          addSuccessMessage(newEnabled ? t('Alert enabled') : t('Alert disabled'));
         },
       }
     );

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -47,7 +47,7 @@ import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 function AutomationDocumentTitle() {
   const title = useFormField('name');
-  return <SentryDocumentTitle title={title ?? t('Edit Automation')} />;
+  return <SentryDocumentTitle title={title ?? t('Edit Alert')} />;
 }
 
 function AutomationBreadcrumbs({automationId}: {automationId: string}) {
@@ -58,7 +58,7 @@ function AutomationBreadcrumbs({automationId}: {automationId: string}) {
     <Breadcrumbs
       crumbs={[
         {
-          label: t('Automation'),
+          label: t('Alerts'),
           to: makeAutomationBasePathname(organization.slug, automationsLinkPrefix),
         },
         {

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -153,7 +153,7 @@ export function useCreateAutomation() {
       });
     },
     onError: _ => {
-      addErrorMessage(t('Unable to create automation'));
+      addErrorMessage(t('Unable to create alert'));
     },
   });
 }
@@ -172,10 +172,10 @@ export function useDeleteAutomationMutation() {
       queryClient.invalidateQueries({
         queryKey: [`/organizations/${org.slug}/workflows/`],
       });
-      addSuccessMessage(t('Automation deleted'));
+      addSuccessMessage(t('Alert deleted'));
     },
     onError: error => {
-      addErrorMessage(t('Unable to delete automation: %s', error.message));
+      addErrorMessage(t('Unable to delete alert: %s', error.message));
     },
   });
 }
@@ -205,10 +205,10 @@ export function useDeleteAutomationsMutation() {
       queryClient.invalidateQueries({
         queryKey: [`/organizations/${org.slug}/workflows/`],
       });
-      addSuccessMessage(t('Automations deleted'));
+      addSuccessMessage(t('Alerts deleted'));
     },
     onError: error => {
-      addErrorMessage(t('Unable to delete automations: %s', error.message));
+      addErrorMessage(t('Unable to delete alerts: %s', error.message));
     },
   });
 }
@@ -241,7 +241,7 @@ export function useUpdateAutomation() {
       });
     },
     onError: _ => {
-      addErrorMessage(t('Unable to update automation'));
+      addErrorMessage(t('Unable to update alert'));
     },
   });
 }
@@ -272,14 +272,12 @@ export function useUpdateAutomationsMutation() {
       queryClient.invalidateQueries({
         queryKey: [`/organizations/${org.slug}/workflows/`],
       });
-      addSuccessMessage(
-        variables.enabled ? t('Automations enabled') : t('Automations disabled')
-      );
+      addSuccessMessage(variables.enabled ? t('Alerts enabled') : t('Alerts disabled'));
     },
     onError: (error, variables) => {
       addErrorMessage(
         t(
-          'Unable to %s automations: %2$s',
+          'Unable to %s alerts: %2$s',
           variables.enabled ? t('enable') : t('disable'),
           error.message
         )

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -32,14 +32,14 @@ export function getAutomationActionsWarning(
   if (totalCount === 0) {
     return {
       color: 'danger' as const,
-      message: t('You must add an action for this automation to run.'),
+      message: t('You must add an action for this alert to run.'),
     };
   }
   if (inactiveCount === totalCount) {
     return {
       color: 'danger' as const,
       message: t(
-        'Automation is invalid because no actions can run. Actions need to be reconfigured.'
+        'Alert is invalid because no actions can run. Actions need to be reconfigured.'
       ),
     };
   }

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -443,11 +443,9 @@ describe('AutomationsList', () => {
       await userEvent.click(masterCheckbox);
 
       // Should show alert with option to select all query results
-      expect(
-        screen.getByText(/20 automations on this page selected/)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/20 alerts on this page selected/)).toBeInTheDocument();
       const selectAllForQuery = screen.getByText(
-        /Select all 50 automations that match this search query/
+        /Select all 50 alerts that match this search query/
       );
       await userEvent.click(selectAllForQuery);
 
@@ -523,7 +521,7 @@ describe('AutomationsList', () => {
       const noActionsIcon = within(noActionsRow).getAllByRole('img')[0]!; // Get the first img (warning icon)
       await userEvent.hover(noActionsIcon);
       expect(
-        await screen.findByText('You must add an action for this automation to run.')
+        await screen.findByText('You must add an action for this alert to run.')
       ).toBeInTheDocument();
 
       // Test second automation (all disabled) - should show "Invalid" and danger tooltip
@@ -535,7 +533,7 @@ describe('AutomationsList', () => {
       await userEvent.hover(allDisabledIcon);
       expect(
         await screen.findByText(
-          'Automation is invalid because no actions can run. Actions need to be reconfigured.'
+          'Alert is invalid because no actions can run. Actions need to be reconfigured.'
         )
       ).toBeInTheDocument();
 

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -79,9 +79,9 @@ export default function AutomationsList() {
   }, [pageLinks]);
 
   return (
-    <SentryDocumentTitle title={t('Automations')}>
+    <SentryDocumentTitle title={t('Alerts')}>
       <PageFiltersContainer>
-        <ListLayout actions={<Actions />} title={t('Automations')}>
+        <ListLayout actions={<Actions />} title={t('Alerts')}>
           <TableHeader />
           <div>
             <AutomationListTable
@@ -147,7 +147,7 @@ function Actions() {
         icon={<IconAdd />}
         size="sm"
       >
-        {t('Create Automation')}
+        {t('Create Alert')}
       </LinkButton>
     </Flex>
   );

--- a/static/app/views/automations/new-settings.spec.tsx
+++ b/static/app/views/automations/new-settings.spec.tsx
@@ -108,14 +108,14 @@ describe('AutomationNewSettings', () => {
     await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
 
     // Submit the form
-    await userEvent.click(screen.getByRole('button', {name: 'Create Automation'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
 
     await waitFor(() =>
       expect(post).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           data: {
-            name: 'New Automation',
+            name: 'New Alert',
             triggers: {
               logicType: 'any-short',
               conditions: [

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -42,9 +42,7 @@ import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 function AutomationDocumentTitle() {
   const title = useFormField('name');
   return (
-    <SentryDocumentTitle
-      title={title ? t('%s - New Automation', title) : t('New Automation')}
-    />
+    <SentryDocumentTitle title={title ? t('%s - New Alert', title) : t('New Alert')} />
   );
 }
 
@@ -56,17 +54,17 @@ function AutomationBreadcrumbs() {
     <Breadcrumbs
       crumbs={[
         {
-          label: t('Automation'),
+          label: t('Alerts'),
           to: makeAutomationBasePathname(organization.slug, automationsLinkPrefix),
         },
-        {label: title ? title : t('New Automation')},
+        {label: title ? title : t('New Alert')},
       ]}
     />
   );
 }
 
 const initialData = {
-  name: 'New Automation',
+  name: 'New Alert',
   environment: null,
   frequency: 1440,
   enabled: true,
@@ -188,7 +186,7 @@ export default function AutomationNewSettings() {
               {t('Back')}
             </LinkButton>
             <Button priority="primary" type="submit">
-              {t('Create Automation')}
+              {t('Create Alert')}
             </Button>
           </Flex>
         </Flex>

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -28,10 +28,10 @@ function AutomationBreadcrumbs() {
     <Breadcrumbs
       crumbs={[
         {
-          label: t('Automations'),
+          label: t('Alerts'),
           to: makeAutomationBasePathname(organization.slug, automationsLinkPrefix),
         },
-        {label: t('New Automation')},
+        {label: t('New Alert')},
       ]}
     />
   );
@@ -60,13 +60,13 @@ export default function AutomationNew() {
   });
 
   return (
-    <SentryDocumentTitle title={t('New Automation')}>
+    <SentryDocumentTitle title={t('New Alert')}>
       <StyledLayoutPage>
         <StyledLayoutHeader>
           <HeaderInner maxWidth={maxWidth}>
             <Layout.HeaderContent>
               <AutomationBreadcrumbs />
-              <Layout.Title>{t('New Automation')}</Layout.Title>
+              <Layout.Title>{t('New Alert')}</Layout.Title>
             </Layout.HeaderContent>
             <div>
               <AutomationFeedbackButton />

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -2,7 +2,7 @@ import type {SentryRouteObject} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 
 export const automationRoutes: SentryRouteObject = {
-  path: 'automations/',
+  path: 'alerts/',
   children: [
     {
       index: true,

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -2,7 +2,7 @@ import type {SentryRouteObject} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 
 export const automationRoutes: SentryRouteObject = {
-  path: 'alerts/',
+  path: 'automations/',
   children: [
     {
       index: true,

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -62,7 +62,7 @@ export function ConnectedAutomationsList({
   automationIds,
   connectedAutomationIds,
   toggleConnected,
-  emptyMessage = t('No automations connected'),
+  emptyMessage = t('No alerts connected'),
   cursor,
   onCursor,
   limit = DEFAULT_AUTOMATIONS_PER_PAGE,

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -18,7 +18,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
     typeof location.query.cursor === 'string' ? location.query.cursor : undefined;
 
   return (
-    <Section title={t('Connected Automations')}>
+    <Section title={t('Connected Alerts')}>
       <ErrorBoundary mini>
         <ConnectedAutomationsList
           automationIds={detector.workflowIds}

--- a/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
+++ b/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
@@ -95,7 +95,7 @@ export function DetectorListConnectedAutomations({
             `}
             showUnderline
           >
-            {tn('%s automation', '%s automations', automationIds.length)}
+            {tn('%s alert', '%s alerts', automationIds.length)}
           </Hovercard>
         )}
       </ClassNames>

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -152,7 +152,7 @@ function DetectorListTable({
               sortKey="connectedWorkflows"
               sort={sort}
             >
-              {t('Automations')}
+              {t('Alerts')}
             </HeaderCell>
           </SimpleTable.Header>
         ) : (

--- a/static/app/views/detectors/components/forms/automateSection.spec.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.spec.tsx
@@ -42,10 +42,10 @@ describe('AutomateSection', () => {
 
     expect(screen.getByText('Automate')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Connect an Automation'));
+    await userEvent.click(screen.getByText('Connect an Alert'));
 
     const drawer = await screen.findByRole('complementary', {
-      name: 'Connect Automations',
+      name: 'Connect Alerts',
     });
 
     await within(drawer).findByText(automation1.name);
@@ -74,12 +74,12 @@ describe('AutomateSection', () => {
     );
 
     // Should display automation as connected
-    expect(screen.getByText('Connected Automations')).toBeInTheDocument();
+    expect(screen.getByText('Connected Alerts')).toBeInTheDocument();
     expect(await screen.findByText(automation1.name)).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Edit Automations'));
+    await userEvent.click(screen.getByText('Edit Alerts'));
     const drawer = await screen.findByRole('complementary', {
-      name: 'Connect Automations',
+      name: 'Connect Alerts',
     });
 
     const connectedAutomationsList = await screen.findByTestId(

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -29,7 +29,7 @@ function ConnectedAutomations({
   const [cursor, setCursor] = useState<string | undefined>(undefined);
 
   return (
-    <Section title={t('Connected Automations')}>
+    <Section title={t('Connected Alerts')}>
       <ConnectedAutomationsList
         data-test-id="drawer-connected-automations-list"
         automationIds={automationIds}
@@ -58,14 +58,14 @@ function AllAutomations({
   }, []);
 
   return (
-    <Section title={t('All Automations')}>
+    <Section title={t('All Alerts')}>
       <AutomationSearch initialQuery={searchQuery} onSearch={onSearch} />
       <ConnectedAutomationsList
         data-test-id="drawer-all-automations-list"
         automationIds={null}
         connectedAutomationIds={new Set(automationIds)}
         toggleConnected={toggleConnected}
-        emptyMessage={t('No automations found')}
+        emptyMessage={t('No alerts found')}
         cursor={cursor}
         onCursor={setCursor}
         query={searchQuery}
@@ -161,7 +161,7 @@ export function AutomateSection() {
         />
       ),
       {
-        ariaLabel: t('Connect Automations'),
+        ariaLabel: t('Connect Alerts'),
         shouldCloseOnInteractOutside: el => {
           if (!ref.current) {
             return true;
@@ -175,7 +175,7 @@ export function AutomateSection() {
   if (workflowIds.length > 0) {
     return (
       <Container>
-        <Section title={t('Connected Automations')}>
+        <Section title={t('Connected Alerts')}>
           <ConnectedAutomationsList
             automationIds={workflowIds}
             cursor={undefined}
@@ -186,10 +186,10 @@ export function AutomateSection() {
         <ButtonWrapper justify="between">
           {/* TODO: Implement create automation flow */}
           <Button size="sm" icon={<IconAdd />} disabled>
-            {t('Create New Automation')}
+            {t('Create New Alert')}
           </Button>
           <Button size="sm" icon={<IconEdit />} onClick={toggleDrawer}>
-            {t('Edit Automations')}
+            {t('Edit Alerts')}
           </Button>
         </ButtonWrapper>
       </Container>
@@ -207,7 +207,7 @@ export function AutomateSection() {
           icon={<IconAdd />}
           onClick={toggleDrawer}
         >
-          {t('Connect an Automation')}
+          {t('Connect an Alert')}
         </Button>
       </Section>
     </Container>

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -174,7 +174,7 @@ describe('DetectorDetails', () => {
           organization,
           initialRouterConfig,
         });
-        expect(await screen.findByText('No automations connected')).toBeInTheDocument();
+        expect(await screen.findByText('No alerts connected')).toBeInTheDocument();
       });
 
       it('displays connected automations', async () => {

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -216,9 +216,9 @@ describe('DetectorEdit', () => {
       expect(screen.queryByRole('button', {name: 'Delete'})).not.toBeInTheDocument();
 
       // Can add an automation and save
-      await userEvent.click(screen.getByRole('button', {name: 'Connect an Automation'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Connect an Alert'}));
       const drawer = await screen.findByRole('complementary', {
-        name: 'Connect Automations',
+        name: 'Connect Alerts',
       });
       await userEvent.click(await within(drawer).findByRole('button', {name: 'Connect'}));
       await userEvent.click(screen.getByRole('button', {name: 'Save'}));

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -126,10 +126,10 @@ describe('DetectorsList', () => {
 
     render(<DetectorsList />, {organization});
     const row = await screen.findByTestId('detector-list-row');
-    expect(within(row).getByText('1 automation')).toBeInTheDocument();
+    expect(within(row).getByText('1 alert')).toBeInTheDocument();
 
     // Tooltip should fetch and display the automation name/action
-    await userEvent.hover(within(row).getByText('1 automation'));
+    await userEvent.hover(within(row).getByText('1 alert'));
     expect(await screen.findByText('Automation 1')).toBeInTheDocument();
     expect(await screen.findByText('Slack')).toBeInTheDocument();
   });

--- a/static/app/views/detectors/monitorViewContainer.tsx
+++ b/static/app/views/detectors/monitorViewContainer.tsx
@@ -7,7 +7,7 @@ export default function MonitorViewContainer() {
     <MonitorViewContext.Provider
       value={{
         monitorsLinkPrefix: `monitors`,
-        automationsLinkPrefix: `monitors/automations`,
+        automationsLinkPrefix: `monitors/alerts`,
       }}
     >
       <Outlet />

--- a/static/app/views/detectors/monitorViewContainer.tsx
+++ b/static/app/views/detectors/monitorViewContainer.tsx
@@ -7,7 +7,7 @@ export default function MonitorViewContainer() {
     <MonitorViewContext.Provider
       value={{
         monitorsLinkPrefix: `monitors`,
-        automationsLinkPrefix: `monitors/alerts`,
+        automationsLinkPrefix: `monitors/automations`,
       }}
     >
       <Outlet />

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -2,8 +2,6 @@ import {Fragment, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
-import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
@@ -84,8 +82,6 @@ export function IssuesSecondaryNav() {
 
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
   const {layout} = useNavContext();
-  const hasWorkflowEngine = useWorkflowEngineFeatureGate();
-
   const isSticky = layout === NavLayout.SIDEBAR;
 
   return (
@@ -95,39 +91,13 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
       collapsible={false}
       isSticky={isSticky}
     >
-      {hasWorkflowEngine ? (
-        <Fragment>
-          <SecondaryNav.Item
-            trailingItems={<FeatureBadge type="alpha" />}
-            to={`${baseUrl}/monitors/`}
-            activeTo={`${baseUrl}/monitors`}
-          >
-            {t('Monitors')}
-          </SecondaryNav.Item>
-          <SecondaryNav.Item
-            trailingItems={<FeatureBadge type="alpha" />}
-            to={`${baseUrl}/automations/`}
-            activeTo={`${baseUrl}/automations`}
-          >
-            {t('Automations')}
-          </SecondaryNav.Item>
-          <SecondaryNav.Item
-            to={`${baseUrl}/alerts/rules/`}
-            activeTo={`${baseUrl}/alerts/`}
-            analyticsItemName="issues_alerts"
-          >
-            {t('Alerts')}
-          </SecondaryNav.Item>
-        </Fragment>
-      ) : (
-        <SecondaryNav.Item
-          to={`${baseUrl}/alerts/rules/`}
-          activeTo={`${baseUrl}/alerts/`}
-          analyticsItemName="issues_alerts"
-        >
-          {t('Alerts')}
-        </SecondaryNav.Item>
-      )}
+      <SecondaryNav.Item
+        to={`${baseUrl}/alerts/rules/`}
+        activeTo={`${baseUrl}/alerts/`}
+        analyticsItemName="issues_alerts"
+      >
+        {t('Alerts')}
+      </SecondaryNav.Item>
     </StickyBottomSection>
   );
 }

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -2,6 +2,8 @@ import {Fragment, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
@@ -82,6 +84,8 @@ export function IssuesSecondaryNav() {
 
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
   const {layout} = useNavContext();
+  const hasWorkflowEngine = useWorkflowEngineFeatureGate();
+
   const isSticky = layout === NavLayout.SIDEBAR;
 
   return (
@@ -91,13 +95,39 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
       collapsible={false}
       isSticky={isSticky}
     >
-      <SecondaryNav.Item
-        to={`${baseUrl}/alerts/rules/`}
-        activeTo={`${baseUrl}/alerts/`}
-        analyticsItemName="issues_alerts"
-      >
-        {t('Alerts')}
-      </SecondaryNav.Item>
+      {hasWorkflowEngine ? (
+        <Fragment>
+          <SecondaryNav.Item
+            trailingItems={<FeatureBadge type="alpha" />}
+            to={`${baseUrl}/monitors/`}
+            activeTo={`${baseUrl}/monitors`}
+          >
+            {t('Monitors')}
+          </SecondaryNav.Item>
+          <SecondaryNav.Item
+            trailingItems={<FeatureBadge type="alpha" />}
+            to={`${baseUrl}/automations/`}
+            activeTo={`${baseUrl}/automations`}
+          >
+            {t('Alerts')}
+          </SecondaryNav.Item>
+          <SecondaryNav.Item
+            to={`${baseUrl}/alerts/rules/`}
+            activeTo={`${baseUrl}/alerts/`}
+            analyticsItemName="issues_alerts"
+          >
+            {t('Alerts')}
+          </SecondaryNav.Item>
+        </Fragment>
+      ) : (
+        <SecondaryNav.Item
+          to={`${baseUrl}/alerts/rules/`}
+          activeTo={`${baseUrl}/alerts/`}
+          analyticsItemName="issues_alerts"
+        >
+          {t('Alerts')}
+        </SecondaryNav.Item>
+      )}
     </StickyBottomSection>
   );
 }

--- a/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
@@ -57,7 +57,7 @@ export function MonitorsSecondaryNav() {
 
         <SecondaryNav.Section id="monitors-automations">
           <SecondaryNav.Item
-            to={`${baseUrl}/alerts/`}
+            to={`${baseUrl}/automations/`}
             analyticsItemName="monitors_automations"
           >
             {t('Alerts')}

--- a/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
@@ -57,10 +57,10 @@ export function MonitorsSecondaryNav() {
 
         <SecondaryNav.Section id="monitors-automations">
           <SecondaryNav.Item
-            to={`${baseUrl}/automations/`}
+            to={`${baseUrl}/alerts/`}
             analyticsItemName="monitors_automations"
           >
-            {t('Automations')}
+            {t('Alerts')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
       </SecondaryNav.Body>


### PR DESCRIPTION
renames user-facing labels/text from `Automations` to `Alerts`

next step is to update routing to `/alerts`, but that will come in a separate PR since we need to fully remove monitors/automations from the issues nav to do that since `issues/alerts` already exists