### PR TITLE
fix(aci): Add top-level monitors path to django routing

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -983,6 +983,12 @@ urlpatterns += [
         react_page_view,
         name="prevent",
     ),
+    # Monitors
+    re_path(
+        r"^monitors/",
+        react_page_view,
+        name="monitors",
+    ),
     # Data Export
     re_path(
         r"^data-export/",


### PR DESCRIPTION
Without this django will redirect to the main page on sentry.io/monitors