### PR TITLE
ref(grouping): Change exception subcomponent order in grouping info

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -406,6 +406,22 @@ class ExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponen
     def key(self) -> str:
         return _get_exception_component_key(self)
 
+    def as_dict(self) -> dict[str, Any]:
+        """
+        Convert to a dictionary, first rearranging the values so they show up in the order we want
+        in grouping info.
+        """
+        ordered_values: Any = []
+
+        for component_id in ["type", "value", "ns_error", "stacktrace"]:
+            subcomponent = self.get_subcomponent(component_id)
+            if subcomponent:
+                ordered_values.append(subcomponent)
+
+        self.values = ordered_values
+
+        return super().as_dict()
+
 
 class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponent]):
     id: str = "chained_exception"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:32.649693+00:00'
+created: '2025-10-27T23:46:00.557065+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "actix_web::pipeline"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2561,24 +2579,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "actix_web::pipeline"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
-              ]
             }
           ]
         }
@@ -2624,6 +2624,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "actix_web::pipeline"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -5167,24 +5185,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "actix_web::pipeline"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:53.838129+00:00'
+created: '2025-10-27T23:46:00.583927+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ApplicationNotResponding"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Application Not Responding for at least <int> ms."
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -3804,24 +3822,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ApplicationNotResponding"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Application Not Responding for at least <int> ms."
-              ]
             }
           ]
         },
@@ -3953,6 +3953,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ApplicationNotResponding"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Application Not Responding for at least <int> ms."
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -7739,24 +7757,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ApplicationNotResponding"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Application Not Responding for at least <int> ms."
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:32.694439+00:00'
+created: '2025-10-27T23:46:00.603773+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "System.Exception"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "sync exception"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1048,24 +1066,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "System.Exception"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "sync exception"
               ]
             }
           ]
@@ -1160,6 +1160,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "System.Exception"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "sync exception"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -2188,24 +2206,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "System.Exception"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "sync exception"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:53.893117+00:00'
+created: '2025-10-27T23:46:00.637520+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "SIGSEGV"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Segfault"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -262,24 +280,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "SIGSEGV"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Segfault"
-              ]
             }
           ]
         }
@@ -325,6 +325,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "SIGSEGV"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Segfault"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -569,24 +587,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "SIGSEGV"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Segfault"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:53.925077+00:00'
+created: '2025-10-27T23:46:00.671846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ChunkLoadError"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "ChunkLoadError: something something..."
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -58,24 +76,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ChunkLoadError"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "ChunkLoadError: something something..."
               ]
             }
           ]
@@ -137,6 +137,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ChunkLoadError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "ChunkLoadError: something something..."
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -175,24 +193,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ChunkLoadError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "ChunkLoadError: something something..."
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:53.909474+00:00'
+created: '2025-10-27T23:46:00.655767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ChunkLoadError"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "ChunkLoadError: something else..."
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -58,24 +76,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ChunkLoadError"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "ChunkLoadError: something else..."
               ]
             }
           ]
@@ -141,6 +141,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ChunkLoadError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "ChunkLoadError: something else..."
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -179,24 +197,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ChunkLoadError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "ChunkLoadError: something else..."
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:32.804736+00:00'
+created: '2025-10-27T23:46:00.689573+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,48 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "<redacted>"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": []
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "ns_error",
+              "name": null,
+              "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "domain",
+                  "name": null,
+                  "values": [
+                    "<redacted>"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "code",
+                  "name": null,
+                  "values": [
+                    2
+                  ]
+                }
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1003,48 +1045,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "<redacted>"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "ns_error",
-              "name": null,
-              "values": [
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "domain",
-                  "name": null,
-                  "values": [
-                    "<redacted>"
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "code",
-                  "name": null,
-                  "values": [
-                    2
-                  ]
-                }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": []
             }
           ]
         }
@@ -1090,6 +1090,48 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "<redacted>"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": []
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "ns_error",
+              "name": null,
+              "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "domain",
+                  "name": null,
+                  "values": [
+                    "<redacted>"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "code",
+                  "name": null,
+                  "values": [
+                    2
+                  ]
+                }
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2076,48 +2118,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "<redacted>"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "ns_error",
-              "name": null,
-              "values": [
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "domain",
-                  "name": null,
-                  "values": [
-                    "<redacted>"
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "code",
-                  "name": null,
-                  "values": [
-                    2
-                  ]
-                }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:32.877288+00:00'
+created: '2025-10-27T23:46:00.752803+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ConnectionError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Error while reading from socket: ('Connection closed by server.',)"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -507,24 +525,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ConnectionError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Error while reading from socket: ('Connection closed by server.',)"
               ]
             }
           ]
@@ -619,6 +619,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ConnectionError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Error while reading from socket: ('Connection closed by server.',)"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -1106,24 +1124,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ConnectionError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Error while reading from socket: ('Connection closed by server.',)"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:32.894796+00:00'
+created: '2025-10-27T23:46:00.769887+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "FailedToFetchError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "FailedToFetchError: Charlie didn't bring the ball back!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -192,24 +210,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "FailedToFetchError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "FailedToFetchError: Charlie didn't bring the ball back!"
-              ]
             }
           ]
         }
@@ -255,6 +255,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "FailedToFetchError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "FailedToFetchError: Charlie didn't bring the ball back!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -429,24 +447,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "FailedToFetchError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "FailedToFetchError: Charlie didn't bring the ball back!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.049244+00:00'
+created: '2025-10-27T23:46:00.786073+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "FailedToFetchError"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "FailedToFetchError: Charlie didn't bring the ball back!"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no contributing frames",
@@ -150,24 +168,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "FailedToFetchError"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "FailedToFetchError: Charlie didn't bring the ball back!"
-              ]
             }
           ]
         }
