### PR TITLE
feat(logs): More detailed chart footer for logs

### DIFF
--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -10,21 +10,25 @@ import {
   usePreviouslyLoaded,
 } from 'sentry/views/explore/components/chart/chartFooter';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import type {RawLogCounts} from 'sentry/views/explore/logs/useLogsQuery';
 
 interface ConfidenceFooterProps {
   chartInfo: ChartInfo;
   isLoading: boolean;
+  rawLogCounts: RawLogCounts;
 }
 
 export function ConfidenceFooter({
   chartInfo: currentChartInfo,
   isLoading,
+  rawLogCounts,
 }: ConfidenceFooterProps) {
   const chartInfo = usePreviouslyLoaded(currentChartInfo, isLoading);
   return (
     <Container>
       <ConfidenceMessage
         isLoading={isLoading}
+        rawLogCounts={rawLogCounts}
         confidence={chartInfo.confidence}
         dataScanned={chartInfo.dataScanned}
         isSampled={chartInfo.isSampled}
@@ -37,6 +41,7 @@ export function ConfidenceFooter({
 
 interface ConfidenceMessageProps {
   isLoading: boolean;
+  rawLogCounts: RawLogCounts;
   confidence?: Confidence;
   dataScanned?: 'full' | 'partial';
   isSampled?: boolean | null;
@@ -45,9 +50,10 @@ interface ConfidenceMessageProps {
 }
 
 function ConfidenceMessage({
+  rawLogCounts,
   sampleCount,
   dataScanned,
-  confidence,
+  confidence: _confidence,
   topEvents,
   isLoading,
   isSampled,
@@ -55,60 +61,69 @@ function ConfidenceMessage({
   const isTopN = defined(topEvents) && topEvents > 1;
 
   if (!defined(sampleCount) || isLoading) {
-    return <Placeholder />;
+    return <Placeholder width={180} />;
   }
 
   const noSampling = defined(isSampled) && !isSampled;
-  const sampleCountComponent = <Count value={sampleCount} />;
+  const matchingLogsCount = <Count value={sampleCount} />;
+  const downsampledLogsCount = rawLogCounts.normal.count ? (
+    <Count value={rawLogCounts.normal.count} />
+  ) : (
+    <Placeholder width={40} />
+  );
+  const allLogsCount = rawLogCounts.highAccuracy.count ? (
+    <Count value={rawLogCounts.highAccuracy.count} />
+  ) : (
+    <Placeholder width={40} />
+  );
 
   if (dataScanned === 'full') {
     // For logs, if the full data was scanned, we can assume that no
     // extrapolation happened and we should remove mentions of extrapolation.
     if (isTopN) {
-      return tct('Log count for top [topEvents] groups: [sampleCountComponent]', {
-        topEvents,
-        sampleCountComponent,
-      });
-    }
-
-    return tct('Log count: [sampleCountComponent]', {
-      sampleCountComponent,
-    });
-  }
-
-  if (confidence === 'low') {
-    const lowAccuracyFullSampleCount = <LowAccuracyFullTooltip noSampling={noSampling} />;
-
-    if (isTopN) {
       return tct(
-        'Top [topEvents] groups extrapolated from [tooltip:[sampleCountComponent] logs]',
+        '[matchingLogsCount] matching logs for top [topEvents] groups after scanning [allLogsCount] logs',
         {
           topEvents,
-          tooltip: lowAccuracyFullSampleCount,
-          sampleCountComponent,
+          matchingLogsCount,
+          allLogsCount,
         }
       );
     }
 
-    return tct('Extrapolated from [tooltip:[sampleCountComponent] logs]', {
-      tooltip: lowAccuracyFullSampleCount,
-      sampleCountComponent,
+    return tct('[matchingLogsCount] matching logs after scanning [allLogsCount] logs', {
+      matchingLogsCount,
+      allLogsCount,
     });
   }
+
+  const downsampledTooltip = <DownsampledTooltip noSampling={noSampling} />;
 
   if (isTopN) {
-    return tct('Top [topEvents] groups extrapolated from [sampleCountComponent] logs', {
-      topEvents,
-      sampleCountComponent,
-    });
+    return tct(
+      'Extrapolated from [matchingLogsCount] matching logs for top [topEvents] groups after scanning [tooltip:[downsampledLogsCount] of [allLogsCount] logs]',
+      {
+        topEvents,
+        matchingLogsCount,
+        downsampledLogsCount,
+        allLogsCount,
+        tooltip: downsampledTooltip,
+      }
+    );
   }
 
-  return tct('Extrapolated from [sampleCountComponent] logs', {
-    sampleCountComponent,
-  });
+  return tct(
+    'Extrapolated from [matchingLogsCount] matching logs after scanning [tooltip:[downsampledLogsCount] of [allLogsCount] logs]',
+    {
+      matchingLogsCount,
+      downsampledLogsCount,
+      allLogsCount,
+      tooltip: downsampledTooltip,
+    }
+  );
 }
 
-function LowAccuracyFullTooltip({
+function DownsampledTooltip({
   noSampling,
   children,
 }: {
@@ -119,10 +134,13 @@ function LowAccuracyFullTooltip({
     <Tooltip
       title={
         <div>
-          {t('Some logs are not shown due to the large volume of logs.')}
+          {t(
+            'The volume of logs in this time range is too large for us to do a full scan.'
+          )}
           <br />
-          <br />
-          {t('Try reducing the date range or number of projects.')}
+          {t(
+            'Try reducing the date range or number of projects to attempt scanning all logs.'
+          )}
         </div>
       }
       disabled={noSampling}
@@ -134,8 +152,9 @@ function LowAccuracyFullTooltip({
   );
 }
 
-const Placeholder = styled('div')`
-  width: 180px;
+const Placeholder = styled('div')<{width: number}>`
+  display: inline-block;
+  width: ${p => p.width}px;
   height: ${p => p.theme.fontSize.md};
   border-radius: ${p => p.theme.borderRadius};
   background-color: ${p => p.theme.backgroundTertiary};

--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -76,48 +76,56 @@ function ConfidenceMessage({
   ) : (
     <Placeholder width={40} />
   );
+  const suffix = rawLogCounts.highAccuracy.count ? t('logs') : '';
 
   if (dataScanned === 'full') {
     // For logs, if the full data was scanned, we can assume that no
     // extrapolation happened and we should remove mentions of extrapolation.
     if (isTopN) {
       return tct(
-        '[matchingLogsCount] matching logs for top [topEvents] groups after scanning [allLogsCount] logs',
+        '[matchingLogsCount] matching logs for top [topEvents] groups after scanning [allLogsCount] [suffix]',
         {
           topEvents,
           matchingLogsCount,
           allLogsCount,
+          suffix,
         }
       );
     }
 
-    return tct('[matchingLogsCount] matching logs after scanning [allLogsCount] logs', {
-      matchingLogsCount,
-      allLogsCount,
-    });
+    return tct(
+      '[matchingLogsCount] matching logs after scanning [allLogsCount] [suffix]',
+      {
+        matchingLogsCount,
+        allLogsCount,
+        suffix,
+      }
+    );
   }
 
   const downsampledTooltip = <DownsampledTooltip noSampling={noSampling} />;
 
   if (isTopN) {
     return tct(
-      'Extrapolated from [matchingLogsCount] matching logs for top [topEvents] groups after scanning [tooltip:[downsampledLogsCount] of [allLogsCount] logs]',
+      'Extrapolated from [matchingLogsCount] matching logs for top [topEvents] groups after scanning [tooltip:[downsampledLogsCount] of [allLogsCount] [suffix]]',
       {
         topEvents,
         matchingLogsCount,
         downsampledLogsCount,
         allLogsCount,
+        suffix,
         tooltip: downsampledTooltip,
       }
     );
   }
 
   return tct(
-    'Extrapolated from [matchingLogsCount] matching logs after scanning [tooltip:[downsampledLogsCount] of [allLogsCount] logs]',
+    'Extrapolated from [matchingLogsCount] matching logs after scanning [tooltip:[downsampledLogsCount] of [allLogsCount] [suffix]]',
     {
       matchingLogsCount,
       downsampledLogsCount,
       allLogsCount,
+      suffix,
       tooltip: downsampledTooltip,
     }
   );

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -334,7 +334,12 @@ describe('LogsPage', () => {
       expect(switchInput).not.toBeChecked();
       expect(switchInput).toBeEnabled();
 
-      expect(eventTableMock).toHaveBeenCalledTimes(1);
+      // 3 calls total
+      // - one for the table
+      // - one for the normal sample mode count
+      // - one for the high accuracy sample mode count
+      expect(eventTableMock).toHaveBeenCalledTimes(3);
+
       eventTableMock.mockClear();
       eventTableMock = setupEventsMock(autorefreshBaseFixtures.slice(0, 5));
 

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -34,6 +34,7 @@ import {
 } from 'sentry/views/explore/hooks/useChartInterval';
 import {TOP_EVENTS_LIMIT} from 'sentry/views/explore/hooks/useTopEvents';
 import {ConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
+import type {RawLogCounts} from 'sentry/views/explore/logs/useLogsQuery';
 import {
   useQueryParamsAggregateFields,
   useQueryParamsAggregateSortBys,
@@ -56,10 +57,11 @@ import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/use
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 interface LogsGraphProps {
+  rawLogCounts: RawLogCounts;
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
 }
 
-export function LogsGraph({timeseriesResult}: LogsGraphProps) {
+export function LogsGraph({rawLogCounts, timeseriesResult}: LogsGraphProps) {
   const visualizes = useQueryParamsVisualizes();
   const setVisualizes = useSetQueryParamsVisualizes();
 
@@ -90,6 +92,7 @@ export function LogsGraph({timeseriesResult}: LogsGraphProps) {
           <Graph
             key={index}
             visualize={visualize}
+            rawLogCounts={rawLogCounts}
             timeseriesResult={timeseriesResult}
             onChartTypeChange={chartType => handleChartTypeChange(index, chartType)}
             onChartVisibilityChange={visible =>
@@ -111,6 +114,7 @@ interface GraphProps extends LogsGraphProps {
 function Graph({
   onChartTypeChange,
   onChartVisibilityChange,
+  rawLogCounts,
   timeseriesResult,
   visualize,
 }: GraphProps) {
@@ -199,6 +203,7 @@ function Graph({
           <ConfidenceFooter
             chartInfo={chartInfo}
             isLoading={timeseriesResult.isLoading}
+            rawLogCounts={rawLogCounts}
           />
         )
       }

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -59,7 +59,10 @@ import {LogsAggregateTable} from 'sentry/views/explore/logs/tables/logsAggregate
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
 import {type OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {useLogsAggregatesTable} from 'sentry/views/explore/logs/useLogsAggregatesTable';
-import {getMaxIngestDelayTimestamp} from 'sentry/views/explore/logs/useLogsQuery';
+import {
+  getMaxIngestDelayTimestamp,
+  useLogsRawCounts,
+} from 'sentry/views/explore/logs/useLogsQuery';
 import {useLogsSearchQueryBuilderProps} from 'sentry/views/explore/logs/useLogsSearchQueryBuilderProps';
 import {useLogsTimeseries} from 'sentry/views/explore/logs/useLogsTimeseries';
 import {usePersistentLogsPageParameters} from 'sentry/views/explore/logs/usePersistentLogsPageParameters';
@@ -123,6 +126,8 @@ export function LogsTabContent({
       setTimeseriesIngestDelay(getMaxIngestDelayTimestamp());
     }
   }, [autorefreshEnabled]);
+
+  const rawLogCounts = useLogsRawCounts();
 
   const yAxes = useMemo(() => {
     const uniqueYAxes = new Set(visualizes.map(visualize => visualize.yAxis));
@@ -355,7 +360,10 @@ export function LogsTabContent({
               <QuotaExceededAlert referrer="logs-explore" traceItemDataset="logs" />
             )}
             <LogsGraphContainer>
-              <LogsGraph timeseriesResult={timeseriesResult} />
+              <LogsGraph
+                rawLogCounts={rawLogCounts}
+                timeseriesResult={timeseriesResult}
+              />
             </LogsGraphContainer>
             <LogsTableActionsContainer>
               <Tabs value={tableTab} onChange={setTableTab} size="sm">

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 import {logger} from '@sentry/react';
 
 import {type ApiResult} from 'sentry/api';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {defined} from 'sentry/utils';
 import {encodeSort, type EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -10,6 +11,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {
   fetchDataQuery,
+  useApiQuery,
   useInfiniteQuery,
   useQueryClient,
   type ApiQueryKey,
@@ -38,6 +40,7 @@ import {
 import {
   OurLogKnownFieldKey,
   type EventsLogsResult,
+  type LogsAggregatesResult,
 } from 'sentry/views/explore/logs/types';
 import {
   isRowVisibleInVirtualStream,
@@ -709,4 +712,80 @@ export function useLogsQueryHighFidelity() {
     sortBys[0]?.field === 'timestamp' &&
     sortBys[0]?.kind === 'desc'
   );
+}
+
+interface RawCount {
+  count: number | null;
+  isLoading: boolean;
+}
+
+export interface RawLogCounts {
+  highAccuracy: RawCount;
+  normal: RawCount;
+}
+
+export function useLogsRawCounts(): RawLogCounts {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const baseQueryParams = {
+    dataset: DiscoverDatasets.OURLOGS,
+    project: selection.projects,
+    environment: selection.environments,
+    ...normalizeDateTimeParams(selection.datetime),
+    field: ['count(message)'],
+    disableAggregateExtrapolation: '1',
+  };
+
+  const normalScanQueryKey: ApiQueryKey = [
+    `/organizations/${organization.slug}/events/`,
+    {
+      query: {
+        ...baseQueryParams,
+        referrer: 'api.explore.log.raw-count.normal',
+        sampling: SAMPLING_MODE.NORMAL,
+      },
+    },
+  ];
+
+  const normalScanResult = useApiQuery<LogsAggregatesResult>(normalScanQueryKey, {
+    enabled: true,
+    staleTime: 0,
+  });
+
+  const highestAccuracyScanQueryKey: ApiQueryKey = [
+    `/organizations/${organization.slug}/events/`,
+    {
+      query: {
+        ...baseQueryParams,
+        referrer: 'api.explore.log.raw-count.high-accuracy',
+        sampling: SAMPLING_MODE.HIGH_ACCURACY,
+      },
+    },
+  ];
+
+  const highestAccuracyScanResult = useApiQuery<LogsAggregatesResult>(
+    highestAccuracyScanQueryKey,
+    {
+      enabled: true,
+      staleTime: 0,
+    }
+  );
+
+  const normalScanCount = (normalScanResult.data?.data?.[0]?.['count(message)'] ||
+    null) as number | null;
+  const highestAccuracyScanCount = (highestAccuracyScanResult.data?.data?.[0]?.[
+    'count(message)'
+  ] || null) as number | null;
+
+  return {
+    normal: {
+      isLoading: normalScanResult.isFetching,
+      count: normalScanCount,
+    },
+    highAccuracy: {
+      isLoading: highestAccuracyScanResult.isFetching,
+      count: highestAccuracyScanCount,
+    },
+  };
 }

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -742,7 +742,7 @@ export function useLogsRawCounts(): RawLogCounts {
     {
       query: {
         ...baseQueryParams,
-        referrer: 'api.explore.log.raw-count.normal',
+        referrer: 'api.explore.logs.raw-count.normal',
         sampling: SAMPLING_MODE.NORMAL,
       },
     },
@@ -758,7 +758,7 @@ export function useLogsRawCounts(): RawLogCounts {
     {
       query: {
         ...baseQueryParams,
-        referrer: 'api.explore.log.raw-count.high-accuracy',
+        referrer: 'api.explore.logs.raw-count.high-accuracy',
         sampling: SAMPLING_MODE.HIGH_ACCURACY,
       },
     },


### PR DESCRIPTION
This shows a more detailed chart footer for logs that shows the number of logs scanned and the number of logs present.

<table>
<tr>
 <td>Full scan without a group by
 <td><img width="806" height="200" alt="image" src="https://github.com/user-attachments/assets/90731d47-3b2e-4f69-8571-7b7adbd6a06c" />
<tr>
 <td>Full scan with a group by
 <td><img width="791" height="196" alt="image" src="https://github.com/user-attachments/assets/c5a4f7aa-4bc6-412f-aac8-6e2781770e2d" />
<tr>
 <td>Partial scan without a group by
 <td><img width="805" height="200" alt="image" src="https://github.com/user-attachments/assets/57d9f2ac-f1bc-438a-8123-4c313489912d" />
<tr>
 <td>Partial scan with a group by
 <td><img width="790" height="200" alt="image" src="https://github.com/user-attachments/assets/08d4317b-65d6-4139-a6b0-015270e9a4c9" />
</table>