### PR TITLE
feat(preprod): add support for missing_dsym_binaries API field

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -59,6 +59,7 @@ def validate_preprod_artifact_update_schema(
                     "certificate_expiration_date": {"type": "string"},
                     "is_code_signature_valid": {"type": "boolean"},
                     "code_signature_errors": {"type": "array", "items": {"type": "string"}},
+                    "missing_dsym_binaries": {"type": "array", "items": {"type": "string"}},
                 },
             },
             "dequeued_at": {"type": "string"},
@@ -82,6 +83,7 @@ def validate_preprod_artifact_update_schema(
         "apple_app_info.profile_name": "The profile_name field must be a string.",
         "apple_app_info.is_code_signature_valid": "The is_code_signature_valid field must be a boolean.",
         "apple_app_info.code_signature_errors": "The code_signature_errors field must be an array of strings.",
+        "apple_app_info.missing_dsym_binaries": "The missing_dsym_binaries field must be an array of strings.",
         "dequeued_at": "The dequeued_at field must be a string.",
         "app_icon_id": "The app_icon_id field must be a string with a maximum length of 255 characters.",
     }
@@ -286,6 +288,7 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 "certificate_expiration_date",
                 "is_code_signature_valid",
                 "code_signature_errors",
+                "missing_dsym_binaries",
             ]:
                 if field in apple_info:
                     extras_updates[field] = apple_info[field]

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -29,6 +29,11 @@ class BuildDetailsAppInfo(BaseModel):
     platform: Platform | None = None
     is_installable: bool
     build_configuration: str | None = None
+    apple_app_info: AppleAppInfo | None = None
+
+
+class AppleAppInfo(BaseModel):
+    missing_dsym_binaries: list[str] = []
 
 
 class BuildDetailsVcsInfo(BaseModel):
@@ -135,6 +140,12 @@ def transform_preprod_artifact_to_build_details(
 
     size_info = to_size_info(size_metrics)
 
+    apple_app_info = AppleAppInfo(
+        missing_dsym_binaries=(
+            artifact.extras.get("missing_dsym_binaries", []) if artifact.extras else []
+        )
+    )
+
     app_info = BuildDetailsAppInfo(
         app_id=artifact.app_id,
         name=artifact.app_name,
@@ -152,6 +163,7 @@ def transform_preprod_artifact_to_build_details(
         build_configuration=(
             artifact.build_configuration.name if artifact.build_configuration else None
         ),
+        apple_app_info=apple_app_info,
     )
 
     vcs_info = BuildDetailsVcsInfo(

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -18,6 +18,10 @@ class Platform(StrEnum):
     MACOS = "macos"
 
 
+class AppleAppInfo(BaseModel):
+    missing_dsym_binaries: list[str] = []
+
+
 class BuildDetailsAppInfo(BaseModel):
     app_id: str | None
     name: str | None
@@ -30,10 +34,6 @@ class BuildDetailsAppInfo(BaseModel):
     is_installable: bool
     build_configuration: str | None = None
     apple_app_info: AppleAppInfo | None = None
-
-
-class AppleAppInfo(BaseModel):
-    missing_dsym_binaries: list[str] = []
 
 
 class BuildDetailsVcsInfo(BaseModel):

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -180,6 +180,36 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert stored_apple_info == apple_info
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    def test_update_preprod_artifact_with_missing_dsym_binaries_truncation(self) -> None:
+        """Test that missing_dsym_binaries list is truncated if it exceeds 1024 chars."""
+        # Create a list that exceeds 1024 chars total
+        # Each item is 30 chars, so 40 items = 1200 chars
+        large_list = [f"VeryLongLibraryName{i:04d}.dylib" for i in range(40)]
+        total_chars = sum(len(s) for s in large_list)
+        assert total_chars > 1024, "Test data should exceed 1024 chars"
+
+        apple_info = {"missing_dsym_binaries": large_list}
+        data = {
+            "artifact_type": 1,
+            "apple_app_info": apple_info,
+        }
+        response = self._make_request(data)
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["success"] is True
+
+        self.preprod_artifact.refresh_from_db()
+        stored_apple_info = self.preprod_artifact.extras or {}
+        stored_binaries = stored_apple_info.get("missing_dsym_binaries", [])
+
+        # Verify the list was truncated
+        assert len(stored_binaries) < len(large_list)
+        # Verify total chars is within limit
+        stored_total_chars = sum(len(s) for s in stored_binaries)
+        assert stored_total_chars <= 1024
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_with_partial_apple_app_info(self) -> None:
         apple_info = {
             "is_simulator": False,

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -159,6 +159,7 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             "profile_name": "Test Profile",
             "is_code_signature_valid": False,
             "code_signature_errors": ["Certificate expired", "Missing entitlements"],
+            "missing_dsym_binaries": ["TestLib.dylib", "TestFramework.framework"],
         }
         data = {
             "date_built": "2024-01-01T00:00:00Z",

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -226,3 +226,22 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         assert response.status_code == 200
         resp_data = response.json()
         assert resp_data["size_info"] is None
+
+    def test_get_build_details_with_missing_dsym_binaries(self) -> None:
+        """Test that missing_dsym_binaries is returned in apple_app_info."""
+        self.preprod_artifact.extras = {
+            "missing_dsym_binaries": ["libTest.dylib", "TestFramework.framework"]
+        }
+        self.preprod_artifact.save()
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["app_info"]["apple_app_info"]["missing_dsym_binaries"] == [
+            "libTest.dylib",
+            "TestFramework.framework",
+        ]


### PR DESCRIPTION
Pipes in the new `missing_dsym_binaries` field to both be saved into our DB as well as serialized through the API response.