### PR TITLE
chore: Change granian dependency to un-break bump-version.yml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "google-cloud-storage-transfer>=1.17.0",
     "google-crc32c>=1.6.0",
     "googleapis-common-protos>=1.63.2",
-    "granian~=2.5",
+    "granian>=2.5",
     "grpc-google-iam-v1>=0.13.1",
     # Note, grpcio>1.30.0 requires setting GRPC_POLL_STRATEGY=epoll1
     # See https://github.com/grpc/grpc/issues/23796 and

--- a/uv.lock
+++ b/uv.lock
@@ -2109,7 +2109,7 @@ requires-dist = [
     { name = "google-cloud-storage-transfer", specifier = ">=1.17.0" },
     { name = "google-crc32c", specifier = ">=1.6.0" },
     { name = "googleapis-common-protos", specifier = ">=1.63.2" },
-    { name = "granian", specifier = "~=2.5" },
+    { name = "granian", specifier = ">=2.5" },
     { name = "grpc-google-iam-v1", specifier = ">=0.13.1" },
     { name = "grpcio", specifier = ">=1.67.0" },
     { name = "hiredis", specifier = ">=2.3.2" },


### PR DESCRIPTION
```
Only >= is allowed for packages in pyproject.toml. Offfending spec: granian~=2.5
```