### PR TITLE
chore(aci): update workflow link to use `/monitors/alerts`

### DIFF
--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -24,7 +24,7 @@ def create_link_to_workflow(organization_id: int, workflow_id: str) -> str:
     """
     Create a link to a workflow
     """
-    return f"/organizations/{organization_id}/issues/automations/{workflow_id}/"
+    return f"/organizations/{organization_id}/monitors/alerts/{workflow_id}/"
 
 
 def get_email_link_extra_params(

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -236,7 +236,7 @@ class OpsgenieClientTest(APITestCase):
             "details": {
                 "Project Name": self.project.name,
                 "Triggering Workflows": rule.label,
-                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.id}/issues/automations/{123}/",
+                "Triggering Workflow URLs": f"http://example.com/organizations/{self.organization.id}/monitors/alerts/{123}/",
                 "Sentry Group": "Hello world",
                 "Sentry ID": group_id,
                 "Logger": "",

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -302,7 +302,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # Assert we are using the workflow id and created a link to the workflow
         assert (
             fallback_text
-            == f"Alert triggered <http://testserver/organizations/{event.organization.id}/issues/automations/1234567890/|ja rule>"
+            == f"Alert triggered <http://testserver/organizations/{event.organization.id}/monitors/alerts/1234567890/|ja rule>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
 

--- a/tests/sentry/rules/actions/test_create_ticket_utils.py
+++ b/tests/sentry/rules/actions/test_create_ticket_utils.py
@@ -38,7 +38,7 @@ class CreateTicketUtilsTest(TestCase):
             self.event, workflow_id, installation, generate_footer
         )
 
-        expected_url = f"/organizations/{self.organization.id}/issues/automations/{workflow_id}/"
+        expected_url = f"/organizations/{self.organization.id}/monitors/alerts/{workflow_id}/"
         assert (
             description
             == f"Test description\n\nThis issue was created by a workflow: {expected_url}"


### PR DESCRIPTION
backend update for https://github.com/getsentry/sentry/pull/101945