### PR TITLE
fix(aci): correctly load condition sub-filters on alert edit

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -111,7 +111,7 @@ export interface DataConditionHandler {
   handlerSubgroup?: DataConditionHandlerSubgroupType;
 }
 
-export interface BaseSubfilter {
+interface BaseSubfilter {
   id: string;
   match: MatchType;
   value: string;

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -1,4 +1,8 @@
 import {PriorityLevel} from 'sentry/types/group';
+import type {
+  Attribute,
+  MatchType,
+} from 'sentry/views/automations/components/actionFilters/constants';
 
 import type {Action} from './actions';
 
@@ -106,3 +110,21 @@ export interface DataConditionHandler {
   type: DataConditionType;
   handlerSubgroup?: DataConditionHandlerSubgroupType;
 }
+
+export interface BaseSubfilter {
+  id: string;
+  match: MatchType;
+  value: string;
+}
+
+export interface AttributeSubfilter extends BaseSubfilter {
+  attribute: Attribute;
+  key: never;
+}
+
+export interface TagSubfilter extends BaseSubfilter {
+  attribute: never;
+  key: string;
+}
+
+export type Subfilter = AttributeSubfilter | TagSubfilter | BaseSubfilter;

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -55,7 +55,7 @@ export enum ModelAge {
   NEWEST = 'newest',
 }
 
-export enum Attributes {
+export enum Attribute {
   MESSAGE = 'message',
   PLATFORM = 'platform',
   ENVIRONMENT = 'environment',

--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -4,7 +4,7 @@ import {t, tct} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
-  Attributes,
+  Attribute,
   MATCH_CHOICES,
   type MatchType,
 } from 'sentry/views/automations/components/actionFilters/constants';
@@ -38,11 +38,11 @@ function AttributeField() {
       aria-label={t('Attribute')}
       placeholder={t('attribute')}
       value={condition.comparison.attribute}
-      options={Object.values(Attributes).map(attribute => ({
+      options={Object.values(Attribute).map(attribute => ({
         value: attribute,
         label: attribute,
       }))}
-      onChange={(option: SelectValue<Attributes>) => {
+      onChange={(option: SelectValue<Attribute>) => {
         onUpdate({comparison: {...condition.comparison, attribute: option.value}});
       }}
     />

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -148,48 +148,42 @@ function Branch({lastChild}: BranchProps) {
 function ComparisonTypeField() {
   const {subfilter, subfilter_id, onUpdate} = useSubfilterContext();
 
-  if (!subfilter.type) {
+  if ('attribute' in subfilter || 'key' in subfilter) {
     return (
-      <AutomationBuilderSelect
-        name={`${subfilter_id}.type`}
-        aria-label={t('Comparison type')}
-        value={subfilter.type ?? ''}
-        placeholder={t('Select value type')}
-        options={[
-          {
-            label: t('Attribute'),
-            value: DataConditionType.EVENT_ATTRIBUTE,
-          },
-          {
-            label: t('Tag'),
-            value: DataConditionType.TAGGED_EVENT,
-          },
-        ]}
-        onChange={(option: SelectValue<DataConditionType>) => {
-          onUpdate({
-            id: subfilter.id,
-            type: option.value,
-            match: MatchType.EQUAL,
-            value: '',
-            ...(option.value === DataConditionType.EVENT_ATTRIBUTE
-              ? {attribute: Attributes.MESSAGE}
-              : {}),
-          });
-        }}
-      />
+      <Fragment>
+        {'attribute' in subfilter ? <AttributeField /> : <KeyField />}
+        <MatchField />
+        <ValueField />
+      </Fragment>
     );
   }
-
   return (
-    <Fragment>
-      {subfilter.type === DataConditionType.EVENT_ATTRIBUTE ? (
-        <AttributeField />
-      ) : (
-        <KeyField />
-      )}
-      <MatchField />
-      <ValueField />
-    </Fragment>
+    <AutomationBuilderSelect
+      name={`${subfilter_id}.type`}
+      aria-label={t('Comparison type')}
+      value={subfilter.type ?? ''}
+      placeholder={t('Select value type')}
+      options={[
+        {
+          label: t('Attribute'),
+          value: DataConditionType.EVENT_ATTRIBUTE,
+        },
+        {
+          label: t('Tag'),
+          value: DataConditionType.TAGGED_EVENT,
+        },
+      ]}
+      onChange={(option: SelectValue<DataConditionType>) => {
+        onUpdate({
+          id: subfilter.id,
+          match: MatchType.EQUAL,
+          value: '',
+          ...(option.value === DataConditionType.EVENT_ATTRIBUTE
+            ? {attribute: Attributes.MESSAGE}
+            : {key: undefined}),
+        });
+      }}
+    />
   );
 }
 

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -11,18 +11,31 @@ import {IconAdd, IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
-import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {
-  Attributes,
+  DataConditionType,
+  type AttributeSubfilter,
+  type Subfilter,
+  type TagSubfilter,
+} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  Attribute,
   MatchType,
 } from 'sentry/views/automations/components/actionFilters/constants';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
+function isAttributeSubfilter(subfilter: Subfilter): subfilter is AttributeSubfilter {
+  return 'attribute' in subfilter;
+}
+
+function isTagSubfilter(subfilter: Subfilter): subfilter is TagSubfilter {
+  return 'key' in subfilter;
+}
+
 interface SubfilterProps {
-  onUpdate: (comparison: Record<string, any>) => void;
+  onUpdate: (comparison: Subfilter) => void;
   removeError: () => void;
-  subfilter: Record<string, any>;
+  subfilter: Subfilter;
   subfilter_id: string;
 }
 
@@ -48,6 +61,8 @@ export function SubfiltersList() {
       ...subfilters,
       {
         id: uuid4(),
+        match: MatchType.EQUAL,
+        value: '',
       },
     ];
     onUpdate({comparison: {...condition.comparison, filters: newSubfilters}});
@@ -55,13 +70,13 @@ export function SubfiltersList() {
 
   function removeSubfilter(id: string) {
     const newSubfilters = subfilters.filter(
-      (subfilter: Record<string, any>) => subfilter.id !== id
+      (subfilter: Subfilter) => subfilter.id !== id
     );
     onUpdate({comparison: {...condition.comparison, filters: newSubfilters}});
   }
 
-  function updateSubfilter(id: string, newSubfilter: Record<string, any>) {
-    const newSubfilters = subfilters.map((subfilter: Record<string, any>) => {
+  function updateSubfilter(id: string, newSubfilter: Subfilter) {
+    const newSubfilters = subfilters.map((subfilter: Subfilter) => {
       if (subfilter.id === id) {
         return newSubfilter;
       }
@@ -73,7 +88,7 @@ export function SubfiltersList() {
   return (
     <div>
       <div>
-        {subfilters.map((subfilter: Record<string, any>, i: number) => {
+        {subfilters.map((subfilter: Subfilter, i: number) => {
           return (
             <SubfilterContext.Provider
               value={{
@@ -148,10 +163,10 @@ function Branch({lastChild}: BranchProps) {
 function ComparisonTypeField() {
   const {subfilter, subfilter_id, onUpdate} = useSubfilterContext();
 
-  if ('attribute' in subfilter || 'key' in subfilter) {
+  if (isAttributeSubfilter(subfilter) || isTagSubfilter(subfilter)) {
     return (
       <Fragment>
-        {'attribute' in subfilter ? <AttributeField /> : <KeyField />}
+        {isAttributeSubfilter(subfilter) ? <AttributeField /> : <KeyField />}
         <MatchField />
         <ValueField />
       </Fragment>
@@ -161,7 +176,7 @@ function ComparisonTypeField() {
     <AutomationBuilderSelect
       name={`${subfilter_id}.type`}
       aria-label={t('Comparison type')}
-      value={subfilter.type ?? ''}
+      value=""
       placeholder={t('Select value type')}
       options={[
         {
@@ -175,13 +190,11 @@ function ComparisonTypeField() {
       ]}
       onChange={(option: SelectValue<DataConditionType>) => {
         onUpdate({
-          id: subfilter.id,
-          match: MatchType.EQUAL,
-          value: '',
+          ...subfilter,
           ...(option.value === DataConditionType.EVENT_ATTRIBUTE
-            ? {attribute: Attributes.MESSAGE}
-            : {key: undefined}),
-        });
+            ? {attribute: Attribute.MESSAGE}
+            : {key: ''}),
+        } as Subfilter);
       }}
     />
   );
@@ -189,17 +202,22 @@ function ComparisonTypeField() {
 
 function AttributeField() {
   const {subfilter, subfilter_id, onUpdate} = useSubfilterContext();
+
+  if (!isAttributeSubfilter(subfilter)) {
+    return null;
+  }
+
   return (
     <AutomationBuilderSelect
       name={`${subfilter_id}.attribute`}
       aria-label={t('Attribute')}
       placeholder={t('Select attribute')}
-      value={subfilter.attribute ?? ''}
-      options={Object.values(Attributes).map(attribute => ({
+      value={subfilter.attribute}
+      options={Object.values(Attribute).map(attribute => ({
         value: attribute,
         label: attribute,
       }))}
-      onChange={(option: SelectValue<string>) => {
+      onChange={(option: SelectValue<Attribute>) => {
         onUpdate({...subfilter, attribute: option.value});
       }}
     />
@@ -208,12 +226,17 @@ function AttributeField() {
 
 function KeyField() {
   const {subfilter, subfilter_id, onUpdate, removeError} = useSubfilterContext();
+
+  if (!isTagSubfilter(subfilter)) {
+    return null;
+  }
+
   return (
     <AutomationBuilderInput
       name={`${subfilter_id}.key`}
       aria-label={t('Tag')}
       placeholder={t('tag')}
-      value={subfilter.key ?? ''}
+      value={subfilter.key}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({...subfilter, key: e.target.value});
         removeError();
@@ -253,7 +276,7 @@ function ValueField() {
       name={`${subfilter_id}.value`}
       aria-label={t('Value')}
       placeholder={t('value')}
-      value={`${subfilter.value ?? ''}`}
+      value={subfilter.value ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({...subfilter, value: e.target.value});
         removeError();
@@ -262,11 +285,7 @@ function ValueField() {
   );
 }
 
-export function SubfilterDetailsList({
-  subfilters,
-}: {
-  subfilters: Array<Record<string, any>>;
-}) {
+export function SubfilterDetailsList({subfilters}: {subfilters: Subfilter[]}) {
   return (
     <DetailsListWrapper>
       {subfilters.map((subfilter, index) => (
@@ -278,20 +297,32 @@ export function SubfilterDetailsList({
   );
 }
 
-function SubfilterDetails({subfilter}: {subfilter: Record<string, any>}) {
+function SubfilterDetails({subfilter}: {subfilter: Subfilter}) {
   return tct('[item] [match] [value]', {
-    item: subfilter.attribute ?? subfilter.key,
+    item: isAttributeSubfilter(subfilter)
+      ? subfilter.attribute
+      : isTagSubfilter(subfilter)
+        ? subfilter.key
+        : '',
     match: subfilter.match === MatchType.EQUAL ? t('is') : t('is not'),
-    value: subfilter.value,
+    value: subfilter.value ?? '',
   });
 }
 
-export function validateSubfilters(
-  subfilters: Array<Record<string, any>>
-): string | undefined {
+export function validateSubfilters(subfilters: Subfilter[]): string | undefined {
   for (const subfilter of subfilters) {
-    const isMissingAttributeOrTag = !subfilter.attribute && !subfilter.key;
-    if (isMissingAttributeOrTag || !subfilter.match || !subfilter.value) {
+    const isMissingAttributeOrTag =
+      !isAttributeSubfilter(subfilter) && !isTagSubfilter(subfilter);
+    const missingAttribute = isAttributeSubfilter(subfilter) && !subfilter.attribute;
+    const missingKey = isTagSubfilter(subfilter) && !subfilter.key;
+
+    if (
+      isMissingAttributeOrTag ||
+      missingAttribute ||
+      missingKey ||
+      !subfilter.match ||
+      !subfilter.value
+    ) {
       return t('Ensure all subfilters are filled in.');
     }
   }

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -95,7 +95,7 @@ export function SubfiltersList() {
                 subfilter,
                 subfilter_id: `${condition_id}.comparison.filters.${subfilter.id}`,
                 onUpdate: newSubfilter => updateSubfilter(subfilter.id, newSubfilter),
-                removeError: () => removeError(subfilter.id),
+                removeError: () => removeError(condition.id),
               }}
               key={subfilter.id}
             >

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -190,7 +190,9 @@ function ComparisonTypeField() {
       ]}
       onChange={(option: SelectValue<DataConditionType>) => {
         onUpdate({
-          ...subfilter,
+          id: subfilter.id,
+          match: subfilter.match,
+          value: subfilter.value,
           ...(option.value === DataConditionType.EVENT_ATTRIBUTE
             ? {attribute: Attribute.MESSAGE}
             : {key: ''}),

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -23,16 +23,15 @@ const stripDataConditionId = (condition: any) => {
       ...conditionWithoutId,
       comparison: {
         ...condition.comparison,
-        filters: condition.comparison.filters?.map(stripSubfilterTypeAndId) || [],
+        filters: condition.comparison.filters?.map(stripSubfilterId) || [],
       },
     };
   }
   return conditionWithoutId;
 };
 
-// subfilters have a `type` for the frontend to distinguish between attribute and tag comparisons, but this is not expected by the backend
-const stripSubfilterTypeAndId = (subfilter: any) => {
-  const {id: _id, type: _type, ...subfilterWithoutTypeAndId} = subfilter;
+const stripSubfilterId = (subfilter: any) => {
+  const {id: _id, ...subfilterWithoutTypeAndId} = subfilter;
   return subfilterWithoutTypeAndId;
 };
 

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -31,8 +31,8 @@ const stripDataConditionId = (condition: any) => {
 };
 
 const stripSubfilterId = (subfilter: any) => {
-  const {id: _id, ...subfilterWithoutTypeAndId} = subfilter;
-  return subfilterWithoutTypeAndId;
+  const {id: _id, ...subfilterWithoutId} = subfilter;
+  return subfilterWithoutId;
 };
 
 const stripActionId = (action: any) => {

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -20,7 +20,7 @@ import {
 } from 'sentry/views/automations/components/actionFilters/assignedTo';
 import {
   AgeComparison,
-  Attributes,
+  Attribute,
   Interval,
   Level,
   MatchType,
@@ -245,7 +245,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       dataCondition: EventAttributeNode,
       details: EventAttributeDetails,
       defaultComparison: {
-        attribute: Attributes.MESSAGE,
+        attribute: Attribute.MESSAGE,
         match: MatchType.CONTAINS,
       },
       validate: validateEventAttributeCondition,


### PR DESCRIPTION
rather than adding a temporary `type` field on condition subfilters, this change adds logic to check for either an `attribute` or `key` field on the subfilter to determine if it's an attribute or tag filter

using the `type` to determine the filter (attribute/tag) would not work when loading an existing alert into the builder when editing an alert, since it was just a temporary field being added in the ui during the alert creation flow