### PR TITLE
fix/ref(search-bar): Inline replace rather than merge and replace

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -1,10 +1,7 @@
 import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
 import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 
-import {
-  replaceFreeTextTokens,
-  type ReplaceTokensWithTextOnPasteAction,
-} from './useQueryBuilderState';
+import {replaceFreeTextTokens} from './useQueryBuilderState';
 
 describe('replaceFreeTextTokens', () => {
   describe('when there are free text tokens', () => {
@@ -15,7 +12,6 @@ describe('replaceFreeTextTokens', () => {
         query: string | undefined;
       };
       input: {
-        action: ReplaceTokensWithTextOnPasteAction;
         currentQuery: string;
         getFieldDefinition: () => null;
         rawSearchReplacement: string[];
@@ -26,12 +22,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there are no tokens',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: '',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: '',
@@ -44,12 +34,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when the replace raw search keys is empty',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: '',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: [],
           currentQuery: '',
@@ -62,12 +46,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when the replace raw search keys is an empty string',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: '',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: [''],
           currentQuery: '',
@@ -80,12 +58,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is no raw search replacement',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: '',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: [],
           currentQuery: `browser.name:${WildcardOperators.CONTAINS}"firefox"`,
@@ -98,12 +70,6 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there are no free text tokens',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: '',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
           currentQuery: `browser.name:${WildcardOperators.CONTAINS}"firefox"`,
@@ -116,15 +82,9 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there only valid action tokens',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'span.op:eq',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: '',
+          currentQuery: 'span.op:eq',
         },
         expected: {
           query: undefined,
@@ -134,15 +94,9 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there only space free text tokens in the action',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'span.op:eq    ',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: '',
+          currentQuery: 'span.op:eq    ',
         },
         expected: {
           query: undefined,
@@ -152,15 +106,9 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is one free text token',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'test',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: '',
+          currentQuery: 'test',
         },
         expected: {
           query: `span.description:${WildcardOperators.CONTAINS}test`,
@@ -170,15 +118,9 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is one free text token that has a space',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'test test',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: '',
+          currentQuery: 'test test',
         },
         expected: {
           query: `span.description:${WildcardOperators.CONTAINS}"test test"`,
@@ -188,15 +130,9 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is already a token present',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'test',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: 'span.op:eq',
+          currentQuery: 'span.op:eq test',
         },
         expected: {
           query: `span.op:eq span.description:${WildcardOperators.CONTAINS}test`,
@@ -206,15 +142,9 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is already a replace token present',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'test2',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: `span.description:${WildcardOperators.CONTAINS}test`,
+          currentQuery: `span.description:${WildcardOperators.CONTAINS}test test2`,
         },
         expected: {
           query: `span.description:${WildcardOperators.CONTAINS}test span.description:${WildcardOperators.CONTAINS}test2`,
@@ -224,15 +154,9 @@ describe('replaceFreeTextTokens', () => {
       {
         description: 'when there is already a replace token present with a space',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'other value',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: `span.description:${WildcardOperators.CONTAINS}test`,
+          currentQuery: `span.description:${WildcardOperators.CONTAINS}test other value`,
         },
         expected: {
           query: `span.description:${WildcardOperators.CONTAINS}test span.description:${WildcardOperators.CONTAINS}"other value"`,
@@ -243,15 +167,9 @@ describe('replaceFreeTextTokens', () => {
         description:
           'when there is already a replace token present with a different operator',
         input: {
-          action: {
-            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
-            text: 'other value',
-            tokens: [],
-            focusOverride: undefined,
-          },
           getFieldDefinition: () => null,
           rawSearchReplacement: ['span.description'],
-          currentQuery: `span.description:test`,
+          currentQuery: `span.description:test other value`,
         },
         expected: {
           query: `span.description:test span.description:${WildcardOperators.CONTAINS}"other value"`,
@@ -262,10 +180,9 @@ describe('replaceFreeTextTokens', () => {
 
     it.each(testCases)('$description', ({input, expected}) => {
       const result = replaceFreeTextTokens(
-        input.action,
+        input.currentQuery,
         input.getFieldDefinition,
-        input.rawSearchReplacement,
-        input.currentQuery
+        input.rawSearchReplacement
       );
 
       expect(result?.newQuery).toBe(expected.query);

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -217,8 +217,8 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: `span.description:${WildcardOperators.CONTAINS}test`,
         },
         expected: {
-          query: `span.description:${WildcardOperators.CONTAINS}[test,test2]`,
-          focusOverride: {itemKey: 'freeText:1'},
+          query: `span.description:${WildcardOperators.CONTAINS}test span.description:${WildcardOperators.CONTAINS}test2`,
+          focusOverride: {itemKey: 'freeText:2'},
         },
       },
       {
@@ -235,8 +235,8 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: `span.description:${WildcardOperators.CONTAINS}test`,
         },
         expected: {
-          query: `span.description:${WildcardOperators.CONTAINS}[test,"other value"]`,
-          focusOverride: {itemKey: 'freeText:1'},
+          query: `span.description:${WildcardOperators.CONTAINS}test span.description:${WildcardOperators.CONTAINS}"other value"`,
+          focusOverride: {itemKey: 'freeText:2'},
         },
       },
       {

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -135,7 +135,7 @@ type UpdateFreeTextActionOnColon = {
   focusOverride?: FocusOverride;
 };
 
-export type ReplaceTokensWithTextOnPasteAction = {
+type ReplaceTokensWithTextOnPasteAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE';

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4344,7 +4344,12 @@ describe('SearchQueryBuilder', () => {
           // Should have tokenized the pasted text
           expect(
             screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}[test,randomValue]`,
+              name: `span.description:${WildcardOperators.CONTAINS}test`,
+            })
+          ).toBeInTheDocument();
+          expect(
+            screen.getByRole('row', {
+              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
             })
           ).toBeInTheDocument();
           // Focus should be at the end of the pasted text

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4429,6 +4429,49 @@ describe('SearchQueryBuilder', () => {
           expect(getLastInput()).toHaveFocus();
         });
       });
+
+      describe('selecting from filter key suggestions', () => {
+        beforeEach(() => {
+          MockApiClient.addMockResponse({
+            url: '/organizations/org-slug/recent-searches/',
+            body: [{query: 'a or b'}, {query: 'some recent query'}],
+          });
+        });
+
+        it('should replace the raw search key with the defined key:value', async () => {
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery=""
+              recentSearches={SavedSearchType.ISSUE}
+              replaceRawSearchKeys={['span.description']}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          await userEvent.click(getLastInput());
+
+          const aOrBOption = await screen.findByRole('option', {name: 'a or b'});
+          expect(aOrBOption).toBeInTheDocument();
+
+          await userEvent.hover(aOrBOption);
+          await userEvent.keyboard('{enter}{enter}');
+
+          expect(
+            await screen.findByRole('row', {
+              name: `span.description:${WildcardOperators.CONTAINS}a`,
+            })
+          ).toBeInTheDocument();
+
+          expect(await screen.findByRole('row', {name: 'OR'})).toBeInTheDocument();
+
+          expect(
+            await screen.findByRole('row', {
+              name: `span.description:${WildcardOperators.CONTAINS}b`,
+            })
+          ).toBeInTheDocument();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This PR is an attempt to fix an issue @malwilley found when selecting `a or b`, by inline replacing rather than trying to merge and replace values.

These changes remove the merging of all raw text values, as that would get into some strange behavior if users were building a complex query with parens or conditional operators.

Example:

Before:

https://github.com/user-attachments/assets/a9374ff9-a942-430e-995a-e209a54df624

After:

https://github.com/user-attachments/assets/90c25a0b-8c99-4f49-8128-1665b0fe604a