### PR TITLE
chore(spans): Remove unused span limit option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2866,13 +2866,6 @@ register(
     default=10 * 1024 * 1024,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Maximum number of spans in a segment. Larger segments drop the oldest spans.
-register(
-    "spans.buffer.max-segment-spans",
-    type=Int,
-    default=1001,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 # TTL for keys in Redis. This is a downside protection in case of bugs.
 register(
     "spans.buffer.redis-ttl",

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -16,7 +16,6 @@ DEFAULT_OPTIONS = {
     "spans.buffer.root-timeout": 10,
     "spans.buffer.segment-page-size": 100,
     "spans.buffer.max-segment-bytes": 10 * 1024 * 1024,
-    "spans.buffer.max-segment-spans": 1001,
     "spans.buffer.redis-ttl": 3600,
     "spans.buffer.max-flush-segments": 500,
     "spans.buffer.max-memory-percentage": 1.0,


### PR DESCRIPTION
This option was unused for a while - the only limit we enforce is a limit on the
size of segments in bytes, currently set at 10MB per segment.

Ref ENG-5743