### PR TITLE
fix(preprod): Format timezone to user prefs

### DIFF
--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -8,7 +8,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconClock, IconFile, IconJson, IconLink, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate, getUtcToSystem} from 'sentry/utils/dates';
 import {unreachable} from 'sentry/utils/unreachable';
 import {openInstallModal} from 'sentry/views/preprod/components/installModal';
 import {
@@ -71,6 +71,11 @@ interface BuildDetailsSidebarAppInfoProps {
 
 export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProps) {
   const labels = getLabels(props.appInfo.platform ?? undefined);
+
+  const datetimeFormat = getFormat({
+    seconds: true,
+    timeZone: true,
+  });
 
   return (
     <Flex direction="column" gap="xl">
@@ -135,7 +140,11 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
                 <IconClock />
               </InfoIcon>
               <Text>
-                {getFormattedDate(props.appInfo.date_added, 'MM/DD/YYYY [at] hh:mm A')}
+                {getFormattedDate(
+                  getUtcToSystem(props.appInfo.date_added),
+                  datetimeFormat,
+                  {local: true}
+                )}
               </Text>
             </Flex>
           </Tooltip>


### PR DESCRIPTION
Resolves: EME-466

Currently:
<img width="768" height="1412" alt="CleanShot 2025-10-27 at 10 19 25@2x" src="https://github.com/user-attachments/assets/1cce2020-c14f-4f68-8f71-61e3ddf0f9f1" />

After: (prefs set to UTC + 12 hour clock)
<img width="3334" height="2190" alt="CleanShot 2025-10-27 at 10 20 07@2x" src="https://github.com/user-attachments/assets/84f7319d-dbc6-41bb-b19e-e7e8b5c0d11f" />

Adjust prefs:
<img width="2242" height="700" alt="CleanShot 2025-10-27 at 10 20 42@2x" src="https://github.com/user-attachments/assets/dc324a49-6987-482d-9a4f-e44acff980ea" />

After new prefs:
<img width="3334" height="2190" alt="CleanShot 2025-10-27 at 10 20 39@2x" src="https://github.com/user-attachments/assets/28604c7d-5f97-43d0-9fd1-fedae955f8bf" />

