### PR TITLE
feat: update codeowners to new team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -486,9 +486,9 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 
 ## SDK
 /src/sentry/utils/sdk.py                                             @getsentry/team-web-sdk-backend
-/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py   @getsentry/team-web-sdk-frontend
-/src/sentry/web/frontend/setup_wizard.py                             @getsentry/team-web-sdk-frontend
-/src/sentry/api/endpoints/setup_wizard.py                            @getsentry/team-web-sdk-frontend
+/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py   @getsentry/team-javascript-sdks
+/src/sentry/web/frontend/setup_wizard.py                             @getsentry/team-javascript-sdks
+/src/sentry/api/endpoints/setup_wizard.py                            @getsentry/team-javascript-sdks
 ## End of SDK
 
 

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -32,4 +32,4 @@ class ApiOwner(Enum):
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
     VISIBILITY = "visibility"
-    WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
+    WEB_FRONTEND_SDKS = "team-javascript-sdks"


### PR DESCRIPTION
The team name has changed to `team-javascript-sdks` and therefore needs to be updated in the CODEOWNERS