### PR TITLE
fix(issue details): Toggle visibility within `NativeFrame`s rather than conditionally rendering

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -191,11 +191,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
   }
 
   if ((isPending && isQueryEnabled) || !match) {
-    return (
-      <StacktraceLinkWrapper>
-        <Placeholder height="14px" width={coverageEnabled ? '40px' : '14px'} />
-      </StacktraceLinkWrapper>
-    );
+    return null;
   }
 
   // Match found - display link to source

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -409,7 +409,7 @@ function NativeFrame({
             </ShowHideButton>
           ) : null}
           <GenericCellWrapper>
-            {hasStacktraceLink && (
+            <div style={{visibility: hasStacktraceLink ? 'visible' : 'hidden'}}>
               <ErrorBoundary>
                 <StacktraceLink
                   frame={frame}
@@ -418,8 +418,12 @@ function NativeFrame({
                   disableSetup={isHoverPreviewed}
                 />
               </ErrorBoundary>
-            )}
-            {showSentryAppStacktraceLinkInFrame && (
+            </div>
+            <div
+              style={{
+                visibility: showSentryAppStacktraceLinkInFrame ? 'visible' : 'hidden',
+              }}
+            >
               <ErrorBoundary mini>
                 <OpenInContextLine
                   lineNo={frame.lineNo}
@@ -427,7 +431,7 @@ function NativeFrame({
                   components={components}
                 />
               </ErrorBoundary>
-            )}
+            </div>
             <TypeCell>
               {frame.inApp ? <Tag type="info">{t('In App')}</Tag> : null}
             </TypeCell>

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -150,8 +150,8 @@ function NativeFrame({
   const [isHovering, setHovering] = useState(false);
 
   const contextLine = (frame?.context || []).find(l => l[0] === frame.lineNo);
-  const hasStacktraceLink = frame.inApp && !!frame.filename && (isHovering || expanded);
-  const showSentryAppStacktraceLinkInFrame = hasStacktraceLink && components.length > 0;
+  const showStacktraceLink = frame.inApp && !!frame.filename && (isHovering || expanded);
+  const showSentryAppStacktraceLinkInFrame = showStacktraceLink && components.length > 0;
 
   const handleMouseEnter = () => setHovering(true);
 
@@ -409,7 +409,7 @@ function NativeFrame({
             </ShowHideButton>
           ) : null}
           <GenericCellWrapper>
-            <div style={{visibility: hasStacktraceLink ? 'visible' : 'hidden'}}>
+            {showStacktraceLink && (
               <ErrorBoundary>
                 <StacktraceLink
                   frame={frame}
@@ -418,12 +418,8 @@ function NativeFrame({
                   disableSetup={isHoverPreviewed}
                 />
               </ErrorBoundary>
-            </div>
-            <div
-              style={{
-                visibility: showSentryAppStacktraceLinkInFrame ? 'visible' : 'hidden',
-              }}
-            >
+            )}
+            {showSentryAppStacktraceLinkInFrame && (
               <ErrorBoundary mini>
                 <OpenInContextLine
                   lineNo={frame.lineNo}
@@ -431,7 +427,7 @@ function NativeFrame({
                   components={components}
                 />
               </ErrorBoundary>
-            </div>
+            )}
             <TypeCell>
               {frame.inApp ? <Tag type="info">{t('In App')}</Tag> : null}
             </TypeCell>


### PR DESCRIPTION
Fixes [ID-1038](https://linear.app/getsentry/issue/ID-1038/initial-mouse-over-causes-stack-frame-lines-to-expand).

We were seeing some text flickering/glitching & stack frame expansion during mouse hover. This fix switches from conditional rendering to visibility toggling in order to keep the row sizes constant.