### PR TITLE
ref(onboarding): Split Deno onboarding doc into multiple files

### DIFF
--- a/static/app/gettingStartedDocs/deno/deno/index.tsx
+++ b/static/app/gettingStartedDocs/deno/deno/index.tsx
@@ -1,0 +1,15 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  feedbackOnboardingJsLoader,
+  replayOnboardingJsLoader,
+} from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
+
+import {onboarding} from './onboarding';
+
+const docs: Docs = {
+  onboarding,
+  replayOnboardingJsLoader,
+  feedbackOnboardingJsLoader,
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/deno/deno/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/deno/deno/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from './deno';
+import docs from '.';
 
 describe('deno onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/deno/deno/onboarding.tsx
+++ b/static/app/gettingStartedDocs/deno/deno/onboarding.tsx
@@ -1,7 +1,4 @@
-import type {
-  DocsParams,
-  OnboardingConfig,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t} from 'sentry/locale';
 
@@ -29,7 +26,7 @@ export const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  configure: (params: DocsParams) => [
+  configure: params => [
     {
       type: StepType.CONFIGURE,
       content: [

--- a/static/app/gettingStartedDocs/deno/deno/onboarding.tsx
+++ b/static/app/gettingStartedDocs/deno/deno/onboarding.tsx
@@ -1,15 +1,11 @@
 import type {
-  Docs,
+  DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  feedbackOnboardingJsLoader,
-  replayOnboardingJsLoader,
-} from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t} from 'sentry/locale';
 
-const onboarding: OnboardingConfig = {
+export const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
@@ -33,7 +29,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  configure: params => [
+  configure: (params: DocsParams) => [
     {
       type: StepType.CONFIGURE,
       content: [
@@ -92,11 +88,3 @@ Sentry.init({
   ],
   nextSteps: () => [],
 };
-
-const docs: Docs = {
-  onboarding,
-  replayOnboardingJsLoader,
-  feedbackOnboardingJsLoader,
-};
-
-export default docs;


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms