### PR TITLE
ref(onboarding): Split capacitor onboarding doc into multiple files

### DIFF
--- a/static/app/gettingStartedDocs/capacitor/capacitor/crashReport.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/crashReport.tsx
@@ -1,0 +1,33 @@
+import {widgetCalloutBlock} from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportJavaScriptInstallSteps,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+
+import type {Params, PlatformOptions} from './utils';
+
+export const crashReport: OnboardingConfig<PlatformOptions> = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportJavaScriptInstallSteps(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+        widgetCalloutBlock({
+          link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/#user-feedback-widget',
+        }),
+      ],
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};

--- a/static/app/gettingStartedDocs/capacitor/capacitor/index.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/index.tsx
@@ -1,0 +1,17 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+import {crashReport} from './crashReport';
+import {onboarding} from './onboarding';
+import {sessionReplay} from './sessionReplay';
+import {userFeedback} from './userFeedback';
+import {platformOptions, type PlatformOptions} from './utils';
+
+const docs: Docs<PlatformOptions> = {
+  onboarding,
+  platformOptions,
+  feedbackOnboardingNpm: userFeedback,
+  replayOnboarding: sessionReplay,
+  crashReportOnboarding: crashReport,
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/capacitor/capacitor/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/onboarding.spec.tsx
@@ -1,7 +1,8 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs, {SiblingOption} from './capacitor';
+import {SiblingOption} from './utils';
+import docs from '.';
 
 describe('capacitor onboarding docs', () => {
   it('renders docs correctly', () => {

--- a/static/app/gettingStartedDocs/capacitor/capacitor/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/onboarding.spec.tsx
@@ -18,7 +18,7 @@ describe('capacitor onboarding docs', () => {
     it(`renders capacitor docs correctly with sibling ${enumMember}`, () => {
       renderWithOnboardingLayout(docs, {
         selectedOptions: {
-          siblingOption: enumMember,
+          siblingOption: enumMember as SiblingOption,
         },
       });
 

--- a/static/app/gettingStartedDocs/capacitor/capacitor/onboarding.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/onboarding.tsx
@@ -1,0 +1,107 @@
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {t, tct} from 'sentry/locale';
+
+import {
+  getNpmPackage,
+  getSetupConfiguration,
+  getSiblingName,
+  type Params,
+  type PlatformOptions,
+} from './utils';
+
+export const onboarding: OnboardingConfig<PlatformOptions> = {
+  install: (params: Params) => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            `Install the Sentry Capacitor SDK as a dependency using [code:npm] or [code:yarn], alongside the Sentry [siblingName:] SDK:`,
+            {
+              code: <code />,
+              siblingName: getSiblingName(params.platformOptions.siblingOption),
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'npm',
+              value: 'npm',
+              language: 'bash',
+              code: `npm install --save @sentry/capacitor ${getNpmPackage(
+                params.platformOptions.siblingOption
+              )}@^7`,
+            },
+            {
+              label: 'yarn',
+              value: 'yarn',
+              language: 'bash',
+              code: `yarn add @sentry/capacitor ${getNpmPackage(
+                params.platformOptions.siblingOption
+              )}@^7 --exact`,
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            `The version of the Sentry [siblingName:] SDK must match with the version referred by Sentry Capacitor. To check which version of the Sentry [siblingName:] SDK is installed, use the following command: [code:npm info @sentry/capacitor peerDependencies]`,
+            {
+              code: <code />,
+              siblingName: getSiblingName(params.platformOptions.siblingOption),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: getSetupConfiguration({params, showExtraStep: true}),
+    },
+    getUploadSourceMapsStep({
+      guideLink:
+        'https://docs.sentry.io/platforms/javascript/guides/capacitor/sourcemaps/',
+      ...params,
+    }),
+  ],
+  verify: _ => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `myUndefinedFunction();`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  nextSteps: () => [
+    {
+      id: 'capacitor-android-setup',
+      name: t('Capacitor 2 Setup'),
+      description: t(
+        'If you are using Capacitor 2 or older, follow this step to add required changes in order to initialize the Capacitor SDK on Android.'
+      ),
+      link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/?#capacitor-2---android-specifics',
+    },
+  ],
+};

--- a/static/app/gettingStartedDocs/capacitor/capacitor/sessionReplay.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/sessionReplay.tsx
@@ -1,0 +1,35 @@
+import {tracePropagationBlock} from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getReplayConfigureDescription,
+  getReplayVerifyStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
+
+import {onboarding} from './onboarding';
+import {getSetupConfiguration, type PlatformOptions} from './utils';
+
+export const sessionReplay: OnboardingConfig<PlatformOptions> = {
+  install: params => onboarding.install(params),
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: getReplayConfigureDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/session-replay/',
+          }),
+        },
+        ...getSetupConfiguration({
+          params,
+          showExtraStep: false,
+          showDescription: false,
+        }),
+        tracePropagationBlock,
+      ],
+    },
+  ],
+  verify: getReplayVerifyStep(),
+  nextSteps: () => [],
+};

--- a/static/app/gettingStartedDocs/capacitor/capacitor/userFeedback.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/userFeedback.tsx
@@ -1,0 +1,40 @@
+import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/crashReportCallout';
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getFeedbackConfigureDescription} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+
+import {onboarding} from './onboarding';
+import {getSetupConfiguration, type Params, type PlatformOptions} from './utils';
+
+export const userFeedback: OnboardingConfig<PlatformOptions> = {
+  install: (params: Params) => onboarding.install(params),
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: getFeedbackConfigureDescription({
+            linkConfig:
+              'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/',
+            linkButton:
+              'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/#bring-your-own-button',
+          }),
+        },
+        ...getSetupConfiguration({
+          params,
+          showExtraStep: false,
+          showDescription: false,
+        }),
+        {
+          type: 'text',
+          text: crashReportCallout({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/#crash-report-modal',
+          }),
+        },
+      ],
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};

