### PR TITLE
fix(dashboards): drill down flow flag always returns false

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -929,7 +929,8 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         """
 
         organization = self.context["organization"]
-        if not features.has("organizations:dashboards-drilldown-flow", organization):
+        user = self.context["request"].user
+        if not features.has("organizations:dashboards-drilldown-flow", organization, actor=user):
             return
 
         with sentry_sdk.start_span(


### PR DESCRIPTION
I think this flag check was always returning false because we didn't provide user context, and the flag is conditional on the user.