### PR TITLE
chonk: show indicator prompt is it was dismissed and not snoozed

### DIFF
--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -401,6 +401,7 @@ export function usePrompt({
   return {
     isLoading: prompt.isPending,
     isError: prompt.isError,
+    data: prompt.data?.data,
     isPromptDismissed,
     dismissPrompt,
     snoozePrompt,

--- a/static/app/utils/theme/ChonkOptInBanner.tsx
+++ b/static/app/utils/theme/ChonkOptInBanner.tsx
@@ -21,7 +21,7 @@ export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
   const {mutate: mutateUserOptions} = useMutateUserOptions();
   const id = useId();
 
-  if (props.collapsed === true || !chonkPrompt.showbannerPrompt) {
+  if (props.collapsed === true || !chonkPrompt.showBannerPrompt) {
     return null;
   }
 

--- a/static/app/utils/theme/ChonkOptInBanner.tsx
+++ b/static/app/utils/theme/ChonkOptInBanner.tsx
@@ -44,7 +44,7 @@ export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
           analyticsEventName="Navigation: Chonk UI Banner Opt In Clicked"
           onClick={() => {
             mutateUserOptions({prefersChonkUI: true});
-            chonkPrompt.dismiss();
+            chonkPrompt.snooze();
           }}
         >
           {t('Try It Out')}
@@ -53,7 +53,7 @@ export function ChonkOptInBanner(props: {collapsed: boolean | 'never'}) {
       <DismissButton
         icon={<IconClose />}
         aria-label={t('Dismiss')}
-        onClick={chonkPrompt.dismissBannerPrompt}
+        onClick={chonkPrompt.snoozeBannerPrompt}
         size="xs"
         borderless
         analyticsEventKey="navigation.banner_dismiss_chonk_ui"

--- a/static/app/utils/theme/useChonkPrompt.spec.tsx
+++ b/static/app/utils/theme/useChonkPrompt.spec.tsx
@@ -66,7 +66,7 @@ describe('useChonkPrompt', () => {
     await waitFor(() => expect(result.current.showBannerPrompt).toBe(true));
     expect(result.current.showDotIndicatorPrompt).toBe(false);
 
-    result.current.dismissBannerPrompt();
+    result.current.snoozeBannerPrompt();
 
     expect(dismissMock).toHaveBeenCalledWith(
       '/organizations/org-slug/prompts-activity/',
@@ -107,7 +107,7 @@ describe('useChonkPrompt', () => {
     await waitFor(() => expect(result.current.showBannerPrompt).toBe(false));
     expect(result.current.showDotIndicatorPrompt).toBe(true);
 
-    result.current.dismissDotIndicatorPrompt();
+    result.current.snoozeDotIndicatorPrompt();
 
     expect(dismissMock).toHaveBeenCalledWith(
       '/organizations/org-slug/prompts-activity/',
@@ -192,7 +192,7 @@ describe('useChonkPrompt', () => {
     });
 
     await waitFor(() => expect(result.current.showBannerPrompt).toBe(true));
-    result.current.dismissBannerPrompt();
+    result.current.snoozeBannerPrompt();
     await waitFor(() => expect(result.current.showDotIndicatorPrompt).toBe(true));
   });
 

--- a/static/app/utils/theme/useChonkPrompt.spec.tsx
+++ b/static/app/utils/theme/useChonkPrompt.spec.tsx
@@ -19,7 +19,7 @@ describe('useChonkPrompt', () => {
       organization: OrganizationFixture({features: []}),
     });
 
-    expect(result.current.showbannerPrompt).toBe(false);
+    expect(result.current.showBannerPrompt).toBe(false);
     expect(result.current.showDotIndicatorPrompt).toBe(false);
   });
 
@@ -29,11 +29,16 @@ describe('useChonkPrompt', () => {
       body: {data: {dismissed_ts: null}},
     });
 
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/prompts-activity/',
+      method: 'PUT',
+    });
+
     const {result} = renderHookWithProviders(() => useChonkPrompt(), {
       organization: OrganizationFixture({features: ['chonk-ui']}),
     });
 
-    await waitFor(() => expect(result.current.showbannerPrompt).toBe(true));
+    await waitFor(() => expect(result.current.showBannerPrompt).toBe(true));
     expect(result.current.showDotIndicatorPrompt).toBe(false);
   });
 
@@ -58,7 +63,7 @@ describe('useChonkPrompt', () => {
       organization: OrganizationFixture({features: ['chonk-ui']}),
     });
 
-    await waitFor(() => expect(result.current.showbannerPrompt).toBe(true));
+    await waitFor(() => expect(result.current.showBannerPrompt).toBe(true));
     expect(result.current.showDotIndicatorPrompt).toBe(false);
 
     result.current.dismissBannerPrompt();
@@ -73,7 +78,7 @@ describe('useChonkPrompt', () => {
       })
     );
 
-    await waitFor(() => expect(result.current.showbannerPrompt).toBe(false));
+    await waitFor(() => expect(result.current.showBannerPrompt).toBe(false));
     await waitFor(() => expect(result.current.showDotIndicatorPrompt).toBe(true));
   });
 
