### PR TITLE
ref(redis): Do not use redis-blaster for auth idpmigration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -193,6 +193,7 @@ SENTRY_HYBRIDCLOUD_BACKFILL_OUTBOXES_REDIS_CLUSTER = "default"
 SENTRY_WEEKLY_REPORTS_REDIS_CLUSTER = "default"
 SENTRY_HYBRIDCLOUD_DELETIONS_REDIS_CLUSTER = "default"
 SENTRY_SESSION_STORE_REDIS_CLUSTER = "default"
+SENTRY_AUTH_IDPMIGRATION_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses

--- a/tests/sentry/auth/test_idpmigration.py
+++ b/tests/sentry/auth/test_idpmigration.py
@@ -31,7 +31,7 @@ class IDPMigrationTests(TestCase):
         )
         assert re.match(r"auth:one-time-key:\w{32}", link.verification_key)
 
-        value = json.loads(idpmigration.get_redis_cluster().get(link.verification_key))
+        value = json.loads(idpmigration._get_redis_client().get(link.verification_key))
         assert value["user_id"] == self.user.id
         assert value["email"] == self.email
         assert value["member_id"] == om.id
@@ -44,7 +44,7 @@ class IDPMigrationTests(TestCase):
             self.user, self.org, self.provider, self.email, self.IDENTITY_ID
         )
 
-        value = json.loads(idpmigration.get_redis_cluster().get(link.verification_key))
+        value = json.loads(idpmigration._get_redis_client().get(link.verification_key))
         assert value["user_id"] == self.user.id
         assert value["email"] == self.email
         assert value["member_id"] is None

--- a/tests/sentry/auth/test_idpmigration.py
+++ b/tests/sentry/auth/test_idpmigration.py
@@ -1,4 +1,5 @@
 import re
+from typing import cast
 
 from django.urls import reverse
 
@@ -31,7 +32,8 @@ class IDPMigrationTests(TestCase):
         )
         assert re.match(r"auth:one-time-key:\w{32}", link.verification_key)
 
-        value = json.loads(idpmigration._get_redis_client().get(link.verification_key))
+        value = json.loads(cast(str, idpmigration._get_redis_client().get(link.verification_key)))
+
         assert value["user_id"] == self.user.id
         assert value["email"] == self.email
         assert value["member_id"] == om.id
@@ -44,7 +46,8 @@ class IDPMigrationTests(TestCase):
             self.user, self.org, self.provider, self.email, self.IDENTITY_ID
         )
 
-        value = json.loads(idpmigration._get_redis_client().get(link.verification_key))
+        value = json.loads(cast(str, idpmigration._get_redis_client().get(link.verification_key)))
+
         assert value["user_id"] == self.user.id
         assert value["email"] == self.email
         assert value["member_id"] is None


### PR DESCRIPTION
<!-- Describe your PR here. -->

Remove another place where we still use redis-blaster.
