### PR TITLE
ref(consumers): A default join timeout of 25 seconds everywhere

### DIFF
--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -142,6 +142,15 @@ class ConsumerDefinition(TypedDict, total=False):
 
     stale_topic: Topic
 
+    # How long to wait for the consumer to shut down.
+    #
+    # By default, the join timeout of a consumer is 25 seconds. None means no
+    # timeout.
+    #
+    # Override this if the consumer is not idempotent and takes longer to shut
+    # down, at the risk of stability issues.
+    default_join_timeout: float | None
+
 
 def validate_consumer_definition(consumer_definition: ConsumerDefinition) -> None:
     if "dlq_topic" not in consumer_definition and (

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -248,14 +248,17 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "topic": Topic.INGEST_MONITORS,
         "strategy_factory": "sentry.monitors.consumers.monitor_consumer.StoreMonitorCheckInStrategyFactory",
         "click_options": ingest_monitors_options(),
+        "default_join_timeout": None,  # XXX(markus): can this be removed?
     },
     "monitors-clock-tick": {
         "topic": Topic.MONITORS_CLOCK_TICK,
         "strategy_factory": "sentry.monitors.consumers.clock_tick_consumer.MonitorClockTickStrategyFactory",
+        "default_join_timeout": None,  # XXX(markus): can this be removed?
     },
     "monitors-clock-tasks": {
         "topic": Topic.MONITORS_CLOCK_TASKS,
         "strategy_factory": "sentry.monitors.consumers.clock_tasks_consumer.MonitorClockTasksStrategyFactory",
+        "default_join_timeout": None,  # XXX(markus): can this be removed?
     },
     "monitors-incident-occurrences": {
         "topic": Topic.MONITORS_INCIDENT_OCCURRENCES,
@@ -266,6 +269,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "strategy_factory": "sentry.uptime.consumers.results_consumer.UptimeResultsStrategyFactory",
         "click_options": uptime_options(),
         "pass_consumer_group": True,
+        "default_join_timeout": None,
     },
     "billing-metrics-consumer": {
         "topic": Topic.SNUBA_GENERIC_METRICS,
@@ -278,6 +282,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "topic": Topic.INGEST_OCCURRENCES,
         "strategy_factory": "sentry.issues.run.OccurrenceStrategyFactory",
         "click_options": issue_occurrence_options(),
+        "default_join_timeout": None,  # XXX(markus): can this be removed?
     },
     "events-subscription-results": {
         "topic": Topic.EVENTS_SUBSCRIPTIONS_RESULTS,
@@ -496,6 +501,11 @@ def get_stream_processor(
 
     if cluster is None:
         cluster = cluster_from_config
+
+    if join_timeout is None:
+        join_timeout = consumer_definition.get("default_join_timeout", 25)
+    if join_timeout == 0:
+        join_timeout = None
 
     cmd = click.Command(
         name=consumer_name, params=list(consumer_definition.get("click_options") or ())

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -477,7 +477,12 @@ def taskbroker_send_tasks(
     type=click.Choice(["earliest", "latest", "error"]),
     help="Position in the commit log topic to begin reading from when no prior offset has been recorded.",
 )
-@click.option("--join-timeout", type=float, help="Join timeout in seconds.", default=None)
+@click.option(
+    "--join-timeout",
+    type=float,
+    help="Join timeout in seconds, how long to wait for the consumer to shut down. Each consumer has its own default, but the default-default is 25 seconds.",
+    default=None,
+)
 @click.option(
     "--max-poll-interval-ms",
     type=int,


### PR DESCRIPTION
ref STREAM-534
ref STREAM-444

Problem statement: We observe various inexplicable partition revocation
failures in production. Most of them are caused by the consumer shutdown
taking too long. This stalls our deployment pipeline.

Solution: Since MOST consumers do not require exactly-once, we can drop
the inflight work and avoid crashes.

A few consumers are overridden to take no timeout since it's not clear
that they are idempotent.
