### PR TITLE
chore(aci): Add VCD component to track performance

### DIFF
--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -24,8 +24,10 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import getDuration from 'sentry/utils/duration/getDuration';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -208,16 +210,13 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
   );
 }
 
-export default function AutomationDetail() {
-  useWorkflowEngineFeatureGate({redirect: true});
-  const params = useParams<{automationId: string}>();
-
+function AutomationDetailLoadingStates({automationId}: {automationId: string}) {
   const {
     data: automation,
     isPending,
     isError,
     refetch,
-  } = useAutomationQuery(params.automationId);
+  } = useAutomationQuery(automationId);
 
   if (isPending) {
     return <LoadingIndicator />;
@@ -228,6 +227,23 @@ export default function AutomationDetail() {
   }
 
   return <AutomationDetailContent automation={automation} />;
+}
+
+export default function AutomationDetail() {
+  useWorkflowEngineFeatureGate({redirect: true});
+  const params = useParams<{automationId: string}>();
+
+  const {data: automation, isPending} = useAutomationQuery(params.automationId);
+
+  return (
+    <VisuallyCompleteWithData
+      id="AutomationDetails-Body"
+      isLoading={isPending}
+      hasData={defined(automation)}
+    >
+      <AutomationDetailLoadingStates automationId={params.automationId} />
+    </VisuallyCompleteWithData>
+  );
 }
 
 function Actions({automation}: {automation: Automation}) {

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -11,6 +11,7 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -84,15 +85,21 @@ export default function AutomationsList() {
         <ListLayout actions={<Actions />} title={t('Alerts')}>
           <TableHeader />
           <div>
-            <AutomationListTable
-              automations={automations ?? []}
-              isPending={isLoading}
-              isError={isError}
-              isSuccess={isSuccess}
-              sort={sort}
-              queryCount={hitsInt > maxHitsInt ? `${maxHits}+` : hits}
-              allResultsVisible={allResultsVisible()}
-            />
+            <VisuallyCompleteWithData
+              hasData={(automations?.length ?? 0) > 0}
+              id="AutomationsList-Table"
+              isLoading={isLoading}
+            >
+              <AutomationListTable
+                automations={automations ?? []}
+                isPending={isLoading}
+                isError={isError}
+                isSuccess={isSuccess}
+                sort={sort}
+                queryCount={hitsInt > maxHitsInt ? `${maxHits}+` : hits}
+                allResultsVisible={allResultsVisible()}
+              />
+            </VisuallyCompleteWithData>
             <Pagination
               pageLinks={pageLinks}
               onCursor={newCursor => {

--- a/static/app/views/detectors/detail.tsx
+++ b/static/app/views/detectors/detail.tsx
@@ -3,27 +3,30 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {DetectorDetailsContent} from 'sentry/views/detectors/components/details';
 import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 
-export default function DetectorDetails() {
-  useWorkflowEngineFeatureGate({redirect: true});
-  const params = useParams<{detectorId: string}>();
-  const {projects, fetching: isFetchingProjects} = useProjects();
-
+function DetectorDetailsLoadingStates({
+  detectorId,
+  project,
+}: {
+  detectorId: string;
+  project: Project | undefined;
+}) {
   const {
     data: detector,
     isPending,
     isError,
     error,
     refetch,
-  } = useDetectorQuery(params.detectorId);
+  } = useDetectorQuery(detectorId);
 
-  const project = projects.find(p => p.id === detector?.projectId);
-
-  if (isPending || isFetchingProjects) {
+  if (isPending || !project) {
     return <LoadingIndicator />;
   }
 
@@ -44,5 +47,27 @@ export default function DetectorDetails() {
     <SentryDocumentTitle title={detector.name}>
       <DetectorDetailsContent detector={detector} project={project} />
     </SentryDocumentTitle>
+  );
+}
+
+export default function DetectorDetails() {
+  useWorkflowEngineFeatureGate({redirect: true});
+  const params = useParams<{detectorId: string}>();
+  const {projects, fetching: isFetchingProjects} = useProjects();
+
+  const {data: detector, isPending} = useDetectorQuery(params.detectorId);
+
+  const project = projects.find(p => p.id === detector?.projectId);
+
+  const isLoading = isPending || isFetchingProjects;
+
+  return (
+    <VisuallyCompleteWithData
+      hasData={defined(detector)}
+      id="DetectorDetails-Body"
+      isLoading={isLoading}
+    >
+      <DetectorDetailsLoadingStates detectorId={params.detectorId} project={project} />
+    </VisuallyCompleteWithData>
   );
 }

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -13,6 +13,7 @@ import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -109,15 +110,21 @@ export default function DetectorsList() {
         <ListLayout actions={<Actions />} title={pageTitle}>
           <TableHeader />
           <div>
-            <DetectorListTable
-              detectors={detectors ?? []}
-              isPending={isLoading}
-              isError={isError}
-              isSuccess={isSuccess}
-              sort={sort}
-              queryCount={hitsInt > maxHitsInt ? `${maxHits}+` : hits}
-              allResultsVisible={allResultsVisible()}
-            />
+            <VisuallyCompleteWithData
+              hasData={(detectors?.length ?? 0) > 0}
+              id="MonitorsList-Table"
+              isLoading={isLoading}
+            >
+              <DetectorListTable
+                detectors={detectors ?? []}
+                isPending={isLoading}
+                isError={isError}
+                isSuccess={isSuccess}
+                sort={sort}
+                queryCount={hitsInt > maxHitsInt ? `${maxHits}+` : hits}
+                allResultsVisible={allResultsVisible()}
+              />
+            </VisuallyCompleteWithData>
             <Pagination
               pageLinks={pageLinks}
               onCursor={newCursor => {


### PR DESCRIPTION
Not sure how well this works anymore, but this is the abstraction we have to better track page load times on the frontend. The main content gets wrapped in this component and sets the `init_to_vcd` tag with the length of time it took to load the main content (from app init).