### PR TITLE
feat(dynamic-sampling): add trace-based health check bias

### DIFF
--- a/src/sentry/dynamic_sampling/__init__.py
+++ b/src/sentry/dynamic_sampling/__init__.py
@@ -1,7 +1,7 @@
 from .rules.base import generate_rules
 from .rules.biases.boost_environments_bias import ENVIRONMENT_GLOBS, BoostEnvironmentsBias
 from .rules.biases.boost_latest_releases_bias import BoostLatestReleasesBias
-from .rules.biases.ignore_health_checks_bias import IgnoreHealthChecksBias
+from .rules.biases.ignore_health_checks_bias import IgnoreHealthChecksTransactionBias
 from .rules.helpers.latest_releases import (
     ExtendedBoostedRelease,
     ProjectBoostedReleases,
@@ -31,7 +31,7 @@ __all__ = [
     "ExtendedBoostedRelease",
     "ProjectBoostedReleases",
     "Platform",
-    "IgnoreHealthChecksBias",
+    "IgnoreHealthChecksTransactionBias",
     "BoostEnvironmentsBias",
     "BoostLatestReleasesBias",
     "LATEST_RELEASE_TTAS",

--- a/src/sentry/dynamic_sampling/rules/biases/ignore_health_checks_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/ignore_health_checks_bias.py
@@ -9,7 +9,7 @@ from sentry.dynamic_sampling.rules.utils import (
 from sentry.models.project import Project
 
 
-class IgnoreHealthChecksBias(Bias):
+class IgnoreHealthChecksTransactionBias(Bias):
     def generate_rules(self, project: Project, base_sample_rate: float) -> list[PolymorphicRule]:
         return [
             {
@@ -24,6 +24,30 @@ class IgnoreHealthChecksBias(Bias):
                         {
                             "op": "glob",
                             "name": "event.transaction",
+                            "value": HEALTH_CHECK_GLOBS,
+                        }
+                    ],
+                },
+                "id": RESERVED_IDS[RuleType.IGNORE_HEALTH_CHECKS_RULE],
+            }
+        ]
+
+
+class IgnoreHealthChecksTraceBias(Bias):
+    def generate_rules(self, project: Project, base_sample_rate: float) -> list[PolymorphicRule]:
+        return [
+            {
+                "samplingValue": {
+                    "type": "sampleRate",
+                    "value": base_sample_rate / IGNORE_HEALTH_CHECKS_FACTOR,
+                },
+                "type": "trace",
+                "condition": {
+                    "op": "or",
+                    "inner": [
+                        {
+                            "op": "glob",
+                            "name": "trace.transaction",
                             "value": HEALTH_CHECK_GLOBS,
                         }
                     ],

--- a/src/sentry/dynamic_sampling/rules/combine.py
+++ b/src/sentry/dynamic_sampling/rules/combine.py
@@ -31,12 +31,12 @@ def get_relay_biases_combinator(organization: Organization) -> BiasesCombinator:
     default_combinator.add_if(
         RuleType.IGNORE_HEALTH_CHECKS_RULE,
         IgnoreHealthChecksTraceBias(),
-        lambda: not is_health_checks_trace_based,
+        lambda: is_health_checks_trace_based,
     )
     default_combinator.add_if(
         RuleType.IGNORE_HEALTH_CHECKS_RULE,
         IgnoreHealthChecksTransactionBias(),
-        lambda: is_health_checks_trace_based,
+        lambda: not is_health_checks_trace_based,
     )
 
     default_combinator.add(RuleType.BOOST_REPLAY_ID_RULE, BoostReplayIdBias())

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -134,6 +134,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:migrate-transaction-queries-to-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new cell actions styling and features for tables that use the component
     manager.add("organizations:discover-cell-actions-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable trace-based health checks rule in dynamic sampling
+    manager.add("organizations:ds-health-checks-trace-based", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=False)
     # Enable custom dynamic sampling rates
     manager.add("organizations:dynamic-sampling-custom", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable dynamic sampling minimum sample rate

--- a/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_ignore_health_checks_bias.py
@@ -1,11 +1,16 @@
 from sentry.constants import HEALTH_CHECK_GLOBS
-from sentry.dynamic_sampling.rules.biases.ignore_health_checks_bias import IgnoreHealthChecksBias
+from sentry.dynamic_sampling.rules.biases.ignore_health_checks_bias import (
+    IgnoreHealthChecksTraceBias,
+    IgnoreHealthChecksTransactionBias,
+)
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @django_db_all
 def test_generate_bias_rules_v2(default_project) -> None:
-    rules = IgnoreHealthChecksBias().generate_rules(project=default_project, base_sample_rate=1.0)
+    rules = IgnoreHealthChecksTransactionBias().generate_rules(
+        project=default_project, base_sample_rate=1.0
+    )
     assert rules == [
         {
             "condition": {
@@ -21,5 +26,29 @@ def test_generate_bias_rules_v2(default_project) -> None:
             "id": 1002,
             "samplingValue": {"type": "sampleRate", "value": 0.2},
             "type": "transaction",
+        }
+    ]
+
+
+@django_db_all
+def test_generate_trace_bias_rules(default_project) -> None:
+    rules = IgnoreHealthChecksTraceBias().generate_rules(
+        project=default_project, base_sample_rate=1.0
+    )
+    assert rules == [
+        {
+            "condition": {
+                "inner": [
+                    {
+                        "name": "trace.transaction",
+                        "op": "glob",
+                        "value": HEALTH_CHECK_GLOBS,
+                    }
+                ],
+                "op": "or",
+            },
+            "id": 1002,
+            "samplingValue": {"type": "sampleRate", "value": 0.2},
+            "type": "trace",
         }
     ]

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -896,7 +896,12 @@ def test_generate_rules_trace_health_checks_feature_enabled(
     default_old_project.update_option(
         "sentry:dynamic_sampling_biases",
         [
+            {"id": RuleType.BOOST_ENVIRONMENTS_RULE.value, "active": False},
             {"id": RuleType.IGNORE_HEALTH_CHECKS_RULE.value, "active": True},
+            {"id": RuleType.BOOST_LATEST_RELEASES_RULE.value, "active": False},
+            {"id": RuleType.BOOST_KEY_TRANSACTIONS_RULE.value, "active": False},
+            {"id": RuleType.BOOST_LOW_VOLUME_TRANSACTIONS_RULE.value, "active": False},
+            {"id": RuleType.BOOST_REPLAY_ID_RULE.value, "active": False},
         ],
     )
 

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -909,14 +909,20 @@ def test_generate_rules_trace_health_checks_feature_enabled(
     assert len(rules) == 2
     assert rules[0]["id"] == 1002
     assert rules[0]["type"] == "transaction"
+    assert rules[0]["condition"]["op"] == "or"
+    assert rules[0]["condition"]["inner"][0]["op"] == "glob"
     assert rules[0]["condition"]["inner"][0]["name"] == "event.transaction"
+    assert rules[0]["condition"]["inner"][0]["value"] == HEALTH_CHECK_GLOBS
 
     with Feature({"organizations:ds-health-checks-trace-based": True}):
         rules = generate_rules(default_old_project)
         assert len(rules) == 2
         assert rules[0]["id"] == 1002
         assert rules[0]["type"] == "trace"
+        assert rules[0]["condition"]["op"] == "or"
+        assert rules[0]["condition"]["inner"][0]["op"] == "glob"
         assert rules[0]["condition"]["inner"][0]["name"] == "trace.transaction"
+        assert rules[0]["condition"]["inner"][0]["value"] == HEALTH_CHECK_GLOBS
 
     _validate_rules(default_old_project)
 

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -545,6 +545,69 @@ def test_project_config_with_all_biases_enabled(
 
 
 @django_db_all
+@region_silo_test
+@patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
+@freeze_time("2022-10-21 18:50:25.000000+00:00")
+def test_project_config_with_trace_health_checks_enabled(
+    eval_dynamic_factor_lr, default_project, default_team
+):
+    eval_dynamic_factor_lr.return_value = 1.5
+
+    default_project.update_option(
+        "sentry:dynamic_sampling_biases",
+        [
+            {"id": "ignoreHealthChecks", "active": True},
+        ],
+    )
+    default_project.add_team(default_team)
+    old_date = datetime.now(tz=timezone.utc) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
+    default_project.organization.date_added = old_date
+    default_project.date_added = old_date
+
+    with Feature(
+        {
+            "organizations:dynamic-sampling": True,
+            "organizations:ds-health-checks-trace-based": True,
+        }
+    ):
+        with patch(
+            "sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate",
+            return_value=0.1,
+        ):
+            project_cfg = get_project_config(default_project)
+
+    cfg = project_cfg.to_dict()
+    _validate_project_config(cfg["config"])
+    dynamic_sampling = get_path(cfg, "config", "sampling")
+    assert dynamic_sampling == {
+        "version": 2,
+        "rules": [
+            {
+                "samplingValue": {"type": "sampleRate", "value": 0.02},
+                "type": "trace",
+                "condition": {
+                    "op": "or",
+                    "inner": [
+                        {
+                            "op": "glob",
+                            "name": "trace.transaction",
+                            "value": HEALTH_CHECK_GLOBS,
+                        }
+                    ],
+                },
+                "id": 1002,
+            },
+            {
+                "samplingValue": {"type": "sampleRate", "value": 0.1},
+                "type": "trace",
+                "condition": {"op": "and", "inner": []},
+                "id": 1000,
+            },
+        ],
+    }
+
+
+@django_db_all
 @pytest.mark.parametrize("transaction_metrics", ("with_metrics", "without_metrics"))
 @region_silo_test
 def test_project_config_with_breakdown(

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -556,7 +556,12 @@ def test_project_config_with_trace_health_checks_enabled(
     default_project.update_option(
         "sentry:dynamic_sampling_biases",
         [
+            {"id": "boostEnvironments", "active": False},
             {"id": "ignoreHealthChecks", "active": True},
+            {"id": "boostLatestRelease", "active": False},
+            {"id": "boostKeyTransactions", "active": False},
+            {"id": "boostLowVolumeTransactions", "active": False},
+            {"id": "boostReplayId", "active": False},
         ],
     )
     default_project.add_team(default_team)


### PR DESCRIPTION
- Add a switch between the trace-based and transaction-based health check bias
- New trace based bias will also work on span-first in addition to the current system, so we can switch it over for everyone. 
- Feature flagged to try it out on a test org before rolling it out more widely

Closes TET-1314