### PR TITLE
fix(uptime): Check for null dataSources instead of empty array

### DIFF
--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -68,8 +68,7 @@ export function OverviewRow({summary, uptimeDetector, timeWindowConfig, single}:
   // XXX(epurkhiser): This is a hack, we're seeing some uptime detectors with
   // missing dataSources. That should never happen, but for now let's make sure
   // we're not totally blowing up customers views
-  // @ts-expect-error - See above
-  if (uptimeDetector.dataSources.length === 0) {
+  if (uptimeDetector.dataSources === null) {
     return null;
   }
 


### PR DESCRIPTION
The check in c0d6b91d911 was incorrect - it checked for an empty array
(dataSources.length === 0), but the actual issue is that dataSources can
be null. This fixes the null check to properly handle the case where
dataSources is missing.

Fixes c0d6b91d911
Fixes [JAVASCRIPT-3448](https://sentry.sentry.io/issues/6969300984/)