### PR TITLE
fix(widget-builder): Exposes all logs values as group bys

### DIFF
--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -275,15 +275,6 @@ function getPrimaryFieldOptions(
   return {...baseFieldOptions, ...logTags};
 }
 
-function _isNotNumericTag(option: FieldValueOption) {
-  // Filter out numeric tags from primary options, they only show up in
-  // the parameter fields for aggregate functions
-  if ('dataType' in option.value.meta) {
-    return option.value.meta.dataType !== 'number';
-  }
-  return true;
-}
-
 function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryFieldValue) {
   // Allow for unknown values to be used for aggregate functions
   // This supports showing the tag value even if it's not in the current
@@ -373,11 +364,7 @@ function getGroupByFieldOptions(
     customMeasurements
   );
   const yAxisFilter = filterYAxisOptions();
-
-  // The only options that should be returned as valid group by options
-  // are string tags
-  const filterGroupByOptions = (option: FieldValueOption) =>
-    _isNotNumericTag(option) && !yAxisFilter(option);
+  const filterGroupByOptions = (option: FieldValueOption) => !yAxisFilter(option);
 
   return pickBy(primaryFieldOptions, filterGroupByOptions);
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -152,7 +152,7 @@ export function GroupBySelector({
 
   // EAP types render their attribute type rather than field/tag/measurement
   const isEAPType =
-    widgetType && [WidgetType.SPANS, WidgetType.LOGS, WidgetType].includes(widgetType);
+    widgetType && [WidgetType.SPANS, WidgetType.LOGS].includes(widgetType);
   const renderTagOverride = isEAPType
     ? (_kind: FieldValueKind, _label: string, meta: FieldValue['meta']) => {
         if (!('dataType' in meta)) {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -3,6 +3,8 @@ import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
+import {Tag} from '@sentry/scraps/badge';
+
 import {OnDemandWarningIcon} from 'sentry/components/alerts/onDemandMetricAlert';
 import {Button} from 'sentry/components/core/button';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
@@ -19,12 +21,12 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   OnDemandExtractionState,
+  WidgetType,
   type ValidateWidgetResponse,
-  type WidgetType,
 } from 'sentry/views/dashboards/types';
 import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
-import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 import type {generateFieldOptions} from 'sentry/views/discover/utils';
 
 import {QueryField} from './queryField';
@@ -148,6 +150,22 @@ export function GroupBySelector({
     }, []);
   }, [columns]);
 
+  // EAP types render their attribute type rather than field/tag/measurement
+  const isEAPType =
+    widgetType && [WidgetType.SPANS, WidgetType.LOGS, WidgetType].includes(widgetType);
+  const renderTagOverride = isEAPType
+    ? (_kind: FieldValueKind, _label: string, meta: FieldValue['meta']) => {
+        if (!('dataType' in meta)) {
+          return null;
+        }
+        return (
+          <Tag type={meta.dataType === 'number' ? 'highlight' : 'warning'}>
+            {meta.dataType}
+          </Tag>
+        );
+      }
+    : undefined;
+
   return (
     <Fragment>
       <StyledField inline={false} style={style} flexibleControlStateSize stacked>
@@ -158,6 +176,7 @@ export function GroupBySelector({
             onChange={value => handleSelect(value, 0)}
             canDelete={canDelete}
             disabled={disable}
+            renderTagOverride={renderTagOverride}
           />
         ) : (
           <DndContext
@@ -204,6 +223,7 @@ export function GroupBySelector({
                     canDrag={canDrag}
                     canDelete={canDelete}
                     disabled={disable}
+                    renderTagOverride={renderTagOverride}
                   />
                 ))}
               </SortableQueryFields>
@@ -221,6 +241,7 @@ export function GroupBySelector({
                     canDrag={canDrag}
                     canDelete={canDelete}
                     disabled={disable}
+                    renderTagOverride={renderTagOverride}
                   />
                 </Ghost>
               ) : null}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import {QueryField as TableQueryField} from 'sentry/views/discover/table/queryField';
-import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 
 export interface QueryFieldProps {
   fieldOptions: React.ComponentProps<typeof TableQueryField>['fieldOptions'];
@@ -23,6 +23,11 @@ export interface QueryFieldProps {
   listeners?: DraggableSyntheticListeners;
   onDelete?: () => void;
   ref?: React.Ref<HTMLDivElement>;
+  renderTagOverride?: (
+    kind: FieldValueKind,
+    label: string,
+    meta: FieldValue['meta']
+  ) => ReactNode;
   style?: React.CSSProperties;
 }
 
@@ -40,6 +45,7 @@ export function QueryField({
   fieldValidationError,
   isDragging,
   disabled,
+  renderTagOverride,
 }: QueryFieldProps) {
   return (
     <QueryFieldWrapper ref={ref} style={style}>
@@ -62,6 +68,7 @@ export function QueryField({
             onChange={onChange}
             disabled={disabled}
             filterPrimaryOptions={option => option.value.kind !== FieldValueKind.FUNCTION}
+            renderTagOverride={renderTagOverride}
           />
           {fieldValidationError ? fieldValidationError : null}
           {canDelete && (

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -1,4 +1,4 @@
-import {Component, createRef} from 'react';
+import {Component, createRef, type ReactNode} from 'react';
 import {withTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
@@ -102,6 +102,14 @@ type Props = {
   otherColumns?: Column[];
   placeholder?: string;
   /**
+   * A custom tag renderer for indicating the type of the field.
+   */
+  renderTagOverride?: (
+    kind: FieldValueKind,
+    label: string,
+    meta: FieldValue['meta']
+  ) => ReactNode;
+  /**
    * Whether or not to add the tag explaining the FieldValueKind of each field
    */
   shouldRenderTag?: boolean;
@@ -127,7 +135,7 @@ class _QueryField extends Component<Props> {
       return (
         <components.SingleValue data={data} {...props}>
           <span data-test-id="label">{data.label}</span>
-          {data.value && this.renderTag(data.value.kind, data.label)}
+          {data.value && this.renderTag(data.value.kind, data.label, data.value.meta)}
         </components.SingleValue>
       );
     },
@@ -455,8 +463,12 @@ class _QueryField extends Component<Props> {
           : descriptor.options;
 
         aggregateParameters.forEach(opt => {
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          opt.trailingItems = this.renderTag(opt.value.kind, String(opt.label));
+          opt.trailingItems = this.renderTag(
+            opt.value.kind,
+            // eslint-disable-next-line @typescript-eslint/no-base-to-string
+            String(opt.label),
+            opt.value.meta
+          );
         });
 
         const portalProps = useMenuPortal
@@ -574,10 +586,13 @@ class _QueryField extends Component<Props> {
     return inputs;
   }
 
-  renderTag(kind: FieldValueKind, label: string) {
-    const {shouldRenderTag} = this.props;
+  renderTag(kind: FieldValueKind, label: string, meta: FieldValue['meta']) {
+    const {shouldRenderTag, renderTagOverride} = this.props;
     if (shouldRenderTag === false) {
       return null;
+    }
+    if (renderTagOverride) {
+      return renderTagOverride(kind, label, meta);
     }
     let text: string;
     let tagType: 'success' | 'highlight' | 'warning' | undefined = undefined;
@@ -636,8 +651,12 @@ class _QueryField extends Component<Props> {
       : Object.values(fieldOptions);
 
     allFieldOptions.forEach(opt => {
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      opt.trailingItems = this.renderTag(opt.value.kind, String(opt.label));
+      opt.trailingItems = this.renderTag(
+        opt.value.kind,
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        String(opt.label),
+        opt.value.meta
+      );
     });
 
     const selectProps: ControlProps<FieldValueOption> = {


### PR DESCRIPTION
Removes the filtering for only string tags. This exposes all of the attributes for the logs dataset grouping. This is consistent with the logs page. Users were unable to select correct values because they were not being exposed

I also updated the tags rendering to support rendering for spans like the trace explorer and logs pages, i.e. tags should render with their type (string or number) as the trailing item, instead of tag/field/measurement/etc