### PR TITLE
feat(dynamic-sampling): use batch org feature check for spans vs transactions

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -142,12 +142,12 @@ def partition_by_measure(
     spans = []
     transactions = []
 
+    # Use batch feature flag check to avoid N+1 queries.
+    feature_results = features.batch_has_for_organizations(
+        "organizations:dynamic-sampling-spans", orgs
+    )
     for org in orgs:
-        # This is an N+1 query that fetches getsentry database models
-        # internally, but we cannot abstract over batches of feature flag
-        # handlers yet. Hence, we must fetch organizations and do individual
-        # feature checks per org.
-        if features.has("organizations:dynamic-sampling-spans", org):
+        if feature_results.get(f"organization:{org.id}"):
             spans.append(org.id)
         else:
             transactions.append(org.id)

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -146,6 +146,11 @@ def partition_by_measure(
     feature_results = features.batch_has_for_organizations(
         "organizations:dynamic-sampling-spans", orgs
     )
+    if feature_results is None:
+        metrics.incr("dynamic_sampling.partition_by_measure.transactions", amount=len(orgs))
+        logger.error("dynamic_sampling.partition_by_measure.features_none", extra={"orgs": orgs})
+        return {SamplingMeasure.TRANSACTIONS: [org.id for org in orgs]}
+
     for org in orgs:
         if feature_results.get(f"organization:{org.id}"):
             spans.append(org.id)

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -149,15 +149,15 @@ def Feature(names: str | Iterable[str] | dict[str, bool]) -> Generator[None]:
         else:
             return default_batch_has_for_organizations(_feature_name, organizations, **kwargs)
 
-    with patch("sentry.features.has") as features_has:
+    with (
+        patch("sentry.features.has") as features_has,
+        patch("sentry.features.batch_has") as features_batch_has,
+        patch("sentry.features.batch_has_for_organizations") as features_batch_has_for_orgs,
+    ):
         features_has.side_effect = features_override
-        with patch("sentry.features.batch_has") as features_batch_has:
-            features_batch_has.side_effect = batch_features_override
-            with patch(
-                "sentry.features.batch_has_for_organizations"
-            ) as features_batch_has_for_orgs:
-                features_batch_has_for_orgs.side_effect = batch_features_override_for_organizations
-                yield
+        features_batch_has.side_effect = batch_features_override
+        features_batch_has_for_orgs.side_effect = batch_features_override_for_organizations
+        yield
 
 
 class FeatureContextManagerOrDecorator:


### PR DESCRIPTION
- Use the newly introduced has_batch_for_organizations method to do the feature checking for hopefully better performance in these tasks.
- Add test utilities to make sure the feature overrides work for this function as well

Closes TET-1151