### PR TITLE
fix(aci): Remove resolution section, preserve radio state

### DIFF
--- a/static/app/views/detectors/components/forms/metric/resolveSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/resolveSection.tsx
@@ -76,6 +76,11 @@ export function ResolveSection() {
   const aggregate = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
   );
+
+  if (detectionType === 'dynamic') {
+    return null;
+  }
+
   const thresholdSuffix = getStaticDetectorThresholdSuffix(aggregate);
 
   const descriptionContent = getResolutionDescription(
@@ -129,16 +134,15 @@ export function ResolveSection() {
     <Container>
       <Section title={t('Resolve')}>
         <div>
-          {detectionType !== 'dynamic' && (
-            <FormRow>
-              <StyledRadioField
-                name={METRIC_DETECTOR_FORM_FIELDS.resolutionStrategy}
-                aria-label={t('Resolution method')}
-                choices={resolutionStrategyChoices}
-                defaultValue="automatic"
-              />
-            </FormRow>
-          )}
+          <FormRow>
+            <StyledRadioField
+              name={METRIC_DETECTOR_FORM_FIELDS.resolutionStrategy}
+              aria-label={t('Resolution method')}
+              choices={resolutionStrategyChoices}
+              defaultValue="automatic"
+              preserveOnUnmount
+            />
+          </FormRow>
           {resolutionStrategy === 'custom' && (
             <DescriptionContainer onClick={e => e.preventDefault()}>
               <Text>


### PR DESCRIPTION
Removes the resolution section completely when the type is dynamic and preserves the form field state when adding and removing the radio.
