### PR TITLE
bug(preprod): Minor preprod polish bugs

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -46,11 +46,13 @@ function BuildButton({buildDetails, icon, label, onRemove}: BuildButtonProps) {
             </Flex>
           )}
         </Flex>
-        <BuildBranch>
-          <Text size="sm" variant="muted">
-            {branchName}
-          </Text>
-        </BuildBranch>
+        {branchName && (
+          <BuildBranch>
+            <Text size="sm" variant="muted">
+              {branchName}
+            </Text>
+          </BuildBranch>
+        )}
         {onRemove && (
           <Button
             onClick={e => {

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -195,6 +195,8 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
   const dateAdded = build.app_info?.date_added;
   const sizeInfo = build.size_info;
 
+  const hasGitInfo = prNumber || branchName || commitHash;
+
   return (
     <BuildItemContainer
       onClick={onSelect}
@@ -203,23 +205,26 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
       gap="md"
     >
       <Flex direction="column" gap="sm" flex={1}>
-        <Flex align="center" gap="md">
-          {(prNumber || branchName) && <IconBranch size="xs" color="gray300" />}
-          {prNumber && (
-            <Flex align="center" gap="sm">
-              <Text>#{prNumber}</Text>
-            </Flex>
-          )}
-          {branchName && (
-            <BuildItemBranchTag>{build.vcs_info?.head_ref}</BuildItemBranchTag>
-          )}
-          {commitHash && (
-            <Flex align="center" gap="sm">
-              <IconCommit size="xs" color="gray300" />
-              <Text>{commitHash}</Text>
-            </Flex>
-          )}
-        </Flex>
+        {hasGitInfo && (
+          <Flex align="center" gap="md">
+            {(prNumber || branchName) && <IconBranch size="xs" color="gray300" />}
+            {prNumber && (
+              <Flex align="center" gap="sm">
+                <Text>#{prNumber}</Text>
+              </Flex>
+            )}
+            {branchName && (
+              <BuildItemBranchTag>{build.vcs_info?.head_ref}</BuildItemBranchTag>
+            )}
+            {commitHash && (
+              <Flex align="center" gap="sm">
+                <IconCommit size="xs" color="gray300" />
+                <Text>{commitHash}</Text>
+              </Flex>
+            )}
+          </Flex>
+        )}
+
         <Flex align="center" gap="md">
           {dateAdded && (
             <Flex align="center" gap="sm">


### PR DESCRIPTION
Fixes two bugs:
- Empty branch tag
- Empty 2px or so content in row when no Git content available

Before
<img width="963" height="421" alt="Screenshot 2025-10-28 at 2 47 10 PM" src="https://github.com/user-attachments/assets/e05cb419-b506-4d28-95d9-b8a23462eaf8" />

After
<img width="901" height="332" alt="Screenshot 2025-10-28 at 2 46 56 PM" src="https://github.com/user-attachments/assets/eb17325e-b0d7-4743-966e-504078173074" />

Resolves EME-480, EME-484