### PR TITLE
ref(seer-explorer): add user id to initial context

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -40,6 +40,7 @@ def _collect_user_org_context(request: Request, organization: Organization) -> d
     if isinstance(user, AnonymousUser):
         return {
             "org_slug": organization.slug,
+            "user_id": None,
             "user_name": None,
             "user_email": None,
             "user_teams": [],

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -62,6 +62,7 @@ def _collect_user_org_context(request: Request, organization: Organization) -> d
 
     return {
         "org_slug": organization.slug,
+        "user_id": user.id,
         "user_name": user.name,
         "user_email": user.email,
         "user_teams": user_teams,

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -91,6 +91,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
     ):
         mock_context = {
             "org_slug": self.organization.slug,
+            "user_id": self.user.id,
             "user_name": self.user.name,
             "user_email": self.user.email,
             "user_teams": [],
@@ -286,6 +287,7 @@ class OrganizationSeerExplorerChatEndpointFeatureFlagTest(APITestCase):
         ):
             mock_context = {
                 "org_slug": self.organization.slug,
+                "user_id": self.user.id,
                 "user_name": self.user.name,
                 "user_email": self.user.email,
                 "user_teams": [],
@@ -336,6 +338,7 @@ class CollectUserOrgContextTest(APITestCase):
 
         assert context is not None
         assert context["org_slug"] == self.organization.slug
+        assert context["user_id"] == self.user.id
         assert context["user_name"] == self.user.name
         assert context["user_email"] == self.user.email
 


### PR DESCRIPTION
Needed for https://github.com/getsentry/seer/pull/3812