### PR TITLE
ref(backend): Replace last old eventstore imports

### DIFF
--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -4,6 +4,8 @@ import logging
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+# sentry.services.eventstore import is required to avoid a ciruclar import issue.
+import sentry.services.eventstore  # NOQA
 from sentry.models.activity import Activity
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.project import Project

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -21,7 +21,7 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from snuba_sdk import Column, Condition, Op
 
-from sentry import eventstore, eventtypes, options, tagstore
+from sentry import eventtypes, options, tagstore
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
@@ -44,6 +44,7 @@ from sentry.issues.priority import (
 from sentry.models.commit import Commit
 from sentry.models.grouphistory import record_group_history, record_group_history_from_activity_type
 from sentry.models.organization import Organization
+from sentry.services import eventstore
 from sentry.services.eventstore.models import GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -4,7 +4,6 @@ from typing import Any, Literal
 
 from django.urls import reverse
 
-from sentry import eventstore
 from sentry.api import client
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.event import EventSerializer, IssueEventSerializerResponse
@@ -21,6 +20,7 @@ from sentry.search.events.types import SnubaParams
 from sentry.seer.autofix.autofix import get_all_tags_overview
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
 from sentry.seer.sentry_data_models import EAPTrace
+from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans


### PR DESCRIPTION
Replace the last few uses of the old eventstore import (`from sentry import eventstore`)
with the new eventstore import (`import sentry.services.eventstore`). 

Unfortunately this reorders the imports of `src/sentry/models/group.py` since:
`from sentry.services import eventstore` sorts much lower than `from sentry import eventstore`.

This in turn causes a circular import issue that was previously hidden:

```
Traceback (most recent call last):
  File "/Users/chromy/work/sentry/.venv/lib/python3.13/site-packages/_pytest/main.py", line 281, in wrap_session
    config._do_configure()
[...snip...]
  File "/Users/chromy/work/sentry/src/sentry/models/__init__.py", line 39, in <module>
    from .group import *  # NOQA
    ^^^^^^^^^^^^^^^^^^^^
  File "/Users/chromy/work/sentry/src/sentry/models/group.py", line 39, in <module>
    from sentry.issues.priority import (
    ...<3 lines>...
    )
  File "/Users/chromy/work/sentry/src/sentry/issues/priority.py", line 9, in <module>
    from sentry.models.project import Project
  File "/Users/chromy/work/sentry/src/sentry/models/project.py", line 49, in <module>
    from sentry.utils.query import RangeQuerySetWrapper
  File "/Users/chromy/work/sentry/src/sentry/utils/query.py", line 18, in <module>
    from sentry.services import eventstore
  File "/Users/chromy/work/sentry/src/sentry/services/eventstore/__init__.py", line 3, in <module>
    from .base import EventStorage, Filter  # NOQA
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chromy/work/sentry/src/sentry/services/eventstore/base.py", line 13, in <module>
    from sentry.services.eventstore.models import Event, GroupEvent
  File "/Users/chromy/work/sentry/src/sentry/services/eventstore/models.py", line 21, in <module>
    from sentry.grouping.api import get_grouping_config_dict_for_project
  File "/Users/chromy/work/sentry/src/sentry/grouping/api.py", line 12, in <module>
    from sentry.grouping.component import ContributingComponent, RootGroupingComponent
  File "/Users/chromy/work/sentry/src/sentry/grouping/component.py", line 11, in <module>
    from sentry.grouping.utils import hash_from_values
  File "/Users/chromy/work/sentry/src/sentry/grouping/utils.py", line 13, in <module>
    from sentry.stacktraces.processing import get_crash_frame_from_event_data
  File "/Users/chromy/work/sentry/src/sentry/stacktraces/processing.py", line 11, in <module>
    from sentry.models.project import Project
ImportError: cannot import name 'Project' from partially initialized module 'sentry.models.project' (most likely due to a circular import) (/Users/chromy/work/sentry/src/sentry/models/project.py)
```

The easiest fix would be to override isort for this one import but I've been unable to find a way
to do that works with all the various hooks. As an alternative we can introduce an otherwise
unused import in `src/sentry/issues/priority.py` and break the chain that way.
