### PR TITLE
feat(select): Introduce 'menuPlacement=auto' by default for all selects

### DIFF
--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -534,7 +534,7 @@ function SelectPicker<OptionType extends OptionTypeBase>({
     Component = ReactSelect;
   }
 
-  return <Component ref={ref as any} {...props} />;
+  return <Component ref={ref as any} {...props} menuPlacement="auto" />;
 }
 
 // XXX (tkdodo): this type assertion is a leftover from when we had forwardRef


### PR DESCRIPTION
Recently, we decided to introduce the prop menuPlacement="auto" as the default behavior for ReactSelect ([see](https://github.com/getsentry/sentry/pull/100658)).

However, I noticed through the [PR](https://github.com/getsentry/sentry/pull/101403#issuecomment-3430936142) that this default was not being applied when the component was a CreatableSelect.

This PR fixes that issue, making `menuPlacement="auto"` the default for all select components.