### PR TITLE
chore(preprod): Minor tweaks to insights sidebar

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
@@ -11,7 +11,6 @@ import {t} from 'sentry/locale';
 import {
   CodeBlockWrapper,
   InlineCode,
-  OrderedList,
 } from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
 
 const HEIC_SCRIPT = `#!/bin/bash
@@ -126,7 +125,7 @@ function AlternativeIconsContent() {
         <Heading as="h3" size="md">
           {t('How to use:')}
         </Heading>
-        <OrderedList>
+        <ol>
           <li>
             <Text>
               {t('Save the script as')} <InlineCode>optimize.sh</InlineCode>
@@ -142,7 +141,7 @@ function AlternativeIconsContent() {
               {t('Optimize your images:')} <InlineCode>{exampleCommand}</InlineCode>
             </Text>
           </li>
-        </OrderedList>
+        </ol>
       </Flex>
     </Fragment>
   );

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -1,9 +1,9 @@
+import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
-import {Container, Flex} from 'sentry/components/core/layout';
+import {Container, Flex, Stack} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t, tn} from 'sentry/locale';
@@ -80,16 +80,16 @@ export function AppSizeInsightsSidebarRow({
         </Flex>
       </Flex>
 
-      <Flex direction="column" gap="xs">
+      <Stack gap="lg" align="start" paddingBottom="md">
         <Text variant="muted" size="sm">
           {insight.description}
         </Text>
         {shouldShowTooltip && (
-          <LinkText onClick={handleOpenModal}>
-            {t('See how to fix this locally →')}
-          </LinkText>
+          <Button priority="link" onClick={handleOpenModal} size="sm">
+            {t('Fix this locally')}
+          </Button>
         )}
-      </Flex>
+      </Stack>
 
       <Container>
         <Button
@@ -139,7 +139,18 @@ function FileRow({file}: {file: ProcessedInsightFile}) {
   }
 
   return (
-    <FlexAlternatingRow>
+    <Flex
+      align="center"
+      justify="between"
+      gap="lg"
+      padding="xs sm"
+      style={{
+        borderRadius: '4px',
+        minWidth: 0,
+        maxWidth: '100%',
+        overflow: 'hidden',
+      }}
+    >
       <Text size="sm" ellipsis style={{flex: 1}}>
         {file.path}
       </Text>
@@ -151,7 +162,7 @@ function FileRow({file}: {file: ProcessedInsightFile}) {
           ({formatUpside(file.percentage / 100)})
         </Text>
       </Flex>
-    </FlexAlternatingRow>
+    </Flex>
   );
 }
 
@@ -177,8 +188,19 @@ function OptimizableImageFileRow({
   );
 
   return (
-    <Container>
-      <FlexAlternatingRow>
+    <Fragment key={file.path}>
+      <Flex
+        align="center"
+        justify="between"
+        gap="lg"
+        padding="xs sm"
+        style={{
+          borderRadius: '4px',
+          minWidth: 0,
+          maxWidth: '100%',
+          overflow: 'hidden',
+        }}
+      >
         <Text size="sm" ellipsis style={{flex: 1}}>
           {file.path}
         </Text>
@@ -190,7 +212,7 @@ function OptimizableImageFileRow({
             ({formatUpside(file.percentage / 100)})
           </Text>
         </Flex>
-      </FlexAlternatingRow>
+      </Flex>
       <Flex direction="column" gap="xs" padding="xs sm">
         {hasMinifySavings && (
           <Flex align="center" gap="sm">
@@ -239,31 +261,6 @@ function OptimizableImageFileRow({
           </Flex>
         )}
       </Flex>
-    </Container>
+    </Fragment>
   );
 }
-
-const FlexAlternatingRow = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-radius: ${({theme}) => theme.borderRadius};
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-  gap: ${({theme}) => theme.space.lg};
-  padding: ${({theme}) => theme.space.xs} ${({theme}) => theme.space.sm};
-`;
-
-const LinkText = styled('span')`
-  color: ${p => p.theme.purple300};
-  font-size: ${p => p.theme.fontSize.sm};
-  cursor: pointer;
-  text-decoration: underline;
-  padding: ${p => p.theme.space.xs} 0;
-  display: inline-block;
-
-  &:hover {
-    color: ${p => p.theme.purple400};
-  }
-`;

--- a/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
@@ -2,7 +2,6 @@ import {Fragment, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {space} from 'sentry/styles/space';
 
 type InsightInfoModalOptions = {
   children: ReactNode;
@@ -17,19 +16,10 @@ export function InsightInfoModal({Header, Body, title, children}: Props) {
       <Header closeButton>
         <h3>{title}</h3>
       </Header>
-      <Body>
-        <ContentWrapper>{children}</ContentWrapper>
-      </Body>
+      <Body>{children}</Body>
     </Fragment>
   );
 }
-
-const ContentWrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(3)};
-  min-width: 0;
-`;
 
 export const CodeBlockWrapper = styled('div')`
   max-height: 300px;
@@ -46,16 +36,4 @@ export const InlineCode = styled('code')`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSize.sm};
   color: ${p => p.theme.purple300};
-`;
-
-export const OrderedList = styled('ol')`
-  margin: 0;
-  padding-left: ${p => p.theme.space.xl};
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.sm};
-
-  li {
-    color: ${p => p.theme.textColor};
-  }
 `;


### PR DESCRIPTION
Some minor tweaks to the insights sidebar. Uses link variant button instead of text and removes some styled components.

Before:
<img width="473" height="192" alt="Screenshot 2025-10-21 at 5 09 24 PM" src="https://github.com/user-attachments/assets/3f2e12d0-1e3e-41da-bf81-05ffab2762d8" />


After
<img width="477" height="204" alt="Screenshot 2025-10-21 at 5 09 18 PM" src="https://github.com/user-attachments/assets/abf81be2-fd85-49da-a8b6-5da559c4e9d5" />
