### PR TITLE
feat(dashboards): carry forward dashboard filters when linking between dashboards

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -3,6 +3,7 @@ import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import partial from 'lodash/partial';
+import * as qs from 'query-string';
 
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
@@ -20,6 +21,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import UserMisery from 'sentry/components/userMisery';
 import Version from 'sentry/components/version';
 import {IconDownload} from 'sentry/icons';
@@ -46,6 +48,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import ViewReplayLink from 'sentry/utils/discover/viewReplayLink';
 import {getShortEventId} from 'sentry/utils/events';
+import {FieldKind} from 'sentry/utils/fields';
 import {formatRate} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {formatApdex} from 'sentry/utils/number/formatApdex';
@@ -56,7 +59,12 @@ import Projects from 'sentry/utils/projects';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {isUrl} from 'sentry/utils/string/isUrl';
 import {hasDrillDownFlowsFeature} from 'sentry/views/dashboards/hooks/useHasDrillDownFlows';
-import type {LinkedDashboard} from 'sentry/views/dashboards/types';
+import {
+  DashboardFilterKeys,
+  type DashboardFilters,
+  type GlobalFilter,
+  type Widget,
+} from 'sentry/views/dashboards/types';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
 import type {TraceItemDetailsMeta} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -1332,10 +1340,11 @@ export function getFieldRenderer(
   field: string,
   meta: MetaType,
   isAlias = true,
-  dashboardLink: LinkedDashboard | undefined = undefined
+  widget: Widget | undefined = undefined,
+  dashboardFilters: DashboardFilters | undefined = undefined
 ): FieldFormatterRenderFunctionPartial {
   const baseRenderer = getFieldRendererBase(field, meta, isAlias);
-  return wrapFieldRendererInDashboardLink(baseRenderer, dashboardLink);
+  return wrapFieldRendererInDashboardLink(baseRenderer, field, widget, dashboardFilters);
 }
 
 /**
@@ -1380,15 +1389,61 @@ function getFieldRendererBase(
 // TODO: Need to handle cases where a field already has a link in it's renderer
 function wrapFieldRendererInDashboardLink(
   renderer: FieldFormatterRenderFunctionPartial,
-  dashboardLink: LinkedDashboard | undefined
+  field: string,
+  widget: Widget | undefined = undefined,
+  dashboardFilters: DashboardFilters | undefined = undefined
 ): FieldFormatterRenderFunctionPartial {
   return function (data, baggage) {
     const {organization} = baggage;
-    if (hasDrillDownFlowsFeature(organization) && dashboardLink) {
-      // TODO: Add filters from the current dashboard to the url
-      const dashboardUrl = `/organizations/${organization.slug}/dashboard/${dashboardLink.dashboardId}/`;
+    const value = data[field];
+    const dashboardUrl = getDashboardUrl(
+      field,
+      value,
+      organization,
+      widget,
+      dashboardFilters
+    );
+    if (hasDrillDownFlowsFeature(organization) && dashboardUrl) {
       return <Link to={dashboardUrl}>{renderer(data, baggage)}</Link>;
     }
     return renderer(data, baggage);
   };
+}
+
+function getDashboardUrl(
+  field: string,
+  value: any,
+  organization: Organization,
+  widget: Widget | undefined = undefined,
+  dashboardFilters: DashboardFilters | undefined = undefined
+) {
+  if (widget?.widgetType && dashboardFilters) {
+    // Table widget only has one query
+    const dashboardLink = widget.queries[0]?.linkedDashboards?.find(
+      linkedDashboard => linkedDashboard.field === field
+    );
+    if (dashboardLink) {
+      const newTemporaryFilters: GlobalFilter[] =
+        dashboardFilters[DashboardFilterKeys.GLOBAL_FILTER] ?? [];
+
+      // Format the value as a proper filter condition string
+      const mutableSearch = new MutableSearch('');
+      const formattedValue = mutableSearch.addFilterValueList(field, [value]).toString();
+
+      newTemporaryFilters.push({
+        dataset: widget.widgetType,
+        tag: {key: field, name: field, kind: FieldKind.TAG},
+        value: formattedValue,
+      });
+      const url = `/organizations/${organization.slug}/dashboard/${dashboardLink.dashboardId}/?${qs.stringify(
+        {
+          [DashboardFilterKeys.TEMPORARY_FILTERS]: newTemporaryFilters.map(filter =>
+            JSON.stringify(filter)
+          ),
+        }
+      )}`;
+      return url;
+    }
+  }
+  return undefined;
 }

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -15,7 +15,12 @@ import {isEquation} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
-import type {DisplayType, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
+import type {
+  DashboardFilters,
+  DisplayType,
+  Widget,
+  WidgetQuery,
+} from 'sentry/views/dashboards/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {getNumEquations} from 'sentry/views/dashboards/utils';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
@@ -144,7 +149,8 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     field: string,
     meta: MetaType,
     widget?: Widget,
-    organization?: Organization
+    organization?: Organization,
+    dashboardFilters?: DashboardFilters
   ) => ReturnType<typeof getFieldRenderer>;
   /**
    * Generate field header used for mapping column

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -224,19 +224,14 @@ export const SpansConfig: DatasetConfig<
   transformTable: transformEventsResponseToTable,
   transformSeries: transformEventsResponseToSeries,
   filterAggregateParams,
-  getCustomFieldRenderer: (field, meta, widget, _organization) => {
+  getCustomFieldRenderer: (field, meta, widget, _organization, dashboardFilters) => {
     if (field === 'id') {
       return renderEventInTraceView;
     }
     if (field === 'trace') {
       return renderTraceAsLinkable(widget);
     }
-    // Dashboard links are applicable to tables, which should only have one query hence the `queries[0]`
-    const dashboardLink = widget?.queries[0]?.linkedDashboards?.find(
-      linkedDashboard => linkedDashboard.field === field
-    );
-
-    return getFieldRenderer(field, meta, false, dashboardLink);
+    return getFieldRenderer(field, meta, false, widget, dashboardFilters);
   },
 };
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -965,6 +965,7 @@ class DashboardDetail extends Component<Props, State> {
                   filters={{}} // Default Dashboards don't have filters set
                   location={location}
                   hasUnsavedChanges={false}
+                  hasTemporaryFilters={false}
                   isEditingDashboard={false}
                   isPreview={false}
                   onDashboardFilterChange={this.handleChangeFilter}

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1046,6 +1046,10 @@ class DashboardDetail extends Component<Props, State> {
       dashboardState !== DashboardState.CREATE &&
       hasUnsavedFilterChanges(dashboard, location);
 
+    const hasTemporaryFilters = defined(
+      location.query?.[DashboardFilterKeys.TEMPORARY_FILTERS]
+    );
+
     const eventView = generatePerformanceEventView(location, projects, {}, organization);
 
     const isDashboardUsingTransaction = dashboard.widgets.some(
@@ -1178,6 +1182,7 @@ class DashboardDetail extends Component<Props, State> {
                                 dashboardCreator={dashboard.createdBy}
                                 location={location}
                                 hasUnsavedChanges={!this.isEmbedded && hasUnsavedFilters}
+                                hasTemporaryFilters={hasTemporaryFilters}
                                 isEditingDashboard={
                                   dashboardState !== DashboardState.CREATE &&
                                   this.isEditingDashboard

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -170,11 +170,14 @@ export type DashboardListItem = {
 export enum DashboardFilterKeys {
   RELEASE = 'release',
   GLOBAL_FILTER = 'globalFilter',
+  // temporary filters are filters that are not saved to the dashboard, they occur when you link from one dashboard to another
+  TEMPORARY_FILTERS = 'temporaryFilters',
 }
 
 export type DashboardFilters = {
   [DashboardFilterKeys.RELEASE]?: string[];
   [DashboardFilterKeys.GLOBAL_FILTER]?: GlobalFilter[];
+  [DashboardFilterKeys.TEMPORARY_FILTERS]?: GlobalFilter[];
 };
 
 export type GlobalFilter = {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -568,9 +568,15 @@ export function getDashboardFiltersFromURL(location: Location): DashboardFilters
           })
           .filter(filter => filter !== null);
       } else if (key === DashboardFilterKeys.TEMPORARY_FILTERS) {
-        dashboardFilters[key] = queryFilters.map(filter => {
-          return JSON.parse(filter);
-        });
+        dashboardFilters[key] = queryFilters
+          .map(filter => {
+            try {
+              return JSON.parse(filter);
+            } catch (error) {
+              return null;
+            }
+          })
+          .filter(filter => filter !== null);
       } else {
         dashboardFilters[key] = queryFilters;
       }

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -567,6 +567,10 @@ export function getDashboardFiltersFromURL(location: Location): DashboardFilters
             }
           })
           .filter(filter => filter !== null);
+      } else if (key === DashboardFilterKeys.TEMPORARY_FILTERS) {
+        dashboardFilters[key] = queryFilters.map(filter => {
+          return JSON.parse(filter);
+        });
       } else {
         dashboardFilters[key] = queryFilters;
       }
@@ -581,7 +585,10 @@ export function dashboardFiltersToString(
 ): string {
   let dashboardFilterConditions = '';
 
-  const pinnedFilters = omit(dashboardFilters, DashboardFilterKeys.GLOBAL_FILTER);
+  const pinnedFilters = omit(dashboardFilters, [
+    DashboardFilterKeys.GLOBAL_FILTER,
+    DashboardFilterKeys.TEMPORARY_FILTERS,
+  ]);
   if (pinnedFilters) {
     for (const [key, activeFilters] of Object.entries(pinnedFilters)) {
       if (activeFilters.length === 1) {

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -566,7 +566,8 @@ function TableComponent({
               field,
               meta as MetaType,
               widget,
-              organization
+              organization,
+              dashboardFilters
             )!;
 
             return customRenderer;


### PR DESCRIPTION
When you link from dashboard A to dashboard B via a table, we now will carry over the global filters from A and the appropriate column filter from the table. 
1. This is done via a new `temporaryFilter` query param which are filters that aren't stored globally, but just applied via the link. 
2. When temporaryFilters are present, the save button is disabled. This may change, but for now this is the behaviour we want.