### PR TITLE
nit(aci): update monitor creation descriptions and fix padding

### DIFF
--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -17,11 +17,7 @@ export function DetectorTypeForm() {
   return (
     <FormContainer>
       <Header>
-        <h3>{t('Monitor type')}</h3>
-        <p>
-          {t("Monitor type can't be edited once the monitor has been created.")}{' '}
-          <a href="#">{t('Learn more about monitor types.')}</a>
-        </p>
+        <h3>{t('Select monitor type')}</h3>
       </Header>
       <MonitorTypeField />
     </FormContainer>

--- a/static/app/views/detectors/components/forms/automateSection.spec.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.spec.tsx
@@ -40,7 +40,7 @@ describe('AutomateSection', () => {
       </Form>
     );
 
-    expect(screen.getByText('Automate')).toBeInTheDocument();
+    expect(screen.getByText('Alert')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Connect an Alert'));
 

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -201,7 +201,10 @@ export function AutomateSection() {
 
   return (
     <Container>
-      <Section title={t('Automate')} description={t('Set up alerts or notifications.')}>
+      <Section
+        title={t('Alert')}
+        description={t('Set up alerts to get notified on issues.')}
+      >
         <Button
           ref={ref}
           size="sm"

--- a/static/app/views/detectors/components/forms/common/assignSection.tsx
+++ b/static/app/views/detectors/components/forms/common/assignSection.tsx
@@ -40,5 +40,5 @@ export function AssignSection() {
 }
 
 const StyledMemberTeamSelectorField = styled(SentryMemberTeamSelectorField)`
-  padding-left: 0;
+  padding: 0;
 `;


### PR DESCRIPTION
* removed message explaining that monitor type can't be changed
<img width="1391" height="622" alt="Screenshot 2025-10-23 at 10 44 00 AM" src="https://github.com/user-attachments/assets/942184df-4e9d-469a-86ae-01775e4dc0e2" />

* fixed padding around the "assign" section
* updated the "automate" section to be "alert"
* updated alert section description
<img width="1019" height="280" alt="Screenshot 2025-10-23 at 10 42 46 AM" src="https://github.com/user-attachments/assets/aa604cea-358e-46f4-b7a8-f1daeabb557f" />
