### PR TITLE
fix(sub v3): Prevent form reopening for billing failure

### DIFF
--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -61,6 +61,11 @@ function CreditCardPanel({
   const [expandInitially, setExpandInitially] = useState(shouldExpandInitially);
 
   const handleCardUpdated = useCallback((data: Subscription) => {
+    // if the card was successfully updated, reset the billing failure state
+    // so we don't trigger side effects nor render outdated content
+    setFromBillingFailure(false);
+    setReferrer(undefined);
+
     setCardLastFourDigits(data.paymentSource?.last4 || null);
     setCardZipCode(data.paymentSource?.zipCode || null);
     SubscriptionStore.set(data.slug, data);


### PR DESCRIPTION
[See replay here](https://sentry.sentry.io/explore/replays/ff3e11368d8440a6aa7cfe04f0150b5c/)

When a customer goes to the billing information page with `referrer` including one of the `billing-failure` strings, we auto-open the payment method form so they can add a new payment method which will then be charged immediately. In the attached replay, this occurs as expected, but it seems to not succeed as the form seemingly stays open. In reality, what was happening was that the form would reopen due to the side effect refiring, since the `subscription` dependency changes on successful payment method update.

To prevent this, we can simply set our referrer state to undefined, since we only open the form when it includes `billing-failure`. Additionally, this PR fixes a bug where reopening the form after successfully updating the card on billing failure would still render the content for updating the payment method on billing failure.