### PR TITLE
Revert "core: override theme colors from base.less (#101838)"

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -138,24 +138,6 @@ const styles = (theme: Theme, isDark: boolean) => css`
     background: ${theme.backgroundSecondary};
   }
 
-  body.theme-dark {
-    background: ${theme.tokens.background.primary};
-
-    .loading .loading-indicator {
-      background: ${theme.tokens.background.primary};
-    }
-  }
-
-  body.theme-system {
-    @media (prefers-color-scheme: dark) {
-      background: ${theme.tokens.background.primary};
-    }
-
-    .loading .loading-indicator {
-      background: ${theme.tokens.background.primary};
-    }
-  }
-
   abbr {
     ${theme.tooltipUnderline()};
   }


### PR DESCRIPTION
This reverts commit 31f4641e47590f7236750406850a6ac7e8dae9f9.

Because the `.loading-indicator` is already styled with [`invert(100%)`](https://github.com/getsentry/sentry/blob/6e307ddda74b0cf25ddd4184f9b95dd8152ba199/static/less/shared-components.less#L529), applying the correct dark theme value leads to a white background once the app hydrates and CSS-in-JS styles mount.