### PR TITLE
fix(explore): Restore `transaction` default column in OTel-friendly UI

### DIFF
--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -159,7 +159,7 @@ describe('getReadableQueryParamsFromLocation', () => {
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
-          fields: ['id', 'span.name', 'span.duration', 'timestamp'],
+          fields: ['id', 'span.name', 'span.duration', 'transaction', 'timestamp'],
         })
       )
     );

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -137,6 +137,7 @@ function defaultFields(organization: Organization): string[] {
       SpanFields.ID,
       SpanFields.NAME,
       SpanFields.SPAN_DURATION,
+      SpanFields.TRANSACTION,
       SpanFields.TIMESTAMP,
     ];
   }


### PR DESCRIPTION
Now that everyone is using the OTel-friendly UI, the lack of this column is making Explore less useful for Sentry (non-OTLP) data. Bring it back.
