### PR TITLE
ref(redis): Change the weekly reports redis client (remove blaster)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -189,6 +189,7 @@ SENTRY_SPAN_BUFFER_CLUSTER = "default"
 SENTRY_ASSEMBLE_CLUSTER = "default"
 SENTRY_UPTIME_DETECTOR_CLUSTER = "default"
 SENTRY_WORKFLOW_ENGINE_REDIS_CLUSTER = "default"
+SENTRY_WEEKLY_REPORTS_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -14,7 +14,6 @@ import sentry_sdk
 from django.conf import settings
 from django.db.models import F
 from django.utils import dateformat, timezone
-from rb.clients import LocalClient
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 from sentry_sdk import set_tag
 
@@ -348,8 +347,8 @@ class _DuplicateDeliveryCheck:
         # Tracks state from `check_for_duplicate_delivery` to `record_delivery`
         self.count: int | None = None
 
-    def _get_redis_cluster(self) -> LocalClient:
-        return redis.clusters.get("default").get_local_client_for_key("weekly_reports")
+    def _get_redis_cluster(self) -> RedisCluster[str] | StrictRedis[str]:
+        return redis.redis_clusters.get(settings.SENTRY_WEEKLY_REPORTS_REDIS_CLUSTER)
 
     @property
     def _redis_name(self) -> str:

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -11,9 +11,11 @@ from functools import partial
 from typing import Any, Final
 
 import sentry_sdk
+from django.conf import settings
 from django.db.models import F
 from django.utils import dateformat, timezone
 from rb.clients import LocalClient
+from sentry_redis_tools.clients import RedisCluster, StrictRedis
 from sentry_sdk import set_tag
 
 from sentry import analytics
@@ -60,7 +62,7 @@ class WeeklyReportProgressTracker:
 
     beginning_of_day_timestamp: float
     duration: int
-    _redis_connection: LocalClient
+    _redis_connection: RedisCluster[str] | StrictRedis[str]
 
     REPORT_REDIS_CLIENT_KEY: Final[str] = "weekly_reports_org_id_min"
 
@@ -76,8 +78,8 @@ class WeeklyReportProgressTracker:
             duration = ONE_DAY * 7
 
         self.duration = duration
-        self._redis_connection = redis.clusters.get("default").get_local_client_for_key(
-            self.REPORT_REDIS_CLIENT_KEY
+        self._redis_connection = redis.redis_clusters.get(
+            settings.SENTRY_WEEKLY_REPORTS_REDIS_CLUSTER
         )
 
     @property


### PR DESCRIPTION
<!-- Describe your PR here. -->

Removing another use of redis-blaster client by migrating to a regular client with possibility to use real redis cluster client as well.

