### PR TITLE
chore(cleanup): Fix File cleanup job timeouts

### DIFF
--- a/src/sentry/deletions/defaults/file.py
+++ b/src/sentry/deletions/defaults/file.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.db.models import Q
 from django.utils import timezone
 
-from sentry.deletions.base import BaseRelation, ModelDeletionTask
+from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.models.files.file import File
 
 
@@ -37,8 +37,5 @@ class FileDeletionTask(ModelDeletionTask[File]):
         from sentry.models.files.fileblobindex import FileBlobIndex
 
         return [
-            BaseRelation(
-                params={"model": FileBlobIndex, "query": {"file_id": instance.id}},
-                task=None,  # Use BulkModelDeletionTask
-            ),
+            ModelRelation(FileBlobIndex, {"file_id": instance.id}),
         ]

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -535,7 +535,7 @@ def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]
         (PullRequest, "date_added", "date_added"),
         (RuleFireHistory, "date_added", "date_added"),
         (Release, "date_added", "date_added"),
-        (File, "timestamp", "timestamp"),
+        (File, "timestamp", "id"),
         (Commit, "date_added", "id"),
     ]
 
@@ -548,7 +548,7 @@ def remove_cross_project_models(
 
     # These models span across projects, so let's skip them
     deletes.remove((ArtifactBundle, "date_added", "date_added"))
-    deletes.remove((File, "timestamp", "timestamp"))
+    deletes.remove((File, "timestamp", "id"))
     return deletes
 
 


### PR DESCRIPTION
The File cleanup job was timing out trying to fetch by ordering the timestamp field which has no index in US. Switched to ordering by ID which is performant. This will cause us to always go through entire table in chunks but we want to do that right now. Once we cleaned a lot of rows we can add an index and revert.

Also corrected the child_relation to use ModelRelation type