### PR TITLE
fix(span-drawer): Don't filter OTel-related attributes

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -33,7 +33,6 @@ import {
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
-import {useOTelFriendlyUI} from 'sentry/views/performance/otlp/useOTelFriendlyUI';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 type CustomRenderersProps = AttributesFieldRendererProps<RenderFunctionBaggage>;
@@ -88,7 +87,6 @@ export function Attributes({
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const traceState = useTraceState();
-  const shouldUseOTelFriendlyUI = useOTelFriendlyUI();
   const columnCount =
     traceState.preferences.layout === 'drawer left' ||
     traceState.preferences.layout === 'drawer right'
@@ -102,26 +100,18 @@ export function Attributes({
       attribute => !HIDDEN_ATTRIBUTES.includes(attribute.name)
     );
 
-    const filteredByOTelMode = onlyVisibleAttributes.filter(attribute => {
-      if (shouldUseOTelFriendlyUI) {
-        return !['span.description', 'span.op'].includes(attribute.name);
-      }
-
-      return attribute.name !== 'span.name';
-    });
-
     if (!searchQuery.trim()) {
-      return filteredByOTelMode;
+      return onlyVisibleAttributes;
     }
 
     const normalizedSearchQuery = searchQuery.toLowerCase().trim();
 
-    const onlyMatchingAttributes = filteredByOTelMode.filter(attribute => {
+    const onlyMatchingAttributes = onlyVisibleAttributes.filter(attribute => {
       return attribute.name.toLowerCase().trim().includes(normalizedSearchQuery);
     });
 
     return onlyMatchingAttributes;
-  }, [attributes, searchQuery, shouldUseOTelFriendlyUI]);
+  }, [attributes, searchQuery]);
 
   const customRenderers: Record<
     string,


### PR DESCRIPTION
Since `span.op`, `span.description` and `span.name` are now relevant to all spans (whether they were ingested via Sentry SDK or OTLP), show them in all cases rather than conditionally hiding them.

Fixes ENG-5761.