### PR TITLE
fix(search-bar): Don't submit query while building

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -781,10 +781,13 @@ function updateFreeTextAndReplaceText(
       : newState.focusOverride;
   }
 
+  // Only update the committed query if we aren't in the middle of creating a filter
+  const committedQuery = action.shouldCommitQuery ? query : state.committedQuery;
+
   return {
     ...newState,
     query,
-    committedQuery: query,
+    committedQuery,
     focusOverride,
   };
 }
@@ -876,7 +879,7 @@ export function useQueryBuilderState({
           );
 
           const query = replacedState?.newQuery ? replacedState.newQuery : action.query;
-          const committedQuery = shouldCommitQuery ? query : state.committedQuery;
+          const committedQuery = state.committedQuery;
           const focusOverride = replacedState?.focusOverride
             ? replacedState.focusOverride
             : (action.focusOverride ?? null);

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -879,7 +879,7 @@ export function useQueryBuilderState({
           );
 
           const query = replacedState?.newQuery ? replacedState.newQuery : action.query;
-          const committedQuery = state.committedQuery;
+          const committedQuery = shouldCommitQuery ? query : state.committedQuery;
           const focusOverride = replacedState?.focusOverride
             ? replacedState.focusOverride
             : (action.focusOverride ?? null);


### PR DESCRIPTION
This fixes an issue that was re-introduced getsentry/sentry/pull/101872 where a query gets submitted as it's being built.