### PR TITLE
sentry: fix custom styles

### DIFF
--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -1,6 +1,5 @@
 import React, {Component, Fragment} from 'react';
 import {ThemeProvider} from '@emotion/react';
-import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import Cookies from 'js-cookie';
 import snakeCase from 'lodash/snakeCase';
@@ -952,10 +951,8 @@ class GSBanner extends Component<Props, State> {
 
       return (
         <Alert.Container>
-          <BannerAlert
-            system
+          <InvertedAlert
             data-test-id="banner-alert-past-due"
-            type="muted"
             trailingItems={<Badge type="warning">{t('Action Required')}</Badge>}
           >
             {billingPermissions
@@ -987,7 +984,7 @@ class GSBanner extends Component<Props, State> {
                     ),
                   }
                 )}
-          </BannerAlert>
+          </InvertedAlert>
         </Alert.Container>
       );
     }
@@ -1016,9 +1013,7 @@ class GSBanner extends Component<Props, State> {
         <React.Fragment>
           {productTrialAlerts && productTrialAlerts.length > 0 && productTrialAlerts}
           <Alert.Container>
-            <BannerAlert
-              system
-              type="muted"
+            <InvertedAlert
               trailingItems={
                 <ButtonBar>
                   <LinkButton
@@ -1061,7 +1056,7 @@ class GSBanner extends Component<Props, State> {
                         }),
                 }
               )}
-            </BannerAlert>
+            </InvertedAlert>
           </Alert.Container>
         </React.Fragment>
       );
@@ -1073,23 +1068,12 @@ class GSBanner extends Component<Props, State> {
 
 export default withPromotions(withApi(withSubscription(GSBanner, {noLoader: true})));
 
-// XXX: We have no alert types with this styling, but for now we would like for
-// it to be differentiated.
-const StyledBannerAlert = styled(Alert)`
-  color: ${p => p.theme.headerBackground};
-  background-color: ${p => p.theme.gray500};
-  border: none;
-`;
-
-function BannerAlert(props: AlertProps) {
+export function InvertedAlert(props: Omit<AlertProps, 'system' | 'type'>) {
   const invertedTheme = useInvertedTheme();
 
-  if (invertedTheme.isChonk) {
-    return (
-      <ThemeProvider theme={invertedTheme}>
-        <Alert {...props} />
-      </ThemeProvider>
-    );
-  }
-  return <StyledBannerAlert {...props} />;
+  return (
+    <ThemeProvider theme={invertedTheme}>
+      <Alert system type="info" {...props} />
+    </ThemeProvider>
+  );
 }

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -1068,7 +1068,7 @@ class GSBanner extends Component<Props, State> {
 
 export default withPromotions(withApi(withSubscription(GSBanner, {noLoader: true})));
 
-export function InvertedAlert(props: Omit<AlertProps, 'system' | 'type'>) {
+function InvertedAlert(props: Omit<AlertProps, 'system' | 'type'>) {
   const invertedTheme = useInvertedTheme();
 
   return (


### PR DESCRIPTION
**Before:**

<img width="1694" height="242" alt="CleanShot 2025-10-24 at 15 19 02@2x" src="https://github.com/user-attachments/assets/28754c95-5585-4d93-88d1-11d950ec949f" />
<img width="1692" height="230" alt="CleanShot 2025-10-24 at 15 18 56@2x" src="https://github.com/user-attachments/assets/498da67e-833f-482e-a2d1-cb4034044912" />

**After old UI: (UI2 was not impacted)**

<img width="2206" height="326" alt="CleanShot 2025-10-24 at 15 17 10@2x" src="https://github.com/user-attachments/assets/287214fa-0958-4a2d-8277-7e9ce700a16f" />
<img width="2206" height="406" alt="CleanShot 2025-10-24 at 15 16 50@2x" src="https://github.com/user-attachments/assets/230933f6-1e45-4695-ba5a-9ccc73d41d9b" />


