### PR TITLE
chore(preprod): Quick preprod design fixes from review with Dan

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -1,14 +1,12 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
-import {Container, Flex, Grid} from 'sentry/components/core/layout';
+import {Flex, Stack} from 'sentry/components/core/layout';
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
-import {IconClose, IconGrid, IconSearch} from 'sentry/icons';
+import {IconClose, IconGrid, IconRefresh, IconSearch} from 'sentry/icons';
 import {IconGraphCircle} from 'sentry/icons/iconGraphCircle';
 import {t} from 'sentry/locale';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
@@ -30,52 +28,6 @@ import {
 import {processInsights} from 'sentry/views/preprod/utils/insightProcessing';
 import {validatedPlatform} from 'sentry/views/preprod/utils/sharedTypesUtils';
 import {filterTreemapElement} from 'sentry/views/preprod/utils/treemapFiltering';
-
-interface LoadingContentProps {
-  children: ReactNode;
-  showSkeleton?: boolean;
-}
-
-function LoadingContent({showSkeleton, children}: LoadingContentProps) {
-  return (
-    <Flex direction="column" gap="lg" minHeight="700px" width="100%">
-      <Grid
-        columns="1fr"
-        rows="1fr"
-        areas={`"all"`}
-        align="center"
-        justify="center"
-        style={{position: 'relative', height: '508px'}}
-        data-testid="treemap-loading-skeleton"
-      >
-        {showSkeleton && (
-          <Container
-            area="all"
-            style={{
-              width: '100%',
-              height: '508px',
-            }}
-          >
-            <Placeholder width="100%" height="508px" />
-          </Container>
-        )}
-        <Flex area="all" direction="column" align="center">
-          {children}
-        </Flex>
-      </Grid>
-      {showSkeleton && (
-        <Flex direction="column" gap="md">
-          <Placeholder width="200px" height="24px" />
-          <Flex gap="md">
-            <Placeholder width="150px" height="60px" />
-            <Placeholder width="150px" height="60px" />
-            <Placeholder width="150px" height="60px" />
-          </Flex>
-        </Flex>
-      )}
-    </Flex>
-  );
-}
 
 interface BuildDetailsMainContentProps {
   appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError>;
@@ -154,9 +106,14 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
 
   if (isLoadingRequests) {
     return (
-      <LoadingContent showSkeleton>
-        <LoadingIndicator size={60}>{t('Requesting data...')}</LoadingIndicator>
-      </LoadingContent>
+      <Stack gap="lg" width="100%">
+        <Flex width="100%" justify="between" align="center" gap="md">
+          <Placeholder width="92px" height="40px" />
+          <Placeholder style={{flex: 1}} height="40px" />
+        </Flex>
+        <Placeholder width="100%" height="540px" />
+        <Placeholder height="140px" />
+      </Stack>
     );
   }
 
@@ -164,12 +121,12 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
 
   if (isSizeInfoProcessing(sizeInfo) || isWaitingForData) {
     return (
-      <LoadingContent>
+      <Flex width="100%" justify="center" align="center" minHeight="60vh">
         <BuildProcessing
           title={t('Running size analysis')}
           message={t('Hang tight, this may take a few minutes...')}
         />
-      </LoadingContent>
+      </Flex>
     );
   }
 
@@ -177,24 +134,34 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   // click to run size analysis.
   if (showNoSizeRequested) {
     return (
-      <LoadingContent>
-        <p>{t('No size analysis.')}</p>
-      </LoadingContent>
+      <Flex width="100%" justify="center" align="center" minHeight="60vh">
+        <BuildError
+          title={t('No size analysis')}
+          message={t('No size analysis is available for this build.')}
+        />
+      </Flex>
     );
   }
 
   if (isSizeFailed) {
     return (
-      <BuildError
-        title={t('Size analysis failed')}
-        message={
-          sizeInfo.error_message || t("Something went wrong, we're looking into it.")
-        }
-      >
-        <Button onClick={onRerunAnalysis} disabled={isRerunning}>
-          {isRerunning ? t('Rerunning...') : t('Retry analysis')}
-        </Button>
-      </BuildError>
+      <Flex width="100%" justify="center" align="center" minHeight="60vh">
+        <BuildError
+          title={t('Size analysis failed')}
+          message={
+            sizeInfo.error_message || t("Something went wrong, we're looking into it.")
+          }
+        >
+          <Button
+            priority="primary"
+            onClick={onRerunAnalysis}
+            disabled={isRerunning}
+            icon={<IconRefresh />}
+          >
+            {isRerunning ? t('Rerunning...') : t('Retry analysis')}
+          </Button>
+        </BuildError>
+      </Flex>
     );
   }
 
@@ -202,25 +169,32 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   // error_{code,message} correctly so we often see this.
   if (isAppSizeError) {
     return (
-      <BuildError
-        title={t('Size analysis failed')}
-        message={appSizeError?.message ?? t('The treemap data could not be loaded')}
-      >
-        <Button onClick={onRerunAnalysis} disabled={isRerunning}>
-          {isRerunning ? t('Rerunning...') : t('Retry analysis')}
-        </Button>
-      </BuildError>
+      <Flex width="100%" justify="center" align="center" minHeight="60vh">
+        <BuildError
+          title={t('Size analysis failed')}
+          message={appSizeError?.message ?? t('The treemap data could not be loaded')}
+        >
+          <Button
+            priority="primary"
+            onClick={onRerunAnalysis}
+            disabled={isRerunning}
+            icon={<IconRefresh />}
+          >
+            {isRerunning ? t('Rerunning...') : t('Retry analysis')}
+          </Button>
+        </BuildError>
+      </Flex>
     );
   }
 
   if (!appSizeData?.treemap?.root) {
     return (
-      <LoadingContent>
+      <Flex width="100%" justify="center" align="center" minHeight="60vh">
         <BuildProcessing
           title={t('Running size analysis')}
           message={t('Hang tight, this may take a few minutes...')}
         />
-      </LoadingContent>
+      </Flex>
     );
   }
 
@@ -279,7 +253,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   }
 
   return (
-    <Flex direction="column" gap="lg" minHeight="700px" width="100%">
+    <Flex direction="column" gap="sm" minHeight="700px" width="100%">
       <Flex align="center" gap="md">
         {categoriesEnabled && (
           <SegmentedControl value={selectedContent} onChange={handleContentChange}>
@@ -312,20 +286,23 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
           </InputGroup>
         )}
       </Flex>
-      {selectedContent === 'treemap' && appSizeData && (
-        <AppSizeLegend
-          root={appSizeData.treemap.root}
-          selectedCategories={selectedCategories}
-          onToggleCategory={handleToggleCategory}
-        />
-      )}
       <ChartContainer>{visualizationContent}</ChartContainer>
-      {processedInsights.length > 0 && (
-        <AppSizeInsights
-          processedInsights={processedInsights}
-          platform={validatedPlatform(buildDetailsData?.app_info?.platform)}
-        />
-      )}
+
+      <Stack gap="xl">
+        {selectedContent === 'treemap' && appSizeData && (
+          <AppSizeLegend
+            root={appSizeData.treemap.root}
+            selectedCategories={selectedCategories}
+            onToggleCategory={handleToggleCategory}
+          />
+        )}
+        {processedInsights.length > 0 && (
+          <AppSizeInsights
+            processedInsights={processedInsights}
+            platform={validatedPlatform(buildDetailsData?.app_info?.platform)}
+          />
+        )}
+      </Stack>
     </Flex>
   );
 }
