### PR TITLE
feat(projectkey): Add integration endpoint to dsn serializer

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -98,6 +98,7 @@ class ProjectKeySerializer(Serializer):
                 "crons": obj.crons_endpoint,
                 "cdn": obj.js_sdk_loader_cdn_url,
                 "playstation": obj.playstation_endpoint,
+                "integration": obj.integration_endpoint,
                 "otlp_traces": obj.otlp_traces_endpoint,
                 "otlp_logs": obj.otlp_logs_endpoint,
             },

--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -28,6 +28,7 @@ class DSN(TypedDict):
     crons: str
     cdn: str
     playstation: str
+    integration: str
     otlp_traces: str
     otlp_logs: str
 

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -18,6 +18,7 @@ KEY_RATE_LIMIT = {
         "security": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/security/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "minidump": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
+        "integration": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/",
         "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/traces",
         "otlp_logs": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/logs",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -271,7 +271,7 @@ class ProjectKey(Model):
         return f"{endpoint}/api/{self.project_id}/integration/"
 
     def build_integration_endpoint(self, integration_name: str, postfix: str = "") -> str:
-        return f"{self.integration_endpoint}/{integration_name}/{postfix}"
+        return f"{self.integration_endpoint}{integration_name}/{postfix}"
 
     @property
     def otlp_traces_endpoint(self):

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -266,16 +266,20 @@ class ProjectKey(Model):
         return f"{endpoint}/api/{self.project_id}/playstation/?sentry_key={self.public_key}"
 
     @property
-    def otlp_traces_endpoint(self):
+    def integration_endpoint(self):
         endpoint = self.get_endpoint()
+        return f"{endpoint}/api/{self.project_id}/integration/"
 
-        return f"{endpoint}/api/{self.project_id}/integration/otlp/v1/traces"
+    def build_integration_endpoint(self, integration_name: str, postfix: str = "") -> str:
+        return f"{self.integration_endpoint}/{integration_name}/{postfix}"
+
+    @property
+    def otlp_traces_endpoint(self):
+        return self.build_integration_endpoint("otlp", "v1/traces")
 
     @property
     def otlp_logs_endpoint(self):
-        endpoint = self.get_endpoint()
-
-        return f"{endpoint}/api/{self.project_id}/integration/otlp/v1/logs"
+        return self.build_integration_endpoint("otlp", "v1/logs")
 
     @property
     def unreal_endpoint(self) -> str:

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -40,6 +40,21 @@ class ListProjectKeysTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["dsn"]["playstation"] == key.playstation_endpoint
 
+    def test_integration_endpoint(self) -> None:
+        project = self.create_project()
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data[0]["dsn"]["integration"] == key.integration_endpoint
+
     def test_otlp_traces_endpoint(self) -> None:
         project = self.create_project()
         key = ProjectKey.objects.get_or_create(project=project)[0]


### PR DESCRIPTION
Alright final try at https://github.com/getsentry/sentry/pull/102083 and https://github.com/getsentry/sentry/pull/101999.

We expose the integration endpoint in the project key serializer. API consumers can build the integrations (similar to how the `build_integration_endpoint` method works) for all the integration's that we'll be exposing in Relay.

We might eventually remove the `otlp_traces_endpoint` and `otlp_logs_endpoint`, but we can explore that afterwards.