### PR TITLE
chore(aci): handle OrganizationMember.DoesNotExist when getting target

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -29,8 +29,12 @@ def human_desc(
     if action_type == AlertRuleTriggerAction.Type.EMAIL.value:
         if action_target:
             if target_type == AlertRuleTriggerAction.TargetType.USER.value:
+                if target is None:
+                    return "Send a notification to [removed]"
                 return "Send a notification to " + target.get_email()
             elif target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
+                if target is None:
+                    return "Send a notification to [removed]"
                 return "Send an email to members of #" + target.slug
     elif action_type == AlertRuleTriggerAction.Type.OPSGENIE.value:
         if priority:

--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -29,13 +29,11 @@ def human_desc(
     if action_type == AlertRuleTriggerAction.Type.EMAIL.value:
         if action_target:
             if target_type == AlertRuleTriggerAction.TargetType.USER.value:
-                if target is None:
-                    return "Send a notification to [removed]"
                 return "Send a notification to " + target.get_email()
             elif target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
-                if target is None:
-                    return "Send a notification to [removed]"
                 return "Send an email to members of #" + target.slug
+        else:
+            return "Send a notification to [removed]"
     elif action_type == AlertRuleTriggerAction.Type.OPSGENIE.value:
         if priority:
             return f"Send a {priority} Opsgenie notification to {target_display}"

--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
@@ -46,10 +46,14 @@ class MetricAlertRegistryHandler(LegacyRegistryHandler):
         target_type = action.config.get("target_type")
         if target_type == ActionTarget.USER.value:
             dcga = DataConditionGroupAction.objects.get(action=action)
-            return OrganizationMember.objects.get(
-                user_id=int(target_identifier),
-                organization=dcga.condition_group.organization,
-            )
+            try:
+                return OrganizationMember.objects.get(
+                    user_id=int(target_identifier),
+                    organization=dcga.condition_group.organization,
+                )
+            except OrganizationMember.DoesNotExist:
+                # user is no longer a member of the organization
+                pass
         elif target_type == ActionTarget.TEAM.value:
             try:
                 return Team.objects.get(id=int(target_identifier))


### PR DESCRIPTION
If there is no org member associated with this user and organization, then we should exit gracefully.