@@ -213,6 +213,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "FailedToFetchError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "FailedToFetchError: Charlie didn't bring the ball back!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -345,24 +363,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "FailedToFetchError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "FailedToFetchError: Charlie didn't bring the ball back!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:33.068626+00:00'
+created: '2025-10-27T23:46:00.952714+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -771,24 +789,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]
@@ -856,6 +856,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -1607,24 +1625,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:33.051565+00:00'
+created: '2025-10-27T23:46:00.935747+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -771,24 +789,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]
@@ -855,6 +855,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -1606,24 +1624,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:33.086075+00:00'
+created: '2025-10-27T23:46:00.970049+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -771,24 +789,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]
@@ -850,6 +850,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -1601,24 +1619,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:33.120005+00:00'
+created: '2025-10-27T23:46:01.003242+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,19 +18,21 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
               "name": null,
               "values": [
                 "iOS_Swift.SampleError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because ns-error info takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
               ]
             },
             {
@@ -61,12 +63,10 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "ignored because ns-error info takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
-              ]
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         },

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.332365+00:00'
+created: '2025-10-27T23:46:01.057008+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "hello world"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:33.135836+00:00'
+created: '2025-10-27T23:46:01.019703+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ValueError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "hello world"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -54,24 +72,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ValueError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "hello world"
               ]
             }
           ]
@@ -121,6 +121,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ValueError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "hello world"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -155,24 +173,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ValueError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "hello world"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:33.151299+00:00'
+created: '2025-10-27T23:46:01.037917+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -26,6 +26,24 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "ValueError"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "hello world"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
                   "id": "stacktrace",
                   "name": "stacktrace",
                   "values": [
@@ -60,24 +78,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
                   ]
                 }
               ]
@@ -91,6 +91,24 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "ValueError"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "hello world"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
                   "id": "stacktrace",
                   "name": "stacktrace",
                   "values": [
@@ -125,24 +143,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
                   ]
                 }
               ]
@@ -200,6 +200,24 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "ValueError"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "hello world"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
                   "id": "stacktrace",
                   "name": "stacktrace",
                   "values": [
@@ -234,24 +252,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
                   ]
                 }
               ]
@@ -265,6 +265,24 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "ValueError"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "hello world"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
                   "id": "stacktrace",
                   "name": "stacktrace",
                   "values": [
@@ -299,24 +317,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
                   ]
                 }
               ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.350839+00:00'
+created: '2025-10-27T23:46:01.072654+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Some Inner Exception"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -89,13 +89,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -113,6 +106,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.386592+00:00'
+created: '2025-10-27T23:46:01.104242+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Nope"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.368885+00:00'
+created: '2025-10-27T23:46:01.088152+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Nope"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.403099+00:00'
+created: '2025-10-27T23:46:01.120411+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "Test <int>"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.421935+00:00'
+created: '2025-10-27T23:46:01.136162+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Whoops"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Nope"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.438244+00:00'
+created: '2025-10-27T23:46:01.151966+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Some Inner Exception"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.456890+00:00'
+created: '2025-10-27T23:46:01.170947+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Nope"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.475666+00:00'
+created: '2025-10-27T23:46:01.186979+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "One or more errors occurred."
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.493405+00:00'
+created: '2025-10-27T23:46:01.203366+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "One or more errors occurred."
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.510856+00:00'
+created: '2025-10-27T23:46:01.219381+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "Test <int>"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.529885+00:00'
+created: '2025-10-27T23:46:01.236397+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "Test <int>"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.547086+00:00'
+created: '2025-10-27T23:46:01.252585+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "And now for something completely different."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -89,13 +89,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -113,6 +106,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.581416+00:00'
+created: '2025-10-27T23:46:01.284036+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "Test <int>"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.563734+00:00'
+created: '2025-10-27T23:46:01.268293+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Some Inner Exception"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:33.398579+00:00'
+created: '2025-10-27T23:46:01.299923+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -23,6 +23,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "DoStuffException"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "Can't do the stuff"
+                  ]
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -96,24 +114,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "DoStuffException"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Can't do the stuff"
-                  ]
                 }
               ]
             },
@@ -123,6 +123,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "DoOtherStuffException"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "Can't do the other stuff"
+                  ]
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -196,24 +214,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "DoOtherStuffException"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Can't do the other stuff"
-                  ]
                 }
               ]
             },
@@ -223,13 +223,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -247,6 +240,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }
@@ -300,6 +300,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "DoStuffException"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "Can't do the stuff"
+                  ]
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -373,24 +391,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "DoStuffException"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Can't do the stuff"
-                  ]
                 }
               ]
             },
@@ -400,6 +400,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "DoOtherStuffException"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "Can't do the other stuff"
+                  ]
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -472,24 +490,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "DoOtherStuffException"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Can't do the other stuff"
                   ]
                 }
               ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.632069+00:00'
+created: '2025-10-27T23:46:01.329817+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -89,13 +89,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -113,6 +106,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.614264+00:00'
+created: '2025-10-27T23:46:01.314528+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Test <int>"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -89,13 +89,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -113,6 +106,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "One or more errors occurred."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.687223+00:00'
+created: '2025-10-27T23:46:01.345948+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "TypeError"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Cannot read property 'submitError' of null"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -110,24 +128,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "TypeError"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Cannot read property 'submitError' of null"
-              ]
             }
           ]
         }
@@ -173,6 +173,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "TypeError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Cannot read property 'submitError' of null"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -265,24 +283,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "TypeError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Cannot read property 'submitError' of null"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.765495+00:00'
+created: '2025-10-27T23:46:01.361602+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -20,13 +20,6 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": false,
               "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
-              "contributes": false,
-              "hint": null,
               "id": "type",
               "name": null,
               "values": []
