### PR TITLE
fix(tracemetrics): Improve table CSS styling

### DIFF
--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -1,6 +1,6 @@
 import type {ComponentProps, CSSProperties, HTMLAttributes, RefObject} from 'react';
-import {css} from '@emotion/react';
 import type {Theme} from '@emotion/react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -56,6 +56,7 @@ const BodyContainer = styled('div')`
   padding: ${p => p.theme.space.md};
   padding-top: 0;
   height: 320px;
+  container-type: inline-size;
 `;
 
 const StyledTabPanels = styled(TabPanels)`

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -63,6 +63,7 @@ export const StyledSimpleTableBody = styled('div')`
   grid-template-columns: subgrid;
   grid-auto-rows: min-content;
   grid-column: 1 / -1;
+  scrollbar-gutter: stable;
 `;
 
 export const StyledSimpleTableHeader = styled(SimpleTable.Header)`
@@ -93,4 +94,12 @@ export const DetailsContent = styled(StyledPanel)`
 
 export const MetricsDetailsWrapper = styled(DetailsWrapper)`
   border-top: 0;
+`;
+
+export const NumericSimpleTableHeaderCell = styled(StyledSimpleTableHeaderCell)`
+  justify-content: flex-end;
+`;
+
+export const NumericSimpleTableRowCell = styled(StyledSimpleTableRowCell)`
+  justify-content: flex-end;
 `;

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab/index.tsx
@@ -358,10 +358,10 @@ function SampleTableRow({
 }
 
 const SimpleTableWithHiddenColumns = styled(StyledSimpleTable)<{numColumns: number}>`
-  grid-template-columns: repeat(${p => p.numColumns}, min-content) auto;
+  grid-template-columns: repeat(${p => p.numColumns}, min-content) 1fr;
 
   @container (max-width: ${SAMPLES_PANEL_MIN_WIDTH + MAX_TELEMETRY_WIDTH * 3}px) {
-    grid-template-columns: repeat(${p => p.numColumns - 1}, min-content) auto;
+    grid-template-columns: repeat(${p => p.numColumns - 1}, min-content) 1fr;
 
     [data-column-name='errors'] {
       display: none;
@@ -369,7 +369,7 @@ const SimpleTableWithHiddenColumns = styled(StyledSimpleTable)<{numColumns: numb
   }
 
   @container (max-width: ${SAMPLES_PANEL_MIN_WIDTH + MAX_TELEMETRY_WIDTH * 2}px) {
-    grid-template-columns: repeat(${p => p.numColumns - 2}, min-content) auto;
+    grid-template-columns: repeat(${p => p.numColumns - 2}, min-content) 1fr;
 
     [data-column-name='spans'] {
       display: none;
@@ -377,7 +377,7 @@ const SimpleTableWithHiddenColumns = styled(StyledSimpleTable)<{numColumns: numb
   }
 
   @container (max-width: ${SAMPLES_PANEL_MIN_WIDTH + MAX_TELEMETRY_WIDTH * 1}px) {
-    grid-template-columns: repeat(${p => p.numColumns - 3}, min-content) auto;
+    grid-template-columns: repeat(${p => p.numColumns - 3}, min-content) 1fr;
 
     [data-column-name='logs'] {
       display: none;

--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -7,6 +7,7 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
 import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
 import MetricInfoTabs from 'sentry/views/explore/metrics/metricInfoTabs';
+import {SAMPLES_PANEL_MIN_WIDTH} from 'sentry/views/explore/metrics/metricInfoTabs/samplesTab';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 
 interface MetricPanelProps {
@@ -17,7 +18,8 @@ interface MetricPanelProps {
 const MIN_LEFT_WIDTH = 400;
 
 // Defined by the size of the expected samples tab component
-const MIN_RIGHT_WIDTH = 450;
+const PADDING_SIZE = 16;
+const MIN_RIGHT_WIDTH = SAMPLES_PANEL_MIN_WIDTH + PADDING_SIZE;
 
 export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
   const measureRef = useRef<HTMLDivElement>(null);
@@ -29,8 +31,8 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
   });
 
   const hasSize = width > 0;
-  // Default split is 60% of the available width, but not less than MIN_LEFT_WIDTH.
-  const defaultSplit = Math.max(width * 0.6, MIN_LEFT_WIDTH);
+  // Default split is 65% of the available width, but not less than MIN_LEFT_WIDTH.
+  const defaultSplit = Math.max(width * 0.65, MIN_LEFT_WIDTH);
 
   return (
     <Panel>

--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -15,7 +15,9 @@ interface MetricPanelProps {
 }
 
 const MIN_LEFT_WIDTH = 400;
-const MIN_RIGHT_WIDTH = 400;
+
+// Defined by the size of the expected samples tab component
+const MIN_RIGHT_WIDTH = 450;
 
 export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
   const measureRef = useRef<HTMLDivElement>(null);
@@ -28,7 +30,7 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
 
   const hasSize = width > 0;
   // Default split is 60% of the available width, but not less than MIN_LEFT_WIDTH.
-  const defaultSplit = Math.min(width * 0.625, width - MIN_LEFT_WIDTH);
+  const defaultSplit = Math.max(width * 0.6, MIN_LEFT_WIDTH);
 
   return (
     <Panel>

--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -31,8 +31,12 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
   });
 
   const hasSize = width > 0;
-  // Default split is 65% of the available width, but not less than MIN_LEFT_WIDTH.
-  const defaultSplit = Math.max(width * 0.65, MIN_LEFT_WIDTH);
+  // Default split is 65% of the available width, but not less than MIN_LEFT_WIDTH
+  // and at most the maximum size allowed for the left panel (i.e. width - MIN_RIGHT_WIDTH)
+  const defaultSplit = Math.min(
+    Math.max(width * 0.65, MIN_LEFT_WIDTH),
+    width - MIN_RIGHT_WIDTH
+  );
 
   return (
     <Panel>


### PR DESCRIPTION
- Update the CSS styling of the samples tab so the telemetry icons have their own columns and render with a predictable size using the count component
- Right aligns the value cell
- Adjusts the panel slider to accommodate for the min size of the right panel.

https://github.com/user-attachments/assets/62282a49-b9c2-460c-87c9-d9856f6e94bf

