### PR TITLE
fix(discover): Improve treatment of `disableAggregateExtrapolation` parameter

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -513,8 +513,10 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         auto_fields=True,
                         use_aggregate_conditions=use_aggregate_conditions,
                         fields_acl=FieldsACL(functions={"time_spent_percentage"}),
-                        disable_aggregate_extrapolation="disableAggregateExtrapolation"
-                        in request.GET,
+                        disable_aggregate_extrapolation=request.GET.get(
+                            "disableAggregateExtrapolation", "0"
+                        )
+                        == "1",
                     )
                 elif scoped_dataset == OurLogs:
                     # ourlogs doesn't have use aggregate conditions

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -250,8 +250,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         config=SearchResolverConfig(
                             auto_fields=False,
                             use_aggregate_conditions=True,
-                            disable_aggregate_extrapolation="disableAggregateExtrapolation"
-                            in request.GET,
+                            disable_aggregate_extrapolation=request.GET.get(
+                                "disableAggregateExtrapolation", "0"
+                            )
+                            == "1",
                         ),
                         sampling_mode=snuba_params.sampling_mode,
                         equations=self.get_equation_list(organization, request),
@@ -286,8 +288,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     config=SearchResolverConfig(
                         auto_fields=False,
                         use_aggregate_conditions=True,
-                        disable_aggregate_extrapolation="disableAggregateExtrapolation"
-                        in request.GET,
+                        disable_aggregate_extrapolation=request.GET.get(
+                            "disableAggregateExtrapolation", "0"
+                        )
+                        == 1,
                     ),
                     sampling_mode=snuba_params.sampling_mode,
                     comparison_delta=comparison_delta,

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -291,7 +291,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         disable_aggregate_extrapolation=request.GET.get(
                             "disableAggregateExtrapolation", "0"
                         )
-                        == 1,
+                        == "1",
                     ),
                     sampling_mode=snuba_params.sampling_mode,
                     comparison_delta=comparison_delta,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -260,7 +260,10 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                 config=SearchResolverConfig(
                     auto_fields=False,
                     use_aggregate_conditions=True,
-                    disable_aggregate_extrapolation="disableAggregateExtrapolation" in request.GET,
+                    disable_aggregate_extrapolation=request.GET.get(
+                        "disableAggregateExtrapolation", "0"
+                    )
+                    == "1",
                 ),
                 sampling_mode=snuba_params.sampling_mode,
                 comparison_delta=comparison_delta,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -226,8 +226,10 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                     config=SearchResolverConfig(
                         auto_fields=False,
                         use_aggregate_conditions=True,
-                        disable_aggregate_extrapolation="disableAggregateExtrapolation"
-                        in request.GET,
+                        disable_aggregate_extrapolation=request.GET.get(
+                            "disableAggregateExtrapolation", "0"
+                        )
+                        == "1",
                     ),
                     sampling_mode=snuba_params.sampling_mode,
                     equations=self.get_equation_list(organization, request, param_name="groupBy"),


### PR DESCRIPTION
Usually, when we send boolean parameters from the frontend, we send either `"0"` or `"1"`. The `disableAggregateExtrapolation"` parameter backend is different, if _any_ value is passed, aggregation is turned off! i.e., sending `"disableAggregateExtrapolation=0"` will turn off extrapolation.

I tripped over this pretty hard. Check for an explicit `"1"` value, instead of just the presence of the parameter. This is safe to change because the frontend _already_ omits the parameter if it's not needed, and the default is `"0"` so the behaviour is preserved.