@@ -39,6 +32,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "hello world"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.793598+00:00'
+created: '2025-10-27T23:46:01.376491+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -38,6 +31,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "hint": null,
               "id": "value",
               "name": null,
+              "values": []
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
               "values": []
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:54.917685+00:00'
+created: '2025-10-27T23:46:01.490854+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,22 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": []
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -210,22 +226,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": []
             }
           ]
         }
@@ -271,6 +271,22 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": []
+            },
             {
               "contributes": true,
               "hint": null,
@@ -464,22 +480,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.194424+00:00'
+created: '2025-10-27T23:46:02.163165+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "*pq.Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "pq: cannot cast jsonb null to type integer"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -94,24 +112,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "*pq.Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "pq: cannot cast jsonb null to type integer"
-              ]
             }
           ]
         }
@@ -157,6 +157,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "*pq.Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "pq: cannot cast jsonb null to type integer"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -233,24 +251,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "*pq.Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "pq: cannot cast jsonb null to type integer"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.610322+00:00'
+created: '2025-10-27T23:46:02.183904+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / 0x00000032"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1216,24 +1234,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / 0x00000032"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / <hex>"
-              ]
             }
           ]
         }
@@ -1279,6 +1279,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / 0x00000032"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2477,24 +2495,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / 0x00000032"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.629753+00:00'
+created: '2025-10-27T23:46:02.205934+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -768,24 +786,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_WRITE"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
-              ]
             }
           ]
         }
@@ -831,6 +831,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1581,24 +1599,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_WRITE"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.650432+00:00'
+created: '2025-10-27T23:46:02.226117+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -896,24 +914,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
             }
           ]
         }
@@ -959,6 +959,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1837,24 +1855,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.671765+00:00'
+created: '2025-10-27T23:46:02.246811+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -776,24 +794,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -839,6 +839,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1597,24 +1615,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.696062+00:00'
+created: '2025-10-27T23:46:02.265508+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1245,24 +1263,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1308,6 +1308,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2535,24 +2553,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.729738+00:00'
+created: '2025-10-27T23:46:02.284698+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1288,24 +1306,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1351,6 +1351,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2621,24 +2639,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.747940+00:00'
+created: '2025-10-27T23:46:02.301623+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -520,24 +538,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
-              ]
             }
           ]
         }
@@ -583,6 +583,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1085,24 +1103,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.764694+00:00'
+created: '2025-10-27T23:46:02.317959+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -543,24 +561,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
-              ]
             }
           ]
         }
@@ -606,6 +606,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1131,24 +1149,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.785699+00:00'
+created: '2025-10-27T23:46:02.338757+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1853,24 +1871,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1916,6 +1916,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -3751,24 +3769,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.806758+00:00'
+created: '2025-10-27T23:46:02.358775+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1774,24 +1792,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1837,6 +1837,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -3593,24 +3611,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.827827+00:00'
+created: '2025-10-27T23:46:02.378602+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1884,24 +1902,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1947,6 +1947,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -3813,24 +3831,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.847502+00:00'
+created: '2025-10-27T23:46:02.400702+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -334,24 +352,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
             }
           ]
         }
@@ -397,6 +397,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -713,24 +731,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.867121+00:00'
+created: '2025-10-27T23:46:02.419649+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x40000015 / 0x00000001"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1090,24 +1108,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x40000015 / 0x00000001"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1153,6 +1153,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x40000015 / 0x00000001"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2225,24 +2243,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x40000015 / 0x00000001"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.886817+00:00'
+created: '2025-10-27T23:46:02.438824+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x40000015 / 0x00000001"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1090,24 +1108,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x40000015 / 0x00000001"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1153,6 +1153,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x40000015 / 0x00000001"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2225,24 +2243,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x40000015 / 0x00000001"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.907556+00:00'
+created: '2025-10-27T23:46:02.458919+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x40000015 / 0x00000001"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1195,24 +1213,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x40000015 / 0x00000001"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1258,6 +1258,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x40000015 / 0x00000001"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2435,24 +2453,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x40000015 / 0x00000001"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.939638+00:00'
+created: '2025-10-27T23:46:02.489806+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -22,13 +22,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -45,6 +38,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "FailedToFetchError: Charlie didn't bring the ball back!"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.521625+00:00'
+created: '2025-10-27T23:46:02.507419+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -22,6 +22,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -776,24 +794,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]
@@ -853,6 +853,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -1604,24 +1622,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.538786+00:00'
+created: '2025-10-27T23:46:02.524372+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -771,24 +789,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]
@@ -855,6 +855,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "SoftTimeLimitExceeded()"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -1606,24 +1624,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "SoftTimeLimitExceeded()"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:55.988931+00:00'
+created: '2025-10-27T23:46:02.540601+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -22,13 +22,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -45,6 +38,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "FailedToFetchError: Charlie didn't bring the ball back!"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.003681+00:00'
+created: '2025-10-27T23:46:02.557114+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -22,13 +22,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -45,6 +38,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "FailedToFetchError: Maisey can't see the ball anymore :-("
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.588525+00:00'
+created: '2025-10-27T23:46:02.576383+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BREAKPOINT"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "autoplayOption"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1110,24 +1128,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BREAKPOINT"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "autoplayOption"
-              ]
             }
           ]
         }
@@ -1173,6 +1173,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BREAKPOINT"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "autoplayOption"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2265,24 +2283,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BREAKPOINT"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "autoplayOption"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.045479+00:00'
+created: '2025-10-27T23:46:02.597425+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -23,6 +23,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "BindException"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "Address already in use"
+                  ]
+                },
                 {
                   "contributes": false,
                   "hint": "ignored because it contains no in-app frames",
@@ -835,24 +853,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "BindException"
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Address already in use"
-                  ]
                 }
               ]
             },
