### PR TITLE
feat(api): Add integration endpoint to project key serializer

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -28,6 +28,7 @@ class DSN(TypedDict):
     crons: str
     cdn: str
     playstation: str
+    integration: str
     otlp_traces: str
     otlp_logs: str
 
@@ -98,6 +99,7 @@ class ProjectKeySerializer(Serializer):
                 "crons": obj.crons_endpoint,
                 "cdn": obj.js_sdk_loader_cdn_url,
                 "playstation": obj.playstation_endpoint,
+                "integration": obj.integration_endpoint,
                 "otlp_traces": obj.otlp_traces_endpoint,
                 "otlp_logs": obj.otlp_logs_endpoint,
             },

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -18,6 +18,7 @@ KEY_RATE_LIMIT = {
         "security": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/security/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "minidump": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
+        "integration": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/",
         "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/traces",
         "otlp_logs": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/logs",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -266,6 +266,12 @@ class ProjectKey(Model):
         return f"{endpoint}/api/{self.project_id}/playstation/?sentry_key={self.public_key}"
 
     @property
+    def integration_endpoint(self):
+        endpoint = self.get_endpoint()
+
+        return f"{endpoint}/api/{self.project_id}/integration/"
+
+    @property
     def otlp_traces_endpoint(self):
         endpoint = self.get_endpoint()
 

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -40,6 +40,22 @@ class ListProjectKeysTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["dsn"]["playstation"] == key.playstation_endpoint
 
+    def test_integration_endpoint(self) -> None:
+        project = self.create_project()
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data[0]["dsn"]["integration"] == key.integration_endpoint
+        assert "integration/" in response.data[0]["dsn"]["integration"]
+
     def test_otlp_traces_endpoint(self) -> None:
         project = self.create_project()
         key = ProjectKey.objects.get_or_create(project=project)[0]
@@ -54,6 +70,7 @@ class ListProjectKeysTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.data[0]["dsn"]["otlp_traces"] == key.otlp_traces_endpoint
+        assert "integration/otlp/v1/traces" in response.data[0]["dsn"]["otlp_traces"]
 
     def test_otlp_logs_endpoint(self) -> None:
         project = self.create_project()


### PR DESCRIPTION
In Relay we've moved toward an `integration` abstraction on endpoints to represent trace and log (and in the future metric) drain endpoints. For example, our current support for OTLP, or future support for Vercel/Netlify Log Drains.

https://github.com/getsentry/relay/blob/b97e972470adb15ac5a479375752b2ede6adfd63/relay-server/src/endpoints/mod.rs#L84-L91

This PR adds that integration endpoint to the project key serializer. This will look something like so: `https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/`.

By default something like `/api/4505281256090153/integration/` will actually do nothing, as you'll need to provide further parameters to specify the integration you're using. For example `/api/4505281256090153/integration/vercel/logs` for the vercel log drain endpoint, or `/api/4505281256090153/integration/vercel/logs`.

From the integration endpoint, we can construct the rest of the endpoints easily. This does mean that the `ProjectKeySerializer` becomes less of a source of truth, but I think the increased flexibility means this is a good change.