### PR TITLE
feat(onboarding): add in-product docs on how to setup and verify MCP monitoring

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -722,3 +722,8 @@ export const agentMonitoringPlatforms: ReadonlySet<PlatformKey> = new Set([
   ...platformKeys.filter(id => id.startsWith('node')),
   ...platformKeys.filter(id => id.startsWith('python')),
 ]);
+
+export const mcpMonitoringPlatforms: ReadonlySet<PlatformKey> = new Set([
+  ...platformKeys.filter(id => id.startsWith('node')),
+  ...platformKeys.filter(id => id.startsWith('python')),
+]);

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -184,6 +185,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -8,6 +8,7 @@ import {
 import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -193,6 +194,7 @@ const docs: Docs = {
   crashReportOnboarding: crashReportOnboardingPython,
   profilingOnboarding: getPythonProfilingOnboarding(),
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -181,6 +182,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -7,6 +7,7 @@ import {
 import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -150,6 +151,7 @@ const docs: Docs = {
   profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[chalice]'}),
   crashReportOnboarding: crashReportOnboardingPython,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -255,6 +256,8 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
+
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -184,6 +185,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -190,6 +191,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -258,6 +259,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -8,6 +8,7 @@ import {
 import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -196,10 +197,10 @@ const logsOnboarding = getPythonLogsOnboarding();
 
 const docs: Docs = {
   onboarding,
-
   crashReportOnboarding: crashReportOnboardingPython,
   profilingOnboarding: getPythonProfilingOnboarding(),
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -660,7 +660,7 @@ sentry_sdk.init(
       ],
     };
 
-    const selected = (params.platformOptions as any)?.integration ?? 'mcp_lowlevel';
+    const selected = (params.platformOptions as any)?.integration ?? 'mcp_fastmcp';
     if (selected === 'mcp_fastmcp') {
       return [mcpFastMcpStep];
     }

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -650,26 +650,6 @@ sentry_sdk.init(
 )
 `,
         },
-        {
-          type: 'text',
-          text: t('TODO: Add description for manual MCP instrumentation setup.'),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-import json
-import sentry_sdk
-
-# Invoke Agent span
-with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather Agent") as span:
-    span.set_data("gen_ai.operation.name", "invoke_agent")
-    span.set_data("gen_ai.system", "openai")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.agent.name", "Weather Agent")
-    span.set_data("gen_ai.response.text", json.dumps(["Hello World"]))
-`,
-        },
       ],
     };
 
@@ -685,7 +665,7 @@ with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather 
     }
     return [mcpLowLevelStep];
   },
-  verify: () => {
+  verify: (params: Params) => {
     const mcpVerifyStep: OnboardingStep = {
       type: StepType.VERIFY,
       content: [
@@ -698,6 +678,40 @@ with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather 
       ],
     };
 
+    const manualVerifyStep: OnboardingStep = {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that MCP monitoring is working correctly by running your manually instrumented code:'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import json
+import sentry_sdk
+
+# Invoke Agent span
+with sentry_sdk.start_span(op="mcp.server", name="tools/call calculate_sum") as span:
+    span.set_data("mcp.method.name", "tools/call")
+    span.set_data("mcp.request.argument.a", "1")
+    span.set_data("mcp.request.argument.b", "2")
+    span.set_data("mcp.request.id", 123)
+    span.set_data("mcp.session.id", "c6d1c6a4c35843d5bdf0f9d88d11c183")
+    span.set_data("mcp.tool.name", "calculate_sum")
+    span.set_data("mcp.tool.result.content_count", 1)
+    span.set_data("mcp.transport", "stdio")
+`,
+        },
+      ],
+    };
+    const selected = (params.platformOptions as any)?.integration ?? 'mcp_fastmcp';
+    if (selected === 'manual') {
+      return [manualVerifyStep];
+    }
     return [mcpVerifyStep];
   },
   nextSteps: () => [],

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -449,6 +449,247 @@ export const featureFlagOnboarding: OnboardingConfig = {
   nextSteps: () => [],
 };
 
+export const mcpOnboarding: OnboardingConfig = {
+  install: () => {
+    const packageName = 'sentry-sdk[mcp]';
+
+    return [
+      {
+        type: StepType.INSTALL,
+        content: [
+          {
+            type: 'text',
+            text: t(
+              'To enable MCP monitoring, you need to install the Sentry SDK with a minimum version of 2.43.0 or higher.'
+            ),
+          },
+          getPythonInstallCodeBlock({packageName}),
+        ],
+      },
+    ];
+  },
+  configure: (params: Params) => {
+    const mcpLowLevelStep: OnboardingStep = {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t('Configure Sentry for MCP low-level monitoring:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import sentry_sdk
+from sentry_sdk.integrations.mcp import MCPIntegration
+
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    traces_sample_rate=1.0,
+    # Add data like inputs and responses to/from MCP servers;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    integrations=[
+        MCPIntegration(),
+    ],
+)`,
+        },
+        {
+          type: 'text',
+          text: t('Set up your low-level MCP server:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+from mcp.server.lowlevel import Server
+from mcp.types import Tool, TextContent
+
+server = Server("mcp-server")
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List all available tools."""
+    return [
+        Tool(
+            name="calculate_sum",
+            description="Add two numbers together",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number", "description": "First number"},
+                    "b": {"type": "number", "description": "Second number"},
+                },
+                "required": ["a", "b"],
+            },
+        )
+    ]
+@server.call_tool()
+async def call_tool(name: str, arguments) -> list[TextContent]:
+    """Handle tool execution based on tool name."""
+
+    if name == "calculate_sum":
+        a = arguments.get("a", 0)
+        b = arguments.get("b", 0)
+        result = a + b
+        return [TextContent(type="text", text=f"The sum of {a} and {b} is {result}")]
+
+`,
+        },
+      ],
+    };
+
+    const mcpFastMcpStep: OnboardingStep = {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t('Configure Sentry for MCP low-level monitoring:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import sentry_sdk
+from sentry_sdk.integrations.mcp import MCPIntegration
+
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    traces_sample_rate=1.0,
+    # Add data like inputs and responses to/from MCP servers;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    integrations=[
+        MCPIntegration(),
+    ],
+)`,
+        },
+        {
+          type: 'text',
+          text: t('Set up your low-level MCP server:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("mcp-server")
+
+@mcp.tool()
+async def calculate_sum(a: int, b: int, ctx: Context) -> int:
+    """Add two numbers together."""
+    return a + b
+`,
+        },
+      ],
+    };
+
+    const fastMcpStandaloneStep: OnboardingStep = {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t('Configure Sentry for MCP low-level monitoring:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import sentry_sdk
+from sentry_sdk.integrations.mcp import MCPIntegration
+
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    traces_sample_rate=1.0,
+    # Add data like inputs and responses to/from MCP servers;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    integrations=[
+        MCPIntegration(),
+    ],
+)`,
+        },
+        {
+          type: 'text',
+          text: t('Set up your low-level MCP server:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+from fastmcp import FastMCP
+
+mcp = FastMCP("mcp-server")
+
+@mcp.tool()
+async def calculate_sum(a: int, b: int, ctx: Context) -> int:
+    """Add two numbers together."""
+    return a + b
+`,
+        },
+      ],
+    };
+
+    const manualStep: OnboardingStep = {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t('Configure Sentry for manual MCP instrumentation:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    traces_sample_rate=1.0,
+    # Add data like inputs and responses to/from MCP servers;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)
+`,
+        },
+        {
+          type: 'text',
+          text: t('TODO: Add description for manual MCP instrumentation setup.'),
+        },
+      ],
+    };
+
+    const selected = (params.platformOptions as any)?.integration ?? 'mcp_lowlevel';
+    if (selected === 'mcp_fastmcp') {
+      return [mcpFastMcpStep];
+    }
+    if (selected === 'fastmcp_standalone') {
+      return [fastMcpStandaloneStep];
+    }
+    if (selected === 'manual') {
+      return [manualStep];
+    }
+    return [mcpLowLevelStep];
+  },
+  verify: () => {
+    const mcpVerifyStep: OnboardingStep = {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that MCP monitoring is working correctly by triggering some MCP server interactions in your application.'
+          ),
+        },
+      ],
+    };
+
+    return [mcpVerifyStep];
+  },
+  nextSteps: () => [],
+};
+
 export const agentMonitoringOnboarding: OnboardingConfig = {
   install: (params: Params) => {
     const selected = (params.platformOptions as any)?.integration ?? 'openai_agents';
@@ -1108,6 +1349,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   profilingOnboarding: getPythonProfilingOnboarding({traceLifecycle: 'manual'}),
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -577,7 +577,7 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("mcp-server")
 
 @mcp.tool()
-async def calculate_sum(a: int, b: int, ctx: Context) -> int:
+async def calculate_sum(a: int, b: int) -> int:
     """Add two numbers together."""
     return a + b
 `,
@@ -623,7 +623,7 @@ from fastmcp import FastMCP
 mcp = FastMCP("mcp-server")
 
 @mcp.tool()
-async def calculate_sum(a: int, b: int, ctx: Context) -> int:
+async def calculate_sum(a: int, b: int) -> int:
     """Add two numbers together."""
     return a + b
 `,
@@ -647,15 +647,28 @@ import sentry_sdk
 sentry_sdk.init(
     dsn="${params.dsn.public}",
     traces_sample_rate=1.0,
-    # Add data like inputs and responses to/from MCP servers;
-    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    send_default_pii=True,
 )
 `,
         },
         {
           type: 'text',
           text: t('TODO: Add description for manual MCP instrumentation setup.'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import json
+import sentry_sdk
+
+# Invoke Agent span
+with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather Agent") as span:
+    span.set_data("gen_ai.operation.name", "invoke_agent")
+    span.set_data("gen_ai.system", "openai")
+    span.set_data("gen_ai.request.model", "o3-mini")
+    span.set_data("gen_ai.agent.name", "Weather Agent")
+    span.set_data("gen_ai.response.text", json.dumps(["Hello World"]))
+`,
         },
       ],
     };

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -451,7 +451,7 @@ export const featureFlagOnboarding: OnboardingConfig = {
 
 export const mcpOnboarding: OnboardingConfig = {
   install: () => {
-    const packageName = 'sentry-sdk[mcp]';
+    const packageName = 'sentry-sdk';
 
     return [
       {

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -183,6 +184,8 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
+
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -147,6 +148,7 @@ const docs: Docs = {
   feedbackOnboardingJsLoader,
   profilingOnboarding: getPythonProfilingOnboarding({basePackage: 'sentry-sdk[sanic]'}),
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -186,6 +187,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -13,6 +13,7 @@ import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
   featureFlagOnboarding,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -199,6 +200,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   feedbackOnboardingJsLoader,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/tryton.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.tsx
@@ -8,6 +8,7 @@ import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -170,6 +171,7 @@ const docs: Docs = {
   profilingOnboarding,
   crashReportOnboarding: crashReportOnboardingPython,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -10,6 +10,7 @@ import {
 import {
   agentMonitoringOnboarding,
   crashReportOnboardingPython,
+  mcpOnboarding,
 } from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 import {
@@ -194,6 +195,7 @@ const docs: Docs = {
   profilingOnboarding: getPythonProfilingOnboarding(),
   crashReportOnboarding: crashReportOnboardingPython,
   agentMonitoringOnboarding,
+  mcpOnboarding,
   logsOnboarding,
 };
 

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -717,18 +717,6 @@ export const getNodeMcpOnboarding = ({
 }: {
   packageName?: `@sentry/${string}`;
 } = {}): OnboardingConfig => ({
-  introduction: () => (
-    <Alert type="info" showIcon={false}>
-      {tct(
-        'MCP is currently in beta with support for [mcp:Model Context Protocol Typescript SDK].',
-        {
-          mcp: (
-            <ExternalLink href="https://www.npmjs.com/package/@modelcontextprotocol/sdk" />
-          ),
-        }
-      )}
-    </Alert>
-  ),
   install: params => [
     {
       type: StepType.INSTALL,

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -1,4 +1,3 @@
-import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
   BasePlatformOptions,

--- a/static/app/views/insights/mcp/views/onboarding.tsx
+++ b/static/app/views/insights/mcp/views/onboarding.tsx
@@ -15,16 +15,15 @@ import type {
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  DocsPageLocation,
-  ProductSolution,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {DocsPageLocation} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
+import {PlatformOptionDropdown} from 'sentry/components/onboarding/platformOptionDropdown';
+import {useUrlPlatformOptions} from 'sentry/components/onboarding/platformOptionsControl';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {SetupTitle} from 'sentry/components/updatedEmptyState';
-import {agentMonitoringPlatforms} from 'sentry/data/platformCategories';
+import {mcpMonitoringPlatforms} from 'sentry/data/platformCategories';
 import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -48,7 +47,7 @@ function useOnboardingProject() {
     projects
   );
   const mcpMonitoringProjects = selectedProject.filter(p =>
-    agentMonitoringPlatforms.has(p.platform as PlatformKey)
+    mcpMonitoringPlatforms.has(p.platform as PlatformKey)
   );
 
   if (mcpMonitoringProjects.length > 0) {
@@ -211,6 +210,24 @@ export function Onboarding() {
     projSlug: project?.slug,
   });
 
+  // Local integration options for MCP monitoring only
+  const isPythonPlatform = (project?.platform ?? '').startsWith('python');
+  const integrationOptions = {
+    integration: {
+      label: t('Integration'),
+      items: isPythonPlatform
+        ? [
+            {label: 'FastMCP', value: 'mcp_fastmcp'},
+            {label: 'FastMCP (Standalone)', value: 'fastmcp_standalone'},
+            {label: 'Low-level', value: 'mcp_lowlevel'},
+            {label: 'Manual', value: 'manual'},
+          ]
+        : [{label: 'MCP SDK', value: 'mcp_sdk'}],
+    },
+  };
+
+  const selectedPlatformOptions = useUrlPlatformOptions(integrationOptions);
+
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
 
@@ -218,7 +235,7 @@ export function Onboarding() {
     return <div>{t('No project found')}</div>;
   }
 
-  if (!agentMonitoringPlatforms.has(project.platform as PlatformKey)) {
+  if (!mcpMonitoringPlatforms.has(project.platform as PlatformKey)) {
     return (
       <OnboardingPanel project={project}>
         <DescriptionWrapper>
@@ -282,7 +299,7 @@ export function Onboarding() {
       isLoading: isLoadingRegistry,
       data: registryData,
     },
-    platformOptions: [ProductSolution.PERFORMANCE_MONITORING],
+    platformOptions: selectedPlatformOptions,
     docsLocation: DocsPageLocation.PROFILING_PAGE,
     newOrg: false,
     urlPrefix,
@@ -300,6 +317,9 @@ export function Onboarding() {
   return (
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
+      <OptionsWrapper>
+        <PlatformOptionDropdown platformOptions={integrationOptions} />
+      </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <GuidedSteps>
         {steps
@@ -458,4 +478,12 @@ const DescriptionWrapper = styled('div')`
       margin-bottom: ${CONTENT_SPACING};
     }
   }
+`;
+
+const OptionsWrapper = styled('div')`
+  display: flex;
+  gap: ${p => p.theme.space.md};
+  align-items: center;
+  flex-wrap: wrap;
+  padding-bottom: ${p => p.theme.space.md};
 `;


### PR DESCRIPTION
Adds onboarding docs for MCP Servers in Python. This is shown in Python projects in the Insights/MCP tab.


https://github.com/user-attachments/assets/cdd0feda-a59e-45d0-9980-7388976fabc9




Closes https://linear.app/getsentry/issue/TET-1327/python-mcp-onboarding-docs