### PR TITLE
fix(preprod): fix column title from wrapping on small screens

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -167,9 +167,7 @@ export function SizeCompareItemDiffTable({diffItems}: SizeCompareItemDiffTablePr
 const SimpleTableWithColumns = styled(SimpleTable)`
   overflow-x: auto;
   overflow-y: auto;
-  grid-template-columns:
-    minmax(120px, 0.5fr) minmax(200px, 3fr) minmax(100px, 0.5fr) minmax(100px, 0.5fr)
-    minmax(100px, 0.5fr);
+  grid-template-columns: 150px minmax(200px, 3fr) 120px 120px 120px;
   border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
   border-left: 0px;
   border-right: 0px;


### PR DESCRIPTION
<img width="477" height="472" alt="Screenshot 2025-10-29 at 11 34 00 AM" src="https://github.com/user-attachments/assets/56b235a1-5d0d-4d7b-8bad-ee9e04ac7bf5" />

Resolves EME-486