### PR TITLE
feat(tracemetrics): Add internal ingest at as datetime

### DIFF
--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -165,6 +165,12 @@ function TimestampRenderer(props: LogFieldRendererProps) {
   );
 }
 
+function InternalIngestedAtRenderer(props: LogFieldRendererProps) {
+  const ingestedAt =
+    props.extra.attributes[OurLogKnownFieldKey.INTERNAL_ONLY_INGESTED_AT];
+  return <DateTime seconds milliseconds date={new Date(Number(ingestedAt))} />;
+}
+
 function RelativeTimestampRenderer(props: LogFieldRendererProps) {
   const preciseTimestamp = props.extra.attributes[OurLogKnownFieldKey.TIMESTAMP_PRECISE];
   const startTimestampMs = props.extra.timestampRelativeTo!;
@@ -637,6 +643,7 @@ export const LogAttributesRendererMap: Record<
     }
     return TimestampRenderer(props);
   },
+  [OurLogKnownFieldKey.INTERNAL_ONLY_INGESTED_AT]: InternalIngestedAtRenderer,
   [OurLogKnownFieldKey.SEVERITY]: SeverityTextRenderer,
   [OurLogKnownFieldKey.MESSAGE]: LogBodyRenderer,
   [OurLogKnownFieldKey.TRACE_ID]: TraceIDRenderer,

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -58,6 +58,9 @@ export enum OurLogKnownFieldKey {
 
   // Replay integration
   REPLAY_ID = 'replay_id',
+
+  // INTERNAL only (these only appear for staff)
+  INTERNAL_ONLY_INGESTED_AT = 'tags[sentry._internal.ingested_at,number]',
 }
 
 export type OurLogFieldKey = OurLogCustomFieldKey | OurLogKnownFieldKey;


### PR DESCRIPTION
This just adds the renderer so it can be more easily compared to the occurred etc. when looking into ingestion delays.


