### PR TITLE
feat(llm-detector): Implement LLM-powered issue detection task

### DIFF
--- a/src/sentry/tasks/llm_issue_detection.py
+++ b/src/sentry/tasks/llm_issue_detection.py
@@ -2,12 +2,62 @@ from __future__ import annotations
 
 import logging
 
+from django.conf import settings
+from pydantic import BaseModel
+
 from sentry import options
+from sentry.models.project import Project
+from sentry.net.http import connection_from_url
 from sentry.seer.explorer.index_data import get_trace_for_transaction, get_transactions_for_project
+from sentry.seer.models import SeerApiError
+from sentry.seer.sentry_data_models import TraceData
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
+from sentry.utils import json
 
 logger = logging.getLogger("sentry.tasks.llm_issue_detection")
+
+SEER_ANALYZE_ISSUE_ENDPOINT_PATH = "/v1/automation/issue-detection/analyze"
+SEER_TIMEOUT_S = 120
+SEER_RETRIES = 1
+
+
+seer_issue_detection_connection_pool = connection_from_url(
+    settings.SEER_DEFAULT_URL,
+    timeout=SEER_TIMEOUT_S,
+    retries=SEER_RETRIES,
+    maxsize=10,
+)
+
+
+class DetectedIssue(BaseModel):
+    explanation: str
+    impact: str
+    evidence: str
+    missing_telemetry: str | None = None
+    title: str
+
+
+class IssueDetectionResponse(BaseModel):
+    issues: list[DetectedIssue]
+
+
+class LLMIssueDetectionError(SeerApiError):
+    def __init__(
+        self,
+        message: str,
+        status: int,
+        project_id: int,
+        trace_id: str,
+        response_data: str,
+        error_message: str | None = None,
+    ):
+        super().__init__(message, status)
+        self.project_id = project_id
+        self.trace_id = trace_id
+        self.response_data = response_data
+        self.error_message = error_message
 
 
 def get_enabled_project_ids() -> list[int]:
@@ -49,10 +99,53 @@ def detect_llm_issues_for_project(project_id: int) -> None:
     """
     Process a single project for LLM issue detection.
     """
+    project = Project.objects.get_from_cache(id=project_id)
+    organization_id = project.organization_id
+
     transactions = get_transactions_for_project(
         project_id, limit=50, start_time_delta={"minutes": 30}
     )
     for transaction in transactions:
-        trace = get_trace_for_transaction(transaction.name, transaction.project_id)
-        if trace:
-            logger.info("Found trace for LLM issue detection", extra={"trace_id": trace.trace_id})
+        trace: TraceData = get_trace_for_transaction(transaction.name, transaction.project_id)
+        if not trace:
+            continue
+
+        logger.info("Found trace for LLM issue detection", extra={"trace_id": trace.trace_id})
+
+        seer_request = {
+            "telemetry": [{**trace.dict(), "kind": "trace"}],
+            "organization_id": organization_id,
+            "project_id": project_id,
+        }
+        response = make_signed_seer_api_request(
+            connection_pool=seer_issue_detection_connection_pool,
+            path=SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
+            body=json.dumps(seer_request).encode("utf-8"),
+        )
+
+        if response.status < 200 or response.status >= 300:
+            raise LLMIssueDetectionError(
+                message="Seer HTTP error",
+                status=response.status,
+                project_id=project_id,
+                trace_id=trace.trace_id,
+                response_data=response.data.decode("utf-8"),
+            )
+
+        try:
+            raw_response_data = response.json()
+            response_data = IssueDetectionResponse.parse_obj(raw_response_data)
+        except (ValueError, TypeError) as e:
+            raise LLMIssueDetectionError(
+                message="Seer response parsing error",
+                status=response.status,
+                project_id=project_id,
+                trace_id=trace.trace_id,
+                response_data=response.data.decode("utf-8"),
+                error_message=str(e),
+            )
+
+        logger.info(
+            "Seer issue detection success",
+            extra={"num_issues": len(response_data.issues), "trace_id": trace.trace_id},
+        )

--- a/src/sentry/tasks/llm_issue_detection.py
+++ b/src/sentry/tasks/llm_issue_detection.py
@@ -106,7 +106,9 @@ def detect_llm_issues_for_project(project_id: int) -> None:
         project_id, limit=50, start_time_delta={"minutes": 30}
     )
     for transaction in transactions:
