### PR TITLE
feat(dashboards): updates dashboard frontend to display prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -13,6 +13,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 
 import {assignTempId} from './layoutUtils';
 import type {DashboardDetails, DashboardListItem} from './types';
@@ -61,7 +62,15 @@ function OrgDashboards({children}: OrgDashboardsProps) {
     retry: false,
   });
 
-  const selectedDashboard = selectedDashboardState ?? fetchedSelectedDashboard;
+  let selectedDashboard = selectedDashboardState ?? fetchedSelectedDashboard;
+
+  // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard
+  if (selectedDashboard?.prebuiltId) {
+    selectedDashboard = {
+      ...selectedDashboard,
+      ...PREBUILT_DASHBOARDS[selectedDashboard.prebuiltId],
+    };
+  }
 
   useEffect(() => {
     if (dashboardId && !isEqual(dashboardId, selectedDashboard?.id)) {

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -4,6 +4,7 @@ import {t} from 'sentry/locale';
 import type {Tag} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
 import {SavedQueryDatasets, type DatasetSource} from 'sentry/utils/discover/types';
+import type {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 
 import type {ThresholdsConfig} from './widgetBuilder/buildSteps/thresholdsStep/thresholds';
 
@@ -201,6 +202,7 @@ export type DashboardDetails = {
   isFavorited?: boolean;
   period?: string;
   permissions?: DashboardPermissions;
+  prebuiltId?: PrebuiltDashboardId;
   start?: string;
   utc?: boolean;
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -1,0 +1,134 @@
+import {t} from 'sentry/locale';
+import {
+  DisplayType,
+  WidgetType,
+  type DashboardDetails,
+} from 'sentry/views/dashboards/types';
+
+export enum PrebuiltDashboardId {
+  FRONTEND_SESSION_HEALTH = 1,
+}
+
+export const PREBUILT_DASHBOARDS: Record<
+  PrebuiltDashboardId,
+  Omit<DashboardDetails, 'id'>
+> = {
+  [PrebuiltDashboardId.FRONTEND_SESSION_HEALTH]: {
+    dateCreated: '',
+    filters: {},
+    projects: [],
+    title: 'Frontend Session Health',
+    widgets: [
+      {
+        id: 'unhealthy-sessions',
+        title: t('Unhealthy Sessions'),
+        displayType: DisplayType.LINE,
+        widgetType: WidgetType.RELEASE,
+        interval: '',
+        queries: [
+          {
+            name: '',
+            conditions: '',
+            fields: ['unhealthy_rate(session)'],
+            aggregates: ['unhealthy_rate(session)'],
+            columns: [],
+            orderby: '',
+          },
+        ],
+        layout: {x: 0, y: 0, w: 3, h: 3, minH: 2},
+      },
+      {
+        id: 'user-health',
+        title: t('User Health'),
+        displayType: DisplayType.AREA,
+        widgetType: WidgetType.RELEASE,
+        interval: '',
+        queries: [
+          {
+            name: '',
+            conditions: '',
+            fields: [
+              'abnormal_rate(user)',
+              'crash_rate(user)',
+              'errored_rate(user)',
+              'unhandled_rate(user)',
+            ],
+            aggregates: [
+              'abnormal_rate(user)',
+              'crash_rate(user)',
+              'errored_rate(user)',
+              'unhandled_rate(user)',
+            ],
+            columns: [],
+            orderby: '',
+          },
+        ],
+        layout: {x: 3, y: 0, w: 3, h: 3, minH: 2},
+      },
+      {
+        id: 'session-health',
+        title: t('Session Health'),
+        displayType: DisplayType.AREA,
+        widgetType: WidgetType.RELEASE,
+        interval: '',
+        queries: [
+          {
+            name: '',
+            conditions: '',
+            fields: [
+              'abnormal_rate(session)',
+              'crash_rate(session)',
+              'errored_rate(session)',
+              'unhandled_rate(session)',
+            ],
+            aggregates: [
+              'abnormal_rate(session)',
+              'crash_rate(session)',
+              'errored_rate(session)',
+              'unhandled_rate(session)',
+            ],
+            columns: [],
+            orderby: '',
+          },
+        ],
+        layout: {x: 0, y: 3, w: 2, h: 3, minH: 2},
+      },
+      {
+        id: 'session-counts',
+        title: t('Session Counts'),
+        displayType: DisplayType.LINE,
+        widgetType: WidgetType.RELEASE,
+        interval: '',
+        queries: [
+          {
+            name: '',
+            conditions: '',
+            fields: ['session.status', 'sum(session)'],
+            aggregates: ['sum(session)'],
+            columns: ['session.status'],
+            orderby: '',
+          },
+        ],
+        layout: {x: 2, y: 3, w: 2, h: 3, minH: 2},
+      },
+      {
+        id: 'user-counts',
+        title: t('User Counts'),
+        displayType: DisplayType.LINE,
+        widgetType: WidgetType.RELEASE,
+        interval: '4h',
+        queries: [
+          {
+            name: '',
+            conditions: '',
+            fields: ['session.status', 'count_unique(user)'],
+            aggregates: ['count_unique(user)'],
+            columns: ['session.status'],
+            orderby: '',
+          },
+        ],
+        layout: {x: 4, y: 3, w: 2, h: 3, minH: 2},
+      },
+    ],
+  },
+};

--- a/static/app/views/insights/sessions/views/platformizedOverview.tsx
+++ b/static/app/views/insights/sessions/views/platformizedOverview.tsx
@@ -3,121 +3,15 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useRouter from 'sentry/utils/useRouter';
 import DashboardDetail from 'sentry/views/dashboards/detail';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
-import {DashboardState, DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {DashboardState} from 'sentry/views/dashboards/types';
+import {
+  PREBUILT_DASHBOARDS,
+  PrebuiltDashboardId,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 
-const RELEASE_HEALTH_WIDGETS: Widget[] = [
-  {
-    id: 'unhealthy-sessions',
-    title: t('Unhealthy Sessions'),
-    displayType: DisplayType.LINE,
-    widgetType: WidgetType.RELEASE,
-    interval: '',
-    queries: [
-      {
-        name: '',
-        conditions: '',
-        fields: ['unhealthy_rate(session)', 'sum(session)'],
-        aggregates: ['unhealthy_rate(session)', 'sum(session)'],
-        columns: [],
-        orderby: '',
-      },
-    ],
-    layout: {x: 0, y: 0, w: 3, h: 3, minH: 2},
-  },
-  {
-    id: 'user-health',
-    title: t('User Health'),
-    displayType: DisplayType.AREA,
-    widgetType: WidgetType.RELEASE,
-    interval: '',
-    queries: [
-      {
-        name: '',
-        conditions: '',
-        fields: [
-          'abnormal_rate(user)',
-          'crash_rate(user)',
-          'errored_rate(user)',
-          'unhandled_rate(user)',
-        ],
-        aggregates: [
-          'abnormal_rate(user)',
-          'crash_rate(user)',
-          'errored_rate(user)',
-          'unhandled_rate(user)',
-        ],
-        columns: [],
-        orderby: '',
-      },
-    ],
-    layout: {x: 3, y: 0, w: 3, h: 3, minH: 2},
-  },
-  {
-    id: 'session-health',
-    title: t('Session Health'),
-    displayType: DisplayType.AREA,
-    widgetType: WidgetType.RELEASE,
-    interval: '',
-    queries: [
-      {
-        name: '',
-        conditions: '',
-        fields: [
-          'abnormal_rate(session)',
-          'crash_rate(session)',
-          'errored_rate(session)',
-          'unhandled_rate(session)',
-        ],
-        aggregates: [
-          'abnormal_rate(session)',
-          'crash_rate(session)',
-          'errored_rate(session)',
-          'unhandled_rate(session)',
-        ],
-        columns: [],
-        orderby: '',
-      },
-    ],
-    layout: {x: 0, y: 3, w: 2, h: 3, minH: 2},
-  },
-  {
-    id: 'session-counts',
-    title: t('Session Counts'),
-    displayType: DisplayType.LINE,
-    widgetType: WidgetType.RELEASE,
-    interval: '',
-    queries: [
-      {
-        name: '',
-        conditions: '',
-        fields: ['session.status', 'sum(session)'],
-        aggregates: ['sum(session)'],
-        columns: ['session.status'],
-        orderby: '',
-      },
-    ],
-    layout: {x: 2, y: 3, w: 2, h: 3, minH: 2},
-  },
-  {
-    id: 'user-counts',
-    title: t('User Counts'),
-    displayType: DisplayType.LINE,
-    widgetType: WidgetType.RELEASE,
-    interval: '4h',
-    queries: [
-      {
-        name: '',
-        conditions: '',
-        fields: ['session.status', 'count_unique(user)'],
-        aggregates: ['count_unique(user)'],
-        columns: ['session.status'],
-        orderby: '',
-      },
-    ],
-    layout: {x: 4, y: 3, w: 2, h: 3, minH: 2},
-  },
-];
+const RELEASE_HEALTH_WIDGETS: Widget[] =
+  PREBUILT_DASHBOARDS[PrebuiltDashboardId.FRONTEND_SESSION_HEALTH].widgets;
 
 const DASHBOARD: DashboardDetails = {
   id: 'session-health-overview',


### PR DESCRIPTION
If loading a dashboard with a `prebuilt_id`, populates the dashboards display using content from `PREBUILT_DASHBOARDS`.

Relies on backend changes: https://github.com/getsentry/sentry/pull/101968