### PR TITLE
fix(tracemetrics): Make metrics footer more similar to logs footer

### DIFF
--- a/static/app/views/explore/metrics/metricGraph.tsx
+++ b/static/app/views/explore/metrics/metricGraph.tsx
@@ -16,7 +16,10 @@ import {
   useMetricVisualize,
   useSetMetricVisualize,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
-import {useQueryParamsTopEventsLimit} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsQuery,
+  useQueryParamsTopEventsLimit,
+} from 'sentry/views/explore/queryParams/context';
 import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
 import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {
@@ -59,7 +62,7 @@ function Graph({onChartTypeChange, timeseriesResult, queryIndex, visualize}: Gra
   const aggregate = visualize.yAxis;
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const metricLabel = useMetricLabel();
-
+  const userQuery = useQueryParamsQuery();
   const [interval, setInterval, intervalOptions] = useChartInterval();
 
   const chartInfo = useMemo(() => {
@@ -126,22 +129,17 @@ function Graph({onChartTypeChange, timeseriesResult, queryIndex, visualize}: Gra
     </Fragment>
   );
 
-  // We explicitly only want to show the confidence footer if we have
-  // scanned partial data.
-  const showConfidenceFooter =
-    chartInfo.dataScanned !== 'full' && !timeseriesResult.isPending;
   return (
     <Widget
       Title={Title}
       Actions={Actions}
       Visualization={visualize.visible && <ChartVisualization chartInfo={chartInfo} />}
       Footer={
-        showConfidenceFooter && (
-          <ConfidenceFooter
-            chartInfo={chartInfo}
-            isLoading={timeseriesResult.isFetching}
-          />
-        )
+        <ConfidenceFooter
+          chartInfo={chartInfo}
+          isLoading={timeseriesResult.isFetching}
+          hasUserQuery={!!userQuery}
+        />
       }
       height={visualize.visible ? undefined : 0}
       revealActions="always"

--- a/static/app/views/explore/metrics/metricGraph.tsx
+++ b/static/app/views/explore/metrics/metricGraph.tsx
@@ -135,11 +135,13 @@ function Graph({onChartTypeChange, timeseriesResult, queryIndex, visualize}: Gra
       Actions={Actions}
       Visualization={visualize.visible && <ChartVisualization chartInfo={chartInfo} />}
       Footer={
-        <ConfidenceFooter
-          chartInfo={chartInfo}
-          isLoading={timeseriesResult.isFetching}
-          hasUserQuery={!!userQuery}
-        />
+        visualize.visible && (
+          <ConfidenceFooter
+            chartInfo={chartInfo}
+            isLoading={timeseriesResult.isFetching}
+            hasUserQuery={!!userQuery}
+          />
+        )
       }
       height={visualize.visible ? undefined : 0}
       revealActions="always"

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -135,9 +135,9 @@ function defaultSortBys(): Sort[] {
 }
 
 function defaultAggregateFields(): AggregateField[] {
-  return [new VisualizeFunction('sum(value)')];
+  return [new VisualizeFunction('per_second(value)')];
 }
 
 function defaultAggregateSortBys(): Sort[] {
-  return [{field: 'sum(value)', kind: 'desc'}];
+  return [{field: 'per_second(value)', kind: 'desc'}];
 }

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -65,6 +65,14 @@ const OPTIONS_BY_TYPE: Record<string, Array<{label: string; value: string}>> = {
       label: 'count',
       value: 'count',
     },
+    {
+      label: 'per_second',
+      value: 'per_second',
+    },
+    {
+      label: 'per_minute',
+      value: 'per_minute',
+    },
   ],
   gauge: [
     {
@@ -83,11 +91,19 @@ const OPTIONS_BY_TYPE: Record<string, Array<{label: string; value: string}>> = {
       label: 'last',
       value: 'last',
     },
+    {
+      label: 'per_second',
+      value: 'per_second',
+    },
+    {
+      label: 'per_minute',
+      value: 'per_minute',
+    },
   ],
 };
 
 const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
-  counter: 'sum',
+  counter: 'per_second',
   distribution: 'p75',
   gauge: 'avg',
 };


### PR DESCRIPTION
As described, should always show like logs.

