### PR TITLE
fix: remove explicit background-color setting for the loading triangle

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -138,10 +138,6 @@ const styles = (theme: Theme, isDark: boolean) => css`
       background: ${theme.tokens.background.primary};
     }
 
-    .loading.triangle .loading-indicator {
-      background: ${theme.tokens.background.secondary};
-    }
-
     color: ${theme.textColor};
     background: ${theme.tokens.background.primary};
   }


### PR DESCRIPTION
this is no longer needed as we take the CSS directly from the splash loader and re-use it, and those styles already handle light-mode/dark-mode with filter: invert(100%), see: https://github.com/getsentry/sentry/blob/870d88d0a3dd11d67016f0be81453bc7c95dc201/static/less/shared-components.less#L528-L539

that also means when react takes over, if we set the color explicitly, the filter will re-invert it to the wrong thing, which is what we are seeing in this issue