### PR TITLE
feat(dashboards): checks flag to enable using timeseries visualization in dashboards widget frontend

### DIFF
--- a/static/app/views/dashboards/utils/useTimeseriesVisualizationEnabled.tsx
+++ b/static/app/views/dashboards/utils/useTimeseriesVisualizationEnabled.tsx
@@ -1,0 +1,6 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
+export const useTimeseriesVisualizationEnabled = () => {
+  const organization = useOrganization();
+  return organization.features.includes('dashboards-widget-timeseries-visualization');
+};

--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -14,6 +14,7 @@ import type {Organization} from 'sentry/types/organization';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useTimeseriesVisualizationEnabled} from 'sentry/views/dashboards/utils/useTimeseriesVisualizationEnabled';
 
 import DashboardDetail from './detail';
 import OrgDashboards from './orgDashboards';
@@ -68,6 +69,8 @@ function ViewEditDashboard(props: Props) {
     }
   }, [location.pathname, location.query]);
 
+  const useTimeseriesVisualization = useTimeseriesVisualizationEnabled();
+
   return (
     <DashboardBasicFeature organization={organization}>
       <OrgDashboards>
@@ -86,6 +89,7 @@ function ViewEditDashboard(props: Props) {
                 onDashboardUpdate={onDashboardUpdate}
                 newWidget={newWidget}
                 onSetNewWidget={() => setNewWidget(undefined)}
+                useTimeseriesVisualization={useTimeseriesVisualization}
               />
             </ErrorBoundary>
           ) : (


### PR DESCRIPTION
Updates dashboard view to use the new timeseries visualization whenever possible if flag is enabled