### PR TITLE
feat(tracemetrics): Add accordion expansion to table rows

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricTraceDetail.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTraceDetail.tsx
@@ -1,0 +1,20 @@
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+export function useMetricTraceDetail(props: {
+  metricId: string;
+  projectId: string;
+  traceId: string;
+  enabled?: boolean;
+}) {
+  const {isReady: pageFiltersReady} = usePageFilters();
+  return useTraceItemDetails({
+    traceItemId: String(props.metricId),
+    projectId: props.projectId,
+    traceId: props.traceId,
+    traceItemType: TraceItemDataset.TRACEMETRICS,
+    referrer: 'api.explore.metric-trace-detail',
+    enabled: props.enabled && pageFiltersReady,
+  });
+}

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -27,35 +27,33 @@ export default function MetricInfoTabs({traceMetric}: MetricInfoTabsProps) {
         setAggregatesMode(mode);
       }}
     >
-      <HeaderWrapper>
-        <TabList>
-          <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
-          <TabList.Item key={Mode.SAMPLES}>{t('Samples')}</TabList.Item>
-        </TabList>
-      </HeaderWrapper>
+      <TabList>
+        <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
+        <TabList.Item key={Mode.SAMPLES}>{t('Samples')}</TabList.Item>
+      </TabList>
 
       {visualize.visible && (
         <BodyContainer>
-          <TabPanels>
+          <StyledTabPanels>
             <TabPanels.Item key={Mode.AGGREGATE}>
               <AggregatesTab metricName={traceMetric.name} />
             </TabPanels.Item>
             <TabPanels.Item key={Mode.SAMPLES}>
               <SamplesTab metricName={traceMetric.name} />
             </TabPanels.Item>
-          </TabPanels>
+          </StyledTabPanels>
         </BodyContainer>
       )}
     </TabStateProvider>
   );
 }
 
