### PR TITLE
ref(uptime): move uptime helper functions to utility file

### DIFF
--- a/src/sentry/uptime/autodetect/result_handler.py
+++ b/src/sentry/uptime/autodetect/result_handler.py
@@ -11,7 +11,6 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
 
 from sentry import audit_log
 from sentry.uptime.autodetect.notifications import send_auto_detected_notifications
-from sentry.uptime.autodetect.ranking import _get_cluster
 from sentry.uptime.autodetect.tasks import set_failed_url
 from sentry.uptime.models import UptimeSubscription, get_audit_log_data
 from sentry.uptime.subscriptions.subscriptions import (
@@ -20,6 +19,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     update_uptime_detector,
 )
 from sentry.uptime.types import UptimeMonitorMode
+from sentry.uptime.utils import get_cluster
 from sentry.utils import metrics
 from sentry.utils.audit import create_system_audit_entry
 from sentry.workflow_engine.models.detector import Detector
@@ -52,7 +52,7 @@ def handle_onboarding_result(
     metric_tags: dict[str, str],
 ) -> None:
     if result["status"] == CHECKSTATUS_FAILURE:
-        redis = _get_cluster()
+        redis = get_cluster()
         key = build_onboarding_failure_key(detector)
         pipeline = redis.pipeline()
         pipeline.incr(key)

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -18,7 +18,6 @@ from sentry.remote_subscriptions.consumers.result_consumer import (
     ResultProcessor,
     ResultsStrategyFactory,
 )
-from sentry.uptime.autodetect.ranking import _get_cluster
 from sentry.uptime.autodetect.result_handler import handle_onboarding_result
 from sentry.uptime.consumers.eap_producer import produce_eap_uptime_result
 from sentry.uptime.grouptype import UptimePacketValue
@@ -30,8 +29,6 @@ from sentry.uptime.models import (
     load_regions_for_uptime_subscription,
 )
 from sentry.uptime.subscriptions.subscriptions import (
-    build_last_seen_interval_key,
-    build_last_update_key,
     check_and_update_regions,
     disable_uptime_detector,
     remove_uptime_subscription_if_unused,
@@ -41,6 +38,7 @@ from sentry.uptime.subscriptions.tasks import (
     update_remote_uptime_subscription,
 )
 from sentry.uptime.types import UptimeMonitorMode
+from sentry.uptime.utils import build_last_seen_interval_key, build_last_update_key, get_cluster
 from sentry.utils import metrics
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
@@ -277,7 +275,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             sample_rate=1.0,
         )
 
-        cluster = _get_cluster()
+        cluster = get_cluster()
         last_update_key = build_last_update_key(detector)
         last_update_raw: str | None = cluster.get(last_update_key)
         last_update_ms = 0 if last_update_raw is None else int(last_update_raw)

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -15,8 +15,8 @@ from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.uptime.endpoints.validators import UptimeDomainCheckFailureValidator
 from sentry.uptime.models import UptimeSubscription
-from sentry.uptime.subscriptions.subscriptions import build_fingerprint
 from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, UptimeMonitorMode
