### PR TITLE
fix(aci milestone 3): don't attempt to create IGOP if no corresponding alert rule

### DIFF
--- a/src/sentry/workflow_engine/models/incident_groupopenperiod.py
+++ b/src/sentry/workflow_engine/models/incident_groupopenperiod.py
@@ -62,7 +62,11 @@ class IncidentGroupOpenPeriod(DefaultFieldsModel):
             # Extract alert_id from evidence_data using the detector_id
             detector_id = occurrence.evidence_data.get("detector_id")
             if detector_id:
-                alert_id = AlertRuleDetector.objects.get(detector_id=detector_id).alert_rule_id
+                try:
+                    alert_id = AlertRuleDetector.objects.get(detector_id=detector_id).alert_rule_id
+                except AlertRuleDetector.DoesNotExist:
+                    # detector does not have an analog in the old system, so we do not need to create an IGOP relationship
+                    return None
             else:
                 raise Exception("No detector_id found in evidence_data for metric issue")
 


### PR DESCRIPTION
If a detector was singly written via the workflow engine, we do not need to create incidents for it. Early quit from IGOP creation logic.