### PR TITLE
chore(aci milestone 3): remove dual write feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -512,7 +512,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable logs to debug metric alert dual processing
     manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
-    manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable Processing for Metric Alerts in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -825,7 +825,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         with (
             self.feature("organizations:incidents"),
-            self.feature("organizations:workflow-engine-metric-alert-dual-write"),
             self.feature("organizations:workflow-engine-rule-serializers"),
             outbox_runner(),
         ):
@@ -996,7 +995,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # we test the logic for this method elsewhere, so just test that it's correctly called
         assert mock_dual_delete.call_count == 1
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_delete_trigger_dual_update_resolve(self) -> None:
         """
         If there is no explicit resolve threshold on an alert rule, then we need to dual update the
@@ -1027,7 +1025,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert len(resp.data["triggers"]) == 1
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_update_trigger_threshold_dual_update_resolve(self) -> None:
         """
         If there is no explicit resolve threshold on an alert rule, then we need to dual update the
@@ -1066,7 +1063,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             )
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_update_trigger_threshold_dual_update_resolve_noop(self) -> None:
         """
         If there is an explicit resolve threshold on an alert rule, then updating triggers should
@@ -1092,7 +1088,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # remains unchanged
         assert_dual_written_resolution_threshold_equals(alert_rule, resolve_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_remove_resolve_threshold_dual_update_resolve(self) -> None:
         """
         If we set the remove the resolve threshold from an alert rule, then we need to update the
@@ -1118,7 +1113,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # resolve threshold changes to the warning threshold
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_dual_update_resolve_all_triggers_removed_and_recreated(self) -> None:
         """
         If a PUT request is made via the API and the trigger IDs are not specified in the

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -384,7 +384,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:workflow-engine-metric-alert-dual-write",
                     "organizations:workflow-engine-rule-serializers",
                 ]
             ),
@@ -398,7 +397,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         detector = Detector.objects.get(alertruledetector__alert_rule_id=int(resp.data.get("id")))
         assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_create_alert_rule_aci(self) -> None:
         with (
             outbox_runner(),

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2200,7 +2200,6 @@ class EnableDisableAlertRuleTest(TestCase, BaseIncidentsTest):
     def setUp(self) -> None:
         self.alert_rule = self.create_alert_rule()
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_enable(self) -> None:
         with self.tasks():
             disable_alert_rule(self.alert_rule)
@@ -2215,7 +2214,6 @@ class EnableDisableAlertRuleTest(TestCase, BaseIncidentsTest):
             for subscription in alert_rule.snuba_query.subscriptions.all():
                 assert subscription.status == QuerySubscription.Status.ACTIVE.value
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_disable(self) -> None:
         with self.tasks():
             disable_alert_rule(self.alert_rule)
@@ -2268,7 +2266,6 @@ class EnableDisableDetectorTest(TestCase, BaseIncidentsTest):
         for qs in query_subscriptions:
             assert qs.status == query_subscription_status
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_enable(self) -> None:
         with self.tasks():
             update_detector(detector=self.detector, enabled=False)
@@ -2280,14 +2277,12 @@ class EnableDisableDetectorTest(TestCase, BaseIncidentsTest):
 
         self.assert_detector_enabled_disabled(detector=self.detector, enabled=True)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_disable(self) -> None:
         with self.tasks():
             update_detector(detector=self.detector, enabled=False)
 
         self.assert_detector_enabled_disabled(detector=self.detector, enabled=False)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_multiple_data_sources_enable_disable(self) -> None:
         with self.tasks():
             self.snuba_query = create_snuba_query(


### PR DESCRIPTION
Remove references to `organizations:workflow-engine-metric-alert-dual-write` and set its default value to True.