### PR TITLE
fix(seer-prefs): allow serializer fields to be blank

### DIFF
--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -38,11 +38,13 @@ class RepositorySerializer(CamelSnakeSerializer):
     owner = serializers.CharField(required=True)
     name = serializers.CharField(required=True)
     external_id = serializers.CharField(required=True)
-    branch_name = serializers.CharField(required=False, allow_null=True)
-    branch_overrides = BranchOverrideSerializer(many=True, required=False)
-    instructions = serializers.CharField(required=False, allow_null=True)
-    base_commit_sha = serializers.CharField(required=False, allow_null=True)
-    provider_raw = serializers.CharField(required=False, allow_null=True)
+    branch_name = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    branch_overrides = BranchOverrideSerializer(
+        many=True, required=False, allow_null=True, allow_blank=True
+    )
+    instructions = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    base_commit_sha = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    provider_raw = serializers.CharField(required=False, allow_null=True, allow_blank=True)
 
 
 class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -40,11 +40,13 @@ class RepositorySerializer(CamelSnakeSerializer):
     external_id = serializers.CharField(required=True)
     branch_name = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     branch_overrides = BranchOverrideSerializer(
-        many=True, required=False, allow_null=True, allow_blank=True
+        many=True,
+        required=False,
+        allow_null=True,
     )
     instructions = serializers.CharField(required=False, allow_null=True, allow_blank=True)
-    base_commit_sha = serializers.CharField(required=False, allow_null=True, allow_blank=True)
-    provider_raw = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    base_commit_sha = serializers.CharField(required=False, allow_null=True)
+    provider_raw = serializers.CharField(required=False, allow_null=True)
 
 
 class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):


### PR DESCRIPTION
We need to allow these fields to be blank not just null
