### PR TITLE
fix(buffer): Do not attempt empty zrem command

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -571,7 +571,9 @@ class RedisBuffer(Buffer):
                             headers={"sentry-propagate-traces": False},
                         )
 
-                self.cluster.zrem(self.pending_key, *keys)
+                if keys:
+                    self.cluster.zrem(self.pending_key, *keys)
+
             elif is_instance_rb_cluster(self.cluster, self.is_redis_cluster):
                 with self.cluster.all() as conn:
                     results = conn.zrange(self.pending_key, 0, -1)


### PR DESCRIPTION
In case of empty pending key, we were still trying to execute ZREM command but without any set members supplied which fails due to wrong number of arguments.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
