### PR TITLE
:sparkles: feat(github): outbound status sync

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -536,12 +536,19 @@ class GitHubBaseClient(
         endpoint = f"/repos/{repo}/issues"
         return self.post(endpoint, data=data)
 
-    def update_issue(self, repo: str, issue_number: str, assignees: list[str]) -> Any:
+    def update_issue_assignees(self, repo: str, issue_number: str, assignees: list[str]) -> Any:
         """
         https://docs.github.com/en/rest/issues/issues#update-an-issue
         """
         endpoint = f"/repos/{repo}/issues/{issue_number}"
         return self.patch(endpoint, data={"assignees": assignees})
+
+    def update_issue_status(self, repo: str, issue_number: str, status: str) -> Any:
+        """
+        https://docs.github.com/en/rest/issues/issues#update-an-issue
+        """
+        endpoint = f"/repos/{repo}/issues/{issue_number}"
+        return self.patch(endpoint, data={"state": status})
 
     def create_comment(self, repo: str, issue_id: str, data: dict[str, Any]) -> Any:
         """

--- a/src/sentry/integrations/github/types.py
+++ b/src/sentry/integrations/github/types.py
@@ -6,3 +6,13 @@ class IssueEvenntWebhookActionType(StrEnum):
     UNASSIGNED = "unassigned"
     CLOSED = "closed"
     REOPENED = "reopened"
+
+
+class GitHubIssueStatus(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"
+
+    @classmethod
+    def get_choices(cls):
+        """Return choices formatted for dropdown selectors"""
+        return [(status.value, status.value.capitalize()) for status in cls]


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Changes
  - Added `sync_status_outbound` method to automatically update GitHub issue status based on Sentry issue state changes
  - Enhanced organization configuration UI to allow per-repository status mapping configuration

**Configuration**

https://github.com/user-attachments/assets/a8c3c61f-dbdb-4823-a927-9716b8c4e651


**Demo**

https://github.com/user-attachments/assets/7c17248b-16eb-4a67-bf63-d3e553b18848




### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
