### PR TITLE
feat: Add 30 second timeout to Seer issue summary request

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -147,6 +147,7 @@ def _call_seer(
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(body),
         },
+        timeout=30,
     )
     response.raise_for_status()
 


### PR DESCRIPTION
This PR adds a 30 second timeout to the HTTP request made to Seer for issue summaries. Previously the requests.post call in _call_seer did not have an explicit timeout parameter which meant it could potentially hang indefinitely if Seer was unresponsive. This change adds a 30 second timeout to prevent the request from hanging for 1 minute+

note that there is an existing timeout for issue summary in alerts specifically, but that is set to 5 seconds and is in the thread pool executor https://github.com/getsentry/sentry/blob/74719114a762857dd1e3b0a5d25527326bc2d777/src/sentry/integrations/utils/issue_summary_for_alerts.py#L57