### PR TITLE
feat(search-bar): Update boolean ops to have a select

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,6 +1,8 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Text} from '@sentry/scraps/text';
+
 import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilder,
@@ -77,6 +79,15 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
   );
 }
 
+function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
+  const label = token.text.toUpperCase();
+  return (
+    <FilterWrapper aria-label={label}>
+      <Text variant="muted">{label}</Text>
+    </FilterWrapper>
+  );
+}
+
 function QueryToken({token}: TokenProps) {
   switch (token.type) {
     case Token.FILTER:
@@ -89,12 +100,12 @@ function QueryToken({token}: TokenProps) {
     case Token.L_PAREN:
     case Token.R_PAREN:
       return (
-        <Boolean>
+        <Paren>
           <SearchQueryBuilderParenIcon token={token} />
-        </Boolean>
+        </Paren>
       );
     case Token.LOGIC_BOOLEAN:
-      return <Boolean>{token.text}</Boolean>;
+      return <Boolean token={token} />;
     default:
       return null;
   }
@@ -197,7 +208,7 @@ const FilterValue = styled('div')`
   ${p => p.theme.overflowEllipsis};
 `;
 
-const Boolean = styled('div')`
+const Paren = styled('div')`
   display: flex;
   align-items: center;
   color: ${p => p.theme.subText};

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
@@ -80,11 +81,23 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
 }
 
 function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
-  const label = token.text.toUpperCase();
+  const hasConditionalsSelect = useOrganization().features.includes(
+    'search-query-builder-add-boolean-operator-select'
+  );
+
+  if (hasConditionalsSelect) {
+    const label = token.text.toUpperCase();
+    return (
+      <FilterWrapper aria-label={label}>
+        <Text variant="muted">{label}</Text>
+      </FilterWrapper>
+    );
+  }
+
   return (
-    <FilterWrapper aria-label={label}>
-      <Text variant="muted">{label}</Text>
-    </FilterWrapper>
+    <Flex align="center">
+      <Text variant="muted">{token.text}</Text>
+    </Flex>
   );
 }
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -203,6 +203,12 @@ type UpdateAggregateArgsAction = {
   focusOverride?: FocusOverride;
 };
 
+type UpdateBooleanOperatorAction = {
+  token: TokenResult<Token.LOGIC_BOOLEAN>;
+  type: 'UPDATE_BOOLEAN_OPERATOR';
+  value: string;
+};
+
 type ResetClearAskSeerFeedbackAction = {type: 'RESET_CLEAR_ASK_SEER_FEEDBACK'};
 
 type UpdateFreeTextActions =
@@ -238,7 +244,8 @@ export type QueryBuilderActions =
   | UpdateTokenValueAction
   | UpdateAggregateArgsAction
   | MultiSelectFilterValueAction
-  | ResetClearAskSeerFeedbackAction;
+  | ResetClearAskSeerFeedbackAction
+  | UpdateBooleanOperatorAction;
 
 function removeQueryTokensFromQuery(
   query: string,
@@ -782,6 +789,22 @@ function updateFreeTextAndReplaceText(
   };
 }
 
