### PR TITLE
fix(aci): Prevent metric chart tooltip clipping

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -309,9 +309,9 @@ function MetricDetectorChart({
     return (
       <Fragment>
         {errorMessage && (
-          <Alert system type="error">
+          <RoundedAlert system type="error">
             {errorMessage}
-          </Alert>
+          </RoundedAlert>
         )}
         <ChartContainerBody>
           <Flex justify="center" align="center">
@@ -378,9 +378,12 @@ export function MetricDetectorDetailsChart({
 const ChartContainer = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  overflow: hidden;
 `;
 
 const ChartContainerBody = styled('div')`
   padding: ${p => p.theme.space.xs} ${p => p.theme.space.lg} ${p => p.theme.space.xs};
+`;
+
+const RoundedAlert = styled(Alert)`
+  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
 `;


### PR DESCRIPTION
The `overflow: hidden` was clipping the chart tooltips.

Removes the style and adds rounding directly to the Alert component. Error state should look the same:

<img width="618" height="214" alt="CleanShot 2025-10-22 at 16 16 30" src="https://github.com/user-attachments/assets/f61c6426-412c-45f0-a8f7-aae76c705ec9" />
