### PR TITLE
chore(aci): update automation routes to alerts + remove monitors/automations from issues nav

### DIFF
--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -24,7 +24,7 @@ def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
     """
     Create a link to a workflow
     """
-    return f"/organizations/{organization_id}/monitors/alerts/{workflow_id}/"
+    return f"/organizations/{organization_id}/issues/automations/{workflow_id}/"
 
 
 def get_email_link_extra_params(

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -24,7 +24,7 @@ def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
     """
     Create a link to a workflow
     """
-    return f"/organizations/{organization_id}/issues/automations/{workflow_id}/"
+    return f"/organizations/{organization_id}/monitors/alerts/{workflow_id}/"
 
 
 def get_email_link_extra_params(

--- a/static/app/views/automations/edit.spec.tsx
+++ b/static/app/views/automations/edit.spec.tsx
@@ -97,7 +97,7 @@ describe('EditAutomation', () => {
     // Redirect to the monitors list
     await waitFor(() =>
       expect(router.location.pathname).toBe(
-        `/organizations/${organization.slug}/issues/automations/`
+        `/organizations/${organization.slug}/monitors/alerts/`
       )
     );
   });

--- a/static/app/views/automations/new-settings.spec.tsx
+++ b/static/app/views/automations/new-settings.spec.tsx
@@ -162,7 +162,7 @@ describe('AutomationNewSettings', () => {
     // Assert navigation to details page
     await waitFor(() =>
       expect(router.location.pathname).toBe(
-        `/organizations/${organization.slug}/issues/automations/${created.id}/`
+        `/organizations/${organization.slug}/monitors/alerts/${created.id}/`
       )
     );
   });

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -2,7 +2,7 @@ import type {SentryRouteObject} from 'sentry/components/route';
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 
 export const automationRoutes: SentryRouteObject = {
-  path: 'automations/',
+  path: 'alerts/',
   children: [
     {
       index: true,

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -141,7 +141,7 @@ describe('DetectorDetails', () => {
 
       await waitFor(() => {
         expect(router.location.pathname).toBe(
-          `/organizations/${organization.slug}/issues/monitors/${snubaQueryDetector.id}/edit/`
+          `/organizations/${organization.slug}/monitors/${snubaQueryDetector.id}/edit/`
         );
       });
     });
@@ -288,7 +288,7 @@ describe('DetectorDetails', () => {
       // Edit button takes you to the edit page
       expect(screen.getByRole('button', {name: 'Edit'})).toHaveAttribute(
         'href',
-        '/organizations/org-slug/issues/monitors/1/edit/'
+        '/organizations/org-slug/monitors/1/edit/'
       );
     });
 

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -34,9 +34,9 @@ describe('DetectorEdit', () => {
   });
   const project = ProjectFixture({id: '1', organization, environments: ['production']});
   const initialRouterConfig = {
-    route: '/organizations/:orgId/issues/monitors/:detectorId/edit/',
+    route: '/organizations/:orgId/monitors/:detectorId/edit/',
     location: {
-      pathname: '/organizations/org-slug/issues/monitors/1/edit/',
+      pathname: '/organizations/org-slug/monitors/1/edit/',
     },
   };
 
@@ -139,7 +139,7 @@ describe('DetectorEdit', () => {
 
       // Redirect to the monitors list
       expect(router.location.pathname).toBe(
-        `/organizations/${organization.slug}/issues/monitors/`
+        `/organizations/${organization.slug}/monitors/`
       );
     });
 
@@ -239,7 +239,7 @@ describe('DetectorEdit', () => {
       // Should navigate back to detector details page
       await waitFor(() => {
         expect(router.location.pathname).toBe(
-          `/organizations/${organization.slug}/issues/monitors/1/`
+          `/organizations/${organization.slug}/monitors/1/`
         );
       });
     });
@@ -329,7 +329,7 @@ describe('DetectorEdit', () => {
 
       // Should navigate back to detector details page
       expect(router.location.pathname).toBe(
-        `/organizations/${organization.slug}/issues/monitors/1/`
+        `/organizations/${organization.slug}/monitors/1/`
       );
     });
 
@@ -454,9 +454,9 @@ describe('DetectorEdit', () => {
       render(<DetectorEdit />, {
         organization,
         initialRouterConfig: {
-          route: '/organizations/:orgId/issues/monitors/:detectorId/edit/',
+          route: '/organizations/:orgId/monitors/:detectorId/edit/',
           location: {
-            pathname: `/organizations/${organization.slug}/issues/monitors/${mockDetector.id}/edit/`,
+            pathname: `/organizations/${organization.slug}/monitors/${mockDetector.id}/edit/`,
           },
         },
       });
@@ -528,9 +528,9 @@ describe('DetectorEdit', () => {
       render(<DetectorEdit />, {
         organization,
         initialRouterConfig: {
-          route: '/organizations/:orgId/issues/monitors/:detectorId/edit/',
+          route: '/organizations/:orgId/monitors/:detectorId/edit/',
           location: {
-            pathname: `/organizations/${organization.slug}/issues/monitors/${testDetector.id}/edit/`,
+            pathname: `/organizations/${organization.slug}/monitors/${testDetector.id}/edit/`,
           },
         },
       });
@@ -779,9 +779,9 @@ describe('DetectorEdit', () => {
       });
 
       const editRouterConfig = {
-        route: '/organizations/:orgId/issues/monitors/:detectorId/edit/',
+        route: '/organizations/:orgId/monitors/:detectorId/edit/',
         location: {
-          pathname: `/organizations/${organizationWithDeprecation.slug}/issues/monitors/123/edit/`,
+          pathname: `/organizations/${organizationWithDeprecation.slug}/monitors/123/edit/`,
         },
       };
 

--- a/static/app/views/detectors/monitorViewContainer.tsx
+++ b/static/app/views/detectors/monitorViewContainer.tsx
@@ -7,7 +7,7 @@ export default function MonitorViewContainer() {
     <MonitorViewContext.Provider
       value={{
         monitorsLinkPrefix: `monitors`,
-        automationsLinkPrefix: `monitors/automations`,
+        automationsLinkPrefix: `monitors/alerts`,
       }}
     >
       <Outlet />

--- a/static/app/views/detectors/monitorViewContext.tsx
+++ b/static/app/views/detectors/monitorViewContext.tsx
@@ -10,8 +10,8 @@ interface MonitorViewContextValue {
 }
 
 const DEFAULT_MONITOR_VIEW_CONTEXT: MonitorViewContextValue = {
-  monitorsLinkPrefix: 'issues/monitors',
-  automationsLinkPrefix: 'issues/automations',
+  monitorsLinkPrefix: 'monitors',
+  automationsLinkPrefix: 'monitors/alerts',
   assigneeFilter: undefined,
   detectorFilter: undefined,
 };

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -19,9 +19,9 @@ describe('DetectorEdit', () => {
   });
   const project = ProjectFixture({organization, environments: ['production']});
   const initialRouterConfig = {
-    route: '/organizations/:orgId/issues/monitors/new/settings/',
+    route: '/organizations/:orgId/monitors/new/settings/',
     location: {
-      pathname: '/organizations/org-slug/issues/monitors/new/settings/',
+      pathname: '/organizations/org-slug/monitors/new/settings/',
     },
   };
 
@@ -159,7 +159,7 @@ describe('DetectorEdit', () => {
       // Should navigate to the new monitor page
       await waitFor(() => {
         expect(router.location.pathname).toBe(
-          `/organizations/${organization.slug}/issues/monitors/123/`
+          `/organizations/${organization.slug}/monitors/123/`
         );
       });
     });

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -36,7 +36,7 @@ describe('DetectorNew', () => {
 
     expect(router.location).toEqual(
       expect.objectContaining({
-        pathname: `/organizations/org-slug/issues/monitors/new/settings/`,
+        pathname: `/organizations/org-slug/monitors/new/settings/`,
         query: {
           detectorType: 'uptime_domain_failure',
           project: '1',
@@ -49,7 +49,7 @@ describe('DetectorNew', () => {
     const {router} = render(<DetectorNew />, {
       initialRouterConfig: {
         location: {
-          pathname: '/organizations/org-slug/issues/monitors/new/',
+          pathname: '/organizations/org-slug/monitors/new/',
           query: {project: '2'},
         },
       },
@@ -63,7 +63,7 @@ describe('DetectorNew', () => {
 
     expect(router.location).toEqual(
       expect.objectContaining({
-        pathname: `/organizations/org-slug/issues/monitors/new/settings/`,
+        pathname: `/organizations/org-slug/monitors/new/settings/`,
         query: {
           detectorType: 'uptime_domain_failure',
           project: '2',

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -2,8 +2,6 @@ import {Fragment, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
-import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
@@ -84,8 +82,6 @@ export function IssuesSecondaryNav() {
 
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
   const {layout} = useNavContext();
-  const hasWorkflowEngine = useWorkflowEngineFeatureGate();
-
   const isSticky = layout === NavLayout.SIDEBAR;
 
   return (
@@ -95,39 +91,13 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
       collapsible={false}
       isSticky={isSticky}
     >
-      {hasWorkflowEngine ? (
-        <Fragment>
-          <SecondaryNav.Item
-            trailingItems={<FeatureBadge type="alpha" />}
-            to={`${baseUrl}/monitors/`}
-            activeTo={`${baseUrl}/monitors`}
-          >
-            {t('Monitors')}
-          </SecondaryNav.Item>
-          <SecondaryNav.Item
-            trailingItems={<FeatureBadge type="alpha" />}
-            to={`${baseUrl}/automations/`}
-            activeTo={`${baseUrl}/automations`}
-          >
-            {t('Alerts')}
-          </SecondaryNav.Item>
-          <SecondaryNav.Item
-            to={`${baseUrl}/alerts/rules/`}
-            activeTo={`${baseUrl}/alerts/`}
-            analyticsItemName="issues_alerts"
-          >
-            {t('Alerts')}
-          </SecondaryNav.Item>
-        </Fragment>
-      ) : (
-        <SecondaryNav.Item
-          to={`${baseUrl}/alerts/rules/`}
-          activeTo={`${baseUrl}/alerts/`}
-          analyticsItemName="issues_alerts"
-        >
-          {t('Alerts')}
-        </SecondaryNav.Item>
-      )}
+      <SecondaryNav.Item
+        to={`${baseUrl}/alerts/rules/`}
+        activeTo={`${baseUrl}/alerts/`}
+        analyticsItemName="issues_alerts"
+      >
+        {t('Alerts')}
+      </SecondaryNav.Item>
     </StickyBottomSection>
   );
 }

--- a/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
@@ -57,7 +57,7 @@ export function MonitorsSecondaryNav() {
 
         <SecondaryNav.Section id="monitors-automations">
           <SecondaryNav.Item
-            to={`${baseUrl}/automations/`}
+            to={`${baseUrl}/alerts/`}
             analyticsItemName="monitors_automations"
           >
             {t('Alerts')}


### PR DESCRIPTION
updates `/monitors/automations` to `/monitors/alerts`

we couldn't do this in the issues nav since `/issues/alerts` already exists, so we've removed monitors and automations from the issues nav (this also reduces the confusion of monitors and automations being in 2 places)

I've left the [linkPrefixes](https://github.com/getsentry/sentry/pull/101747#discussion_r2441367924) for now while we wait for approval on the top-level monitors nav