@@ -333,4 +310,5 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
 const ChartContainer = styled('div')`
   width: 100%;
   height: 508px;
+  padding-top: ${p => p.theme.space.md};
 `;

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -35,8 +35,8 @@ export function AppSizeInsightsSidebar({
     size: width,
   } = useResizableDrawer({
     direction: 'right',
-    initialSize: 502,
-    min: 502,
+    initialSize: 700,
+    min: 700,
     onResize: () => {},
     sizeStorageKey: 'app-size-insights-sidebar-width',
   });

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -6,6 +6,7 @@ import {Button} from 'sentry/components/core/button';
 import {Container, Flex, Stack} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconInfo} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconFlag} from 'sentry/icons/iconFlag';
 import {t, tn} from 'sentry/locale';
@@ -87,8 +88,8 @@ export function AppSizeInsightsSidebarRow({
           {insight.description}
         </Text>
         {shouldShowTooltip && (
-          <Button priority="link" onClick={handleOpenModal} size="xs">
-            {t('Fix this locally')}
+          <Button priority="link" onClick={handleOpenModal} size="xs" icon={<IconInfo />}>
+            {t('How to fix this locally')}
           </Button>
         )}
       </Stack>

--- a/static/app/views/preprod/components/buildError.tsx
+++ b/static/app/views/preprod/components/buildError.tsx
@@ -17,11 +17,11 @@ export function BuildError({title, message, children}: BuildErrorProps) {
       direction="column"
       align="center"
       justify="center"
-      gap="3xl"
+      gap="xl"
       padding="md"
       minHeight="60vh"
     >
-      <Flex maxWidth="500px" direction="column" align="center" gap="lg" padding="md">
+      <Flex maxWidth="500px" direction="column" align="center" gap="md" padding="md">
         <AlertImage src={Missing} alt="Error image" />
         <Heading as="h2" align="center">
           {title}

--- a/static/app/views/preprod/components/buildProcessing.tsx
+++ b/static/app/views/preprod/components/buildProcessing.tsx
@@ -16,24 +16,24 @@ export function BuildProcessing({title, message, children}: BuildProcessingProps
       direction="column"
       align="center"
       justify="center"
-      gap="3xl"
+      gap="xl"
       padding="md"
       minHeight="60vh"
       maxWidth="500px"
     >
-      <Flex direction="column" align="center" gap="xl">
+      <Flex direction="column" align="center" gap="md">
         <Heading as="h2" align="center">
           {title}
         </Heading>
         <Text align="center">{message}</Text>
-        <Flex align="center" justify="center">
-          <RotatingIcon>
-            <IconSettings size="2xl" />
-          </RotatingIcon>
-          <RotatingIconReverse>
-            <IconSettings size="2xl" />
-          </RotatingIconReverse>
-        </Flex>
+      </Flex>
+      <Flex align="center" justify="center">
+        <RotatingIcon>
+          <IconSettings size="2xl" />
+        </RotatingIcon>
+        <RotatingIconReverse>
+          <IconSettings size="2xl" />
+        </RotatingIconReverse>
       </Flex>
       {children}
     </Flex>


### PR DESCRIPTION
Had a design review with Dan today, this PR addressed some quick things that I could implement immediately while we chatted:

- Updated Skeleton loaders to match loaded content sizing almost 1:1
<img width="1576" height="959" alt="Screenshot 2025-10-27 at 3 47 38 PM" src="https://github.com/user-attachments/assets/184b7a32-9490-437c-9d2e-0bfa8cbc17b6" />

- Updated category filtering to be below treemap
<img width="1143" height="786" alt="Screenshot 2025-10-27 at 3 48 26 PM" src="https://github.com/user-attachments/assets/40e97775-0fc1-4d11-88a3-247b79672690" />


- Update "Fix this locally" to be "How to fix this locally" with an icon
<img width="190" height="208" alt="Screenshot 2025-10-27 at 3 48 31 PM" src="https://github.com/user-attachments/assets/15870cf9-343c-427e-8b43-6fa0c4be3965" />


Other general padding and layout tweaks