### PR TITLE
feat(explorer): Add copy and navigation for issue details tool

### DIFF
--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -54,6 +54,17 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
       : `Viewed waterfall for trace ${traceId.slice(0, 8)}`;
   },
 
+  get_issue_details: (args, isLoading) => {
+    const issueId = args.issue_id || '';
+    const selectedEvent = args.selected_event;
+    if (selectedEvent && selectedEvent !== 'recommended') {
+      return isLoading
+        ? `Inspecting issue ${issueId} (${selectedEvent} event)...`
+        : `Inspected issue ${issueId} (${selectedEvent} event)`;
+    }
+    return isLoading ? `Inspecting issue ${issueId}...` : `Inspected issue ${issueId}`;
+  },
+
   code_search: (args, isLoading) => {
     const repoName = args.repo_name || 'repository';
     const mode = args.mode || 'search';
@@ -210,6 +221,11 @@ export function buildToolLinkUrl(
         pathname,
         query,
       };
+    }
+    case 'get_issue_details': {
+      const {event_id, issue_id} = toolLink.params;
+
+      return {pathname: `/issues/${issue_id}/events/${event_id}/`};
     }
     default:
       return null;


### PR DESCRIPTION
Adds custom copy and navigation links for the get_issue_details tool
<img width="779" height="287" alt="Screenshot 2025-10-22 at 12 06 12 PM" src="https://github.com/user-attachments/assets/31e1a183-8c5c-41a3-8596-8b043ff6ef5d" />
