### PR TITLE
feat(explorer): Adds hot key to interrupt agent

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -20,6 +20,7 @@ interface BlockProps {
   blockIndex: number;
   isFocused?: boolean;
   isLast?: boolean;
+  isPolling?: boolean;
   onClick?: () => void;
   onDelete?: () => void;
   onNavigate?: () => void;
@@ -84,6 +85,7 @@ function BlockComponent({
   blockIndex: _blockIndex,
   isLast,
   isFocused,
+  isPolling,
   onClick,
   onDelete,
   onNavigate,
@@ -218,7 +220,7 @@ function BlockComponent({
     }
   };
 
-  const showActions = (isFocused || isHovered) && !block.loading;
+  const showActions = (isFocused || isHovered) && !block.loading && !isPolling;
 
   return (
     <Block

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -220,7 +220,7 @@ function BlockComponent({
     }
   };
 
-  const showActions = (isFocused || isHovered) && !block.loading && !isPolling;
+  const showActions = (isFocused || isHovered) && !block.loading;
 
   return (
     <Block
@@ -279,9 +279,11 @@ function BlockComponent({
                 transition={{duration: 0.1}}
               >
                 <ActionButtonBar gap="sm">
-                  <Button size="xs" priority="default" onClick={handleDeleteClick}>
-                    Rethink from here ⌫
-                  </Button>
+                  {!isPolling && (
+                    <Button size="xs" priority="default" onClick={handleDeleteClick}>
+                      Rethink from here ⌫
+                    </Button>
+                  )}
                   {hasValidLinks && (
                     <ButtonBar merged gap="0">
                       {validToolLinks.map((_, idx) => (

--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -135,6 +135,8 @@ describe('ExplorerPanel', () => {
         isPending: false,
         runId: 123,
         deletedFromIndex: null,
+        interruptRun: jest.fn(),
+        interruptRequested: false,
       });
 
       render(<ExplorerPanel isVisible />, {organization});

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -30,8 +30,15 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
 
   // Custom hooks
   const {panelSize, handleMaxSize, handleMedSize} = usePanelSizing();
-  const {sessionData, sendMessage, deleteFromIndex, startNewSession, isPolling} =
-    useSeerExplorer();
+  const {
+    sessionData,
+    sendMessage,
+    deleteFromIndex,
+    startNewSession,
+    isPolling,
+    interruptRun,
+    interruptRequested,
+  } = useSeerExplorer();
 
   // Get blocks from session data or empty array
   const blocks = useMemo(() => sessionData?.blocks || [], [sessionData]);
@@ -106,7 +113,10 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
   }, [blocks]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Escape' && isPolling && !interruptRequested) {
+      e.preventDefault();
+      interruptRun();
+    } else if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (inputValue.trim() && !isPolling) {
         sendMessage(inputValue.trim());
@@ -194,6 +204,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
               blockIndex={index}
               isLast={index === blocks.length - 1}
               isFocused={focusedBlockIndex === index}
+              isPolling={isPolling}
               onClick={() => handleBlockClick(index)}
               onDelete={() => deleteFromIndex(index)}
               onNavigate={() => setIsMinimized(true)}
@@ -209,6 +220,8 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
         inputValue={inputValue}
         focusedBlockIndex={focusedBlockIndex}
         showSlashCommands={showSlashCommands}
+        isPolling={isPolling}
+        interruptRequested={interruptRequested}
         onInputChange={handleInputChange}
         onKeyDown={handleKeyDown}
         onInputClick={handleInputClick}

--- a/static/app/views/seerExplorer/inputSection.tsx
+++ b/static/app/views/seerExplorer/inputSection.tsx
@@ -8,6 +8,8 @@ import SlashCommands, {type SlashCommand} from './slashCommands';
 interface InputSectionProps {
   focusedBlockIndex: number;
   inputValue: string;
+  interruptRequested: boolean;
+  isPolling: boolean;
   onClear: () => void;
   onCommandSelect: (command: SlashCommand) => void;
   onInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -23,6 +25,8 @@ interface InputSectionProps {
 function InputSection({
   inputValue,
   focusedBlockIndex,
+  isPolling,
+  interruptRequested,
   onClear,
   onInputChange,
   onKeyDown,
@@ -33,6 +37,19 @@ function InputSection({
   onMedSize,
   ref,
 }: InputSectionProps) {
+  const getPlaceholder = () => {
+    if (focusedBlockIndex !== -1) {
+      return 'Press Tab ⇥ to return here';
+    }
+    if (interruptRequested) {
+      return 'Winding down...';
+    }
+    if (isPolling) {
+      return 'Press Esc to interrupt';
+    }
+    return 'Type your message or / command and press Enter ↵';
+  };
+
   return (
     <InputBlock>
       <InputContainer onClick={onInputClick}>
@@ -51,11 +68,7 @@ function InputSection({
             value={inputValue}
             onChange={onInputChange}
             onKeyDown={onKeyDown}
-            placeholder={
-              focusedBlockIndex === -1
-                ? 'Type your message or / command and press Enter ↵'
-                : 'Press Tab ⇥ to return here'
-            }
+            placeholder={getPlaceholder()}
             rows={1}
           />
         </InputRow>


### PR DESCRIPTION
Prompts the user to press the escape key to interrupt the agent while it's in progress. Pressing it calls the explorer update endpoint and puts a "winding down..." placeholder, which lasts until the agent stops.

<img width="428" height="142" alt="Screenshot 2025-10-23 at 2 00 41 PM" src="https://github.com/user-attachments/assets/0219c564-7740-466b-b3d3-75a9544c376f" />
<img width="332" height="180" alt="Screenshot 2025-10-23 at 2 00 47 PM" src="https://github.com/user-attachments/assets/a4648e69-7125-40b8-9e2e-0173368c4cbc" />
