### PR TITLE
chore(aci): Remove uses of workflow_engine.use_cohort_selection

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_schedule.py
+++ b/tests/sentry/workflow_engine/processors/test_schedule.py
@@ -95,42 +95,6 @@ class ProcessBufferedWorkflowsTest(CreateEventTestCase):
         # Should still contain our project
         assert project.id in all_project_ids
 
-    @override_options(
-        {"delayed_workflow.rollout": True, "workflow_engine.use_cohort_selection": False}
-    )
-    @patch("sentry.workflow_engine.processors.schedule.process_in_batches")
-    def test_processes_all_projects_without_cohort_selection(
-        self, mock_process_in_batches: MagicMock
-    ) -> None:
-        """Test that all projects are processed when cohort selection is disabled."""
-        project = self.create_project()
-        project_two = self.create_project()
-        group = self.create_group(project)
-        group_two = self.create_group(project_two)
-
-        # Push data to buffer
-        self.batch_client.for_project(project.id).push_to_hash(
-            batch_key=None,
-            data={f"345:{group.id}": json.dumps({"event_id": "event-1"})},
-        )
-        self.batch_client.for_project(project_two.id).push_to_hash(
-            batch_key=None,
-            data={f"345:{group_two.id}": json.dumps({"event_id": "event-2"})},
-        )
-
-        # Add projects to sorted set
-        self.batch_client.add_project_ids([project.id, project_two.id])
-
-        process_buffered_workflows(self.batch_client)
-
-        # All projects should be processed (no cohort filtering)
-        assert mock_process_in_batches.call_count == 2
-
-        # Verify that the buffer keys are cleaned up
-        fetch_time = datetime.now().timestamp()
-        all_project_ids = self.batch_client.get_project_ids(min=0, max=fetch_time)
-        assert all_project_ids == {}
-
 
 class ProcessInBatchesTest(CreateEventTestCase):
     def setUp(self) -> None:
@@ -542,15 +506,6 @@ class TestChosenProjects:
                 raise RuntimeError("Processing failed")
 
         mock_buffer_client.persist_updates.assert_not_called()
-
-    def test_chosen_projects_without_cohort_selection(self):
-        """Test chosen_projects when project_chooser is None (cohort selection disabled)."""
-        fetch_time = 1000.0
-        all_project_ids = [1, 2, 3, 4, 5]
-
-        # When project_chooser is None, all projects should be yielded without redis interaction
-        with chosen_projects(None, fetch_time, all_project_ids) as result:
-            assert result == all_project_ids
 
 
 @override_options({"workflow_engine.scheduler.use_conditional_delete": True})


### PR DESCRIPTION
It has always been True, and at this point we'd get misbehavior if we let it be set to False.