### PR TITLE
fix(dashboards): `linkedDashboards` not part of response in dashboards request

### DIFF
--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -58,6 +58,7 @@ DASHBOARD_OBJECT = {
                     ],
                     "isHidden": False,
                     "selectedAggregate": None,
+                    "linkedDashboards": [],
                 }
             ],
             "limit": None,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3039,6 +3039,12 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         with self.feature("organizations:dashboards-drilldown-flow"):
             response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 200, response.data
+        assert response.data.get("widgets")[0].get("queries")[0].get("linkedDashboards") == [
+            {
+                "field": "project",
+                "dashboardId": linked_dashboard.id,
+            }
+        ]
 
         widgets = self.get_widgets(self.dashboard.id)
         assert len(widgets) == 1


### PR DESCRIPTION
We need to return the linkedDashboards so they populate correctly on the frontend