### PR TITLE
chore(uptime): Remove epoch cutoff date

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3230,13 +3230,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "uptime.date_cutoff_epoch_seconds",
-    type=Int,
-    default=0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Controls whether uptime monitoring creates issues via the issue platform.
 register(
     "uptime.create-issues",

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, cast
 
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -24,7 +24,6 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
-from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -95,13 +94,6 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         start: datetime,
         end: datetime,
     ) -> list[EapCheckEntrySerializerResponse]:
-        maybe_cutoff = self._get_date_cutoff_epoch_seconds()
-        epoch_cutoff = (
-            datetime.fromtimestamp(maybe_cutoff, tz=timezone.utc) if maybe_cutoff else None
-        )
-        if epoch_cutoff and epoch_cutoff > start:
-            start = epoch_cutoff
-
         start_timestamp = Timestamp()
         start_timestamp.FromDatetime(start)
         end_timestamp = Timestamp()
@@ -231,7 +223,3 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
             return None
         val_str = check_status_reason_val.val_str
         return cast(CheckStatusReasonType, val_str) if val_str != "" else None
-
-    def _get_date_cutoff_epoch_seconds(self) -> float | None:
-        value = float(options.get("uptime.date_cutoff_epoch_seconds"))
-        return None if value == 0 else value

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta, timezone
 
 from sentry.testutils.cases import UptimeResultEAPTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 from sentry.uptime.types import IncidentStatus
 from sentry.utils.cursors import Cursor
@@ -158,19 +157,6 @@ class ProjectUptimeAlertCheckIndexBaseTest(UptimeAlertBaseEndpointTest):
                 self.project.slug,
                 self.detector.id,
                 qs_params={"cursor": Cursor(0, 20), "per_page": 2},
-            )
-            assert response.data is not None
-            assert len(response.data) == 0
-
-    @override_options(
-        {"uptime.date_cutoff_epoch_seconds": (MOCK_DATETIME - timedelta(seconds=1)).timestamp()}
-    )
-    def test_get_with_date_cutoff(self) -> None:
-        with self.feature(self.features):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.project.slug,
-                self.detector.id,
             )
             assert response.data is not None
             assert len(response.data) == 0


### PR DESCRIPTION
This date was used with the old EAP tables. Removing this unused code.
