### PR TITLE
fix(aci): Remove old issue monitor/alert routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2661,8 +2661,6 @@ function buildRoutes(): RouteObject[] {
       deprecatedRouteProps: true,
     },
     traceView,
-    automationRoutes,
-    detectorRoutes,
   ];
   const issueRoutes: SentryRouteObject = {
     path: '/issues/',


### PR DESCRIPTION
These could be conflicting with the /issues/alerts/ routes. Let's just remove them since we are using `/monitors/` as the base route now