@@ -862,6 +862,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "LifecycleException"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "service.getName(): \"Tomcat\";  Protocol handler start failed"
+                  ]
+                },
                 {
                   "contributes": false,
                   "hint": "ignored because it contains no in-app frames",
@@ -1394,7 +1412,15 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "exception",
+              "name": "exception",
+              "values": [
                 {
                   "contributes": true,
                   "hint": null,
@@ -1406,21 +1432,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": true,
-                  "hint": null,
+                  "hint": "stripped event-specific values",
                   "id": "value",
                   "name": null,
                   "values": [
-                    "service.getName(): \"Tomcat\";  Protocol handler start failed"
+                    "Failed to start component [Connector[HTTP/<float><int>]]"
                   ]
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "exception",
-              "name": "exception",
-              "values": [
+                },
                 {
                   "contributes": false,
                   "hint": "ignored because it contains no in-app frames",
@@ -1918,24 +1936,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "LifecycleException"
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": "stripped event-specific values",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Failed to start component [Connector[HTTP/<float><int>]]"
-                  ]
                 }
               ]
             }
@@ -2034,6 +2034,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "BindException"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "Address already in use"
+                  ]
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -2846,24 +2864,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "BindException"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Address already in use"
-                  ]
                 }
               ]
             },
@@ -2873,6 +2873,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "LifecycleException"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "service.getName(): \"Tomcat\";  Protocol handler start failed"
+                  ]
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -3405,7 +3423,15 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "exception",
+              "name": "exception",
+              "values": [
                 {
                   "contributes": true,
                   "hint": null,
@@ -3421,17 +3447,9 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "id": "value",
                   "name": null,
                   "values": [
-                    "service.getName(): \"Tomcat\";  Protocol handler start failed"
+                    "Failed to start component [Connector[HTTP/<float><int>]]"
                   ]
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "exception",
-              "name": "exception",
-              "values": [
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -3928,24 +3946,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "LifecycleException"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "Failed to start component [Connector[HTTP/<float><int>]]"
                   ]
                 }
               ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.067119+00:00'
+created: '2025-10-27T23:46:02.617034+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ArithmeticException"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "/ by zero"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1949,24 +1967,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ArithmeticException"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "/ by zero"
-              ]
             }
           ]
         }
@@ -2057,6 +2057,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ArithmeticException"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "/ by zero"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -3988,24 +4006,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ArithmeticException"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "/ by zero"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.098818+00:00'
+created: '2025-10-27T23:46:02.647708+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "Loading chunk <int> failed.\n(timeout: <url>"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.084098+00:00'
+created: '2025-10-27T23:46:02.632058+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>) at offset <hex>"
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.116515+00:00'
+created: '2025-10-27T23:46:02.665234+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ReferenceError"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "varant is not defined"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -420,24 +438,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ReferenceError"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "varant is not defined"
-              ]
             }
           ]
         }
@@ -483,6 +483,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "ReferenceError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "varant is not defined"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -885,24 +903,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ReferenceError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "varant is not defined"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.163962+00:00'
+created: '2025-10-27T23:46:02.710918+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -123,24 +141,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -186,6 +186,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no contributing frames",
@@ -291,24 +309,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.180198+00:00'
+created: '2025-10-27T23:46:02.726889+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -158,24 +176,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -221,6 +221,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -361,24 +379,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.197437+00:00'
+created: '2025-10-27T23:46:02.742844+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -350,24 +368,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -413,6 +413,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -745,24 +763,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.214485+00:00'
+created: '2025-10-27T23:46:02.758784+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -354,24 +372,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -417,6 +417,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -753,24 +771,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.232303+00:00'
+created: '2025-10-27T23:46:02.774496+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -319,24 +337,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -382,6 +382,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -683,24 +701,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.249306+00:00'
+created: '2025-10-27T23:46:02.790081+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -368,24 +386,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -431,6 +431,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -781,24 +799,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.267077+00:00'
+created: '2025-10-27T23:46:02.806707+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -372,24 +390,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -435,6 +435,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -789,24 +807,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.283782+00:00'
+created: '2025-10-27T23:46:02.822319+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -337,24 +355,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -400,6 +400,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -719,24 +737,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.300714+00:00'
+created: '2025-10-27T23:46:02.837989+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -399,24 +417,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -462,6 +462,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -843,24 +861,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.318068+00:00'
+created: '2025-10-27T23:46:02.855149+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -383,24 +401,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -446,6 +446,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -811,24 +829,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.886867+00:00'
+created: '2025-10-27T23:46:02.873704+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NotFoundError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "GET /issues/<int>/events/latest/ <int>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -815,24 +833,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NotFoundError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "GET /issues/<int>/events/latest/ <int>"
               ]
             }
           ]
@@ -882,6 +882,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NotFoundError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "GET /issues/<int>/events/latest/ <int>"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -1677,24 +1695,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NotFoundError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "GET /issues/<int>/events/latest/ <int>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.904704+00:00'
+created: '2025-10-27T23:46:02.890843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NotFoundError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "GET /issues/<int>/events/latest/ <int>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -673,24 +691,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NotFoundError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "GET /issues/<int>/events/latest/ <int>"
-              ]
             }
           ]
         }
@@ -736,6 +736,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NotFoundError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "GET /issues/<int>/events/latest/ <int>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1391,24 +1409,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NotFoundError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "GET /issues/<int>/events/latest/ <int>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.941441+00:00'
+created: '2025-10-27T23:46:02.926843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Exception"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "LARAVEL TEST"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2121,24 +2139,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Exception"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "LARAVEL TEST"
               ]
             }
           ]
