### PR TITLE
fix(aci): Special case 7 day errors dataset w/ 1m intervals

### DIFF
--- a/static/app/views/detectors/datasetConfig/errors.spec.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import type {SnubaQuery} from 'sentry/types/workflowEngine/detectors';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {DetectorErrorsConfig} from 'sentry/views/detectors/datasetConfig/errors';
@@ -31,5 +33,26 @@ describe('DetectorErrorsConfig.toSnubaQueryString', () => {
 
     const result = DetectorErrorsConfig.toSnubaQueryString(snubaQuery);
     expect(result).toBe('event.type:error is:unresolved');
+  });
+});
+
+describe('DetectorErrorsConfig.getSeriesQueryOptions', () => {
+  it('adjusts statsPeriod from 7d to 9998m when interval is 60 seconds', () => {
+    const options = {
+      aggregate: 'count()',
+      organization: OrganizationFixture(),
+      projectId: '1',
+      query: 'is:unresolved',
+      environment: '',
+      comparisonDelta: undefined,
+      dataset: Dataset.ERRORS,
+      eventTypes: [EventTypes.ERROR],
+      interval: 60,
+      statsPeriod: '7d',
+    };
+
+    const result = DetectorErrorsConfig.getSeriesQueryOptions(options);
+
+    expect(result[1]!.query!.statsPeriod).toBe('9998m');
   });
 });

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -81,6 +81,12 @@ export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> =
   defaultField: DEFAULT_FIELD,
   getAggregateOptions: () => AGGREGATE_OPTIONS,
   getSeriesQueryOptions: options => {
+    // If interval is 1 minute and statsPeriod is 7 days, apply a 9998m statsPeriod to avoid the 10k results limit.
+    // Applied specifically to errors dataset because it has 1m intervals, spans/logs have a minimum of 5m intervals.
+    if (options.interval === 60 && options.statsPeriod === '7d') {
+      options.statsPeriod = '9998m';
+    }
+
     return getDiscoverSeriesQueryOptions({
       ...options,
       dataset: DetectorErrorsConfig.getDiscoverDataset(),


### PR DESCRIPTION
Adds a special case for the errors graph when the interval is 1m. Prevents the intervals from jumping automatically to 1 hour.
