### PR TITLE
chore(kafka): allow `max.poll.interval.ms` in the new kafka config

### DIFF
--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -11,6 +11,7 @@ SUPPORTED_KAFKA_CONFIGURATION = (
     # for the full list of available options
     "bootstrap.servers",
     "compression.type",
+    "max.poll.interval.ms",
     "message.max.bytes",
     "sasl.mechanism",
     "sasl.username",


### PR DESCRIPTION
The new Kafka configuration format (https://github.com/getsentry/getsentry/pull/18416) requires configuration keys to be explicitly allowed:
https://github.com/getsentry/sentry/blob/7f48524dc19f93d7628b09937532c1027499321e/src/sentry/utils/kafka_config.py#L74-L75

We already set `"max.poll.interval.ms": 60 * 1000` for transactions consumers:
https://github.com/getsentry/getsentry/blob/07aafa3cb815308849bbe4db749a7d4776df7365/getsentry/conf/settings/prod.py#L654

hence we need to allow it here.