### PR TITLE
feat(models): Expose endpoint in project key model serializer

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -30,6 +30,7 @@ class DSN(TypedDict):
     playstation: str
     otlp_traces: str
     otlp_logs: str
+    endpoint: str
 
 
 class BrowserSDK(TypedDict):
@@ -100,6 +101,7 @@ class ProjectKeySerializer(Serializer):
                 "playstation": obj.playstation_endpoint,
                 "otlp_traces": obj.otlp_traces_endpoint,
                 "otlp_logs": obj.otlp_logs_endpoint,
+                "endpoint": obj.get_endpoint(),
             },
             "browserSdkVersion": get_selected_browser_sdk_version(obj),
             "browserSdk": {"choices": get_browser_sdk_version_choices(obj.project)},

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -20,6 +20,7 @@ KEY_RATE_LIMIT = {
         "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/traces",
         "otlp_logs": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/logs",
+        "endpoint": "https://o4504765715316736.ingest.sentry.io",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "unreal": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/",
         "cdn": "https://js.sentry-cdn.com/a785682ddda719b7a8a4011110d75598.min.js",

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -71,6 +71,21 @@ class ListProjectKeysTest(APITestCase):
         assert response.data[0]["dsn"]["otlp_logs"] == key.otlp_logs_endpoint
         assert "integration/otlp/v1/logs" in response.data[0]["dsn"]["otlp_logs"]
 
+    def test_endpoint(self) -> None:
+        project = self.create_project()
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data[0]["dsn"]["endpoint"] == key.get_endpoint()
+
     def test_use_case(self) -> None:
         """Regular user can access user DSNs but not internal DSNs"""
         project = self.create_project()


### PR DESCRIPTION
This is an alternative to https://github.com/getsentry/sentry/pull/101999. By just exposing the endpoint (which is internally can be exposed with the `get_endpoint` method), we can construct the integration endpoints arbitrarily.