### PR TITLE
feat(explorer): Update trace query tool urls to select project if provided

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -111,8 +111,6 @@ function BlockComponent({
     selectedLinkIndexRef.current = selectedLinkIndex;
   }, [selectedLinkIndex]);
 
-  const projectSlugs = projects.map(p => ({id: String(p.id), slug: p.slug}));
-
   // Get valid tool links with their corresponding tool call indices
   const validToolLinksWithIndices = (block.tool_links || [])
     .map(link => {
@@ -120,7 +118,7 @@ function BlockComponent({
         call => link && call.function === link.kind
       );
       const canBuildUrl =
-        link && buildToolLinkUrl(link, organization.slug, projectSlugs) !== null;
+        link && buildToolLinkUrl(link, organization.slug, projects) !== null;
 
       if (toolCallIndex !== undefined && toolCallIndex >= 0 && canBuildUrl) {
         return {link, toolCallIndex};
@@ -184,7 +182,7 @@ function BlockComponent({
         const currentIndex = selectedLinkIndexRef.current;
         const selectedLink = validToolLinks[currentIndex];
         if (selectedLink) {
-          const url = buildToolLinkUrl(selectedLink, organization.slug, projectSlugs);
+          const url = buildToolLinkUrl(selectedLink, organization.slug, projects);
           if (url) {
             navigate(url);
           }
@@ -199,7 +197,7 @@ function BlockComponent({
     hasValidLinks,
     validToolLinks,
     organization.slug,
-    projectSlugs,
+    projects,
     navigate,
     onRegisterEnterHandler,
   ]);
@@ -218,7 +216,7 @@ function BlockComponent({
     // Navigate to the clicked link
     const selectedLink = validToolLinks[linkIndex];
     if (selectedLink) {
-      const url = buildToolLinkUrl(selectedLink, organization.slug, projectSlugs);
+      const url = buildToolLinkUrl(selectedLink, organization.slug, projects);
       if (url) {
         navigate(url);
         onNavigate?.();

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -195,17 +195,27 @@ export function getToolsStringFromBlock(block: Block): string[] {
  */
 export function buildToolLinkUrl(
   toolLink: ToolLink,
-  orgSlug: string
+  orgSlug: string,
+  projects?: Array<{id: string; slug: string}>
 ): LocationDescriptor | null {
   switch (toolLink.kind) {
     case 'trace_explorer_query': {
-      const {query, stats_period, y_axes, group_by, sort, mode} = toolLink.params;
+      const {query, stats_period, y_axes, group_by, sort, mode, project_slug} =
+        toolLink.params;
 
       // Transform backend params to frontend format
       const queryParams: Record<string, any> = {
         query: query || '',
         project: null,
       };
+
+      // If project_slug is provided, look up the project ID
+      if (project_slug && projects) {
+        const project = projects.find(p => p.slug === project_slug);
+        if (project) {
+          queryParams.project = project.id;
+        }
+      }
 
       const aggregateFields: any[] = [];
       if (stats_period) {


### PR DESCRIPTION
If the agent runs a query for a specific project slug, the URL navigation will now select that project as well.