### PR TITLE
feat(tracemetrics): Add onboarding skeleton for metrics

### DIFF
--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
@@ -47,6 +47,7 @@ export function FeatureFlagOnboardingLayout({
       platformKey,
       project,
       isLogsSelected: false,
+      isMetricsSelected: false,
       isFeedbackSelected: false,
       isPerformanceSelected: false,
       isProfilingSelected: false,

--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -47,6 +47,7 @@ export function FeedbackOnboardingLayout({
       project,
       isLogsSelected: false,
       isFeedbackSelected: true,
+      isMetricsSelected: false,
       isPerformanceSelected: false,
       isProfilingSelected: false,
       isReplaySelected: false,

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -86,6 +86,7 @@ export function OnboardingLayout({
       project,
       isLogsSelected: activeProductSelection.includes(ProductSolution.LOGS),
       isFeedbackSelected: false,
+      isMetricsSelected: activeProductSelection.includes(ProductSolution.METRICS),
       isPerformanceSelected: activeProductSelection.includes(
         ProductSolution.PERFORMANCE_MONITORING
       ),

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -87,6 +87,7 @@ export enum ProductSolution {
   SESSION_REPLAY = 'session-replay',
   PROFILING = 'profiling',
   LOGS = 'logs',
+  METRICS = 'metrics',
 }
 
 export interface DocsParams<
@@ -96,6 +97,7 @@ export interface DocsParams<
   dsn: ProjectKey['dsn'];
   isFeedbackSelected: boolean;
   isLogsSelected: boolean;
+  isMetricsSelected: boolean;
   isPerformanceSelected: boolean;
   isProfilingSelected: boolean;
   isReplaySelected: boolean;
@@ -167,6 +169,7 @@ export interface Docs<PlatformOptions extends BasePlatformOptions = BasePlatform
   feedbackOnboardingNpm?: OnboardingConfig<PlatformOptions>;
   logsOnboarding?: OnboardingConfig<PlatformOptions>;
   mcpOnboarding?: OnboardingConfig<PlatformOptions>;
+  metricsOnboarding?: OnboardingConfig<PlatformOptions>;
   performanceOnboarding?: OnboardingConfig<PlatformOptions>;
   platformOptions?: PlatformOptions;
   profilingOnboarding?: OnboardingConfig<PlatformOptions>;

--- a/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.ts
@@ -7,6 +7,7 @@ import {
   feedbackOnboardingPlatforms,
   replayPlatforms,
   withLoggingOnboarding,
+  withMetricsOnboarding,
   withPerformanceOnboarding,
 } from 'sentry/data/platformCategories';
 import type {Organization} from 'sentry/types/organization';
@@ -17,7 +18,13 @@ import {useProjectKeys} from 'sentry/utils/useProjectKeys';
 type Props = {
   orgSlug: Organization['slug'];
   platform: PlatformIntegration;
-  productType?: 'feedback' | 'replay' | 'performance' | 'featureFlags' | 'logs';
+  productType?:
+    | 'feedback'
+    | 'replay'
+    | 'performance'
+    | 'featureFlags'
+    | 'logs'
+    | 'metrics';
   projSlug?: Project['slug'];
 };
 
@@ -54,7 +61,8 @@ export function useLoadGettingStarted({
         (productType === 'feedback' &&
           !feedbackOnboardingPlatforms.includes(platform.id)) ||
         (productType === 'featureFlags' &&
-          !featureFlagOnboardingPlatforms.includes(platform.id))
+          !featureFlagOnboardingPlatforms.includes(platform.id)) ||
+        (productType === 'metrics' && !withMetricsOnboarding.has(platform.id))
       ) {
         setModule('none');
         return;

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -310,6 +310,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     project: currentProject,
     isFeedbackSelected: false,
     isLogsSelected: false,
+    isMetricsSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: false,
     isReplaySelected: false,

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -327,6 +327,7 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     project: props.project,
     isLogsSelected: false,
     isFeedbackSelected: false,
+    isMetricsSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: true,
     isReplaySelected: false,

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -47,6 +47,7 @@ export function ReplayOnboardingLayout({
       project,
       isLogsSelected: false,
       isFeedbackSelected: false,
+      isMetricsSelected: false,
       isPerformanceSelected: false,
       isProfilingSelected: false,
       isReplaySelected: true,

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -92,6 +92,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     platformKey: currentPlatformKey,
     project,
     isLogsSelected: false,
+    isMetricsSelected: false,
     isFeedbackSelected: false,
     isPerformanceSelected: false,
     isProfilingSelected: false,

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -390,6 +390,12 @@ export const withoutLoggingSupport: Set<PlatformKey> = new Set([
   'native',
 ]);
 
+// List of platforms that have metrics onboarding checklist content
+export const withMetricsOnboarding: Set<PlatformKey> = new Set([]);
+
+// List of platforms that do not have metrics support. We make use of this list in the product to not provide any Metrics
+export const withoutMetricsSupport: Set<PlatformKey> = new Set([]);
+
 export const profiling: PlatformKey[] = [
   'android',
   'apple',

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -46,6 +46,7 @@ export type Project = {
   hasProfiles: boolean;
   hasReplays: boolean;
   hasSessions: boolean;
+  hasTraceMetrics: boolean;
   id: string;
   isBookmarked: boolean;
   isInternal: boolean;

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -23,6 +23,10 @@ import {
   logsAnalyticsEventMap,
   type LogsAnalyticsEventParameters,
 } from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {
+  metricsAnalyticsEventMap,
+  type MetricsAnalyticsEventParameters,
+} from 'sentry/utils/analytics/metricsAnalyticsEvent';
 import {navigationAnalyticsEventMap} from 'sentry/utils/analytics/navigationAnalyticsEvents';
 import {nextJsInsightsEventMap} from 'sentry/utils/analytics/nextJsInsightsAnalyticsEvents';
 import {
@@ -120,6 +124,7 @@ interface EventParameters
     ProjectCreationEventParameters,
     SignupAnalyticsParameters,
     LogsAnalyticsEventParameters,
+    MetricsAnalyticsEventParameters,
     TracingEventParameters,
     StatsEventParameters,
     ExploreAnalyticsEventParameters,
@@ -146,6 +151,7 @@ const allEventMap: Record<string, string | null> = {
   ...profilingEventMap,
   ...exploreAnalyticsEventMap,
   ...logsAnalyticsEventMap,
+  ...metricsAnalyticsEventMap,
   ...releasesEventMap,
   ...replayEventMap,
   ...searchEventMap,

--- a/static/app/utils/analytics/metricsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/metricsAnalyticsEvent.tsx
@@ -1,0 +1,34 @@
+import type {Organization} from 'sentry/types/organization';
+import type {PlatformKey} from 'sentry/types/project';
+
+export enum MetricsAnalyticsPageSource {
+  EXPLORE_METRICS = 'explore',
+  ISSUE_DETAILS = 'issue details',
+  TRACE_DETAILS = 'trace details',
+}
+
+export type MetricsAnalyticsEventParameters = {
+  'metrics.explorer.setup_button_clicked': {
+    organization: Organization;
+    platform: PlatformKey | 'unknown';
+    supports_onboarding_checklist: boolean;
+  };
+  'metrics.onboarding': {
+    organization: Organization;
+    platform: PlatformKey | 'unknown';
+    supports_onboarding_checklist: boolean;
+  };
+  'metrics.onboarding_platform_docs_viewed': {
+    organization: Organization;
+    platform: PlatformKey | 'unknown';
+  };
+};
+
+type MetricsAnalyticsEventKey = keyof MetricsAnalyticsEventParameters;
+
+export const metricsAnalyticsEventMap: Record<MetricsAnalyticsEventKey, string | null> = {
+  'metrics.explorer.setup_button_clicked': 'Metrics Setup Button Clicked',
+  'metrics.onboarding': 'Metrics Explore Empty State (Onboarding)',
+  'metrics.onboarding_platform_docs_viewed':
+    'Metrics Explore Empty State (Onboarding) - Platform Docs Viewed',
+};

--- a/static/app/utils/analytics/metricsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/metricsAnalyticsEvent.tsx
@@ -1,12 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
 
-export enum MetricsAnalyticsPageSource {
-  EXPLORE_METRICS = 'explore',
-  ISSUE_DETAILS = 'issue details',
-  TRACE_DETAILS = 'trace details',
-}
-
 export type MetricsAnalyticsEventParameters = {
   'metrics.explorer.setup_button_clicked': {
     organization: Organization;

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -6,9 +6,13 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
+import {MetricsTabOnboarding} from 'sentry/views/explore/metrics/metricsOnboarding';
 import {MetricsTabContent} from 'sentry/views/explore/metrics/metricsTab';
+import {metricsPickableDays} from 'sentry/views/explore/metrics/utils';
+import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 
 function FeedbackButton() {
   const openForm = useFeedbackForm();
@@ -38,14 +42,14 @@ function FeedbackButton() {
 
 export default function MetricsContent() {
   const organization = useOrganization();
-
+  const onboardingProject = useOnboardingProject({property: 'hasTraceMetrics'});
+  const {defaultPeriod, maxPickableDays, relativeOptions} = metricsPickableDays();
   return (
     <SentryDocumentTitle title={t('Metrics')} orgSlug={organization?.slug}>
       <PageFiltersContainer
-        // TODO(nar): Setup maxPickableDays and other date selection constraints
         defaultSelection={{
           datetime: {
-            period: '24h',
+            period: defaultPeriod,
             start: null,
             end: null,
             utc: null,
@@ -54,18 +58,21 @@ export default function MetricsContent() {
       >
         <Layout.Page>
           <MetricsHeader />
-          <MetricsTabContent
-            defaultPeriod="24h"
-            maxPickableDays={7}
-            relativeOptions={({arbitraryOptions}) => ({
-              ...arbitraryOptions,
-              '24h': t('Last 24 hours'),
-              '7d': t('Last 7 days'),
-              '14d': t('Last 14 days'),
-              '30d': t('Last 30 days'),
-              '90d': t('Last 90 days'),
-            })}
-          />
+          {defined(onboardingProject) ? (
+            <MetricsTabOnboarding
+              organization={organization}
+              project={onboardingProject}
+              defaultPeriod={defaultPeriod}
+              maxPickableDays={maxPickableDays}
+              relativeOptions={relativeOptions}
+            />
+          ) : (
+            <MetricsTabContent
+              defaultPeriod={defaultPeriod}
+              maxPickableDays={maxPickableDays}
+              relativeOptions={relativeOptions}
+            />
+          )}
         </Layout.Page>
       </PageFiltersContainer>
     </SentryDocumentTitle>

--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -22,7 +22,7 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {BodyTitle, SetupTitle} from 'sentry/components/updatedEmptyState';
-import {withoutLoggingSupport} from 'sentry/data/platformCategories';
+import {withoutMetricsSupport} from 'sentry/data/platformCategories';
 import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -39,7 +39,7 @@ import {
   FilterBarContainer,
   StyledPageFilterBar,
   TopSectionBody,
-} from 'sentry/views/explore/logs/styles';
+} from 'sentry/views/explore/metrics/styles';
 import type {PickableDays} from 'sentry/views/explore/utils';
 
 type OnboardingProps = {
@@ -61,18 +61,28 @@ function OnboardingPanel({
           <div>
             <HeaderWrapper>
               <HeaderText>
-                <Title>{t('Your Source for Log-ical Data')}</Title>
+                <Title>{t('Measure What Matters with Metrics')}</Title>
                 <SubTitle>
                   {t(
-                    "It's about time we offered something a bit more robust than breadcrumbs. With logs, you'll be able to have a lot more control and context over all your data."
+                    'Track custom business metrics and monitor application performance with powerful aggregation and visualization capabilities.'
                   )}
                 </SubTitle>
                 <BulletList>
-                  <li>{t('Access logs in real time and query them by any attribute')}</li>
                   <li>
-                    {t('Correlate your logs with errors and traces for full context')}
+                    {t(
+                      'Send custom metrics to track business KPIs and technical indicators'
+                    )}
                   </li>
-                  <li>{t('Build alerts and dashboard widgets based on log queries')}</li>
+                  <li>
+                    {t(
+                      'Create dashboards and alerts based on metric queries and aggregations'
+                    )}
+                  </li>
+                  <li>
+                    {t(
+                      'Analyze metrics alongside errors, traces, and logs for full context'
+                    )}
+                  </li>
                 </BulletList>
               </HeaderText>
               <Image src={connectDotsImg} />
@@ -81,7 +91,7 @@ function OnboardingPanel({
             <Body>
               <Setup>{children}</Setup>
               <Preview>
-                <BodyTitle>{t('Preview a Sentry Log')}</BodyTitle>
+                <BodyTitle>{t('Preview a Sentry Metric')}</BodyTitle>
                 <Arcade
                   src="https://demo.arcade.software/dLjHGrPJITrt7JKpmX5V?embed"
                   loading="lazy"
@@ -115,14 +125,14 @@ function Onboarding({organization, project}: OnboardingProps) {
     platform: currentPlatform || otherPlatform,
     orgSlug: organization.slug,
     projSlug: project.slug,
-    productType: 'logs',
+    productType: 'metrics',
   });
 
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
 
-  const doesNotSupportLogging = project.platform
-    ? withoutLoggingSupport.has(project.platform)
+  const doesNotSupportMetrics = project.platform
+    ? withoutMetricsSupport.has(project.platform)
     : false;
 
   const analyticsPlatform = currentPlatform?.id ?? project.platform ?? 'unknown';
@@ -132,10 +142,10 @@ function Onboarding({organization, project}: OnboardingProps) {
       return;
     }
 
-    trackAnalytics('logs.onboarding', {
+    trackAnalytics('metrics.onboarding', {
       organization,
       platform: analyticsPlatform,
-      supports_onboarding_checklist: !doesNotSupportLogging,
+      supports_onboarding_checklist: !doesNotSupportMetrics,
     });
   }, [
     currentPlatform,
@@ -143,22 +153,22 @@ function Onboarding({organization, project}: OnboardingProps) {
     dsn,
     projectKeyId,
     organization,
-    doesNotSupportLogging,
+    doesNotSupportMetrics,
     analyticsPlatform,
   ]);
 
-  const logsDocs = docs?.logsOnboarding ?? docs?.onboarding;
+  const metricsDocs = docs?.metricsOnboarding ?? docs?.onboarding;
 
   if (isLoading) {
     return <LoadingIndicator />;
   }
 
-  if (doesNotSupportLogging) {
+  if (doesNotSupportMetrics) {
     return (
       <OnboardingPanel project={project}>
         <div>
           {tct(
-            'Fiddlesticks. Application Logging isn’t available for your [platform] project yet, but we’re definitely still working on it. Stay tuned.',
+            "Fiddlesticks. Metrics isn't available for your [platform] project yet, but we're definitely still working on it. Stay tuned.",
             {platform: currentPlatform?.name || project.slug}
           )}
         </div>
@@ -169,7 +179,7 @@ function Onboarding({organization, project}: OnboardingProps) {
             href="https://docs.sentry.io/platforms/"
             external
             onClick={() => {
-              trackAnalytics('logs.onboarding_platform_docs_viewed', {
+              trackAnalytics('metrics.onboarding_platform_docs_viewed', {
                 organization,
                 platform: analyticsPlatform,
               });
@@ -182,12 +192,12 @@ function Onboarding({organization, project}: OnboardingProps) {
     );
   }
 
-  if (!currentPlatform || !logsDocs || !dsn || !projectKeyId) {
+  if (!currentPlatform || !metricsDocs || !dsn || !projectKeyId) {
     return (
       <OnboardingPanel project={project}>
         <div>
           {tct(
-            'Fiddlesticks. The logging onboarding checklist isn’t available for your [project] project yet, but for now, go to Sentry docs for installation details.',
+            "Fiddlesticks. The metrics onboarding checklist isn't available for your [project] project yet, but for now, go to Sentry docs for installation details.",
             {project: project.slug}
           )}
         </div>
@@ -195,10 +205,10 @@ function Onboarding({organization, project}: OnboardingProps) {
         <div>
           <LinkButton
             size="sm"
-            href="https://docs.sentry.io/product/explore/logs/getting-started/"
+            href="https://docs.sentry.io/product/metrics/"
             external
             onClick={() => {
-              trackAnalytics('logs.onboarding_platform_docs_viewed', {
+              trackAnalytics('metrics.onboarding_platform_docs_viewed', {
                 organization,
                 platform: analyticsPlatform,
               });
@@ -218,8 +228,8 @@ function Onboarding({organization, project}: OnboardingProps) {
     organization,
     platformKey: project.platform || 'other',
     project,
-    isLogsSelected: true,
-    isMetricsSelected: false,
+    isLogsSelected: false,
+    isMetricsSelected: true,
     isFeedbackSelected: false,
     isPerformanceSelected: false,
     isProfilingSelected: false,
@@ -228,16 +238,16 @@ function Onboarding({organization, project}: OnboardingProps) {
       isLoading: isLoadingRegistry,
       data: registryData,
     },
-    platformOptions: [ProductSolution.LOGS],
+    platformOptions: [ProductSolution.METRICS],
     newOrg: false,
     feedbackOptions: {},
     urlPrefix,
     isSelfHosted,
   };
 
-  const installSteps = logsDocs.install(docParams);
-  const configureSteps = logsDocs.configure(docParams);
-  const verifySteps = logsDocs.verify(docParams);
+  const installSteps = metricsDocs.install(docParams);
+  const configureSteps = metricsDocs.configure(docParams);
+  const verifySteps = metricsDocs.verify(docParams);
 
   const steps = [...installSteps, ...configureSteps, ...verifySteps];
 
@@ -370,18 +380,18 @@ const Arcade = styled('iframe')`
   border: 0;
 `;
 
-type LogsTabOnboardingProps = {
+type MetricsTabOnboardingProps = {
   organization: Organization;
   project: Project;
 } & PickableDays;
 
-export function LogsTabOnboarding({
+export function MetricsTabOnboarding({
   organization,
   project,
   defaultPeriod,
   maxPickableDays,
   relativeOptions,
-}: LogsTabOnboardingProps) {
+}: MetricsTabOnboardingProps) {
   return (
     <TopSectionBody noRowGap>
       <Layout.Main width="full">

--- a/static/app/views/explore/metrics/styles.tsx
+++ b/static/app/views/explore/metrics/styles.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+import {Body} from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {space} from 'sentry/styles/space';
+
+export const FilterBarContainer = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  margin-bottom: ${space(1)};
+`;
+
+export const StyledPageFilterBar = styled(PageFilterBar)`
+  width: auto;
+`;
+
+export const TopSectionBody = styled(Body)`
+  padding-bottom: 0;
+  flex: 0 0 auto;
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    padding-bottom: ${space(2)};
+  }
+`;

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -1,5 +1,9 @@
+import type {ReactNode} from 'react';
+
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
+import {t} from 'sentry/locale';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import type {PickableDays} from 'sentry/views/explore/utils';
 
 export function makeMetricsPathname({
   organizationSlug,
@@ -24,4 +28,27 @@ export function createMetricNameFilter(
         [`sentry._internal.cooccuring.name.${metricName}`]: ['true'],
       }).formatString()
     : undefined;
+}
+
+export function metricsPickableDays(): PickableDays {
+  const relativeOptions: Array<[string, ReactNode]> = [
+    ['1h', t('Last hour')],
+    ['24h', t('Last 24 hours')],
+    ['7d', t('Last 7 days')],
+    ['14d', t('Last 14 days')],
+    ['30d', t('Last 30 days')],
+  ];
+
+  return {
+    defaultPeriod: '24h',
+    maxPickableDays: 30, // May change with downsampled multi month support.
+    relativeOptions: ({
+      arbitraryOptions,
+    }: {
+      arbitraryOptions: Record<string, ReactNode>;
+    }) => ({
+      ...arbitraryOptions,
+      ...Object.fromEntries(relativeOptions),
+    }),
+  };
 }

--- a/static/app/views/insights/agents/views/onboarding.tsx
+++ b/static/app/views/insights/agents/views/onboarding.tsx
@@ -292,6 +292,7 @@ export function Onboarding() {
     project,
     isLogsSelected: false,
     isFeedbackSelected: false,
+    isMetricsSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: false,
     isReplaySelected: false,

--- a/static/app/views/insights/common/queries/useOnboardingProject.tsx
+++ b/static/app/views/insights/common/queries/useOnboardingProject.tsx
@@ -6,7 +6,7 @@ import useProjects from 'sentry/utils/useProjects';
 export function useOnboardingProject({
   property,
 }: {
-  property?: keyof Pick<Project, 'hasLogs' | 'firstTransactionEvent'>;
+  property?: keyof Pick<Project, 'hasLogs' | 'hasTraceMetrics' | 'firstTransactionEvent'>;
 } = {}): Project | undefined {
   const {projects} = useProjects();
   const pageFilters = usePageFilters();

--- a/static/app/views/insights/mcp/views/onboarding.tsx
+++ b/static/app/views/insights/mcp/views/onboarding.tsx
@@ -275,6 +275,7 @@ export function Onboarding() {
     project,
     isLogsSelected: false,
     isFeedbackSelected: false,
+    isMetricsSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: false,
     isReplaySelected: false,

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -535,6 +535,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
     project,
     isLogsSelected: false,
     isFeedbackSelected: false,
+    isMetricsSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: false,
     isReplaySelected: false,

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -260,6 +260,7 @@ export function Onboarding() {
     project,
     isLogsSelected: false,
     isFeedbackSelected: false,
+    isMetricsSelected: false,
     isPerformanceSelected: true,
     isProfilingSelected: true,
     isReplaySelected: false,

--- a/tests/js/fixtures/project.ts
+++ b/tests/js/fixtures/project.ts
@@ -32,6 +32,7 @@ export function ProjectFixture(params: Partial<Project> = {}): Project {
     hasProfiles: false,
     hasReplays: false,
     hasFlags: false,
+    hasTraceMetrics: false,
     hasSessions: false,
     hasMonitors: false,
     hasLogs: false,


### PR DESCRIPTION
### Summary
This makes use of the hasTraceMetrics flag to properly show onboarding or not, but does not actually include the onboarding steps (which can be added later by us or the sdk maintainers).

