### PR TITLE
fix(eap): ignore None-value item attributes

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -54,6 +54,8 @@ def encode_attributes(
     for key, value in event_data.items():
         if key in ignore_fields:
             continue
+        if not value:
+            continue
         attributes[key] = _encode_value(value)
 
     if event.group_id:

--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -54,7 +54,7 @@ def encode_attributes(
     for key, value in event_data.items():
         if key in ignore_fields:
             continue
-        if not value:
+        if value is None:
             continue
         attributes[key] = _encode_value(value)
 

--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -62,6 +62,8 @@ def encode_attributes(
         attributes["group_id"] = AnyValue(int_value=event.group_id)
 
     for key, value in event_data["tags"]:
+        if value is None:
+            continue
         attributes[f"tags[{key}]"] = _encode_value(value)
 
     return attributes

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -267,6 +267,7 @@ class ItemHelpersTest(TestCase):
             "contexts": {"trace": {"trace_id": "h" * 32}},
             "other_field": "should_be_included",
             "tags": [("level", "info")],
+            "empty": None,
         }
 
         event = self.create_group_event(event_data)
@@ -276,6 +277,7 @@ class ItemHelpersTest(TestCase):
         assert "event_id" not in result.attributes
         assert "timestamp" not in result.attributes
         assert "tags" not in result.attributes
+        assert "empty" not in result.attributes
         # other_field should be present
         assert result.attributes["other_field"] == AnyValue(string_value="should_be_included")
         # group_id should be added


### PR DESCRIPTION
Fix for https://sentry-st.sentry.io/issues/6966533067/?project=1513938&query=is%3Aarchived&referrer=issue-stream

Some attributes have keys but no values. Ignore them