+function updateBooleanOperator(
+  state: QueryBuilderState,
+  action: UpdateBooleanOperatorAction
+): QueryBuilderState {
+  const newQuery = replaceQueryToken(state.query, action.token, action.value);
+  if (newQuery === state.query) {
+    return state;
+  }
+
+  return {
+    ...state,
+    query: newQuery,
+    committedQuery: newQuery,
+  };
+}
+
 export function useQueryBuilderState({
   initialQuery,
   getFieldDefinition,
@@ -963,6 +986,8 @@ export function useQueryBuilderState({
             ...state,
             query: modifyFilterValue(state.query, action.token, action.value),
           };
+        case 'UPDATE_BOOLEAN_OPERATOR':
+          return updateBooleanOperator(state, action);
         case 'UPDATE_AGGREGATE_ARGS':
           return updateAggregateArgs(state, action, {getFieldDefinition});
         case 'TOGGLE_FILTER_VALUE':

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -811,13 +811,48 @@ describe('SearchQueryBuilder', () => {
       expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
     });
 
-    it('can remove boolean ops by clicking the delete button', async () => {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
+    describe('boolean ops', () => {
+      describe('flag disabled', () => {
+        it('can remove boolean ops by clicking the delete button', async () => {
+          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
 
-      expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
-      await userEvent.click(screen.getByRole('gridcell', {name: 'Delete OR'}));
+          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
+          await userEvent.click(screen.getByRole('gridcell', {name: 'Delete OR'}));
 
-      expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
+          expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
+        });
+      });
+
+      describe('flag enabled', () => {
+        it('can remove boolean selector by clicking the delete button', async () => {
+          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />, {
+            organization: {
+              features: ['search-query-builder-add-boolean-operator-select'],
+            },
+          });
+
+          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
+          await userEvent.click(screen.getByRole('button', {name: 'Remove boolean: OR'}));
+
+          expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
+        });
+
+        it('can select a different boolean operator', async () => {
+          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />, {
+            organization: {
+              features: ['search-query-builder-add-boolean-operator-select'],
+            },
+          });
+
+          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit boolean operator: OR'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'AND'}));
+
+          expect(screen.getByRole('row', {name: 'AND'})).toBeInTheDocument();
+        });
+      });
     });
 
     it('can click and drag to select tokens', async () => {

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -1,6 +1,5 @@
 import {useRef, useState} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
@@ -9,10 +8,13 @@ import type {Node} from '@react-types/shared';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Container, Flex} from '@sentry/scraps/layout';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
+import {
+  BaseGridCell,
+  FilterWrapper,
+} from 'sentry/components/searchQueryBuilder/tokens/components';
 import {DeletableToken} from 'sentry/components/searchQueryBuilder/tokens/deletableToken';
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
@@ -131,12 +133,6 @@ function SearchQueryBuilderBooleanSelect({
 
   return (
     <FilterWrapper
-      border="muted"
-      position="relative"
-      radius="sm"
-      height="24px"
-      /* Ensures that filters do not grow outside of the container */
-      minWidth="0"
       ref={ref}
       aria-label={token.text}
       aria-invalid={tokenHasError}
@@ -150,7 +146,7 @@ function SearchQueryBuilderBooleanSelect({
         containerDisplayMode="grid"
         forceVisible={filterMenuOpen ? false : undefined}
       >
-        <Flex align="stretch" position="relative" {...gridCellProps}>
+        <BaseGridCell {...gridCellProps}>
           <CompactSelect
             disabled={disabled}
             size="sm"
@@ -173,10 +169,10 @@ function SearchQueryBuilderBooleanSelect({
               dispatch({type: 'UPDATE_BOOLEAN_OPERATOR', token, value: option.value});
             }}
           />
-        </Flex>
-        <Flex align="stretch" position="relative" {...gridCellProps}>
+        </BaseGridCell>
+        <BaseGridCell {...gridCellProps}>
           <FilterDelete token={token} state={state} item={item} />
-        </Flex>
+        </BaseGridCell>
       </GridInvalidTokenTooltip>
     </FilterWrapper>
   );
@@ -195,28 +191,6 @@ const OpButton = styled(UnstyledButton, {shouldForwardProp: isPropValid})`
     border-right: 1px solid ${p => p.theme.innerBorder};
     border-left: 1px solid ${p => p.theme.innerBorder};
   }
-`;
-
-const FilterWrapper = styled(Container)<{state: 'invalid' | 'warning' | 'valid'}>`
-  :focus,
-  &[aria-selected='true'] {
-    background-color: ${p => p.theme.gray100};
-    border-color: ${p => (p.theme.isChonk ? p.theme.tokens.border.accent : undefined)};
-    outline: none;
-  }
-
-  ${p =>
-    p.state === 'invalid'
-      ? css`
-          border-color: ${p.theme.red200};
-          background-color: ${p.theme.red100};
-        `
-      : p.state === 'warning'
-        ? css`
-            border-color: ${p.theme.gray300};
-            background-color: ${p.theme.gray100};
-          `
-        : ''}
 `;
 
 const DeleteButton = styled(UnstyledButton)`

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -9,14 +9,14 @@ import type {Node} from '@react-types/shared';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {DeletableToken} from 'sentry/components/searchQueryBuilder/tokens/deletableToken';
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
-import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
+import {GridInvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import type {
   ParseResultToken,
   Token,
@@ -143,46 +143,41 @@ function SearchQueryBuilderBooleanSelect({
       state={tokenHasWarning ? 'warning' : tokenHasError ? 'invalid' : 'valid'}
       {...modifiedRowProps}
     >
-      <Grid align="stretch" height="22px" columns="auto auto auto auto">
-        {props => (
-          <InvalidTokenTooltip
-            token={token}
-            state={state}
-            item={item}
-            containerDisplayMode="grid"
-            forceVisible={filterMenuOpen ? false : undefined}
-            {...props}
-          >
-            <Flex align="stretch" position="relative" {...gridCellProps}>
-              <CompactSelect
-                disabled={disabled}
-                size="sm"
-                value={tokenText}
-                options={BOOLEAN_OPERATOR_OPTIONS}
-                trigger={triggerProps => {
-                  return (
-                    <OpButton
-                      disabled={disabled}
-                      aria-label={t('Edit boolean operator: %s', tokenText)}
-                      {...mergeProps(triggerProps, filterButtonProps, focusWithinProps)}
-                    >
-                      <InteractionStateLayer />
-                      {tokenText}
-                    </OpButton>
-                  );
-                }}
-                onOpenChange={setFilterMenuOpen}
-                onChange={option => {
-                  dispatch({type: 'UPDATE_BOOLEAN_OPERATOR', token, value: option.value});
-                }}
-              />
-            </Flex>
-            <Flex align="stretch" position="relative" {...gridCellProps}>
-              <FilterDelete token={token} state={state} item={item} />
-            </Flex>
-          </InvalidTokenTooltip>
-        )}
-      </Grid>
+      <GridInvalidTokenTooltip
+        token={token}
+        state={state}
+        item={item}
+        containerDisplayMode="grid"
+        forceVisible={filterMenuOpen ? false : undefined}
+      >
+        <Flex align="stretch" position="relative" {...gridCellProps}>
+          <CompactSelect
+            disabled={disabled}
+            size="sm"
+            value={tokenText}
+            options={BOOLEAN_OPERATOR_OPTIONS}
+            trigger={triggerProps => {
+              return (
+                <OpButton
+                  disabled={disabled}
+                  aria-label={t('Edit boolean operator: %s', tokenText)}
+                  {...mergeProps(triggerProps, filterButtonProps, focusWithinProps)}
+                >
+                  <InteractionStateLayer />
+                  {tokenText}
+                </OpButton>
+              );
+            }}
+            onOpenChange={setFilterMenuOpen}
+            onChange={option => {
+              dispatch({type: 'UPDATE_BOOLEAN_OPERATOR', token, value: option.value});
+            }}
+          />
+        </Flex>
+        <Flex align="stretch" position="relative" {...gridCellProps}>
+          <FilterDelete token={token} state={state} item={item} />
+        </Flex>
+      </GridInvalidTokenTooltip>
     </FilterWrapper>
   );
 }

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -1,12 +1,31 @@
+import {useRef, useState} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import {useFocusWithin} from '@react-aria/interactions';
+import {mergeProps} from '@react-aria/utils';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
+import {Flex, Grid} from '@sentry/scraps/layout';
+
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {DeletableToken} from 'sentry/components/searchQueryBuilder/tokens/deletableToken';
+import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
+import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
+import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import type {
   ParseResultToken,
   Token,
   TokenResult,
 } from 'sentry/components/searchSyntax/parser';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type SearchQueryBuilderBooleanProps = {
   item: Node<ParseResultToken>;
@@ -15,6 +34,22 @@ type SearchQueryBuilderBooleanProps = {
 };
 
 export function SearchQueryBuilderBoolean({
+  item,
+  state,
+  token,
+}: SearchQueryBuilderBooleanProps) {
+  const showBooleanOpSelector = useOrganization().features.includes(
+    'search-query-builder-add-boolean-operator-select'
+  );
+
+  if (showBooleanOpSelector) {
+    return <SearchQueryBuilderBooleanSelect item={item} state={state} token={token} />;
+  }
+
+  return <SearchQueryBuilderBooleanDeletable item={item} state={state} token={token} />;
+}
+
+function SearchQueryBuilderBooleanDeletable({
   item,
   state,
   token,
@@ -31,3 +66,175 @@ export function SearchQueryBuilderBoolean({
     </DeletableToken>
   );
 }
+
+function FilterDelete({token, state, item}: SearchQueryBuilderBooleanProps) {
+  const {dispatch, disabled} = useSearchQueryBuilder();
+  const filterButtonProps = useFilterButtonProps({state, item});
+
+  return (
+    <DeleteButton
+      aria-label={t('Remove boolean: %s', token.text)}
+      onClick={() => {
+        dispatch({type: 'DELETE_TOKEN', token});
+      }}
+      disabled={disabled}
+      {...filterButtonProps}
+    >
+      <InteractionStateLayer />
+      <IconClose legacySize="8px" />
+    </DeleteButton>
+  );
+}
+
+function SearchQueryBuilderBooleanSelect({
+  item,
+  state,
+  token,
+}: SearchQueryBuilderBooleanProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
+  const {disabled, dispatch} = useSearchQueryBuilder();
+  const {rowProps, gridCellProps} = useQueryBuilderGridItem(item, state, ref);
+
+  const isFocused = item.key === state.selectionManager.focusedKey;
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Backspace' || e.key === 'Delete') {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Only delete if full filter token is focused, otherwise focus it
+      if (ref.current === document.activeElement) {
+        dispatch({type: 'DELETE_TOKEN', token});
+      } else {
+        ref.current?.focus();
+      }
+    }
+  };
+
+  const modifiedRowProps = mergeProps(rowProps, {
+    tabIndex: isFocused ? 0 : -1,
+    onKeyDown,
+  });
+
+  const filterButtonProps = useFilterButtonProps({state, item});
+  const {focusWithinProps} = useFocusWithin({});
+
+  const tokenText = token.text.toUpperCase();
+
+  const tokenHasError = 'invalid' in token && defined(token.invalid);
+  const tokenHasWarning = 'warning' in token && defined(token.warning);
+
+  return (
+    <FilterWrapper
+      ref={ref}
+      aria-label={token.text}
+      aria-invalid={tokenHasError}
+      state={tokenHasWarning ? 'warning' : tokenHasError ? 'invalid' : 'valid'}
+      {...modifiedRowProps}
+    >
+      <Grid align="stretch" height="22px" columns="auto auto auto auto">
+        {props => (
+          <InvalidTokenTooltip
+            token={token}
+            state={state}
+            item={item}
+            containerDisplayMode="grid"
+            forceVisible={filterMenuOpen ? false : undefined}
+            {...props}
+          >
+            <Flex align="stretch" position="relative" {...gridCellProps}>
+              <CompactSelect
+                disabled={disabled}
+                size="sm"
+                value={tokenText}
+                options={[
+                  {value: 'AND', label: 'AND'},
+                  {value: 'OR', label: 'OR'},
+                ]}
+                trigger={triggerProps => {
+                  return (
+                    <OpButton
+                      disabled={disabled}
+                      aria-label={t('Edit boolean operator: %s', tokenText)}
+                      {...mergeProps(triggerProps, filterButtonProps, focusWithinProps)}
+                    >
+                      <InteractionStateLayer />
+                      {tokenText}
+                    </OpButton>
+                  );
+                }}
+                onOpenChange={setFilterMenuOpen}
+                onChange={option => {
+                  dispatch({type: 'UPDATE_BOOLEAN_OPERATOR', token, value: option.value});
+                }}
+              />
+            </Flex>
+            <Flex align="stretch" position="relative" {...gridCellProps}>
+              <FilterDelete token={token} state={state} item={item} />
+            </Flex>
+          </InvalidTokenTooltip>
+        )}
+      </Grid>
+    </FilterWrapper>
+  );
+}
+
+const OpButton = styled(UnstyledButton, {
+  shouldForwardProp: isPropValid,
+})<{onlyOperator?: boolean}>`
+  padding: 0 ${p => p.theme.space['2xs']} 0 ${p => p.theme.space.xs};
+  color: ${p => p.theme.subText};
+  height: 100%;
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+
+  border-radius: ${p => (p.onlyOperator ? '3px 0 0 3px' : 0)};
+
+  :focus {
+    background-color: ${p => p.theme.translucentGray100};
+    border-right: 1px solid ${p => p.theme.innerBorder};
+    border-left: 1px solid ${p => p.theme.innerBorder};
+  }
+`;
+
+const FilterWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
+  position: relative;
+  border: 1px solid ${p => p.theme.innerBorder};
+  border-radius: ${p => p.theme.borderRadius};
+  height: 24px;
+  /* Ensures that filters do not grow outside of the container */
+  min-width: 0;
+
+  :focus,
+  &[aria-selected='true'] {
+    background-color: ${p => p.theme.gray100};
+    border-color: ${p => (p.theme.isChonk ? p.theme.tokens.border.accent : undefined)};
+    outline: none;
+  }
+
+  ${p =>
+    p.state === 'invalid'
+      ? css`
+          border-color: ${p.theme.red200};
+          background-color: ${p.theme.red100};
+        `
+      : p.state === 'warning'
+        ? css`
+            border-color: ${p.theme.gray300};
+            background-color: ${p.theme.gray100};
+          `
+        : ''}
+`;
+
+const DeleteButton = styled(UnstyledButton)`
+  padding: 0 ${p => p.theme.space.sm} 0 ${p => p.theme.space.xs};
+  border-radius: 0 3px 3px 0;
+  color: ${p => p.theme.subText};
+  border-left: 1px solid transparent;
+
+  :focus {
+    background-color: ${p => p.theme.translucentGray100};
+    border-left: 1px solid ${p => p.theme.innerBorder};
+  }
+`;

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -140,6 +140,7 @@ function SearchQueryBuilderBooleanSelect({
       {...modifiedRowProps}
     >
       <GridInvalidTokenTooltip
+        columnCount={2}
         token={token}
         state={state}
         item={item}

--- a/static/app/components/searchQueryBuilder/tokens/components.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/components.tsx
@@ -1,0 +1,61 @@
+import type {DOMAttributes} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import type {FocusableElement} from '@react-types/shared';
+
+import {Container, Flex, type FlexProps} from '@sentry/scraps/layout';
+import type {ContainerProps} from '@sentry/scraps/layout/container';
+
+type BaseGridCellProps = FlexProps & DOMAttributes<FocusableElement>;
+
+export function BaseGridCell({children, ...props}: BaseGridCellProps) {
+  return (
+    <Flex align="stretch" position="relative" {...props}>
+      {children}
+    </Flex>
+  );
+}
+
+type FilterWrapperProps = ContainerProps & {
+  state: 'invalid' | 'warning' | 'valid';
+};
+
+export function FilterWrapper({children, ...props}: FilterWrapperProps) {
+  return (
+    <StyledFilterWrapper
+      border="muted"
+      position="relative"
+      radius="sm"
+      height="24px"
+      /* Ensures that filters do not grow outside of the container */
+      minWidth="0"
+      {...props}
+    >
+      {typeof children === 'function'
+        ? children({className: props.className ?? ''})
+        : children}
+    </StyledFilterWrapper>
+  );
+}
+
+const StyledFilterWrapper = styled(Container)<{state: 'invalid' | 'warning' | 'valid'}>`
+  :focus,
+  &[aria-selected='true'] {
+    background-color: ${p => p.theme.gray100};
+    border-color: ${p => (p.theme.isChonk ? p.theme.tokens.border.accent : undefined)};
+    outline: none;
+  }
+
+  ${p =>
+    p.state === 'invalid'
+      ? css`
+          border-color: ${p.theme.red200};
+          background-color: ${p.theme.red100};
+        `
+      : p.state === 'warning'
+        ? css`
+            border-color: ${p.theme.gray300};
+            background-color: ${p.theme.gray100};
+          `
+        : ''}
+`;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -237,6 +237,7 @@ export function SearchQueryBuilderFilter({item, state, token}: SearchQueryTokenP
         token={token}
         state={state}
         item={item}
+        columnCount={4}
         containerDisplayMode="grid"
         forceVisible={filterMenuOpen ? false : undefined}
       >

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useLayoutEffect, useRef, useState} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
@@ -10,6 +9,10 @@ import InteractionStateLayer from 'sentry/components/core/interactionStateLayer'
 import {DateTime} from 'sentry/components/dateTime';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
+import {
+  BaseGridCell,
+  FilterWrapper,
+} from 'sentry/components/searchQueryBuilder/tokens/components';
 import {AggregateKey} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
 import {FilterKey} from 'sentry/components/searchQueryBuilder/tokens/filter/filterKey';
 import {FilterOperator} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
@@ -281,41 +284,6 @@ export function SearchQueryBuilderFilter({item, state, token}: SearchQueryTokenP
     </FilterWrapper>
   );
 }
-
-const FilterWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
-  position: relative;
-  border: 1px solid ${p => p.theme.innerBorder};
-  border-radius: ${p => p.theme.borderRadius};
-  height: 24px;
-  /* Ensures that filters do not grow outside of the container */
-  min-width: 0;
-
-  :focus,
-  &[aria-selected='true'] {
-    background-color: ${p => p.theme.gray100};
-    border-color: ${p => (p.theme.isChonk ? p.theme.tokens.border.accent : undefined)};
-    outline: none;
-  }
-
-  ${p =>
-    p.state === 'invalid'
-      ? css`
-          border-color: ${p.theme.red200};
-          background-color: ${p.theme.red100};
-        `
-      : p.state === 'warning'
-        ? css`
-            border-color: ${p.theme.gray300};
-            background-color: ${p.theme.gray100};
-          `
-        : ''}
-`;
-
-const BaseGridCell = styled('div')`
-  display: flex;
-  align-items: stretch;
-  position: relative;
-`;
 
 const FilterValueGridCell = styled(BaseGridCell)`
   /* When we run out of space, shrink the value */

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -20,7 +20,7 @@ import {
   isAggregateFilterToken,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {SearchQueryBuilderValueCombobox} from 'sentry/components/searchQueryBuilder/tokens/filter/valueCombobox';
-import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
+import {GridInvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import {
   FilterType,
   Token,
@@ -309,13 +309,6 @@ const FilterWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
             background-color: ${p.theme.gray100};
           `
         : ''}
-`;
-
-const GridInvalidTokenTooltip = styled(InvalidTokenTooltip)`
-  display: grid;
-  grid-template-columns: auto auto auto auto;
-  align-items: stretch;
-  height: 22px;
 `;
 
 const BaseGridCell = styled('div')`

--- a/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
@@ -2,6 +2,8 @@ import type {ReactNode} from 'react';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
+import {Grid} from '@sentry/scraps/layout';
+
 import {Tooltip, type TooltipProps} from 'sentry/components/core/tooltip';
 import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
@@ -62,5 +64,24 @@ export function InvalidTokenTooltip({
     >
       {children}
     </Tooltip>
+  );
+}
+
+type GridInvalidTokenTooltipProps = InvalidTokenTooltipProps & {
+  children: React.ReactNode;
+};
+
+export function GridInvalidTokenTooltip({
+  children,
+  ...props
+}: GridInvalidTokenTooltipProps) {
+  return (
+    <Grid align="stretch" height="22px" columns="auto auto auto auto">
+      {styleProps => (
+        <InvalidTokenTooltip {...props} {...styleProps}>
+          {children}
+        </InvalidTokenTooltip>
+      )}
+    </Grid>
   );
 }

--- a/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
@@ -69,14 +69,16 @@ export function InvalidTokenTooltip({
 
 type GridInvalidTokenTooltipProps = InvalidTokenTooltipProps & {
   children: React.ReactNode;
+  columnCount: number;
 };
 
 export function GridInvalidTokenTooltip({
   children,
+  columnCount,
   ...props
 }: GridInvalidTokenTooltipProps) {
   return (
-    <Grid align="stretch" height="22px" columns="auto auto auto auto">
+    <Grid align="stretch" height="22px" columns={`repeat(${columnCount}, auto)`}>
       {styleProps => (
         <InvalidTokenTooltip {...props} {...styleProps}>
           {children}


### PR DESCRIPTION
This PR adds in a replacement component for the current boolean operator in the search query builder to have a compact select with the boolean values (`AND`/`OR`).

This new select is styled to match that of the current filter components:
<img width="99" height="127" alt="Screenshot 2025-10-23 at 14 16 09" src="https://github.com/user-attachments/assets/61052616-cd97-4196-be68-e8311285f840" />

Ticket: EXP-508