### PR TITLE
fix(prevent-ai): Consider only sentry app onboarded orgs

### DIFF
--- a/src/sentry/prevent/endpoints/organization_github_repos.py
+++ b/src/sentry/prevent/endpoints/organization_github_repos.py
@@ -94,9 +94,6 @@ class OrganizationPreventGitHubReposEndpoint(OrganizationEndpoint):
             for integration in integration_service.get_integrations(integration_ids=integration_ids)
         }
 
-        # Fetch all repos integrated with Seer for the organization
-        seer_integrated_repos = self._fetch_seer_integrated_repos(list(integration_map.keys()))
-
         # Fetch all repos integrated with Sentry for the organization
         integration_id_to_name = {
             integration.id: integration.name for integration in integration_map.values()
@@ -111,20 +108,16 @@ class OrganizationPreventGitHubReposEndpoint(OrganizationEndpoint):
         for repo in all_installed_repos:
             repos_by_integration[integration_id_to_name[repo.integration_id]].append(repo)
 
-        # Determine what repos are installed in Sentry and Seer for each GitHub org
         org_repos = []
         for github_org_name, integration in integration_map.items():
             installed_repos = repos_by_integration.get(github_org_name, [])
 
-            sentry_repos = {repo.name.split("/")[-1]: repo for repo in installed_repos}
-            sentry_repo_names = set(sentry_repos.keys())
-            seer_repo_names = set(seer_integrated_repos.get(github_org_name, []))
-
             repos = []
-            for repo_name in sentry_repo_names & seer_repo_names:
+            for repo in installed_repos:
+                repo_name = repo.name.split("/")[-1]
                 repos.append(
                     {
-                        "id": sentry_repos[repo_name].external_id,
+                        "id": repo.external_id,
                         "name": repo_name,
                         "fullName": f"{github_org_name}/{repo_name}",
                     }

--- a/tests/sentry/prevent/endpoints/test_organization_github_repos.py
+++ b/tests/sentry/prevent/endpoints/test_organization_github_repos.py
@@ -1,7 +1,3 @@
-from unittest.mock import Mock, patch
-
-import orjson
-
 from sentry.testutils.cases import APITestCase
 
 
@@ -22,16 +18,9 @@ class OrganizationPreventGitHubReposTest(APITestCase):
 
         assert response.data == {"orgRepos": []}
 
-    @patch("sentry.prevent.endpoints.organization_github_repos.make_signed_seer_api_request")
-    def test_get_prevent_github_repos_with_integration(self, mock_make_seer_request):
+    def test_get_prevent_github_repos_with_integration(self):
         """Test that the endpoint returns GitHub org data when integrations exist"""
         self.login_as(user=self.user)
-
-        # Mock the Seer API response (empty response since we're just testing Sentry integration)
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {"integrated_repos": {"test-github-org": ["test-repo"]}}
-        mock_make_seer_request.return_value = mock_response
 
         # Create a GitHub integration
         integration = self.create_integration(
@@ -72,80 +61,9 @@ class OrganizationPreventGitHubReposTest(APITestCase):
         assert repo_data["fullName"] == "test-github-org/test-repo"
         assert repo_data["id"] == "111222"
 
-    @patch("sentry.prevent.endpoints.organization_github_repos.make_signed_seer_api_request")
-    def test_get_prevent_github_repos_with_seer_integration(self, mock_make_seer_request):
-        """Test that repos from both Sentry and Seer are merged correctly"""
-        self.login_as(user=self.user)
-
-        # Create a GitHub integration
-        integration = self.create_integration(
-            organization=self.organization,
-            provider="github",
-            name="test-org",
-            external_id="123456",
-            metadata={
-                "account_id": "987654",
-                "icon": "https://avatars.githubusercontent.com/u/123456",
-                "domain_name": "github.com/test-org",
-            },
-        )
-
-        # Create a project and repository in Sentry
-        project = self.create_project(organization=self.organization)
-        self.create_repo(
-            project=project,
-            name="test-org/sentry-repo",
-            provider="integrations:github",
-            integration_id=integration.id,
-            external_id="111222",
-        )
-
-        # Mock the Seer API response
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {
-            "integrated_repos": {
-                "test-org": [
-                    "sentry-repo",  # This exists in Sentry (matches "test-org/sentry-repo")
-                    "seer-only-repo",  # This only exists in Seer
-                ]
-            }
-        }
-        mock_make_seer_request.return_value = mock_response
-
-        response = self.get_success_response(self.organization.slug)
-
-        assert len(response.data["orgRepos"]) == 1
-
-        github_org = response.data["orgRepos"][0]
-        assert github_org["githubOrganizationId"] == "987654"
-        assert github_org["name"] == "test-org"
-        assert len(github_org["repos"]) == 1
-        assert "seer-only-repo" not in {repo["name"] for repo in github_org["repos"]}
-
-        # Verify the Seer API was called correctly
-        mock_make_seer_request.assert_called_once()
-        call_args = mock_make_seer_request.call_args
-
-        request_body = orjson.loads(call_args[1]["body"])
-        assert request_body["organization_names"] == ["test-org"]
-        assert request_body["provider"] == "github"
-
-    @patch("sentry.prevent.endpoints.organization_github_repos.make_signed_seer_api_request")
-    def test_get_prevent_github_repos_multiple_orgs(self, mock_make_seer_request):
+    def test_get_prevent_github_repos_multiple_orgs(self):
         """Test that multiple GitHub orgs are handled"""
         self.login_as(user=self.user)
-
-        # Mock empty Seer response
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {
-            "integrated_repos": {
-                "github-org-1": ["repo1"],
-                "github-org-2": ["repo2"],
-            }
-        }
-        mock_make_seer_request.return_value = mock_response
 
         # Create two GitHub integrations
         integration1 = self.create_integration(
@@ -201,18 +119,9 @@ class OrganizationPreventGitHubReposTest(APITestCase):
         assert orgs_by_name["github-org-2"]["repos"][0]["name"] == "repo2"
         assert orgs_by_name["github-org-2"]["repos"][0]["id"] == "222"
 
-    @patch("sentry.prevent.endpoints.organization_github_repos.make_signed_seer_api_request")
-    def test_get_prevent_github_repos_multiple_repos_same_org(self, mock_make_seer_request):
+    def test_get_prevent_github_repos_multiple_repos_same_org(self):
         """Test that multiple repositories for the same GitHub organization are all returned"""
         self.login_as(user=self.user)
-
-        # Mock empty Seer response
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {
-            "integrated_repos": {"github-org": ["repo1", "repo2", "repo3"]}
-        }
-        mock_make_seer_request.return_value = mock_response
 
         # Create one GitHub integration
         integration = self.create_integration(
@@ -263,18 +172,12 @@ class OrganizationPreventGitHubReposTest(APITestCase):
         repo_names = {repo["name"] for repo in github_org["repos"]}
         assert repo_names == {"repo1", "repo2", "repo3"}
 
-    @patch("sentry.prevent.endpoints.organization_github_repos.make_signed_seer_api_request")
-    def test_get_prevent_github_repos_seer_error(self, mock_make_seer_request):
-        """Test that the endpoint gracefully handles Seer API errors"""
+    def test_get_prevent_github_repos_no_repos(self):
+        """Test that the endpoint gracefully handles missing repos if integration exists but there are no repos"""
         self.login_as(user=self.user)
 
-        # Mock Seer API returning an error
-        mock_response = Mock()
-        mock_response.status = 500
-        mock_make_seer_request.return_value = mock_response
-
-        # Create a GitHub integration and repo
-        integration = self.create_integration(
+        # Create a GitHub integration but no repos
+        self.create_integration(
             organization=self.organization,
             provider="github",
             name="test-github-org",
@@ -282,30 +185,12 @@ class OrganizationPreventGitHubReposTest(APITestCase):
             metadata={"account_id": "987654"},
         )
 
-        project = self.create_project(organization=self.organization)
-        self.create_repo(
-            project=project,
-            name="test-github-org/test-repo",
-            provider="integrations:github",
-            integration_id=integration.id,
-            external_id="111222",
-        )
-
-        # Should return no repos since Seer failed
         response = self.get_success_response(self.organization.slug)
         assert response.data == {"orgRepos": []}
 
-    @patch("sentry.prevent.endpoints.organization_github_repos.make_signed_seer_api_request")
-    def test_get_prevent_github_repos_seer_integration_account_id_is_number(
-        self, mock_make_seer_request
-    ):
+    def test_get_prevent_github_repos_seer_integration_account_id_is_number(self):
         """Test that the endpoint returns the correct orgRepos when account_id is a number"""
         self.login_as(user=self.user)
-
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {"integrated_repos": {"test-github-org": ["test-repo"]}}
-        mock_make_seer_request.return_value = mock_response
 
         integration = self.create_integration(
             organization=self.organization,


### PR DESCRIPTION
We are moving towards only requiring a single github app (sentry app) for what is considered a Prevent AI onboarded repo. So remove the need to look up seer app onboarded org/repos.
