### PR TITLE
fix(seer/aci): Set AlertInSeer source_id consistently

### DIFF
--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -158,7 +158,9 @@ def send_historical_data_to_seer(
         expected_seasonality=data_condition.comparison.get("seasonality"),
     )
     alert = AlertInSeer(
-        id=None, source_id=data_source.id, source_type=DataSourceType.SNUBA_QUERY_SUBSCRIPTION
+        id=None,
+        source_id=int(data_source.source_id),
+        source_type=DataSourceType.SNUBA_QUERY_SUBSCRIPTION,
     )
     body = StoreDataRequest(
         organization_id=project.organization.id,

--- a/src/sentry/seer/anomaly_detection/types.py
+++ b/src/sentry/seer/anomaly_detection/types.py
@@ -19,7 +19,7 @@ class DataSourceType(IntEnum):
 
 class AlertInSeer(TypedDict):
     id: int | None
-    source_id: NotRequired[
+    source_id: NotRequired[  # For source_type = SNUBA_QUERY_SUBSCRIPTION, the query subscription ID.
         int
     ]  # during our dual processing rollout, some requests will be sending ID and some will send source_id/source_type
     source_type: NotRequired[DataSourceType]


### PR DESCRIPTION
AlertInSeer wants a 'source_id'; previously we were sending DataSource.id, but for consistency with AlertRule uses, it looks like QuerySubscription.id (or DataSource.source_id) is actually needed here.

Updated type docs to clarify.