### PR TITLE
Support more than 0999 migrations

### DIFF
--- a/tools/migrations/squash.py
+++ b/tools/migrations/squash.py
@@ -1,6 +1,7 @@
 import ast
 import contextlib
 import os.path
+import string
 import subprocess
 from collections.abc import Generator
 from typing import NamedTuple
@@ -81,7 +82,7 @@ def _migration_root(app: str) -> str:
 
 def _migrations(root: str) -> Generator[str]:
     for fname in os.listdir(root):
-        if fname.startswith("0") and fname.endswith(".py"):
+        if fname[0] in string.digits and fname.endswith(".py"):
             yield fname
 
 


### PR DESCRIPTION
The 1000th migration ([https://github.com/getsentry/sentry/pull/102006](https://github.com/getsentry/sentry/pull/102006/files#diff-7b6c509147de8d7a7eb571ae38176cbaee01940401c74ecf0d0a90843a97fb3dR25))

Suffered from a CI error:

```
django.db.migrations.exceptions.NodeNotFoundError: Migration sentry.1000_add_project_distribution_scope dependencies reference nonexistent parent node ('sentry', '0999_add_extrapolation_mode_to_snuba_query')
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/sentry/sentry/tools/migrations/squash.py", line 293, in <module>
    raise SystemExit(main())
                     ~~~~^^
  File "/home/runner/work/sentry/sentry/tools/migrations/squash.py", line 282, in main
    subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('sentry', 'django', 'makemigrations', '-n', 'squash')' returned non-zero exit status 1.
```

Where we could not find the parent migration: `0999_add_extrapolation_mode_to_snuba_query`
This turned out to be due to the code which finds migrations expecting them to begin with a `0`:

```
def _migrations(root: str) -> Generator[str]:
    for fname in os.listdir(root):
        if fname.startswith("0") and fname.endswith(".py"):
            yield fname
```

Change this to allow migrations to begin with any digit.