### PR TITLE
chore(preprod): Add extra info about colorspace/idiom for duplicate image insights

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -51,32 +51,6 @@ export function AppSizeInsightsSidebar({
     setExpandedInsights(newExpanded);
   };
 
-  const duplicateFilePathsByInsightType = new Map<string, Set<string>>();
-  const insightsByKey = new Map<string, ProcessedInsight[]>();
-
-  processedInsights.forEach(insight => {
-    const existing = insightsByKey.get(insight.key) || [];
-    existing.push(insight);
-    insightsByKey.set(insight.key, existing);
-  });
-
-  insightsByKey.forEach((insights, key) => {
-    const filePathCounts = new Map<string, number>();
-    insights.forEach(ins => {
-      ins.files.forEach(f => {
-        filePathCounts.set(f.path, (filePathCounts.get(f.path) || 0) + 1);
-      });
-    });
-
-    const duplicatePaths = new Set<string>();
-    filePathCounts.forEach((count, path) => {
-      if (count > 1) {
-        duplicatePaths.add(path);
-      }
-    });
-    duplicateFilePathsByInsightType.set(key, duplicatePaths);
-  });
-
   // Constrain width to viewport (leave 50px margin from screen edge)
   const constrainedWidth = Math.min(width, window.innerWidth - 50);
 
@@ -144,9 +118,6 @@ export function AppSizeInsightsSidebar({
                     isExpanded={expandedInsights.has(insight.key)}
                     onToggleExpanded={() => toggleExpanded(insight.key)}
                     platform={platform}
-                    duplicateFilePaths={
-                      duplicateFilePathsByInsightType.get(insight.key) || new Set()
-                    }
                   />
                 ))}
               </Flex>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -51,6 +51,32 @@ export function AppSizeInsightsSidebar({
     setExpandedInsights(newExpanded);
   };
 
+  const duplicateFilePathsByInsightType = new Map<string, Set<string>>();
+  const insightsByKey = new Map<string, ProcessedInsight[]>();
+
+  processedInsights.forEach(insight => {
+    const existing = insightsByKey.get(insight.key) || [];
+    existing.push(insight);
+    insightsByKey.set(insight.key, existing);
+  });
+
+  insightsByKey.forEach((insights, key) => {
+    const filePathCounts = new Map<string, number>();
+    insights.forEach(ins => {
+      ins.files.forEach(f => {
+        filePathCounts.set(f.path, (filePathCounts.get(f.path) || 0) + 1);
+      });
+    });
+
+    const duplicatePaths = new Set<string>();
+    filePathCounts.forEach((count, path) => {
+      if (count > 1) {
+        duplicatePaths.add(path);
+      }
+    });
+    duplicateFilePathsByInsightType.set(key, duplicatePaths);
+  });
+
   // Constrain width to viewport (leave 50px margin from screen edge)
   const constrainedWidth = Math.min(width, window.innerWidth - 50);
 
@@ -118,6 +144,9 @@ export function AppSizeInsightsSidebar({
                     isExpanded={expandedInsights.has(insight.key)}
                     onToggleExpanded={() => toggleExpanded(insight.key)}
                     platform={platform}
+                    duplicateFilePaths={
+                      duplicateFilePathsByInsightType.get(insight.key) || new Set()
+                    }
                   />
                 ))}
               </Flex>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -74,6 +74,7 @@ describe('AppSizeInsightsSidebarRow', () => {
             fileType: 'optimizable_image' as const,
             minifyPercentage: 6.67, // 200000 / 3000000 * 100
             conversionPercentage: 10, // 300000 / 3000000 * 100
+            isDuplicateVariant: false,
             originalFile: {
               file_path: 'image.png',
               current_size: 1000000,
@@ -81,6 +82,8 @@ describe('AppSizeInsightsSidebarRow', () => {
               minified_size: 800000,
               conversion_savings: 300000,
               heic_size: 700000,
+              colorspace: null,
+              idiom: null,
             },
           },
         },
@@ -121,6 +124,7 @@ describe('AppSizeInsightsSidebarRow', () => {
             fileType: 'optimizable_image' as const,
             minifyPercentage: 0,
             conversionPercentage: 10,
+            isDuplicateVariant: false,
             originalFile: {
               file_path: 'already-optimized.png',
               current_size: 802388,
@@ -128,6 +132,8 @@ describe('AppSizeInsightsSidebarRow', () => {
               minified_size: null,
               conversion_savings: 472700,
               heic_size: 329688,
+              colorspace: null,
+              idiom: null,
             },
           },
         },
@@ -158,6 +164,7 @@ describe('AppSizeInsightsSidebarRow', () => {
             fileType: 'optimizable_image' as const,
             minifyPercentage: 5,
             conversionPercentage: 0,
+            isDuplicateVariant: false,
             originalFile: {
               file_path: 'no-heic.png',
               current_size: 505980,
@@ -165,6 +172,8 @@ describe('AppSizeInsightsSidebarRow', () => {
               minified_size: 485960,
               conversion_savings: 0,
               heic_size: null,
+              colorspace: null,
+              idiom: null,
             },
           },
         },

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -231,7 +231,7 @@ function OptimizableImageFileRow({
         }}
       >
         <Flex align="center" gap="xs" style={{minWidth: 0, overflow: 'hidden'}}>
-          <Text size="sm" ellipsis>
+          <Text size="sm" ellipsis style={{flex: 1}}>
             {file.path}
           </Text>
           {hasMetadata && (

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -41,9 +41,7 @@ export function AppSizeInsightsSidebarRow({
   isExpanded,
   onToggleExpanded,
   platform,
-  duplicateFilePaths,
 }: {
-  duplicateFilePaths: Set<string>;
   insight: ProcessedInsight;
   isExpanded: boolean;
   onToggleExpanded: () => void;
@@ -128,11 +126,7 @@ export function AppSizeInsightsSidebarRow({
             })}
           >
             {insight.files.map((file, fileIndex) => (
-              <FileRow
-                key={`${file.path}-${fileIndex}`}
-                file={file}
-                filePathHasMultipleOfSameInsight={duplicateFilePaths.has(file.path)}
-              />
+              <FileRow key={`${file.path}-${fileIndex}`} file={file} />
             ))}
           </Container>
         )}
@@ -141,21 +135,9 @@ export function AppSizeInsightsSidebarRow({
   );
 }
 
-function FileRow({
-  file,
-  filePathHasMultipleOfSameInsight,
-}: {
-  file: ProcessedInsightFile;
-  filePathHasMultipleOfSameInsight: boolean;
-}) {
+function FileRow({file}: {file: ProcessedInsightFile}) {
   if (file.data.fileType === 'optimizable_image') {
-    return (
-      <OptimizableImageFileRow
-        file={file}
-        originalFile={file.data.originalFile}
-        filePathHasMultipleOfSameInsight={filePathHasMultipleOfSameInsight}
-      />
-    );
+    return <OptimizableImageFileRow file={file} originalFile={file.data.originalFile} />;
   }
 
   return (
@@ -189,10 +171,8 @@ function FileRow({
 function OptimizableImageFileRow({
   file,
   originalFile,
-  filePathHasMultipleOfSameInsight,
 }: {
   file: ProcessedInsightFile;
-  filePathHasMultipleOfSameInsight: boolean;
   originalFile: OptimizableImageFile;
 }) {
   if (file.data.fileType !== 'optimizable_image') {
@@ -210,13 +190,13 @@ function OptimizableImageFileRow({
   );
 
   const hasMetadata =
-    (originalFile.idiom || originalFile.colorspace) && filePathHasMultipleOfSameInsight;
+    (originalFile.idiom || originalFile.colorspace) && file.data.isDuplicateVariant;
   // TODO (EME-460): Add link to formal documentation about idiom/colorspaces in apple binaries as well as more info about app thinning
   const tooltipContent = hasMetadata && (
     <Flex direction="column" gap="lg" align="start">
       <Text size="xs" align="left">
         {t(
-          'This image shows up multiple times because this build likely did not have app thinning applied. That means your binary can include different copies of the same image meant for different device types.'
+          'This image shows up multiple times because this build likely did not have app thinning applied. That means your asset catalog can include different copies of the same image meant for different device types.'
         )}
       </Text>
       <Flex direction="column" gap="xs" align="start">

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -146,10 +146,12 @@ interface LooseImagesInsightResult extends GroupsInsightResult {}
 interface MainBinaryExportMetadataResult extends FilesInsightResult {}
 
 export interface OptimizableImageFile {
+  colorspace: string | null;
   conversion_savings: number;
   current_size: number;
   file_path: string;
   heic_size: number | null;
+  idiom: string | null;
   minified_size: number | null;
   minify_savings: number;
 }

--- a/tests/js/fixtures/preProdAppSize.ts
+++ b/tests/js/fixtures/preProdAppSize.ts
@@ -1,7 +1,4 @@
-import type {
-  AppleInsightResults,
-  OptimizableImageFile,
-} from 'sentry/views/preprod/types/appSizeTypes';
+import type {AppleInsightResults} from 'sentry/views/preprod/types/appSizeTypes';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 
 export function ProcessedInsightFixture(
@@ -46,16 +43,17 @@ export function ProcessedInsightFixture(
           fileType: 'optimizable_image' as const,
           minifyPercentage: 0,
           conversionPercentage: 2.0,
+          isDuplicateVariant: false,
           originalFile: {
-            best_optimization_type: 'convert_to_heic',
-            conversion_savings: 128000,
-            current_size: 256000,
             file_path: 'src/assets/logo.png',
-            heic_size: 128000,
-            minified_size: null,
+            current_size: 256000,
             minify_savings: 0,
-            potential_savings: 128000,
-          } as OptimizableImageFile,
+            minified_size: null,
+            conversion_savings: 128000,
+            heic_size: 128000,
+            colorspace: null,
+            idiom: null,
+          },
         },
       },
     ],


### PR DESCRIPTION
If app-thinning is not applied, there is a common situation where a build will have multiple duplicates of an image and therefore could have duplicate image insights, which can be confusing. 

This adds some tooltip info to clarify why you might see duplicate image insights

<img width="507" height="869" alt="Screenshot 2025-10-22 at 2 51 17 PM" src="https://github.com/user-attachments/assets/016bcc50-3bd6-42e3-b4fe-acdc5d28b39e" />
