### PR TITLE
perf(eap): Optimize some count() query on EAP

### DIFF
--- a/src/sentry/search/eap/ourlogs/aggregates.py
+++ b/src/sentry/search/eap/ourlogs/aggregates.py
@@ -1,7 +1,11 @@
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Function
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Function
 
 from sentry.search.eap import constants
-from sentry.search.eap.columns import AggregateDefinition, AttributeArgumentDefinition
+from sentry.search.eap.columns import (
+    AggregateDefinition,
+    AttributeArgumentDefinition,
+    count_argument_resolver_optimized,
+)
 
 
 def count_processor(count_value: int | None) -> int:
@@ -10,6 +14,10 @@ def count_processor(count_value: int | None) -> int:
     else:
         return count_value
 
+
+LOGS_ALWAYS_PRESENT_ATTRIBUTES = [
+    AttributeKey(name="sentry.body", type=AttributeKey.Type.TYPE_STRING),
+]
 
 LOG_AGGREGATE_DEFINITIONS = {
     "count": AggregateDefinition(
@@ -27,6 +35,7 @@ LOG_AGGREGATE_DEFINITIONS = {
                 default_arg="log.body",
             )
         ],
+        attribute_resolver=count_argument_resolver_optimized(LOGS_ALWAYS_PRESENT_ATTRIBUTES),
     ),
     "count_unique": AggregateDefinition(
         internal_function=Function.FUNCTION_UNIQ,

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -21,6 +21,7 @@ from sentry.search.eap.columns import (
     ConditionalAggregateDefinition,
     ResolvedArguments,
     ValueArgumentDefinition,
+    count_argument_resolver_optimized,
 )
 from sentry.search.eap.normalizer import unquote_literal
 from sentry.search.eap.spans.utils import WEB_VITALS_MEASUREMENTS, transform_vital_score_to_ratio
@@ -32,6 +33,11 @@ def count_processor(count_value: int | None) -> int:
         return 0
     else:
         return count_value
+
+
+SPANS_ALWAYS_PRESENT_ATTRIBUTES = [
+    AttributeKey(name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE),
+]
 
 
 def resolve_count_op(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
@@ -523,6 +529,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 default_arg="span.duration",
             )
         ],
+        attribute_resolver=count_argument_resolver_optimized(SPANS_ALWAYS_PRESENT_ATTRIBUTES),
     ),
     "count_sample": AggregateDefinition(
         internal_function=Function.FUNCTION_COUNT,

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -241,7 +241,7 @@ def test_count_default_argument() -> None:
     resolved_column, virtual_context = resolver.resolve_column("count()")
     assert resolved_column.proto_definition == AttributeAggregation(
         aggregate=Function.FUNCTION_COUNT,
-        key=AttributeKey(name="sentry.body", type=AttributeKey.Type.TYPE_STRING),
+        key=AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT),
         label="count()",
         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
     )

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -286,9 +286,7 @@ class SearchResolverQueryTest(TestCase):
                 comparison_filter=AggregationComparisonFilter(
                     aggregation=AttributeAggregation(
                         aggregate=Function.FUNCTION_COUNT,
-                        key=AttributeKey(
-                            name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE
-                        ),
+                        key=AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT),
                         label="count()",
                         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
                     ),
@@ -312,9 +310,7 @@ class SearchResolverQueryTest(TestCase):
                 comparison_filter=AggregationComparisonFilter(
                     aggregation=AttributeAggregation(
                         aggregate=Function.FUNCTION_COUNT,
-                        key=AttributeKey(
-                            name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE
-                        ),
+                        key=AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT),
                         label="count()",
                         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
                     ),
