### PR TITLE
ref(explorer): show 'recommended event' for issue tool

### DIFF
--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -57,7 +57,7 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
   get_issue_details: (args, isLoading) => {
     const issueId = args.issue_id || '';
     const selectedEvent = args.selected_event;
-    if (selectedEvent && selectedEvent !== 'recommended') {
+    if (selectedEvent) {
       return isLoading
         ? `Inspecting issue ${issueId} (${selectedEvent} event)...`
         : `Inspected issue ${issueId} (${selectedEvent} event)`;


### PR DESCRIPTION
Think recommended is useful to show here, also with recent seer fix ~~full~~ truncated event IDs will go here too