-const HeaderWrapper = styled('div')`
-  padding-bottom: ${p => p.theme.space.sm};
-`;
-
 const BodyContainer = styled('div')`
   padding: ${p => p.theme.space.md};
   padding-top: 0;
-  height: 250px;
+  height: 320px;
+`;
+
+const StyledTabPanels = styled(TabPanels)`
+  overflow: auto;
 `;

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab/index.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useRef} from 'react';
+import {Fragment, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -11,7 +11,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import LoadingMask from 'sentry/components/loadingMask';
 import type {Alignments} from 'sentry/components/tables/gridEditable/sortLink';
 import {GridBodyCell, GridHeadCell} from 'sentry/components/tables/gridEditable/styles';
-import {IconFire, IconSpan, IconTerminal} from 'sentry/icons';
+import {IconChevron, IconFire, IconSpan, IconTerminal} from 'sentry/icons';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
@@ -22,19 +22,27 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {
+  Table,
   TableBody,
   TableHead,
+  TableHeadCellContent,
   TableRow,
   TableStatus,
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {LogAttributesRendererMap} from 'sentry/views/explore/logs/fieldRenderers';
-import {getLogColors} from 'sentry/views/explore/logs/styles';
+import {
+  FirstTableHeadCell,
+  getLogColors,
+  LogFirstCellContent,
+  LogsTableBodyFirstCell,
+  StyledChevronButton,
+} from 'sentry/views/explore/logs/styles';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {SeverityLevel} from 'sentry/views/explore/logs/utils';
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
 import {useTraceTelemetry} from 'sentry/views/explore/metrics/hooks/useTraceTelemetry';
-import {Table} from 'sentry/views/explore/multiQueryMode/components/miniTable';
+import {TraceDetails} from 'sentry/views/explore/metrics/metricInfoTabs/samplesTab/traceDetails';
 import {
   useQueryParamsSortBys,
   useSetQueryParamsSortBys,
@@ -43,24 +51,21 @@ import {FieldRenderer} from 'sentry/views/explore/tables/fieldRenderer';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
-const TABLE_HEIGHT = 230;
 const RESULT_LIMIT = 50;
 const TWO_MINUTE_DELAY = 120;
+
+const METRIC_SAMPLE_COLUMNS = ['timestamp', 'value', 'trace'];
 
 interface SamplesTabProps {
   metricName: string;
 }
 
 export function SamplesTab({metricName}: SamplesTabProps) {
-  const organization = useOrganization();
-  const location = useLocation();
-  const {selection} = usePageFilters();
-
   const {result, eventView, fields} = useMetricSamplesTable({
     enabled: Boolean(metricName),
     limit: RESULT_LIMIT,
     metricName,
-    fields: ['timestamp', 'value', 'trace'],
+    fields: ['timestamp', 'trace', 'value', 'id', 'project.id'],
     ingestionDelaySeconds: TWO_MINUTE_DELAY,
   });
 
@@ -85,6 +90,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
   const tableRef = useRef<HTMLTableElement>(null);
   const {initialTableStyles} = useTableStyles(fields, tableRef, {
     minimumColumnWidth: 50,
+    prefixColumnWidth: 'min-content',
   });
 
   const meta = result.meta ?? {};
@@ -95,9 +101,108 @@ export function SamplesTab({metricName}: SamplesTabProps) {
     timestamp: t('Timestamp'),
   };
 
-  const theme = useTheme();
+  return (
+    <TableContainer>
+      {(result.isPending || isTelemetryLoading) && <TransparentLoadingMask />}
+      <StyledTable ref={tableRef} style={initialTableStyles}>
+        <TableHead>
+          <TableRow>
+            <StyledFirstTableHeadCell isFirst align="left">
+              <TableHeadCellContent isFrozen />
+            </StyledFirstTableHeadCell>
+            {METRIC_SAMPLE_COLUMNS.map((field, i) => {
+              const label = fieldLabels[field] ?? field;
+              const fieldType = meta.fields?.[field];
+              const align = fieldAlignment(field, fieldType);
 
-  const renderTraceCell = (row: any, traceId: string, telemetry: any) => {
+              const direction = sorts.find(s => s.field === field)?.kind;
+
+              function updateSort() {
+                const kind = direction === 'desc' ? 'asc' : 'desc';
+                setSorts([{field, kind}]);
+              }
+
+              return (
+                <TableHeadCell align={align} key={i} isFirst={i === 0}>
+                  <TableHeadCellContent onClick={updateSort}>
+                    <Tooltip showOnlyOnOverflow title={label}>
+                      {label}
+                    </Tooltip>
+                    {defined(direction) && (
+                      <IconArrow
+                        size="xs"
+                        direction={
+                          direction === 'desc'
+                            ? 'down'
+                            : direction === 'asc'
+                              ? 'up'
+                              : undefined
+                        }
+                      />
+                    )}
+                  </TableHeadCellContent>
+                </TableHeadCell>
+              );
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {result.isError ? (
+            <TableStatus>
+              <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+            </TableStatus>
+          ) : result.data?.length ? (
+            result.data.map((row, i) => (
+              <SampleTableRow
+                key={i}
+                row={row}
+                telemetryData={telemetryData}
+                fields={fields}
+                columns={columns}
+                meta={meta}
+              />
+            ))
+          ) : result.isPending ? (
+            <TableStatus>
+              <LoadingIndicator />
+            </TableStatus>
+          ) : (
+            <TableStatus>
+              <EmptyStateWarning>
+                <p>{t('No samples found')}</p>
+              </EmptyStateWarning>
+            </TableStatus>
+          )}
+        </TableBody>
+      </StyledTable>
+    </TableContainer>
+  );
+}
+
+function SampleTableRow({
+  row,
+  telemetryData,
+  fields,
+  columns,
+  meta,
+}: {
+  columns: any;
+  fields: string[];
+  meta: any;
+  row: any;
+  telemetryData: any;
+}) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const location = useLocation();
+  const theme = useTheme();
+  const measureRef = useRef<HTMLTableRowElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const traceId = row.trace as string;
+  const telemetry = telemetryData.get(traceId);
+
+  const renderTraceCell = () => {
     const timestamp = row.timestamp as number;
     const target = getTraceDetailsUrl({
       organization,
@@ -133,7 +238,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
     );
   };
 
-  const renderTimestampCell = (field: string, row: any, originalFieldIndex: number) => {
+  const renderTimestampCell = (field: string, originalFieldIndex: number) => {
     const customRenderer = LogAttributesRendererMap[OurLogKnownFieldKey.TIMESTAMP];
 
     if (!customRenderer) {
@@ -164,7 +269,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
     });
   };
 
-  const renderDefaultCell = (field: string, row: any, originalFieldIndex: number) => {
+  const renderDefaultCell = (field: string, originalFieldIndex: number) => {
     return (
       <FieldRenderer
         column={columns[originalFieldIndex]}
@@ -175,124 +280,78 @@ export function SamplesTab({metricName}: SamplesTabProps) {
     );
   };
 
-  const renderFieldCell = (field: string, row: any, traceId: string, telemetry: any) => {
+  const renderFieldCell = (field: string) => {
     const originalFieldIndex = fields.indexOf(field);
-
     if (originalFieldIndex === -1) {
       return null;
     }
 
     switch (field) {
       case 'trace':
-        return renderTraceCell(row, traceId, telemetry);
+        return renderTraceCell();
       case 'timestamp':
-        return renderTimestampCell(field, row, originalFieldIndex);
+        return renderTimestampCell(field, originalFieldIndex);
       default:
-        return renderDefaultCell(field, row, originalFieldIndex);
+        return renderDefaultCell(field, originalFieldIndex);
     }
   };
 
   return (
-    <TableContainer>
-      {(result.isPending || isTelemetryLoading) && <TransparentLoadingMask />}
-      <Table ref={tableRef} style={initialTableStyles} scrollable height={TABLE_HEIGHT}>
-        <TableHead>
-          <TableRow>
-            {fields.map((field, i) => {
-              const label = fieldLabels[field] ?? field;
-              const fieldType = meta.fields?.[field];
-              const align = fieldAlignment(field, fieldType);
-
-              const direction = sorts.find(s => s.field === field)?.kind;
-
-              function updateSort() {
-                const kind = direction === 'desc' ? 'asc' : 'desc';
-                setSorts([{field, kind}]);
-              }
-
-              return (
-                <TableHeadCell align={align} key={i} isFirst={i === 0}>
-                  <TableHeadCellContent align="center" gap="sm" onClick={updateSort}>
-                    <Tooltip showOnlyOnOverflow title={label}>
-                      {label}
-                    </Tooltip>
-                    {defined(direction) && (
-                      <IconArrow
-                        size="xs"
-                        direction={
-                          direction === 'desc'
-                            ? 'down'
-                            : direction === 'asc'
-                              ? 'up'
-                              : undefined
-                        }
-                      />
-                    )}
-                  </TableHeadCellContent>
-                </TableHeadCell>
-              );
-            })}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {result.isError ? (
-            <TableStatus>
-              <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
-            </TableStatus>
-          ) : result.data?.length ? (
-            result.data.map((row, i) => {
-              const traceId = row.trace as string;
-              const telemetry = telemetryData.get(traceId);
-
-              return (
-                <TableRow key={i}>
-                  {fields.map((field, j) => (
-                    <StyledTableBodyCell key={j}>
-                      {renderFieldCell(field, row, traceId, telemetry)}
-                    </StyledTableBodyCell>
-                  ))}
-                </TableRow>
-              );
-            })
-          ) : result.isPending ? (
-            <TableStatus>
-              <LoadingIndicator />
-            </TableStatus>
-          ) : (
-            <TableStatus>
-              <EmptyStateWarning>
-                <p>{t('No samples found')}</p>
-              </EmptyStateWarning>
-            </TableStatus>
-          )}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <Fragment>
+      <TableRow>
+        <LogsTableBodyFirstCell key="first">
+          <LogFirstCellContent>
+            <StyledChevronButton
+              icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
+              aria-label={t('Toggle trace details')}
+              aria-expanded={isExpanded}
+              size="zero"
+              borderless
+              onClick={() => setIsExpanded(!isExpanded)}
+            />
+          </LogFirstCellContent>
+        </LogsTableBodyFirstCell>
+        {METRIC_SAMPLE_COLUMNS.map((field, i) => (
+          <StyledTableBodyCell key={i} isFirst={i === 0}>
+            {renderFieldCell(field)}
+          </StyledTableBodyCell>
+        ))}
+      </TableRow>
+      {isExpanded && <TraceDetails dataRow={row} ref={measureRef} />}
+    </Fragment>
   );
 }
 
+const StyledTable = styled(Table)`
+  height: 100%;
+  overflow: auto;
+`;
+
 const TableContainer = styled('div')`
+  height: 100%;
   position: relative;
 `;
 
-const StyledTableBodyCell = styled(GridBodyCell)<{align?: Alignments}>`
+const StyledTableBodyCell = styled(GridBodyCell)<{align?: Alignments; isFirst?: boolean}>`
   font-size: ${p => p.theme.fontSize.sm};
   min-height: 12px;
   ${p => p.align && `justify-content: ${p.align};`}
+  ${p => p.isFirst && `padding-left: 0;`}
 `;
 
-const TableHeadCell = styled(GridHeadCell)<{align?: Alignments}>`
+const TableHeadCell = styled(GridHeadCell)<{align?: Alignments; isFirst?: boolean}>`
   ${p => p.align && `justify-content: ${p.align};`}
   font-size: ${p => p.theme.fontSize.sm};
   height: 33px;
-`;
-
-const TableHeadCellContent = styled(Flex)`
-  cursor: pointer;
-  user-select: none;
+  ${p => p.isFirst && `padding-left: 0;`}
 `;
 
 const TransparentLoadingMask = styled(LoadingMask)`
   opacity: 0.4;
   z-index: 1;
+`;
+
+const StyledFirstTableHeadCell = styled(FirstTableHeadCell)`
+  height: 100%;
+  border-right: none;
 `;

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab/index.tsx
@@ -88,7 +88,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
   const setSorts = useSetQueryParamsSortBys();
 
   const tableRef = useRef<HTMLTableElement>(null);
-  const {initialTableStyles} = useTableStyles(fields, tableRef, {
+  const {initialTableStyles} = useTableStyles(METRIC_SAMPLE_COLUMNS, tableRef, {
     minimumColumnWidth: 50,
     prefixColumnWidth: 'min-content',
   });

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab/traceDetails.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab/traceDetails.tsx
@@ -1,0 +1,87 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {EmptyStreamWrapper} from 'sentry/components/emptyStateWarning';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconWarning} from 'sentry/icons';
+import {tct} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {getShortEventId} from 'sentry/utils/events';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {LogAttributesRendererMap} from 'sentry/views/explore/logs/fieldRenderers';
+import {
+  DetailsBody,
+  DetailsContent,
+  DetailsWrapper,
+  getLogColors,
+  LogAttributeTreeWrapper,
+  LogDetailTableBodyCell,
+} from 'sentry/views/explore/logs/styles';
+import {SeverityLevel} from 'sentry/views/explore/logs/utils';
+import {useMetricTraceDetail} from 'sentry/views/explore/metrics/hooks/useMetricTraceDetail';
+
+export function TraceDetails({
+  dataRow,
+  ref,
+}: {
+  dataRow: any;
+  ref: React.RefObject<HTMLTableRowElement | null>;
+}) {
+  const theme = useTheme();
+  const location = useLocation();
+  const organization = useOrganization();
+
+  const traceDetailResult = useMetricTraceDetail({
+    metricId: String(dataRow.id ?? ''),
+    projectId: String(dataRow['project.id'] ?? ''),
+    traceId: String(dataRow.trace ?? ''),
+    enabled:
+      defined(dataRow.id) && defined(dataRow['project.id']) && defined(dataRow.trace),
+  });
+
+  const {data, isPending, isError} = traceDetailResult;
+
+  if (isError) {
+    return (
+      <DetailsWrapper ref={ref}>
+        <EmptyStreamWrapper>
+          <IconWarning color="gray300" size="lg" />
+        </EmptyStreamWrapper>
+      </DetailsWrapper>
+    );
+  }
+
+  return (
+    <DetailsWrapper ref={isPending ? undefined : ref}>
+      <LogDetailTableBodyCell colSpan={0}>
+        {isPending && <LoadingIndicator />}
+        {!isPending && data && (
+          <Fragment>
+            <DetailsContent>
+              <DetailsBody>
+                {tct('Trace: [traceId]', {traceId: getShortEventId(dataRow.trace)})}
+              </DetailsBody>
+              <LogAttributeTreeWrapper>
+                <AttributesTree
+                  attributes={data.attributes}
+                  renderers={LogAttributesRendererMap}
+                  rendererExtra={{
+                    attributeTypes: {},
+                    attributes: {},
+                    highlightTerms: [],
+                    logColors: getLogColors(SeverityLevel.INFO, theme),
+                    location,
+                    organization,
+                    theme,
+                  }}
+                />
+              </LogAttributeTreeWrapper>
+            </DetailsContent>
+          </Fragment>
+        )}
+      </LogDetailTableBodyCell>
+    </DetailsWrapper>
+  );
+}


### PR DESCRIPTION
Adds accordion-style functionality to table rows. Expanding a row fetches the rest of the trace item details for that sample and displays it underneath in the key-value tree component we use in logs.

This heavily imports a lot of logs related components at the moment that should be generalized, but I will follow that work up in another PR. I also need to update the actions to be able to add to the filters, but for now this PR focuses on adding the expanding behaviour.


https://github.com/user-attachments/assets/cc25e441-385b-4cea-8ba7-2c9550830b59

