### PR TITLE
chore(cleanup): Drop option for deleting group hash metadata

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -258,28 +258,21 @@ def delete_group_hashes(
             logger.warning("Error scheduling task to delete hashes from seer")
         finally:
             hash_ids = [gh[0] for gh in hashes_chunk]
-            if options.get("deletions.group.delete_group_hashes_metadata_first"):
-                metrics.incr("deletions.group.delete_group_hashes_metadata_first", sample_rate=1.0)
-                # If we delete the grouphash metadata rows first we will not need to update the references to the other grouphashes.
-                # If we try to delete the group hashes first, then it will require the updating of the columns first.
-                #
-                # To understand this, let's say we have the following relationships:
-                # gh A -> ghm A -> no reference to another grouphash
-                # gh B -> ghm B -> gh C
-                # gh C -> ghm C -> gh A
-                #
-                # Deleting group hashes A, B & C (since they all point to the same group) will require:
-                # * Updating columns ghmB & ghmC to point to None
-                # * Deleting the group hash metadata rows
-                # * Deleting the group hashes
-                #
-                # If we delete the metadata first, we will not need to update the columns before deleting them.
-                try:
-                    GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
-                except Exception:
-                    # XXX: Let's make sure that no issues are caused by this and then remove it
-                    logger.exception("Error deleting group hash metadata")
-
+            # If we delete the grouphash metadata rows first we will not need to update the references to the other grouphashes.
+            # If we try to delete the group hashes first, then it will require the updating of the columns first.
+            #
+            # To understand this, let's say we have the following relationships:
+            # gh A -> ghm A -> no reference to another grouphash
+            # gh B -> ghm B -> gh C
+            # gh C -> ghm C -> gh A
+            #
+            # Deleting group hashes A, B & C (since they all point to the same group) will require:
+            # * Updating columns ghmB & ghmC to point to None
+            # * Deleting the group hash metadata rows
+            # * Deleting the group hashes
+            #
+            # If we delete the metadata first, we will not need to update the columns before deleting them.
+            GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
             GroupHash.objects.filter(id__in=hash_ids).delete()
 
         iterations += 1

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -342,12 +342,6 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "deletions.group.delete_group_hashes_metadata_first",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Filestore (default)
 register("filestore.backend", default="filesystem", flags=FLAG_NOSTORE)

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -331,13 +331,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             assert not GroupHash.objects.filter(id=grouphash_b.id).exists()
             assert not GroupHashMetadata.objects.filter(id=metadata_b_id).exists()
 
-    def test_delete_grouphashes_and_metadata_and_metadata_but_delete_metadata_first(self) -> None:
-        """
-        Test that when deleting group hashes, the group hash metadata is deleted first (which will not update the references to the other group hashes)
-        """
-        with self.options({"deletions.group.delete_group_hashes_metadata_first": True}):
-            self.test_delete_grouphashes_and_metadata()
-
 
 class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
     referrer = Referrer.TESTING_TEST.value


### PR DESCRIPTION
This was added in #101720 and it's not needed anymore.