### PR TITLE
fix(tracemetrics): Fix denylist keys

### DIFF
--- a/src/sentry/metrics/sentry_sdk.py
+++ b/src/sentry/metrics/sentry_sdk.py
@@ -36,7 +36,8 @@ class SentrySDKMetricsBackend(MetricsBackend):
         unit: str | None = None,
         stacklevel: int = 0,
     ) -> None:
-        if not self._should_send(key):
+        full_key = self._get_key(key)
+        if not self._should_send(full_key):
             return
 
         if not self._should_sample(sample_rate):
@@ -47,7 +48,7 @@ class SentrySDKMetricsBackend(MetricsBackend):
             metric_attributes["instance"] = instance
 
         metrics.count(
-            self._get_key(key),
+            full_key,
             amount,
             unit=unit,
             attributes=metric_attributes,
@@ -74,7 +75,8 @@ class SentrySDKMetricsBackend(MetricsBackend):
         unit: str | None = None,
         stacklevel: int = 0,
     ) -> None:
-        if not self._should_send(key):
+        full_key = self._get_key(key)
+        if not self._should_send(full_key):
             return
 
         if not self._should_sample(sample_rate):
@@ -85,7 +87,7 @@ class SentrySDKMetricsBackend(MetricsBackend):
             metric_attributes["instance"] = instance
 
         metrics.gauge(
-            self._get_key(key),
+            full_key,
             value,
             unit=unit,
             attributes=metric_attributes,
@@ -101,7 +103,8 @@ class SentrySDKMetricsBackend(MetricsBackend):
         unit: str | None = None,
         stacklevel: int = 0,
     ) -> None:
-        if not self._should_send(key):
+        full_key = self._get_key(key)
+        if not self._should_send(full_key):
             return
 
         if not self._should_sample(sample_rate):
@@ -112,7 +115,7 @@ class SentrySDKMetricsBackend(MetricsBackend):
             metric_attributes["instance"] = instance
 
         metrics.distribution(
-            self._get_key(key),
+            full_key,
             value,
             unit=unit,
             attributes=metric_attributes,

--- a/tests/sentry/metrics/test_dualwrite.py
+++ b/tests/sentry/metrics/test_dualwrite.py
@@ -42,7 +42,7 @@ def test_dualwrite_experimental_backend(dogstatsd_incr, sentry_sdk_incr):
     backend = DualWriteMetricsBackend(
         primary_backend="sentry.metrics.dogstatsd.DogStatsdMetricsBackend",
         experimental_backend="sentry.metrics.sentry_sdk.SentrySDKMetricsBackend",
-        experimental_args={"deny_list": ["denied"], "experimental_sample_rate": 1.0},
+        experimental_args={"deny_list": ["sentry.denied"], "experimental_sample_rate": 1.0},
     )
 
     backend.incr("allowed", tags={"test": "tag"}, unit="none")

--- a/tests/sentry/metrics/test_sentry_sdk.py
+++ b/tests/sentry/metrics/test_sentry_sdk.py
@@ -85,7 +85,7 @@ class TestSentrySDKMetricsBackend:
     @mock.patch("sentry_sdk._metrics.count")
     def test_incr_deny_list(self, mock_count):
         backend = SentrySDKMetricsBackend(
-            prefix="test.", experimental_sample_rate=1.0, deny_list=["denied"]
+            prefix="test.", experimental_sample_rate=1.0, deny_list=["test.denied"]
         )
         backend.incr("denied.metric", amount=1)
         mock_count.assert_not_called()


### PR DESCRIPTION
This way you we can actually fix denylist keys based on their final value, not an intermediate value you have to look up

s.
