### PR TITLE
feat(spans-migration): expose extrapolation type for alert rules

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -277,7 +277,7 @@ class AlertRuleSerializer(Serializer):
         if aggregate == "upsampled_count()":
             aggregate = "count()"
 
-        extrapolation_mode = obj.snuba_query.extrapolation_mod
+        extrapolation_mode = obj.snuba_query.extrapolation_mode
 
         data: AlertRuleSerializerResponse = {
             "id": str(obj.id),

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -28,7 +28,7 @@ from sentry.sentry_apps.models.sentry_app_installation import prepare_ui_compone
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.app.model import RpcSentryAppComponentContext
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import SnubaQueryEventType
+from sentry.snuba.models import ExtrapolationMode, SnubaQueryEventType
 from sentry.uptime.endpoints.serializers import UptimeDetectorSerializer
 from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE
 from sentry.users.models.user import User
@@ -57,6 +57,7 @@ class AlertRuleSerializerResponseOptional(TypedDict, total=False):
     errors: list[str] | None
     sensitivity: str | None
     seasonality: str | None
+    extrapolationMode: str | None
 
 
 @extend_schema_serializer(
@@ -276,6 +277,8 @@ class AlertRuleSerializer(Serializer):
         if aggregate == "upsampled_count()":
             aggregate = "count()"
 
+        extrapolation_mode = obj.snuba_query.extrapolation_mod
+
         data: AlertRuleSerializerResponse = {
             "id": str(obj.id),
             "name": obj.name,
@@ -316,6 +319,9 @@ class AlertRuleSerializer(Serializer):
             data["latestIncident"] = attrs.get("latestIncident", None)
         if "errors" in attrs:
             data["errors"] = attrs["errors"]
+
+        if extrapolation_mode is not None:
+            data["extrapolationMode"] = ExtrapolationMode(extrapolation_mode).name.lower()
 
         return data
 

--- a/src/sentry/incidents/endpoints/serializers/query_subscription.py
+++ b/src/sentry/incidents/endpoints/serializers/query_subscription.py
@@ -5,7 +5,7 @@ from typing import Any
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.models import ExtrapolationMode, QuerySubscription, SnubaQuery
 
 
 @register(SnubaQuery)
@@ -27,6 +27,11 @@ class SnubaQuerySerializer(Serializer):
             "timeWindow": obj.time_window,
             "environment": obj.environment.name if obj.environment else None,
             "eventTypes": [event_type.name.lower() for event_type in obj.event_types],
+            "extrapolationMode": (
+                ExtrapolationMode(obj.extrapolation_mode).name.lower()
+                if obj.extrapolation_mode is not None
+                else None
+            ),
         }
 
 

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -31,7 +31,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTrigger,
 )
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import QuerySubscription
+from sentry.snuba.models import ExtrapolationMode, QuerySubscription
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule_trigger,
@@ -189,6 +189,12 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                 raise serializers.ValidationError(
                     "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
                 )
+
+        if data.get("extrapolation_mode") is not None:
+            extrapolation_mode = data.get("extrapolation_mode")
+            extrapolation_options = [option[0] for option in ExtrapolationMode.as_text_choices()]
+            if extrapolation_mode not in extrapolation_options:
+                raise serializers.ValidationError("Invalid Extrapolation Mode")
 
         return data
 

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -31,7 +31,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTrigger,
 )
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import ExtrapolationMode, QuerySubscription
+from sentry.snuba.models import QuerySubscription
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_delete_migrated_alert_rule_trigger,
@@ -189,12 +189,6 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                 raise serializers.ValidationError(
                     "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
                 )
-
-        if data.get("extrapolation_mode") is not None:
-            extrapolation_mode = data.get("extrapolation_mode")
-            extrapolation_options = [option[0] for option in ExtrapolationMode.as_text_choices()]
-            if extrapolation_mode not in extrapolation_options:
-                raise serializers.ValidationError("Invalid Extrapolation Mode")
 
         return data
 

--- a/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
@@ -127,8 +127,6 @@ class BaseAlertRuleSerializerTest:
                 rule.owner_user_id = actor.id
             if actor.is_team:
                 rule.owner_team_id = actor.id
-        if data.get("extrapolation_mode"):
-            rule.extrapolation_mode = data["extrapolation_mode"]
 
         rule.save()
         return rule

