### PR TITLE
feat(aci): Links in connected alerts/monitor drawers should open in new tab

### DIFF
--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -7,9 +7,10 @@ import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 interface Props {
   automation: Automation;
+  openInNewTab?: boolean;
 }
 
-export default function AutomationTitleCell({automation}: Props) {
+export default function AutomationTitleCell({automation, openInNewTab}: Props) {
   const organization = useOrganization();
   const {automationsLinkPrefix} = useMonitorViewContext();
 
@@ -26,6 +27,7 @@ export default function AutomationTitleCell({automation}: Props) {
       systemCreated={!automation.createdBy}
       disabled={!automation.enabled}
       warning={warning}
+      openInNewTab={openInNewTab}
     />
   );
 }

--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
-import {Link} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconSentry, IconWarning} from 'sentry/icons';
@@ -16,6 +16,7 @@ export type TitleCellProps = {
   className?: string;
   details?: React.ReactNode;
   disabled?: boolean;
+  openInNewTab?: boolean;
   systemCreated?: boolean;
   warning?: StatusWarning | null;
 };
@@ -28,9 +29,10 @@ export function TitleCell({
   disabled = false,
   className,
   warning,
+  openInNewTab,
 }: TitleCellProps) {
-  return (
-    <TitleWrapper to={link} className={className}>
+  const content = (
+    <Fragment>
       <Name>
         <NameText>{name}</NameText>
         {systemCreated && <CreatedBySentryIcon size="xs" color="subText" />}
@@ -48,6 +50,25 @@ export function TitleCell({
         {disabled && <DisabledText>&mdash; Disabled</DisabledText>}
       </Name>
       {defined(details) && <DetailsWrapper>{details}</DetailsWrapper>}
+    </Fragment>
+  );
+
+  if (openInNewTab) {
+    return (
+      <TitleWrapperAnchor
+        href={link}
+        className={className}
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        {content}
+      </TitleWrapperAnchor>
+    );
+  }
+
+  return (
+    <TitleWrapper to={link} className={className}>
+      {content}
     </TitleWrapper>
   );
 }
@@ -73,7 +94,7 @@ const CreatedBySentryIcon = styled(IconSentry)`
   flex-shrink: 0;
 `;
 
-const TitleWrapper = styled(Link)`
+const TitleBase = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(0.5)};
@@ -87,6 +108,9 @@ const TitleWrapper = styled(Link)`
     }
   }
 `;
+
+const TitleWrapper = TitleBase.withComponent(Link);
+const TitleWrapperAnchor = TitleBase.withComponent(ExternalLink);
 
 const DetailsWrapper = styled('div')`
   display: inline-grid;

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -23,6 +23,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   connectedDetectorIds?: Automation['detectorIds'];
   emptyMessage?: string;
   numSkeletons?: number;
+  openInNewTab?: boolean;
   toggleConnected?: (params: {detector: Detector}) => void;
 };
 
@@ -65,6 +66,7 @@ export default function ConnectedMonitorsList({
   toggleConnected,
   emptyMessage = t('No monitors connected'),
   numSkeletons = 10,
+  openInNewTab,
   ...props
 }: Props) {
   const canEdit = Boolean(connectedDetectorIds && typeof toggleConnected === 'function');
@@ -93,7 +95,7 @@ export default function ConnectedMonitorsList({
         {detectors.map(detector => (
           <SimpleTable.Row key={detector.id}>
             <SimpleTable.RowCell>
-              <DetectorLink detector={detector} />
+              <DetectorLink detector={detector} openInNewTab={openInNewTab} />
             </SimpleTable.RowCell>
             <SimpleTable.RowCell data-column-name="type">
               <DetectorTypeCell type={detector.type} />

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -49,6 +49,7 @@ function SelectedMonitors({
         isError={isError}
         toggleConnected={toggleConnected}
         numSkeletons={connectedIds.length}
+        openInNewTab
         {...props}
       />
     </StyledSection>
@@ -100,6 +101,7 @@ function AllMonitors({
           toggleConnected={toggleConnected}
           emptyMessage={t('No monitors found')}
           numSkeletons={10}
+          openInNewTab
         />
         <Flex justify="between">
           <div>{footerContent}</div>

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -29,6 +29,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   connectedAutomationIds?: Set<string>;
   emptyMessage?: string;
   limit?: number | null;
+  openInNewTab?: boolean;
   query?: string;
   toggleConnected?: (params: {automation: Automation}) => void;
 };
@@ -67,6 +68,7 @@ export function ConnectedAutomationsList({
   onCursor,
   limit = DEFAULT_AUTOMATIONS_PER_PAGE,
   query,
+  openInNewTab,
   ...props
 }: Props) {
   const canEdit = Boolean(
@@ -126,7 +128,10 @@ export function ConnectedAutomationsList({
               variant={automation.enabled ? 'default' : 'faded'}
             >
               <SimpleTable.RowCell>
-                <AutomationTitleCell automation={automation} />
+                <AutomationTitleCell
+                  automation={automation}
+                  openInNewTab={openInNewTab}
+                />
               </SimpleTable.RowCell>
               <SimpleTable.RowCell data-column-name="last-triggered">
                 <TimeAgoCell date={automation.lastTriggered} />

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -37,6 +37,7 @@ import {scheduleAsText} from 'sentry/views/insights/crons/utils/scheduleAsText';
 type DetectorLinkProps = {
   detector: Detector;
   className?: string;
+  openInNewTab?: boolean;
 };
 
 function formatConditionType(condition: MetricCondition) {
@@ -204,7 +205,7 @@ function Details({detector}: {detector: Detector}) {
   }
 }
 
-export function DetectorLink({detector, className}: DetectorLinkProps) {
+export function DetectorLink({detector, className, openInNewTab}: DetectorLinkProps) {
   const org = useOrganization();
   const {monitorsLinkPrefix} = useMonitorViewContext();
   const project = useProjectFromId({project_id: detector.projectId});
@@ -216,6 +217,7 @@ export function DetectorLink({detector, className}: DetectorLinkProps) {
       link={makeMonitorDetailsPathname(org.slug, detector.id, monitorsLinkPrefix)}
       systemCreated={!detectorTypeIsUserCreateable(detector.type)}
       disabled={!detector.enabled}
+      openInNewTab={openInNewTab}
       details={
         <Fragment>
           {project && (

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -38,6 +38,7 @@ function ConnectedAutomations({
         cursor={cursor}
         onCursor={setCursor}
         limit={null}
+        openInNewTab
       />
     </Section>
   );
@@ -69,6 +70,7 @@ function AllAutomations({
         cursor={cursor}
         onCursor={setCursor}
         query={searchQuery}
+        openInNewTab
       />
     </Section>
   );
@@ -181,6 +183,7 @@ export function AutomateSection() {
             cursor={undefined}
             onCursor={() => {}}
             limit={null}
+            openInNewTab
           />
         </Section>
         <ButtonWrapper justify="between">


### PR DESCRIPTION
Adds an `openInNewTab` prop to the detector and alert link components. We reuse the same component for the list/detail pages as we do on the edit pages, but on the edit pages we want to open in a new tab so you don't lose progress on the form.