### PR TITLE
fix(debug_files): Add `.debug` extension for Mach-O debug files

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -165,7 +165,7 @@ class ProjectDebugFile(Model):
         if self.file_format == "breakpad":
             return ".sym"
         if self.file_format == "macho":
-            return ""
+            return ".debug" if self.file_type == "dbg" else ""
         if self.file_format == "proguard":
             return ".txt"
         if self.file_format == "elf":

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -147,7 +147,7 @@ class DebugFileTest(TestCase):
         # Verify that file_extension returns .json
         assert dif.file_extension == ".json"
 
-    def test_file_extension_macho(self) -> None:
+    def test_file_extension_macho_dbg(self) -> None:
         """Test that macho files return empty file extension."""
         file = File.objects.create(
             name="foo",
@@ -163,6 +163,44 @@ class DebugFileTest(TestCase):
             project_id=self.project.id,
             debug_id="b8e43a-f242-3d73-a453-aeb6a777ef75",
             data={"type": "dbg"},
+        )
+
+        assert dif.file_extension == ".debug"
+
+    def test_file_extension_macho_exe(self) -> None:
+        file = File.objects.create(
+            name="foo",
+            type="project.dif",
+            headers={"Content-Type": "application/x-mach-binary"},
+        )
+
+        dif = ProjectDebugFile.objects.create(
+            file=file,
+            checksum="test-checksum",
+            object_name="foo",
+            cpu_name="x86_64",
+            project_id=self.project.id,
+            debug_id="b8e43a-f242-3d73-a453-aeb6a777ef75",
+            data={"type": "exe"},
+        )
+
+        assert dif.file_extension == ""
+
+    def test_file_extension_macho_lib(self) -> None:
+        file = File.objects.create(
+            name="foo",
+            type="project.dif",
+            headers={"Content-Type": "application/x-mach-binary"},
+        )
+
+        dif = ProjectDebugFile.objects.create(
+            file=file,
+            checksum="test-checksum",
+            object_name="foo",
+            cpu_name="x86_64",
+            project_id=self.project.id,
+            debug_id="b8e43a-f242-3d73-a453-aeb6a777ef75",
+            data={"type": "lib"},
         )
 
         assert dif.file_extension == ""


### PR DESCRIPTION
In #102012, we removed the incorrect `.dSYM` extensions from downloaded Mach-O debug files. However, as @jan-auer noted, these debug files potentially share the same debug ID as the corresponding executable or dynamic library. Therefore, we should add a file extension to the debug files to distinguish them. We are picking `.debug` to align with the extension used for `elf` files.