### PR TITLE
feat(tracemetrics): Hide unnecessary attributes and allow adding to filter

### DIFF
--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -1,0 +1,30 @@
+import {
+  TraceMetricKnownFieldKey,
+  type TraceMetricFieldKey,
+} from 'sentry/views/explore/metrics/types';
+
+const AlwaysHiddenTraceMetricFields: TraceMetricFieldKey[] = [
+  TraceMetricKnownFieldKey.ID,
+  TraceMetricKnownFieldKey.ORGANIZATION_ID,
+  TraceMetricKnownFieldKey.SEVERITY_NUMBER,
+  TraceMetricKnownFieldKey.ITEM_TYPE,
+  TraceMetricKnownFieldKey.TIMESTAMP_PRECISE,
+  TraceMetricKnownFieldKey.PROJECT_ID,
+  'project_id', // these are both aliases that might show up
+];
+
+/**
+ * These are fields that should be hidden in metric details view when receiving all data from the API.
+ */
+export const HiddenTraceMetricDetailFields: TraceMetricFieldKey[] = [
+  ...AlwaysHiddenTraceMetricFields,
+  TraceMetricKnownFieldKey.SPAN_ID,
+  'sentry.span_id',
+
+  // deprecated/otel fields that clutter the UI
+  TraceMetricKnownFieldKey.TIMESTAMP_NANOS,
+  'sentry.observed_timestamp_nanos',
+  'tags[sentry.trace_flags,number]',
+  'metric.name',
+  'metric.type',
+];

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab/traceDetails.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab/traceDetails.tsx
@@ -19,7 +19,9 @@ import {
   LogAttributeTreeWrapper,
   LogDetailTableBodyCell,
 } from 'sentry/views/explore/logs/styles';
+import {useLogAttributesTreeActions} from 'sentry/views/explore/logs/useLogAttributesTreeActions';
 import {SeverityLevel} from 'sentry/views/explore/logs/utils';
+import {HiddenTraceMetricDetailFields} from 'sentry/views/explore/metrics/constants';
 import {useMetricTraceDetail} from 'sentry/views/explore/metrics/hooks/useMetricTraceDetail';
 
 export function TraceDetails({
@@ -32,6 +34,7 @@ export function TraceDetails({
   const theme = useTheme();
   const location = useLocation();
   const organization = useOrganization();
+  const getActions = useLogAttributesTreeActions({embedded: false});
 
   const traceDetailResult = useMetricTraceDetail({
     metricId: String(dataRow.id ?? ''),
@@ -65,7 +68,10 @@ export function TraceDetails({
               </DetailsBody>
               <LogAttributeTreeWrapper>
                 <AttributesTree
-                  attributes={data.attributes}
+                  attributes={data.attributes.filter(
+                    attribute => !HiddenTraceMetricDetailFields.includes(attribute.name)
+                  )}
+                  getCustomActions={getActions}
                   renderers={LogAttributesRendererMap}
                   rendererExtra={{
                     attributeTypes: {},

--- a/static/app/views/explore/metrics/types.tsx
+++ b/static/app/views/explore/metrics/types.tsx
@@ -1,0 +1,53 @@
+// This enum is used to represent known fields or attributes in the metrics response.
+// Should always map to the public alias from the backend (.../search/eap/trace_metrics/attributes.py)
+// This is not an exhaustive list, it's only the fields which have special handling in the frontend
+export enum TraceMetricKnownFieldKey {
+  TRACE_ID = 'trace',
+  MESSAGE = 'message',
+  SEVERITY_NUMBER = 'severity_number',
+  SEVERITY = 'severity',
+  ORGANIZATION_ID = 'organization.id',
+  PROJECT_ID = 'project.id',
+  PROJECT = 'project',
+  SPAN_ID = 'span_id',
+  TIMESTAMP = 'timestamp',
+  TIMESTAMP_PRECISE = 'timestamp_precise',
+  OBSERVED_TIMESTAMP_PRECISE = 'observed_timestamp',
+
+  PAYLOAD_SIZE = 'payload_size',
+
+  TEMPLATE = 'message.template',
+  PARENT_SPAN_ID = 'trace.parent_span_id',
+
+  // Field renderer aliases
+  CODE_FILE_PATH = 'code.file.path',
+  CODE_LINE_NUMBER = 'tags[code.line.number,number]',
+  CODE_FUNCTION_NAME = 'code.function.name',
+
+  // SDK attributes https://develop.sentry.dev/sdk/telemetry/logs/#default-attributes
+  RELEASE = 'release',
+  SDK_NAME = 'sdk.name',
+  SDK_VERSION = 'sdk.version',
+  BROWSER_NAME = 'browser.name',
+  BROWSER_VERSION = 'browser.version',
+  USER_ID = 'user.id',
+  USER_EMAIL = 'user.email',
+  USER_NAME = 'user.name',
+  SERVER_ADDRESS = 'server.address',
+
+  // From the EAP dataset directly not using a column alias.
+  ID = 'id',
+
+  // From the EAP dataset directly not using a column alias, should be hidden.
+  ITEM_TYPE = 'sentry.item_type',
+
+  // Deprecated fields
+  TIMESTAMP_NANOS = 'sentry.timestamp_nanos',
+
+  // Replay integration
+  REPLAY_ID = 'replay_id',
+}
+
+type TraceMetricCustomFieldKey = string;
+
+export type TraceMetricFieldKey = TraceMetricCustomFieldKey | TraceMetricKnownFieldKey;


### PR DESCRIPTION
Adds some types to define fields we want to hide in the trace details UI. Also passes along the custom actions so trace detail keys can be added to the filter. The way the hook is setup for the attribute options, it works for both logs and tracemetrics use cases so I'm just reusing it for now. It should be moved to some general util in the future.

<img width="745" height="418" alt="Screenshot 2025-10-24 at 2 26 42 PM" src="https://github.com/user-attachments/assets/c40ac0cd-edea-47da-a974-654b1ee30d21" />

Closes LOGS-452