### PR TITLE
fix(ui): Update mutable search to quote values with commas

### DIFF
--- a/static/app/components/searchSyntax/mutableSearch.spec.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.spec.tsx
@@ -338,7 +338,7 @@ describe('MutableSearch', () => {
     });
 
     it('addFilterValueList', () => {
-      const results = new MutableSearch('');
+      let results = new MutableSearch('');
 
       results.addFilterValueList('a', ['a1', 'a2']);
       expect(results.formatString()).toBe('a:[a1,a2]');
@@ -357,6 +357,11 @@ describe('MutableSearch', () => {
       expect(results.formatString()).toBe(
         `a:[a1,a2] b:${WildcardOperators.CONTAINS}[b1,b2] c:${WildcardOperators.STARTS_WITH}[c1,c2] d:${WildcardOperators.ENDS_WITH}[d1,d2]`
       );
+
+      // Quotes values with commas to avoid breaking list parsing
+      results = new MutableSearch('');
+      results.addFilterValueList('message', [',testA,', ',testB,']);
+      expect(results.formatString()).toBe('message:[",testA,",",testB,"]');
     });
   });
 

--- a/static/app/components/searchSyntax/mutableSearch.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.tsx
@@ -16,7 +16,7 @@ const EMPTY_OPTION_VALUE = '(empty)';
 // Hoisted regular expressions to avoid recompilation in hot paths
 const TRIMMABLE_ENDS_RE = /^["(]+|[")]+$/g;
 const WILDCARD_ESCAPE_RE = /([*])/g;
-const NEEDS_QUOTING_RE = /[\s()\\"]/;
+const NEEDS_QUOTING_RE = /[\s(),\\"]/;
 const VALUE_IS_LIST_RE = /^\[.*\]$/;
 const VALUE_IS_QUOTED_RE = /^".*"$/;
 const BRACKET_QUOTE_PATTERN_RE = /^(.*), (\[[^\]]+\])"]$/;


### PR DESCRIPTION
While working on global filters, I ran into an edge case when adding filter value lists. Tag values with commas weren't being parsed correctly (not quoted), so commas were treated as value separators when using `addFilterValueList`.

- Adds commas to the regex that determines whether values should be quoted when adding a filter value (avoids the problem when adding filter value lists, but parsing behaviour remains the same).