### PR TITLE
ref(onboarding): Split ruby onboarding doc into multiple files

### DIFF
--- a/static/app/gettingStartedDocs/ruby/rack.tsx
+++ b/static/app/gettingStartedDocs/ruby/rack.tsx
@@ -6,9 +6,9 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {getRubyProfilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
+import {logs} from 'sentry/gettingStartedDocs/ruby/ruby/logs';
+import {profiling} from 'sentry/gettingStartedDocs/ruby/ruby/profiling';
 import {t, tct} from 'sentry/locale';
-import {getRubyLogsOnboarding} from 'sentry/utils/gettingStartedDocs/ruby';
 
 type Params = DocsParams;
 
@@ -166,8 +166,8 @@ const onboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
-  profilingOnboarding: getRubyProfilingOnboarding(),
-  logsOnboarding: getRubyLogsOnboarding({
+  profilingOnboarding: profiling(),
+  logsOnboarding: logs({
     docsPlatform: 'rack',
   }),
 };

--- a/static/app/gettingStartedDocs/ruby/rails.tsx
+++ b/static/app/gettingStartedDocs/ruby/rails.tsx
@@ -14,9 +14,9 @@ import {
   feedbackOnboardingJsLoader,
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
-import {getRubyProfilingOnboarding} from 'sentry/gettingStartedDocs/ruby/ruby';
+import {logs} from 'sentry/gettingStartedDocs/ruby/ruby/logs';
+import {profiling} from 'sentry/gettingStartedDocs/ruby/ruby/profiling';
 import {t, tct} from 'sentry/locale';
-import {getRubyLogsOnboarding} from 'sentry/utils/gettingStartedDocs/ruby';
 
 type Params = DocsParams;
 
@@ -249,8 +249,8 @@ const docs: Docs = {
   replayOnboardingJsLoader,
   crashReportOnboarding,
   feedbackOnboardingJsLoader,
-  profilingOnboarding: getRubyProfilingOnboarding({frameworkPackage: 'sentry-rails'}),
-  logsOnboarding: getRubyLogsOnboarding({
+  profilingOnboarding: profiling({frameworkPackage: 'sentry-rails'}),
+  logsOnboarding: logs({
     docsPlatform: 'rails',
   }),
 };

--- a/static/app/gettingStartedDocs/ruby/ruby/index.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby/index.tsx
@@ -1,0 +1,17 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+
+import {logs} from './logs';
+import {onboarding} from './onboarding';
+import {profiling} from './profiling';
+
+const docs: Docs = {
+  onboarding,
+  crashReportOnboarding: CrashReportWebApiOnboarding,
+  profilingOnboarding: profiling(),
+  logsOnboarding: logs({
+    docsPlatform: 'ruby',
+  }),
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/ruby/ruby/logs.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby/logs.tsx
@@ -1,14 +1,12 @@
 import {ExternalLink} from 'sentry/components/core/link';
-import {
-  StepType,
-  type BasePlatformOptions,
-  type OnboardingConfig,
+import type {
+  BasePlatformOptions,
+  OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-export const getRubyLogsOnboarding = <
-  PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
->({
+export const logs = <PlatformOptions extends BasePlatformOptions = BasePlatformOptions>({
   docsPlatform,
 }: {
   docsPlatform: string;

--- a/static/app/gettingStartedDocs/ruby/ruby/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './ruby';
+import docs from '.';
 
 describe('getting started with ruby', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/ruby/ruby/onboarding.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby/onboarding.tsx
@@ -1,109 +1,15 @@
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
-  Docs,
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
-import {getRubyLogsOnboarding} from 'sentry/utils/gettingStartedDocs/ruby';
 
-type Params = DocsParams;
-
-export const getRubyProfilingOnboarding = ({
-  frameworkPackage,
-}: {frameworkPackage?: string} = {}): OnboardingConfig => ({
-  install: () => [
-    {
-      type: StepType.INSTALL,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'We use the [code:stackprof] [stackprofLink:gem] to collect profiles for Ruby.',
-            {
-              code: <code />,
-              stackprofLink: <ExternalLink href="https://github.com/tmm1/stackprof" />,
-            }
-          ),
-        },
-        {
-          type: 'text',
-          text: tct(
-            'First add [code:stackprof] to your [code:Gemfile] and make sure it is loaded before the Sentry SDK.',
-            {
-              code: <code />,
-            }
-          ),
-        },
-        {
-          type: 'code',
-          language: 'ruby',
-          code: `
-gem 'stackprof'
-gem 'sentry-ruby'${
-            frameworkPackage
-              ? `
-gem '${frameworkPackage}'`
-              : ''
-          }`,
-        },
-      ],
-    },
-  ],
-  configure: (params: Params) => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Then, make sure both [code:traces_sample_rate] and [code:profiles_sample_rate] are set and non-zero in your Sentry initializer.',
-            {
-              code: <code />,
-            }
-          ),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'Ruby',
-              filename: 'config/initializers/sentry.rb',
-              language: 'ruby',
-              code: `
-Sentry.init do |config|
-  config.dsn = "${params.dsn.public}"
-  config.traces_sample_rate = 1.0
-  config.profiles_sample_rate = 1.0
-end
-                   `,
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            'Verify that profiling is working correctly by simply using your application.'
-          ),
-        },
-      ],
-    },
-  ],
-});
-
-const getInstallSnippet = (params: Params) =>
+const getInstallSnippet = (params: DocsParams) =>
   `${params.isProfilingSelected ? 'gem "stackprof"\n' : ''}gem "sentry-ruby"`;
 
-const getConfigureSnippet = (params: Params) => `
+const getConfigureSnippet = (params: DocsParams) => `
 require 'sentry-ruby'
 
 Sentry.init do |config|
@@ -153,8 +59,8 @@ end
 
 Sentry.capture_message("test message")`;
 
-const onboarding: OnboardingConfig = {
-  install: (params: Params) => [
+export const onboarding: OnboardingConfig = {
+  install: (params: DocsParams) => [
     {
       type: StepType.INSTALL,
       content: [
@@ -240,14 +146,3 @@ const onboarding: OnboardingConfig = {
     },
   ],
 };
-
-const docs: Docs = {
-  onboarding,
-  crashReportOnboarding: CrashReportWebApiOnboarding,
-  profilingOnboarding: getRubyProfilingOnboarding(),
-  logsOnboarding: getRubyLogsOnboarding({
-    docsPlatform: 'ruby',
-  }),
-};
-
-export default docs;

--- a/static/app/gettingStartedDocs/ruby/ruby/profiling.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby/profiling.tsx
@@ -1,0 +1,96 @@
+import {ExternalLink} from 'sentry/components/core/link';
+import type {
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+
+export const profiling = ({
+  frameworkPackage,
+}: {frameworkPackage?: string} = {}): OnboardingConfig => ({
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'We use the [code:stackprof] [stackprofLink:gem] to collect profiles for Ruby.',
+            {
+              code: <code />,
+              stackprofLink: <ExternalLink href="https://github.com/tmm1/stackprof" />,
+            }
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
+            'First add [code:stackprof] to your [code:Gemfile] and make sure it is loaded before the Sentry SDK.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'code',
+          language: 'ruby',
+          code: `
+gem 'stackprof'
+gem 'sentry-ruby'${
+            frameworkPackage
+              ? `
+gem '${frameworkPackage}'`
+              : ''
+          }`,
+        },
+      ],
+    },
+  ],
+  configure: (params: DocsParams) => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Then, make sure both [code:traces_sample_rate] and [code:profiles_sample_rate] are set and non-zero in your Sentry initializer.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'Ruby',
+              filename: 'config/initializers/sentry.rb',
+              language: 'ruby',
+              code: `
+Sentry.init do |config|
+  config.dsn = "${params.dsn.public}"
+  config.traces_sample_rate = 1.0
+  config.profiles_sample_rate = 1.0
+end
+                   `,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that profiling is working correctly by simply using your application.'
+          ),
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms