### PR TITLE
ref(redis): Do not use redis-blaster for redis session store

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -192,6 +192,7 @@ SENTRY_WORKFLOW_ENGINE_REDIS_CLUSTER = "default"
 SENTRY_HYBRIDCLOUD_BACKFILL_OUTBOXES_REDIS_CLUSTER = "default"
 SENTRY_WEEKLY_REPORTS_REDIS_CLUSTER = "default"
 SENTRY_HYBRIDCLOUD_DELETIONS_REDIS_CLUSTER = "default"
+SENTRY_SESSION_STORE_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -1,9 +1,10 @@
 from uuid import uuid4
 
 import sentry_sdk
+from django.conf import settings
 
+from sentry.utils import redis
 from sentry.utils.json import dumps, loads
-from sentry.utils.redis import clusters
 
 EXPIRATION_TTL = 10 * 60
 
@@ -57,7 +58,7 @@ class RedisSessionStore:
 
     @property
     def _client(self):
-        return clusters.get("default").get_local_client_for_key(self.redis_key)
+        return redis.redis_clusters.get(settings.SENTRY_SESSION_STORE_REDIS_CLUSTER)
 
     @property
     def session_key(self) -> str:


### PR DESCRIPTION
<!-- Describe your PR here. -->

Do not user redis-blaster for the session store redis backend.

