### PR TITLE
chore: Use integrations otlp traces endpoint in js tests

### DIFF
--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -100,7 +100,7 @@ describe('LoaderScript', () => {
           crons: '',
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
-          otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+          otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
           otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },
         public: '188ee45a58094d939428d8585aa6f662',
@@ -242,7 +242,7 @@ describe('LoaderScript', () => {
           crons: '',
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
-          otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+          otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
           otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },
         public: '188ee45a58094d939428d8585aa6f662',

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -163,7 +163,7 @@ describe('ProjectKeys', () => {
           crons: '',
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
-          otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+          otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
           otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },
         dateCreated: '2018-02-28T07:13:51.087Z',

--- a/tests/js/fixtures/projectKeys.ts
+++ b/tests/js/fixtures/projectKeys.ts
@@ -17,7 +17,7 @@ export function ProjectKeysFixture(params: ProjectKey[] = []): ProjectKey[] {
           'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f661',
         playstation:
           'http://dev.getsentry.net:8000/api/1/playstation/?sentry_key=188ee45a58094d939428d8585aa6f661',
-        otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+        otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
         otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
       },
       public: '188ee45a58094d939428d8585aa6f661',


### PR DESCRIPTION
Just a follow up from https://github.com/getsentry/sentry/pull/101970 to adjust the otlp traces endpoint in the fixtures.