### PR TITLE
chore(Replay): Adding Span for Kafka Payload

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -410,14 +410,13 @@ def emit_trace_items_to_eap(trace_items: list[TraceItem]) -> None:
         default=None,
     )
 
-    with sentry_sdk.start_span(op="process", name="EAP Trace Items Details") as span:
+    with sentry_sdk.start_span(op="process", name="write_trace_items") as span:
         if largest_attribute:
             ti, name, size = largest_attribute
             span.set_data("largest_attr_trace_id", ti.trace_id)
             span.set_data("largest_attr_name", name)
             span.set_data("largest_attr_size_bytes", size)
-
-    write_trace_items(trace_items)
+        write_trace_items(trace_items)
 
 
 @sentry_sdk.trace

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -38,7 +38,6 @@ class SingletonProducer:
     ) -> _ProducerFuture:
         future = self._get().produce(destination, payload)
         self._track_futures(future)
-
         return future
 
     def _get(self) -> KafkaProducer:

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -5,7 +5,6 @@ from collections import deque
 from collections.abc import Callable
 from typing import Deque
 
-import sentry_sdk
 from arroyo.backends.abstract import ProducerFuture
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_producer_configuration
 from arroyo.types import BrokerValue, Partition
@@ -38,18 +37,7 @@ class SingletonProducer:
         self, destination: ArroyoTopic | Partition, payload: KafkaPayload
     ) -> _ProducerFuture:
         future = self._get().produce(destination, payload)
-
         self._track_futures(future)
-        sorted_headers = sorted(payload.headers, key=lambda h: len(h[1]), reverse=True)
-        with sentry_sdk.start_span(op="process", name="Kafka Payload Details for Replay") as span:
-
-            if len(sorted_headers) > 0:
-                span.set_data("top_header_1_name", sorted_headers[0][0])
-                span.set_data("top_header_1_size_bytes", len(sorted_headers[0][1]))
-
-            if len(sorted_headers) > 1:
-                span.set_data("top_header_2_name", sorted_headers[1][0])
-                span.set_data("top_header_2_size_bytes", len(sorted_headers[1][1]))
 
         return future
 

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -5,6 +5,7 @@ from collections import deque
 from collections.abc import Callable
 from typing import Deque
 
+import sentry_sdk
 from arroyo.backends.abstract import ProducerFuture
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_producer_configuration
 from arroyo.types import BrokerValue, Partition
@@ -37,7 +38,19 @@ class SingletonProducer:
         self, destination: ArroyoTopic | Partition, payload: KafkaPayload
     ) -> _ProducerFuture:
         future = self._get().produce(destination, payload)
+
         self._track_futures(future)
+        sorted_headers = sorted(payload.headers, key=lambda h: len(h[1]), reverse=True)
+        with sentry_sdk.start_span(op="process", name="Kafka Payload Details for Replay") as span:
+
+            if len(sorted_headers) > 0:
+                span.set_data("top_header_1_name", sorted_headers[0][0])
+                span.set_data("top_header_1_size_bytes", len(sorted_headers[0][1]))
+
+            if len(sorted_headers) > 1:
+                span.set_data("top_header_2_name", sorted_headers[1][0])
+                span.set_data("top_header_2_size_bytes", len(sorted_headers[1][1]))
+
         return future
 
     def _get(self) -> KafkaProducer:


### PR DESCRIPTION
To debug the following kafka payload sizing issue: https://sentry.sentry.io/issues/6779186130/?project=1, we add a span to determine the largest field causing the issue.

Relates to: REPLAY-807
