### PR TITLE
feat(span-enrichment): set & propagate `sentry.segment.name`

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -61,6 +61,7 @@ def process_segment(
         # If the project does not exist then it might have been deleted during ingestion.
         return []
 
+    _add_segment_name(segment_span, spans)
     _compute_breakdowns(segment_span, spans, project)
     _create_models(segment_span, project)
     _detect_performance_problems(segment_span, spans, project)
@@ -137,6 +138,21 @@ def _enrich_spans(
     groupings.write_to_spans(spans)
 
     return segment, spans
+
+
+@metrics.wraps("spans.consumers.process_segments.add_segment_name")
+def _add_segment_name(segment: CompatibleSpan, spans: Sequence[CompatibleSpan]) -> None:
+    segment_name = segment["name"]
+    if not segment_name:
+        return
+
+    for span in spans:
+        if not attribute_value(span, "sentry.segment.name"):
+            segment["attributes"] = segment.get("attributes") or {}
+            span["attributes"]["sentry.segment.name"] = {  # type: ignore[index]
+                "type": "string",
+                "value": segment_name,
+            }
 
 
 @metrics.wraps("spans.consumers.process_segments.compute_breakdowns")

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -148,7 +148,7 @@ def _add_segment_name(segment: CompatibleSpan, spans: Sequence[CompatibleSpan]) 
 
     for span in spans:
         if not attribute_value(span, "sentry.segment.name"):
-            segment["attributes"] = segment.get("attributes") or {}
+            span["attributes"] = span.get("attributes") or {}
             span["attributes"]["sentry.segment.name"] = {  # type: ignore[index]
                 "type": "string",
                 "value": segment_name,

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -240,6 +240,25 @@ class TestSpansTask(TestCase):
         signals = [args[0][1] for args in mock_track.call_args_list]
         assert signals == ["has_transactions", "has_insights_http"]
 
+    def test_segment_name_propagation(self):
+        child_span, segment_span = self.generate_basic_spans()
+        segment_span["name"] = "my segment name"
+
+        processed_spans = process_segment([child_span, segment_span])
+
+        assert len(processed_spans) == 2
+        child_span, segment_span = processed_spans
+        segment_attributes = segment_span["attributes"] or {}
+        assert segment_attributes["sentry.segment.name"] == {
+            "type": "string",
+            "value": "my segment name",
+        }
+        child_attributes = child_span["attributes"] or {}
+        assert child_attributes["sentry.segment.name"] == {
+            "type": "string",
+            "value": "my segment name",
+        }
+
 
 def test_verify_compatibility():
     spans: list[dict[str, Any]] = [


### PR DESCRIPTION
The `sentry.segment.name` attribute (see [sentry-conventions definition](https://github.com/getsentry/sentry-conventions/blob/main/model/attributes/sentry/sentry__segment__name.json)) will be used to move from an individual span up to its related segment's details page in Insights. During span enrichment, set segment span's `span.segment.name` to be equal to its `name`, and then propagate that to all of the segment's children.

Fixes ENG-5746.