### PR TITLE
ref(logging): Silence noisy rediscluster info logs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1252,6 +1252,7 @@ LOGGING: LoggingConfig = {
         },
         "boto3": {"level": "WARNING", "handlers": ["console"], "propagate": False},
         "botocore": {"level": "WARNING", "handlers": ["console"], "propagate": False},
+        "rediscluster": {"level": "WARNING", "handlers": ["console"], "propagate": False},
     },
 }
 


### PR DESCRIPTION
Set the redis-cluster log level to warning. these [logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22rediscluster.connection%22;summaryFields=:true:32:beginning;lfeCustomFields=jsonPayload%252Fevent;duration=PT15S?project=internal-sentry) are very noisy, cost a lot, and don't seem to provide any actionable information to me.