### PR TITLE
fix(otlp): Use integration path in otlp traces endpoint

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -18,7 +18,7 @@ KEY_RATE_LIMIT = {
         "security": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/security/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "minidump": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
-        "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/otlp/v1/traces",
+        "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/traces",
         "otlp_logs": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/logs",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "unreal": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/",

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -269,7 +269,7 @@ class ProjectKey(Model):
     def otlp_traces_endpoint(self):
         endpoint = self.get_endpoint()
 
-        return f"{endpoint}/api/{self.project_id}/otlp/v1/traces"
+        return f"{endpoint}/api/{self.project_id}/integration/otlp/v1/traces"
 
     @property
     def otlp_logs_endpoint(self):


### PR DESCRIPTION
This matches what is in our docs https://docs.sentry.io/concepts/otlp/#using-an-opentelemetry-sdk, and the endpoint in relay: https://github.com/getsentry/relay/blob/46dfaa850b8717a6e22c3e9a275ba17fe673b9da/relay-server/src/endpoints/mod.rs#L89

I validated this by testing locally.