### PR TITLE
fix(aci): handle condition details with no when conditions

### DIFF
--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -185,7 +185,7 @@ export const useAutomationBuilderContext = () => {
   return context;
 };
 
-export const initialAutomationBuilderState: AutomationBuilderState = {
+const initialAutomationBuilderState: AutomationBuilderState = {
   triggers: {
     id: 'when',
     logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -39,7 +39,7 @@ function ConditionsPanel({triggers, actionFilters}: ConditionsPanelProps) {
                 ?.label || t('any'),
           })}
         </ConditionGroupHeader>
-        {triggers?.conditions.map((trigger, index) => (
+        {triggers?.conditions?.map((trigger, index) => (
           <div key={index}>
             <DataConditionDetails condition={trigger} />
           </div>

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -30,26 +30,28 @@ type ConditionsPanelProps = {
 function ConditionsPanel({triggers, actionFilters}: ConditionsPanelProps) {
   return (
     <Panel>
-      {triggers && (
-        <ConditionGroupWrapper>
-          <ConditionGroupHeader>
-            {tct('[when:When] [logicType] of the following occur', {
-              when: <ConditionBadge />,
-              logicType:
-                TRIGGER_MATCH_OPTIONS.find(choice => choice.value === triggers.logicType)
-                  ?.label || triggers.logicType,
-            })}
-          </ConditionGroupHeader>
-          {triggers.conditions.map((trigger, index) => (
-            <div key={index}>
-              <DataConditionDetails condition={trigger} />
-            </div>
-          ))}
-        </ConditionGroupWrapper>
-      )}
+      <ConditionGroupWrapper>
+        <ConditionGroupHeader>
+          {tct('[when:When] [logicType] of the following occur', {
+            when: <ConditionBadge />,
+            logicType:
+              TRIGGER_MATCH_OPTIONS.find(choice => choice.value === triggers?.logicType)
+                ?.label || t('any'),
+          })}
+        </ConditionGroupHeader>
+        {triggers?.conditions.map((trigger, index) => (
+          <div key={index}>
+            <DataConditionDetails condition={trigger} />
+          </div>
+        ))}
+        {(!triggers || triggers.conditions.length === 0) && t('An event is captured')}
+      </ConditionGroupWrapper>
       {actionFilters.map((actionFilter, index) => (
         <div key={index}>
-          <ActionFilter actionFilter={actionFilter} totalFilters={actionFilters.length} />
+          <ActionFilter
+            actionFilter={actionFilter}
+            showDivider={actionFilters.length > 1}
+          />
         </div>
       ))}
     </Panel>
@@ -75,14 +77,14 @@ function findActionHandler(
 
 interface ActionFilterProps {
   actionFilter: DataConditionGroup;
-  totalFilters: number;
+  showDivider: boolean;
 }
 
-function ActionFilter({actionFilter, totalFilters}: ActionFilterProps) {
+function ActionFilter({actionFilter, showDivider}: ActionFilterProps) {
   const {data: availableActions = [], isLoading} = useAvailableActionsQuery();
 
   return (
-    <ConditionGroupWrapper showDivider={totalFilters > 1}>
+    <ConditionGroupWrapper showDivider={showDivider}>
       <ConditionGroupHeader>
         {tct('[if:If] [logicType] of these filters match', {
           if: <ConditionBadge />,

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -24,7 +24,6 @@ import {useParams} from 'sentry/utils/useParams';
 import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
 import {
   AutomationBuilderContext,
-  initialAutomationBuilderState,
   useAutomationBuilderReducer,
 } from 'sentry/views/automations/components/automationBuilderContext';
 import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
@@ -120,7 +119,11 @@ function AutomationEditForm({automation}: {automation: Automation}) {
     return {
       triggers: automation.triggers
         ? automation.triggers
-        : initialAutomationBuilderState.triggers,
+        : {
+            id: 'when',
+            logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+            conditions: [],
+          },
       actionFilters: automation.actionFilters,
     };
   }, [automation]);


### PR DESCRIPTION
we should display something even when there's no triggers. also fixed edit page where we were adding trigger conditions to existing workflows if `triggers=null`

before
<img width="344" height="201" alt="Screenshot 2025-10-27 at 11 35 29 AM" src="https://github.com/user-attachments/assets/8bb85ed4-6a4a-427a-bcd2-c284e0cdcf59" />

after
<img width="379" height="279" alt="Screenshot 2025-10-27 at 11 35 45 AM" src="https://github.com/user-attachments/assets/b4a6d39d-dc2e-428b-af50-15eb1424d49b" />
