### PR TITLE
feat: wraps reserved keywords on event search actions

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -121,6 +121,15 @@ export default function EventTagsTreeRow({
   );
 }
 
+const escapeEventTagForQuery = (key: string) => {
+  // Reserved keywords that conflict with issue search query
+  if (['project.name', 'project_id'].includes(key)) {
+    return `tags[${key}]`;
+  }
+
+  return escapeIssueTagKey(key);
+};
+
 function EventTagsTreeRowDropdown({
   content,
   event,
@@ -151,7 +160,7 @@ function EventTagsTreeRowDropdown({
     {referrer},
     {
       ...originalTag,
-      key: escapeIssueTagKey(originalTag.key),
+      key: escapeEventTagForQuery(originalTag.key),
     }
   );
 

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -121,15 +121,6 @@ export default function EventTagsTreeRow({
   );
 }
 
-const escapeEventTagForQuery = (key: string) => {
-  // Reserved keywords that conflict with issue search query
-  if (['project.name', 'project_id'].includes(key)) {
-    return `tags[${key}]`;
-  }
-
-  return escapeIssueTagKey(key);
-};
-
 function EventTagsTreeRowDropdown({
   content,
   event,
@@ -160,7 +151,7 @@ function EventTagsTreeRowDropdown({
     {referrer},
     {
       ...originalTag,
-      key: escapeEventTagForQuery(originalTag.key),
+      key: escapeIssueTagKey(originalTag.key),
     }
   );
 

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -101,6 +101,11 @@ export function escapeIssueTagKey(key: string) {
     return key;
   }
 
+  // Reserved keywords that conflict with issue search query
+  if (['project.name', 'project_id'].includes(key)) {
+    return `tags[${key}]`;
+  }
+
   if (ISSUE_EVENT_FIELDS_THAT_MAY_CONFLICT_WITH_TAGS.has(key as FieldKey)) {
     return `tags[${key}]`;
   }


### PR DESCRIPTION
when reserved keywords project_id or project.name are used as custom tags, search actions will correctly redirect in issue search

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
