### PR TITLE
chore(search-bar): Small wildcard op tweaks

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -176,6 +176,18 @@ describe('replaceFreeTextTokens', () => {
           focusOverride: {itemKey: 'freeText:2'},
         },
       },
+      {
+        description: 'when the value contains an asterisks, it sets to is',
+        input: {
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `span.description:test te*st`,
+        },
+        expected: {
+          query: `span.description:test span.description:te*st`,
+          focusOverride: {itemKey: 'freeText:2'},
+        },
+      },
     ];
 
     it.each(testCases)('$description', ({input, expected}) => {

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -727,7 +727,13 @@ export function replaceFreeTextTokens(
     }
 
     const value = escapeTagValue(token.text.trim());
-    replacedQuery.push(`${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`);
+    replacedQuery.push(
+      // We don't want to break user flows, so if they include an asterisk in their free
+      // text value, leave it as an `is` filter.
+      value.includes('*')
+        ? `${primarySearchKey}:${value}`
+        : `${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`
+    );
   }
 
   const finalQuery = replacedQuery.join(' ').trim();

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -224,7 +224,7 @@ describe('SearchQueryBuilder', () => {
         ).not.toBeInTheDocument();
       });
 
-      it('does not display footer when using a wildcard operator', async () => {
+      it('renders swap to is for * when using a wildcard operator', async () => {
         render(
           <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />,
           {organization: {features: ['search-query-builder-wildcard-operators']}}
@@ -250,10 +250,9 @@ describe('SearchQueryBuilder', () => {
         await userEvent.click(
           screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
         );
-
         expect(
-          screen.queryByText('Wildcard (*) matching allowed')
-        ).not.toBeInTheDocument();
+          screen.getByText('Switch to "is" operator to use wildcard (*) matching')
+        ).toBeInTheDocument();
       });
     });
   });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4250,6 +4250,25 @@ describe('SearchQueryBuilder', () => {
       ).toBeInTheDocument();
     });
 
+    it('escapes * for is op but not contains op', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery=""
+          replaceRawSearchKeys={['span.description']}
+        />,
+        {organization: {features: ['search-query-builder-wildcard-operators']}}
+      );
+
+      await userEvent.type(screen.getByRole('textbox'), 'test*');
+
+      const options = within(screen.getByRole('listbox')).getAllByRole('option');
+      expect(options).toHaveLength(2);
+
+      expect(options[0]).toHaveTextContent('span.description contains test\\*');
+      expect(options[1]).toHaveTextContent('span.description is test*');
+    });
+
     describe('with wildcard operators enabled', () => {
       describe('selecting suggestions', () => {
         it('should replace raw search keys with defined key:contains:value', async () => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -57,7 +57,7 @@ function WildcardFooter({
   token: TokenResult<Token.FILTER>;
 }) {
   if (isWildcardOperator(token.operator)) {
-    return null;
+    return <Label>{t('Switch to "is" operator to use wildcard (*) matching')}</Label>;
   }
 
   if (canUseWildcard) {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -156,10 +156,10 @@ export function createRawSearchFilterIsValueItem(
   key: string,
   value: string
 ): RawSearchFilterIsValueItem {
-  const filter = `${key}:${escapeFilterValue(value)}`;
+  const filter = `${key}:${value}`;
 
   return {
-    key: getEscapedKey(`${key}:${value}`),
+    key: getEscapedKey(filter),
     label: <FormattedQuery query={filter} />,
     value: filter,
     textValue: filter,


### PR DESCRIPTION
This PR fixes three issues in regards to the wildcard operators and raw search replacement:

- If a user types in a query `test*` we won't auto replace with a `contains` query, rather just an `is` query
- The dropdown raw search replace `is` option no longer escapes asterisks
- Add in a footer message when using a wildcard operator to prompt users to switch to an `is` operator if they want to the wildcard character. 