@@ -2188,6 +2188,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Exception"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "LARAVEL TEST"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -4289,24 +4307,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Exception"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "LARAVEL TEST"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:34.920860+00:00'
+created: '2025-10-27T23:46:02.907414+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Exception"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "LARAVEL TEST"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -148,24 +166,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Exception"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "LARAVEL TEST"
-              ]
             }
           ]
         }
@@ -211,6 +211,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Exception"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "LARAVEL TEST"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -341,24 +359,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Exception"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "LARAVEL TEST"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.455095+00:00'
+created: '2025-10-27T23:46:02.975430+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1539,24 +1557,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1602,6 +1602,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -3123,24 +3141,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.480745+00:00'
+created: '2025-10-27T23:46:02.994855+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": "stripped event-specific values",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -1903,24 +1921,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "stripped event-specific values",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1966,6 +1966,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "0x00000000 / 0x00000000"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -3851,24 +3869,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "0x00000000 / 0x00000000"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.505244+00:00'
+created: '2025-10-27T23:46:03.013365+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SIGABRT"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "<redacted>"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -780,24 +798,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SIGABRT"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "<redacted>"
-              ]
             }
           ]
         }
@@ -843,6 +843,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "SIGABRT"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "<redacted>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1605,24 +1623,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "SIGABRT"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "<redacted>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.578006+00:00'
+created: '2025-10-27T23:46:03.076981+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,22 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NS_ERROR_NOT_INITIALIZED"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": []
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -992,22 +1008,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NS_ERROR_NOT_INITIALIZED"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": []
             }
           ]
         }
@@ -1053,6 +1053,22 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NS_ERROR_NOT_INITIALIZED"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": []
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2028,22 +2044,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NS_ERROR_NOT_INITIALIZED"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.594395+00:00'
+created: '2025-10-27T23:46:03.095157+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -117,24 +135,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
-              ]
             }
           ]
         }
@@ -180,6 +180,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -279,24 +297,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.611181+00:00'
+created: '2025-10-27T23:46:03.114196+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -239,24 +257,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
             }
           ]
         }
@@ -302,6 +302,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -523,24 +541,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.628266+00:00'
+created: '2025-10-27T23:46:03.131020+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -206,24 +224,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
             }
           ]
         }
@@ -269,6 +269,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -457,24 +475,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.647007+00:00'
+created: '2025-10-27T23:46:03.148206+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -268,24 +286,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
             }
           ]
         }
@@ -331,6 +331,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -581,24 +599,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_READ"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.664677+00:00'
+created: '2025-10-27T23:46:03.165178+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -117,24 +135,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
-              ]
             }
           ]
         }
@@ -180,6 +180,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -279,24 +297,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.682160+00:00'
+created: '2025-10-27T23:46:03.183171+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -210,24 +228,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
-              ]
             }
           ]
         }
@@ -273,6 +273,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -465,24 +483,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.222394+00:00'
+created: '2025-10-27T23:46:03.200491+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -457,24 +475,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]
@@ -522,6 +522,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
+            {
               "contributes": true,
               "hint": null,
               "id": "stacktrace",
@@ -961,24 +979,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.722913+00:00'
+created: '2025-10-27T23:46:03.215967+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -117,24 +135,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
-              ]
             }
           ]
         }
@@ -180,6 +180,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -279,24 +297,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.740900+00:00'
+created: '2025-10-27T23:46:03.231405+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -189,24 +207,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_WRITE"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
-              ]
             }
           ]
         }
@@ -252,6 +252,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -423,24 +441,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXCEPTION_ACCESS_VIOLATION_WRITE"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.758784+00:00'
+created: '2025-10-27T23:46:03.248770+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -156,24 +174,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
             }
           ]
         },
@@ -226,6 +226,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -364,24 +382,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.288915+00:00'
+created: '2025-10-27T23:46:03.272156+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bla"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -445,24 +463,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bla"
               ]
             }
           ]
@@ -512,6 +512,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "bla"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -937,24 +955,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "bla"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.793090+00:00'
+created: '2025-10-27T23:46:03.290964+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -92,24 +110,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
             }
           ]
         }
@@ -155,6 +155,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Error"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "bad"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no contributing frames",
@@ -229,24 +247,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.319326+00:00'
+created: '2025-10-27T23:46:03.307225+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -23,6 +23,24 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "ValueError"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "hello world"
+                  ]
+                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -61,7 +79,15 @@ source: tests/sentry/grouping/test_grouping_info.py
                       ]
                     }
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "exception",
+              "name": "exception",
+              "values": [
                 {
                   "contributes": true,
                   "hint": null,
@@ -72,22 +98,14 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 },
                 {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
+                  "contributes": true,
+                  "hint": null,
                   "id": "value",
                   "name": null,
                   "values": [
                     "hello world"
                   ]
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "exception",
-              "name": "exception",
-              "values": [
+                },
                 {
                   "contributes": false,
                   "hint": "ignored because it contains no in-app frames",
@@ -125,24 +143,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
                   ]
                 }
               ]
@@ -200,6 +200,24 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "ValueError"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "hello world"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
                   "id": "stacktrace",
                   "name": "stacktrace",
                   "values": [
@@ -234,24 +252,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
                   ]
                 }
               ]
@@ -265,6 +265,24 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
+                  "id": "type",
+                  "name": null,
+                  "values": [
+                    "ValueError"
+                  ]
+                },
+                {
+                  "contributes": false,
+                  "hint": "ignored because stacktrace takes precedence",
+                  "id": "value",
+                  "name": null,
+                  "values": [
+                    "hello world"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
                   "id": "stacktrace",
                   "name": "stacktrace",
                   "values": [
@@ -299,24 +317,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                         }
                       ]
                     }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
                   ]
                 }
               ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.336443+00:00'
