### PR TITLE
fix(releases): Normalize resolution reason between ResolutionBox and GroupActivityItem for semver inNextRelease

### DIFF
--- a/static/app/components/resolutionBox.spec.tsx
+++ b/static/app/components/resolutionBox.spec.tsx
@@ -161,30 +161,6 @@ describe('ResolutionBox', () => {
       `This issue has been marked as resolved in version ${release.version}.`
     );
   });
-  it('handles inRelease with activity', () => {
-    const {container} = render(
-      <ResolutionBox
-        statusDetails={{
-          inRelease: release.version,
-        }}
-        project={project}
-        organization={organization}
-        activities={[
-          {
-            id: '1',
-            type: GroupActivityType.SET_RESOLVED_IN_RELEASE,
-            data: {
-              version: release.version,
-            },
-            dateCreated: new Date().toISOString(),
-          },
-        ]}
-      />
-    );
-    expect(container).toHaveTextContent(
-      `This issue has been marked as resolved in version ${release.version}.`
-    );
-  });
   it('handles inRelease with actor', () => {
     const {container} = render(
       <ResolutionBox

--- a/static/app/components/resolutionBox.spec.tsx
+++ b/static/app/components/resolutionBox.spec.tsx
@@ -73,7 +73,7 @@ describe('ResolutionBox', () => {
       'David Cramer marked this issue as resolved in the upcoming release.'
     );
   });
-  it('handles in next release (semver current_release_version)', () => {
+  it('handles inNextRelease (semver current_release_version)', () => {
     const currentReleaseVersion = '1.2.0';
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/releases/${currentReleaseVersion}/`,
@@ -89,7 +89,7 @@ describe('ResolutionBox', () => {
     const {container} = render(
       <ResolutionBox
         statusDetails={{
-          inNextRelease: true,
+          inRelease: currentReleaseVersion,
           actor: UserFixture(),
         }}
         project={project}
@@ -118,6 +118,30 @@ describe('ResolutionBox', () => {
         }}
         project={project}
         organization={organization}
+      />
+    );
+    expect(container).toHaveTextContent(
+      `This issue has been marked as resolved in version ${release.version}.`
+    );
+  });
+  it('handles inRelease with activity', () => {
+    const {container} = render(
+      <ResolutionBox
+        statusDetails={{
+          inRelease: release.version,
+        }}
+        project={project}
+        organization={organization}
+        activities={[
+          {
+            id: '1',
+            type: GroupActivityType.SET_RESOLVED_IN_RELEASE,
+            data: {
+              version: release.version,
+            },
+            dateCreated: new Date().toISOString(),
+          },
+        ]}
       />
     );
     expect(container).toHaveTextContent(

--- a/static/app/components/resolutionBox.spec.tsx
+++ b/static/app/components/resolutionBox.spec.tsx
@@ -73,7 +73,7 @@ describe('ResolutionBox', () => {
       'David Cramer marked this issue as resolved in the upcoming release.'
     );
   });
-  it('handles inNextRelease (semver current_release_version)', () => {
+  it('handles inRelease with semver current_release_version)', () => {
     const currentReleaseVersion = '1.2.0';
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/releases/${currentReleaseVersion}/`,
@@ -90,6 +90,43 @@ describe('ResolutionBox', () => {
       <ResolutionBox
         statusDetails={{
           inRelease: currentReleaseVersion,
+          actor: UserFixture(),
+        }}
+        project={project}
+        organization={organization}
+        activities={[
+          {
+            id: '1',
+            type: GroupActivityType.SET_RESOLVED_IN_RELEASE,
+            data: {
+              current_release_version: currentReleaseVersion,
+            },
+            dateCreated: new Date().toISOString(),
+          },
+        ]}
+      />
+    );
+    expect(container).toHaveTextContent(
+      'Foo Bar marked this issue as resolved in versions greater than 1.2.0'
+    );
+  });
+  it('handles inNextRelease with semver current_release_version)', () => {
+    const currentReleaseVersion = '1.2.0';
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/releases/${currentReleaseVersion}/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/${currentReleaseVersion}/deploys/`,
+      method: 'GET',
+      body: [],
+    });
+
+    const {container} = render(
+      <ResolutionBox
+        statusDetails={{
+          inNextRelease: true,
           actor: UserFixture(),
         }}
         project={project}

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -50,21 +50,16 @@ export function renderResolutionReason({
   );
 
   // Resolved in next release has current_release_version (semver only)
-  if (
-    (statusDetails.inNextRelease || statusDetails.inRelease) &&
-    relevantActivity &&
-    'current_release_version' in relevantActivity.data
-  ) {
+  if (relevantActivity && 'current_release_version' in relevantActivity.data) {
+    const releaseVersion =
+      statusDetails.inRelease ?? relevantActivity.data.current_release_version;
     const version = (
       <VersionHoverCard
         organization={organization}
         projectSlug={project.slug}
-        releaseVersion={relevantActivity.data.current_release_version}
+        releaseVersion={releaseVersion}
       >
-        <VersionComponent
-          version={relevantActivity.data.current_release_version}
-          projectId={project.id}
-        />
+        <VersionComponent version={releaseVersion} projectId={project.id} />
       </VersionHoverCard>
     );
     return statusDetails.actor

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -49,33 +49,6 @@ export function renderResolutionReason({
     activity => activity.type === GroupActivityType.SET_RESOLVED_IN_RELEASE
   );
 
-  // Resolved in next release has current_release_version (semver only)
-  if (relevantActivity && 'current_release_version' in relevantActivity.data) {
-    const version = (
-      <VersionHoverCard
-        organization={organization}
-        projectSlug={project.slug}
-        releaseVersion={relevantActivity.data.current_release_version}
-      >
-        <VersionComponent
-          version={relevantActivity.data.current_release_version}
-          projectId={project.id}
-        />
-      </VersionHoverCard>
-    );
-    return statusDetails.actor
-      ? tct('[actor] marked this issue as resolved in versions greater than [version].', {
-          actor,
-          version,
-        })
-      : tct(
-          'This issue has been marked as resolved in versions greater than [version].',
-          {
-            version,
-          }
-        );
-  }
-
   if (statusDetails.inNextRelease) {
     return actor
       ? tct('[actor] marked this issue as resolved in the upcoming release.', {
@@ -84,6 +57,36 @@ export function renderResolutionReason({
       : t('This issue has been marked as resolved in the upcoming release.');
   }
   if (statusDetails.inRelease) {
+    // Resolved in next release has current_release_version (semver only)
+    if (relevantActivity && 'current_release_version' in relevantActivity.data) {
+      const version = (
+        <VersionHoverCard
+          organization={organization}
+          projectSlug={project.slug}
+          releaseVersion={relevantActivity.data.current_release_version}
+        >
+          <VersionComponent
+            version={relevantActivity.data.current_release_version}
+            projectId={project.id}
+          />
+        </VersionHoverCard>
+      );
+      return statusDetails.actor
+        ? tct(
+            '[actor] marked this issue as resolved in versions greater than [version].',
+            {
+              actor,
+              version,
+            }
+          )
+        : tct(
+            'This issue has been marked as resolved in versions greater than [version].',
+            {
+              version,
+            }
+          );
+    }
+
     const version = (
       <VersionHoverCard
         organization={organization}

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -15,7 +15,6 @@ import {GroupActivityType} from 'sentry/types/group';
 import type {Repository} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {isSemverRelease} from 'sentry/utils/versions/isSemverRelease';
 
 type Props = {
   organization: Organization;
@@ -50,7 +49,7 @@ export function renderResolutionReason({
     activity => activity.type === GroupActivityType.SET_RESOLVED_IN_RELEASE
   );
 
-  // Resolved in next release has current_release_version
+  // Resolved in next release has current_release_version (semver only)
   if (relevantActivity && 'current_release_version' in relevantActivity.data) {
     const version = (
       <VersionHoverCard
@@ -64,20 +63,14 @@ export function renderResolutionReason({
         />
       </VersionHoverCard>
     );
-    const isSemver = isSemverRelease(relevantActivity.data.current_release_version);
     return statusDetails.actor
-      ? tct(
-          '[actor] marked this issue as resolved in versions [semver_comparison] than [version].',
-          {
-            actor,
-            semver_comparison: isSemver ? t('greater') : t('later'),
-            version,
-          }
-        )
+      ? tct('[actor] marked this issue as resolved in versions greater than [version].', {
+          actor,
+          version,
+        })
       : tct(
-          'This issue has been marked as resolved in versions [semver_comparison] than [version].',
+          'This issue has been marked as resolved in versions greater than [version].',
           {
-            semver_comparison: isSemver ? t('greater') : t('later'),
             version,
           }
         );

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -49,6 +49,37 @@ export function renderResolutionReason({
     activity => activity.type === GroupActivityType.SET_RESOLVED_IN_RELEASE
   );
 
+  // Resolved in next release has current_release_version (semver only)
+  if (
+    (statusDetails.inNextRelease || statusDetails.inRelease) &&
+    relevantActivity &&
+    'current_release_version' in relevantActivity.data
+  ) {
+    const version = (
+      <VersionHoverCard
+        organization={organization}
+        projectSlug={project.slug}
+        releaseVersion={relevantActivity.data.current_release_version}
+      >
+        <VersionComponent
+          version={relevantActivity.data.current_release_version}
+          projectId={project.id}
+        />
+      </VersionHoverCard>
+    );
+    return statusDetails.actor
+      ? tct('[actor] marked this issue as resolved in versions greater than [version].', {
+          actor,
+          version,
+        })
+      : tct(
+          'This issue has been marked as resolved in versions greater than [version].',
+          {
+            version,
+          }
+        );
+  }
+
   if (statusDetails.inNextRelease) {
     return actor
       ? tct('[actor] marked this issue as resolved in the upcoming release.', {
@@ -57,36 +88,6 @@ export function renderResolutionReason({
       : t('This issue has been marked as resolved in the upcoming release.');
   }
   if (statusDetails.inRelease) {
-    // Resolved in next release has current_release_version (semver only)
-    if (relevantActivity && 'current_release_version' in relevantActivity.data) {
-      const version = (
-        <VersionHoverCard
-          organization={organization}
-          projectSlug={project.slug}
-          releaseVersion={relevantActivity.data.current_release_version}
-        >
-          <VersionComponent
-            version={relevantActivity.data.current_release_version}
-            projectId={project.id}
-          />
-        </VersionHoverCard>
-      );
-      return statusDetails.actor
-        ? tct(
-            '[actor] marked this issue as resolved in versions greater than [version].',
-            {
-              actor,
-              version,
-            }
-          )
-        : tct(
-            'This issue has been marked as resolved in versions greater than [version].',
-            {
-              version,
-            }
-          );
-    }
-
     const version = (
       <VersionHoverCard
         organization={organization}


### PR DESCRIPTION
Previously we were showing two different message strings in `ResolutionBox` and `GroupActivityItem` when resolving in next release, where the current release version in the project is semver.

# Before

When resolving in the next release, `ResolutionBox` always says we resolve _in_ release x, whereas `GroupActivityItem` says we resolve in releases _greater_ than release x if semver. 

The problem here is that we're not really resolving _in_ the greatest semver release--we resolve in the release _after_ it. Per the regression logic, we [detect a regression if given release version > `GroupResolution.current_release_version`](https://github.com/getsentry/sentry/blob/c2cb4fadaad0a20357f25f264ac85581ea6462ec/src/sentry/models/groupresolution.py#L127). It therefore makes more sense for the messages in these components to both say we resolve in releases _greater_ than release x, like `GroupActivityItem` already says.

<img width="1223" height="938" alt="image" src="https://github.com/user-attachments/assets/832d5c14-d8b2-4af9-9669-97a02e50a3d8" />

# After
Since we resolve in the next release after the current one (release x), let's normalize `ResolutionBox` to say the same thing as `GroupActivityItem`.

Originally we were mostly not hitting the logic checking for `current_release_version` because **we set the resolution type to `inRelease` when resolving in next release for both [semver](https://github.com/getsentry/sentry/blob/a7b5c0930060cc753cb617c414cae5ff6b689b08/src/sentry/api/helpers/group_index/update.py#L544) and [non-semver](https://github.com/getsentry/sentry/blob/a7b5c0930060cc753cb617c414cae5ff6b689b08/src/sentry/api/helpers/group_index/update.py#L584)**. `current_release_version` is only set in the activity data when we're resolving in next release in a semver project. In this PR we now check for either `statusDetails.inNextRelease` or `statusDetails.inRelease` to run the `current_release_version` logic.

## semver case (messages now match)
<img width="1220" height="938" alt="image" src="https://github.com/user-attachments/assets/15d7b1b2-9ae6-42cc-af9c-33fb3d110c6e" />

## non-semver case (no change)
<img width="1391" height="923" alt="image" src="https://github.com/user-attachments/assets/26406b14-2ec2-4576-8387-073fa447e87a" />

## resolving inRelease (no change)
<img width="1390" height="922" alt="image" src="https://github.com/user-attachments/assets/182f09b8-a6dc-4fba-b7b0-a67f77331aac" />