### PR TITLE
fix(issue details): Close Seer drawer on outside interaction

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -371,9 +371,6 @@ export const useOpenSeerDrawer = ({
         height: fit-content;
         max-height: 100%;
       `,
-      shouldCloseOnInteractOutside: () => {
-        return false;
-      },
       onClose: () => {
         navigate(
           {


### PR DESCRIPTION
Clicking outside the Seer drawer or on a button that opens a new drawer (e.g. breadcrumbs) will now close the Seer drawer.

https://sentry.slack.com/archives/C04KZQBNQ2U/p1761594231516099