### PR TITLE
feat(explorer): Add update endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -513,6 +513,9 @@ from sentry.seer.endpoints.organization_events_anomalies import OrganizationEven
 from sentry.seer.endpoints.organization_seer_explorer_chat import (
     OrganizationSeerExplorerChatEndpoint,
 )
+from sentry.seer.endpoints.organization_seer_explorer_update import (
+    OrganizationSeerExplorerUpdateEndpoint,
+)
 from sentry.seer.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheck
 from sentry.seer.endpoints.organization_trace_summary import OrganizationTraceSummaryEndpoint
 from sentry.seer.endpoints.project_seer_preferences import ProjectSeerPreferencesEndpoint
@@ -2285,6 +2288,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/seer/explorer-chat/(?:(?P<run_id>[^/]+)/)?$",
         OrganizationSeerExplorerChatEndpoint.as_view(),
         name="sentry-api-0-organization-seer-explorer-chat",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/explorer-update/(?P<run_id>[^/]+)/$",
+        OrganizationSeerExplorerUpdateEndpoint.as_view(),
+        name="sentry-api-0-organization-seer-explorer-update",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/seer/setup-check/$",

--- a/src/sentry/seer/endpoints/organization_seer_explorer_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_update.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+
+import orjson
+import requests
+from django.conf import settings
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.organization import Organization
+from sentry.seer.seer_setup import get_seer_org_acknowledgement
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationSeerExplorerUpdatePermission(OrganizationPermission):
+    scope_map = {
+        "POST": ["org:read"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationSeerExplorerUpdateEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    permission_classes = (OrganizationSeerExplorerUpdatePermission,)
+
+    def post(self, request: Request, organization: Organization, run_id: int) -> Response:
+        """
+        Send an update event to explorer for a given run.
+        """
+        user = request.user
+        if not features.has(
+            "organizations:gen-ai-features", organization, actor=user
+        ) or not features.has("organizations:seer-explorer", organization, actor=user):
+            return Response({"detail": "Feature flag not enabled"}, status=400)
+        if organization.get_option("sentry:hide_ai_features"):
+            return Response(
+                {"detail": "AI features are disabled for this organization."}, status=403
+            )
+        if not get_seer_org_acknowledgement(organization.id):
+            return Response(
+                {"detail": "Seer has not been acknowledged by the organization."}, status=403
+            )
+
+        if not request.data:
+            return Response(status=400, data={"error": "Need a body with a payload"})
+
+        path = "/v1/automation/explorer/update"
+
+        body = orjson.dumps(
+            {
+                "run_id": run_id,
+                **request.data,
+            }
+        )
+
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}{path}",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(body),
+            },
+        )
+
+        response.raise_for_status()
+
+        return Response(status=202, data=response.json())

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock, patch
+
+import orjson
+from django.conf import settings
+from rest_framework import status
+
+from sentry.testutils.cases import APITestCase
+
+
+class TestOrganizationSeerExplorerUpdate(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.organization = self.create_organization(owner=self.user)
+        self.url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-update/123/"
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.requests.post")
+    def test_explorer_update_successful(self, mock_post: MagicMock) -> None:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"run_id": 123}
+
+        response = self.client.post(
+            self.url,
+            data={
+                "payload": {
+                    "type": "interrupt",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.data == {"run_id": 123}
+
+        # Verify the request was made to Seer
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert f"{settings.SEER_AUTOFIX_URL}/v1/automation/explorer/update" in call_args[0]
+
+        # Verify the payload
+        sent_data = orjson.loads(call_args[1]["data"])
+        assert sent_data["run_id"] == 123
+        assert sent_data["payload"]["type"] == "interrupt"
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.requests.post")
+    def test_explorer_update_missing_payload(self, mock_post: MagicMock) -> None:
+        response = self.client.post(
+            self.url,
+            data={},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Need a body with a payload" in response.data["error"]
+        mock_post.assert_not_called()

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
@@ -5,8 +5,11 @@ from django.conf import settings
 from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 
 
+@with_feature("organizations:seer-explorer")
+@with_feature("organizations:gen-ai-features")
 class TestOrganizationSeerExplorerUpdate(APITestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -14,8 +17,12 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
         self.organization = self.create_organization(owner=self.user)
         self.url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-update/123/"
 
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.get_seer_org_acknowledgement")
     @patch("sentry.seer.endpoints.organization_seer_explorer_update.requests.post")
-    def test_explorer_update_successful(self, mock_post: MagicMock) -> None:
+    def test_explorer_update_successful(
+        self, mock_post: MagicMock, mock_get_seer_org_acknowledgement: MagicMock
+    ) -> None:
+        mock_get_seer_org_acknowledgement.return_value = True
         mock_post.return_value.status_code = 200
         mock_post.return_value.json.return_value = {"run_id": 123}
 
@@ -39,11 +46,16 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
 
         # Verify the payload
         sent_data = orjson.loads(call_args[1]["data"])
-        assert sent_data["run_id"] == 123
+        assert sent_data["run_id"] == "123"
         assert sent_data["payload"]["type"] == "interrupt"
 
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.get_seer_org_acknowledgement")
     @patch("sentry.seer.endpoints.organization_seer_explorer_update.requests.post")
-    def test_explorer_update_missing_payload(self, mock_post: MagicMock) -> None:
+    def test_explorer_update_missing_payload(
+        self, mock_post: MagicMock, mock_get_seer_org_acknowledgement: MagicMock
+    ) -> None:
+        mock_get_seer_org_acknowledgement.return_value = True
+
         response = self.client.post(
             self.url,
             data={},
@@ -51,5 +63,71 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Need a body with a payload" in response.data["error"]
+        assert "Need a body with a payload" in str(response.data)
         mock_post.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.get_seer_org_acknowledgement")
+    def test_explorer_update_ai_features_hidden(
+        self, mock_get_seer_org_acknowledgement: MagicMock
+    ) -> None:
+        mock_get_seer_org_acknowledgement.return_value = True
+        self.organization.update_option("sentry:hide_ai_features", True)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "payload": {
+                    "type": "interrupt",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "AI features are disabled" in str(response.data)
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.get_seer_org_acknowledgement")
+    def test_explorer_update_no_seer_acknowledgement(
+        self, mock_get_seer_org_acknowledgement: MagicMock
+    ) -> None:
+        mock_get_seer_org_acknowledgement.return_value = False
+
+        response = self.client.post(
+            self.url,
+            data={
+                "payload": {
+                    "type": "interrupt",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Seer has not been acknowledged" in str(response.data)
+
+
+class TestOrganizationSeerExplorerUpdateFeatureFlags(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.organization = self.create_organization(owner=self.user)
+        self.url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-update/123/"
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.get_seer_org_acknowledgement")
+    def test_explorer_update_feature_flag_disabled(
+        self, mock_get_seer_org_acknowledgement: MagicMock
+    ) -> None:
+        mock_get_seer_org_acknowledgement.return_value = True
+
+        response = self.client.post(
+            self.url,
+            data={
+                "payload": {
+                    "type": "interrupt",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Feature flag not enabled" in str(response.data)


### PR DESCRIPTION
Adds an update endpoint for seer explorer similar to the autofix update endpoint. Basically acts as a passthrough.