### PR TITLE
fix(ai-trace): query for both status and span.status

### DIFF
--- a/static/app/views/insights/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/agents/components/aiSpanList.tsx
@@ -386,10 +386,15 @@ function hasError(node: AITraceSpanNode) {
   }
 
   if (isEAPSpanNode(node)) {
-    const status = node.value.additional_attributes?.[SpanFields.SPAN_STATUS];
-    if (typeof status === 'string') {
+    const spanStatus = node.value.additional_attributes?.[SpanFields.SPAN_STATUS];
+    if (!!spanStatus && typeof spanStatus === 'string') {
+      return spanStatus.includes('error');
+    }
+    const status = node.value.additional_attributes?.status;
+    if (!!status && typeof status === 'string') {
       return status.includes('error');
     }
+
     return false;
   }
 

--- a/static/app/views/insights/agents/hooks/useAITrace.tsx
+++ b/static/app/views/insights/agents/hooks/useAITrace.tsx
@@ -43,7 +43,7 @@ export function useAITrace(traceSlug: string): UseAITraceResult {
       SpanFields.GEN_AI_USAGE_TOTAL_TOKENS,
       SpanFields.GEN_AI_USAGE_TOTAL_COST,
       SpanFields.GEN_AI_TOOL_NAME,
-      'span.status',
+      SpanFields.SPAN_STATUS,
       'status',
     ],
   });

--- a/static/app/views/insights/agents/hooks/useAITrace.tsx
+++ b/static/app/views/insights/agents/hooks/useAITrace.tsx
@@ -43,7 +43,8 @@ export function useAITrace(traceSlug: string): UseAITraceResult {
       SpanFields.GEN_AI_USAGE_TOTAL_TOKENS,
       SpanFields.GEN_AI_USAGE_TOTAL_COST,
       SpanFields.GEN_AI_TOOL_NAME,
-      SpanFields.SPAN_STATUS,
+      'span.status',
+      'status',
     ],
   });
 


### PR DESCRIPTION
Additional attributes returned by the trace endpoint sometimes contain `span.status: ""` even though span status is set. `status` seems to be reliable  so this PR uses it as a fallback until we fix the endpoint in [TET-1335: Trace endpoint returns span.status: "" even though span status is set](https://linear.app/getsentry/issue/TET-1335/trace-endpoint-returns-spanstatus-even-though-span-status-is-set)