### PR TITLE
chore(comparative workflows): Filter attrs with prefix

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -302,17 +302,14 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
 
         for i, (attr, _) in enumerate(scored_attrs_rrf):
 
-            public_alias, _, _ = translate_internal_to_public_alias(
-                attr, "string", SupportedTraceItemType.SPANS
+            public_alias = (
+                translate_internal_to_public_alias(attr, "string", SupportedTraceItemType.SPANS)[0]
+                or attr
             )
 
-            if (
-                public_alias is not None
-                and not public_alias.startswith("tags[")
-                and (
-                    not public_alias.startswith("sentry.")
-                    or public_alias == "sentry.normalized_description"
-                )
+            if not public_alias.startswith("tags[") and (
+                not public_alias.startswith("sentry.")
+                or public_alias == "sentry.normalized_description"
             ):
                 distribution = {
                     "attributeName": public_alias,

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -302,10 +302,11 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
 
         for i, (attr, _) in enumerate(scored_attrs_rrf):
 
-            public_alias = (
-                translate_internal_to_public_alias(attr, "string", SupportedTraceItemType.SPANS)[0]
-                or attr
+            public_alias, _, _ = translate_internal_to_public_alias(
+                attr, "string", SupportedTraceItemType.SPANS
             )
+            if public_alias is None:
+                public_alias = attr
 
             if not public_alias.startswith("tags[") and (
                 not public_alias.startswith("sentry.")

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes_ranked.py
@@ -95,15 +95,6 @@ class OrganizationTraceItemsAttributesRankedEndpointTest(
         assert response.status_code == 200, response.data
         assert "cohort1Total" in response.data
         assert "cohort2Total" in response.data
-        distributions = response.data["rankedAttributes"]
-
-        # Verify filtering: no attributes should start with "tags[" or "sentry." (except sentry.normalized_description)
-        for attr in distributions:
-            assert not attr["attributeName"].startswith("tags[")
-            assert not (
-                attr["attributeName"].startswith("sentry.")
-                and attr["attributeName"] != "sentry.normalized_description"
-            )
 
         assert mock_compare_distributions.called
         call_args = mock_compare_distributions.call_args


### PR DESCRIPTION
- Filter out attributes that start with `sentry.` and `tags[`
	- Exception is `sentry.normalized_description`
- Clean up tests to remove mocks