### PR TITLE
fix(integrations): change create to not auto-enable all projects

### DIFF
--- a/src/sentry/integrations/api/serializers/rest_framework/data_forwarder.py
+++ b/src/sentry/integrations/api/serializers/rest_framework/data_forwarder.py
@@ -182,7 +182,7 @@ class DataForwarderSerializer(Serializer):
     def create(self, validated_data: Mapping[str, Any]) -> DataForwarder:
         data_forwarder = DataForwarder.objects.create(**validated_data)
 
-        # Auto-enroll all existing projects in the organization
+        # Add rows for all existing projects in the organization
         project_ids = Project.objects.filter(
             organization_id=validated_data["organization_id"]
         ).values_list("id", flat=True)
@@ -192,7 +192,7 @@ class DataForwarderSerializer(Serializer):
                 DataForwarderProject(
                     data_forwarder=data_forwarder,
                     project_id=project_id,
-                    is_enabled=True,
+                    is_enabled=False,
                 )
                 for project_id in project_ids
             ]

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
@@ -296,7 +296,7 @@ class DataForwardingIndexPostTest(DataForwardingIndexEndpointTest):
         response = self.get_error_response(self.organization.slug, status_code=400, **payload)
         assert "message_group_id" in str(response.data).lower()
 
-    def test_create_auto_enrolls_all_organization_projects(self) -> None:
+    def test_create_auto_adds_all_organization_projects(self) -> None:
         # should be enrolled
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)
@@ -315,9 +315,12 @@ class DataForwardingIndexPostTest(DataForwardingIndexEndpointTest):
 
         data_forwarder = DataForwarder.objects.get(id=response.data["id"])
 
-        enrolled_projects = DataForwarderProject.objects.filter(
-            data_forwarder=data_forwarder
-        ).values_list("project_id", flat=True)
+        enrolled_projects = DataForwarderProject.objects.filter(data_forwarder=data_forwarder)
 
-        assert set(enrolled_projects) == {project1.id, project2.id, project3.id}
-        assert other_project.id not in enrolled_projects
+        enrolled_project_ids = set(enrolled_projects.values_list("project_id", flat=True))
+        assert enrolled_project_ids == {project1.id, project2.id, project3.id}
+        assert other_project.id not in enrolled_project_ids
+
+        # Verify all auto-added projects are disabled by default
+        for enrollment in enrolled_projects:
+            assert enrollment.is_enabled is False


### PR DESCRIPTION
make it so that when we create a new data forwarder, it makes rows for all the data forwarder projects, but sets is_enrolled to false. want to do this because if user has many projects and didn't expect all the projects to start forwarding right away, it would be expensive for them.