### PR TITLE
feat(aci): add page header tooltips to list views

### DIFF
--- a/static/app/components/workflowEngine/layout/list.tsx
+++ b/static/app/components/workflowEngine/layout/list.tsx
@@ -1,10 +1,13 @@
 import {Flex} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 
 interface WorkflowEngineListLayoutProps {
   actions: React.ReactNode;
   /** The main content for this page */
   children: React.ReactNode;
+  description: string;
+  docsUrl: string;
   title: string;
 }
 
@@ -16,12 +19,17 @@ function WorkflowEngineListLayout({
   children,
   actions,
   title,
+  description,
+  docsUrl,
 }: WorkflowEngineListLayoutProps) {
   return (
     <Layout.Page>
       <Layout.Header unified>
         <Layout.HeaderContent>
-          <Layout.Title>{title}</Layout.Title>
+          <Layout.Title>
+            {title}
+            <PageHeadingQuestionTooltip docsUrl={docsUrl} title={description} />
+          </Layout.Title>
         </Layout.HeaderContent>
         <Layout.HeaderActions>{actions}</Layout.HeaderActions>
       </Layout.Header>

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -81,7 +81,14 @@ export default function AutomationsList() {
   return (
     <SentryDocumentTitle title={t('Alerts')}>
       <PageFiltersContainer>
-        <ListLayout actions={<Actions />} title={t('Alerts')}>
+        <ListLayout
+          actions={<Actions />}
+          title={t('Alerts')}
+          description={t(
+            'Alerts are triggered when issue changes state, is created, or passes a threshold. They perform external actions like sending notifications, creating tickets, or calling webhooks and integrations.'
+          )}
+          docsUrl="https://docs.sentry.io/product/automations/"
+        >
           <TableHeader />
           <div>
             <AutomationListTable

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -27,11 +27,41 @@ import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
 import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
 
-const DETECTOR_TYPE_TITLE_MAPPING: Record<DetectorType, string> = {
-  error: t('Error Monitors'),
-  metric_issue: t('Metric Monitors'),
-  monitor_check_in_failure: t('Cron Monitors'),
-  uptime_domain_failure: t('Uptime Monitors'),
+interface DetectorHeadingInfo {
+  description: string;
+  docsUrl: string;
+  title: string;
+}
+
+const DETECTOR_TYPE_HEADING_MAPPING: Record<DetectorType, DetectorHeadingInfo> = {
+  error: {
+    title: t('Error Monitors'),
+    description: t(
+      'Error monitors are created by default for each project based on issue grouping/fingerprint rules.'
+    ),
+    docsUrl: 'https://docs.sentry.io/product/monitors/',
+  },
+  metric_issue: {
+    title: t('Metric Monitors'),
+    description: t(
+      'Metric monitors track errors based on span attributes and custom metrics.'
+    ),
+    docsUrl: 'https://docs.sentry.io/product/monitors/',
+  },
+  monitor_check_in_failure: {
+    title: t('Cron Monitors'),
+    description: t(
+      'Cron monitors check in on recurring jobs and tell you if they’re running on schedule, failing, or succeeding.'
+    ),
+    docsUrl: 'https://docs.sentry.io/product/crons/',
+  },
+  uptime_domain_failure: {
+    title: t('Uptime Monitors'),
+    description: t(
+      'Uptime monitors continuously track configured URLs, delivering alerts and insights to quickly identify downtime and troubleshoot issues.'
+    ),
+    docsUrl: 'https://docs.sentry.io/product/alerts/uptime-monitoring/',
+  },
 };
 
 export default function DetectorsList() {
@@ -96,17 +126,38 @@ export default function DetectorsList() {
     return links && !links.previous!.results && !links.next!.results;
   }, [pageLinks]);
 
-  // Determine the page title based on active filters
-  const pageTitle = detectorFilter
-    ? DETECTOR_TYPE_TITLE_MAPPING[detectorFilter]
+  // Determine the page heading info based on active filters
+  const {
+    title: pageTitle,
+    description: pageDescription,
+    docsUrl,
+  } = detectorFilter
+    ? DETECTOR_TYPE_HEADING_MAPPING[detectorFilter]
     : assigneeFilter === 'me'
-      ? t('My Monitors')
-      : t('Monitors');
+      ? {
+          title: t('My Monitors'),
+          description: t(
+            'Monitors assigned to you or your team. Monitors are used to customize when to turn errors and performance problems into issues.'
+          ),
+          docsUrl: 'https://docs.sentry.io/product/monitors/',
+        }
+      : {
+          title: t('Monitors'),
+          description: t(
+            'Monitors are used to customize when to turn errors and performance problems into issues.'
+          ),
+          docsUrl: 'https://docs.sentry.io/product/monitors/',
+        };
 
   return (
     <SentryDocumentTitle title={pageTitle}>
       <PageFiltersContainer>
-        <ListLayout actions={<Actions />} title={pageTitle}>
+        <ListLayout
+          actions={<Actions />}
+          title={pageTitle}
+          description={pageDescription}
+          docsUrl={docsUrl}
+        >
           <TableHeader />
           <div>
             <DetectorListTable


### PR DESCRIPTION
<img width="429" height="115" alt="Screenshot 2025-10-28 at 9 48 33 AM" src="https://github.com/user-attachments/assets/a5103314-3d2a-44b3-8569-ffbbfd6448b2" />

we can workshop the wording of each description. not all links work right now since ACI docs aren't posted yet.