### PR TITLE
chore(commits): Remove `get_or_create_commit` dual write function

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -32,6 +32,7 @@ from sentry.db.models.fields.jsonfield import LegacyTextJSONField
 from sentry.db.models.indexes import IndexWithPostgresNameLimits
 from sentry.db.models.manager.base import BaseManager
 from sentry.models.artifactbundle import ArtifactBundle
+from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.releases.constants import (
     DB_VERSION_LENGTH,
@@ -41,7 +42,6 @@ from sentry.models.releases.constants import (
 from sentry.models.releases.exceptions import UnsafeReleaseDeletion
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.releases.util import ReleaseQuerySet, SemverFilter, SemverVersion
-from sentry.releases.commits import get_or_create_commit
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.db import atomic_transaction
@@ -618,8 +618,8 @@ class Release(Model):
             for ref in refs:
                 repo = repos_by_name[ref["repository"]]
 
-                commit = get_or_create_commit(
-                    organization=self.organization, repo_id=repo.id, key=ref["commit"]
+                commit = Commit.objects.get_or_create(
+                    organization_id=self.organization_id, repository_id=repo.id, key=ref["commit"]
                 )[0]
                 # update head commit for repo/release if exists
                 ReleaseHeadCommit.objects.create_or_update(

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -11,6 +11,7 @@ from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.locks import locks
 from sentry.models.activity import Activity
+from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
@@ -34,7 +35,6 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.plugins.providers.repository import RepositoryProvider
-from sentry.releases.commits import get_or_create_commit
 
 
 class _CommitDataKwargs(TypedDict, total=False):
@@ -123,15 +123,11 @@ def set_commit(idx, data, release):
     if "timestamp" in data:
         commit_data["date_added"] = data["timestamp"]
 
-    commit, new_commit, created = get_or_create_commit(
-        organization=release.organization,
-        repo_id=repo.id,
+    commit, created = Commit.objects.get_or_create(
+        organization_id=release.organization_id,
+        repository_id=repo.id,
         key=data["id"],
-        message=commit_data.get("message"),
-        author=commit_data.get("author"),
-        # XXX: This code was in place before and passes either a string or datetime, but
-        # works ok. Just skipping the type checking
-        date_added=commit_data.get("date_added"),  # type: ignore[arg-type]
+        defaults=commit_data,
     )
     if not created and any(getattr(commit, key) != value for key, value in commit_data.items()):
         commit.update(**commit_data)

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -65,39 +65,3 @@ def create_commit(
         )
         new_commit = _dual_write_commit(old_commit)
     return old_commit, new_commit
-
-
-def get_or_create_commit(
-    organization: Organization,
-    repo_id: int,
-    key: str,
-    message: str | None = None,
-    author: CommitAuthor | None = None,
-    date_added: datetime | None = None,
-) -> tuple[OldCommit, Commit, bool]:
-    """
-    Gets or creates a commit with dual write support.
-    """
-    defaults = {
-        "author": author,
-        "message": message,
-    }
-    if date_added is not None:
-        defaults["date_added"] = date_added  # type: ignore[assignment]
-
-    with atomic_transaction(
-        using=(
-            router.db_for_write(OldCommit),
-            router.db_for_write(Commit),
-        )
-    ):
-        old_commit, created = OldCommit.objects.get_or_create(
-            organization_id=organization.id,
-            repository_id=repo_id,
-            key=key,
-            defaults=defaults,
-        )
-
-        new_commit = _dual_write_commit(old_commit)
-
-    return old_commit, new_commit, created


### PR DESCRIPTION
We're no longer planning on using the dual written tables, so removing these functions

<!-- Describe your PR here. -->