@@ -99,7 +104,7 @@ describe('useChonkPrompt', () => {
       organization: OrganizationFixture({features: ['chonk-ui']}),
     });
 
-    await waitFor(() => expect(result.current.showbannerPrompt).toBe(false));
+    await waitFor(() => expect(result.current.showBannerPrompt).toBe(false));
     expect(result.current.showDotIndicatorPrompt).toBe(true);
 
     result.current.dismissDotIndicatorPrompt();
@@ -114,8 +119,81 @@ describe('useChonkPrompt', () => {
       })
     );
 
-    await waitFor(() => expect(result.current.showbannerPrompt).toBe(false));
+    await waitFor(() => expect(result.current.showBannerPrompt).toBe(false));
     await waitFor(() => expect(result.current.showDotIndicatorPrompt).toBe(false));
+  });
+
+  it('dismissed prompts more than 7 days ago are shown again', async () => {
+    const oldTimestamp = Date.now() / 1000 - 8 * 24 * 60 * 60;
+
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/prompts-activity/',
+      body: {
+        data: {
+          dismissed_ts: oldTimestamp,
+        },
+      },
+      match: [MockApiClient.matchQuery({feature: 'chonk_ui_banner'})],
+    });
+
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/prompts-activity/',
+      body: {
+        data: {
+          dismissed_ts: oldTimestamp,
+        },
+      },
+      match: [MockApiClient.matchQuery({feature: 'chonk_ui_dot_indicator'})],
+    });
+
+    const showPromptMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/prompts-activity/',
+      method: 'PUT',
+    });
+
+    const {result} = renderHookWithProviders(() => useChonkPrompt(), {
+      organization: OrganizationFixture({features: ['chonk-ui']}),
+    });
+
+    await waitFor(() => {
+      expect(showPromptMock.mock.calls[0][0]).toBe(
+        '/organizations/org-slug/prompts-activity/'
+      );
+    });
+
+    await waitFor(() => {
+      expect(showPromptMock.mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            feature: 'chonk_ui_banner',
+            status: 'visible',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(showPromptMock.mock.calls[1][0]).toBe(
+        '/organizations/org-slug/prompts-activity/'
+      );
+    });
+
+    await waitFor(() => {
+      expect(showPromptMock.mock.calls[1][1]).toEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            feature: 'chonk_ui_dot_indicator',
+            status: 'visible',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => expect(result.current.showBannerPrompt).toBe(true));
+    result.current.dismissBannerPrompt();
+    await waitFor(() => expect(result.current.showDotIndicatorPrompt).toBe(true));
   });
 
   it('user prefers chonk-ui does not show prompts', () => {
@@ -138,7 +216,7 @@ describe('useChonkPrompt', () => {
       organization: OrganizationFixture({features: ['chonk-ui']}),
     });
 
-    expect(result.current.showbannerPrompt).toBe(false);
+    expect(result.current.showBannerPrompt).toBe(false);
     expect(result.current.showDotIndicatorPrompt).toBe(false);
   });
 });

--- a/static/app/utils/theme/useChonkPrompt.tsx
+++ b/static/app/utils/theme/useChonkPrompt.tsx
@@ -1,8 +1,32 @@
-import {usePrompt} from 'sentry/actionCreators/prompts';
+import {useEffect} from 'react';
+import moment from 'moment-timezone';
+
+import {usePrompt, type PromptResponse} from 'sentry/actionCreators/prompts';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 
 function noop() {}
