### PR TITLE
feat(scopes): Add Distribution permission UI for integration tokens

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -121,7 +121,7 @@ type PermissionChoice = {
   scopes: Scope[];
 };
 
-type PermissionObj = {
+export type PermissionObj = {
   choices: {
     'no-access': PermissionChoice;
     admin?: PermissionChoice;
@@ -169,7 +169,7 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
   },
   {
     resource: 'Distribution',
-    help: 'Distribution metadata for releases',
+    help: 'Pre-release app distribution for trusted testers.',
     choices: {
       'no-access': {label: 'No Access', scopes: []},
       read: {label: 'Read', scopes: ['project:distribution']},

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -43,6 +43,7 @@ export const API_ACCESS_SCOPES = [
   'org:read',
   'org:write',
   'project:admin',
+  'project:distribution',
   'project:read',
   'project:releases',
   'project:write',
@@ -68,6 +69,7 @@ export const ALLOWED_SCOPES = [
   'org:superuser', // not an assignable API access scope
   'org:write',
   'project:admin',
+  'project:distribution',
   'project:read',
   'project:releases',
   'project:write',
@@ -163,6 +165,14 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
     choices: {
       'no-access': {label: 'No Access', scopes: []},
       admin: {label: 'Admin', scopes: ['project:releases']},
+    },
+  },
+  {
+    resource: 'Distribution',
+    help: 'Distribution metadata for releases',
+    choices: {
+      'no-access': {label: 'No Access', scopes: []},
+      read: {label: 'Read', scopes: ['project:distribution']},
     },
   },
   {

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -24,6 +24,7 @@ export type Permissions = {
   Release: PermissionValue;
   Team: PermissionValue;
   Alerts?: PermissionValue;
+  Distribution?: PermissionValue;
 };
 
 export type PermissionResource = keyof Permissions;

--- a/static/app/utils/consolidatedScopes.tsx
+++ b/static/app/utils/consolidatedScopes.tsx
@@ -98,7 +98,7 @@ function toResourcePermissions(scopes: string[]): Permissions {
   // row for Releases.
   if (scopes.includes(PROJECT_RELEASES)) {
     permissions.Release = 'admin';
-    filteredScopes = scopes.filter((scope: string) => scope !== PROJECT_RELEASES); // remove project:releases
+    filteredScopes = filteredScopes.filter((scope: string) => scope !== PROJECT_RELEASES); // remove project:releases
   }
 
   // The scope for distribution is `project:distribution`, but instead of displaying
@@ -106,7 +106,9 @@ function toResourcePermissions(scopes: string[]): Permissions {
   // row for Distribution.
   if (scopes.includes(PROJECT_DISTRIBUTION)) {
     permissions.Distribution = 'read';
-    filteredScopes = scopes.filter((scope: string) => scope !== PROJECT_DISTRIBUTION); // remove project:distribution
+    filteredScopes = filteredScopes.filter(
+      (scope: string) => scope !== PROJECT_DISTRIBUTION
+    ); // remove project:distribution
   }
 
   // We have a special case with the org:integrations scope. This scope is

--- a/static/app/utils/consolidatedScopes.tsx
+++ b/static/app/utils/consolidatedScopes.tsx
@@ -15,6 +15,7 @@ const HUMAN_RESOURCE_NAMES = {
   project: 'Project',
   team: 'Team',
   release: 'Release',
+  distribution: 'Distribution',
   event: 'Event',
   org: 'Organization',
   member: 'Member',
@@ -25,6 +26,7 @@ const DEFAULT_RESOURCE_PERMISSIONS: Permissions = {
   Project: 'no-access',
   Team: 'no-access',
   Release: 'no-access',
+  Distribution: 'no-access',
   Event: 'no-access',
   Organization: 'no-access',
   Member: 'no-access',
@@ -32,6 +34,7 @@ const DEFAULT_RESOURCE_PERMISSIONS: Permissions = {
 };
 
 const PROJECT_RELEASES = 'project:releases';
+const PROJECT_DISTRIBUTION = 'project:distribution';
 const ORG_INTEGRATIONS = 'org:integrations';
 
 type PermissionLevelResources = {
@@ -96,6 +99,14 @@ function toResourcePermissions(scopes: string[]): Permissions {
   if (scopes.includes(PROJECT_RELEASES)) {
     permissions.Release = 'admin';
     filteredScopes = scopes.filter((scope: string) => scope !== PROJECT_RELEASES); // remove project:releases
+  }
+
+  // The scope for distribution is `project:distribution`, but instead of displaying
+  // it as a permission of Project, we want to separate it out into its own
+  // row for Distribution.
+  if (scopes.includes(PROJECT_DISTRIBUTION)) {
+    permissions.Distribution = 'read';
+    filteredScopes = scopes.filter((scope: string) => scope !== PROJECT_DISTRIBUTION); // remove project:distribution
   }
 
   // We have a special case with the org:integrations scope. This scope is

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -38,7 +38,7 @@ export default function ApiNewToken() {
   const [preview, setPreview] = useState<string>('');
 
   const hasPreprodFeature =
-    organization?.features.includes('organizations:preprod-frontend-routes') ?? false;
+    organization?.features.includes('organizations:preprod-build-distribution') ?? false;
 
   const displayedPermissions = SENTRY_APP_PERMISSIONS.filter(
     o => o.resource !== 'Distribution' || hasPreprodFeature

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -14,6 +14,7 @@ import type {Permissions} from 'sentry/types/integrations';
 import type {NewInternalAppApiToken} from 'sentry/types/user';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -32,8 +33,16 @@ export default function ApiNewToken() {
     Alerts: 'no-access',
   });
   const navigate = useNavigate();
+  const organization = useOrganization({allowNull: true});
   const [hasNewToken, setHasnewToken] = useState(false);
   const [preview, setPreview] = useState<string>('');
+
+  const hasPreprodFeature =
+    organization?.features.includes('organizations:preprod-frontend-routes') ?? false;
+
+  const displayedPermissions = SENTRY_APP_PERMISSIONS.filter(
+    o => o.resource !== 'Distribution' || hasPreprodFeature
+  );
 
   const getPreview = () => {
     let previewString = '';
@@ -108,9 +117,7 @@ export default function ApiNewToken() {
                   setPermissions(p);
                   setPreview(getPreview());
                 }}
-                displayedPermissions={SENTRY_APP_PERMISSIONS.filter(
-                  o => o.resource !== 'Distribution'
-                )}
+                displayedPermissions={displayedPermissions}
               />
             </PanelBody>
             <TextareaField

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -8,6 +8,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {SENTRY_APP_PERMISSIONS} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import type {Permissions} from 'sentry/types/integrations';
 import type {NewInternalAppApiToken} from 'sentry/types/user';
@@ -107,7 +108,9 @@ export default function ApiNewToken() {
                   setPermissions(p);
                   setPreview(getPreview());
                 }}
-                hiddenPermissions={['Distribution']}
+                displayedPermissions={SENTRY_APP_PERMISSIONS.filter(
+                  o => o.resource !== 'Distribution'
+                )}
               />
             </PanelBody>
             <TextareaField

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -31,6 +31,7 @@ export default function ApiNewToken() {
     Release: 'no-access',
     Organization: 'no-access',
     Alerts: 'no-access',
+    Distribution: 'no-access',
   });
   const navigate = useNavigate();
   const organization = useOrganization({allowNull: true});

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -107,6 +107,7 @@ export default function ApiNewToken() {
                   setPermissions(p);
                   setPreview(getPreview());
                 }}
+                hiddenPermissions={['Distribution']}
               />
             </PanelBody>
             <TextareaField

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -84,6 +84,11 @@ type Props = {
   appPublished: boolean;
   onChange: (permissions: Permissions) => void;
   permissions: Permissions;
+  /**
+   * Optional list of resources to hide from the permission selection.
+   * Useful for limiting permissions available to personal tokens vs integration tokens.
+   */
+  hiddenPermissions?: PermissionResource[];
 };
 
 type State = {
@@ -132,10 +137,13 @@ export default class PermissionSelection extends Component<Props, State> {
 
   render() {
     const {permissions} = this.state;
+    const {hiddenPermissions = []} = this.props;
 
     return (
       <Fragment>
-        {SENTRY_APP_PERMISSIONS.map(config => {
+        {SENTRY_APP_PERMISSIONS.filter(
+          config => !hiddenPermissions.includes(config.resource)
+        ).map(config => {
           const options = Object.entries(config.choices).map(([value, {label}]) => ({
             value,
             label,

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -2,7 +2,7 @@ import {Component, Fragment} from 'react';
 
 import SelectField from 'sentry/components/forms/fields/selectField';
 import FormContext from 'sentry/components/forms/formContext';
-import {SENTRY_APP_PERMISSIONS} from 'sentry/constants';
+import {SENTRY_APP_PERMISSIONS, type PermissionObj} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import type {
   PermissionResource,
@@ -85,10 +85,11 @@ type Props = {
   onChange: (permissions: Permissions) => void;
   permissions: Permissions;
   /**
-   * Optional list of resources to hide from the permission selection.
+   * Optional list of permissions to display in the selection.
+   * Defaults to SENTRY_APP_PERMISSIONS if not provided.
    * Useful for limiting permissions available to personal tokens vs integration tokens.
    */
-  hiddenPermissions?: PermissionResource[];
+  displayedPermissions?: PermissionObj[];
 };
 
 type State = {
@@ -137,13 +138,11 @@ export default class PermissionSelection extends Component<Props, State> {
 
   render() {
     const {permissions} = this.state;
-    const {hiddenPermissions = []} = this.props;
+    const {displayedPermissions = SENTRY_APP_PERMISSIONS} = this.props;
 
     return (
       <Fragment>
-        {SENTRY_APP_PERMISSIONS.filter(
-          config => !hiddenPermissions.includes(config.resource)
-        ).map(config => {
+        {displayedPermissions.map(config => {
           const options = Object.entries(config.choices).map(([value, {label}]) => ({
             value,
             label,


### PR DESCRIPTION
This PR adds frontend support for the `project:distribution` permission scope, building on top of #102295.

## Changes

- Add `Distribution` resource to `SENTRY_APP_PERMISSIONS` with read-only access
- Add `project:distribution` to `API_ACCESS_SCOPES` and `ALLOWED_SCOPES`
- Update `Permissions` TypeScript type to include optional `Distribution` field
- Add scope conversion logic for `project:distribution` in `consolidatedScopes.tsx`
- Add `hiddenPermissions` prop to `PermissionSelection` component to filter out specific permissions
- Use `hiddenPermissions` in personal token creation UI to hide Distribution permission

## Behavior

**Integration Tokens (Sentry Apps):**
- Can select Distribution permission with read-only access
- Grants the `project:distribution` scope

**Personal Tokens:**
- Distribution permission is hidden from the UI
- Cannot access distribution-related endpoints

This ensures that only integration tokens can use the distribution permission, while personal tokens cannot.

## Depends On

- #102295 (backend changes)