### PR TITLE
task(preprod): Remove secondary/unneeded FF

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -293,8 +293,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-transaction-deprecation-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod artifact assembly endpointAdd commentMore actions
-    manager.add("organizations:preprod-artifact-assemble", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod frontend routes
     manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables PR page

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -117,7 +117,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
         )
 
         if not settings.IS_DEV and not features.has(
-            "organizations:preprod-artifact-assemble", project.organization, actor=request.user
+            "organizations:preprod-frontend-routes", project.organization, actor=request.user
         ):
             return Response({"error": "Feature not enabled"}, status=403)
 

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_download.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_download.py
@@ -62,7 +62,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpoint(PreprodArtifactEndpoint
         )
 
         if not settings.IS_DEV and not features.has(
-            "organizations:preprod-artifact-assemble", project.organization, actor=request.user
+            "organizations:preprod-frontend-routes", project.organization, actor=request.user
         ):
             return Response({"error": "Feature not enabled"}, status=403)
 

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
@@ -9,7 +9,6 @@ from sentry.testutils.cases import APITestCase
 @override_settings(
     SENTRY_FEATURES={
         "organizations:preprod-frontend-routes": True,
-        "organizations:preprod-artifact-assemble": True,
     }
 )
 class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -185,7 +185,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             args=[self.organization.slug, self.project.slug],
         )
 
-        self.feature_context = Feature("organizations:preprod-artifact-assemble")
+        self.feature_context = Feature("organizations:preprod-frontend-routes")
         self.feature_context.__enter__()
 
     def tearDown(self) -> None:
@@ -210,7 +210,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             )
             assert response.status_code == 403
         finally:
-            self.feature_context = Feature("organizations:preprod-artifact-assemble")
+            self.feature_context = Feature("organizations:preprod-frontend-routes")
             self.feature_context.__enter__()
 
     def test_assemble_json_schema_integration(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
@@ -71,7 +71,7 @@ class ProjectPreprodArtifactDownloadEndpointTest(TestCase):
 
         headers = self._get_authenticated_request_headers(url)
 
-        with self.feature("organizations:preprod-artifact-assemble"):
+        with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.get(url, **headers)
 
         assert response.status_code == 404


### PR DESCRIPTION
Consolidate to only use `organizations:preprod-frontend-routes` FF

Closes EME-421