### PR TITLE
fix(mcp-insights): simplify mcp in-product onboarding

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -496,7 +496,7 @@ sentry_sdk.init(
         },
         {
           type: 'text',
-          text: t('Set up your low-level MCP server:'),
+          text: t('Set up your Low-level MCP server:'),
         },
         {
           type: 'code',
@@ -566,59 +566,14 @@ sentry_sdk.init(
         },
         {
           type: 'text',
-          text: t('Set up your low-level MCP server:'),
+          text: t('Set up your FastMCP server:'),
         },
         {
           type: 'code',
           language: 'python',
           code: `
 from mcp.server.fastmcp import FastMCP
-
-mcp = FastMCP("mcp-server")
-
-@mcp.tool()
-async def calculate_sum(a: int, b: int) -> int:
-    """Add two numbers together."""
-    return a + b
-`,
-        },
-      ],
-    };
-
-    const fastMcpStandaloneStep: OnboardingStep = {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: t('Configure Sentry for MCP low-level monitoring:'),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-import sentry_sdk
-from sentry_sdk.integrations.mcp import MCPIntegration
-
-sentry_sdk.init(
-    dsn="${params.dsn.public}",
-    traces_sample_rate=1.0,
-    # Add data like inputs and responses to/from MCP servers;
-    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    send_default_pii=True,
-    integrations=[
-        MCPIntegration(),
-    ],
-)`,
-        },
-        {
-          type: 'text',
-          text: t('Set up your low-level MCP server:'),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-from fastmcp import FastMCP
+# from fastmcp import FastMCP if you are using the standalone version
 
 mcp = FastMCP("mcp-server")
 
@@ -656,9 +611,6 @@ sentry_sdk.init(
     const selected = (params.platformOptions as any)?.integration ?? 'mcp_fastmcp';
     if (selected === 'mcp_fastmcp') {
       return [mcpFastMcpStep];
-    }
-    if (selected === 'fastmcp_standalone') {
-      return [fastMcpStandaloneStep];
     }
     if (selected === 'manual') {
       return [manualStep];

--- a/static/app/views/insights/mcp/views/onboarding.tsx
+++ b/static/app/views/insights/mcp/views/onboarding.tsx
@@ -218,7 +218,6 @@ export function Onboarding() {
       items: isPythonPlatform
         ? [
             {label: 'FastMCP', value: 'mcp_fastmcp'},
-            {label: 'FastMCP (Standalone)', value: 'fastmcp_standalone'},
             {label: 'Low-level', value: 'mcp_lowlevel'},
             {label: 'Manual', value: 'manual'},
           ]


### PR DESCRIPTION
Closes [TET-1351: Simplify python MCP onboarding](https://linear.app/getsentry/issue/TET-1351/simplify-python-mcp-onboarding)
- Removes the FastMCP standalone version since the only difference between it and FastMCP is the import line
- Fixes a typo