### PR TITLE
fix(aci milestone 3): fake IDs in serializer if new models don't have old model equivalents

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/utils.py
+++ b/src/sentry/incidents/endpoints/serializers/utils.py
@@ -1,0 +1,15 @@
+OFFSET = 10**9
+
+
+def get_fake_id_from_object_id(obj_id: int) -> int:
+    """
+    Return object_id + 1 billion to avoid any ID collisions with the model whose ID we're faking.
+    """
+    return obj_id + OFFSET
+
+
+def get_object_id_from_fake_id(fake_id: int) -> int:
+    """
+    Undo the object_id + offset operation to recover the object ID.
+    """
+    return fake_id - OFFSET

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -10,6 +10,7 @@ from sentry.incidents.endpoints.serializers.alert_rule_trigger_action import (
     get_input_channel_id,
     human_desc,
 )
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.notifications.models.notificationaction import ActionService, ActionTarget
 from sentry.notifications.notification_action.group_type_notification_registry.handlers.metric_alert_registry_handler import (
     MetricAlertRegistryHandler,
@@ -26,8 +27,6 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-
-OFFSET = 10**9
 
 
 class WorkflowEngineActionSerializer(Serializer):
@@ -63,7 +62,7 @@ class WorkflowEngineActionSerializer(Serializer):
         except DataConditionAlertRuleTrigger.DoesNotExist:
             # this data condition does not have an analog in the old system,
             # but we need to return *something*
-            return detector_trigger.id + OFFSET
+            return get_fake_id_from_object_id(detector_trigger.id)
 
     def serialize(
         self, obj: Action, attrs: Mapping[str, Any], user: User | RpcUser | AnonymousUser, **kwargs
@@ -95,7 +94,7 @@ class WorkflowEngineActionSerializer(Serializer):
             "id": (
                 str(aarta.alert_rule_trigger_action_id)
                 if aarta is not None
-                else str(obj.id + OFFSET)
+                else str(get_fake_id_from_object_id(obj.id))
             ),
             "alertRuleTriggerId": str(self.get_alert_rule_trigger_id(obj)),
             "type": obj.type,

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import Subquery
 
 from sentry.api.serializers import Serializer, serialize
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.endpoints.serializers.workflow_engine_action import (
     WorkflowEngineActionSerializer,
 )
@@ -26,8 +27,6 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
-
-OFFSET = 10**9
 
 
 class WorkflowEngineDataConditionSerializer(Serializer):
@@ -98,14 +97,14 @@ class WorkflowEngineDataConditionSerializer(Serializer):
         except DataConditionAlertRuleTrigger.DoesNotExist:
             # this data condition does not have an analog in the old system,
             # but we need to return *something*
-            alert_rule_trigger_id = obj.id + OFFSET
+            alert_rule_trigger_id = get_fake_id_from_object_id(obj.id)
         try:
             alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
                 detector=detector.id
             )
         except AlertRuleDetector.DoesNotExist:
             # this detector does not have an analog in the old system
-            alert_rule_id = detector.id + OFFSET
+            alert_rule_id = get_fake_id_from_object_id(detector.id)
 
         if obj.type == Condition.ANOMALY_DETECTION:
             threshold_type = obj.comparison["threshold_type"]

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -7,6 +7,10 @@ from django.db.models import Q, Subquery
 
 from sentry.api.serializers import Serializer, serialize
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.utils import (
+    get_fake_id_from_object_id,
+    get_object_id_from_fake_id,
+)
 from sentry.incidents.endpoints.serializers.workflow_engine_data_condition import (
     WorkflowEngineDataConditionSerializer,
 )
@@ -34,8 +38,6 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.workflow_action_group_status import WorkflowActionGroupStatus
 from sentry.workflow_engine.types import DetectorPriorityLevel
-
-OFFSET = 10**9
 
 
 class WorkflowEngineDetectorSerializer(Serializer):
@@ -84,7 +86,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
                     alert_rule_id=alert_rule_id
                 )
             except AlertRuleDetector.DoesNotExist:
-                detector_id = int(alert_rule_id) - OFFSET
+                detector_id = get_object_id_from_fake_id(alert_rule_id)
 
             detector = detectors[int(detector_id)]
             alert_rule_triggers = result[detector].setdefault("triggers", [])
@@ -338,7 +340,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
             except AlertRuleDetector.DoesNotExist:
                 # this detector does not have an analog in the old system,
                 # but we need to return *something*
-                alert_rule_id = obj.id + OFFSET
+                alert_rule_id = get_fake_id_from_object_id(obj.id)
 
         data: AlertRuleSerializerResponse = {
             "id": str(alert_rule_id),

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -86,7 +86,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
                     alert_rule_id=alert_rule_id
                 )
             except AlertRuleDetector.DoesNotExist:
-                detector_id = get_object_id_from_fake_id(alert_rule_id)
+                detector_id = get_object_id_from_fake_id(int(alert_rule_id))
 
             detector = detectors[int(detector_id)]
             alert_rule_triggers = result[detector].setdefault("triggers", [])


### PR DESCRIPTION
Actions use new -> old model serializers even if the workflow engine objects were single written, and thus we were failing to serialize and failing to send actions if the lookup table objects do not exist. 

To fix this, if we cannot find a lookup table equivalent for a workflow engine object, set a fake ID for it equal to (workflow engine object ID + ONE BILLION). This is safe because the serialized legacy IDs are not used for action firing, with the exception of charts. 

The charts will not show incident demarcation lines until we switch to using the open period serializer instead of the incidents serializer; however, because the actions currently fail to send at all, I feel that this is acceptable until the chart change lands.