### PR TITLE
fix(events): Bail out of event-redirect snuba preprocessing

### DIFF
--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -1,23 +1,35 @@
 from collections.abc import Sequence
 
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 
 from sentry.models.groupredirect import GroupRedirect
 
 """
 Clickhouse can only handle a query of size 131072b. Our IDs are about 10b and there are
 commas & spaces, so each ID ends up ~12b in the query. That gives ~10k possible group
-IDs; we halve here both for breathing room and to ensure that we're still fine if a
-poorly-formatted query has the same list twice.
+IDs; we quarter that here both for breathing room and to ensure that we're still fine if
+a poorly-formatted query has the same list twice.
 """
-SIZE_THRESHOLD_FOR_CLICKHOUSE = 5000
+SIZE_THRESHOLD_FOR_CLICKHOUSE = 2500
+
+
+def _get_all_related_redirects_query(
+    group_ids: set[str | int],
+) -> QuerySet[GroupRedirect, tuple[int, int]]:
+    return (
+        GroupRedirect.objects.filter(
+            Q(group_id__in=group_ids) | Q(previous_group_id__in=group_ids)
+        ).values_list("group_id", "previous_group_id")
+        # This order returns the newest redirects first. i.e. we're implicitly dropping
+        # the oldest redirects if we have >THRESHOLD. We choose to drop the oldest
+        # because they're least likely to have data in retention
+        .order_by("-date_added")
+    )[:SIZE_THRESHOLD_FOR_CLICKHOUSE]
 
 
 def get_all_merged_group_ids(group_ids: Sequence[str | int]) -> set[str | int]:
     group_id_set = set(group_ids)
-    all_related_rows = GroupRedirect.objects.filter(
-        Q(group_id__in=group_id_set) | Q(previous_group_id__in=group_id_set)
-    ).values_list("group_id", "previous_group_id")
+    all_related_rows = _get_all_related_redirects_query(group_id_set)
     for r in all_related_rows:
         group_id_set.update(r)
         if len(group_id_set) > SIZE_THRESHOLD_FOR_CLICKHOUSE:

--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -4,6 +4,14 @@ from django.db.models import Q
 
 from sentry.models.groupredirect import GroupRedirect
 
+"""
+Clickhouse can only handle a query of size 131072b. Our IDs are about 10b and there are
+commas & spaces, so each ID ends up ~12b in the query. That gives ~10k possible group
+IDs; we halve here both for breathing room and to ensure that we're still fine if a
+poorly-formatted query has the same list twice.
+"""
+SIZE_THRESHOLD_FOR_CLICKHOUSE = 5000
+
 
 def get_all_merged_group_ids(group_ids: Sequence[str | int]) -> set[str | int]:
     group_id_set = set(group_ids)
@@ -12,4 +20,6 @@ def get_all_merged_group_ids(group_ids: Sequence[str | int]) -> set[str | int]:
     ).values_list("group_id", "previous_group_id")
     for r in all_related_rows:
         group_id_set.update(r)
+        if len(group_id_set) > SIZE_THRESHOLD_FOR_CLICKHOUSE:
+            return set(group_ids)
     return group_id_set

--- a/tests/sentry/services/eventstore/test_query_preprocessing.py
+++ b/tests/sentry/services/eventstore/test_query_preprocessing.py
@@ -1,5 +1,10 @@
+from datetime import UTC, datetime, timedelta
+
 from sentry.models.groupredirect import GroupRedirect
-from sentry.services.eventstore.query_preprocessing import get_all_merged_group_ids
+from sentry.services.eventstore.query_preprocessing import (
+    _get_all_related_redirects_query,
+    get_all_merged_group_ids,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_snuba
 
@@ -7,24 +12,37 @@ pytestmark = [requires_snuba]
 
 
 class TestQueryPreprocessing(TestCase):
-    def test_get_all_merged_group_ids(self) -> None:
-        g1 = self.create_group(id=1)
-        g2 = self.create_group(id=2)
-        g3 = self.create_group(id=3)
+    def setUp(self) -> None:
+        self.g1 = self.create_group(id=1)
+        self.g2 = self.create_group(id=2)
+        self.g3 = self.create_group(id=3)
         self.create_group(id=4)
 
-        GroupRedirect.objects.create(
-            organization_id=g1.project.organization_id,
-            group_id=g1.id,
-            previous_group_id=g2.id,
+        self.gr21 = GroupRedirect.objects.create(
+            organization_id=self.g1.project.organization_id,
+            group_id=self.g1.id,
+            previous_group_id=self.g2.id,
+            date_added=datetime.now(UTC) - timedelta(hours=1),
         )
-        GroupRedirect.objects.create(
-            organization_id=g1.project.organization_id,
-            group_id=g1.id,
-            previous_group_id=g3.id,
+        self.gr31 = GroupRedirect.objects.create(
+            organization_id=self.g1.project.organization_id,
+            group_id=self.g1.id,
+            previous_group_id=self.g3.id,
+            date_added=datetime.now(UTC) - timedelta(hours=4),
         )
 
-        assert get_all_merged_group_ids([g1.id]) == {g1.id, g2.id, g3.id}
-        assert get_all_merged_group_ids([g2.id]) == {g1.id, g2.id}
-        assert get_all_merged_group_ids([g3.id]) == {g1.id, g3.id}
-        assert get_all_merged_group_ids([g2.id, g3.id]) == {g1.id, g2.id, g3.id}
+    def test_get_all_related_groups_query(self) -> None:
+        """
+        What we want is for this to return the newest redirects first.
+        """
+        assert _get_all_related_redirects_query({self.g1.id})[0] == (self.g1.id, self.g2.id)
+
+    def test_get_all_merged_group_ids(self) -> None:
+        assert get_all_merged_group_ids([self.g1.id]) == {self.g1.id, self.g2.id, self.g3.id}
+        assert get_all_merged_group_ids([self.g2.id]) == {self.g1.id, self.g2.id}
+        assert get_all_merged_group_ids([self.g3.id]) == {self.g1.id, self.g3.id}
+        assert get_all_merged_group_ids([self.g2.id, self.g3.id]) == {
+            self.g1.id,
+            self.g2.id,
+            self.g3.id,
+        }


### PR DESCRIPTION
If we have too many group IDs in a snuba request then Clickhouse can't handle it. We're seeing that (RARELY) in production. Let's bail if we have too many group IDs (which is a VERY rare case). Fallback will just be original group_id, which will miss the merged groups. We can talk about the plan around those later.
