### PR TITLE
chore(aci): capture nodestore request duration

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -596,7 +596,8 @@ def bulk_fetch_events(event_ids: list[str], project: Project) -> dict[str, Event
 
     bulk_data = {}
     for node_id_chunk in chunked(node_ids, EVENT_LIMIT):
-        bulk_results = fetch_retry_policy(lambda: nodestore.backend.get_multi(node_id_chunk))
+        with metrics.timer("workflow_engine.process_workflows.fetch_from_nodestore"):
+            bulk_results = fetch_retry_policy(lambda: nodestore.backend.get_multi(node_id_chunk))
         bulk_data.update(bulk_results)
 
     result: dict[str, Event] = {}


### PR DESCRIPTION
Add a timer to the nodestore request so we can create a monitor for its duration.