### PR TITLE
feat(tracemetrics): Add rate function for metrics

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -338,6 +338,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 return "1/second", field_type
             elif field in ["epm()", "spm()", "tpm()", "sample_epm()"]:
                 return "1/minute", field_type
+            elif field.startswith("rate(") and field.endswith(")"):
+                return "1/second", field_type
             else:
                 logger.warning(
                     "sentry.api.bases.organization_events.get_unit_and_type encountered an unknown rate type",

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -338,8 +338,10 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 return "1/second", field_type
             elif field in ["epm()", "spm()", "tpm()", "sample_epm()"]:
                 return "1/minute", field_type
-            elif field.startswith("rate(") and field.endswith(")"):
+            elif field in ["per_second()"]:
                 return "1/second", field_type
+            elif field in ["per_minute()"]:
+                return "1/minute", field_type
             else:
                 logger.warning(
                     "sentry.api.bases.organization_events.get_unit_and_type encountered an unknown rate type",

--- a/src/sentry/search/eap/trace_metrics/definitions.py
+++ b/src/sentry/search/eap/trace_metrics/definitions.py
@@ -6,11 +6,12 @@ from sentry.search.eap.trace_metrics.attributes import (
     TRACE_METRICS_ATTRIBUTE_DEFINITIONS,
     TRACE_METRICS_VIRTUAL_CONTEXTS,
 )
+from sentry.search.eap.trace_metrics.formulas import TRACE_METRICS_FORMULA_DEFINITIONS
 
 TRACE_METRICS_DEFINITIONS = ColumnDefinitions(
     aggregates=TRACE_METRICS_AGGREGATE_DEFINITIONS,
     conditional_aggregates={},
-    formulas={},
+    formulas=TRACE_METRICS_FORMULA_DEFINITIONS,
     columns=TRACE_METRICS_ATTRIBUTE_DEFINITIONS,
     contexts=TRACE_METRICS_VIRTUAL_CONTEXTS,
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_METRIC,

--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -11,9 +11,16 @@ from sentry.search.eap.columns import FormulaDefinition, ResolvedArguments, Reso
 
 def _rate_internal(divisor: int, settings: ResolverSettings) -> Column.BinaryFormula:
     """
-    Internal rate calculation function with hardcoded divisor.
+    Calculate rate per X (assumed second if not passed) for trace metrics using the value attribute.
     """
     extrapolation_mode = settings["extrapolation_mode"]
+    is_timeseries_request = settings["snuba_params"].is_timeseries_request
+
+    time_interval = (
+        settings["snuba_params"].timeseries_granularity_secs
+        if is_timeseries_request
+        else settings["snuba_params"].interval
+    )
 
     return Column.BinaryFormula(
         left=Column(
@@ -25,7 +32,7 @@ def _rate_internal(divisor: int, settings: ResolverSettings) -> Column.BinaryFor
         ),
         op=Column.BinaryFormula.OP_DIVIDE,
         right=Column(
-            literal=LiteralValue(val_double=divisor),
+            literal=LiteralValue(val_double=time_interval / divisor),
         ),
     )
 

--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -39,7 +39,7 @@ def rate(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFo
         else settings["snuba_params"].interval
     )
 
-    divisor = cast(int, args[0]) if args else 1
+    divisor = int(cast(str, args[0])) if args else 1
 
     if divisor > time_interval:
         raise InvalidSearchQuery(

--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -1,0 +1,82 @@
+from typing import cast
+
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    Function,
+)
+
+from sentry.exceptions import InvalidSearchQuery
+from sentry.search.eap.columns import (
+    FormulaDefinition,
+    ResolvedArguments,
+    ResolverSettings,
+    ValueArgumentDefinition,
+)
+
+
+def rate_divisor_validator(divisor: str) -> bool:
+    """Validate that divisor is a positive integer."""
+    try:
+        divisor_int = int(divisor)
+        return divisor_int > 0
+    except (ValueError, TypeError):
+        return False
+
+
+def rate(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+    """
+    Calculate rate per X (assumed second if not passed) for trace metrics using the value attribute.
+    """
+    extrapolation_mode = settings["extrapolation_mode"]
+    is_timeseries_request = settings["snuba_params"].is_timeseries_request
+
+    time_interval = (
+        settings["snuba_params"].timeseries_granularity_secs
+        if is_timeseries_request
+        else settings["snuba_params"].interval
+    )
+
+    divisor = cast(int, args[0]) if args else 1
+
+    if divisor > time_interval:
+        raise InvalidSearchQuery(
+            f"Divisor {divisor} cannot be greater than time interval {time_interval}"
+        )
+
+    if time_interval % divisor != 0:
+        raise InvalidSearchQuery(
+            f"Divisor {divisor} must divide evenly into time interval {time_interval}"
+        )
+
+    return Column.BinaryFormula(
+        left=Column(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_COUNT,
+                key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.value"),
+                extrapolation_mode=extrapolation_mode,
+            ),
+        ),
+        op=Column.BinaryFormula.OP_DIVIDE,
+        right=Column(
+            literal=LiteralValue(val_double=divisor),
+        ),
+    )
+
+
+TRACE_METRICS_FORMULA_DEFINITIONS = {
+    "rate": FormulaDefinition(
+        default_search_type="rate",
+        arguments=[
+            ValueArgumentDefinition(
+                argument_types={"integer"},
+                default_arg="1",
+                validator=rate_divisor_validator,
+            ),
+        ],
+        formula_resolver=rate,
+        is_aggregate=True,
+    ),
+}

--- a/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+import pytest
+
 from sentry.testutils.helpers.datetime import before_now
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
@@ -14,10 +16,10 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         self.start = self.day_ago = before_now(days=1).replace(
             hour=10, minute=0, second=0, microsecond=0
         )
-        self.end = self.start + timedelta(hours=6)
+        self.end = self.start + timedelta(hours=4)
 
     def test_simple(self) -> None:
-        metric_values = [1, 2, 3, 4, 5, 6]
+        metric_values = [1, 2, 3, 4]
 
         trace_metrics = [
             self.create_trace_metric(
@@ -45,15 +47,16 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         ]
 
     def test_per_second_function(self) -> None:
-        for i in range(6):
-            for _ in range(2):
-                self.store_trace_metrics(
-                    [
-                        self.create_trace_metric(
-                            "test_metric", 1.0, timestamp=self.start + timedelta(hours=i)
-                        )
-                    ]
+        metrics = []
+
+        # Only place events in the first bucket to save time in the test
+        for _ in range(36):
+            metrics.append(
+                self.create_trace_metric(
+                    "test_metric", 1.0, timestamp=self.start + timedelta(hours=0)
                 )
+            )
+        self.store_trace_metrics(metrics)
 
         response = self.do_request(
             {
@@ -67,7 +70,6 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         )
 
         assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 6
-        # Each bucket should have 2 events / 1 second = 2 events per second
-        for _, bucket in response.data["data"]:
-            assert bucket[0]["count"] == 2.0
+        assert len(response.data["data"]) == 4
+
+        assert response.data["data"][0][1][0]["count"] == pytest.approx(0.01, abs=0.001)

--- a/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
@@ -44,7 +44,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
             [{"count": value}] for value in metric_values
         ]
 
-    def test_rate_function(self) -> None:
+    def test_per_second_function(self) -> None:
         for i in range(6):
             for _ in range(2):
                 self.store_trace_metrics(
@@ -60,7 +60,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                 "start": self.start,
                 "end": self.end,
                 "interval": "1h",
-                "yAxis": "rate(3600)",  # 3600 seconds = 1 hour
+                "yAxis": "per_second()",
                 "project": self.project.id,
                 "dataset": self.dataset,
             }
@@ -68,6 +68,6 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
 
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 6
-        # Each bucket should have 2 events / 3600 seconds = 0.000555... events per second
+        # Each bucket should have 2 events / 1 second = 2 events per second
         for _, bucket in response.data["data"]:
-            assert abs(bucket[0]["count"] - (2 / 3600)) < 0.0001
+            assert bucket[0]["count"] == 2.0

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -72,8 +72,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        # 6 events / 60 seconds = 0.1 events per second
-        assert data[0]["per_minute()"] == 0.1
+        assert data[0]["per_minute()"] == 0.6
         assert meta["fields"]["per_minute()"] == "rate"
         assert meta["dataset"] == "tracemetrics"
 
@@ -95,7 +94,8 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        # 6 events / 1 second = 6 events per second
-        assert data[0]["per_second()"] == 6.0
+        assert (
+            data[0]["per_second()"] == 0.01
+        )  # Over ten minute period, 6 events / 600 seconds = 0.01 events per second
         assert meta["fields"]["per_second()"] == "rate"
         assert meta["dataset"] == "tracemetrics"

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -54,14 +54,14 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             },
         ]
 
-    def test_rate_formula(self) -> None:
+    def test_per_minute_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
         for _ in range(6):
             self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
 
         response = self.do_request(
             {
-                "field": ["rate(60)"],
+                "field": ["per_minute()"],
                 "query": "",
                 "project": self.project.id,
                 "dataset": self.dataset,
@@ -73,49 +73,18 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         meta = response.data["meta"]
         assert len(data) == 1
         # 6 events / 60 seconds = 0.1 events per second
-        assert data[0]["rate(60)"] == 0.1
-        assert meta["fields"]["rate(60)"] == "rate"
-        assert meta["units"]["rate(60)"] == "1/second"
+        assert data[0]["per_minute()"] == 0.1
+        assert meta["fields"]["per_minute()"] == "rate"
         assert meta["dataset"] == "tracemetrics"
 
-    def test_rate_formula_validation_divisor_too_large(self) -> None:
-        self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
-
-        # Test with divisor larger than interval (600 seconds for 10m period)
-        response = self.do_request(
-            {
-                "field": ["rate(700)"],
-                "query": "",
-                "project": self.project.id,
-                "dataset": self.dataset,
-                "statsPeriod": "10m",
-            }
-        )
-        assert response.status_code == 400, response.content
-
-    def test_rate_formula_validation_divisor_not_divisible(self) -> None:
-        self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
-
-        # Test with divisor that doesn't divide evenly into interval (600 seconds for 10m period)
-        response = self.do_request(
-            {
-                "field": ["rate(7)"],
-                "query": "",
-                "project": self.project.id,
-                "dataset": self.dataset,
-                "statsPeriod": "10m",
-            }
-        )
-        assert response.status_code == 400, response.content
-
-    def test_rate_formula_no_params(self) -> None:
+    def test_per_second_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
         for _ in range(6):
             self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
 
         response = self.do_request(
             {
-                "field": ["rate()"],
+                "field": ["per_second()"],
                 "query": "",
                 "project": self.project.id,
                 "dataset": self.dataset,
@@ -127,7 +96,6 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         meta = response.data["meta"]
         assert len(data) == 1
         # 6 events / 1 second = 6 events per second
-        assert data[0]["rate()"] == 6.0
-        assert meta["fields"]["rate()"] == "rate"
-        assert meta["units"]["rate()"] == "1/second"
+        assert data[0]["per_second()"] == 6.0
+        assert meta["fields"]["per_second()"] == "rate"
         assert meta["dataset"] == "tracemetrics"

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -53,3 +53,81 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
                 "sum(value)": 1,
             },
         ]
+
+    def test_rate_formula(self) -> None:
+        # Store 6 trace metrics over a 10 minute period
+        for _ in range(6):
+            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
+
+        response = self.do_request(
+            {
+                "field": ["rate(60)"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        # 6 events / 60 seconds = 0.1 events per second
+        assert data[0]["rate(60)"] == 0.1
+        assert meta["fields"]["rate(60)"] == "rate"
+        assert meta["units"]["rate(60)"] == "1/second"
+        assert meta["dataset"] == "tracemetrics"
+
+    def test_rate_formula_validation_divisor_too_large(self) -> None:
+        self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
+
+        # Test with divisor larger than interval (600 seconds for 10m period)
+        response = self.do_request(
+            {
+                "field": ["rate(700)"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 400, response.content
+
+    def test_rate_formula_validation_divisor_not_divisible(self) -> None:
+        self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
+
+        # Test with divisor that doesn't divide evenly into interval (600 seconds for 10m period)
+        response = self.do_request(
+            {
+                "field": ["rate(7)"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 400, response.content
+
+    def test_rate_formula_no_params(self) -> None:
+        # Store 6 trace metrics over a 10 minute period
+        for _ in range(6):
+            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
+
+        response = self.do_request(
+            {
+                "field": ["rate()"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        # 6 events / 1 second = 6 events per second
+        assert data[0]["rate()"] == 6.0
+        assert meta["fields"]["rate()"] == "rate"
+        assert meta["units"]["rate()"] == "1/second"
+        assert meta["dataset"] == "tracemetrics"


### PR DESCRIPTION
### Summary
All metrics implementations have rates. We -could- re-use eps and epm but those are likely far more limiting than people are used to for metrics. This function is experimental since we'll be using it in the open beta for metrics, we'll see if we need to change it over time.


