### PR TITLE
fix(aci): Remove 'sentry created' alert icon/text

### DIFF
--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -24,7 +24,6 @@ export default function AutomationTitleCell({automation, openInNewTab}: Props) {
         automation.id,
         automationsLinkPrefix
       )}
-      systemCreated={!automation.createdBy}
       disabled={!automation.enabled}
       warning={warning}
       openInNewTab={openInNewTab}

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -278,7 +278,7 @@ function UserDisplayName({id}: {id: string | undefined}) {
     id: id ? Number(id) : undefined,
   });
   if (!id) {
-    return t('Sentry');
+    return '—';
   }
   if (isPending) {
     return <Placeholder height="20px" />;


### PR DESCRIPTION
Alerts are never managed by sentry, so this removes the icon and "Sentry" text when createdBy is null.

<img width="339" height="132" alt="CleanShot 2025-10-23 at 14 26 39" src="https://github.com/user-attachments/assets/ec33d4fe-0e4d-40a8-94d5-27dedfc87bec" />
