### PR TITLE
fix(sub v3): Correct Overview background

### DIFF
--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
@@ -180,7 +180,7 @@ function SubscriptionHeader(props: Props) {
   }
 
   return (
-    <Flex direction="column" gap="xl">
+    <Flex direction="column" gap="xl" background="secondary">
       <SentryDocumentTitle title={t('Subscription')} orgSlug={organization.slug} />
 
       <Flex


### PR DESCRIPTION
Unsure when the regression happened but at least it was a quick fix:

# before 
<img width="2561" height="1351" alt="Screenshot 2025-10-27 at 10 33 25 AM" src="https://github.com/user-attachments/assets/110f1784-5218-4570-a76f-37036ca6112a" />


# after 
<img width="2560" height="1351" alt="Screenshot 2025-10-27 at 10 33 02 AM" src="https://github.com/user-attachments/assets/c8319cc6-6e21-44be-922a-6f0e966b926f" />