+created: '2025-10-27T23:46:03.323755+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "MultiValueDictKeyError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "\"'user'\""
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -464,24 +482,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "MultiValueDictKeyError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "\"'user'\""
-              ]
             }
           ]
         }
@@ -527,6 +527,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "MultiValueDictKeyError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "\"'user'\""
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -973,24 +991,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "MultiValueDictKeyError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "\"'user'\""
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.842887+00:00'
+created: '2025-10-27T23:46:03.340665+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "MultiValueDictKeyError"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "\"'user'\""
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no contributing frames",
@@ -464,24 +482,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "MultiValueDictKeyError"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "\"'user'\""
-              ]
             }
           ]
         }
@@ -527,6 +527,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "MultiValueDictKeyError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "\"'user'\""
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -973,24 +991,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "MultiValueDictKeyError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "\"'user'\""
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.368216+00:00'
+created: '2025-10-27T23:46:03.357222+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "HTTPError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "<int> Client Error: Too Many Requests for url: <url>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -156,24 +174,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "HTTPError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "<int> Client Error: Too Many Requests for url: <url>"
-              ]
             }
           ]
         }
@@ -264,6 +264,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "HTTPError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "<int> Client Error: Too Many Requests for url: <url>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -402,24 +420,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "HTTPError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "<int> Client Error: Too Many Requests for url: <url>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.910088+00:00'
+created: '2025-10-27T23:46:03.402596+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Load failed"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.876673+00:00'
+created: '2025-10-27T23:46:03.372351+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -18,13 +18,6 @@ source: tests/sentry/grouping/test_grouping_info.py
           "name": "exception",
           "values": [
             {
-              "contributes": false,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": []
-            },
-            {
               "contributes": true,
               "hint": null,
               "id": "type",
@@ -41,6 +34,13 @@ source: tests/sentry/grouping/test_grouping_info.py
               "values": [
                 "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
               ]
+            },
+            {
+              "contributes": false,
+              "hint": null,
+              "id": "stacktrace",
+              "name": "stacktrace",
+              "values": []
             }
           ]
         }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:56.893698+00:00'
+created: '2025-10-27T23:46:03.387551+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -24,13 +24,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "name": "exception",
               "values": [
                 {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
-                {
                   "contributes": true,
                   "hint": null,
                   "id": "type",
@@ -47,6 +40,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "Load failed"
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             },
@@ -56,13 +56,6 @@ source: tests/sentry/grouping/test_grouping_info.py
               "id": "exception",
               "name": "exception",
               "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": []
-                },
                 {
                   "contributes": true,
                   "hint": null,
@@ -80,6 +73,13 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
                   ]
+                },
+                {
+                  "contributes": false,
+                  "hint": null,
+                  "id": "stacktrace",
+                  "name": "stacktrace",
+                  "values": []
                 }
               ]
             }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.435236+00:00'
+created: '2025-10-27T23:46:03.420859+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "TypeError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "undefined is not a function (evaluating '({}).invalidFunction()')"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -978,24 +996,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "TypeError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "undefined is not a function (evaluating '({}).invalidFunction()')"
               ]
             }
           ]
@@ -1045,6 +1045,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "TypeError"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "undefined is not a function (evaluating '({}).invalidFunction()')"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -2003,24 +2021,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "TypeError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "undefined is not a function (evaluating '({}).invalidFunction()')"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:57.056955+00:00'
+created: '2025-10-27T23:46:03.527851+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": false,
               "hint": "discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2)",
@@ -241,24 +259,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
-              ]
             }
           ]
         }
@@ -304,6 +304,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -527,24 +545,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-07T22:42:57.123253+00:00'
+created: '2025-10-27T23:46:03.596297+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": false,
               "hint": "ignored because it contains no in-app frames",
@@ -241,24 +259,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
-              ]
             }
           ]
         }
@@ -304,6 +304,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -527,24 +545,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.621660+00:00'
+created: '2025-10-27T23:46:03.615686+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -241,24 +259,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
-              ]
             }
           ]
         }
@@ -304,6 +304,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -527,24 +545,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.638040+00:00'
+created: '2025-10-27T23:46:03.633004+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -241,24 +259,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
-              ]
             }
           ]
         }
@@ -304,6 +304,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "log_demo"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Holy shit everything is on fire!"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -527,24 +545,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "log_demo"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Holy shit everything is on fire!"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.718556+00:00'
+created: '2025-10-27T23:46:03.712365+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NullReferenceException"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Object reference not set to an instance of an object"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -288,24 +306,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NullReferenceException"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Object reference not set to an instance of an object"
-              ]
             }
           ]
         }
@@ -351,6 +351,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "NullReferenceException"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Object reference not set to an instance of an object"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -621,24 +639,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "NullReferenceException"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Object reference not set to an instance of an object"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.736917+00:00'
+created: '2025-10-27T23:46:03.730133+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1016,24 +1034,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
-              ]
             }
           ]
         }
@@ -1079,6 +1079,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "EXC_BAD_ACCESS"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2077,24 +2095,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "EXC_BAD_ACCESS"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.755112+00:00'
+created: '2025-10-27T23:46:03.747485+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "SIGTRAP"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Trap"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -764,24 +782,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "SIGTRAP"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Trap"
-              ]
             }
           ]
         }
@@ -827,6 +827,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "SIGTRAP"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Trap"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1573,24 +1591,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "SIGTRAP"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Trap"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.774840+00:00'
+created: '2025-10-27T23:46:03.767524+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "unknown 0x00004000 / 0x7ff89574837a"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: unknown <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1367,24 +1385,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "unknown 0x00004000 / 0x7ff89574837a"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: unknown <hex> / <hex>"
-              ]
             }
           ]
         }
