### PR TITLE
feat(objectstore): Add default for objectstore URL in dev

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -375,7 +375,11 @@ register("fileblob.upload.use_lock", default=True, flags=FLAG_AUTOMATOR_MODIFIAB
 register("fileblob.upload.use_blobid_cache", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # New `objectstore` service configuration
-register("objectstore.config", default={}, flags=FLAG_NOSTORE)
+register(
+    "objectstore.config",
+    default={"base_url": "http://127.0.0.1:8888"},
+    flags=FLAG_NOSTORE,
+)
 
 
 # Symbol server

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -91,13 +91,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
     def test_doublewrite_objectstore(self) -> None:
         self.login_as(user=self.user)
 
-        with override_options(
-            {
-                # TODO: we should make sure the default works for local tests
-                "objectstore.config": {"base_url": "http://localhost:8888/"},
-                "objectstore.double_write.attachments": 1,
-            }
-        ):
+        with override_options({"objectstore.double_write.attachments": 1}):
             attachment = self.create_attachment()
 
             assert attachment.blob_path is not None
@@ -122,13 +116,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
     def test_download_objectstore(self) -> None:
         self.login_as(user=self.user)
 
-        with override_options(
-            {
-                # TODO: we should make sure the default works for local tests
-                "objectstore.config": {"base_url": "http://localhost:8888/"},
-                "objectstore.enable_for.attachments": 1,
-            }
-        ):
+        with override_options({"objectstore.enable_for.attachments": 1}):
             attachment = self.create_attachment()
 
             assert attachment.blob_path is not None


### PR DESCRIPTION
Similar to other services, we add a default for objectstore's URL. It's not started in devservices by default yet, but there are separate options controlling whether it is used.