### PR TITLE
feat(dashboards): Numeric global filters

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -269,7 +269,7 @@ function deleteQueryTokens(
   };
 }
 
-function modifyFilterOperatorQuery(
+export function modifyFilterOperatorQuery(
   query: string,
   token: TokenResult<Token.FILTER>,
   newOperator: TermOperator,
@@ -531,7 +531,7 @@ function replaceTokensWithText(
   };
 }
 
-function modifyFilterValue(
+export function modifyFilterValue(
   query: string,
   token: TokenResult<Token.FILTER>,
   newValue: string

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -19,11 +19,11 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import AddFilter from 'sentry/views/dashboards/globalFilter/addFilter';
+import GenericFilterSelector from 'sentry/views/dashboards/globalFilter/genericFilterSelector';
 import {useDatasetSearchBarData} from 'sentry/views/dashboards/hooks/useDatasetSearchBarData';
 import {useInvalidateStarredDashboards} from 'sentry/views/dashboards/hooks/useInvalidateStarredDashboards';
 import {getDashboardFiltersFromURL} from 'sentry/views/dashboards/utils';
 
-import FilterSelector from './globalFilter/filterSelector';
 import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import ReleasesSelectControl from './releasesSelectControl';
 import type {DashboardFilters, DashboardPermissions, GlobalFilter} from './types';
@@ -146,8 +146,8 @@ export default function FiltersBar({
       {organization.features.includes('dashboards-global-filters') && (
         <Fragment>
           {activeGlobalFilters.map(filter => (
-            <FilterSelector
-              key={filter.tag.key}
+            <GenericFilterSelector
+              key={filter.tag.key + filter.value}
               globalFilter={filter}
               searchBarData={getSearchBarData(filter.dataset)}
               onUpdateFilter={updatedFilter => {

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -20,6 +20,7 @@ import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import AddFilter from 'sentry/views/dashboards/globalFilter/addFilter';
 import GenericFilterSelector from 'sentry/views/dashboards/globalFilter/genericFilterSelector';
+import {globalFilterKeysAreEqual} from 'sentry/views/dashboards/globalFilter/utils';
 import {useDatasetSearchBarData} from 'sentry/views/dashboards/hooks/useDatasetSearchBarData';
 import {useInvalidateStarredDashboards} from 'sentry/views/dashboards/hooks/useInvalidateStarredDashboards';
 import {getDashboardFiltersFromURL} from 'sentry/views/dashboards/utils';
@@ -153,13 +154,15 @@ export default function FiltersBar({
               onUpdateFilter={updatedFilter => {
                 updateGlobalFilters(
                   activeGlobalFilters.map(f =>
-                    f.tag.key === updatedFilter.tag.key ? updatedFilter : f
+                    globalFilterKeysAreEqual(f, updatedFilter) ? updatedFilter : f
                   )
                 );
               }}
               onRemoveFilter={removedFilter => {
                 updateGlobalFilters(
-                  activeGlobalFilters.filter(f => f.tag.key !== removedFilter.tag.key)
+                  activeGlobalFilters.filter(
+                    f => !globalFilterKeysAreEqual(f, removedFilter)
+                  )
                 );
               }}
             />

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -15,11 +15,11 @@ import type {Tag} from 'sentry/types/group';
 import {
   FieldKind,
   FieldValueType,
-  getFieldDefinition,
   prettifyTagKey,
   type FieldDefinition,
 } from 'sentry/utils/fields';
 import type {SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
+import {getFieldDefinitionForDataset} from 'sentry/views/dashboards/globalFilter/utils';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
 import {shouldExcludeTracingKeys} from 'sentry/views/performance/utils';
 
@@ -74,21 +74,7 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
   // Get filter keys for the selected dataset
   const filterKeyOptions = selectedDataset
     ? Object.entries(filterKeys).flatMap(([_, tag]) => {
-        const fieldType = (datasetType: WidgetType) => {
-          switch (datasetType) {
-            case WidgetType.SPANS:
-              return 'span';
-            case WidgetType.LOGS:
-              return 'log';
-            default:
-              return 'event';
-          }
-        };
-        const fieldDefinition = getFieldDefinition(
-          tag.key,
-          fieldType(selectedDataset),
-          tag.kind
-        );
+        const fieldDefinition = getFieldDefinitionForDataset(tag, selectedDataset);
         const valueType = fieldDefinition?.valueType;
         if (!valueType || UNSUPPORTED_FIELD_VALUE_TYPES.includes(valueType)) {
           return [];

--- a/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
@@ -1,7 +1,8 @@
-import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {FieldValueType} from 'sentry/utils/fields';
 import type {SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
 import FilterSelector from 'sentry/views/dashboards/globalFilter/filterSelector';
 import NumericFilterSelector from 'sentry/views/dashboards/globalFilter/numericFilterSelector';
+import {getFieldDefinitionForDataset} from 'sentry/views/dashboards/globalFilter/utils';
 import type {GlobalFilter} from 'sentry/views/dashboards/types';
 
 export type GenericFilterSelectorProps = {
@@ -14,7 +15,10 @@ export type GenericFilterSelectorProps = {
 function getFilterSelector(
   globalFilter: GlobalFilter
 ): React.ComponentType<GenericFilterSelectorProps> {
-  const fieldDefinition = getFieldDefinition(globalFilter.tag.key);
+  const fieldDefinition = getFieldDefinitionForDataset(
+    globalFilter.tag,
+    globalFilter.dataset
+  );
   switch (fieldDefinition?.valueType) {
     case FieldValueType.NUMBER:
     case FieldValueType.DURATION:

--- a/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
@@ -1,0 +1,33 @@
+import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import type {SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
+import FilterSelector from 'sentry/views/dashboards/globalFilter/filterSelector';
+import NumericFilterSelector from 'sentry/views/dashboards/globalFilter/numericFilterSelector';
+import type {GlobalFilter} from 'sentry/views/dashboards/types';
+
+export type GenericFilterSelectorProps = {
+  globalFilter: GlobalFilter;
+  onRemoveFilter: (filter: GlobalFilter) => void;
+  onUpdateFilter: (filter: GlobalFilter) => void;
+  searchBarData: SearchBarData;
+};
+
+function getFilterSelector(
+  globalFilter: GlobalFilter
+): React.ComponentType<GenericFilterSelectorProps> {
+  const fieldDefinition = getFieldDefinition(globalFilter.tag.key);
+  switch (fieldDefinition?.valueType) {
+    case FieldValueType.NUMBER:
+    case FieldValueType.DURATION:
+      return NumericFilterSelector;
+    case FieldValueType.STRING:
+    default:
+      return FilterSelector;
+  }
+}
+
+function GenericFilterSelector({globalFilter, ...props}: GenericFilterSelectorProps) {
+  const FilterSelectorForType = getFilterSelector(globalFilter);
+  return <FilterSelectorForType globalFilter={globalFilter} {...props} />;
+}
+
+export default GenericFilterSelector;

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -12,11 +12,11 @@ import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/util
 import {TermOperator} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {getFieldDefinition} from 'sentry/utils/fields';
 import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
 import type {GenericFilterSelectorProps} from 'sentry/views/dashboards/globalFilter/genericFilterSelector';
 import NumericFilterSelectorTrigger from 'sentry/views/dashboards/globalFilter/numericFilterSelectorTrigger';
 import {
+  getFieldDefinitionForDataset,
   isValidNumericFilterValue,
   newNumericFilterQuery,
   parseFilterValue,
@@ -44,13 +44,16 @@ function NumericFilterSelector({
         ? getOperatorInfo({
             filterToken: globalFilterToken,
             hasWildcardOperators: false,
-            fieldDefinition: getFieldDefinition(globalFilterToken?.key?.text ?? ''),
+            fieldDefinition: getFieldDefinitionForDataset(
+              globalFilter.tag,
+              globalFilter.dataset
+            ),
           })
         : {
             operator: TermOperator.EQUAL,
             options: [],
           },
-    [globalFilterToken]
+    [globalFilterToken, globalFilter.tag, globalFilter.dataset]
   );
 
   const [stagedFilterOperator, setStagedFilterOperator] =

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -107,7 +107,7 @@ function NumericFilterSelector({
               }))}
             />
             <Input
-              aria-label="Filter value"
+              aria-label={t('Filter value')}
               value={stagedFilterValue}
               onChange={e => {
                 setStagedFilterValue(e.target.value);
@@ -160,7 +160,7 @@ function NumericFilterSelector({
                       closeOverlay();
                     }}
                   >
-                    Apply
+                    {t('Apply')}
                   </Button>
                 </FooterInnerWrap>
               </FooterWrap>

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -32,8 +32,8 @@ function NumericFilterSelector({
 
   // Parse global filter condition to retrieve initial state
   const globalFilterTokens = useMemo(
-    () => parseFilterValue(globalFilter.value, filterKeys),
-    [globalFilter.value, filterKeys]
+    () => parseFilterValue(globalFilter.value, filterKeys, globalFilter),
+    [filterKeys, globalFilter]
   );
 
   const globalFilterToken = globalFilterTokens ? globalFilterTokens[0] : null;
@@ -135,7 +135,11 @@ function NumericFilterSelector({
                     priority="primary"
                     disabled={
                       !globalFilterToken ||
-                      !isValidNumericFilterValue(stagedFilterValue, globalFilterToken)
+                      !isValidNumericFilterValue(
+                        stagedFilterValue,
+                        globalFilterToken,
+                        globalFilter
+                      )
                     }
                     onClick={() => {
                       if (!globalFilterToken) return;
@@ -143,7 +147,8 @@ function NumericFilterSelector({
                         stagedFilterValue,
                         stagedFilterOperator,
                         globalFilterToken,
-                        filterKeys
+                        filterKeys,
+                        globalFilter
                       );
                       onUpdateFilter({
                         ...globalFilter,

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -1,0 +1,199 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Input} from '@sentry/scraps/input';
+import {Flex} from '@sentry/scraps/layout';
+
+import {Button} from 'sentry/components/core/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {getOperatorInfo} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
+import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {TermOperator} from 'sentry/components/searchSyntax/parser';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {getFieldDefinition} from 'sentry/utils/fields';
+import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
+import type {GenericFilterSelectorProps} from 'sentry/views/dashboards/globalFilter/genericFilterSelector';
+import NumericFilterSelectorTrigger from 'sentry/views/dashboards/globalFilter/numericFilterSelectorTrigger';
+import {
+  isValidNumericFilterValue,
+  newNumericFilterQuery,
+  parseFilterValue,
+} from 'sentry/views/dashboards/globalFilter/utils';
+
+function NumericFilterSelector({
+  globalFilter,
+  searchBarData,
+  onRemoveFilter,
+  onUpdateFilter,
+}: GenericFilterSelectorProps) {
+  const filterKeys = useMemo(() => searchBarData.getFilterKeys(), [searchBarData]);
+
+  // Parse global filter condition to retrieve initial state
+  const globalFilterToken = useMemo(
+    () => parseFilterValue(globalFilter.value, filterKeys),
+    [globalFilter.value, filterKeys]
+  );
+
+  const {operator: globalFilterOperator, options} = useMemo(
+    () =>
+      getOperatorInfo({
+        filterToken: globalFilterToken,
+        hasWildcardOperators: false,
+        fieldDefinition: getFieldDefinition(globalFilterToken.key.text),
+      }),
+    [globalFilterToken]
+  );
+
+  const [stagedFilterOperator, setStagedFilterOperator] =
+    useState<TermOperator>(globalFilterOperator);
+  const [stagedFilterValue, setStagedFilterValue] = useState<string>(
+    globalFilterToken.value?.text || ''
+  );
+
+  const hasStagedChanges =
+    stagedFilterOperator !== globalFilterOperator ||
+    stagedFilterValue !== globalFilterToken.value?.text;
+
+  return (
+    <CompactSelect
+      disabled={false}
+      value=""
+      options={[]}
+      hideOptions
+      onChange={() => {}}
+      onClose={() => {
+        setStagedFilterOperator(globalFilterOperator);
+        setStagedFilterValue(globalFilterToken.value?.text || '');
+      }}
+      menuTitle={t('%s Filter', getDatasetLabel(globalFilter.dataset))}
+      menuHeaderTrailingItems={() => (
+        <StyledButton
+          aria-label={t('Remove Filter')}
+          size="zero"
+          onClick={() => onRemoveFilter(globalFilter)}
+        >
+          {t('Remove Filter')}
+        </StyledButton>
+      )}
+      menuBody={
+        <MenuBodyWrap>
+          <Flex gap="xs">
+            <DropdownMenu
+              usePortal
+              trigger={triggerProps => (
+                <StyledOperatorButton {...triggerProps}>
+                  {OP_LABELS[stagedFilterOperator]}
+                </StyledOperatorButton>
+              )}
+              items={options.map(option => ({
+                textValue: option.textValue,
+                label: option.label,
+                key: option.value,
+                onClick: () => {
+                  setStagedFilterOperator(option.value);
+                },
+              }))}
+            />
+            <Input
+              aria-label="Filter value"
+              value={stagedFilterValue}
+              onChange={e => {
+                setStagedFilterValue(e.target.value);
+              }}
+            />
+          </Flex>
+        </MenuBodyWrap>
+      }
+      triggerProps={{
+        children: (
+          <NumericFilterSelectorTrigger
+            globalFilter={globalFilter}
+            globalFilterOperator={globalFilterOperator}
+            globalFilterValue={globalFilterToken.value?.text || ''}
+          />
+        ),
+      }}
+      menuFooter={
+        hasStagedChanges
+          ? ({closeOverlay}: any) => (
+              <FooterWrap>
+                <FooterInnerWrap>
+                  <Button borderless size="xs" onClick={closeOverlay}>
+                    {t('Cancel')}
+                  </Button>
+                  <Button
+                    size="xs"
+                    priority="primary"
+                    disabled={
+                      !isValidNumericFilterValue(stagedFilterValue, globalFilterToken)
+                    }
+                    onClick={() => {
+                      const newFilterQuery = newNumericFilterQuery(
+                        stagedFilterValue,
+                        stagedFilterOperator,
+                        globalFilterToken,
+                        filterKeys
+                      );
+                      onUpdateFilter({
+                        ...globalFilter,
+                        value: newFilterQuery,
+                      });
+                      closeOverlay();
+                    }}
+                  >
+                    Apply
+                  </Button>
+                </FooterInnerWrap>
+              </FooterWrap>
+            )
+          : null
+      }
+    />
+  );
+}
+
+export default NumericFilterSelector;
+
+const MenuBodyWrap = styled('div')`
+  margin: 4px;
+`;
+
+const FooterWrap = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  gap: ${space(2)};
+
+  /* If there's FooterMessage above */
+  &:not(:first-child) {
+    margin-top: ${space(1)};
+  }
+`;
+const FooterInnerWrap = styled('div')`
+  grid-row: -1;
+  display: grid;
+  grid-auto-flow: column;
+  gap: ${space(1)};
+  justify-self: end;
+  justify-items: end;
+
+  &:empty {
+    display: none;
+  }
+`;
+
+const StyledOperatorButton = styled(Button)`
+  width: 40%;
+`;
+
+const StyledButton = styled(Button)`
+  font-size: inherit;
+  font-weight: ${p => p.theme.fontWeight.normal};
+  color: ${p => p.theme.subText};
+  padding: 0 ${space(0.5)};
+  margin: ${p =>
+    p.theme.isChonk
+      ? `-${space(0.5)} -${space(0.5)}`
+      : `-${space(0.25)} -${space(0.25)}`};
+`;

--- a/static/app/views/dashboards/globalFilter/numericFilterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelectorTrigger.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+
+import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import type {TermOperator} from 'sentry/components/searchSyntax/parser';
+import TextOverflow from 'sentry/components/textOverflow';
+import {prettifyTagKey} from 'sentry/utils/fields';
+import type {GlobalFilter} from 'sentry/views/dashboards/types';
+
+type NumericFilterSelectorTriggerProps = {
+  globalFilter: GlobalFilter;
+  globalFilterOperator: TermOperator;
+  globalFilterValue: string;
+};
+
+function FilterSelectorTrigger({
+  globalFilter,
+  globalFilterOperator,
+  globalFilterValue,
+}: NumericFilterSelectorTriggerProps) {
+  const {tag} = globalFilter;
+
+  return (
+    <ButtonLabelWrapper>
+      <TextOverflow>
+        {prettifyTagKey(tag.key)} {OP_LABELS[globalFilterOperator]}{' '}
+        <FilterValueWrapper>{globalFilterValue}</FilterValueWrapper>
+      </TextOverflow>
+    </ButtonLabelWrapper>
+  );
+}
+
+export default FilterSelectorTrigger;
+
+const ButtonLabelWrapper = styled('span')`
+  width: 100%;
+  text-align: left;
+  align-items: center;
+  display: inline-grid;
+  grid-template-columns: 1fr auto;
+  line-height: 1;
+`;
+
+const FilterValueWrapper = styled('span')`
+  font-weight: normal;
+`;

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -14,6 +14,10 @@ import type {Tag, TagCollection} from 'sentry/types/group';
 import {getFieldDefinition, type FieldDefinition} from 'sentry/utils/fields';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
 
+export function globalFilterKeysAreEqual(a: GlobalFilter, b: GlobalFilter): boolean {
+  return a.tag.key === b.tag.key && a.dataset === b.dataset;
+}
+
 export function getFieldDefinitionForDataset(
   tag: Tag,
   datasetType: WidgetType

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -31,12 +31,17 @@ export function getFieldDefinitionForDataset(
   return getFieldDefinition(tag.key, fieldType(), tag.kind);
 }
 
-export function parseFilterValue(filterValue: string, filterKeys: TagCollection) {
+export function parseFilterValue(
+  filterValue: string,
+  filterKeys: TagCollection
+): Array<TokenResult<Token.FILTER>> {
   const parsedResult = parseQueryBuilderValue(filterValue, getFieldDefinition, {
     filterKeys,
   });
-  const filterTokens = parsedResult?.filter(token => token.type === Token.FILTER);
-  return filterTokens?.[0] as TokenResult<Token.FILTER>;
+  if (!parsedResult) {
+    return [];
+  }
+  return parsedResult.filter(token => token.type === Token.FILTER);
 }
 
 export function isValidNumericFilterValue(
@@ -74,7 +79,12 @@ export function newNumericFilterQuery(
     filterToken,
     cleanedValue
   );
-  const filterTokenWithNewValue = parseFilterValue(filterWithNewValue, filterKeys);
+
+  const newFilterTokens = parseFilterValue(filterWithNewValue, filterKeys);
+  const filterTokenWithNewValue = newFilterTokens?.[0];
+  if (!filterTokenWithNewValue) {
+    return '';
+  }
 
   // Update the operator of the filter
   const newFilterQuery = modifyFilterOperatorQuery(

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -1,0 +1,69 @@
+import {
+  modifyFilterOperatorQuery,
+  modifyFilterValue,
+} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderState';
+import {getFilterValueType} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {cleanFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {
+  TermOperator,
+  Token,
+  type TokenResult,
+} from 'sentry/components/searchSyntax/parser';
+import type {TagCollection} from 'sentry/types/group';
+import {getFieldDefinition} from 'sentry/utils/fields';
+
+export function parseFilterValue(filterValue: string, filterKeys: TagCollection) {
+  const parsedResult = parseQueryBuilderValue(filterValue, getFieldDefinition, {
+    filterKeys,
+  });
+  const filterTokens = parsedResult?.filter(token => token.type === Token.FILTER);
+  return filterTokens?.[0] as TokenResult<Token.FILTER>;
+}
+
+export function isValidNumericFilterValue(
+  value: string,
+  filterToken: TokenResult<Token.FILTER>
+) {
+  const fieldDefinition = getFieldDefinition(filterToken.key.text);
+  const valueType = getFilterValueType(filterToken, fieldDefinition);
+  return (
+    cleanFilterValue({
+      value,
+      valueType,
+      token: filterToken,
+    }) !== null
+  );
+}
+
+export function newNumericFilterQuery(
+  newValue: string,
+  newOperator: TermOperator,
+  filterToken: TokenResult<Token.FILTER>,
+  filterKeys: TagCollection
+) {
+  // Update the value of the filter
+  const fieldDefinition = getFieldDefinition(filterToken.key.text);
+  const valueType = getFilterValueType(filterToken, fieldDefinition);
+  const cleanedValue = cleanFilterValue({
+    value: newValue,
+    valueType,
+    token: filterToken,
+  });
+  if (!cleanedValue) return '';
+  const filterWithNewValue = modifyFilterValue(
+    filterToken.text,
+    filterToken,
+    cleanedValue
+  );
+  const filterTokenWithNewValue = parseFilterValue(filterWithNewValue, filterKeys);
+
+  // Update the operator of the filter
+  const newFilterQuery = modifyFilterOperatorQuery(
+    filterWithNewValue,
+    filterTokenWithNewValue,
+    newOperator,
+    false
+  );
+  return newFilterQuery;
+}

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -10,8 +10,26 @@ import {
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
-import type {TagCollection} from 'sentry/types/group';
-import {getFieldDefinition} from 'sentry/utils/fields';
+import type {Tag, TagCollection} from 'sentry/types/group';
+import {getFieldDefinition, type FieldDefinition} from 'sentry/utils/fields';
+import {WidgetType} from 'sentry/views/dashboards/types';
+
+export function getFieldDefinitionForDataset(
+  tag: Tag,
+  datasetType: WidgetType
+): FieldDefinition | null {
+  const fieldType = () => {
+    switch (datasetType) {
+      case WidgetType.SPANS:
+        return 'span';
+      case WidgetType.LOGS:
+        return 'log';
+      default:
+        return 'event';
+    }
+  };
+  return getFieldDefinition(tag.key, fieldType(), tag.kind);
+}
 
 export function parseFilterValue(filterValue: string, filterKeys: TagCollection) {
   const parsedResult = parseQueryBuilderValue(filterValue, getFieldDefinition, {


### PR DESCRIPTION
- Creates a numeric global filter selector
- Creates a generic filter selector that uses the corresponding filter selector depending on tag value type
- Sets default value when creating global filters (numeric filters must have valid default values instead of empty string)

https://github.com/user-attachments/assets/3a3bbf75-60bb-4e07-8145-7822a8bf1662

Fixes [BROWSE-73](https://linear.app/getsentry/issue/BROWSE-73/create-numeric-global-filter-selector)