@@ -1430,6 +1430,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": false,
+              "hint": "ignored because exception is synthetic",
+              "id": "type",
+              "name": null,
+              "values": [
+                "unknown 0x00004000 / 0x7ff89574837a"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Fatal Error: unknown <hex> / <hex>"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -2779,24 +2797,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because exception is synthetic",
-              "id": "type",
-              "name": null,
-              "values": [
-                "unknown 0x00004000 / 0x7ff89574837a"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Fatal Error: unknown <hex> / <hex>"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.795443+00:00'
+created: '2025-10-27T23:46:03.789764+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Ensure failed"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1406,24 +1424,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Ensure failed"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
               ]
             }
           ]
@@ -2872,6 +2872,24 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Ensure failed"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
+              ]
+            },
+            {
+              "contributes": true,
+              "hint": null,
               "id": "stacktrace",
               "name": "stacktrace",
               "values": [
@@ -4258,24 +4276,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Ensure failed"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
               ]
             }
           ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T21:57:35.819046+00:00'
+created: '2025-10-27T23:46:03.810131+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -17,6 +17,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Ensure failed"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -1592,24 +1610,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                   ]
                 }
               ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Ensure failed"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
-              ]
             }
           ]
         }
@@ -1655,6 +1655,24 @@ source: tests/sentry/grouping/test_grouping_info.py
           "id": "exception",
           "name": "exception",
           "values": [
+            {
+              "contributes": true,
+              "hint": null,
+              "id": "type",
+              "name": null,
+              "values": [
+                "Ensure failed"
+              ]
+            },
+            {
+              "contributes": false,
+              "hint": "ignored because stacktrace takes precedence",
+              "id": "value",
+              "name": null,
+              "values": [
+                "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
+              ]
+            },
             {
               "contributes": true,
               "hint": null,
@@ -3229,24 +3247,6 @@ source: tests/sentry/grouping/test_grouping_info.py
                     }
                   ]
                 }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Ensure failed"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
               ]
             }
           ]

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -40,6 +40,20 @@ class GetStacktraceStringTest(TestCase):
                         "hint": None,
                         "values": [
                             {
+                                "id": "type",
+                                "name": None,
+                                "contributes": True,
+                                "hint": None,
+                                "values": ["ZeroDivisionError"],
+                            },
+                            {
+                                "id": "value",
+                                "name": None,
+                                "contributes": False,
+                                "hint": None,
+                                "values": ["division by zero"],
+                            },
+                            {
                                 "id": "stacktrace",
                                 "name": "stacktrace",
                                 "contributes": True,
@@ -83,20 +97,6 @@ class GetStacktraceStringTest(TestCase):
                                     }
                                 ],
                             },
-                            {
-                                "id": "type",
-                                "name": None,
-                                "contributes": True,
-                                "hint": None,
-                                "values": ["ZeroDivisionError"],
-                            },
-                            {
-                                "id": "value",
-                                "name": None,
-                                "contributes": False,
-                                "hint": None,
-                                "values": ["division by zero"],
-                            },
                         ],
                     }
                 ],
@@ -127,6 +127,20 @@ class GetStacktraceStringTest(TestCase):
                                 "contributes": True,
                                 "hint": None,
                                 "values": [
+                                    {
+                                        "id": "type",
+                                        "name": None,
+                                        "contributes": True,
+                                        "hint": None,
+                                        "values": ["ZeroDivisionError"],
+                                    },
+                                    {
+                                        "id": "value",
+                                        "name": None,
+                                        "contributes": False,
+                                        "hint": None,
+                                        "values": ["division by zero"],
+                                    },
                                     {
                                         "id": "stacktrace",
                                         "name": "stacktrace",
@@ -171,20 +185,6 @@ class GetStacktraceStringTest(TestCase):
                                             }
                                         ],
                                     },
-                                    {
-                                        "id": "type",
-                                        "name": None,
-                                        "contributes": True,
-                                        "hint": None,
-                                        "values": ["ZeroDivisionError"],
-                                    },
-                                    {
-                                        "id": "value",
-                                        "name": None,
-                                        "contributes": False,
-                                        "hint": None,
-                                        "values": ["division by zero"],
-                                    },
                                 ],
                             },
                             {
@@ -193,6 +193,20 @@ class GetStacktraceStringTest(TestCase):
                                 "contributes": True,
                                 "hint": None,
                                 "values": [
+                                    {
+                                        "id": "type",
+                                        "name": None,
+                                        "contributes": True,
+                                        "hint": None,
+                                        "values": ["Exception"],
+                                    },
+                                    {
+                                        "id": "value",
+                                        "name": None,
+                                        "contributes": False,
+                                        "hint": None,
+                                        "values": ["Catch divide by zero error"],
+                                    },
                                     {
                                         "id": "stacktrace",
                                         "name": "stacktrace",
@@ -274,20 +288,6 @@ class GetStacktraceStringTest(TestCase):
                                                 ],
                                             },
                                         ],
-                                    },
-                                    {
-                                        "id": "type",
-                                        "name": None,
-                                        "contributes": True,
-                                        "hint": None,
-                                        "values": ["Exception"],
-                                    },
-                                    {
-                                        "id": "value",
-                                        "name": None,
-                                        "contributes": False,
-                                        "hint": None,
-                                        "values": ["Catch divide by zero error"],
                                     },
                                 ],
                             },
@@ -407,6 +407,13 @@ class GetStacktraceStringTest(TestCase):
             "hint": None,
             "values": [
                 {
+                    "id": "value",
+                    "name": None,
+                    "contributes": False,
+                    "hint": None,
+                    "values": [exception_value],
+                },
+                {
                     "id": "stacktrace",
                     "name": "stacktrace",
                     "contributes": True,
@@ -419,13 +426,6 @@ class GetStacktraceStringTest(TestCase):
                     "contributes": True,
                     "hint": None,
                     "values": [exception_type_str],
-                },
-                {
-                    "id": "value",
-                    "name": None,
-                    "contributes": False,
-                    "hint": None,
-                    "values": [exception_value],
                 },
             ],
         }