-        trace: TraceData = get_trace_for_transaction(transaction.name, transaction.project_id)
+        trace: TraceData | None = get_trace_for_transaction(
+            transaction.name, transaction.project_id
+        )
         if not trace:
             continue
 

--- a/src/sentry/tasks/llm_issue_detection.py
+++ b/src/sentry/tasks/llm_issue_detection.py
@@ -48,9 +48,9 @@ class LLMIssueDetectionError(SeerApiError):
         self,
         message: str,
         status: int,
-        project_id: int,
-        trace_id: str,
-        response_data: str,
+        project_id: int | None = None,
+        trace_id: str | None = None,
+        response_data: str | None = None,
         error_message: str | None = None,
     ):
         super().__init__(message, status)
@@ -106,48 +106,67 @@ def detect_llm_issues_for_project(project_id: int) -> None:
         project_id, limit=50, start_time_delta={"minutes": 30}
     )
     for transaction in transactions:
-        trace: TraceData | None = get_trace_for_transaction(
-            transaction.name, transaction.project_id
-        )
-        if not trace:
-            continue
-
-        logger.info("Found trace for LLM issue detection", extra={"trace_id": trace.trace_id})
-
-        seer_request = {
-            "telemetry": [{**trace.dict(), "kind": "trace"}],
-            "organization_id": organization_id,
-            "project_id": project_id,
-        }
-        response = make_signed_seer_api_request(
-            connection_pool=seer_issue_detection_connection_pool,
-            path=SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
-            body=json.dumps(seer_request).encode("utf-8"),
-        )
-
-        if response.status < 200 or response.status >= 300:
-            raise LLMIssueDetectionError(
-                message="Seer HTTP error",
-                status=response.status,
-                project_id=project_id,
-                trace_id=trace.trace_id,
-                response_data=response.data.decode("utf-8"),
-            )
-
         try:
