### PR TITLE
fix(tracemetrics): Fix per_second based on type

### DIFF
--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
 from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
@@ -53,7 +55,6 @@ def per_second(args: ResolvedArguments, settings: ResolverSettings) -> Column.Bi
     """
     Calculate rate per second for trace metrics using the value attribute.
     """
-    from typing import cast
 
     metric_type = cast(str, args[1]) if len(args) > 1 else "counter"
     return _rate_internal(1, metric_type, settings)
@@ -63,7 +64,6 @@ def per_minute(args: ResolvedArguments, settings: ResolverSettings) -> Column.Bi
     """
     Calculate rate per minute for trace metrics using the value attribute.
     """
-    from typing import cast
 
     metric_type = cast(str, args[1]) if len(args) > 1 else "counter"
     return _rate_internal(60, metric_type, settings)

--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -6,12 +6,19 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     Function,
 )
 
-from sentry.search.eap.columns import FormulaDefinition, ResolvedArguments, ResolverSettings
+from sentry.search.eap.columns import (
+    FormulaDefinition,
+    ResolvedArguments,
+    ResolverSettings,
+    ValueArgumentDefinition,
+)
 
 
-def _rate_internal(divisor: int, settings: ResolverSettings) -> Column.BinaryFormula:
+def _rate_internal(
+    divisor: int, metric_type: str, settings: ResolverSettings
+) -> Column.BinaryFormula:
     """
-    Calculate rate per X (assumed second if not passed) for trace metrics using the value attribute.
+    Calculate rate per X for trace metrics using the value attribute.
     """
     extrapolation_mode = settings["extrapolation_mode"]
     is_timeseries_request = settings["snuba_params"].is_timeseries_request
@@ -22,10 +29,15 @@ def _rate_internal(divisor: int, settings: ResolverSettings) -> Column.BinaryFor
         else settings["snuba_params"].interval
     )
 
+    if metric_type == "counter":
+        aggregate_func = Function.FUNCTION_SUM
+    else:
+        aggregate_func = Function.FUNCTION_COUNT
+
     return Column.BinaryFormula(
         left=Column(
             aggregation=AttributeAggregation(
-                aggregate=Function.FUNCTION_COUNT,
+                aggregate=aggregate_func,
                 key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.value"),
                 extrapolation_mode=extrapolation_mode,
             ),
@@ -37,30 +49,52 @@ def _rate_internal(divisor: int, settings: ResolverSettings) -> Column.BinaryFor
     )
 
 
-def per_second(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+def per_second(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
     """
     Calculate rate per second for trace metrics using the value attribute.
     """
-    return _rate_internal(1, settings)
+    from typing import cast
+
+    metric_type = cast(str, args[1]) if len(args) > 1 else "counter"
+    return _rate_internal(1, metric_type, settings)
 
 
-def per_minute(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+def per_minute(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
     """
     Calculate rate per minute for trace metrics using the value attribute.
     """
-    return _rate_internal(60, settings)
+    from typing import cast
+
+    metric_type = cast(str, args[1]) if len(args) > 1 else "counter"
+    return _rate_internal(60, metric_type, settings)
 
 
 TRACE_METRICS_FORMULA_DEFINITIONS = {
     "per_second": FormulaDefinition(
         default_search_type="rate",
-        arguments=[],
+        arguments=[
+            ValueArgumentDefinition(
+                argument_types={"string"},
+            ),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                default_arg="counter",
+            ),
+        ],
         formula_resolver=per_second,
         is_aggregate=True,
     ),
     "per_minute": FormulaDefinition(
         default_search_type="rate",
-        arguments=[],
+        arguments=[
+            ValueArgumentDefinition(
+                argument_types={"string"},
+            ),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                default_arg="counter",
+            ),
+        ],
         formula_resolver=per_minute,
         is_aggregate=True,
     ),

--- a/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
@@ -63,7 +63,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                 "start": self.start,
                 "end": self.end,
                 "interval": "1h",
-                "yAxis": "per_second()",
+                "yAxis": "per_second(test_metric, counter)",
                 "project": self.project.id,
                 "dataset": self.dataset,
             }

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
 
@@ -61,7 +63,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
         response = self.do_request(
             {
-                "field": ["per_minute()"],
+                "field": ["per_minute(test_metric)"],
                 "query": "",
                 "project": self.project.id,
                 "dataset": self.dataset,
@@ -72,8 +74,8 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["per_minute()"] == 0.6
-        assert meta["fields"]["per_minute()"] == "rate"
+        assert data[0]["per_minute(test_metric)"] == 0.6
+        assert meta["fields"]["per_minute(test_metric)"] == "rate"
         assert meta["dataset"] == "tracemetrics"
 
     def test_per_second_formula(self) -> None:
@@ -83,7 +85,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
         response = self.do_request(
             {
-                "field": ["per_second()"],
+                "field": ["per_second(test_metric, counter)"],
                 "query": "",
                 "project": self.project.id,
                 "dataset": self.dataset,
@@ -95,7 +97,53 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         meta = response.data["meta"]
         assert len(data) == 1
         assert (
-            data[0]["per_second()"] == 0.01
+            data[0]["per_second(test_metric, counter)"] == 0.01
         )  # Over ten minute period, 6 events / 600 seconds = 0.01 events per second
-        assert meta["fields"]["per_second()"] == "rate"
+        assert meta["fields"]["per_second(test_metric, counter)"] == "rate"
         assert meta["dataset"] == "tracemetrics"
+
+    def test_per_second_formula_with_counter_metric_type(self) -> None:
+        counter_metrics = [
+            self.create_trace_metric(
+                "request_count", 5.0, attributes={"sentry.metric_type": "counter"}
+            ),
+            self.create_trace_metric(
+                "request_count", 3.0, attributes={"sentry.metric_type": "counter"}
+            ),
+        ]
+        self.store_trace_metrics(counter_metrics)
+
+        response = self.do_request(
+            {
+                "field": ["per_second(request_count,counter)"],
+                "query": "metric.name:request_count",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data[0] == {"per_second(request_count,counter)": pytest.approx(8 / 600, abs=0.001)}
+
+    def test_per_second_formula_with_gauge_metric_type(self) -> None:
+        gauge_metrics = [
+            self.create_trace_metric("cpu_usage", 75.0, attributes={"sentry.metric_type": "gauge"}),
+            self.create_trace_metric("cpu_usage", 80.0, attributes={"sentry.metric_type": "gauge"}),
+        ]
+        self.store_trace_metrics(gauge_metrics)
+
+        response = self.do_request(
+            {
+                "field": [
+                    "per_second(cpu_usage, gauge)"
+                ],  # Trying space in the formula here to make sure it works.
+                "query": "metric.name:cpu_usage",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data[0] == {"per_second(cpu_usage, gauge)": pytest.approx(2 / 600, abs=0.001)}


### PR DESCRIPTION
### Summary
Count types should be summing 'value' vs. counting rows


