### PR TITLE
fix(preprod): fix insight handling for 0 files and percentage

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -19,7 +19,7 @@ describe('AppSizeInsightsSidebarRow', () => {
       screen.getByText('You have files that are duplicated across your app')
     ).toBeInTheDocument();
     expect(screen.getByText('Potential savings 1.02 MB')).toBeInTheDocument();
-    expect(screen.getByText('15.5%')).toBeInTheDocument();
+    expect(screen.getByText('-15.5%')).toBeInTheDocument();
   });
 
   it('shows file count button', () => {
@@ -193,7 +193,7 @@ describe('AppSizeInsightsSidebarRow', () => {
     expect(screen.queryByText('Convert to HEIC:')).not.toBeInTheDocument();
   });
 
-  it('renders with no files', () => {
+  it('hides file count button when there are no files', () => {
     const insightWithNoFiles = ProcessedInsightFixture({
       files: [],
     });
@@ -206,7 +206,8 @@ describe('AppSizeInsightsSidebarRow', () => {
       />
     );
 
-    expect(screen.getByText('0 files')).toBeInTheDocument();
+    // Button should not be rendered when there are 0 files
+    expect(screen.queryByRole('button', {name: /files/i})).not.toBeInTheDocument();
     expect(screen.queryByText(/^src\//)).not.toBeInTheDocument();
   });
 

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -241,4 +241,37 @@ describe('AppSizeInsightsSidebarRow', () => {
     expect(screen.getByText('Potential savings 5.24 GB')).toBeInTheDocument();
     expect(screen.getByText(/-2\.15\s*GB/i)).toBeInTheDocument();
   });
+
+  it('shows ~0% for very small percentage savings', () => {
+    const insightWithTinySavings = ProcessedInsightFixture({
+      totalSavings: 100, // 100 bytes
+      percentage: 0.05, // 0.05% - less than 0.1% threshold
+      files: [
+        {
+          path: 'tiny-file.js',
+          savings: 100,
+          percentage: 0.05,
+          data: {
+            fileType: 'regular' as const,
+            originalFile: {
+              file_path: 'tiny-file.js',
+              total_savings: 100,
+            },
+          },
+        },
+      ],
+    });
+
+    render(
+      <AppSizeInsightsSidebarRow
+        {...getDefaultProps()}
+        insight={insightWithTinySavings}
+        isExpanded
+      />
+    );
+
+    // Should show ~0% for percentages less than 0.1%
+    expect(screen.getByText('~0%')).toBeInTheDocument();
+    expect(screen.getByText('Potential savings 100 B')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -76,13 +76,13 @@ export function AppSizeInsightsSidebarRow({
           </Text>
           <Tag type="success" style={{minWidth: '56px', justifyContent: 'center'}}>
             <Text size="sm" tabular variant="success">
-              {formatPercentage(insight.percentage / 100, 1)}
+              {formatUpside(insight.percentage / 100)}
             </Text>
           </Tag>
         </Flex>
       </Flex>
 
-      <Stack gap="lg" align="start" paddingBottom="md">
+      <Stack gap="lg" align="start">
         <Text variant="muted" size="sm">
           {insight.description}
         </Text>
@@ -93,44 +93,46 @@ export function AppSizeInsightsSidebarRow({
         )}
       </Stack>
 
-      <Container>
-        <Button
-          size="sm"
-          onClick={onToggleExpanded}
-          style={{marginBottom: isExpanded ? '16px' : '0'}}
-          icon={
-            <IconChevron
-              style={{
-                transition: 'transform 0.2s ease',
-                color: 'inherit',
-                transform: isExpanded ? 'rotate(180deg)' : 'rotate(90deg)',
-              }}
-            />
-          }
-        >
-          <Text variant="primary" size="md" bold>
-            {tn('%s file', '%s files', insight.files.length)}
-          </Text>
-        </Button>
-
-        {isExpanded && (
-          <Container
-            display="flex"
-            css={() => ({
-              flexDirection: 'column',
-              width: '100%',
-              overflow: 'hidden',
-              '& > :nth-child(odd)': {
-                backgroundColor: theme.backgroundSecondary,
-              },
-            })}
+      {insight.files.length > 0 && (
+        <Container paddingTop="md">
+          <Button
+            size="sm"
+            onClick={onToggleExpanded}
+            style={{marginBottom: isExpanded ? '16px' : '0'}}
+            icon={
+              <IconChevron
+                style={{
+                  transition: 'transform 0.2s ease',
+                  color: 'inherit',
+                  transform: isExpanded ? 'rotate(180deg)' : 'rotate(90deg)',
+                }}
+              />
+            }
           >
-            {insight.files.map((file, fileIndex) => (
-              <FileRow key={`${file.path}-${fileIndex}`} file={file} />
-            ))}
-          </Container>
-        )}
-      </Container>
+            <Text variant="primary" size="md" bold>
+              {tn('%s file', '%s files', insight.files.length)}
+            </Text>
+          </Button>
+
+          {isExpanded && (
+            <Container
+              display="flex"
+              css={() => ({
+                flexDirection: 'column',
+                width: '100%',
+                overflow: 'hidden',
+                '& > :nth-child(odd)': {
+                  backgroundColor: theme.backgroundSecondary,
+                },
+              })}
+            >
+              {insight.files.map((file, fileIndex) => (
+                <FileRow key={`${file.path}-${fileIndex}`} file={file} />
+              ))}
+            </Container>
+          )}
+        </Container>
+      )}
     </Flex>
   );
 }


### PR DESCRIPTION
Hides the file button when there are no files:

<img width="508" height="320" alt="Screenshot 2025-10-24 at 12 02 25 PM" src="https://github.com/user-attachments/assets/48d72b6a-9718-4aae-8ed3-bb4506cb46ca" />

I also fixed the percentage display for the overall insight savings to use our helper function:

<img width="451" height="65" alt="Screenshot 2025-10-24 at 12 04 46 PM" src="https://github.com/user-attachments/assets/e4fc0abc-98a5-4f57-a4a6-0e84c2d90b7d" />

Resolves EME-223