### PR TITLE
chore(aci milestone 3): remove dual processing feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -504,7 +504,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable dual writing for issue alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow processing for metric issues
-    manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable single processing through workflow engine for issue alerts
     manager.add("organizations:workflow-engine-single-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable logging to debug workflow engine process workflows
@@ -516,7 +516,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable Processing for Metric Alerts in the workflow_engine
-    manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable ingestion through trusted relays only

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -123,13 +123,7 @@ class SubscriptionProcessor:
                 "organizations:workflow-engine-single-process-metric-issues",
                 project.organization,
             )
-            self._has_workflow_engine_processing = (
-                features.has(
-                    "organizations:workflow-engine-metric-alert-processing",
-                    project.organization,
-                )
-                or self._has_workflow_engine_processing_only
-            )
+            self._has_workflow_engine_processing = True
         except Project.DoesNotExist:
             # No more init needed; process_update knows to log and return early in this case.
             return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1046,13 +1046,6 @@ def process_workflow_engine_metric_issues(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
 
-    org = job["event"].project.organization
-    if not (
-        features.has("organizations:workflow-engine-process-metric-issue-workflows", org)
-        or features.has("organizations:workflow-engine-single-process-metric-issues", org)
-    ):
-        return
-
     process_workflow_engine(job)
 
 

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -1,6 +1,5 @@
 import logging
 
-from sentry import features
 from sentry.issues.status_change_consumer import group_status_update_registry
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
@@ -43,26 +42,8 @@ def workflow_status_update_handler(
         metrics.incr("workflow_engine.tasks.error.no_detector_id")
         return
 
-    # We should only fire actions for activity updates if we should be firing actions
-    # if dual proccessing or single proccessing is enabled
-    if features.has(  # Metric issue single processing
-        "organizations:workflow-engine-single-process-metric-issues",
-        group.organization,
-    ) or features.has(  # Metric dual processing
-        "organizations:workflow-engine-metric-alert-processing",
-        group.organization,
-    ):
-        process_workflow_activity.delay(
-            activity_id=activity.id,
-            group_id=group.id,
-            detector_id=detector_id,
-        )
-    else:
-        logger.info(
-            "workflow_engine.tasks.process_workflows.activity_update.skipped",
-            extra={
-                "activity_id": activity.id,
-                "group_id": group.id,
-                "detector_id": detector_id,
-            },
-        )
+    process_workflow_activity.delay(
+        activity_id=activity.id,
+        group_id=group.id,
+        detector_id=detector_id,
+    )

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -50,7 +50,6 @@ from tests.sentry.incidents.subscription_processor.test_subscription_processor i
 @freeze_time()
 class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_alert_metrics_logging(self, mock_logger: MagicMock, mock_metrics: MagicMock) -> None:
@@ -111,7 +110,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_snoozed_alert_metrics_logging(
@@ -155,7 +153,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_resolve_metrics_logging(self, mock_logger: MagicMock, mock_metrics: MagicMock) -> None:
@@ -207,7 +204,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_snoozed_resolve_metrics_logging(
@@ -345,7 +341,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
             ]
         )
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.process_data_packet")
     def test_process_data_packet_called(self, mock_process_data_packet: MagicMock) -> None:
         rule = self.rule
@@ -361,7 +356,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         assert data_packet.source_id == str(self.sub.id)
         assert data_packet.packet.values == {"value": 10}
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.process_data_packet")
     @patch("sentry.incidents.subscription_processor.get_comparison_aggregation_value")
     def test_process_data_packet_not_called(
@@ -430,7 +424,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         # Ensure that single processing metric is sent
         mock_metric.incr.assert_any_call("incidents.workflow_engine.processing.single")
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_process_update__dual_processing__result_log(self, mock_logger):
         self.detector = self.create_detector(type=MetricIssue.slug)
@@ -459,7 +452,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
             },
         )
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_process_update__dual_processing__missing_detector(self, mock_logger: MagicMock):
         """
@@ -550,7 +542,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_seer_call_dual_processing__warning(self, mock_seer_request: MagicMock) -> None:
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -579,7 +570,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_seer_call_dual_processing__critical(self, mock_seer_request: MagicMock) -> None:
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -625,7 +615,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_seer_call_dual_processing__resolution(self, mock_seer_request: MagicMock) -> None:
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -680,7 +669,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
@@ -753,7 +741,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
@@ -812,7 +799,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
@@ -898,7 +884,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"

--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -10,7 +10,6 @@ from sentry.models.group import Group
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.services import eventstore
 from sentry.tasks.post_process import post_process_group
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.features import Feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Detector
@@ -201,7 +200,6 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
         self.call_post_process_group(occurrence)
         assert mock_trigger.call_count == 2  # both actions
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_resolution_from_critical(self, mock_trigger: MagicMock) -> None:
         value = self.critical_detector_trigger.comparison + 1
         data_packet = self.create_subscription_packet(value)
@@ -232,7 +230,6 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
                 sample_rate=1.0,
             )
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_resolution_from_warning(self, mock_trigger: MagicMock) -> None:
         value = self.warning_detector_trigger.comparison + 1
         data_packet = self.create_subscription_packet(value)

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -95,7 +95,6 @@ class BaseWorkflowIntegrationTest(BaseWorkflowTest):
 
 
 class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__to_metric_issue_workflow(self) -> None:
         """
         This test ensures that a data_source can create the correct event in Issue Platform
@@ -112,7 +111,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
             mock_producer.assert_called_once()
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__different_type(self) -> None:
         with mock.patch(
             "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
@@ -124,7 +122,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
             assert detectors == []
             mock_producer.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__no_detectors(self) -> None:
         self.detector.delete()
 
@@ -142,7 +139,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
 class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest):
     @with_feature("organizations:issue-metric-issue-post-process-group")
-    @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
     def test_workflow_engine__workflows(self) -> None:
         """
         This test ensures that the workflow engine is correctly hooked up to tasks/post_process.py.

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -122,7 +122,6 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
                 detector_id=detector.id,
             )
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_dual_processing(self) -> None:
         detector = self.create_detector(project=self.project)
         group = self.create_group(project=self.project, type=MetricIssue.type_id)
@@ -285,7 +284,6 @@ class TestProcessWorkflowActivity(TestCase):
             )
 
     @with_feature("organizations:workflow-engine-single-process-metric-issues")
-    @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
     @mock.patch("sentry.issues.status_change_consumer.get_group_from_fingerprint")
     @mock.patch(
         "sentry.workflow_engine.models.incident_groupopenperiod.update_incident_based_on_open_period_status_change"


### PR DESCRIPTION
Remove references to `organizations:workflow-engine-metric-alert-processing` and `organizations:workflow-engine-process-metric-issue-workflows` from the code and set their defaults to True.