### PR TITLE
docs: Fix broken links in Performance Issues documentation

### DIFF
--- a/src/sentry/issue_detection/README.md
+++ b/src/sentry/issue_detection/README.md
@@ -26,7 +26,7 @@ Performance Issues are built on top of the [Issue Platform](https://develop.sent
   - It will map each `PerformanceProblem` into an `IssueOccurrence`
   - Then run `produce_occurrence_to_kafka` from [producer.py](../issues/producer.py) which passes the occurrence along to the [Issue Platform](https://develop.sentry.dev/backend/issue-platform/)
 
-For context, the Issue Platform operates off of the the GroupType subclasses (from [group_type.py](../issues/grouptype.py)). The [issue platform docs](https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type) provide a way to control the rollout of new `GroupType`s via the `released` property. Keep in mind, **this rollout is entirely separate from the PerformanceDetector**! The checks within `_detect_performance_problem` may skip running the detector, or skip creating problems completely all before they ever reach the Issue Platform.
+For context, the Issue Platform operates off of the the GroupType subclasses (from [grouptype.py](../issues/grouptype.py)). The [issue platform docs](https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type) provide a way to control the rollout of new `GroupType`s via the `released` property. Keep in mind, **this rollout is entirely separate from the PerformanceDetector**! The checks within `_detect_performance_problem` may skip running the detector, or skip creating problems completely all before they ever reach the Issue Platform.
 
 ### Detector Assumptions
 


### PR DESCRIPTION
The `README.md` file in the `issue_detection` directory had a large number of broken links pointing to paths that did not exist. 
I believe this is because the module had been renamed (from `performance_issues` in #100762) and moved around.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