+from sentry.uptime.utils import build_fingerprint
 from sentry.utils import metrics
 from sentry.workflow_engine.handlers.detector.base import DetectorOccurrence, EventData
 from sentry.workflow_engine.handlers.detector.stateful import (

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -1,7 +1,6 @@
 import logging
 from collections.abc import Sequence
 
-from django.conf import settings
 from django.db import router, transaction
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CHECKSTATUS_FAILURE,
@@ -40,7 +39,7 @@ from sentry.uptime.types import (
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
     UptimeMonitorMode,
 )
-from sentry.utils import redis
+from sentry.uptime.utils import build_fingerprint, build_last_update_key, get_cluster
 from sentry.utils.db import atomic_transaction
 from sentry.utils.not_set import NOT_SET, NotSet, default_if_not_set
 from sentry.utils.outcomes import Outcome
@@ -56,22 +55,6 @@ UPTIME_SUBSCRIPTION_TYPE = "uptime_monitor"
 MAX_AUTO_SUBSCRIPTIONS_PER_ORG = 1
 MAX_MANUAL_SUBSCRIPTIONS_PER_ORG = 100
 MAX_MONITORS_PER_DOMAIN = 100
-
-
-def build_last_update_key(detector: Detector) -> str:
-    return f"project-sub-last-update:detector:{detector.id}"
-
-
-def build_last_seen_interval_key(detector: Detector) -> str:
-    return f"project-sub-last-seen-interval:detector:{detector.id}"
-
-
-def build_detector_fingerprint_component(detector: Detector) -> str:
-    return f"uptime-detector:{detector.id}"
-
-
-def build_fingerprint(detector: Detector) -> list[str]:
-    return [build_detector_fingerprint_component(detector)]
 
 
 def resolve_uptime_issue(detector: Detector) -> None:
@@ -474,7 +457,7 @@ def disable_uptime_detector(detector: Detector, skip_quotas: bool = False):
             # start from a good state
             detector_state.update(state=DetectorPriorityLevel.OK, is_triggered=False)
 
-        cluster = redis.redis_clusters.get(settings.SENTRY_UPTIME_DETECTOR_CLUSTER)
+        cluster = get_cluster()
         last_update_key = build_last_update_key(detector)
         cluster.delete(last_update_key)
 

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from redis.client import StrictRedis
+from rediscluster import RedisCluster
+
+from sentry.utils import redis
+from sentry.workflow_engine.models.detector import Detector
+
+
+def build_last_update_key(detector: Detector) -> str:
+    return f"project-sub-last-update:detector:{detector.id}"
+
+
+def build_last_seen_interval_key(detector: Detector) -> str:
+    return f"project-sub-last-seen-interval:detector:{detector.id}"
+
+
+def build_detector_fingerprint_component(detector: Detector) -> str:
+    return f"uptime-detector:{detector.id}"
+
+
+def build_fingerprint(detector: Detector) -> list[str]:
+    return [build_detector_fingerprint_component(detector)]
+
+
+def get_cluster() -> RedisCluster | StrictRedis:
+    return redis.redis_clusters.get(settings.SENTRY_UPTIME_DETECTOR_CLUSTER)

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -75,7 +75,8 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
-from sentry.uptime.autodetect.ranking import _get_cluster, get_organization_bucket_key
+from sentry.uptime.autodetect.ranking import get_organization_bucket_key
+from sentry.uptime.utils import get_cluster
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
 from sentry.utils.cache import cache
@@ -2314,7 +2315,7 @@ class UserReportEventLinkTestMixin(BasePostProgressGroupMixin):
 class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
     def assert_organization_key(self, organization: Organization, exists: bool) -> None:
         key = get_organization_bucket_key(organization)
-        cluster = _get_cluster()
+        cluster = get_cluster()
         assert exists == cluster.sismember(key, str(organization.id))
 
     def test_uptime_detection_feature_url(self) -> None:

--- a/tests/sentry/uptime/autodetect/test_detector.py
+++ b/tests/sentry/uptime/autodetect/test_detector.py
@@ -2,13 +2,14 @@ from sentry.models.organization import Organization
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.uptime.autodetect.detector import autodetect_base_url_for_project
-from sentry.uptime.autodetect.ranking import _get_cluster, get_organization_bucket_key
+from sentry.uptime.autodetect.ranking import get_organization_bucket_key
+from sentry.uptime.utils import get_cluster
 
 
 class DetectBaseUrlForProjectTest(UptimeTestCase):
     def assert_organization_key(self, organization: Organization, exists: bool) -> None:
         key = get_organization_bucket_key(organization)
-        cluster = _get_cluster()
+        cluster = get_cluster()
         assert exists == cluster.sismember(key, str(organization.id))
 
     def test(self) -> None:

--- a/tests/sentry/uptime/autodetect/test_ranking.py
+++ b/tests/sentry/uptime/autodetect/test_ranking.py
@@ -5,7 +5,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.autodetect.ranking import (
-    _get_cluster,
     add_base_url_to_rank,
     build_org_projects_key,
     delete_candidate_urls_for_project,
@@ -17,6 +16,7 @@ from sentry.uptime.autodetect.ranking import (
     should_autodetect_for_organization,
     should_autodetect_for_project,
 )
+from sentry.uptime.utils import get_cluster
 
 
 class AddBaseUrlToRankTest(UptimeTestCase):
@@ -24,7 +24,7 @@ class AddBaseUrlToRankTest(UptimeTestCase):
         self, project: Project, count: int | None, expiry: int | None
     ) -> int | None:
         key = build_org_projects_key(project.organization)
-        cluster = _get_cluster()
+        cluster = get_cluster()
         if count is None:
             assert not cluster.zscore(key, str(project.id))
             return None
@@ -36,7 +36,7 @@ class AddBaseUrlToRankTest(UptimeTestCase):
         self, project: Project, url: str, count: int | None, expiry: int | None
     ) -> int | None:
         key = get_project_base_url_rank_key(project)
