### PR TITLE
fix(auth): Require 2FA before redirecting to organization invite acceptance

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -477,12 +477,16 @@ class AuthLoginView(BaseView):
 
     def _handle_login(
         self, request: HttpRequest, user: User, organization: RpcOrganization | None
-    ) -> None:
+    ) -> bool:
         """
         Logs a user in and determines their active org.
+        Returns True if login was successful, False if 2FA is required.
         """
-        login(request=request, user=user, organization_id=coerce_id_from(m=organization))
+        logged_in = login(
+            request=request, user=user, organization_id=coerce_id_from(m=organization)
+        )
         self.active_organization = determine_active_organization(request=request)
+        return logged_in
 
     def refresh_organization_status(
         self, request: HttpRequest, user: User, organization: RpcOrganization
@@ -686,13 +690,14 @@ class AuthLoginView(BaseView):
             elif login_form.is_valid():
                 user = login_form.get_user()
 
-                self._handle_login(request, user, organization)
+                logged_in = self._handle_login(request, user, organization)
                 metrics.incr(
                     "login.attempt", instance="success", skip_internal=True, sample_rate=1.0
                 )
 
                 if not user.is_active:
                     return self.redirect(reverse("sentry-reactivate-account"))
+
                 if organization:
                     # Check if the user is a member of the provided organization based on their email
                     membership = organization_service.check_membership_by_email(
@@ -703,8 +708,10 @@ class AuthLoginView(BaseView):
 
                     # If the user is a member, the user_id is None, and they are in a "pending invite acceptance" state with a valid invitation link,
                     # we redirect them to the invitation page to explicitly accept the invite
+                    # Only redirect if user is logged in (passed 2FA if required)
                     if (
-                        membership
+                        logged_in
+                        and membership
                         and membership.user_id is None
                         and membership.is_pending
                         and invitation_link

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -998,8 +998,8 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
             self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
         )
 
-        invitation_link = "/" + member.get_invite_link().split("/", 3)[-1]
-        assert resp.redirect_chain == [(invitation_link, 302)]
+        # Users with 2FA should be redirected to 2FA dialog first, even with pending invites
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]
 
     def test_correct_redirect_as_2fa_user_invited(self) -> None:
         user = self.create_user("foor@example.com")
@@ -1018,8 +1018,8 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
             self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
         )
 
-        invitation_link = "/" + member.get_invite_link().split("/", 3)[-1]
-        assert resp.redirect_chain == [(invitation_link, 302)]
+        # Users with 2FA should be redirected to 2FA dialog first, even with pending invites
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]
 
     @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
     @with_feature({"organizations:create": False})


### PR DESCRIPTION
When users with 2FA enabled accepted organization invites, they were bypassing the 2FA flow and being redirected to the invite acceptance page after entering their username and password. Since 2FA was not completed, the user was never actually logged in, causing them to be stuck in a loop where they would be taken back to the accept invite page without being able to complete the login flow.

Root Cause:

PR #82005 (ffe2e436c29d) added logic to redirect users with pending invites to the invite acceptance page. However, this redirect happened regardless of whether 2FA was required, which broke the 2FA flow for users with pending invites.

The Fix:

1. Modified `_handle_login()` to return a boolean indicating whether login succeeded (True) or 2FA is required (False)
2. Modified the invite redirect condition to only redirect when `logged_in` is True, ensuring users complete 2FA before being redirected to the invite acceptance page

When 2FA is required, `logged_in` will be False, so the invite redirect is skipped and the user flows through to the final redirect which takes them to the 2FA dialog. After completing 2FA, they can then accept the invite.

This fix preserves the original subdomain redirect fix from PR #82005 while ensuring users with 2FA always complete the 2FA flow before being redirected to the invite acceptance page.

Test Changes:

Updated two tests that were changed in PR #82005 to expect the buggy behavior (redirecting to invite page instead of 2FA dialog). These tests were originally written correctly by Josh Ferge in 2021 but were updated to match the broken behavior when the bug was introduced:
- test_correct_redirect_as_2fa_user_single_org_invited
- test_correct_redirect_as_2fa_user_invited

Both now correctly expect redirect to /auth/2fa/ for users with 2FA enabled, even when they have pending organization invites.

Fixes [RTC-915: Accounts with 2FA aren't redirected to 2FA step in login flow for orgs they are not a member of](https://linear.app/getsentry/issue/RTC-915/accounts-with-2fa-arent-redirected-to-2fa-step-in-login-flow-for-orgs)