### PR TITLE
fix(explore): Top events unextrapolated spans footer

### DIFF
--- a/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
@@ -89,7 +89,7 @@ describe('ConfidenceFooter', () => {
     it('unextrapolated loading', () => {
       render(<ConfidenceFooter extrapolate={false} />, {wrapper: Wrapper});
 
-      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span Count: \u2026');
+      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: \u2026');
     });
 
     it('unextrapolated loaded', () => {
@@ -97,7 +97,17 @@ describe('ConfidenceFooter', () => {
         wrapper: Wrapper,
       });
 
-      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span Count: 100');
+      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
+    });
+
+    it('unextrapolated loaded with grouping', () => {
+      render(<ConfidenceFooter extrapolate={false} sampleCount={100} topEvents={5} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Top 5 groups span count: 100'
+      );
     });
   });
 });

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -35,11 +35,15 @@ function confidenceMessage({
 
   if (defined(extrapolate) && !extrapolate) {
     if (!defined(sampleCount)) {
-      return t('Span Count: \u2026');
+      return t('Span count: \u2026');
     }
-    return tct('Span Count: [sampleCountComponent]', {
-      sampleCountComponent: <Count value={sampleCount} />,
-    });
+    return isTopN
+      ? tct('Top [topEvents] groups spans count: [sampleCountComponent]', {
+          sampleCountComponent: <Count value={sampleCount} />,
+        })
+      : tct('Span count: [sampleCountComponent]', {
+          sampleCountComponent: <Count value={sampleCount} />,
+        });
   }
 
   if (!defined(sampleCount)) {

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -38,7 +38,8 @@ function confidenceMessage({
       return t('Span count: \u2026');
     }
     return isTopN
-      ? tct('Top [topEvents] groups spans count: [sampleCountComponent]', {
+      ? tct('Top [topEvents] groups span count: [sampleCountComponent]', {
+          topEvents,
           sampleCountComponent: <Count value={sampleCount} />,
         })
       : tct('Span count: [sampleCountComponent]', {


### PR DESCRIPTION
When in top n mode, it should have a custom copy.