### PR TITLE
fix(ai-insights): ai conversations pagination

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -89,6 +89,8 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsV2EndpointBase):
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),
                 on_results=lambda results: results,
+                default_per_page=10,
+                max_per_page=100,
             )
 
     def _get_conversations(
@@ -121,7 +123,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsV2EndpointBase):
             limit=limit,
             referrer=Referrer.API_AI_CONVERSATIONS.value,
             config=SearchResolverConfig(auto_fields=True),
-            sampling_mode=None,
+            sampling_mode="HIGHEST_ACCURACY",
         )
 
         conversation_ids: list[str] = [
@@ -159,7 +161,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsV2EndpointBase):
             limit=len(conversation_ids),
             referrer=Referrer.API_AI_CONVERSATIONS_COMPLETE.value,
             config=SearchResolverConfig(auto_fields=True),
-            sampling_mode=None,
+            sampling_mode="HIGHEST_ACCURACY",
         )
 
         # Create a map of conversation data by ID
@@ -211,6 +213,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsV2EndpointBase):
                 "gen_ai.conversation.id",
                 "span.op",
                 "span.description",
+                "gen_ai.agent.name",
                 "trace",
                 "precise.start_ts",
             ],
@@ -219,7 +222,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsV2EndpointBase):
             limit=10000,
             referrer=Referrer.API_AI_CONVERSATIONS_ENRICHMENT.value,
             config=SearchResolverConfig(auto_fields=True),
-            sampling_mode=None,
+            sampling_mode="HIGHEST_ACCURACY",
         )
 
         flows_by_conversation = defaultdict(list)
@@ -237,7 +240,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsV2EndpointBase):
 
             # Collect agent flow (only from invoke_agent spans)
             if row.get("span.op") == "gen_ai.invoke_agent":
-                agent_name = row.get("span.description", "")
+                agent_name = row.get("gen_ai.agent.name", "")
                 if agent_name:
                     flows_by_conversation[conv_id].append(agent_name)
 

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -29,6 +29,7 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
         tokens=None,
         cost=None,
         trace_id=None,
+        agent_name=None,
     ):
         span_data = {"gen_ai.conversation.id": conversation_id}
         if operation_type:
@@ -37,6 +38,8 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
             span_data["gen_ai.usage.total_tokens"] = tokens
         if cost is not None:
             span_data["gen_ai.usage.total_cost"] = cost
+        if agent_name is not None:
+            span_data["gen_ai.agent.name"] = agent_name
 
         extra_data = {
             "description": description or "default",
@@ -109,6 +112,7 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
             timestamp=now - timedelta(seconds=4),
             op="gen_ai.invoke_agent",
             description="Customer Support Agent",
+            agent_name="Customer Support Agent",
             trace_id=trace_id,
         )
 
@@ -134,6 +138,7 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
             timestamp=now - timedelta(seconds=1),
             op="gen_ai.invoke_agent",
             description="Response Generator",
+            agent_name="Response Generator",
             trace_id=trace_id,
         )
 
@@ -184,6 +189,7 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
             timestamp=now - timedelta(seconds=3),
             op="gen_ai.invoke_agent",
             description="Research Agent",
+            agent_name="Research Agent",
             trace_id=trace_id_1,
         )
 
@@ -202,6 +208,7 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
             timestamp=now - timedelta(seconds=1),
             op="gen_ai.invoke_agent",
             description="Summarization Agent",
+            agent_name="Summarization Agent",
             trace_id=trace_id_2,
         )
 
@@ -405,6 +412,7 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
                 timestamp=timestamp,
                 op="gen_ai.invoke_agent",
                 description=agent_name,
+                agent_name=agent_name,
                 trace_id=trace_id,
             )
 


### PR DESCRIPTION
Fixes a couple independent issues with ai conversation endpoint:
- page size reduced to 10 by default
- turns off extrapolation
- uses gen_ai.agent.name instead of span.description