### PR TITLE
feat(search-bar): Add conditionals section to filter key dropdown

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -40,6 +40,7 @@ interface SearchQueryBuilderContextData {
   currentInputValueRef: React.RefObject<string>;
   disabled: boolean;
   disallowFreeText: boolean;
+  disallowLogicalOperators: boolean;
   disallowWildcard: boolean;
   dispatch: Dispatch<QueryBuilderActions>;
   displayAskSeer: boolean;
@@ -204,6 +205,7 @@ export function SearchQueryBuilderProvider({
       ...state,
       disabled,
       disallowFreeText: Boolean(disallowFreeText),
+      disallowLogicalOperators: Boolean(disallowLogicalOperators),
       disallowWildcard: Boolean(disallowWildcard),
       enableAISearch,
       parseQuery,
@@ -245,6 +247,7 @@ export function SearchQueryBuilderProvider({
     caseInsensitive,
     disabled,
     disallowFreeText,
+    disallowLogicalOperators,
     disallowWildcard,
     dispatch,
     displayAskSeer,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -203,9 +203,9 @@ type UpdateAggregateArgsAction = {
   focusOverride?: FocusOverride;
 };
 
-type UpdateBooleanOperatorAction = {
+type UpdateLogicOperatorAction = {
   token: TokenResult<Token.LOGIC_BOOLEAN>;
-  type: 'UPDATE_BOOLEAN_OPERATOR';
+  type: 'UPDATE_LOGIC_OPERATOR';
   value: string;
 };
 
@@ -245,7 +245,7 @@ export type QueryBuilderActions =
   | UpdateAggregateArgsAction
   | MultiSelectFilterValueAction
   | ResetClearAskSeerFeedbackAction
-  | UpdateBooleanOperatorAction;
+  | UpdateLogicOperatorAction;
 
 function removeQueryTokensFromQuery(
   query: string,
@@ -798,9 +798,9 @@ function updateFreeTextAndReplaceText(
   };
 }
 
-function updateBooleanOperator(
+function updateLogicOperator(
   state: QueryBuilderState,
-  action: UpdateBooleanOperatorAction
+  action: UpdateLogicOperatorAction
 ): QueryBuilderState {
   const newQuery = replaceQueryToken(state.query, action.token, action.value);
   if (newQuery === state.query) {
@@ -995,8 +995,8 @@ export function useQueryBuilderState({
             ...state,
             query: modifyFilterValue(state.query, action.token, action.value),
           };
-        case 'UPDATE_BOOLEAN_OPERATOR':
-          return updateBooleanOperator(state, action);
+        case 'UPDATE_LOGIC_OPERATOR':
+          return updateLogicOperator(state, action);
         case 'UPDATE_AGGREGATE_ARGS':
           return updateAggregateArgs(state, action, {getFieldDefinition});
         case 'TOGGLE_FILTER_VALUE':

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -204,7 +204,7 @@ type UpdateAggregateArgsAction = {
 };
 
 type UpdateLogicOperatorAction = {
-  token: TokenResult<Token.LOGIC_BOOLEAN>;
+  token: TokenResult<Token.LOGIC_BOOLEAN | Token.L_PAREN | Token.R_PAREN>;
   type: 'UPDATE_LOGIC_OPERATOR';
   value: string;
 };

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -204,7 +204,7 @@ type UpdateAggregateArgsAction = {
 };
 
 type UpdateLogicOperatorAction = {
-  token: TokenResult<Token.LOGIC_BOOLEAN | Token.L_PAREN | Token.R_PAREN>;
+  token: TokenResult<Token.LOGIC_BOOLEAN>;
   type: 'UPDATE_LOGIC_OPERATOR';
   value: string;
 };

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3778,9 +3778,7 @@ describe('SearchQueryBuilder', () => {
       expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
 
       await waitFor(() =>
-        expect(
-          screen.queryByRole('button', {name: 'Conditionals'})
-        ).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', {name: 'Logic'})).not.toBeInTheDocument()
       );
     });
   });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -839,9 +839,9 @@ describe('SearchQueryBuilder', () => {
       expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
     });
 
-    describe('boolean ops', () => {
+    describe('logic ops', () => {
       describe('flag disabled', () => {
-        it('can remove boolean ops by clicking the delete button', async () => {
+        it('can remove logic ops by clicking the delete button', async () => {
           render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
 
           expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
@@ -852,20 +852,7 @@ describe('SearchQueryBuilder', () => {
       });
 
       describe('flag enabled', () => {
-        it('can remove boolean selector by clicking the delete button', async () => {
-          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />, {
-            organization: {
-              features: ['search-query-builder-add-boolean-operator-select'],
-            },
-          });
-
-          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
-          await userEvent.click(screen.getByRole('button', {name: 'Remove boolean: OR'}));
-
-          expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
-        });
-
-        it('can select a different boolean operator', async () => {
+        it('can remove logic selector by clicking the delete button', async () => {
           render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />, {
             organization: {
               features: ['search-query-builder-add-boolean-operator-select'],
@@ -874,7 +861,22 @@ describe('SearchQueryBuilder', () => {
 
           expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
           await userEvent.click(
-            screen.getByRole('button', {name: 'Edit boolean operator: OR'})
+            screen.getByRole('button', {name: 'Remove logic operator: OR'})
+          );
+
+          expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
+        });
+
+        it('can select a different logic operator', async () => {
+          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />, {
+            organization: {
+              features: ['search-query-builder-add-boolean-operator-select'],
+            },
+          });
+
+          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit logic operator: OR'})
           );
           await userEvent.click(screen.getByRole('option', {name: 'AND'}));
 
@@ -1547,7 +1549,7 @@ describe('SearchQueryBuilder', () => {
       expect(screen.queryByRole('row', {name: '('})).not.toBeInTheDocument();
     });
 
-    it('can remove boolean ops with the keyboard', async () => {
+    it('can remove logic ops with the keyboard', async () => {
       render(<SearchQueryBuilder {...defaultProps} initialQuery="and" />);
 
       expect(screen.getByRole('row', {name: 'and'})).toBeInTheDocument();

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -716,8 +716,8 @@ describe('SearchQueryBuilder', () => {
       });
     });
 
-    describe('conditionals category', () => {
-      it('does not render conditionals category when on first input', async () => {
+    describe('logic category', () => {
+      it('does not render logic category when on first input', async () => {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="" />, {
           organization: {features: ['search-query-builder-conditionals-combobox-menus']},
         });
@@ -725,21 +725,17 @@ describe('SearchQueryBuilder', () => {
         await userEvent.click(getLastInput());
         expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
 
-        expect(
-          screen.queryByRole('button', {name: 'Conditionals'})
-        ).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Logic'})).not.toBeInTheDocument();
       });
 
-      it('renders conditionals category when not on first input', async () => {
+      it('renders logic category when not on first input', async () => {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="span.op:test" />, {
           organization: {features: ['search-query-builder-conditionals-combobox-menus']},
         });
 
         await userEvent.click(getLastInput());
         // Should show conditionals button
-        expect(
-          await screen.findByRole('button', {name: 'Conditionals'})
-        ).toBeInTheDocument();
+        expect(await screen.findByRole('button', {name: 'Logic'})).toBeInTheDocument();
       });
     });
   });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -425,13 +425,16 @@ describe('SearchQueryBuilder', () => {
 
   describe('filter key menu', () => {
     it('breaks keys into sections', async () => {
-      render(<SearchQueryBuilder {...defaultProps} />);
+      render(<SearchQueryBuilder {...defaultProps} />, {
+        organization: {features: ['search-query-builder-conditionals-combobox-menus']},
+      });
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
 
       // Should show tab button for each section
       expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Category 1'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Category 2'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Conditionals'})).toBeInTheDocument();
 
       const menu = screen.getByRole('listbox');
       const groups = within(menu).getAllByRole('group');
@@ -3733,6 +3736,21 @@ describe('SearchQueryBuilder', () => {
       expect(
         await screen.findByText('Parentheses are not supported in this search')
       ).toBeInTheDocument();
+    });
+
+    it('should not add the conditionals section to filter key menu', async () => {
+      render(<SearchQueryBuilder {...defaultProps} disallowLogicalOperators />, {
+        organization: {features: ['search-query-builder-conditionals-combobox-menus']},
+      });
+
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', {name: 'Conditionals'})
+        ).not.toBeInTheDocument()
+      );
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -434,7 +434,6 @@ describe('SearchQueryBuilder', () => {
       expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Category 1'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Category 2'})).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Conditionals'})).toBeInTheDocument();
 
       const menu = screen.getByRole('listbox');
       const groups = within(menu).getAllByRole('group');
@@ -714,6 +713,33 @@ describe('SearchQueryBuilder', () => {
             data: {query: 'assigned:me', type: SavedSearchType.ISSUE},
           })
         );
+      });
+    });
+
+    describe('conditionals category', () => {
+      it('does not render conditionals category when on first input', async () => {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="" />, {
+          organization: {features: ['search-query-builder-conditionals-combobox-menus']},
+        });
+
+        await userEvent.click(getLastInput());
+        expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
+
+        expect(
+          screen.queryByRole('button', {name: 'Conditionals'})
+        ).not.toBeInTheDocument();
+      });
+
+      it('renders conditionals category when not on first input', async () => {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="span.op:test" />, {
+          organization: {features: ['search-query-builder-conditionals-combobox-menus']},
+        });
+
+        await userEvent.click(getLastInput());
+        // Should show conditionals button
+        expect(
+          await screen.findByRole('button', {name: 'Conditionals'})
+        ).toBeInTheDocument();
       });
     });
   });
@@ -3739,11 +3765,18 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('should not add the conditionals section to filter key menu', async () => {
-      render(<SearchQueryBuilder {...defaultProps} disallowLogicalOperators />, {
-        organization: {features: ['search-query-builder-conditionals-combobox-menus']},
-      });
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="span.op:test"
+          disallowLogicalOperators
+        />,
+        {
+          organization: {features: ['search-query-builder-conditionals-combobox-menus']},
+        }
+      );
 
-      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.click(getLastInput());
       expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
 
       await waitFor(() =>

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -75,7 +75,7 @@ function FilterDelete({token, state, item}: SearchQueryBuilderBooleanProps) {
 
   return (
     <DeleteButton
-      aria-label={t('Remove boolean: %s', token.text)}
+      aria-label={t('Remove logic operator: %s', token.text)}
       onClick={() => {
         dispatch({type: 'DELETE_TOKEN', token});
       }}
@@ -88,7 +88,7 @@ function FilterDelete({token, state, item}: SearchQueryBuilderBooleanProps) {
   );
 }
 
-const BOOLEAN_OPERATOR_OPTIONS = [
+const LOGIC_OPERATOR_OPTIONS = [
   {value: 'AND', label: 'AND'},
   {value: 'OR', label: 'OR'},
 ];
@@ -152,12 +152,12 @@ function SearchQueryBuilderBooleanSelect({
             disabled={disabled}
             size="sm"
             value={tokenText}
-            options={BOOLEAN_OPERATOR_OPTIONS}
+            options={LOGIC_OPERATOR_OPTIONS}
             trigger={triggerProps => {
               return (
                 <OpButton
                   disabled={disabled}
-                  aria-label={t('Edit boolean operator: %s', tokenText)}
+                  aria-label={t('Edit logic operator: %s', tokenText)}
                   {...mergeProps(triggerProps, filterButtonProps, focusWithinProps)}
                 >
                   <InteractionStateLayer />
@@ -167,7 +167,7 @@ function SearchQueryBuilderBooleanSelect({
             }}
             onOpenChange={setFilterMenuOpen}
             onChange={option => {
-              dispatch({type: 'UPDATE_BOOLEAN_OPERATOR', token, value: option.value});
+              dispatch({type: 'UPDATE_LOGIC_OPERATOR', token, value: option.value});
             }}
           />
         </BaseGridCell>

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -91,8 +91,6 @@ function FilterDelete({token, state, item}: SearchQueryBuilderBooleanProps) {
 const LOGIC_OPERATOR_OPTIONS = [
   {value: 'AND', label: 'AND'},
   {value: 'OR', label: 'OR'},
-  {value: '(', label: '('},
-  {value: ')', label: ')'},
 ];
 
 function SearchQueryBuilderBooleanSelect({

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -91,6 +91,8 @@ function FilterDelete({token, state, item}: SearchQueryBuilderBooleanProps) {
 const LOGIC_OPERATOR_OPTIONS = [
   {value: 'AND', label: 'AND'},
   {value: 'OR', label: 'OR'},
+  {value: '(', label: '('},
+  {value: ')', label: ')'},
 ];
 
 function SearchQueryBuilderBooleanSelect({

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -23,6 +23,7 @@ import type {CustomComboboxMenuProps} from 'sentry/components/searchQueryBuilder
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
 import type {Section} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {
+  BOOLEAN_CATEGORY_VALUE,
   createRecentFilterOptionKey,
   RECENT_SEARCH_CATEGORY_VALUE,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
@@ -152,7 +153,10 @@ function useHighlightFirstOptionOnSectionChange({
   state: ComboBoxState<SelectOptionOrSectionWithKey<string>>;
 }) {
   const displayedListItems = useMemo(() => {
-    if (selectedSection === RECENT_SEARCH_CATEGORY_VALUE) {
+    if (
+      selectedSection === RECENT_SEARCH_CATEGORY_VALUE ||
+      selectedSection === BOOLEAN_CATEGORY_VALUE
+    ) {
       return [...state.collection].filter(item => !hiddenOptions.has(item.key));
     }
     const options = state.collection.getChildren?.(selectedSection ?? sections[0]!.value);
@@ -169,6 +173,7 @@ function useHighlightFirstOptionOnSectionChange({
     if (selectedSection === previousSection) {
       return;
     }
+
     const firstItem = displayedListItems[0];
     if (firstItem) {
       state.selectionManager.setFocusedKey(firstItem.key);

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -23,8 +23,8 @@ import type {CustomComboboxMenuProps} from 'sentry/components/searchQueryBuilder
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
 import type {Section} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {
-  BOOLEAN_CATEGORY_VALUE,
   createRecentFilterOptionKey,
+  LOGIC_CATEGORY_VALUE,
   RECENT_SEARCH_CATEGORY_VALUE,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
 import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
@@ -154,7 +154,7 @@ function useHighlightFirstOptionOnSectionChange({
   const displayedListItems = useMemo(() => {
     if (
       selectedSection === RECENT_SEARCH_CATEGORY_VALUE ||
-      selectedSection === BOOLEAN_CATEGORY_VALUE
+      selectedSection === LOGIC_CATEGORY_VALUE
     ) {
       return [...state.collection].filter(item => !hiddenOptions.has(item.key));
     }

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -31,7 +31,6 @@ import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
 import {getKeyLabel, getKeyName} from 'sentry/components/searchSyntax/utils';
 import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import usePrevious from 'sentry/utils/usePrevious';
 
@@ -482,7 +481,7 @@ const SectionedOverlayFooter = styled('div')`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding: ${space(1)};
+  padding: ${p => p.theme.space.md};
   border-top: 1px solid ${p => p.theme.innerBorder};
 `;
 
@@ -491,8 +490,8 @@ const RecentFiltersPane = styled('ul')`
   display: flex;
   flex-wrap: wrap;
   background: ${p => p.theme.backgroundSecondary};
-  padding: ${space(1)} 10px;
-  gap: ${space(0.25)};
+  padding: ${p => p.theme.space.md} 10px;
+  gap: ${p => p.theme.space['2xs']};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   margin: 0;
 `;
@@ -510,10 +509,10 @@ const DetailsPane = styled('div')`
 
 const SectionedListBoxTabPane = styled('div')`
   grid-area: tabs;
-  padding: ${space(0.5)};
+  padding: ${p => p.theme.space.xs};
   display: flex;
   flex-wrap: wrap;
-  gap: ${space(0.25)};
+  gap: ${p => p.theme.space['2xs']};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
 `;
 
@@ -524,7 +523,7 @@ const RecentFilterPill = styled('li')`
   height: 22px;
   font-weight: ${p => p.theme.fontWeight.normal};
   font-size: ${p => p.theme.fontSize.md};
-  padding: 0 ${space(1.5)} 0 ${space(0.75)};
+  padding: 0 ${p => p.theme.space.lg} 0 ${p => p.theme.space.sm};
   background-color: ${p => p.theme.background};
   box-shadow: inset 0 0 0 1px ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius} 0 0 ${p => p.theme.borderRadius};
@@ -541,7 +540,7 @@ const RecentFilterPill = styled('li')`
     background: linear-gradient(
       to left,
       ${p => p.theme.backgroundSecondary} 0 2px,
-      transparent ${space(2)} 100%
+      transparent ${p => p.theme.space.xl} 100%
     );
   }
 `;
@@ -556,7 +555,7 @@ const SectionButton = styled(Button)`
   text-align: left;
   font-weight: ${p => p.theme.fontWeight.normal};
   font-size: ${p => p.theme.fontSize.sm};
-  padding: 0 ${space(1.5)};
+  padding: 0 ${p => p.theme.space.lg};
   color: ${p => p.theme.subText};
   border: 0;
 
@@ -579,7 +578,7 @@ const EmptyState = styled('div')`
   align-items: center;
   justify-content: center;
   height: 100%;
-  padding: ${space(4)};
+  padding: ${p => p.theme.space['3xl']};
   text-align: center;
   color: ${p => p.theme.subText};
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -58,6 +58,11 @@ export interface AskSeerConsentItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
+export interface BooleanFilterItem extends SelectOptionWithKey<string> {
+  type: 'boolean-filter';
+  value: 'AND' | 'OR';
+}
+
 export type SearchKeyItem =
   | KeySectionItem
   | KeyItem
@@ -65,7 +70,8 @@ export type SearchKeyItem =
   | FilterValueItem
   | RawSearchFilterIsValueItem
   | AskSeerItem
-  | AskSeerConsentItem;
+  | AskSeerConsentItem
+  | BooleanFilterItem;
 
 export type FilterKeyItem =
   | KeyItem
@@ -76,7 +82,8 @@ export type FilterKeyItem =
   | FilterValueItem
   | RawSearchFilterIsValueItem
   | AskSeerItem
-  | AskSeerConsentItem;
+  | AskSeerConsentItem
+  | BooleanFilterItem;
 
 export type Section = {
   label: ReactNode;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -58,8 +58,8 @@ export interface AskSeerConsentItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
-export interface BooleanFilterItem extends SelectOptionWithKey<string> {
-  type: 'boolean-filter';
+export interface LogicFilterItem extends SelectOptionWithKey<string> {
+  type: 'logic-filter';
   value: 'AND' | 'OR';
 }
 
@@ -71,7 +71,7 @@ export type SearchKeyItem =
   | RawSearchFilterIsValueItem
   | AskSeerItem
   | AskSeerConsentItem
-  | BooleanFilterItem;
+  | LogicFilterItem;
 
 export type FilterKeyItem =
   | KeyItem
@@ -83,7 +83,7 @@ export type FilterKeyItem =
   | RawSearchFilterIsValueItem
   | AskSeerItem
   | AskSeerConsentItem
-  | BooleanFilterItem;
+  | LogicFilterItem;
 
 export type Section = {
   label: ReactNode;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -60,7 +60,7 @@ export interface AskSeerConsentItem extends SelectOptionWithKey<string> {
 
 export interface LogicFilterItem extends SelectOptionWithKey<string> {
   type: 'logic-filter';
-  value: 'AND' | 'OR';
+  value: 'AND' | 'OR' | '(' | ')';
 }
 
 export type SearchKeyItem =

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -19,7 +19,7 @@ import {
   ALL_CATEGORY_VALUE,
   createAskSeerConsentItem,
   createAskSeerItem,
-  createBooleanFilterItem,
+  createLogicFilterItem,
   createRecentFilterItem,
   createRecentFilterOptionKey,
   createRecentQueryItem,
@@ -201,8 +201,8 @@ function useFilterKeySections({
 }
 
 const conditionalFilterItems = [
-  createBooleanFilterItem({value: 'AND'}),
-  createBooleanFilterItem({value: 'OR'}),
+  createLogicFilterItem({value: 'AND'}),
+  createLogicFilterItem({value: 'OR'}),
 ];
 
 interface UseFilterKeyListBoxArgs {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -17,8 +17,6 @@ import {useRecentSearchFilters} from 'sentry/components/searchQueryBuilder/token
 import {
   ALL_CATEGORY,
   ALL_CATEGORY_VALUE,
-  BOOLEAN_CATEGORY,
-  BOOLEAN_CATEGORY_VALUE,
   createAskSeerConsentItem,
   createAskSeerItem,
   createBooleanFilterItem,
@@ -26,6 +24,8 @@ import {
   createRecentFilterOptionKey,
   createRecentQueryItem,
   createSection,
+  LOGIC_CATEGORY,
+  LOGIC_CATEGORY_VALUE,
   RECENT_SEARCH_CATEGORY,
   RECENT_SEARCH_CATEGORY_VALUE,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
@@ -164,14 +164,14 @@ function useFilterKeySections({
       ];
 
       if (!disallowLogicalOperators && !isFirstItem && hasConditionalsInCombobox) {
-        recentSearchesSections.push(BOOLEAN_CATEGORY);
+        recentSearchesSections.push(LOGIC_CATEGORY);
       }
       return recentSearchesSections;
     }
 
     const customSections: Section[] = [ALL_CATEGORY, ...definedSections];
     if (!disallowLogicalOperators && !isFirstItem && hasConditionalsInCombobox) {
-      customSections.push(BOOLEAN_CATEGORY);
+      customSections.push(LOGIC_CATEGORY);
     }
 
     return customSections;
@@ -265,7 +265,7 @@ export function useFilterKeyListBox({filterValue, filterItem}: UseFilterKeyListB
 
     if (
       !disallowLogicalOperators &&
-      selectedSection === BOOLEAN_CATEGORY_VALUE &&
+      selectedSection === LOGIC_CATEGORY_VALUE &&
       hasConditionalsInCombobox
     ) {
       return [...askSeerItem, ...conditionalFilterItems];

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -203,6 +203,8 @@ function useFilterKeySections({
 const conditionalFilterItems = [
   createLogicFilterItem({value: 'AND'}),
   createLogicFilterItem({value: 'OR'}),
+  createLogicFilterItem({value: '('}),
+  createLogicFilterItem({value: ')'}),
 ];
 
 interface UseFilterKeyListBoxArgs {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -8,10 +8,10 @@ import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filter
 import type {
   AskSeerConsentItem,
   AskSeerItem,
-  BooleanFilterItem,
   FilterValueItem,
   KeyItem,
   KeySectionItem,
+  LogicFilterItem,
   RawSearchFilterIsValueItem,
   RawSearchItem,
   RecentQueryItem,
@@ -37,14 +37,14 @@ import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 
 export const ALL_CATEGORY_VALUE = '__all';
 export const RECENT_SEARCH_CATEGORY_VALUE = '__recent_searches';
-export const BOOLEAN_CATEGORY_VALUE = '__boolean_filters';
+export const LOGIC_CATEGORY_VALUE = '__logic_filters';
 
 export const ALL_CATEGORY = {value: ALL_CATEGORY_VALUE, label: t('All')};
 export const RECENT_SEARCH_CATEGORY = {
   value: RECENT_SEARCH_CATEGORY_VALUE,
   label: t('Recent'),
 };
-export const BOOLEAN_CATEGORY = {value: BOOLEAN_CATEGORY_VALUE, label: t('Conditionals')};
+export const LOGIC_CATEGORY = {value: LOGIC_CATEGORY_VALUE, label: t('Conditionals')};
 
 const RECENT_FILTER_KEY_PREFIX = '__recent_filter_key__';
 const RECENT_QUERY_KEY_PREFIX = '__recent_search__';
@@ -249,14 +249,10 @@ export function createAskSeerConsentItem(): AskSeerConsentItem {
   };
 }
 
-export function createBooleanFilterItem({
-  value,
-}: {
-  value: 'AND' | 'OR';
-}): BooleanFilterItem {
+export function createBooleanFilterItem({value}: {value: 'AND' | 'OR'}): LogicFilterItem {
   return {
     key: getEscapedKey(value),
-    type: 'boolean-filter' as const,
+    type: 'logic-filter' as const,
     value,
     label: value,
     textValue: value,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -249,7 +249,11 @@ export function createAskSeerConsentItem(): AskSeerConsentItem {
   };
 }
 
-export function createLogicFilterItem({value}: {value: 'AND' | 'OR'}): LogicFilterItem {
+export function createLogicFilterItem({
+  value,
+}: {
+  value: 'AND' | 'OR' | '(' | ')';
+}): LogicFilterItem {
   return {
     key: getEscapedKey(value),
     type: 'logic-filter' as const,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -8,6 +8,7 @@ import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filter
 import type {
   AskSeerConsentItem,
   AskSeerItem,
+  BooleanFilterItem,
   FilterValueItem,
   KeyItem,
   KeySectionItem,
@@ -36,12 +37,14 @@ import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 
 export const ALL_CATEGORY_VALUE = '__all';
 export const RECENT_SEARCH_CATEGORY_VALUE = '__recent_searches';
+export const BOOLEAN_CATEGORY_VALUE = '__boolean_filters';
 
 export const ALL_CATEGORY = {value: ALL_CATEGORY_VALUE, label: t('All')};
 export const RECENT_SEARCH_CATEGORY = {
   value: RECENT_SEARCH_CATEGORY_VALUE,
   label: t('Recent'),
 };
+export const BOOLEAN_CATEGORY = {value: BOOLEAN_CATEGORY_VALUE, label: t('Conditionals')};
 
 const RECENT_FILTER_KEY_PREFIX = '__recent_filter_key__';
 const RECENT_QUERY_KEY_PREFIX = '__recent_search__';
@@ -243,6 +246,22 @@ export function createAskSeerConsentItem(): AskSeerConsentItem {
     type: 'ask-seer-consent' as const,
     label: t('Enable Gen AI'),
     hideCheck: true,
+  };
+}
+
+export function createBooleanFilterItem({
+  value,
+}: {
+  value: 'AND' | 'OR';
+}): BooleanFilterItem {
+  return {
+    key: getEscapedKey(value),
+    type: 'boolean-filter' as const,
+    value,
+    label: value,
+    textValue: value,
+    hideCheck: true,
+    showDetailsInOverlay: true,
   };
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -44,7 +44,7 @@ export const RECENT_SEARCH_CATEGORY = {
   value: RECENT_SEARCH_CATEGORY_VALUE,
   label: t('Recent'),
 };
-export const LOGIC_CATEGORY = {value: LOGIC_CATEGORY_VALUE, label: t('Conditionals')};
+export const LOGIC_CATEGORY = {value: LOGIC_CATEGORY_VALUE, label: t('Logic')};
 
 const RECENT_FILTER_KEY_PREFIX = '__recent_filter_key__';
 const RECENT_QUERY_KEY_PREFIX = '__recent_search__';
@@ -249,7 +249,7 @@ export function createAskSeerConsentItem(): AskSeerConsentItem {
   };
 }
 
-export function createBooleanFilterItem({value}: {value: 'AND' | 'OR'}): LogicFilterItem {
+export function createLogicFilterItem({value}: {value: 'AND' | 'OR'}): LogicFilterItem {
   return {
     key: getEscapedKey(value),
     type: 'logic-filter' as const,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -440,6 +440,18 @@ function SearchQueryBuilderInputInternal({
             return;
           }
 
+          if (option.type === 'boolean-filter') {
+            dispatch({
+              type: 'UPDATE_FREE_TEXT_ON_SELECT',
+              tokens: [token],
+              text: option.value,
+              shouldCommitQuery: true,
+              focusOverride: calculateNextFocusForInsertedToken(item),
+            });
+            resetInputValue();
+            return;
+          }
+
           if (option.type === 'raw-search') {
             dispatch({
               type: 'UPDATE_FREE_TEXT_ON_SELECT',

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -301,6 +301,7 @@ function SearchQueryBuilderInputInternal({
 
   const {customMenu, sectionItems, maxOptions, onKeyDownCapture, handleOptionSelected} =
     useFilterKeyListBox({
+      filterItem: item,
       filterValue,
     });
   const sortedFilteredItems = useSortedFilterKeyItems({

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -441,7 +441,7 @@ function SearchQueryBuilderInputInternal({
             return;
           }
 
-          if (option.type === 'boolean-filter') {
+          if (option.type === 'logic-filter') {
             dispatch({
               type: 'UPDATE_FREE_TEXT_ON_SELECT',
               tokens: [token],


### PR DESCRIPTION
This PR adds in a new `Conditionals` section that contains `AND` and `OR`. We conditionally render this section, once the user has moved off of the first item as you can not start a filter with a conditional.

Ticket: EXP-562

Example:

<img width="1166" height="242" alt="Screenshot 2025-10-29 at 07 33 46" src="https://github.com/user-attachments/assets/4feaa07c-59ad-41b6-8dab-f60011e291b7" />