### PR TITLE
fix(uptime): Hotfix uptime detectors missing dataSources

### DIFF
--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -64,6 +64,14 @@ export function OverviewRow({summary, uptimeDetector, timeWindowConfig, single}:
     organization,
   });
 
+  // XXX(epurkhiser): This is a hack, we're seeing some uptime detectors with
+  // missing dataSources. That should never happen, but for now let's make sure
+  // we're not totally blowing up customers views
+  // @ts-expect-error - See above
+  if (uptimeDetector.dataSources.length === 0) {
+    return null;
+  }
+
   const subscription = uptimeDetector.dataSources[0].queryObj;
 
   const ruleDetails = single ? null : (


### PR DESCRIPTION
Refs [RTC-1240: Uptime Insights page not loading for chptr-eng](https://linear.app/getsentry/issue/RTC-1240/uptime-insights-page-not-loading-for-chptr-eng)