@@ -494,13 +494,13 @@ class GetStacktraceStringTest(TestCase):
 
     def test_contributing_exception_no_frames(self) -> None:
         data_non_contributing_frame = copy.deepcopy(self.BASE_APP_DATA)
-        data_non_contributing_frame["app"]["component"]["values"][0]["values"][0]["values"] = []
+        data_non_contributing_frame["app"]["component"]["values"][0]["values"][2]["values"] = []
         stacktrace_str = get_stacktrace_string(data_non_contributing_frame)
         assert stacktrace_str == "ZeroDivisionError: division by zero"
 
     def test_contributing_exception_no_contributing_frames(self) -> None:
         data_no_contributing_frame = copy.deepcopy(self.BASE_APP_DATA)
-        data_no_contributing_frame["app"]["component"]["values"][0]["values"][0]["values"] = (
+        data_no_contributing_frame["app"]["component"]["values"][0]["values"][2]["values"] = (
             self.create_frames(1, False)
         )
         stacktrace_str = get_stacktrace_string(data_no_contributing_frame)
@@ -722,15 +722,15 @@ class GetStacktraceStringTest(TestCase):
         """
         data_frames = copy.deepcopy(self.BASE_APP_DATA)
         # Create 30 contributing frames, 1-20 -> last 10 should be included
-        data_frames["app"]["component"]["values"][0]["values"][0]["values"] = self.create_frames(
+        data_frames["app"]["component"]["values"][0]["values"][2]["values"] = self.create_frames(
             20, True
         )
         # Create 20 non-contributing frames, 21-40 -> none should be included
-        data_frames["app"]["component"]["values"][0]["values"][0]["values"] += self.create_frames(
+        data_frames["app"]["component"]["values"][0]["values"][2]["values"] += self.create_frames(
             20, False, 21
         )
         # Create 20 contributing frames, 41-60 -> all should be included
-        data_frames["app"]["component"]["values"][0]["values"][0]["values"] += self.create_frames(
+        data_frames["app"]["component"]["values"][0]["values"][2]["values"] += self.create_frames(
             20, True, 41
         )
         stacktrace_str = get_stacktrace_string(data_frames)
@@ -781,7 +781,7 @@ class GetStacktraceStringTest(TestCase):
         for base64_prefix in BASE64_ENCODED_PREFIXES:
             base64_filename = f"{base64_prefix} extra content that could be long and useless"
             data_base64_encoded_filename = copy.deepcopy(self.BASE_APP_DATA)
-            data_base64_encoded_filename["app"]["component"]["values"][0]["values"][0]["values"][0][
+            data_base64_encoded_filename["app"]["component"]["values"][0]["values"][2]["values"][0][
                 "values"
             ][1]["values"][0] = base64_filename
             stacktrace_str = get_stacktrace_string(data_base64_encoded_filename)
@@ -794,7 +794,7 @@ class GetStacktraceStringTest(TestCase):
     def test_replace_file_with_module(self) -> None:
         exception = copy.deepcopy(self.BASE_APP_DATA)
         # delete filename from the exception
-        del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][1]
+        del exception["app"]["component"]["values"][0]["values"][2]["values"][0]["values"][1]
         stacktrace_string = get_stacktrace_string(exception)
         assert (
             stacktrace_string
@@ -804,9 +804,9 @@ class GetStacktraceStringTest(TestCase):
     def test_no_filename_or_module(self) -> None:
         exception = copy.deepcopy(self.BASE_APP_DATA)
         # delete module from the exception
-        del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
+        del exception["app"]["component"]["values"][0]["values"][2]["values"][0]["values"][0]
         # delete filename from the exception
-        del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
+        del exception["app"]["component"]["values"][0]["values"][2]["values"][0]["values"][0]
         stacktrace_string = get_stacktrace_string(exception)
         assert (
             stacktrace_string
@@ -817,9 +817,9 @@ class GetStacktraceStringTest(TestCase):
         for ignored_filename in IGNORED_FILENAMES:
             exception = copy.deepcopy(self.BASE_APP_DATA)
             # delete module from the exception so we don't fall back to that
-            del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
+            del exception["app"]["component"]["values"][0]["values"][2]["values"][0]["values"][0]
             # replace filename with ignored value
-            exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0][
+            exception["app"]["component"]["values"][0]["values"][2]["values"][0]["values"][0][
                 "values"
             ][0] = ignored_filename
             stacktrace_string = get_stacktrace_string(exception)

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -50,6 +50,8 @@ from sentry.utils.snuba import QueryTooManySimultaneous, RateLimitExceeded, bulk
 EXCEPTION: dict[str, Any] = {
     "values": [
         {
+            "type": "ZeroDivisionError",
+            "value": "division by zero",
             "stacktrace": {
                 "frames": [
                     {
@@ -62,8 +64,6 @@ EXCEPTION: dict[str, Any] = {
                     },
                 ]
             },
-            "type": "ZeroDivisionError",
-            "value": "division by zero",
         }
     ],
 }


### PR DESCRIPTION
This is a small change to grouping info to prep for the new grouping config, in which the order of the subcomponents in `ExceptionGroupingComponent` will be changed. So that there's no inconsistency between the way the current config's grouping info displays and the way the new config's grouping info will display, this manually reorders the elements when serializing them, to match the new order. Once we're fully switched over to the new config, we can delete this shim.

(The reason for the reordering is that currently, stacktrace comes first, with the result that unless the stacktrace is either very short or collapsed, you can't see the error type and value components without scrolling.)