### PR TITLE
fix(explorer): focus blocks on hover to prevent dup actions

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -23,6 +23,8 @@ interface BlockProps {
   isPolling?: boolean;
   onClick?: () => void;
   onDelete?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
   onNavigate?: () => void;
   onRegisterEnterHandler?: (
     handler: (key: 'Enter' | 'ArrowUp' | 'ArrowDown') => boolean
@@ -88,6 +90,8 @@ function BlockComponent({
   isPolling,
   onClick,
   onDelete,
+  onMouseEnter,
+  onMouseLeave,
   onNavigate,
   onRegisterEnterHandler,
   ref,
@@ -97,8 +101,6 @@ function BlockComponent({
   const toolsUsed = getToolsStringFromBlock(block);
   const hasTools = toolsUsed.length > 0;
   const hasContent = hasValidContent(block.message.content);
-
-  const [isHovered, setIsHovered] = useState(false);
 
   // State to track selected tool link (for navigation)
   const [selectedLinkIndex, setSelectedLinkIndex] = useState(0);
@@ -220,15 +222,15 @@ function BlockComponent({
     }
   };
 
-  const showActions = (isFocused || isHovered) && !block.loading;
+  const showActions = isFocused && !block.loading;
 
   return (
     <Block
       ref={ref}
       isLast={isLast}
       onClick={onClick}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <AnimatePresence>
         <motion.div

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -206,6 +206,8 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
               isFocused={focusedBlockIndex === index}
               isPolling={isPolling}
               onClick={() => handleBlockClick(index)}
+              onMouseEnter={() => setFocusedBlockIndex(index)}
+              onMouseLeave={() => setFocusedBlockIndex(-1)}
               onDelete={() => deleteFromIndex(index)}
               onNavigate={() => setIsMinimized(true)}
               onRegisterEnterHandler={handler => {

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -207,7 +207,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
               isPolling={isPolling}
               onClick={() => handleBlockClick(index)}
               onMouseEnter={() => setFocusedBlockIndex(index)}
-              onMouseLeave={() => setFocusedBlockIndex(-1)}
               onDelete={() => deleteFromIndex(index)}
               onNavigate={() => setIsMinimized(true)}
               onRegisterEnterHandler={handler => {


### PR DESCRIPTION
Right now we have weird UI behavior where clicking a block shows a purple indicator and actions, but hovering on another block shows actions too without the indicator.

This PR fixes the dup actions by setting block to focused rather than having a separate isHovered state. Only the block we're currently hovering has actions + indicator. Only difference between onClick and onMouseEnter now is onClick sets minimized to false

The input box is only focused when it's clicked, otherwise the last hovered block is focused.

https://github.com/user-attachments/assets/3c6a6e96-29d3-4914-9305-82abd206b5f9


