### PR TITLE
Fix: support callout wording in subscription footer

### DIFF
--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -7,7 +7,6 @@ import {Text} from 'sentry/components/core/text';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconSupport} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -328,13 +327,14 @@ function Overview({location, subscription, promotionData}: Props) {
         border="primary"
       >
         <Flex align="center" gap="sm">
-          <IconSupport />
           <Text bold>{t('Having trouble?')}</Text>
         </Flex>
         <Text>
-          {tct('Reach out to [supportLink], or vent to a real human on [discordLink]', {
+          {tct('Reach out to our [supportLink], or join us on [discordLink]', {
             supportLink: (
-              <ExternalLink href="https://support.sentry.io">{t('Support')}</ExternalLink>
+              <ExternalLink href="https://support.sentry.io">
+                {t('Support team')}
+              </ExternalLink>
             ),
             discordLink: (
               <ExternalLink href="https://discord.com/invite/sentry">


### PR DESCRIPTION
Quick fix to change the wording in the support callout in subscriptions

Before:
<img width="459" height="77" alt="image" src="https://github.com/user-attachments/assets/ec23e22e-c165-4458-880c-6e735ae741c6" />

After:
<img width="417" height="89" alt="image" src="https://github.com/user-attachments/assets/438e82ef-3e79-41ef-935c-446ae2cb1143" />
