### PR TITLE
chore(ask-seer): Ensure that ask seer is fully gated by gen-ai-features

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -84,7 +84,8 @@ function useUpdateOverlayPositionOnContentChange({
 interface AskSeerComboBoxProps<T extends QueryTokensProps>
   extends Omit<AriaComboBoxProps<unknown>, 'children'> {
   /**
-   * The source of the analytics event
+   * The source of the analytics event, must be a dot-separated identifier like "trace.
+   * explorer" or "issue.list"
    * @example 'trace.explorer'
    *
    * The combobox has the following analytic events, that will need to be tracked with your provided analyticsSource:
@@ -104,7 +105,8 @@ interface AskSeerComboBoxProps<T extends QueryTokensProps>
     string
   >;
   /**
-   * The owner of the feedback form
+   * The owner of the feedback form, must be an underscore-separated identifier like
+   * "trace_explorer_ai_query" or "issue_list_ai_query"
    *
    * @example 'trace_explorer_ai_query'
    */

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -138,6 +138,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     askSeerNLQueryRef,
     autoSubmitSeer,
     setAutoSubmitSeer,
+    enableAISearch,
   } = useSearchQueryBuilder();
 
   const {
@@ -397,10 +398,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     state.selectionManager.setFocusedKey(null);
   };
 
-  const areAiFeaturesAllowed =
-    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
-
-  if (!areAiFeaturesAllowed) {
+  if (!enableAISearch) {
     return null;
   }
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -32,7 +32,6 @@ import {useMutation, type MutationOptions} from 'sentry/utils/queryClient';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import useOverlay from 'sentry/utils/useOverlay';
-import {useTraceExploreAiQuerySetup} from 'sentry/views/explore/hooks/useTraceExploreAiQuerySetup';
 
 // The menu size can change from things like loading states, long options,
 // or custom menus like a date picker. This hook ensures that the overlay
@@ -84,6 +83,16 @@ function useUpdateOverlayPositionOnContentChange({
 
 interface AskSeerComboBoxProps<T extends QueryTokensProps>
   extends Omit<AriaComboBoxProps<unknown>, 'children'> {
+  /**
+   * The source of the analytics event
+   * @example 'trace.explorer'
+   *
+   * The combobox has the following analytic events, that will need to be tracked with your provided analyticsSource:
+   * - `<analyticsSource>.ai_query_rejected`
+   * - `<analyticsSource>.ai_query_interface`
+   * - `<analyticsSource>.ai_query_submitted`
+   */
+  analyticsSource: string;
   applySeerSearchQuery: (item: T) => void;
   askSeerMutationOptions: MutationOptions<
     {
@@ -94,11 +103,19 @@ interface AskSeerComboBoxProps<T extends QueryTokensProps>
     Error,
     string
   >;
+  /**
+   * The owner of the feedback form
+   *
+   * @example 'trace_explorer_ai_query'
+   */
+  feedbackSource: string;
   initialQuery: string;
 }
 
 export function AskSeerComboBox<T extends QueryTokensProps>({
   initialQuery,
+  feedbackSource,
+  analyticsSource,
   ...props
 }: AskSeerComboBoxProps<T>) {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -107,6 +124,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
   const containerRef = useRef<HTMLInputElement>(null);
   const isInitialRender = useRef(true);
   const inputRef = useRef<HTMLInputElement>(null);
+  const organization = useOrganization();
 
   const [searchQuery, setSearchQuery] = useState(() =>
     formatQueryToNaturalLanguage(initialQuery)
@@ -135,16 +153,12 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     },
   });
 
-  const organization = useOrganization();
-  const areAiFeaturesAllowed =
-    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
-
   const handleNoneOfTheseClick = () => {
     if (openForm) {
       openForm({
         messagePlaceholder: t('Why were these queries incorrect?'),
         tags: {
-          ['feedback.source']: 'trace_explorer_ai_query',
+          ['feedback.source']: feedbackSource,
           ['feedback.owner']: 'ml-ai',
           ['feedback.natural_language_query']: searchQuery,
           ['feedback.raw_result']: JSON.stringify(data?.queries).replace(/\n/g, ''),
@@ -189,7 +203,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
       if (typeof key !== 'string') return;
 
       if (key === 'none-of-these') {
-        trackAnalytics('trace.explorer.ai_query_rejected', {
+        trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
           organization,
           natural_language_query: searchQuery,
           num_queries_returned: data?.queries?.length ?? 0,
@@ -239,8 +253,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     },
   });
 
-  useTraceExploreAiQuerySetup({enableAISearch: areAiFeaturesAllowed && state.isOpen});
-
   const {inputProps, listBoxProps} = useSearchTokenCombobox(
     {
       ...props,
@@ -259,7 +271,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
         switch (e.key) {
           case 'Escape':
             if (!state.isOpen) {
-              trackAnalytics('trace.explorer.ai_query_interface', {
+              trackAnalytics(`${analyticsSource}.ai_query_interface`, {
                 organization,
                 action: 'closed',
               });
@@ -271,7 +283,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             return;
           case 'Enter':
             if (state.isOpen && state.selectionManager.focusedKey === 'none-of-these') {
-              trackAnalytics('trace.explorer.ai_query_rejected', {
+              trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
                 organization,
                 natural_language_query: searchQuery,
                 num_queries_returned: data?.queries?.length ?? 0,
@@ -301,7 +313,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               searchQuery.trim() !== null &&
               searchQuery.trim() !== ''
             ) {
-              trackAnalytics('trace.explorer.ai_query_submitted', {
+              trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
                 organization,
                 natural_language_query: searchQuery.trim(),
               });
@@ -365,18 +377,32 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
 
   useLayoutEffect(() => {
     if (autoSubmitSeer && searchQuery.trim()) {
-      trackAnalytics('trace.explorer.ai_query_submitted', {
+      trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
         organization,
         natural_language_query: searchQuery.trim(),
       });
       submitQuery(searchQuery.trim());
       setAutoSubmitSeer(false);
     }
-  }, [autoSubmitSeer, searchQuery, organization, submitQuery, setAutoSubmitSeer]);
+  }, [
+    analyticsSource,
+    autoSubmitSeer,
+    organization,
+    searchQuery,
+    setAutoSubmitSeer,
+    submitQuery,
+  ]);
 
   const onMouseLeave = () => {
     state.selectionManager.setFocusedKey(null);
   };
+
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
+
+  if (!areAiFeaturesAllowed) {
+    return null;
+  }
 
   return (
     <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
@@ -398,7 +424,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
           icon={<IconClose />}
           onFocus={() => !state.isOpen && state.open()}
           onClick={() => {
-            trackAnalytics('trace.explorer.ai_query_interface', {
+            trackAnalytics(`${analyticsSource}.ai_query_interface`, {
               organization,
               action: 'closed',
             });
@@ -458,7 +484,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
                   openForm({
                     messagePlaceholder: t('How can we make Seer search better for you?'),
                     tags: {
-                      ['feedback.source']: 'seer_trace_explorer_search',
+                      ['feedback.source']: feedbackSource,
                       ['feedback.owner']: 'ml-ai',
                     },
                   })

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -119,17 +119,23 @@ export function SearchQueryBuilderProvider({
 }: SearchQueryBuilderProps & {children: React.ReactNode}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const actionBarRef = useRef<HTMLDivElement>(null);
-  const organization = useOrganization();
-
-  const enableAISearch = Boolean(enableAISearchProp) && !organization.hideAiFeatures;
-  const {setupAcknowledgement} = useOrganizationSeerSetup({enabled: enableAISearch});
 
   const [autoSubmitSeer, setAutoSubmitSeer] = useState(false);
-  const [displayAskSeer, setDisplayAskSeer] = useState(false);
   const [displayAskSeerFeedback, setDisplayAskSeerFeedback] = useState(false);
   const currentInputValueRef = useRef<string>('');
   const askSeerNLQueryRef = useRef<string | null>(null);
   const askSeerSuggestedQueryRef = useRef<string | null>(null);
+
+  const organization = useOrganization();
+  const enableAISearch =
+    Boolean(enableAISearchProp) &&
+    !organization.hideAiFeatures &&
+    organization.features.includes('gen-ai-features');
+
+  const {setupAcknowledgement} = useOrganizationSeerSetup({enabled: enableAISearch});
+
+  const [displayAskSeerState, setDisplayAskSeerState] = useState(false);
+  const displayAskSeer = enableAISearch ? displayAskSeerState : false;
 
   const {state, dispatch} = useQueryBuilderState({
     initialQuery,
@@ -217,7 +223,7 @@ export function SearchQueryBuilderProvider({
       autoSubmitSeer,
       setAutoSubmitSeer,
       displayAskSeer,
-      setDisplayAskSeer,
+      setDisplayAskSeer: setDisplayAskSeerState,
       replaceRawSearchKeys,
       matchKeySuggestions,
       filterKeyAliases,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4601,6 +4601,8 @@ describe('SearchQueryBuilder', () => {
           return displayAskSeer ? (
             <AskSeerComboBox
               initialQuery={query}
+              analyticsSource="test"
+              feedbackSource="test"
               applySeerSearchQuery={() => {}}
               askSeerMutationOptions={mutationOptions({
                 mutationFn: async (_value: string) => {

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -420,6 +420,24 @@ describe('SpansTabContent', () => {
       });
     });
 
+    describe('when the AI features are disabled', () => {
+      it('does not display the Ask Seer combobox', async () => {
+        render(
+          <Wrapper>
+            <SpansTabContent datePageFilterProps={datePageFilterProps} />
+          </Wrapper>,
+          {organization: {...organization, features: []}}
+        );
+
+        const input = screen.getByRole('combobox');
+        await userEvent.click(input);
+
+        expect(
+          screen.queryByText(/Ask Seer to build your query/)
+        ).not.toBeInTheDocument();
+      });
+    });
+
     it('brings along the query', async () => {
       render(
         <Wrapper>

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -52,8 +52,13 @@ export function SpansTabSeerComboBox() {
   const {projects} = useProjects();
   const pageFilters = usePageFilters();
   const organization = useOrganization();
-  const {currentInputValueRef, query, committedQuery, askSeerSuggestedQueryRef} =
-    useSearchQueryBuilder();
+  const {
+    currentInputValueRef,
+    query,
+    committedQuery,
+    askSeerSuggestedQueryRef,
+    enableAISearch,
+  } = useSearchQueryBuilder();
 
   let initialSeerQuery = '';
   const queryDetails = useMemo(() => {
@@ -191,7 +196,9 @@ export function SpansTabSeerComboBox() {
   );
 
   const areAiFeaturesAllowed =
-    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
+    enableAISearch &&
+    !organization?.hideAiFeatures &&
+    organization.features.includes('gen-ai-features');
 
   useTraceExploreAiQuerySetup({enableAISearch: areAiFeaturesAllowed});
 

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -12,6 +12,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useTraceExploreAiQuerySetup} from 'sentry/views/explore/hooks/useTraceExploreAiQuerySetup';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -189,11 +190,18 @@ export function SpansTabSeerComboBox() {
     [askSeerSuggestedQueryRef, navigate, organization, pageFilters.selection]
   );
 
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
+
+  useTraceExploreAiQuerySetup({enableAISearch: areAiFeaturesAllowed});
+
   return (
     <AskSeerComboBox
       initialQuery={initialSeerQuery}
       askSeerMutationOptions={spansTabAskSeerMutationOptions}
       applySeerSearchQuery={applySeerSearchQuery}
+      analyticsSource="trace.explorer"
+      feedbackSource="trace_explorer_ai_query"
     />
   );
 }


### PR DESCRIPTION
Small PR making things a little more agnostic in the base ask seer combobox implementation, and adding a couple more checks for `gen-ai-features` are respected fully.

Ticket: EXP-554