### PR TITLE
fix(poller): Resource leak in IssueListOverview

### DIFF
--- a/static/app/utils/cursorPoller.tsx
+++ b/static/app/utils/cursorPoller.tsx
@@ -48,7 +48,7 @@ class CursorPoller {
   }
 
   enable() {
-    // Proactively cleanup to prevent intervals per class instance
+    // Proactively cleanup to prevent multiple setTimeout per class instance
     this.disable();
 
     this.active = true;

--- a/static/app/utils/cursorPoller.tsx
+++ b/static/app/utils/cursorPoller.tsx
@@ -48,15 +48,10 @@ class CursorPoller {
   }
 
   enable() {
-    this.active = true;
+    // Proactively cleanup to prevent intervals per class instance
+    this.disable();
 
-    // Proactively clear timeout and last request
-    if (this.timeoutId) {
-      window.clearTimeout(this.timeoutId);
-    }
-    if (this.lastRequest) {
-      this.lastRequest.cancel();
-    }
+    this.active = true;
     this.timeoutId = window.setTimeout(this.poll.bind(this), this.getDelay());
   }
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -176,6 +176,12 @@ function IssueListOverview({
   );
 
   useEffect(() => {
+    // Either cleanup or reuse the poller to prevent a resource leak.
+    if (pollerRef.current) {
+      pollerRef.current.setEndpoint(parseLinkHeader(pageLinks)?.previous?.href!);
+      return;
+    }
+
     pollerRef.current = new CursorPoller({
       linkPreviousHref: parseLinkHeader(pageLinks)?.previous?.href!,
       success: onRealtimePoll,


### PR DESCRIPTION
Replication steps:
1. Go to IssueList. Set filter by project-1. 
2. Turn on realtime. 
3. See the network requests for project-1.
4. Select filter by project-2.
5. See the network requests both project-1 and project-2.

`CursorPoller` has a recursive `setTimeout` method. If the poller is not cleaned up for `project-1`, the recursive method will keep calling itself and preventing garbage collector from killing it.