### PR TITLE
feat(tracemetrics): Tweak chart and table styles

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -71,11 +71,7 @@ class RetentionSettings:
 
 # This mirrors the Retentions struct in relay
 # https://github.com/getsentry/relay/blob/641e7f20cd/relay-dynamic-config/src/project.rs#L34-L45
-RETENTIONS_CONFIG_MAPPING = {
-    DataCategory.SPAN: "span",
-    DataCategory.LOG_BYTE: "log",
-    DataCategory.TRACE_METRIC: "trace_metric",
-}
+RETENTIONS_CONFIG_MAPPING = {DataCategory.SPAN: "span", DataCategory.LOG_BYTE: "log"}
 
 
 def build_metric_abuse_quotas() -> list[AbuseQuota]:

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -71,7 +71,11 @@ class RetentionSettings:
 
 # This mirrors the Retentions struct in relay
 # https://github.com/getsentry/relay/blob/641e7f20cd/relay-dynamic-config/src/project.rs#L34-L45
-RETENTIONS_CONFIG_MAPPING = {DataCategory.SPAN: "span", DataCategory.LOG_BYTE: "log"}
+RETENTIONS_CONFIG_MAPPING = {
+    DataCategory.SPAN: "span",
+    DataCategory.LOG_BYTE: "log",
+    DataCategory.TRACE_METRIC: "trace_metric",
+}
 
 
 def build_metric_abuse_quotas() -> list[AbuseQuota]:

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -105,6 +105,8 @@ function RowCell({
 const StyledPanel = styled(Panel)`
   display: grid;
   margin: 0;
+  width: 100%;
+  overflow: hidden;
 `;
 
 const StyledPanelHeader = styled('div')`
@@ -120,6 +122,9 @@ const StyledPanelHeader = styled('div')`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1 / -1;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 `;
 
 const StyledRowCell = styled(Flex)`

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -145,7 +145,7 @@ export function SeverityCircleRenderer(props: Omit<LogFieldRendererProps, 'item'
   );
 }
 
-function TimestampRenderer(props: LogFieldRendererProps) {
+export function TimestampRenderer(props: LogFieldRendererProps) {
   const preciseTimestamp = props.extra.attributes[OurLogKnownFieldKey.TIMESTAMP_PRECISE];
 
   const timestampToUse = preciseTimestamp

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -6,11 +6,10 @@ import {
 const AlwaysHiddenTraceMetricFields: TraceMetricFieldKey[] = [
   TraceMetricKnownFieldKey.ID,
   TraceMetricKnownFieldKey.ORGANIZATION_ID,
-  TraceMetricKnownFieldKey.SEVERITY_NUMBER,
   TraceMetricKnownFieldKey.ITEM_TYPE,
   TraceMetricKnownFieldKey.TIMESTAMP_PRECISE,
   TraceMetricKnownFieldKey.PROJECT_ID,
-  'project_id', // these are both aliases that might show up
+  TraceMetricKnownFieldKey.OLD_PROJECT_ID,
 ];
 
 /**
@@ -19,12 +18,21 @@ const AlwaysHiddenTraceMetricFields: TraceMetricFieldKey[] = [
 export const HiddenTraceMetricDetailFields: TraceMetricFieldKey[] = [
   ...AlwaysHiddenTraceMetricFields,
   TraceMetricKnownFieldKey.SPAN_ID,
-  'sentry.span_id',
 
   // deprecated/otel fields that clutter the UI
   TraceMetricKnownFieldKey.TIMESTAMP_NANOS,
-  'sentry.observed_timestamp_nanos',
-  'tags[sentry.trace_flags,number]',
-  'metric.name',
-  'metric.type',
+  TraceMetricKnownFieldKey.OBSERVED_TIMESTAMP_NANOS,
+  TraceMetricKnownFieldKey.TRACE_FLAGS,
+  TraceMetricKnownFieldKey.METRIC_NAME,
+  TraceMetricKnownFieldKey.METRIC_TYPE,
+];
+
+export const HiddenTraceMetricSearchFields: TraceMetricFieldKey[] = [
+  ...AlwaysHiddenTraceMetricFields,
+  TraceMetricKnownFieldKey.METRIC_NAME,
+  TraceMetricKnownFieldKey.METRIC_TYPE,
+];
+
+export const HiddenTraceMetricGroupByFields: TraceMetricFieldKey[] = [
+  ...HiddenTraceMetricSearchFields,
 ];

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {TabList, TabPanels, TabStateProvider} from 'sentry/components/core/tabs';
 import {t} from 'sentry/locale';
 import {AggregatesTab} from 'sentry/views/explore/metrics/metricInfoTabs/aggregatesTab';
+import {TabListWrapper} from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 import {SamplesTab} from 'sentry/views/explore/metrics/metricInfoTabs/samplesTab';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
@@ -26,11 +27,14 @@ export default function MetricInfoTabs({traceMetric}: MetricInfoTabsProps) {
       onChange={mode => {
         setAggregatesMode(mode);
       }}
+      size="xs"
     >
-      <TabList>
-        <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
-        <TabList.Item key={Mode.SAMPLES}>{t('Samples')}</TabList.Item>
-      </TabList>
+      <TabListWrapper>
+        <TabList>
+          <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
+          <TabList.Item key={Mode.SAMPLES}>{t('Samples')}</TabList.Item>
+        </TabList>
+      </TabListWrapper>
 
       {visualize.visible && (
         <BodyContainer>

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -1,0 +1,141 @@
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+
+import type {Alignments} from 'sentry/components/tables/gridEditable/sortLink';
+import {GridBodyCell, GridHeadCell} from 'sentry/components/tables/gridEditable/styles';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {TopResultsIndicator} from 'sentry/views/discover/table/topResultsIndicator';
+import {Table} from 'sentry/views/explore/components/table';
+import {DetailsWrapper, FirstTableHeadCell} from 'sentry/views/explore/logs/styles';
+import {StyledPanel} from 'sentry/views/explore/tables/tracesTable/styles';
+
+export const TableContainer = styled('div')`
+  height: 100%;
+  position: relative;
+`;
+
+export const StyledTableBodyCell = styled(GridBodyCell)<{
+  align?: Alignments;
+  isFirst?: boolean;
+}>`
+  font-size: ${p => p.theme.fontSize.sm};
+  min-height: 12px;
+  ${p => p.align && `justify-content: ${p.align};`}
+  ${p => p.isFirst && `padding-left: 0;`}
+`;
+
+export const TableHeadCell = styled(GridHeadCell)<{
+  align?: Alignments;
+  isFirst?: boolean;
+}>`
+  ${p => p.align && `justify-content: ${p.align};`}
+  font-size: ${p => p.theme.fontSize.sm};
+  height: 26px;
+  ${p => p.isFirst && `padding-left: 0;`}
+`;
+
+export const TabListWrapper = styled('div')`
+  padding-top: ${p => p.theme.space.sm};
+`;
+
+export const TableHeadCellContent = styled(Flex)`
+  cursor: pointer;
+  user-select: none;
+`;
+
+export const StyledTopResultsIndicator = styled(TopResultsIndicator)``;
+
+export const StyledFirstTableHeadCell = styled(FirstTableHeadCell)`
+  height: 100%;
+  border-right: none;
+`;
+
+export const StyledTable = styled(Table)`
+  height: 100%;
+  overflow-x: hidden;
+`;
+
+export const StyledSimpleTable = styled(SimpleTable)`
+  position: relative;
+  height: 100%;
+  grid-template-rows: min-content 1fr;
+`;
+
+export const TransparentLoadingMask = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${p => p.theme.backgroundSecondary};
+  opacity: 0.6;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const WrappingText = styled('div')`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  gap: ${p => p.theme.space.sm};
+  align-items: center;
+`;
+
+export const ExpandedRowContainer = styled('div')`
+  grid-column: 1 / -1;
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+`;
+
+export const StyledSimpleTableRowCell = styled(SimpleTable.RowCell)<{
+  hasPadding?: boolean;
+}>`
+  padding: ${p => (p.hasPadding ? p.theme.space.xs : 0)};
+  font-size: ${p => p.theme.fontSize.sm};
+`;
+
+export const StyledSimpleTableHeaderCell = styled(SimpleTable.HeaderCell)`
+  font-size: ${p => p.theme.fontSize.sm};
+`;
+export const StyledSimpleTableBody = styled('div')`
+  position: relative;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-auto-rows: min-content;
+  grid-column: 1 / -1;
+`;
+
+export const StyledSimpleTableHeader = styled(SimpleTable.Header)`
+  height: 33px;
+  z-index: unset;
+`;
+
+export const StickyTableRow = styled(SimpleTable.Row)<{
+  isSticky?: boolean;
+}>`
+  ${p =>
+    p.isSticky &&
+    `
+    top: 0px;
+    z-index: 1;
+    background: ${p.theme.background};
+    position: sticky;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  `}
+`;
+
+export const DetailsContent = styled(StyledPanel)`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+`;
+
+export const MetricsDetailsWrapper = styled(DetailsWrapper)`
+  border-top: 0;
+`;

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -1,60 +1,15 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
-
-import type {Alignments} from 'sentry/components/tables/gridEditable/sortLink';
-import {GridBodyCell, GridHeadCell} from 'sentry/components/tables/gridEditable/styles';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {TopResultsIndicator} from 'sentry/views/discover/table/topResultsIndicator';
-import {Table} from 'sentry/views/explore/components/table';
-import {DetailsWrapper, FirstTableHeadCell} from 'sentry/views/explore/logs/styles';
+import {DetailsWrapper} from 'sentry/views/explore/logs/styles';
 import {StyledPanel} from 'sentry/views/explore/tables/tracesTable/styles';
-
-export const TableContainer = styled('div')`
-  height: 100%;
-  position: relative;
-`;
-
-export const StyledTableBodyCell = styled(GridBodyCell)<{
-  align?: Alignments;
-  isFirst?: boolean;
-}>`
-  font-size: ${p => p.theme.fontSize.sm};
-  min-height: 12px;
-  ${p => p.align && `justify-content: ${p.align};`}
-  ${p => p.isFirst && `padding-left: 0;`}
-`;
-
-export const TableHeadCell = styled(GridHeadCell)<{
-  align?: Alignments;
-  isFirst?: boolean;
-}>`
-  ${p => p.align && `justify-content: ${p.align};`}
-  font-size: ${p => p.theme.fontSize.sm};
-  height: 26px;
-  ${p => p.isFirst && `padding-left: 0;`}
-`;
 
 export const TabListWrapper = styled('div')`
   padding-top: ${p => p.theme.space.sm};
 `;
 
-export const TableHeadCellContent = styled(Flex)`
-  cursor: pointer;
-  user-select: none;
-`;
-
 export const StyledTopResultsIndicator = styled(TopResultsIndicator)``;
-
-export const StyledFirstTableHeadCell = styled(FirstTableHeadCell)`
-  height: 100%;
-  border-right: none;
-`;
-
-export const StyledTable = styled(Table)`
-  height: 100%;
-  overflow-x: hidden;
-`;
 
 export const StyledSimpleTable = styled(SimpleTable)`
   position: relative;

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab/metricDetails.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab/metricDetails.tsx
@@ -4,17 +4,12 @@ import {useTheme} from '@emotion/react';
 import {EmptyStreamWrapper} from 'sentry/components/emptyStateWarning';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconWarning} from 'sentry/icons';
-import {tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
-import {getShortEventId} from 'sentry/utils/events';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {LogAttributesRendererMap} from 'sentry/views/explore/logs/fieldRenderers';
 import {
-  DetailsBody,
-  DetailsContent,
-  DetailsWrapper,
   getLogColors,
   LogAttributeTreeWrapper,
   LogDetailTableBodyCell,
@@ -23,8 +18,12 @@ import {useLogAttributesTreeActions} from 'sentry/views/explore/logs/useLogAttri
 import {SeverityLevel} from 'sentry/views/explore/logs/utils';
 import {HiddenTraceMetricDetailFields} from 'sentry/views/explore/metrics/constants';
 import {useMetricTraceDetail} from 'sentry/views/explore/metrics/hooks/useMetricTraceDetail';
+import {
+  DetailsContent,
+  MetricsDetailsWrapper,
+} from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 
-export function TraceDetails({
+export function MetricDetails({
   dataRow,
   ref,
 }: {
@@ -48,24 +47,21 @@ export function TraceDetails({
 
   if (isError) {
     return (
-      <DetailsWrapper ref={ref}>
+      <MetricsDetailsWrapper ref={ref}>
         <EmptyStreamWrapper>
           <IconWarning color="gray300" size="lg" />
         </EmptyStreamWrapper>
-      </DetailsWrapper>
+      </MetricsDetailsWrapper>
     );
   }
 
   return (
-    <DetailsWrapper ref={isPending ? undefined : ref}>
+    <MetricsDetailsWrapper ref={isPending ? undefined : ref}>
       <LogDetailTableBodyCell colSpan={0}>
         {isPending && <LoadingIndicator />}
         {!isPending && data && (
           <Fragment>
             <DetailsContent>
-              <DetailsBody>
-                {tct('Trace: [traceId]', {traceId: getShortEventId(dataRow.trace)})}
-              </DetailsBody>
               <LogAttributeTreeWrapper>
                 <AttributesTree
                   attributes={data.attributes.filter(
@@ -88,6 +84,6 @@ export function TraceDetails({
           </Fragment>
         )}
       </LogDetailTableBodyCell>
-    </DetailsWrapper>
+    </MetricsDetailsWrapper>
   );
 }

--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -61,6 +61,8 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
   );
 
   const hasSize = width > 0;
+  // Default split is 60% of the available width, but not less than MIN_LEFT_WIDTH.
+  const defaultSplit = Math.min(width * 0.625, width - MIN_LEFT_WIDTH);
 
   return (
     <Panel>
@@ -76,7 +78,7 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
                     queryIndex={queryIndex}
                   />
                 ),
-                default: width * 0.65,
+                default: defaultSplit,
                 min: MIN_LEFT_WIDTH,
                 max: width - MIN_RIGHT_WIDTH,
               }}

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -8,6 +8,7 @@ import {
   type TraceItemSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {createMetricNameFilter} from 'sentry/views/explore/metrics/utils';
 import {
@@ -42,12 +43,28 @@ export function Filter({traceMetric}: FilterProps) {
     query: metricNameFilter,
   });
 
+  const visibleNumberTags = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(numberTags ?? {}).filter(
+        ([key]) => !HiddenTraceMetricSearchFields.includes(key)
+      )
+    );
+  }, [numberTags]);
+
+  const visibleStringTags = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(stringTags ?? {}).filter(
+        ([key]) => !HiddenTraceMetricSearchFields.includes(key)
+      )
+    );
+  }, [stringTags]);
+
   const tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps =
     useMemo(() => {
       return {
         itemType: TraceItemDataset.TRACEMETRICS,
-        numberAttributes: numberTags ?? EMPTY_TAG_COLLECTION,
-        stringAttributes: stringTags ?? EMPTY_TAG_COLLECTION,
+        numberAttributes: visibleNumberTags ?? EMPTY_TAG_COLLECTION,
+        stringAttributes: visibleStringTags ?? EMPTY_TAG_COLLECTION,
         numberSecondaryAliases: EMPTY_ALIASES,
         stringSecondaryAliases: EMPTY_ALIASES,
         initialQuery: query,
@@ -55,7 +72,7 @@ export function Filter({traceMetric}: FilterProps) {
         searchSource: 'tracemetrics',
         namespace: traceMetric.name,
       };
-    }, [query, setQuery, numberTags, stringTags, traceMetric.name]);
+    }, [query, setQuery, visibleNumberTags, visibleStringTags, traceMetric.name]);
 
   const searchQueryBuilderProviderProps = useSearchQueryBuilderProps(
     tracesItemSearchQueryBuilderProps

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -1,8 +1,11 @@
+import {useMemo} from 'react';
+
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import type {SelectOption} from 'sentry/components/core/compactSelect/types';
 import {t} from 'sentry/locale';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 import {createMetricNameFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsGroupBys,
@@ -43,10 +46,26 @@ export function GroupBySelector({metricName}: GroupBySelectorProps) {
       query: metricNameFilter,
     });
 
+  const visibleNumberTags = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(numberTags ?? {}).filter(
+        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
+      )
+    );
+  }, [numberTags]);
+
+  const visibleStringTags = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(stringTags ?? {}).filter(
+        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
+      )
+    );
+  }, [stringTags]);
+
   const enabledOptions: Array<SelectOption<string>> = useGroupByFields({
     groupBys: [],
-    numberTags: numberTags ?? {},
-    stringTags: stringTags ?? {},
+    numberTags: visibleNumberTags ?? {},
+    stringTags: visibleStringTags ?? {},
     traceItemType: TraceItemDataset.TRACEMETRICS,
     hideEmptyOption: true,
   });

--- a/static/app/views/explore/metrics/types.tsx
+++ b/static/app/views/explore/metrics/types.tsx
@@ -4,8 +4,6 @@
 export enum TraceMetricKnownFieldKey {
   TRACE_ID = 'trace',
   MESSAGE = 'message',
-  SEVERITY_NUMBER = 'severity_number',
-  SEVERITY = 'severity',
   ORGANIZATION_ID = 'organization.id',
   PROJECT_ID = 'project.id',
   PROJECT = 'project',
@@ -14,9 +12,11 @@ export enum TraceMetricKnownFieldKey {
   TIMESTAMP_PRECISE = 'timestamp_precise',
   OBSERVED_TIMESTAMP_PRECISE = 'observed_timestamp',
 
+  METRIC_NAME = 'metric.name',
+  METRIC_TYPE = 'metric.type',
+
   PAYLOAD_SIZE = 'payload_size',
 
-  TEMPLATE = 'message.template',
   PARENT_SPAN_ID = 'trace.parent_span_id',
 
   // Field renderer aliases
@@ -43,6 +43,9 @@ export enum TraceMetricKnownFieldKey {
 
   // Deprecated fields
   TIMESTAMP_NANOS = 'sentry.timestamp_nanos',
+  OBSERVED_TIMESTAMP_NANOS = 'observed_timestamp_nanos',
+  TRACE_FLAGS = 'tags[sentry.trace_flags,number]',
+  OLD_PROJECT_ID = 'project_id',
 
   // Replay integration
   REPLAY_ID = 'replay_id',


### PR DESCRIPTION
### Summary
This updates some of the chart and table styles to give more room to visualize the metrics sample table, and improves it's accordion behaviour with position:sticky etc.

