### PR TITLE
feat(seer): Add thumbs up/down feedback buttons to autofix steps

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -331,7 +331,7 @@ export function AutofixChanges({
             {step.termination_reason && (
               <TerminationReasonText>{step.termination_reason}</TerminationReasonText>
             )}
-            <Flex justify="flex-end" align="center" gap="md">
+            <Flex justify="end" align="center" gap="md">
               {!prsMade && (
                 <ButtonBar>
                   {branchesMade ? (

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -9,6 +9,7 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Flex} from 'sentry/components/core/layout';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
@@ -330,7 +331,7 @@ export function AutofixChanges({
             {step.termination_reason && (
               <TerminationReasonText>{step.termination_reason}</TerminationReasonText>
             )}
-            <ButtonContainer>
+            <Flex justify="flex-end" align="center" gap="md">
               {!prsMade && (
                 <ButtonBar>
                   {branchesMade ? (
@@ -400,7 +401,7 @@ export function AutofixChanges({
                     )}
                   </ScrollCarousel>
                 ))}
-            </ButtonContainer>
+            </Flex>
           </BottomButtonContainer>
         </ChangesContainer>
       </AnimationWrapper>
@@ -512,13 +513,6 @@ const TerminationReasonText = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
   flex: 1;
   min-width: 0;
-`;
-
-const ButtonContainer = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: ${space(1)};
 `;
 
 function CreatePRsButton({

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -189,7 +189,6 @@ export function AutofixChanges({
   isChangesFirstAppearance,
 }: AutofixChangesProps) {
   const {data} = useAutofixData({groupId});
-  const organization = useOrganization();
   const isBusy = step.status === AutofixStatus.PROCESSING;
   const iconCodeRef = useRef<HTMLDivElement>(null);
   const firstChangeRef = useRef<HTMLDivElement | null>(null);
@@ -369,12 +368,7 @@ export function AutofixChanges({
                 </ButtonBar>
               )}
               {step.status === AutofixStatus.COMPLETED && (
-                <AutofixStepFeedback
-                  stepType="changes"
-                  groupId={groupId}
-                  runId={runId}
-                  organization={organization}
-                />
+                <AutofixStepFeedback stepType="changes" groupId={groupId} runId={runId} />
               )}
               {prsMade &&
                 (step.changes.length === 1 && step.changes[0]?.pull_request?.pr_url ? (

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -14,6 +14,7 @@ import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighl
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {replaceHeadersWithBold} from 'sentry/components/events/autofix/autofixRootCause';
 import {AutofixSetupWriteAccessModal} from 'sentry/components/events/autofix/autofixSetupWriteAccessModal';
+import {AutofixStepFeedback} from 'sentry/components/events/autofix/autofixStepFeedback';
 import {
   AutofixStatus,
   type AutofixChangesStep,
@@ -188,6 +189,7 @@ export function AutofixChanges({
   isChangesFirstAppearance,
 }: AutofixChangesProps) {
   const {data} = useAutofixData({groupId});
+  const organization = useOrganization();
   const isBusy = step.status === AutofixStatus.PROCESSING;
   const iconCodeRef = useRef<HTMLDivElement>(null);
   const firstChangeRef = useRef<HTMLDivElement | null>(null);
@@ -366,6 +368,14 @@ export function AutofixChanges({
                   />
                 </ButtonBar>
               )}
+              {step.status === AutofixStatus.COMPLETED && (
+                <AutofixStepFeedback
+                  stepType="changes"
+                  groupId={groupId}
+                  runId={runId}
+                  organization={organization}
+                />
+              )}
               {prsMade &&
                 (step.changes.length === 1 && step.changes[0]?.pull_request?.pr_url ? (
                   <LinkButton
@@ -513,6 +523,8 @@ const TerminationReasonText = styled('div')`
 const ButtonContainer = styled('div')`
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: ${space(1)};
 `;
 
 function CreatePRsButton({

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -3,6 +3,7 @@ import {AutofixRootCauseData} from 'sentry-fixture/autofixRootCauseData';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {AutofixRootCause} from 'sentry/components/events/autofix/autofixRootCause';
+import {AutofixStatus} from 'sentry/components/events/autofix/types';
 
 describe('AutofixRootCause', () => {
   beforeEach(() => {
@@ -27,6 +28,7 @@ describe('AutofixRootCause', () => {
     groupId: '1',
     rootCauseSelection: null,
     runId: '101',
+    status: AutofixStatus.COMPLETED,
   } satisfies React.ComponentProps<typeof AutofixRootCause>;
 
   it('can view a relevant code snippet', async () => {

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -10,7 +10,9 @@ import {Flex} from 'sentry/components/core/layout';
 import {TextArea} from 'sentry/components/core/textarea';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
+import {AutofixStepFeedback} from 'sentry/components/events/autofix/autofixStepFeedback';
 import {
+  AutofixStatus,
   type AutofixRootCauseData,
   type AutofixRootCauseSelection,
   type CommentThread,
@@ -80,6 +82,7 @@ type AutofixRootCauseProps = {
   groupId: string;
   rootCauseSelection: AutofixRootCauseSelection;
   runId: string;
+  status: AutofixStatus;
   agentCommentThread?: CommentThread;
   event?: Event;
   isRootCauseFirstAppearance?: boolean;
@@ -249,6 +252,7 @@ function AutofixRootCauseDisplay({
   groupId,
   runId,
   rootCauseSelection,
+  status,
   previousDefaultStepIndex,
   previousInsightCount,
   agentCommentThread,
@@ -362,10 +366,20 @@ function AutofixRootCauseDisplay({
           <CauseDescription>{rootCauseSelection.custom_root_cause}</CauseDescription>
           <BottomDivider />
           <BottomButtonContainer>
-            <CopyRootCauseButton
-              customRootCause={rootCauseSelection.custom_root_cause}
-              event={event}
-            />
+            <ButtonBar>
+              <CopyRootCauseButton
+                customRootCause={rootCauseSelection.custom_root_cause}
+                event={event}
+              />
+            </ButtonBar>
+            {status === AutofixStatus.COMPLETED && (
+              <AutofixStepFeedback
+                stepType="root_cause"
+                groupId={groupId}
+                runId={runId}
+                organization={organization}
+              />
+            )}
           </BottomButtonContainer>
         </CustomRootCausePadding>
       </CausesContainer>
@@ -498,6 +512,14 @@ function AutofixRootCauseDisplay({
             </Button>
           )}
         </ButtonBar>
+        {status === AutofixStatus.COMPLETED && (
+          <AutofixStepFeedback
+            stepType="root_cause"
+            groupId={groupId}
+            runId={runId}
+            organization={organization}
+          />
+        )}
       </BottomButtonContainer>
     </CausesContainer>
   );
@@ -594,6 +616,8 @@ const BottomDivider = styled('div')`
 const BottomButtonContainer = styled('div')`
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: ${space(1)};
   padding-top: ${p => p.theme.space.xl};
 `;
 

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -377,7 +377,6 @@ function AutofixRootCauseDisplay({
                 stepType="root_cause"
                 groupId={groupId}
                 runId={runId}
-                organization={organization}
               />
             )}
           </BottomButtonContainer>
@@ -513,12 +512,7 @@ function AutofixRootCauseDisplay({
           )}
         </ButtonBar>
         {status === AutofixStatus.COMPLETED && (
-          <AutofixStepFeedback
-            stepType="root_cause"
-            groupId={groupId}
-            runId={runId}
-            organization={organization}
-          />
+          <AutofixStepFeedback stepType="root_cause" groupId={groupId} runId={runId} />
         )}
       </BottomButtonContainer>
     </CausesContainer>

--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -8,6 +8,7 @@ import {
 
 import {AutofixSolution} from 'sentry/components/events/autofix/autofixSolution';
 import {
+  AutofixStatus,
   type AutofixData,
   type AutofixSolutionTimelineEvent,
 } from 'sentry/components/events/autofix/types';
@@ -37,6 +38,7 @@ describe('AutofixSolution', () => {
     groupId: '123',
     runId: 'run-123',
     solutionSelected: false,
+    status: AutofixStatus.COMPLETED,
   } satisfies React.ComponentProps<typeof AutofixSolution>;
 
   beforeEach(() => {

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -660,12 +660,7 @@ function AutofixSolutionDisplay({
           </Tooltip>
         </ButtonBar>
         {status === AutofixStatus.COMPLETED && (
-          <AutofixStepFeedback
-            stepType="solution"
-            groupId={groupId}
-            runId={runId}
-            organization={organization}
-          />
+          <AutofixStepFeedback stepType="solution" groupId={groupId} runId={runId} />
         )}
       </BottomFooter>
     </SolutionContainer>

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -11,6 +11,7 @@ import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {SolutionEventItem} from 'sentry/components/events/autofix/autofixSolutionEventItem';
+import {AutofixStepFeedback} from 'sentry/components/events/autofix/autofixStepFeedback';
 import {
   AutofixStatus,
   AutofixStepType,
@@ -118,6 +119,7 @@ type AutofixSolutionProps = {
   runId: string;
   solution: AutofixSolutionTimelineEvent[];
   solutionSelected: boolean;
+  status: AutofixStatus;
   agentCommentThread?: CommentThread;
   changesDisabled?: boolean;
   customSolution?: string;
@@ -341,6 +343,7 @@ function AutofixSolutionDisplay({
   description,
   groupId,
   runId,
+  status,
   previousDefaultStepIndex,
   previousInsightCount,
   customSolution,
@@ -656,6 +659,14 @@ function AutofixSolutionDisplay({
             </Button>
           </Tooltip>
         </ButtonBar>
+        {status === AutofixStatus.COMPLETED && (
+          <AutofixStepFeedback
+            stepType="solution"
+            groupId={groupId}
+            runId={runId}
+            organization={organization}
+          />
+        )}
       </BottomFooter>
     </SolutionContainer>
   );

--- a/static/app/components/events/autofix/autofixStepFeedback.tsx
+++ b/static/app/components/events/autofix/autofixStepFeedback.tsx
@@ -1,19 +1,18 @@
 import {useCallback, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 
 type StepType = 'root_cause' | 'solution' | 'changes';
 
 interface AutofixStepFeedbackProps {
   groupId: string;
-  organization: Organization;
   runId: string;
   stepType: StepType;
 }
@@ -22,9 +21,9 @@ export function AutofixStepFeedback({
   stepType,
   groupId,
   runId,
-  organization,
 }: AutofixStepFeedbackProps) {
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+  const organization = useOrganization();
   const user = useUser();
 
   const handleFeedback = useCallback(
@@ -47,47 +46,26 @@ export function AutofixStepFeedback({
 
   if (feedbackSubmitted) {
     return (
-      <FeedbackContainer>
-        <ThankYouText>{t('Thanks!')}</ThankYouText>
-      </FeedbackContainer>
+      <Flex align="center" gap="sm">
+        <Text variant="muted">{t('Thanks!')}</Text>
+      </Flex>
     );
   }
 
   return (
-    <FeedbackContainer>
-      <ButtonGroup>
-        <Button
-          size="xs"
-          icon={<IconThumb direction="up" size="sm" />}
-          onClick={() => handleFeedback(true)}
-          aria-label={t('This step was helpful')}
-        />
-        <Button
-          size="xs"
-          icon={<IconThumb direction="down" size="sm" />}
-          onClick={() => handleFeedback(false)}
-          aria-label={t('This step was not helpful')}
-        />
-      </ButtonGroup>
-    </FeedbackContainer>
+    <Flex align="center" gap="xs">
+      <Button
+        size="xs"
+        icon={<IconThumb direction="up" size="sm" />}
+        onClick={() => handleFeedback(true)}
+        aria-label={t('This step was helpful')}
+      />
+      <Button
+        size="xs"
+        icon={<IconThumb direction="down" size="sm" />}
+        onClick={() => handleFeedback(false)}
+        aria-label={t('This step was not helpful')}
+      />
+    </Flex>
   );
 }
-
-const FeedbackContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: ${space(0.5)};
-`;
-
-const ThankYouText = styled('span')`
-  font-size: ${p => p.theme.fontSize.md};
-  line-height: 1.5;
-  color: ${p => p.theme.subText};
-  white-space: nowrap;
-`;
-
-const ButtonGroup = styled('div')`
-  display: flex;
-  gap: ${space(0.25)};
-`;

--- a/static/app/components/events/autofix/autofixStepFeedback.tsx
+++ b/static/app/components/events/autofix/autofixStepFeedback.tsx
@@ -1,0 +1,93 @@
+import {useCallback, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import {IconThumb} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useUser} from 'sentry/utils/useUser';
+
+type StepType = 'root_cause' | 'solution' | 'changes';
+
+interface AutofixStepFeedbackProps {
+  groupId: string;
+  organization: Organization;
+  runId: string;
+  stepType: StepType;
+}
+
+export function AutofixStepFeedback({
+  stepType,
+  groupId,
+  runId,
+  organization,
+}: AutofixStepFeedbackProps) {
+  const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+  const user = useUser();
+
+  const handleFeedback = useCallback(
+    (positive: boolean) => {
+      const analyticsData = {
+        step_type: stepType,
+        positive,
+        group_id: groupId,
+        autofix_run_id: runId,
+        user_id: user.id,
+        organization,
+      };
+
+      trackAnalytics('seer.autofix.feedback_submitted', analyticsData);
+
+      setFeedbackSubmitted(true);
+    },
+    [stepType, groupId, runId, organization, user]
+  );
+
+  if (feedbackSubmitted) {
+    return (
+      <FeedbackContainer>
+        <ThankYouText>{t('Thanks!')}</ThankYouText>
+      </FeedbackContainer>
+    );
+  }
+
+  return (
+    <FeedbackContainer>
+      <ButtonGroup>
+        <Button
+          size="xs"
+          icon={<IconThumb direction="up" size="sm" />}
+          onClick={() => handleFeedback(true)}
+          aria-label={t('This step was helpful')}
+        />
+        <Button
+          size="xs"
+          icon={<IconThumb direction="down" size="sm" />}
+          onClick={() => handleFeedback(false)}
+          aria-label={t('This step was not helpful')}
+        />
+      </ButtonGroup>
+    </FeedbackContainer>
+  );
+}
+
+const FeedbackContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
+
+const ThankYouText = styled('span')`
+  font-size: ${p => p.theme.fontSize.md};
+  line-height: 1.5;
+  color: ${p => p.theme.subText};
+  white-space: nowrap;
+`;
+
+const ButtonGroup = styled('div')`
+  display: flex;
+  gap: ${space(0.25)};
+`;

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -104,6 +104,7 @@ function Step({
                   runId={runId}
                   causes={step.causes}
                   rootCauseSelection={step.selection}
+                  status={step.status}
                   terminationReason={step.termination_reason}
                   agentCommentThread={step.agent_comment_thread ?? undefined}
                   previousDefaultStepIndex={previousDefaultStepIndex}
@@ -119,6 +120,7 @@ function Step({
                   solution={step.solution}
                   description={step.description}
                   solutionSelected={step.solution_selected}
+                  status={step.status}
                   customSolution={step.custom_solution}
                   previousDefaultStepIndex={previousDefaultStepIndex}
                   previousInsightCount={previousInsightCount}

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -166,6 +166,13 @@ export type TeamInsightsEventParameters = {
   'releases_list.click_add_release_health': {
     project_id: number;
   };
+  'seer.autofix.feedback_submitted': {
+    autofix_run_id: string;
+    group_id: string;
+    positive: boolean;
+    step_type: 'root_cause' | 'solution' | 'changes';
+    user_id: string;
+  };
   'suspect_commit.feedback_submitted': {
     choice_selected: boolean;
     group_owner_id: number;
@@ -244,6 +251,7 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'project_detail.releases_tour.close': 'Project Detail: Releases Tour Close',
   'release_detail.pagination': 'Release Detail: Pagination',
   'releases_list.click_add_release_health': 'Releases List: Click Add Release Health',
+  'seer.autofix.feedback_submitted': 'Seer: Autofix Feedback Submitted',
   trace_timeline_clicked: 'Trace Timeline Clicked',
   trace_timeline_more_events_clicked: 'Trace Timeline More Events Clicked',
   'suspect_commit.feedback_submitted': 'Suspect Commit Feedback Submitted',


### PR DESCRIPTION
## Summary

Adds thumbs up/down feedback buttons to the Seer UI issue details flyout to monitor the overall quality of agent output and gauge customer sentiment.

Resolves https://linear.app/getsentry/issue/AIML-1426/add-thumbs-up-thumbs-down-button-to-seer-ui

This PR was generated with claude code.

## Changes

- Created reusable `AutofixStepFeedback` component following the pattern from `SuspectCommitFeedback`
- Integrated feedback buttons into all three autofix steps:
  - Root Cause Analysis
  - Solution
  - Coding Changes
- Buttons appear to the right of action buttons (e.g., "Find Solution", "Code It Up", "Draft PR")
- Only visible when step status is `COMPLETED`
- Feedback state resets when drawer closes (no persistence)
- Added analytics event `seer.autofix.feedback_submitted` with parameters:
  - `step_type`: 'root_cause' | 'solution' | 'changes'
  - `positive`: boolean
  - `group_id`: string
  - `autofix_run_id`: string
  - `user_id`: string
  - `organization`: Organization

## Test Plan

- [x] Verify thumbs up/down buttons appear after each step completes
- [x] Verify buttons are positioned to the right of action buttons
- [x] Test clicking thumbs up - should show "Thanks!" message
- [x] Test clicking thumbs down - should show "Thanks!" message
- [x] Verify analytics event is emitted with correct parameters
- [x] Verify feedback state resets when closing and reopening drawer
- [x] Test on all three steps (root cause, solution, changes)

## Screenshots:
<img width="721" height="544" alt="Screenshot 2025-10-28 at 2 05 24 PM" src="https://github.com/user-attachments/assets/557b19f0-c9a7-4310-a036-8f733e35cded" />
<img width="716" height="360" alt="Screenshot 2025-10-28 at 2 05 16 PM" src="https://github.com/user-attachments/assets/70976635-6ba6-44f3-914e-8b2acd85ea7c" />
<img width="716" height="472" alt="Screenshot 2025-10-28 at 2 05 05 PM" src="https://github.com/user-attachments/assets/4bcdb282-e752-4db5-887d-6fc71105c7a5" />
<img width="709" height="533" alt="Screenshot 2025-10-28 at 2 05 33 PM" src="https://github.com/user-attachments/assets/d2ec1e83-d461-4522-95d9-205cfd5e3466" />
