### PR TITLE
feat(trace-metrics): Add inbound filter for trace metric names

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1143,6 +1143,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             f"filters:{FilterTypes.LOG_MESSAGES}": "\n".join(
                 options.get(f"sentry:{FilterTypes.LOG_MESSAGES}", [])
             ),
+            f"filters:{FilterTypes.TRACE_METRIC_NAMES}": "\n".join(
+                options.get(f"sentry:{FilterTypes.TRACE_METRIC_NAMES}", [])
+            ),
             "feedback:branding": options.get("feedback:branding", "1") == "1",
             "sentry:feedback_user_report_notifications": bool(
                 self.get_value_with_default(attrs, "sentry:feedback_user_report_notifications")

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -922,6 +922,21 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     )
                 else:
                     return Response({"detail": "You do not have that feature enabled"}, status=400)
+            if f"filters:{FilterTypes.TRACE_METRIC_NAMES}" in options:
+                if features.has(
+                    "projects:custom-inbound-filters", project, actor=request.user
+                ) and features.has(
+                    "organizations:tracemetrics-ingestion", project.organization, actor=request.user
+                ):
+                    project.update_option(
+                        f"sentry:{FilterTypes.TRACE_METRIC_NAMES}",
+                        clean_newline_inputs(
+                            options[f"filters:{FilterTypes.TRACE_METRIC_NAMES}"],
+                            case_insensitive=False,
+                        ),
+                    )
+                else:
+                    return Response({"detail": "You do not have that feature enabled"}, status=400)
             if "copy_from_project" in result:
                 if not project.copy_settings_from(result["copy_from_project"]):
                     return Response({"detail": "Copy project settings failed."}, status=409)

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -52,6 +52,7 @@ class FilterTypes:
     ERROR_MESSAGES = "error_messages"
     RELEASES = "releases"
     LOG_MESSAGES = "log_messages"
+    TRACE_METRIC_NAMES = "trace_metric_names"
 
 
 def get_filter_key(flt):
@@ -433,5 +434,20 @@ def get_log_messages_generic_filter(log_messages: list[str]) -> GenericFilter | 
             "op": "glob",
             "name": "log.body",
             "value": log_messages,
+        },
+    }
+
+
+def get_trace_metric_names_generic_filter(trace_metric_names: list[str]) -> GenericFilter | None:
+    if not trace_metric_names:
+        return None
+
+    return {
+        "id": "trace-metric-name",
+        "isEnabled": True,
+        "condition": {
+            "op": "glob",
+            "name": "trace_metric.name",
+            "value": trace_metric_names,
         },
     }

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -28,6 +28,7 @@ from sentry.ingest.inbound_filters import (
     get_filter_key,
     get_generic_filters,
     get_log_messages_generic_filter,
+    get_trace_metric_names_generic_filter,
 )
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.meta import get_clusterer_meta
@@ -164,6 +165,17 @@ def get_filter_settings(project: Project) -> Mapping[str, Any]:
                 log_messages_filter = get_log_messages_generic_filter(log_messages)
                 if log_messages_filter:
                     base_generic_filters.append(log_messages_filter)
+
+        if features.has("organizations:tracemetrics-ingestion", project.organization):
+            trace_metric_names = (
+                project.get_option(f"sentry:{FilterTypes.TRACE_METRIC_NAMES}") or []
+            )
+            if trace_metric_names:
+                trace_metric_names_filter = get_trace_metric_names_generic_filter(
+                    trace_metric_names
+                )
+                if trace_metric_names_filter:
+                    base_generic_filters.append(trace_metric_names_filter)
 
     if error_messages:
         filter_settings["errorMessages"] = {"patterns": error_messages}

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -632,6 +632,7 @@ class ProjectUpdateTest(APITestCase):
             "filters:releases": "1.*\n2.1.*",
             "filters:error_messages": "TypeError*\n*: integer division by modulo or zero",
             "filters:log_messages": "Updated*\n*.sentry.io",
+            "filters:trace_metric_names": "counter.*\n*.duration",
             "mail:subject_prefix": "[Sentry]",
             "sentry:scrub_ip_address": False,
             "sentry:origins": "*",
@@ -649,7 +650,13 @@ class ProjectUpdateTest(APITestCase):
             "filters:chunk-load-error": True,
         }
         with (
-            self.feature(["projects:custom-inbound-filters", "organizations:ourlogs-ingestion"]),
+            self.feature(
+                [
+                    "projects:custom-inbound-filters",
+                    "organizations:ourlogs-ingestion",
+                    "organizations:tracemetrics-ingestion",
+                ]
+            ),
             outbox_runner(),
         ):
             self.get_success_response(self.org_slug, self.proj_slug, options=options)
@@ -708,6 +715,10 @@ class ProjectUpdateTest(APITestCase):
         assert project.get_option("sentry:log_messages") == [
             "Updated*",
             "*.sentry.io",
+        ]
+        assert project.get_option("sentry:trace_metric_names") == [
+            "counter.*",
+            "*.duration",
         ]
         assert project.get_option("mail:subject_prefix", "[Sentry]")
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -271,10 +271,12 @@ def test_project_config_uses_filter_features(
     default_project, has_custom_filters, has_blacklisted_ips
 ):
     log_messages = ["some log"]
+    trace_metric_names = ["some metric"]
     error_messages = ["some_error"]
     releases = ["1.2.3", "4.5.6"]
     blacklisted_ips = ["112.69.248.54"]
     default_project.update_option("sentry:log_messages", log_messages)
+    default_project.update_option("sentry:trace_metric_names", trace_metric_names)
     default_project.update_option("sentry:error_messages", error_messages)
     default_project.update_option("sentry:releases", releases)
     default_project.update_option("filters:react-hydration-errors", "0")
@@ -287,6 +289,7 @@ def test_project_config_uses_filter_features(
         {
             "projects:custom-inbound-filters": has_custom_filters,
             "organizations:ourlogs-ingestion": True,
+            "organizations:tracemetrics-ingestion": True,
         }
     ):
         project_cfg = get_project_config(default_project)
@@ -308,6 +311,15 @@ def test_project_config_uses_filter_features(
                 "op": "glob",
                 "name": "log.body",
                 "value": ["some log"],
+            },
+        } in cfg_generic
+        assert {
+            "id": "trace-metric-name",
+            "isEnabled": True,
+            "condition": {
+                "op": "glob",
+                "name": "trace_metric.name",
+                "value": ["some metric"],
             },
         } in cfg_generic
     else:


### PR DESCRIPTION
This will allow metric names to be filtered by inbound rules. Follows from https://github.com/getsentry/sentry/pull/97285. We can add relay test too to ensure the generic inbound filter target remains correct.

Refs LOGS-374

