### PR TITLE
fix(timeseries): Fix incorrect extrapolation URL query parameter

### DIFF
--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -64,6 +64,38 @@ describe('useFetchEventsTimeSeries', () => {
     );
   });
 
+  it('turns off extrapolation', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: [],
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useFetchEventsTimeSeries(
+        DiscoverDatasets.SPANS,
+        {
+          yAxis: 'epm()',
+          extrapolate: false,
+        },
+        REFERRER
+      )
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        method: 'GET',
+        query: expect.objectContaining({
+          disableAggregateExtrapolation: '1',
+        }),
+      })
+    );
+  });
+
   it('can be disabled', async () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-timeseries/`,

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -142,11 +142,9 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
           topEvents,
           groupBy,
           sort: sort ? encodeSort(sort) : undefined,
-          disableAggregateExtrapolation: defined(extrapolate)
-            ? extrapolate
-              ? '0'
-              : '1'
-            : undefined,
+          // Careful! The value of `disableAggregateExtrapolation` does not matter. Any value will turn extrapolation off immediately. Pass `undefined` if extrapolation is on, otherwise pass `"1"`
+          disableAggregateExtrapolation:
+            defined(extrapolate) && !extrapolate ? '1' : undefined,
         },
       },
     ],


### PR DESCRIPTION
I made an incorrect (though IMO understandable assumption) that the parameter works on `"1"` vs `"0"` but actually it just checks if there's a value at all.
