### PR TITLE
feat(replay): Catch rejections from `video.play()`

### DIFF
--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -10,6 +10,9 @@ import {VideoReplayer} from './videoReplayer';
 // advancing by 2000ms ~== 20000s in Timer, but this may depend on hardware, TBD
 jest.useFakeTimers();
 jest.spyOn(window.HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+jest
+  .spyOn(window.HTMLMediaElement.prototype, 'play')
+  .mockImplementation(() => Promise.resolve());
 
 describe('VideoReplayer - no starting gap', () => {
   beforeEach(() => {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -454,13 +454,12 @@ export class VideoReplayer {
       this.setBuffering(true);
     }
 
-    const playPromise = video.play();
-    try {
-      await playPromise;
-    } catch {
+    const playPromise = video.play().catch(() => {
       // `play()` throws lots of noisy errors that are unimportant e.g.
       // AbortError: The play() request was interrupted by a call to pause().
-    }
+    });
+
+    await playPromise;
 
     // Buffering is over after play promise is resolved
     this.setBuffering(false);

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -455,7 +455,12 @@ export class VideoReplayer {
     }
 
     const playPromise = video.play();
-    await playPromise;
+    try {
+      await playPromise;
+    } catch {
+      // `play()` throws lots of noisy errors that are unimportant e.g.
+      // AbortError: The play() request was interrupted by a call to pause().
+    }
 
     // Buffering is over after play promise is resolved
     this.setBuffering(false);


### PR DESCRIPTION
For mobile replays, they are video and may be throwing this (could also happen in web replays if we record `<video>` elements).

Fixes JAVASCRIPT-2NXM