-        cluster = _get_cluster()
+        cluster = get_cluster()
         if count is None:
             assert cluster.zscore(key, url) is None
             return None
@@ -45,7 +45,7 @@ class AddBaseUrlToRankTest(UptimeTestCase):
             return self.check_expiry(key, expiry)
 
     def check_expiry(self, key: str, expiry: int | None) -> int:
-        cluster = _get_cluster()
+        cluster = get_cluster()
         ttl = cluster.ttl(key)
         if expiry is None:
             assert ttl > 0
@@ -94,7 +94,7 @@ class AddBaseUrlToRankTest(UptimeTestCase):
             url_1 = "https://sentry.io"
             url_2 = "https://sentry.sentry.io"
             url_3 = "https://santry.sentry.io"
-            cluster = _get_cluster()
+            cluster = get_cluster()
             add_base_url_to_rank(self.project, url_1)
             add_base_url_to_rank(self.project, url_1)
             add_base_url_to_rank(self.project, url_1)

--- a/tests/sentry/uptime/autodetect/test_tasks.py
+++ b/tests/sentry/uptime/autodetect/test_tasks.py
@@ -17,7 +17,6 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.uptime.autodetect.ranking import (
     NUMBER_OF_BUCKETS,
-    _get_cluster,
     add_base_url_to_rank,
     get_organization_bucket,
     get_project_base_url_rank_key,
@@ -41,6 +40,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     is_url_auto_monitored_for_project,
 )
 from sentry.uptime.types import UptimeMonitorMode
+from sentry.uptime.utils import get_cluster
 from sentry.workflow_engine.models import Detector
 
 
@@ -55,7 +55,7 @@ class ScheduleDetectionsTest(UptimeTestCase):
     def test_no_last_processed(self) -> None:
         # The first time this runs we don't expect much to happen,
         # just that it'll update the last processed date in redis
-        cluster = _get_cluster()
+        cluster = get_cluster()
         assert not cluster.get(LAST_PROCESSED_KEY)
         with mock.patch(
             "sentry.uptime.autodetect.tasks.process_autodetection_bucket"
@@ -69,7 +69,7 @@ class ScheduleDetectionsTest(UptimeTestCase):
         )
 
     def test_processes(self) -> None:
-        cluster = _get_cluster()
+        cluster = get_cluster()
         current_bucket = timezone.now().replace(second=0, microsecond=0)
         last_processed_bucket = current_bucket - timedelta(minutes=10)
         cluster.set(LAST_PROCESSED_KEY, int(last_processed_bucket.timestamp()))
@@ -181,7 +181,7 @@ class ProcessOrganizationUrlRankingTest(UptimeTestCase):
             get_project_base_url_rank_key(self.project),
             get_project_base_url_rank_key(project_2),
         ]
-        redis = _get_cluster()
+        redis = get_cluster()
         assert all(redis.exists(key) for key in keys)
 
         with mock.patch(

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -26,12 +26,9 @@ from sentry.uptime.grouptype import (
     build_evidence_display,
 )
 from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
-from sentry.uptime.subscriptions.subscriptions import (
-    build_detector_fingerprint_component,
-    build_fingerprint,
-    resolve_uptime_issue,
-)
+from sentry.uptime.subscriptions.subscriptions import resolve_uptime_issue
 from sentry.uptime.types import UptimeMonitorMode
+from sentry.uptime.utils import build_detector_fingerprint_component, build_fingerprint
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorPriorityLevel


### PR DESCRIPTION
Sorry.  But these are functions that have moved around a couple of times due to circular dependency issues, so let's just push them into their own file.  I also looked at most of the major files in uptime to see if there were any other obvious candidates to be moved here, but from what I can tell, it's relatively tidy.

(I also put back the get_cluster() call I had to inline, in a preceding PR.)
