### PR TITLE
feat: Add integration button for GH on TA preonb

### DIFF
--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -18,7 +18,8 @@ export type IntegrationView = {
     | 'onboarding'
     | 'project_creation'
     | 'developer_settings'
-    | 'new_integration_modal';
+    | 'new_integration_modal'
+    | 'test_analytics_onboarding';
 };
 
 type SingleIntegrationEventParams = {

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -74,7 +74,7 @@ export default function TestsOnboardingPage() {
   );
 
   const regionData = getRegionDataFromOrganization(organization);
-  const isUSStorage = regionData?.name === 'us';
+  const isUSStorage = regionData?.name?.toLowerCase() === 'us';
   const cameFromTestsRoute = location.state?.from === '/prevent/tests';
 
   // We want to navigate to show TA if this repo should have data to show, if we need to show

--- a/static/app/views/prevent/tests/preOnboarding.spec.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.spec.tsx
@@ -16,6 +16,16 @@ describe('TestsPreOnboardingPage', () => {
     features: ['codecov-integration'],
   });
 
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/config/integrations/`,
+      method: 'GET',
+      body: {
+        providers: [],
+      },
+    });
+  });
+
   it('displays the US storage alert when organization is not in US region', () => {
     // Mock non-US region
     mockGetRegionData.mockReturnValue({

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -3,16 +3,24 @@ import styled from '@emotion/styled';
 import testsAnalyticsSummaryDark from 'sentry-images/features/test-analytics-summary-dark.svg';
 import testsAnalyticsSummary from 'sentry-images/features/test-analytics-summary.svg';
 
+import Access from 'sentry/components/acl/access';
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import type {Integration} from 'sentry/types/integrations';
+import {getIntegrationStatus} from 'sentry/utils/integrationUtil';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
+import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
+import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
+import type {IntegrationInformation} from 'sentry/views/settings/organizationIntegrations/integrationDetailedView';
 
 const INSTRUCTIONS_TEXT = {
   header: t('Get Started by installing the GitHub Sentry App'),
@@ -26,10 +34,33 @@ const INSTRUCTIONS_TEXT = {
 export default function TestsPreOnboardingPage() {
   const organization = useOrganization();
   const regionData = getRegionDataFromOrganization(organization);
-  const isUSStorage = regionData?.name === 'us';
+  const isUSStorage =
+    regionData?.name?.toLowerCase() === 'us' || regionData?.name === '--monolith--';
 
   const config = useLegacyStore(ConfigStore);
   const isDarkMode = config.theme === 'dark';
+
+  const {data: integrationInfo, isPending: isIntegrationPending} =
+    useApiQuery<IntegrationInformation>(
+      [
+        `/organizations/${organization.slug}/config/integrations/`,
+        {
+          query: {
+            provider_key: 'github',
+          },
+        },
+      ],
+      {
+        staleTime: Infinity,
+        retry: false,
+      }
+    );
+
+  const provider = integrationInfo?.providers[0];
+
+  const handleAddIntegration = (_integration: Integration) => {
+    window.location.reload();
+  };
 
   return (
     <LayoutGap>
@@ -72,18 +103,53 @@ export default function TestsPreOnboardingPage() {
           <InstructionsSection>
             <h2>{INSTRUCTIONS_TEXT.header}</h2>
             <SubtextParagraph>{INSTRUCTIONS_TEXT.subtext}</SubtextParagraph>
-            <Flex gap="xl">
-              <LinkButton
-                external
-                priority="primary"
-                href={INSTRUCTIONS_TEXT.mainCTALink}
+            {isIntegrationPending ? (
+              <LoadingIndicator />
+            ) : provider ? (
+              <IntegrationContext
+                value={{
+                  provider,
+                  type: 'first_party',
+                  // if there is an integration, we don't show preonboarding
+                  installStatus: 'Not Installed',
+                  analyticsParams: {
+                    view: 'test_analytics_onboarding',
+                    already_installed: false,
+                  },
+                }}
               >
-                {INSTRUCTIONS_TEXT.mainCTA}
-              </LinkButton>
-              <LinkButton priority="default" href="/settings/integrations/github">
-                Learn more
-              </LinkButton>
-            </Flex>
+                <Flex gap="xl">
+                  <Access access={['org:integrations']} organization={organization}>
+                    {({hasAccess}) => (
+                      <IntegrationButton
+                        userHasAccess={hasAccess}
+                        onAddIntegration={handleAddIntegration}
+                        onExternalClick={() => {}}
+                        buttonProps={{
+                          priority: 'primary',
+                        }}
+                      />
+                    )}
+                  </Access>
+                  <LinkButton priority="default" href="/settings/integrations/github">
+                    Learn more
+                  </LinkButton>
+                </Flex>
+              </IntegrationContext>
+            ) : (
+              <Flex gap="xl">
+                <LinkButton
+                  external
+                  priority="primary"
+                  href={INSTRUCTIONS_TEXT.mainCTALink}
+                >
+                  {INSTRUCTIONS_TEXT.mainCTA}
+                </LinkButton>
+                <LinkButton priority="default" href="/settings/integrations/github">
+                  Learn more
+                </LinkButton>
+              </Flex>
+            )}
           </InstructionsSection>
         </Panel>
       )}

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -14,7 +14,6 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Integration} from 'sentry/types/integrations';
-import {getIntegrationStatus} from 'sentry/utils/integrationUtil';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -34,8 +33,7 @@ const INSTRUCTIONS_TEXT = {
 export default function TestsPreOnboardingPage() {
   const organization = useOrganization();
   const regionData = getRegionDataFromOrganization(organization);
-  const isUSStorage =
-    regionData?.name?.toLowerCase() === 'us' || regionData?.name === '--monolith--';
+  const isUSStorage = regionData?.name?.toLowerCase() === 'us';
 
   const config = useLegacyStore(ConfigStore);
   const isDarkMode = config.theme === 'dark';

--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -197,6 +197,14 @@ describe('CoveragePageWrapper', () => {
   });
   describe('when the organization is not in the US region', () => {
     it('renders the pre-onboarding page', () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/config/integrations/`,
+        method: 'GET',
+        body: {
+          providers: [],
+        },
+      });
+
       mockGetRegionData.mockReturnValue({
         name: 'eu',
         displayName: 'European Union (EU)',

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -63,7 +63,7 @@ export default function TestsPage() {
   const {data: integrations = [], isPending: isIntegrationsPending} =
     useGetActiveIntegratedOrgs({organization});
   const regionData = getRegionDataFromOrganization(organization);
-  const isUSStorage = regionData?.name === 'us';
+  const isUSStorage = regionData?.name?.toLowerCase() === 'us';
 
   let mainContent: React.ReactNode;
   if (isIntegrationsPending) {

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -22,7 +22,8 @@ type Props = {
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
       | 'onboarding'
-      | 'project_creation';
+      | 'project_creation'
+      | 'test_analytics_onboarding';
   };
   modalParams?: Record<string, string>;
 };

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -11,7 +11,8 @@ type IntegrationContextProps = {
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
       | 'onboarding'
-      | 'project_creation';
+      | 'project_creation'
+      | 'test_analytics_onboarding';
     referrer?: string;
   };
   installStatus: string;

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -56,7 +56,7 @@ const FirstPartyIntegrationAdditionalCTA = HookOrDefault({
   defaultComponent: () => null,
 });
 
-type IntegrationInformation = {
+export type IntegrationInformation = {
   providers: IntegrationProvider[];
 };
 


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1689/redirect-the-integrated-org-link

This PR replaces the purple "Add installation" button link in preonboarding with the same type of button from the Sentry integration settings "Add/Request Installation" button at the top right for GH specifically (ex: https://codecov.sentry.io/settings/integrations/github/). The user still needs to choose a GH org at first before authorization, but afterwards, the "Install on Existing GitHub Organization" screen will be shown.

These are screenshots from testing in local using ngrok and creating my own test GH app to install.

No GH installed before:
<img width="1673" height="747" alt="Screenshot 2025-10-24 at 1 33 44 PM" src="https://github.com/user-attachments/assets/87aacaca-9fa4-4899-aa9c-52d03febbe84" />
<img width="1014" height="495" alt="Screenshot 2025-10-23 at 1 29 03 AM" src="https://github.com/user-attachments/assets/702543da-8324-4adb-bc4f-2c0aba493d56" />
<img width="1016" height="997" alt="Screenshot 2025-10-23 at 1 29 14 AM" src="https://github.com/user-attachments/assets/df3f12ed-3dd3-4554-8b71-d52d4d6149b8" />
<img width="1026" height="907" alt="Screenshot 2025-10-23 at 1 29 39 AM" src="https://github.com/user-attachments/assets/0e8ef376-b1bd-4b08-aca4-4d9357d67054" />
<img width="1027" height="756" alt="Screenshot 2025-10-23 at 1 29 53 AM" src="https://github.com/user-attachments/assets/994221d7-ba5a-472b-a4d8-62790aa8565b" />
<img width="1022" height="1035" alt="Screenshot 2025-10-23 at 9 31 23 AM" src="https://github.com/user-attachments/assets/3a092826-17d2-424d-b25d-0d40b33f078d" />
After installation: <img width="2005" height="1370" alt="Screenshot 2025-10-23 at 4 46 18 PM" src="https://github.com/user-attachments/assets/d96d2b97-25ff-4263-b76f-ea40a3451ee0" />