### PR TITLE
fix(debug_files): Do not add `.dSYM` extension to mach-o files

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -165,7 +165,7 @@ class ProjectDebugFile(Model):
         if self.file_format == "breakpad":
             return ".sym"
         if self.file_format == "macho":
-            return "" if self.file_type == "exe" else ".dSYM"
+            return ""
         if self.file_format == "proguard":
             return ".txt"
         if self.file_format == "elf":

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -147,6 +147,26 @@ class DebugFileTest(TestCase):
         # Verify that file_extension returns .json
         assert dif.file_extension == ".json"
 
+    def test_file_extension_macho(self) -> None:
+        """Test that macho files return empty file extension."""
+        file = File.objects.create(
+            name="foo",
+            type="project.dif",
+            headers={"Content-Type": "application/x-mach-binary"},
+        )
+
+        dif = ProjectDebugFile.objects.create(
+            file=file,
+            checksum="test-checksum",
+            object_name="foo",
+            cpu_name="x86_64",
+            project_id=self.project.id,
+            debug_id="b8e43a-f242-3d73-a453-aeb6a777ef75",
+            data={"type": "dbg"},
+        )
+
+        assert dif.file_extension == ""
+
 
 class CreateDebugFileTest(APITestCase):
     @property


### PR DESCRIPTION
These files are binaries, not dSYM directories, so it is inaccurate and misleading to add the `.dSYM` extension.

Fixes #102011
Fixes ENG-5763