-            raw_response_data = response.json()
-            response_data = IssueDetectionResponse.parse_obj(raw_response_data)
-        except (ValueError, TypeError) as e:
-            raise LLMIssueDetectionError(
-                message="Seer response parsing error",
-                status=response.status,
-                project_id=project_id,
-                trace_id=trace.trace_id,
-                response_data=response.data.decode("utf-8"),
-                error_message=str(e),
+            trace: TraceData | None = get_trace_for_transaction(
+                transaction.name, transaction.project_id
+            )
+            if not trace:
+                continue
+
+            logger.info(
+                "Found trace for LLM issue detection",
+                extra={
+                    "trace_id": trace.trace_id,
+                    "project_id": project_id,
+                },
             )
 
-        logger.info(
-            "Seer issue detection success",
-            extra={"num_issues": len(response_data.issues), "trace_id": trace.trace_id},
-        )
+            seer_request = {
+                "telemetry": [{**trace.dict(), "kind": "trace"}],
+                "organization_id": organization_id,
+                "project_id": project_id,
+            }
+            response = make_signed_seer_api_request(
+                connection_pool=seer_issue_detection_connection_pool,
+                path=SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
+                body=json.dumps(seer_request).encode("utf-8"),
+            )
+
+            if response.status < 200 or response.status >= 300:
+                raise LLMIssueDetectionError(
+                    message="Seer HTTP error",
+                    status=response.status,
+                    project_id=project_id,
+                    trace_id=trace.trace_id,
+                    response_data=response.data.decode("utf-8"),
+                )
+
+            try:
+                raw_response_data = response.json()
+                response_data = IssueDetectionResponse.parse_obj(raw_response_data)
+            except (ValueError, TypeError) as e:
+                raise LLMIssueDetectionError(
+                    message="Seer response parsing error",
+                    status=response.status,
+                    project_id=project_id,
+                    trace_id=trace.trace_id,
+                    response_data=response.data.decode("utf-8"),
+                    error_message=str(e),
+                )
+
+            n_found_issues = len(response_data.issues)
+            logger.info(
+                "Seer issue detection success",
+                extra={
+                    "num_issues": n_found_issues,
+                    "trace_id": trace.trace_id,
+                    "project_id": project_id,
+                    "titles": (
+                        [issue.title for issue in response_data.issues]
+                        if n_found_issues > 0
+                        else None
+                    ),
+                },
+            )
+        except LLMIssueDetectionError:
+            continue  # if one transaction encounters an error, don't block processing of the others

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -1,12 +1,49 @@
-from unittest.mock import patch
+import uuid
+from unittest.mock import Mock, patch
 
-from sentry.tasks.llm_issue_detection import run_llm_issue_detection
-from sentry.testutils.cases import TestCase
+import pytest
+from urllib3 import BaseHTTPResponse
+
+from sentry.tasks.llm_issue_detection import (
+    LLMIssueDetectionError,
+    detect_llm_issues_for_project,
+    run_llm_issue_detection,
+)
+from sentry.testutils.cases import APITransactionTestCase, SnubaTestCase, SpanTestCase
+from sentry.testutils.helpers.datetime import before_now
 
 
-class LLMIssueDetectionTest(TestCase):
+@patch("sentry.tasks.llm_issue_detection.make_signed_seer_api_request")
+class LLMIssueDetectionTest(APITransactionTestCase, SnubaTestCase, SpanTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.ten_mins_ago = before_now(minutes=10)
+
+    def _create_test_transaction_data(self):
+        transaction_name = "test_transaction"
+        trace_id = uuid.uuid4().hex
+
+        spans = []
+        for i in range(3):
+            span = self.create_span(
+                {
+                    "description": f"span-{i}",
+                    "sentry_tags": {"transaction": transaction_name},
+                    "trace_id": trace_id,
+                    "parent_span_id": None if i == 0 else f"parent-{i - 1}",
+                    "is_segment": i == 0,
+                },
+                start_ts=self.ten_mins_ago,
+            )
+            spans.append(span)
+
+        # Store spans in EAP (required for get_transactions_for_project and get_trace_for_transaction)
+        self.store_spans(spans, is_eap=True)
+
+        return spans, transaction_name, trace_id
+
     @patch("sentry.tasks.llm_issue_detection.detect_llm_issues_for_project.delay")
-    def test_run_detection_dispatches_sub_tasks(self, mock_delay):
+    def test_run_detection_dispatches_sub_tasks(self, mock_delay, *_):
         """Test run_detection spawns sub-tasks for each project."""
         project = self.create_project()
 
@@ -20,3 +57,114 @@ class LLMIssueDetectionTest(TestCase):
 
         assert mock_delay.called
         assert mock_delay.call_args[0][0] == project.id
+
+    def test_detect_llm_issues_http_error(self, mock_seer_api):
+        """Test HTTP error handling with proper exception fields."""
+        self._create_test_transaction_data()
+        mock_response = Mock(spec=BaseHTTPResponse)
+        mock_response.status = 500
+        mock_response.data = b'{"error": "Internal server error"}'
+        mock_seer_api.return_value = mock_response
+
+        with pytest.raises(LLMIssueDetectionError) as exc_info:
+            detect_llm_issues_for_project(self.project.id)
+
+        exception = exc_info.value
+        assert exception.message == "Seer HTTP error"
+        assert exception.status == 500
+        assert exception.project_id == self.project.id
+        assert exception.trace_id is not None
+        assert exception.response_data == '{"error": "Internal server error"}'
+        assert exception.error_message is None
+
+    def test_detect_llm_issues_parsing_error(self, mock_seer_api):
+        """Test response parsing error handling with error_message field."""
+        self._create_test_transaction_data()
+        mock_response = Mock(spec=BaseHTTPResponse)
+        mock_response.status = 200
+        mock_response.data = b"invalid json"
+        mock_response.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+        mock_seer_api.return_value = mock_response
+
+        with pytest.raises(LLMIssueDetectionError) as exc_info:
+            detect_llm_issues_for_project(self.project.id)
+
+        exception = exc_info.value
+        assert exception.message == "Seer response parsing error"
+        assert exception.status == 200
+        assert exception.project_id == self.project.id
+        assert exception.trace_id is not None
+        assert exception.response_data == "invalid json"
+        assert "Expecting value" in exception.error_message
+
+    def test_detect_llm_issues_invalid_schema(self, mock_seer_api):
+        """Test Pydantic validation error handling."""
+        self._create_test_transaction_data()
+        mock_response = Mock(spec=BaseHTTPResponse)
+        mock_response.status = 200
+        mock_response.data = b'{"wrong_field": "value"}'
+        mock_response.json.return_value = {"wrong_field": "value"}
+        mock_seer_api.return_value = mock_response
+
+        with pytest.raises(LLMIssueDetectionError) as exc_info:
+            detect_llm_issues_for_project(self.project.id)
+
+        exception = exc_info.value
+        assert exception.message == "Seer response parsing error"
+        assert exception.status == 200
+        assert exception.project_id == self.project.id
+        assert exception.trace_id is not None
+        assert exception.response_data == '{"wrong_field": "value"}'
+        assert exception.error_message is not None
+
+    @patch("sentry.tasks.llm_issue_detection.logger")
+    def test_detect_llm_issues_success_with_logging(self, mock_logger, mock_seer_api):
+        """Test successful issue detection with proper logging."""
+        self._create_test_transaction_data()
+        mock_response = Mock(spec=BaseHTTPResponse)
+        mock_response.status = 200
+        mock_response.data = b'{"issues": [{"title": "Test Issue", "explanation": "Test explanation", "impact": "High", "evidence": "Test evidence"}]}'
+        mock_response.json.return_value = {
+            "issues": [
+                {
+                    "title": "Test Issue",
+                    "explanation": "Test explanation",
+                    "impact": "High",
+                    "evidence": "Test evidence",
+                }
+            ]
+        }
+        mock_seer_api.return_value = mock_response
+
+        detect_llm_issues_for_project(self.project.id)
+
+        success_log_calls = [
+            call
+            for call in mock_logger.info.call_args_list
+            if "Seer issue detection success" in call[0]
+        ]
+        assert len(success_log_calls) > 0
+        success_call = success_log_calls[0]
+        log_extra = success_call[1]["extra"]
+        assert log_extra["num_issues"] == 1
+        assert "trace_id" in log_extra
+
+    def test_detect_llm_issues_no_transactions(self, mock_seer_api):
+        """Test handling when no transactions are found."""
+        # This should complete without errors (just no work done)
+        detect_llm_issues_for_project(self.project.id)
+
+        # Verify Seer API was never called since no transactions were found
+        mock_seer_api.assert_not_called()
+
+    def test_detect_llm_issues_no_traces(self, mock_seer_api):
+        """Test handling when transactions exist but no traces are found."""
+        # Create some transaction data but mock get_trace_for_transaction to return None
+        self._create_test_transaction_data()
+
+        with patch("sentry.tasks.llm_issue_detection.get_trace_for_transaction", return_value=None):
+            # This should complete without errors and not call Seer API
+            detect_llm_issues_for_project(self.project.id)
+
+        # Verify Seer API was never called since no traces were found
+        mock_seer_api.assert_not_called()

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -95,6 +95,7 @@ class LLMIssueDetectionTest(APITransactionTestCase, SnubaTestCase, SpanTestCase)
         assert exception.project_id == self.project.id
         assert exception.trace_id is not None
         assert exception.response_data == "invalid json"
+        assert exception.error_message is not None
         assert "Expecting value" in exception.error_message
 
     def test_detect_llm_issues_invalid_schema(self, mock_seer_api):
@@ -116,6 +117,7 @@ class LLMIssueDetectionTest(APITransactionTestCase, SnubaTestCase, SpanTestCase)
         assert exception.trace_id is not None
         assert exception.response_data == '{"wrong_field": "value"}'
         assert exception.error_message is not None
+        assert "field required" in exception.error_message
 
     @patch("sentry.tasks.llm_issue_detection.logger")
     def test_detect_llm_issues_success_with_logging(self, mock_logger, mock_seer_api):

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -150,6 +150,8 @@ class LLMIssueDetectionTest(APITransactionTestCase, SnubaTestCase, SpanTestCase)
         log_extra = success_call[1]["extra"]
         assert log_extra["num_issues"] == 1
         assert "trace_id" in log_extra
+        assert log_extra["project_id"] == self.project.id
+        assert log_extra["titles"] == ["Test Issue"]
 
     def test_detect_llm_issues_no_transactions(self, mock_seer_api):
         """Test handling when no transactions are found."""


### PR DESCRIPTION
  ## Summary
Connects the task to the new Seer endpoint - enables sending performance data to Seer to analyze.
Currently just logging the results, next step is to create Issues from the data returned by Seer.

  ## Changes
  - Add `detect_llm_issues_for_project` task implementation
    - Fetches recent transactions for enabled projects
    - Retrieves trace data and sends to Seer `/v1/automation/issue-detection/analyze` endpoint
    - Handles HTTP errors and JSON parsing failures with structured error reporting
  - Create Pydantic models for API request/response validation
  - Add dedicated connection pool for issue detection endpoints
  - Implement comprehensive error handling with `LLMIssueDetectionError`
  - Add structured logging for success and failure cases

  The task is behind feature flags and project allowlists, ready for controlled rollout.
