### PR TITLE
feat(aci): Add automatic naming when creating a new metric monitor

### DIFF
--- a/static/app/components/workflowEngine/form/getFormFieldValue.tsx
+++ b/static/app/components/workflowEngine/form/getFormFieldValue.tsx
@@ -1,0 +1,14 @@
+import type FormModel from 'sentry/components/forms/model';
+import type {FieldValue} from 'sentry/components/forms/types';
+
+/**
+ * The form values returned by form.getValue are not typed, so this is a
+ * convenient helper to do a type assertion while getting the value.
+ */
+export function getFormFieldValue<T extends FieldValue = FieldValue>(
+  form: FormModel,
+  field: string
+): T {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  return form.getValue(field) as FieldValue;
+}

--- a/static/app/components/workflowEngine/form/useFormField.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.tsx
@@ -4,6 +4,7 @@ import {observe} from 'mobx';
 
 import FormContext from 'sentry/components/forms/formContext';
 import type {FieldValue} from 'sentry/components/forms/types';
+import {getFormFieldValue} from 'sentry/components/workflowEngine/form/getFormFieldValue';
 
 export function useFormField<Value extends FieldValue = FieldValue>(
   field: string
@@ -42,8 +43,7 @@ export function useFormField<Value extends FieldValue = FieldValue>(
       return undefined;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return context.form.getValue(field) as Value;
+    return getFormFieldValue<Value>(context.form, field);
   }, [context.form, field]);
 
   return useSyncExternalStore(subscribe, getSnapshot);

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -46,6 +46,7 @@ import {
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {MetricDetectorPreviewChart} from 'sentry/views/detectors/components/forms/metric/previewChart';
 import {ResolveSection} from 'sentry/views/detectors/components/forms/metric/resolveSection';
+import {useAutoMetricDetectorName} from 'sentry/views/detectors/components/forms/metric/useAutoMetricDetectorName';
 import {useInitialMetricDetectorFormData} from 'sentry/views/detectors/components/forms/metric/useInitialMetricDetectorFormData';
 import {useIntervalChoices} from 'sentry/views/detectors/components/forms/metric/useIntervalChoices';
 import {Visualize} from 'sentry/views/detectors/components/forms/metric/visualize';
@@ -57,6 +58,8 @@ import {getStaticDetectorThresholdSuffix} from 'sentry/views/detectors/utils/met
 import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
 
 function MetricDetectorForm() {
+  useAutoMetricDetectorName();
+
   return (
     <FormStack>
       <TransactionsDatasetWarningListener />

--- a/static/app/views/detectors/components/forms/metric/useAutoMetricDetectorName.tsx
+++ b/static/app/views/detectors/components/forms/metric/useAutoMetricDetectorName.tsx
@@ -1,0 +1,114 @@
+import type FormModel from 'sentry/components/forms/model';
+import {getFormFieldValue} from 'sentry/components/workflowEngine/form/getFormFieldValue';
+import {t} from 'sentry/locale';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import getDuration from 'sentry/utils/duration/getDuration';
+import {unreachable} from 'sentry/utils/unreachable';
+import {useSetAutomaticName} from 'sentry/views/detectors/components/forms/common/useSetAutomaticName';
+import {
+  METRIC_DETECTOR_FORM_FIELDS,
+  type MetricDetectorFormData,
+} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {getStaticDetectorThresholdSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+
+/**
+ * Automatically generates a name for the metric detector form based on the values:
+ * - Dataset
+ * - Aggregate function
+ * - Detection type
+ * - Direction (above or below)
+ * - Threshold value
+ * - Interval
+ *
+ * e.g. "p95(span.duration) above 100ms compared to past 1 hour"
+ */
+export function useAutoMetricDetectorName() {
+  useSetAutomaticName((form: FormModel): string | null => {
+    const detectionType = getFormFieldValue<MetricDetectorFormData['detectionType']>(
+      form,
+      METRIC_DETECTOR_FORM_FIELDS.detectionType
+    );
+    const aggregate = getFormFieldValue<MetricDetectorFormData['aggregateFunction']>(
+      form,
+      METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
+    );
+    const interval = getFormFieldValue<MetricDetectorFormData['interval']>(
+      form,
+      METRIC_DETECTOR_FORM_FIELDS.interval
+    );
+    const dataset = getFormFieldValue<MetricDetectorFormData['dataset']>(
+      form,
+      METRIC_DETECTOR_FORM_FIELDS.dataset
+    );
+    const datasetConfig = getDatasetConfig(dataset);
+
+    if (!aggregate || !interval || !detectionType || !dataset) {
+      return null;
+    }
+
+    switch (detectionType) {
+      case 'static': {
+        const conditionType = getFormFieldValue<MetricDetectorFormData['conditionType']>(
+          form,
+          METRIC_DETECTOR_FORM_FIELDS.conditionType
+        );
+        const conditionValue = getFormFieldValue<
+          MetricDetectorFormData['conditionValue']
+        >(form, METRIC_DETECTOR_FORM_FIELDS.conditionValue);
+
+        if (!conditionType || !conditionValue) {
+          return null;
+        }
+
+        const suffix = getStaticDetectorThresholdSuffix(aggregate);
+        const direction =
+          conditionType === DataConditionType.GREATER ? t('above') : t('below');
+
+        return t(
+          '%(aggregate)s %(aboveOrBelow)s %(value)s%(unit)s over past %(interval)s',
+          {
+            aggregate: datasetConfig.formatAggregateForTitle?.(aggregate) ?? aggregate,
+            aboveOrBelow: direction,
+            value: conditionValue,
+            unit: suffix,
+            interval: getDuration(interval),
+          }
+        );
+      }
+      case 'percent': {
+        const conditionType = getFormFieldValue<MetricDetectorFormData['conditionType']>(
+          form,
+          METRIC_DETECTOR_FORM_FIELDS.conditionType
+        );
+        const conditionValue = getFormFieldValue<
+          MetricDetectorFormData['conditionValue']
+        >(form, METRIC_DETECTOR_FORM_FIELDS.conditionValue);
+
+        if (!conditionType || !conditionValue) {
+          return null;
+        }
+
+        const direction =
+          conditionType === DataConditionType.GREATER ? t('higher') : t('lower');
+
+        return t(
+          '%(aggregate)s %(aboveOrBelow)s by %(value)s%% compared to past %(interval)s',
+          {
+            aggregate: datasetConfig.formatAggregateForTitle?.(aggregate) ?? aggregate,
+            aboveOrBelow: direction,
+            value: conditionValue,
+            interval: getDuration(interval),
+          }
+        );
+      }
+      case 'dynamic':
+        return t('%(aggregate)s is anomalous', {
+          aggregate: datasetConfig.formatAggregateForTitle?.(aggregate) ?? aggregate,
+        });
+      default:
+        unreachable(detectionType);
+        return null;
+    }
+  });
+}

--- a/static/app/views/detectors/datasetConfig/base.tsx
+++ b/static/app/views/detectors/datasetConfig/base.tsx
@@ -138,4 +138,12 @@ export interface DetectorDatasetConfig<SeriesResponse> {
     data: SeriesResponse | undefined,
     aggregate: string
   ) => Series[];
+
+  /**
+   * When automatically generating a detector name, this function will be called to format the aggregate function.
+   * If this function is not provided, the aggregate function will be used as is.
+   *
+   * e.g. For the errors dataset, count() will be formatted as 'Number of errors'
+   */
+  formatAggregateForTitle?: (aggregate: string) => string;
 }

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -131,4 +131,13 @@ export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> =
     parseEventTypesFromQuery(query, DEFAULT_EVENT_TYPES),
   // TODO: This should use the discover dataset unless `is:unresolved` is in the query
   getDiscoverDataset: () => DiscoverDatasets.ERRORS,
+  formatAggregateForTitle: aggregate => {
+    if (aggregate === 'count()') {
+      return t('Number of errors');
+    }
+    if (aggregate === 'count_unique(user)') {
+      return t('Users experiencing errors');
+    }
+    return aggregate;
+  },
 };

--- a/static/app/views/detectors/datasetConfig/logs.tsx
+++ b/static/app/views/detectors/datasetConfig/logs.tsx
@@ -63,4 +63,10 @@ export const DetectorLogsConfig: DetectorDatasetConfig<LogsSeriesRepsonse> = {
   },
   supportedDetectionTypes: ['static', 'percent', 'dynamic'],
   getDiscoverDataset: () => DiscoverDatasets.OURLOGS,
+  formatAggregateForTitle: aggregate => {
+    if (aggregate === 'count()') {
+      return t('Number of logs');
+    }
+    return aggregate;
+  },
 };

--- a/static/app/views/detectors/datasetConfig/spans.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.tsx
@@ -79,4 +79,10 @@ export const DetectorSpansConfig: DetectorDatasetConfig<SpansSeriesResponse> = {
   },
   supportedDetectionTypes: ['static', 'percent', 'dynamic'],
   getDiscoverDataset: () => DiscoverDatasets.SPANS,
+  formatAggregateForTitle: aggregate => {
+    if (aggregate.startsWith('count(span.duration)')) {
+      return t('Number of spans');
+    }
+    return aggregate;
+  },
 };


### PR DESCRIPTION
Uses `useSetAutomaticName` to set a default title for metric monitors if the user has not edited it.

Let me know if you have wording improvements.

<img width="800" height="794" alt="CleanShot 2025-10-27 at 13 39 59" src="https://github.com/user-attachments/assets/3c322f29-89be-4108-99d2-dd31984f9b0b" />
