### PR TITLE
feat(aci): add crons empty state and no project message

### DIFF
--- a/static/app/components/workflowEngine/layout/list.tsx
+++ b/static/app/components/workflowEngine/layout/list.tsx
@@ -1,6 +1,8 @@
 import {Flex} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface WorkflowEngineListLayoutProps {
   actions: React.ReactNode;
@@ -22,24 +24,28 @@ function WorkflowEngineListLayout({
   description,
   docsUrl,
 }: WorkflowEngineListLayoutProps) {
+  const organization = useOrganization();
+
   return (
     <Layout.Page>
-      <Layout.Header unified>
-        <Layout.HeaderContent>
-          <Layout.Title>
-            {title}
-            <PageHeadingQuestionTooltip docsUrl={docsUrl} title={description} />
-          </Layout.Title>
-        </Layout.HeaderContent>
-        <Layout.HeaderActions>{actions}</Layout.HeaderActions>
-      </Layout.Header>
-      <Layout.Body>
-        <Layout.Main width="full">
-          <Flex direction="column" gap="lg">
-            {children}
-          </Flex>
-        </Layout.Main>
-      </Layout.Body>
+      <NoProjectMessage organization={organization}>
+        <Layout.Header unified>
+          <Layout.HeaderContent>
+            <Layout.Title>
+              {title}
+              <PageHeadingQuestionTooltip docsUrl={docsUrl} title={description} />
+            </Layout.Title>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>{actions}</Layout.HeaderActions>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main width="full">
+            <Flex direction="column" gap="lg">
+              {children}
+            </Flex>
+          </Layout.Main>
+        </Layout.Body>
+      </NoProjectMessage>
     </Layout.Page>
   );
 }

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -27,6 +27,7 @@ import {DETECTOR_LIST_PAGE_LIMIT} from 'sentry/views/detectors/constants';
 import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
 import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
+import {CronsLandingPanel} from 'sentry/views/insights/crons/components/cronsLandingPanel';
 
 interface DetectorHeadingInfo {
   description: string;
@@ -160,32 +161,36 @@ export default function DetectorsList() {
           docsUrl={docsUrl}
         >
           <TableHeader />
-          <div>
-            <VisuallyCompleteWithData
-              hasData={(detectors?.length ?? 0) > 0}
-              id="MonitorsList-Table"
-              isLoading={isLoading}
-            >
-              <DetectorListTable
-                detectors={detectors ?? []}
-                isPending={isLoading}
-                isError={isError}
-                isSuccess={isSuccess}
-                sort={sort}
-                queryCount={hitsInt > maxHitsInt ? `${maxHits}+` : hits}
-                allResultsVisible={allResultsVisible()}
+          {detectors?.length || detectorFilter !== 'monitor_check_in_failure' ? (
+            <div>
+              <VisuallyCompleteWithData
+                hasData={(detectors?.length ?? 0) > 0}
+                id="MonitorsList-Table"
+                isLoading={isLoading}
+              >
+                <DetectorListTable
+                  detectors={detectors ?? []}
+                  isPending={isLoading}
+                  isError={isError}
+                  isSuccess={isSuccess}
+                  sort={sort}
+                  queryCount={hitsInt > maxHitsInt ? `${maxHits}+` : hits}
+                  allResultsVisible={allResultsVisible()}
+                />
+              </VisuallyCompleteWithData>
+              <Pagination
+                pageLinks={pageLinks}
+                onCursor={newCursor => {
+                  navigate({
+                    pathname: location.pathname,
+                    query: {...location.query, cursor: newCursor},
+                  });
+                }}
               />
-            </VisuallyCompleteWithData>
-            <Pagination
-              pageLinks={pageLinks}
-              onCursor={newCursor => {
-                navigate({
-                  pathname: location.pathname,
-                  query: {...location.query, cursor: newCursor},
-                });
-              }}
-            />
-          </div>
+            </div>
+          ) : (
+            <CronsLandingPanel />
+          )}
         </ListLayout>
       </PageFiltersContainer>
     </SentryDocumentTitle>


### PR DESCRIPTION
crons
<img width="1512" height="982" alt="Screenshot 2025-10-28 at 2 01 29 PM" src="https://github.com/user-attachments/assets/b73d17c9-033d-449d-8ab5-2aaadbe7b19e" />

no project
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/4984fb34-40a1-45b4-aa73-80cd1d9f8506" />

other monitor types will show an empty table when there are no monitors