### PR TITLE
fix(explore): Restore `description` default column in OTel-friendly UI

### DIFF
--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -159,7 +159,14 @@ describe('getReadableQueryParamsFromLocation', () => {
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
-          fields: ['id', 'span.name', 'span.duration', 'transaction', 'timestamp'],
+          fields: [
+            'id',
+            'span.name',
+            'span.description',
+            'span.duration',
+            'transaction',
+            'timestamp',
+          ],
         })
       )
     );

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -136,6 +136,7 @@ function defaultFields(organization: Organization): string[] {
     return [
       SpanFields.ID,
       SpanFields.NAME,
+      SpanFields.SPAN_DESCRIPTION,
       SpanFields.SPAN_DURATION,
       SpanFields.TRANSACTION,
       SpanFields.TIMESTAMP,


### PR DESCRIPTION
Now that everyone is using the OTel-friendly UI, the lack of this column is making Explore less useful for Sentry (non-OTLP) data. Bring it back.

See also https://github.com/getsentry/sentry/pull/102007.