### PR TITLE
fix(workflow_engine): Finish dataSource => dataSources

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -136,7 +136,6 @@ class MetricIssueConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
-    data_source = SnubaQueryValidator(required=False, timeWindowSeconds=True)
     data_sources = serializers.ListField(
         child=SnubaQueryValidator(timeWindowSeconds=True), required=False
     )
@@ -253,9 +252,7 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
 
         data_source: SnubaQueryDataSourceType | None = None
 
-        if "data_source" in validated_data:
-            data_source = validated_data.pop("data_source")
-        elif "data_sources" in validated_data:
+        if "data_sources" in validated_data:
             data_source = validated_data.pop("data_sources")[0]
 
         if data_source is not None:
@@ -267,11 +264,6 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
         return instance
 
     def create(self, validated_data: dict[str, Any]):
-        if "data_source" in validated_data:
-            self._validate_transaction_dataset_deprecation(
-                validated_data["data_source"].get("dataset")
-            )
-
         if "data_sources" in validated_data:
             for validated_data_source in validated_data["data_sources"]:
                 self._validate_transaction_dataset_deprecation(validated_data_source.get("dataset"))

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -684,16 +684,13 @@ class MonitorIncidentDetectorValidator(BaseDetectorTypeValidator):
     data_source field (MonitorDataSourceValidator).
     """
 
-    data_source = MonitorDataSourceValidator(required=False)
     data_sources = serializers.ListField(child=MonitorDataSourceValidator(), required=False)
 
     def update(self, instance: Detector, validated_data: dict[str, Any]) -> Detector:
         super().update(instance, validated_data)
 
         data_source_data = None
-        if "data_source" in validated_data:
-            data_source_data = validated_data.pop("data_source")
-        elif "data_sources" in validated_data:
+        if "data_sources" in validated_data:
             data_source_data = validated_data.pop("data_sources")[0]
 
         if data_source_data is not None:

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -460,16 +460,13 @@ class UptimeMonitorDataSourceValidator(BaseDataSourceValidator[UptimeSubscriptio
 
 
 class UptimeDomainCheckFailureValidator(BaseDetectorTypeValidator):
-    data_source = UptimeMonitorDataSourceValidator(required=False)
     data_sources = serializers.ListField(child=UptimeMonitorDataSourceValidator(), required=False)
 
     def update(self, instance: Detector, validated_data: dict[str, Any]) -> Detector:
         super().update(instance, validated_data)
 
         data_source = None
-        if "data_source" in validated_data:
-            data_source = validated_data.pop("data_source")
-        elif "data_sources" in validated_data:
+        if "data_sources" in validated_data:
             data_source = validated_data.pop("data_sources")[0]
 
         if data_source is not None:

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -15,7 +15,6 @@ from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.validators.base import (
     BaseDataConditionGroupValidator,
     BaseDataConditionValidator,
-    BaseDataSourceValidator,
 )
 from sentry.workflow_engine.endpoints.validators.utils import (
     get_unknown_detector_type_error,
@@ -65,11 +64,6 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         # TODO: Probably need to check a feature flag to decide if a given
         # org/user is allowed to add a detector
         return type
-
-    @property
-    def data_source(self) -> BaseDataSourceValidator | None:
-        # Moving this field to optional
-        return None
 
     @property
     def data_sources(self) -> serializers.ListField:
@@ -201,10 +195,6 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 raise serializers.ValidationError({"config": [str(error)]})
 
             detector.save()
-
-            if "data_source" in validated_data:
-                validated_data_source = validated_data["data_source"]
-                self._create_data_source(validated_data_source, detector)
 
             if "data_sources" in validated_data:
                 for validated_data_source in validated_data["data_sources"]:

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -139,15 +139,17 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
         self.valid_data = {
             "name": "Test Detector",
             "type": MetricIssue.slug,
-            "dataSource": {
-                "queryType": SnubaQuery.Type.ERROR.value,
-                "dataset": Dataset.Events.value,
-                "query": "test query",
-                "aggregate": "count()",
-                "timeWindow": 3600,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.ERROR.value,
+                    "dataset": Dataset.Events.value,
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,
@@ -481,15 +483,17 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
     def test_transaction_dataset_deprecation_transactions(self) -> None:
         data = {
             **self.valid_data,
-            "dataSource": {
-                "queryType": SnubaQuery.Type.PERFORMANCE.value,
-                "dataset": Dataset.Transactions.value,
-                "query": "test query",
-                "aggregate": "count()",
-                "timeWindow": 3600,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.TRANSACTION.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.PERFORMANCE.value,
+                    "dataset": Dataset.Transactions.value,
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.TRANSACTION.name.lower()],
+                }
+            ],
         }
         validator = MetricIssueDetectorValidator(data=data, context=self.context)
         assert validator.is_valid(), validator.errors
@@ -504,15 +508,17 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
     def test_transaction_dataset_deprecation_generic_metrics(self) -> None:
         data = {
             **self.valid_data,
-            "dataSource": {
-                "queryType": SnubaQuery.Type.PERFORMANCE.value,
-                "dataset": Dataset.PerformanceMetrics.value,
-                "query": "test query",
-                "aggregate": "count()",
-                "timeWindow": 3600,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.TRANSACTION.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.PERFORMANCE.value,
+                    "dataset": Dataset.PerformanceMetrics.value,
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.TRANSACTION.name.lower()],
+                }
+            ],
         }
         validator = MetricIssueDetectorValidator(data=data, context=self.context)
         assert validator.is_valid(), validator.errors
@@ -538,7 +544,7 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
                 },
             ],
         }
-        data.pop("dataSource", None)
+
         validator = MetricIssueDetectorValidator(data=data, context=self.context)
         assert validator.is_valid(), validator.errors
         with self.assertRaisesMessage(
@@ -582,21 +588,22 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
                 },
             ],
         }
-        data.pop("dataSource", None)
         validator = MetricIssueDetectorValidator(data=data, context=self.context)
         assert validator.is_valid(), validator.errors
         detector = validator.save()
 
         update_data = {
-            "dataSource": {
-                "queryType": SnubaQuery.Type.PERFORMANCE.value,
-                "dataset": Dataset.PerformanceMetrics.value,
-                "query": "updated query",
-                "aggregate": "count()",
-                "timeWindow": 3600,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.TRANSACTION.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.PERFORMANCE.value,
+                    "dataset": Dataset.PerformanceMetrics.value,
+                    "query": "updated query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.TRANSACTION.name.lower()],
+                }
+            ],
         }
         update_validator = MetricIssueDetectorValidator(
             instance=detector, data=update_data, context=self.context, partial=True
@@ -610,19 +617,3 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
             with_feature("organizations:discover-saved-queries-deprecation"),
         ):
             update_validator.save()
-
-
-class TestMetricAlertDetectorDataSourcesValidator(TestMetricAlertsDetectorValidator):
-    def setUp(self) -> None:
-        """
-        These are a temporary suite of tests that run the same ones as `TestMetricAlertsDetectorValidator`
-        but changes the dataSource attribute to dataSources.
-        """
-        super().setUp()
-
-        data_source = self.valid_data["dataSource"]
-
-        # This is a temporary line of code; works fine when inlining the [] which
-        # is the longer term solution.
-        self.valid_data["dataSources"] = [data_source]  # type: ignore[list-item]
-        del self.valid_data["dataSource"]

--- a/tests/sentry/monitors/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_index.py
@@ -100,13 +100,15 @@ class OrganizationDetectorIndexPostTest(APITestCase):
             "projectId": self.project.id,
             "type": MonitorIncidentType.slug,
             "name": "Test Monitor Detector",
-            "dataSource": {
-                "name": "Test Monitor",
-                "config": {
-                    "schedule": "0 * * * *",
-                    "scheduleType": "crontab",
-                },
-            },
+            "dataSources": [
+                {
+                    "name": "Test Monitor",
+                    "config": {
+                        "schedule": "0 * * * *",
+                        "scheduleType": "crontab",
+                    },
+                }
+            ],
         }
         data.update(overrides)
         return data
@@ -155,38 +157,42 @@ class OrganizationDetectorIndexPostTest(APITestCase):
 
     def test_create_monitor_incident_detector_validation_error(self):
         data = self._get_detector_post_data(
-            dataSource={
-                "config": {
-                    "schedule": "invalid cron",
-                    "scheduleType": "crontab",
-                },
-            }
+            dataSources=[
+                {
+                    "config": {
+                        "schedule": "invalid cron",
+                        "scheduleType": "crontab",
+                    },
+                }
+            ]
         )
         response = self.get_error_response(
             self.organization.slug,
             **data,
             status_code=status.HTTP_400_BAD_REQUEST,
         )
-        assert "dataSource" in response.data
-        assert "Either name or slug must be provided" in str(response.data["dataSource"])
+        assert "dataSources" in response.data
+        assert "Either name or slug must be provided" in str(response.data["dataSources"])
 
     def test_create_monitor_with_optional_fields(self):
         data = self._get_detector_post_data(
-            dataSource={
-                "name": "Full Config Monitor",
-                "slug": "full-config-monitor",
-                "status": "disabled",
-                "isMuted": True,
-                "config": {
-                    "schedule": "*/30 * * * *",
-                    "scheduleType": "crontab",
-                    "checkinMargin": 15,
-                    "maxRuntime": 120,
-                    "timezone": "America/New_York",
-                    "failureIssueThreshold": 3,
-                    "recoveryThreshold": 2,
-                },
-            },
+            dataSources=[
+                {
+                    "name": "Full Config Monitor",
+                    "slug": "full-config-monitor",
+                    "status": "disabled",
+                    "isMuted": True,
+                    "config": {
+                        "schedule": "*/30 * * * *",
+                        "scheduleType": "crontab",
+                        "checkinMargin": 15,
+                        "maxRuntime": 120,
+                        "timezone": "America/New_York",
+                        "failureIssueThreshold": 3,
+                        "recoveryThreshold": 2,
+                    },
+                }
+            ],
         )
         with self.tasks():
             self.get_success_response(
@@ -250,15 +256,17 @@ class OrganizationDetectorIndexPutTest(BaseDetectorTestCase):
     def test_update_monitor_config_through_detector(self):
         data = {
             "name": "Updated Detector With Monitor Config",
-            "dataSource": {
-                "name": "Updated Monitor Name",
-                "config": {
-                    "schedule": "*/30 * * * *",
-                    "scheduleType": "crontab",
-                    "checkinMargin": 10,
-                    "maxRuntime": 60,
-                },
-            },
+            "dataSources": [
+                {
+                    "name": "Updated Monitor Name",
+                    "config": {
+                        "schedule": "*/30 * * * *",
+                        "scheduleType": "crontab",
+                        "checkinMargin": 10,
+                        "maxRuntime": 60,
+                    },
+                }
+            ],
         }
         with self.tasks():
             self.get_success_response(

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -13,12 +13,14 @@ def _get_valid_data(project_id, environment_name, **overrides):
         "projectId": project_id,
         "name": "Test Uptime Detector",
         "type": UptimeDomainCheckFailure.slug,
-        "dataSource": {
-            "timeout_ms": 30000,
-            "name": "Test Uptime Detector",
-            "url": "https://www.google.com",
-            "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
-        },
+        "dataSources": [
+            {
+                "timeout_ms": 30000,
+                "name": "Test Uptime Detector",
+                "url": "https://www.google.com",
+                "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
+            }
+        ],
         "conditionGroup": {
             "logicType": "any",
             "conditions": [
@@ -85,9 +87,11 @@ class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
             "type": UptimeDomainCheckFailure.slug,
             "dateCreated": self.detector.date_added,
             "dateUpdated": timezone.now(),
-            "dataSource": {
-                "timeout_ms": 15000,
-            },
+            "dataSources": [
+                {
+                    "timeout_ms": 15000,
+                }
+            ],
             "conditionGroup": {
                 "id": self.detector.workflow_condition_group.id,
                 "organizationId": self.organization.id,
@@ -118,9 +122,11 @@ class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
             "type": UptimeDomainCheckFailure.slug,
             "dateCreated": self.detector.date_added,
             "dateUpdated": timezone.now(),
-            "dataSource": {
-                "timeout_ms": 80000,
-            },
+            "dataSources": [
+                {
+                    "timeout_ms": 80000,
+                }
+            ],
             "conditionGroup": {
                 "id": self.detector.workflow_condition_group.id,
                 "organizationId": self.organization.id,
@@ -136,9 +142,9 @@ class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
             method="PUT",
         )
 
-        assert "dataSource" in response.data
+        assert "dataSources" in response.data
         assert "Ensure this value is less than or equal to 60000." in str(
-            response.data["dataSource"]
+            response.data["dataSources"]
         )
 
 
@@ -152,7 +158,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
 
     def test_create_detector_validation_error(self):
         invalid_data = _get_valid_data(
-            self.project.id, self.environment.name, dataSource={"timeout_ms": 80000}
+            self.project.id, self.environment.name, dataSources=[{"timeout_ms": 80000}]
         )
 
         response = self.get_error_response(
@@ -161,9 +167,9 @@ class OrganizationDetectorIndexPostTest(APITestCase):
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 
-        assert "dataSource" in response.data
+        assert "dataSources" in response.data
         assert "Ensure this value is less than or equal to 60000" in str(
-            response.data["dataSource"]
+            response.data["dataSources"]
         )
 
     def test_create_detector(self):
@@ -193,16 +199,18 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         valid_data = _get_valid_data(
             self.project.id,
             self.environment.name,
-            dataSource={
-                "timeout_ms": 30000,
-                "name": "Test Uptime Detector",
-                "url": "https://www.google.com",
-                "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
-                "method": "PUT",
-                "headers": [["key", "value"]],
-                "body": "<html/>",
-                "trace_sampling": True,
-            },
+            dataSources=[
+                {
+                    "timeout_ms": 30000,
+                    "name": "Test Uptime Detector",
+                    "url": "https://www.google.com",
+                    "interval_seconds": UptimeSubscription.IntervalSeconds.ONE_MINUTE,
+                    "method": "PUT",
+                    "headers": [["key", "value"]],
+                    "body": "<html/>",
+                    "trace_sampling": True,
+                }
+            ],
         )
 
         response = self.get_success_response(

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -101,7 +101,7 @@ class MockConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MockDetectorValidator(BaseDetectorTypeValidator):
-    data_source = MockDataSourceValidator()
+    data_sources = serializers.ListField(child=MockDataSourceValidator(), required=True)
     condition_group = MockConditionGroupValidator()
 
 
@@ -165,10 +165,12 @@ class DetectorValidatorTest(BaseValidatorTest):
         self.valid_data = {
             "name": "Test Detector",
             "type": MetricIssue.slug,
-            "dataSource": {
-                "field1": "test",
-                "field2": 123,
-            },
+            "dataSources": [
+                {
+                    "field1": "test",
+                    "field2": 123,
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,


### PR DESCRIPTION
# Description
This PR finishes the dataSource to dataSources transition on the API validator, removing `data_source` from validators and updating tests.