### PR TITLE
:bug: fix(github): make inbound/outbound assignment sync case-insensitive

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -451,6 +451,8 @@ class GitHubIntegration(
 
             # Strip the @ from the username
             github_username = external_actor.external_name.lstrip("@")
+            # lowercase the username
+            github_username = github_username.lower()
 
         # Only update GitHub if we have a username to assign or if we're explicitly deassigning
         if github_username or not assign:

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -139,7 +139,7 @@ def sync_group_assignee_inbound_by_external_actor(
 
         external_actors = ExternalActor.objects.filter(
             provider=EXTERNAL_PROVIDERS_REVERSE[ExternalProviderEnum(integration.provider)].value,
-            external_name=external_user_name,
+            external_name__iexact=external_user_name,
             integration_id=integration.id,
             user_id__isnull=False,
         ).values_list("user_id", flat=True)

--- a/tests/sentry/integrations/utils/test_sync.py
+++ b/tests/sentry/integrations/utils/test_sync.py
@@ -345,6 +345,41 @@ class TestSyncAssigneeInboundByExternalActor(TestCase):
         assert updated_assignee.email == "test@example.com"
         mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_assignment_with_external_actor_case_insensitive(
+        self,
+        mock_record_event: mock.MagicMock,
+    ) -> None:
+        """Test assigning a group to a user via external actor."""
+        assert self.group.get_assignee() is None
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-123",
+            integration=self.example_integration,
+        )
+
+        # Create external user mapping
+        self.create_external_user(
+            user=self.test_user,
+            external_name="@JohnDoe",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="@johndoe",
+            external_issue_key=external_issue.key,
+            assign=True,
+        )
+
+        updated_assignee = self.group.get_assignee()
+        assert updated_assignee is not None
+        assert updated_assignee.id == self.test_user.id
+        assert updated_assignee.email == "test@example.com"
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
+
     @mock.patch("sentry.integrations.utils.sync.where_should_sync")
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_assign_with_multiple_groups(


### PR DESCRIPTION
<!-- Describe your PR here. -->

Github usernames are case-insensitive and users currently can configure their usernames with any captialization they see fit. 

To correctly attribute usernames to users, we need to do a case-insensitive search when looking for `ExternalActor` and send Github a case-insensitive username back as well. The second point is probably not needed but good to do.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
