### PR TITLE
ref(uptime): Deprioritize missed checks in timeline when zoomed out

### DIFF
--- a/static/app/views/insights/uptime/timelineConfig.tsx
+++ b/static/app/views/insights/uptime/timelineConfig.tsx
@@ -10,8 +10,8 @@ import {
 export const checkStatusPrecedent: CheckStatus[] = [
   CheckStatus.FAILURE_INCIDENT,
   CheckStatus.FAILURE,
-  CheckStatus.MISSED_WINDOW,
   CheckStatus.SUCCESS,
+  CheckStatus.MISSED_WINDOW,
 ];
 
 export const statusToText: Record<CheckStatus, string> = {


### PR DESCRIPTION
When viewing the uptime timeline zoomed way out, unknown/missed checks
were being shown prominently. We've reduced their priority so that
more actionable information (failures and downtime) is displayed more
prominently.

Fixes [NEW-598](https://linear.app/getsentry/issue/NEW-598/deprioritize-missed-checks-in-uptime-timeline-when-zoomed-out)