### PR TITLE
fix(profiling): Only show python continuous profiling validation when…

### DIFF
--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -263,6 +263,7 @@ sentry_sdk.init(
     profiles_sample_rate=1.0`
     }
 )${
+  params.profilingOptions?.defaultProfilingMode === 'continuous' &&
   traceLifecycle === 'manual'
     ? `
 


### PR DESCRIPTION
… needed

This was showing in AM1 plans where transaction profiling instructions are shown.