+
+const DAYS_SINCE_DISMISS = 7;
+
+function promptWasDismissedWithoutSnoozing(
+  promptData: PromptResponse['data'],
+  daysSinceDismiss: number
+): boolean {
+  // We used to use the dismissed mechnism. We are going to re-trigger the prompt
+  // if the dismiss time is more than N days ago and fallback to the prompt snooze mechanism
+  if (!promptData) {
+    return false;
+  }
+
+  if (promptData.snoozed_ts) {
+    return false;
+  }
+
+  const now = moment.utc();
+  const dismissedOn = moment.unix(promptData.dismissed_ts ?? 0).utc();
+  return now.diff(dismissedOn, 'days') > daysSinceDismiss;
+}
 
 export function useChonkPrompt() {
   const user = useUser();
@@ -12,22 +36,48 @@ export function useChonkPrompt() {
   const bannerPrompt = usePrompt({
     organization,
     feature: 'chonk_ui_banner',
-    daysToSnooze: 7,
+    daysToSnooze: DAYS_SINCE_DISMISS,
     options: {enabled: hasChonkUI},
   });
 
   const dotIndicatorPrompt = usePrompt({
     organization,
     feature: 'chonk_ui_dot_indicator',
-    daysToSnooze: 7,
+    daysToSnooze: DAYS_SINCE_DISMISS,
     options: {enabled: hasChonkUI},
   });
+
+  useEffect(() => {
+    if (!hasChonkUI) {
+      return;
+    }
+
+    if (user?.options?.prefersChonkUI) {
+      return;
+    }
+
+    if (
+      bannerPrompt.data &&
+      bannerPrompt.isPromptDismissed &&
+      promptWasDismissedWithoutSnoozing(bannerPrompt.data, DAYS_SINCE_DISMISS)
+    ) {
+      bannerPrompt.showPrompt();
+    }
+
+    if (
+      dotIndicatorPrompt.data &&
+      dotIndicatorPrompt.isPromptDismissed &&
+      promptWasDismissedWithoutSnoozing(dotIndicatorPrompt.data, DAYS_SINCE_DISMISS)
+    ) {
+      dotIndicatorPrompt.showPrompt();
+    }
+  }, [bannerPrompt, dotIndicatorPrompt, hasChonkUI, user?.options?.prefersChonkUI]);
 
   // UsePrompt returns undefined if the prompt is loading or has failed to load
   // so we need to check for that before rendering the component
   if (bannerPrompt.isLoading || dotIndicatorPrompt.isLoading) {
     return {
-      showbannerPrompt: false,
+      showBannerPrompt: false,
       showDotIndicatorPrompt: false,
       dismissBannerPrompt: noop,
       dismissDotIndicatorPrompt: noop,
@@ -42,7 +92,7 @@ export function useChonkPrompt() {
     user?.options?.prefersChonkUI
   ) {
     return {
-      showbannerPrompt: false,
+      showBannerPrompt: false,
       showDotIndicatorPrompt: false,
       dismissBannerPrompt: noop,
       dismissDotIndicatorPrompt: noop,
@@ -56,7 +106,7 @@ export function useChonkPrompt() {
   );
 
   return {
-    showbannerPrompt: !bannerPrompt.isPromptDismissed,
+    showBannerPrompt: !bannerPrompt.isPromptDismissed,
     showDotIndicatorPrompt,
     dismissBannerPrompt: () => {
       if (bannerPrompt.isPromptDismissed) {

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -65,8 +65,8 @@ export function PrimaryNavigationHelp() {
     <SidebarMenu
       triggerWrap={StackedNavigationTourReminder}
       onOpen={() => {
-        chonkPrompt.dismissDotIndicatorPrompt();
-        chonkPrompt.dismissBannerPrompt();
+        chonkPrompt.snoozeDotIndicatorPrompt();
+        chonkPrompt.snoozeBannerPrompt();
       }}
       items={[
         {


### PR DESCRIPTION
We were previously using the dismiss functionality whereas we should have been using the snooze. To encourage more folks to switch, we're adding a check to check if there is a dismiss timestamp, but no snooze timestamp, and re-shows the prompt.