### PR TITLE
feat(logs): Add alert for partial timeseries and full table scans

### DIFF
--- a/static/app/views/explore/logs/logsDownsamplingAlert.tsx
+++ b/static/app/views/explore/logs/logsDownsamplingAlert.tsx
@@ -1,0 +1,69 @@
+import {useMemo} from 'react';
+
+import {Alert} from 'sentry/components/core/alert';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import type {UseInfiniteLogsQueryResult} from 'sentry/views/explore/logs/useLogsQuery';
+import {useQueryParamsTopEventsLimit} from 'sentry/views/explore/queryParams/context';
+import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+interface LogsDownSamplingAlertProps {
+  tableResult: UseInfiniteLogsQueryResult;
+  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
+}
+
+export function LogsDownSamplingAlert({
+  tableResult,
+  timeseriesResult,
+}: LogsDownSamplingAlertProps) {
+  const topEventsLimit = useQueryParamsTopEventsLimit();
+  const isTopEvents = defined(topEventsLimit);
+
+  const timeseriesSamples = useMemo(() => {
+    for (const series of Object.values(timeseriesResult.data || {})) {
+      const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopEvents);
+      return samplingMeta.sampleCount;
+    }
+    return 0;
+  }, [timeseriesResult.data, isTopEvents]);
+
+  const timeseriesDataScanned = useMemo(() => {
+    const dataScannedList = Object.values(timeseriesResult.data || {})
+      .flat()
+      .map(series => series.meta.dataScanned);
+    if (!dataScannedList.length) {
+      return undefined;
+    }
+    return dataScannedList.includes('partial') ? ('partial' as const) : ('full' as const);
+  }, [timeseriesResult.data]);
+
+  const tableDataScanned = tableResult.dataScanned;
+  const tableSamples = tableResult.data.length;
+
+  if (
+    // It's possible that the timeseries data and table data are produced using
+    // different tiers of data. When this happens, specifically, when the table
+    // is using the full data and the chart is using partial data, this warning
+    // is here to educate the user that the results they're seeing may be a
+    // little strange as there is more data in the table than the chart leads
+    // one to believe.
+    timeseriesDataScanned === 'partial' &&
+    tableDataScanned === 'full' &&
+    // If the number of samples in the timeseries is greater than or equals to
+    // the number of samples in the table, then any potential discrepancy isn't
+    // very noticable so no need to explicitly call it out.
+    timeseriesSamples < tableSamples
+  ) {
+    return (
+      <Alert.Container>
+        <Alert type="warning">
+          {t(
+            'The volume of logs in this time range is too large for us to do a full scan for the chart. Try reducing the date range or number of projects to attempt scanning all logs.'
+          )}
+        </Alert>
+      </Alert.Container>
+    );
+  }
+  return null;
+}

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -25,7 +25,10 @@ import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/sc
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
-import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {
+  useLogsPageData,
+  useLogsPageDataQueryResult,
+} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {usePersistedLogsPageParams} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -39,6 +42,7 @@ import {
   HiddenLogSearchFields,
 } from 'sentry/views/explore/logs/constants';
 import {AutorefreshToggle} from 'sentry/views/explore/logs/logsAutoRefresh';
+import {LogsDownSamplingAlert} from 'sentry/views/explore/logs/logsDownsamplingAlert';
 import {LogsExportButton} from 'sentry/views/explore/logs/logsExport';
 import {LogsGraph} from 'sentry/views/explore/logs/logsGraph';
 import {LogsToolbar} from 'sentry/views/explore/logs/logsToolbar';
@@ -275,6 +279,8 @@ export function LogsTabContent({
     return false;
   }, [pageFilters.selection.datetime]);
 
+  const {infiniteLogsQueryResult} = useLogsPageData();
+
   return (
     <SearchQueryBuilderProvider {...searchQueryBuilderProviderProps}>
       <TopSectionBody noRowGap>
@@ -359,6 +365,10 @@ export function LogsTabContent({
             {!tableData.isPending && tableData.isEmpty && (
               <QuotaExceededAlert referrer="logs-explore" traceItemDataset="logs" />
             )}
+            <LogsDownSamplingAlert
+              timeseriesResult={timeseriesResult}
+              tableResult={infiniteLogsQueryResult}
+            />
             <LogsGraphContainer>
               <LogsGraph
                 rawLogCounts={rawLogCounts}
@@ -393,7 +403,6 @@ export function LogsTabContent({
                 </Button>
               </TableActionsContainer>
             </LogsTableActionsContainer>
-
             <LogsItemContainer>
               {tableTab === 'logs' ? (
                 <LogsInfiniteTable

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -661,6 +661,12 @@ export function useInfiniteLogsQuery({
     [hasNextPage, fetchNextPage, isFetching, isError, nextPageHasData]
   );
 
+  const dataScannedList = data?.pages?.map(page => page[0].meta?.dataScanned);
+  const dataScanned = defined(dataScannedList)
+    ? dataScannedList.includes('partial')
+      ? ('partial' as const)
+      : ('full' as const)
+    : undefined;
   const lastPageLength = data?.pages?.[data.pages.length - 1]?.[0]?.data?.length ?? 0;
   const limit = autoRefresh ? QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH : QUERY_PAGE_LIMIT;
   const shouldAutoFetchNextPage =
@@ -715,6 +721,7 @@ export function useInfiniteLogsQuery({
     isFetchingNextPage: _data.length > 0 && (waitingToAutoFetch || isFetchingNextPage),
     isFetchingPreviousPage,
     lastPageLength,
+    dataScanned,
     bytesScanned: totalBytesScanned,
   };
 }

--- a/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
+++ b/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
@@ -101,6 +101,7 @@ describe('useLogsTimeseries', () => {
             isFetchingPreviousPage: false,
             lastPageLength: 0,
             bytesScanned: 0,
+            dataScanned: undefined,
           },
         }),
       {additionalWrapper: Wrapper}

--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
@@ -102,6 +102,7 @@ describe('useStreamingTimeseriesResult', () => {
       isFetchingPreviousPage: false,
       lastPageLength: logFixtures.length,
       bytesScanned: 0,
+      dataScanned: undefined,
     } as UseInfiniteLogsQueryResult;
   }
 


### PR DESCRIPTION
It's possible that more logs appear in the table than is in the timeseries. When this happens we should render a warning to the user so they are aware that downsampling occurred and to narrow the time range if they don't want downsampling. The message also only occurrs when the number of logs matched by the timeseris is less than the number of logs rendered by the table. This is because if the number of logs matched by the timeseries is more than the number of logs rendered by the table, the effect of downsampling is less likely to be noticeable.