### PR TITLE
feat(settings): Add vercel log drain endpoint to project key settings

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -112,6 +112,7 @@ export type ProjectKey = {
     cdn: string;
     crons: string;
     csp: string;
+    integration: string;
     minidump: string;
     otlp_logs: string;
     otlp_traces: string;

--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -100,6 +100,7 @@ describe('LoaderScript', () => {
           crons: '',
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
+          integration: 'http://dev.getsentry.net:8000/api/1/integration/',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
           otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },
@@ -242,6 +243,7 @@ describe('LoaderScript', () => {
           crons: '',
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
+          integration: 'http://dev.getsentry.net:8000/api/1/integration/',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
           otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },

--- a/static/app/views/settings/project/projectKeys/credentials/index.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/index.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {CodeBlock} from 'sentry/components/core/code/codeBlock';
 import {ExternalLink, Link} from 'sentry/components/core/link';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
@@ -11,6 +10,8 @@ import type {ProjectKey} from 'sentry/types/project';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {OtlpTab} from 'sentry/views/settings/project/projectKeys/credentials/otlp';
+import {VercelTab} from 'sentry/views/settings/project/projectKeys/credentials/vercel';
 
 type Props = {
   data: ProjectKey;
@@ -25,140 +26,15 @@ type Props = {
   showSecretKey?: boolean;
   showSecurityEndpoint?: boolean;
   showUnreal?: boolean;
+  showVercelLogDrainEndpoint?: boolean;
 };
 
-type TabValue = 'otlp' | 'security' | 'minidump' | 'unreal' | 'credentials';
+type TabValue = 'otlp' | 'security' | 'minidump' | 'unreal' | 'vercel' | 'credentials';
 
 interface TabConfig {
   key: TabValue;
   label: string;
   visible: boolean;
-}
-
-interface OtlpTabProps {
-  logsEndpoint: string;
-  publicKey: string;
-  showOtlpLogs: boolean;
-  showOtlpTraces: boolean;
-  tracesEndpoint: string;
-}
-
-function OtlpTab({
-  logsEndpoint,
-  tracesEndpoint,
-  publicKey,
-  showOtlpLogs,
-  showOtlpTraces,
-}: OtlpTabProps) {
-  // Build the OTEL collector config example
-  const buildCollectorConfig = useMemo(() => {
-    const lines = ['exporters:', '  otlphttp:'];
-
-    if (showOtlpLogs) {
-      lines.push(`    logs_endpoint: ${logsEndpoint}`);
-    }
-
-    if (showOtlpTraces) {
-      lines.push(`    traces_endpoint: ${tracesEndpoint}`);
-    }
-
-    lines.push(
-      '    headers:',
-      `      x-sentry-auth: "sentry sentry_key=${publicKey}"`,
-      '    compression: gzip',
-      '    encoding: proto',
-      '    timeout: 30s'
-    );
-
-    return lines.join('\n');
-  }, [showOtlpLogs, showOtlpTraces, logsEndpoint, tracesEndpoint, publicKey]);
-
-  if (!showOtlpLogs && !showOtlpTraces) {
-    return undefined;
-  }
-
-  return (
-    <Fragment>
-      {showOtlpLogs && (
-        <Fragment>
-          <FieldGroup
-            label={t('OTLP Logs Endpoint')}
-            help={tct(
-              `Set this URL as your OTLP exporter's log endpoint. [link:Learn more]`,
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/#opentelemetry-logs" />
-                ),
-              }
-            )}
-            inline={false}
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('OTLP Logs Endpoint')}>
-              {logsEndpoint}
-            </TextCopyInput>
-          </FieldGroup>
-
-          <FieldGroup
-            label={t('OTLP Logs Endpoint Headers')}
-            help={t(`Set these security headers when configuring your OTLP exporter.`)}
-            inline={false}
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('OTLP Logs Endpoint Headers')}>
-              {`x-sentry-auth=sentry sentry_key=${publicKey}`}
-            </TextCopyInput>
-          </FieldGroup>
-        </Fragment>
-      )}
-
-      {showOtlpTraces && (
-        <Fragment>
-          <FieldGroup
-            label={t('OTLP Traces Endpoint')}
-            help={tct(
-              `Set this URL as your OTLP exporter's trace endpoint. [link:Learn more]`,
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/#opentelemetry-traces" />
-                ),
-              }
-            )}
-            inline={false}
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('OTLP Traces Endpoint')}>
-              {tracesEndpoint}
-            </TextCopyInput>
-          </FieldGroup>
-
-          <FieldGroup
-            label={t('OTLP Traces Endpoint Headers')}
-            help={t(`Set these security headers when configuring your OTLP exporter.`)}
-            inline={false}
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('OTLP Traces Endpoint Headers')}>
-              {`x-sentry-auth=sentry sentry_key=${publicKey}`}
-            </TextCopyInput>
-          </FieldGroup>
-        </Fragment>
-      )}
-
-      <FieldGroup
-        label={t('OpenTelemetry Collector Exporter Configuration')}
-        help={t(
-          'Use this example configuration in your OpenTelemetry Collector config file to export OTLP data to Sentry.'
-        )}
-        inline={false}
-        flexibleControlStateSize
-      >
-        <CodeBlock language="yaml" filename="config.yaml">
-          {buildCollectorConfig}
-        </CodeBlock>
-      </FieldGroup>
-    </Fragment>
-  );
 }
 
 interface SecurityTabProps {
@@ -299,6 +175,7 @@ function ProjectKeyCredentials({
   showSecretKey = false,
   showOtlpTraces = false,
   showOtlpLogs = false,
+  showVercelLogDrainEndpoint = false,
   showSecurityEndpoint = true,
   showUnreal = true,
 }: Props) {
@@ -333,12 +210,18 @@ function ProjectKeyCredentials({
         label: t('Unreal Engine'),
         visible: showUnreal,
       },
+      {
+        key: 'vercel',
+        label: t('Vercel Log Drain'),
+        visible: showVercelLogDrainEndpoint || showOtlpTraces,
+      },
     ];
     return tabs.filter(tab => tab.visible);
   }, [
     showOtlpTraces,
     showOtlpLogs,
     showSecurityEndpoint,
+    showVercelLogDrainEndpoint,
     showMinidump,
     showUnreal,
     showPublicKey,
@@ -397,6 +280,16 @@ function ProjectKeyCredentials({
             showPublicKey={showPublicKey}
             showSecretKey={showSecretKey}
             showProjectId={showProjectId}
+          />
+        );
+      case 'vercel':
+        return (
+          <VercelTab
+            showVercelLogDrainEndpoint={showVercelLogDrainEndpoint}
+            integrationEndpoint={data.dsn.integration}
+            publicKey={data.public}
+            showOtlpTraces={showOtlpTraces}
+            tracesEndpoint={data.dsn.otlp_traces}
           />
         );
       default:

--- a/static/app/views/settings/project/projectKeys/credentials/index.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/index.tsx
@@ -212,7 +212,7 @@ function ProjectKeyCredentials({
       },
       {
         key: 'vercel',
-        label: t('Vercel Log Drain'),
+        label: t('Vercel Drains'),
         visible: showVercelLogDrainEndpoint || showOtlpTraces,
       },
     ];

--- a/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
@@ -1,0 +1,134 @@
+import {Fragment, useMemo} from 'react';
+
+import {CodeBlock} from '@sentry/scraps/code';
+
+import {ExternalLink} from 'sentry/components/core/link';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t, tct} from 'sentry/locale';
+
+interface OtlpTabProps {
+  logsEndpoint: string;
+  publicKey: string;
+  showOtlpLogs: boolean;
+  showOtlpTraces: boolean;
+  tracesEndpoint: string;
+}
+
+export function OtlpTab({
+  logsEndpoint,
+  tracesEndpoint,
+  publicKey,
+  showOtlpLogs,
+  showOtlpTraces,
+}: OtlpTabProps) {
+  // Build the OTEL collector config example
+  const buildCollectorConfig = useMemo(() => {
+    const lines = ['exporters:', '  otlphttp:'];
+
+    if (showOtlpLogs) {
+      lines.push(`    logs_endpoint: ${logsEndpoint}`);
+    }
+
+    if (showOtlpTraces) {
+      lines.push(`    traces_endpoint: ${tracesEndpoint}`);
+    }
+
+    lines.push(
+      '    headers:',
+      `      x-sentry-auth: "sentry sentry_key=${publicKey}"`,
+      '    compression: gzip',
+      '    encoding: proto',
+      '    timeout: 30s'
+    );
+
+    return lines.join('\n');
+  }, [showOtlpLogs, showOtlpTraces, logsEndpoint, tracesEndpoint, publicKey]);
+
+  if (!showOtlpLogs && !showOtlpTraces) {
+    return undefined;
+  }
+
+  return (
+    <Fragment>
+      {showOtlpLogs && (
+        <Fragment>
+          <FieldGroup
+            label={t('OTLP Logs Endpoint')}
+            help={tct(
+              `Set this URL as your OTLP exporter's log endpoint. [link:Learn more]`,
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/#opentelemetry-logs" />
+                ),
+              }
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('OTLP Logs Endpoint')}>
+              {logsEndpoint}
+            </TextCopyInput>
+          </FieldGroup>
+
+          <FieldGroup
+            label={t('OTLP Logs Endpoint Headers')}
+            help={t(`Set these security headers when configuring your OTLP exporter.`)}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('OTLP Logs Endpoint Headers')}>
+              {`x-sentry-auth=sentry sentry_key=${publicKey}`}
+            </TextCopyInput>
+          </FieldGroup>
+        </Fragment>
+      )}
+
+      {showOtlpTraces && (
+        <Fragment>
+          <FieldGroup
+            label={t('OTLP Traces Endpoint')}
+            help={tct(
+              `Set this URL as your OTLP exporter's trace endpoint. [link:Learn more]`,
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/#opentelemetry-traces" />
+                ),
+              }
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('OTLP Traces Endpoint')}>
+              {tracesEndpoint}
+            </TextCopyInput>
+          </FieldGroup>
+
+          <FieldGroup
+            label={t('OTLP Traces Endpoint Headers')}
+            help={t(`Set these security headers when configuring your OTLP exporter.`)}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('OTLP Traces Endpoint Headers')}>
+              {`x-sentry-auth=sentry sentry_key=${publicKey}`}
+            </TextCopyInput>
+          </FieldGroup>
+        </Fragment>
+      )}
+
+      <FieldGroup
+        label={t('OpenTelemetry Collector Exporter Configuration')}
+        help={t(
+          'Use this example configuration in your OpenTelemetry Collector config file to export OTLP data to Sentry.'
+        )}
+        inline={false}
+        flexibleControlStateSize
+      >
+        <CodeBlock language="yaml" filename="config.yaml">
+          {buildCollectorConfig}
+        </CodeBlock>
+      </FieldGroup>
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/project/projectKeys/credentials/vercel.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/vercel.tsx
@@ -1,0 +1,95 @@
+import {Fragment} from 'react';
+
+import {ExternalLink} from 'sentry/components/core/link';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t, tct} from 'sentry/locale';
+
+interface VercelTabProps {
+  integrationEndpoint: string;
+  publicKey: string;
+  showOtlpTraces: boolean;
+  showVercelLogDrainEndpoint: boolean;
+  tracesEndpoint: string;
+}
+
+export function VercelTab({
+  showVercelLogDrainEndpoint,
+  integrationEndpoint,
+  publicKey,
+  showOtlpTraces,
+  tracesEndpoint,
+}: VercelTabProps) {
+  return (
+    <Fragment>
+      {showVercelLogDrainEndpoint && (
+        <Fragment>
+          <FieldGroup
+            label={t('Vercel Log Drain Endpoint')}
+            help={tct(
+              'Use this endpoint to configure Vercel Log Drains. [link:Learn more]',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/#log-drains" />
+                ),
+              }
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('Vercel Log Drain Endpoint')}>
+              {`${integrationEndpoint}vercel/logs`}
+            </TextCopyInput>
+          </FieldGroup>
+
+          <FieldGroup
+            label={t('Log Drain Authentication Headers')}
+            help={t(
+              'Set these authentication headers when configuring your Vercel Log Drain.'
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('Log Drain Authentication Header')}>
+              {`x-sentry-auth: sentry sentry_key=${publicKey}`}
+            </TextCopyInput>
+          </FieldGroup>
+        </Fragment>
+      )}
+      {showOtlpTraces && (
+        <Fragment>
+          <FieldGroup
+            label={t('Vercel Trace Drain Endpoint')}
+            help={tct(
+              `Set this URL as your Vercel Trace Drain Endpoint (OTLP format). [link:Learn more]`,
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/#trace-drains" />
+                ),
+              }
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('Vercel Trace Drain Endpoint')}>
+              {tracesEndpoint}
+            </TextCopyInput>
+          </FieldGroup>
+
+          <FieldGroup
+            label={t('Vercel Trace Drain Authentication Headers')}
+            help={t(
+              `Set these security headers when configuring your Vercel Trace Drain.`
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('Vercel Trace Drain Authentication Header')}>
+              {`x-sentry-auth: sentry sentry_key=${publicKey}`}
+            </TextCopyInput>
+          </FieldGroup>
+        </Fragment>
+      )}
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -22,9 +22,9 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project, ProjectKey} from 'sentry/types/project';
 import useApi from 'sentry/utils/useApi';
 import {useOTelFriendlyUI} from 'sentry/views/performance/otlp/useOTelFriendlyUI';
+import ProjectKeyCredentials from 'sentry/views/settings/project/projectKeys/credentials';
 import KeyRateLimitsForm from 'sentry/views/settings/project/projectKeys/details/keyRateLimitsForm';
 import {LoaderSettings} from 'sentry/views/settings/project/projectKeys/details/loaderSettings';
-import ProjectKeyCredentials from 'sentry/views/settings/project/projectKeys/projectKeyCredentials';
 
 type Props = {
   data: ProjectKey;
@@ -72,6 +72,9 @@ export function KeySettings({
   const showOtlpTraces =
     useOTelFriendlyUI() && organization.features.includes('relay-otlp-traces-endpoint');
   const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
+  const showVercelLogDrainEndpoint = organization.features.includes(
+    'relay-vercel-log-drain-endpoint'
+  );
 
   return (
     <Fragment>
@@ -153,6 +156,7 @@ export function KeySettings({
                   data={data}
                   showOtlpTraces={showOtlpTraces}
                   showOtlpLogs={showOtlpLogs}
+                  showVercelLogDrainEndpoint={showVercelLogDrainEndpoint}
                   showPublicKey
                   showSecretKey
                   showProjectId

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -176,6 +176,7 @@ describe('ProjectKeys', () => {
           crons: '',
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
+          integration: 'http://dev.getsentry.net:8000/api/1/integration/',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
           otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -16,8 +16,8 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project, ProjectKey} from 'sentry/types/project';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import {useOTelFriendlyUI} from 'sentry/views/performance/otlp/useOTelFriendlyUI';
+import ProjectKeyCredentials from 'sentry/views/settings/project/projectKeys/credentials';
 import {LoaderScript} from 'sentry/views/settings/project/projectKeys/list/loaderScript';
-import ProjectKeyCredentials from 'sentry/views/settings/project/projectKeys/projectKeyCredentials';
 
 type Props = {
   data: ProjectKey;
@@ -50,6 +50,9 @@ function KeyRow({
   const showOtlpTraces =
     useOTelFriendlyUI() && organization.features.includes('relay-otlp-traces-endpoint');
   const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
+  const showVercelLogDrainEndpoint = organization.features.includes(
+    'relay-vercel-log-drain-endpoint'
+  );
 
   return (
     <Panel>
@@ -104,6 +107,7 @@ function KeyRow({
             data={data}
             showOtlpTraces={showOtlpTraces}
             showOtlpLogs={showOtlpLogs}
+            showVercelLogDrainEndpoint={showVercelLogDrainEndpoint}
             showMinidump={!isJsPlatform}
             showUnreal={!isJsPlatform}
             showSecurityEndpoint={!isJsPlatform}

--- a/tests/js/fixtures/projectKeys.ts
+++ b/tests/js/fixtures/projectKeys.ts
@@ -17,6 +17,7 @@ export function ProjectKeysFixture(params: ProjectKey[] = []): ProjectKey[] {
           'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f661',
         playstation:
           'http://dev.getsentry.net:8000/api/1/playstation/?sentry_key=188ee45a58094d939428d8585aa6f661',
+        integration: 'http://dev.getsentry.net:8000/api/1/integration/',
         otlp_traces: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/traces',
         otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
       },

--- a/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
+++ b/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
@@ -77,6 +77,7 @@ export function renderWithOnboardingLayout<
         minidump: 'test-minidump',
         unreal: 'test-unreal',
         playstation: 'test-playstation',
+        integration: 'test-integration',
         otlp_traces: 'test-otlp_traces',
         otlp_logs: 'test-otlp_logs',
       }}


### PR DESCRIPTION
Cannot be merged before https://github.com/getsentry/sentry-docs/pull/15322 merges in.

This PR adds the vercel drain config to the dsn settings. This is for both traces (via OTLP) and logs (via the vercel log drain endpoint).