### PR TITLE
chore(commits): Remove `update_commit` dual write function

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -28,8 +28,7 @@ from sentry.issues.auto_source_code_config.code_mapping import (
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
-from sentry.releases.commits import create_commit, update_commit
-from sentry.releases.models import Commit as NewCommit
+from sentry.releases.commits import create_commit
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import metrics
 from sentry.utils.committers import get_stacktrace_path_from_event_frame
@@ -140,9 +139,7 @@ def get_or_create_commit_from_blame(
             key=blame.commit.commitId,
         )
         if commit.message == "":
-            new_commit = NewCommit.objects.get(id=commit.id)
-            update_commit(commit, new_commit, message=blame.commit.commitMessage)
-
+            commit.update(message=blame.commit.commitMessage)
         return commit
     except Commit.DoesNotExist:
         logger.info(

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -34,11 +34,7 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.plugins.providers.repository import RepositoryProvider
-from sentry.releases.commits import (
-    bulk_create_commit_file_changes,
-    get_or_create_commit,
-    update_commit,
-)
+from sentry.releases.commits import bulk_create_commit_file_changes, get_or_create_commit
 
 
 class _CommitDataKwargs(TypedDict, total=False):
@@ -138,7 +134,7 @@ def set_commit(idx, data, release):
         date_added=commit_data.get("date_added"),  # type: ignore[arg-type]
     )
     if not created and any(getattr(commit, key) != value for key, value in commit_data.items()):
-        update_commit(commit, new_commit, **commit_data)
+        commit.update(**commit_data)
 
     if author is None:
         author = commit.author

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -128,18 +128,6 @@ def get_or_create_commit(
     return old_commit, new_commit, created
 
 
-def update_commit(old_commit: OldCommit, new_commit: Commit, **fields) -> None:
-    """Update a commit in both tables if dual write is enabled."""
-    with atomic_transaction(
-        using=(
-            router.db_for_write(OldCommit),
-            router.db_for_write(Commit),
-        )
-    ):
-        old_commit.update(**fields)
-        new_commit.update(**fields)
-
-
 def bulk_create_commit_file_changes(
     file_changes: list[OldCommitFileChange],
 ) -> tuple[list[OldCommitFileChange], list[CommitFileChange]]:


### PR DESCRIPTION
We're no longer planning on using the dual written tables, so removing these functions