--- a/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
@@ -19,7 +19,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.models.rule import Rule
-from sentry.snuba.models import SnubaQueryEventType
+from sentry.snuba.models import ExtrapolationMode, SnubaQueryEventType
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.types.actor import Actor
 from sentry.uptime.endpoints.serializers import UptimeDetectorSerializer
@@ -84,6 +84,14 @@ class BaseAlertRuleSerializerTest:
         else:
             assert result["comparisonDelta"] is None
 
+        if alert_rule.snuba_query.extrapolation_mode is not None:
+            assert (
+                result["extrapolationMode"]
+                == ExtrapolationMode(alert_rule.snuba_query.extrapolation_mode).name.lower()
+            )
+        else:
+            assert result.get("extrapolationMode") is None
+
     def create_issue_alert_rule(self, data: dict[str, Any]) -> Rule:
         """data format
         {
@@ -119,6 +127,8 @@ class BaseAlertRuleSerializerTest:
                 rule.owner_user_id = actor.id
             if actor.is_team:
                 rule.owner_team_id = actor.id
+        if data.get("extrapolation_mode"):
+            rule.extrapolation_mode = data["extrapolation_mode"]
 
         rule.save()
         return rule
@@ -205,6 +215,11 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         )
         result = serialize(alert_rule)
         self.assert_alert_rule_serialized(alert_rule, result, resolve_threshold=10)
+
+    def test_extrapolation_mode(self) -> None:
+        alert_rule = self.create_alert_rule()
+        result = serialize(alert_rule)
+        self.assert_alert_rule_serialized(alert_rule, result)
 
 
 class DetailedAlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):

--- a/tests/sentry/incidents/endpoints/serializers/test_query_subscription.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_query_subscription.py
@@ -1,5 +1,10 @@
 from sentry.api.serializers import serialize
-from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.models import (
+    ExtrapolationMode,
+    QuerySubscription,
+    SnubaQuery,
+    SnubaQueryEventType,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -28,6 +33,7 @@ class TestSnubaQuerySerializer(TestCase):
             "timeWindow": 60,
             "environment": self.environment.name,
             "eventTypes": ["error"],
+            "extrapolationMode": "unknown",
         }
 
     def test_serialize_no_environment(self) -> None:
@@ -53,6 +59,34 @@ class TestSnubaQuerySerializer(TestCase):
             "timeWindow": 60,
             "environment": None,
             "eventTypes": ["error"],
+            "extrapolationMode": "unknown",
+        }
+
+    def test_serialize_with_extrapolation_mode(self) -> None:
+        snuba_query = SnubaQuery.objects.create(
+            type=SnubaQuery.Type.ERROR.value,
+            dataset="spans",
+            query="test query",
+            aggregate="count()",
+            time_window=60,
+            resolution=60,
+            extrapolation_mode=ExtrapolationMode.SERVER_WEIGHTED.value,
+        )
+        SnubaQueryEventType.objects.create(
+            snuba_query=snuba_query, type=SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.value
+        )
+
+        result = serialize(snuba_query)
+
+        assert result == {
+            "id": str(snuba_query.id),
+            "dataset": "spans",
+            "query": "test query",
+            "aggregate": "count()",
+            "timeWindow": 60,
+            "environment": None,
+            "eventTypes": ["trace_item_span"],
+            "extrapolationMode": "server_weighted",
         }
 
 
@@ -91,5 +125,6 @@ class TestQuerySubscriptionSerializer(TestCase):
                 "timeWindow": 60,
                 "environment": None,
                 "eventTypes": ["error"],
+                "extrapolationMode": "unknown",
             },
         }

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_data_source_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_data_source_serializer.py
@@ -51,6 +51,7 @@ class TestDataSourceSerializer(TestCase):
                     "query": "hello",
                     "timeWindow": 60,
                     "eventTypes": ["error"],
+                    "extrapolationMode": "unknown",
                 },
                 "status": 1,
                 "subscription": None,

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
@@ -135,6 +135,7 @@ class TestDetectorSerializer(TestCase):
                             "query": "hello",
                             "timeWindow": 60,
                             "eventTypes": ["error"],
+                            "extrapolationMode": "unknown",
                         },
                         "status": 1,
                         "subscription": None,


### PR DESCRIPTION
make sure get endpoint exposes extrapolation type for alert rules.