@@ -367,7 +363,7 @@ class SearchResolverQueryTest(TestCase):
                             aggregation=AttributeAggregation(
                                 aggregate=Function.FUNCTION_COUNT,
                                 key=AttributeKey(
-                                    name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE
+                                    name="sentry.project_id", type=AttributeKey.Type.TYPE_INT
                                 ),
                                 label="count()",
                                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
@@ -403,7 +399,7 @@ class SearchResolverQueryTest(TestCase):
                             aggregation=AttributeAggregation(
                                 aggregate=Function.FUNCTION_COUNT,
                                 key=AttributeKey(
-                                    name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE
+                                    name="sentry.project_id", type=AttributeKey.Type.TYPE_INT
                                 ),
                                 label="count()",
                                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
@@ -439,7 +435,7 @@ class SearchResolverQueryTest(TestCase):
                             aggregation=AttributeAggregation(
                                 aggregate=Function.FUNCTION_COUNT,
                                 key=AttributeKey(
-                                    name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE
+                                    name="sentry.project_id", type=AttributeKey.Type.TYPE_INT
                                 ),
                                 label="count()",
                                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
@@ -480,8 +476,8 @@ class SearchResolverQueryTest(TestCase):
                                         aggregation=AttributeAggregation(
                                             aggregate=Function.FUNCTION_COUNT,
                                             key=AttributeKey(
-                                                name="sentry.duration_ms",
-                                                type=AttributeKey.Type.TYPE_DOUBLE,
+                                                name="sentry.project_id",
+                                                type=AttributeKey.Type.TYPE_INT,
                                             ),
                                             label="count()",
                                             extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
@@ -516,8 +512,8 @@ class SearchResolverQueryTest(TestCase):
                                         aggregation=AttributeAggregation(
                                             aggregate=Function.FUNCTION_COUNT,
                                             key=AttributeKey(
-                                                name="sentry.duration_ms",
-                                                type=AttributeKey.Type.TYPE_DOUBLE,
+                                                name="sentry.project_id",
+                                                type=AttributeKey.Type.TYPE_INT,
                                             ),
                                             label="count()",
                                             extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
@@ -644,7 +640,7 @@ class SearchResolverColumnTest(TestCase):
         resolved_column, virtual_context = self.resolver.resolve_column("count()")
         assert resolved_column.proto_definition == AttributeAggregation(
             aggregate=Function.FUNCTION_COUNT,
-            key=AttributeKey(name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE),
+            key=AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT),
             label="count()",
             extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
         )
@@ -652,7 +648,7 @@ class SearchResolverColumnTest(TestCase):
         resolved_column, virtual_context = self.resolver.resolve_column("count(span.duration)")
         assert resolved_column.proto_definition == AttributeAggregation(
             aggregate=Function.FUNCTION_COUNT,
-            key=AttributeKey(name="sentry.duration_ms", type=AttributeKey.Type.TYPE_DOUBLE),
+            key=AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT),
             label="count(span.duration)",
             extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
         )

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -311,7 +311,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest):
             )
             assert (
                 createSubscriptionRequest.time_series_request.expressions[0].aggregation.key.name
-                == "sentry.duration_ms"
+                == "sentry.project_id"
             )
             # Validate that the spm function uses the correct time window
             sub = QuerySubscription.objects.get(id=sub.id)

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -902,3 +902,16 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         response = self.do_request(request)
         assert response.status_code == 200
         assert response.data["meta"]["bytesScanned"] > 0
+
+    def test_count_message(self):
+        self.store_ourlogs([self.create_ourlog({"body": "log"}, timestamp=self.ten_mins_ago)])
+        request = {
+            "field": ["count(message)"],
+            "project": self.project.id,
+            "dataset": self.dataset,
+            "statsPeriod": "1h",
+        }
+
+        response = self.do_request(request)
+        assert response.status_code == 200
+        assert response.data["data"] == [{"count(message)": 1}]

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6681,3 +6681,24 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert len(data) == 0
         assert data == []
         assert meta["dataset"] == "spans"
+
+    def test_count_span_duration(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        request = {
+            "field": ["count(span.duration)"],
+            "project": self.project.id,
+            "dataset": "spans",
+            "statsPeriod": "1h",
+        }
+
+        response = self.do_request(request)
+        assert response.status_code == 200
+        assert response.data["data"] == [{"count(span.duration)": 1}]


### PR DESCRIPTION
This applies an optimization on the `count(message)` query by replacing the argument with project id instead. This allows the query to avoid reading the attributes column containing message in some cases which provides a noticeable speedup.

The same is applicable to `count(span.duration)` spans.