### PR TITLE
fix(tracemetrics): Send metric type to per_second and per_minute fxn

### DIFF
--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -135,9 +135,9 @@ function defaultSortBys(): Sort[] {
 }
 
 function defaultAggregateFields(): AggregateField[] {
-  return [new VisualizeFunction('per_second(value)')];
+  return [new VisualizeFunction('per_second()')];
 }
 
 function defaultAggregateSortBys(): Sort[] {
-  return [{field: 'per_second(value)', kind: 'desc'}];
+  return [{field: 'per_second()', kind: 'desc'}];
 }

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -40,7 +40,7 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
         onClick={toggleVisibility}
       />
       <MetricSelector traceMetric={traceMetric} />
-      <AggregateDropdown type={traceMetric.type} />
+      <AggregateDropdown traceMetric={traceMetric} />
       <GroupBySelector metricName={traceMetric.name} />
       <Filter traceMetric={traceMetric} />
       {metricQueries.length > 1 && <DeleteMetricButton />}


### PR DESCRIPTION
### Summary
This sends the type to the per_second and per_minute functions allowing for per-type behaviour (changing how the rate works since counter is a sum, not a row count)