--- a/static/app/gettingStartedDocs/capacitor/capacitor/utils.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/utils.tsx
@@ -8,7 +8,7 @@ import {getFeedbackConfigOptions} from 'sentry/components/onboarding/gettingStar
 import {getReplayConfigOptions} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t, tct} from 'sentry/locale';
 
-enum SiblingOption {
+export enum SiblingOption {
   ANGULARV10 = 'angularV10',
   ANGULARV12 = 'angularV12',
   REACT = 'react',

--- a/static/app/gettingStartedDocs/capacitor/capacitor/utils.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor/utils.tsx
@@ -1,31 +1,14 @@
 import {buildSdkConfig} from 'sentry/components/onboarding/gettingStartedDoc/buildSdkConfig';
-import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/crashReportCallout';
-import {widgetCalloutBlock} from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
-import {tracePropagationBlock} from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
   ContentBlock,
-  Docs,
   DocsParams,
-  OnboardingConfig,
   PlatformOption,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
-import {
-  getCrashReportJavaScriptInstallSteps,
-  getCrashReportModalConfigDescription,
-  getCrashReportModalIntroduction,
-  getFeedbackConfigOptions,
-  getFeedbackConfigureDescription,
-} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {
-  getReplayConfigOptions,
-  getReplayConfigureDescription,
-  getReplayVerifyStep,
-} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
+import {getFeedbackConfigOptions} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import {getReplayConfigOptions} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t, tct} from 'sentry/locale';
 
-export enum SiblingOption {
+enum SiblingOption {
   ANGULARV10 = 'angularV10',
   ANGULARV12 = 'angularV12',
   REACT = 'react',
@@ -33,9 +16,7 @@ export enum SiblingOption {
   VUE2 = 'vue2',
 }
 
-type PlatformOptionKey = 'siblingOption';
-
-const platformOptions: Record<PlatformOptionKey, PlatformOption> = {
+export const platformOptions: PlatformOptions = {
   siblingOption: {
     label: t('Sibling Package'),
     items: [
@@ -63,8 +44,11 @@ const platformOptions: Record<PlatformOptionKey, PlatformOption> = {
   },
 };
 
-type PlatformOptions = typeof platformOptions;
-type Params = DocsParams<PlatformOptions>;
+// Note: platformOptions is defined in index.tsx where it's used
+export type PlatformOptions = {
+  siblingOption: PlatformOption<SiblingOption>;
+};
+export type Params = DocsParams<PlatformOptions>;
 
 const isAngular = (siblingOption: string): boolean =>
   siblingOption === SiblingOption.ANGULARV10 ||
@@ -94,101 +78,6 @@ const performanceAngularErrorHandler = `,
   deps: [SentryAngular.TraceService],
   multi: true,
 },`;
-
-const onboarding: OnboardingConfig<PlatformOptions> = {
-  install: (params: Params) => [
-    {
-      type: StepType.INSTALL,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            `Install the Sentry Capacitor SDK as a dependency using [code:npm] or [code:yarn], alongside the Sentry [siblingName:] SDK:`,
-            {
-              code: <code />,
-              siblingName: getSiblingName(params.platformOptions.siblingOption),
-            }
-          ),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'npm',
-              value: 'npm',
-              language: 'bash',
-              code: `npm install --save @sentry/capacitor ${getNpmPackage(
-                params.platformOptions.siblingOption
-              )}@^7`,
-            },
-            {
-              label: 'yarn',
-              value: 'yarn',
-              language: 'bash',
-              code: `yarn add @sentry/capacitor ${getNpmPackage(
-                params.platformOptions.siblingOption
-              )}@^7 --exact`,
-            },
-          ],
-        },
-        {
-          type: 'text',
-          text: tct(
-            `The version of the Sentry [siblingName:] SDK must match with the version referred by Sentry Capacitor. To check which version of the Sentry [siblingName:] SDK is installed, use the following command: [code:npm info @sentry/capacitor peerDependencies]`,
-            {
-              code: <code />,
-              siblingName: getSiblingName(params.platformOptions.siblingOption),
-            }
-          ),
-        },
-      ],
-    },
-  ],
-  configure: params => [
-    {
-      type: StepType.CONFIGURE,
-      content: getSetupConfiguration({params, showExtraStep: true}),
-    },
-    getUploadSourceMapsStep({
-      guideLink:
-        'https://docs.sentry.io/platforms/javascript/guides/capacitor/sourcemaps/',
-      ...params,
-    }),
-  ],
-  verify: _ => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-          ),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'JavaScript',
-              language: 'javascript',
-              code: `myUndefinedFunction();`,
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  nextSteps: () => [
-    {
-      id: 'capacitor-android-setup',
-      name: t('Capacitor 2 Setup'),
-      description: t(
-        'If you are using Capacitor 2 or older, follow this step to add required changes in order to initialize the Capacitor SDK on Android.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/?#capacitor-2---android-specifics',
-    },
-  ],
-};
 
 function getSiblingImportsSetupConfiguration(siblingOption: string): string {
   switch (siblingOption) {
@@ -289,7 +178,7 @@ const getStaticParts = (params: Params): string[] => {
   return staticParts;
 };
 
-function getSetupConfiguration({
+export function getSetupConfiguration({
   params,
   showExtraStep,
   showDescription,
@@ -371,7 +260,7 @@ export class AppModule {}`,
   return configuration;
 }
 
-function getNpmPackage(siblingOption: string): string {
+export function getNpmPackage(siblingOption: string): string {
   const packages: Record<SiblingOption, string> = {
     [SiblingOption.ANGULARV10]: '@sentry/angular',
     [SiblingOption.ANGULARV12]: '@sentry/angular-ivy',
@@ -383,7 +272,7 @@ function getNpmPackage(siblingOption: string): string {
   return packages[siblingOption];
 }
 
-function getSiblingName(siblingOption: string): string {
+export function getSiblingName(siblingOption: string): string {
   switch (siblingOption) {
     case SiblingOption.ANGULARV10:
     case SiblingOption.ANGULARV12:
@@ -398,7 +287,7 @@ function getSiblingName(siblingOption: string): string {
   }
 }
 
-function getSiblingImportName(siblingOption: string): string {
+export function getSiblingImportName(siblingOption: string): string {
   switch (siblingOption) {
     case SiblingOption.ANGULARV10:
     case SiblingOption.ANGULARV12:
@@ -412,94 +301,3 @@ function getSiblingImportName(siblingOption: string): string {
       return '';
   }
 }
-
-const replayOnboarding: OnboardingConfig<PlatformOptions> = {
-  install: params => onboarding.install(params),
-  configure: params => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: getReplayConfigureDescription({
-            link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/session-replay/',
-          }),
-        },
-        ...getSetupConfiguration({
-          params,
-          showExtraStep: false,
-          showDescription: false,
-        }),
-        tracePropagationBlock,
-      ],
-    },
-  ],
-  verify: getReplayVerifyStep(),
-  nextSteps: () => [],
-};
-
-const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
-  install: (params: Params) => onboarding.install(params),
-  configure: (params: Params) => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: getFeedbackConfigureDescription({
-            linkConfig:
-              'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/',
-            linkButton:
-              'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/#bring-your-own-button',
-          }),
-        },
-        ...getSetupConfiguration({
-          params,
-          showExtraStep: false,
-          showDescription: false,
-        }),
-        {
-          type: 'text',
-          text: crashReportCallout({
-            link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/#crash-report-modal',
-          }),
-        },
-      ],
-    },
-  ],
-  verify: () => [],
-  nextSteps: () => [],
-};
-
-const crashReportOnboarding: OnboardingConfig<PlatformOptions> = {
-  introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportJavaScriptInstallSteps(params),
-  configure: () => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: getCrashReportModalConfigDescription({
-            link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/#crash-report-modal',
-          }),
-        },
-        widgetCalloutBlock({
-          link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/#user-feedback-widget',
-        }),
-      ],
-    },
-  ],
-  verify: () => [],
-  nextSteps: () => [],
-};
-
-const docs: Docs<PlatformOptions> = {
-  onboarding,
-  platformOptions,
-  feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboarding,
-  crashReportOnboarding,
-};
-
-export default docs;


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms