### PR TITLE
feat(seer-prefs): add automation_handoff field to endpoint

### DIFF
--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -49,9 +49,22 @@ class RepositorySerializer(CamelSnakeSerializer):
     provider_raw = serializers.CharField(required=False, allow_null=True)
 
 
+class SeerAutomationHandoffConfigurationSerializer(CamelSnakeSerializer):
+    handoff_point = serializers.CharField(required=True)
+    target = serializers.CharField(required=True)
+
+
 class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):
     repositories = RepositorySerializer(many=True, required=True)
     automated_run_stopping_point = serializers.CharField(required=False, allow_null=True)
+    automation_handoff = SeerAutomationHandoffConfigurationSerializer(
+        required=False, allow_null=True
+    )
+
+
+class SeerAutomationHandoffConfiguration(BaseModel):
+    handoff_point: str
+    target: str
 
 
 class SeerProjectPreference(BaseModel):
@@ -59,6 +72,7 @@ class SeerProjectPreference(BaseModel):
     project_id: int
     repositories: list[SeerRepoDefinition]
     automated_run_stopping_point: str | None = None
+    automation_handoff: SeerAutomationHandoffConfiguration | None = None
 
 
 class PreferenceResponse(BaseModel):

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from enum import StrEnum
 from typing import Literal
 
 import orjson
@@ -59,6 +60,7 @@ class SeerAutomationHandoffConfigurationSerializer(CamelSnakeSerializer):
         choices=["cursor_background_agent"],
         required=True,
     )
+    integration_id = serializers.IntegerField(required=True)
 
 
 class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):
@@ -69,9 +71,14 @@ class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):
     )
 
 
+class AutofixHandoffPoint(StrEnum):
+    ROOT_CAUSE = "root_cause"
+
+
 class SeerAutomationHandoffConfiguration(BaseModel):
-    handoff_point: Literal["root_cause"]
+    handoff_point: AutofixHandoffPoint
     target: Literal["cursor_background_agent"]
+    integration_id: int
 
 
 class SeerProjectPreference(BaseModel):

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 import orjson
 import requests
@@ -50,8 +51,14 @@ class RepositorySerializer(CamelSnakeSerializer):
 
 
 class SeerAutomationHandoffConfigurationSerializer(CamelSnakeSerializer):
-    handoff_point = serializers.CharField(required=True)
-    target = serializers.CharField(required=True)
+    handoff_point = serializers.ChoiceField(
+        choices=["root_cause"],
+        required=True,
+    )
+    target = serializers.ChoiceField(
+        choices=["cursor_background_agent"],
+        required=True,
+    )
 
 
 class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):
@@ -63,8 +70,8 @@ class ProjectSeerPreferencesSerializer(CamelSnakeSerializer):
 
 
 class SeerAutomationHandoffConfiguration(BaseModel):
-    handoff_point: str
-    target: str
+    handoff_point: Literal["root_cause"]
+    target: Literal["cursor_background_agent"]
 
 
 class SeerProjectPreference(BaseModel):

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -275,3 +275,224 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
 
         # Verify the URL used
         assert args[0] == f"{settings.SEER_AUTOFIX_URL}/v1/project-preference/set"
+
+    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
+    def test_post_with_automation_handoff(self, mock_post: MagicMock) -> None:
+        """Test that POST request correctly handles automation_handoff field"""
+        # Setup the mock
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        # Request data with automation_handoff
+        request_data = {
+            "repositories": [
+                {
+                    "organization_id": self.org.id,
+                    "integration_id": "111",
+                    "provider": "github",
+                    "owner": "getsentry",
+                    "name": "sentry",
+                    "external_id": "123456",
+                }
+            ],
+            "automation_handoff": {
+                "handoff_point": "root_cause",
+                "target": "cursor_background_agent",
+            },
+        }
+
+        # Make the request
+        response = self.client.post(self.url, data=request_data)
+
+        # Assert the response is successful
+        assert response.status_code == 204
+
+        # Assert that the mock was called
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+
+        # Verify the URL used
+        assert args[0] == f"{settings.SEER_AUTOFIX_URL}/v1/project-preference/set"
+
+        # Verify the request body contains automation_handoff
+        body_dict = orjson.loads(kwargs["data"])
+        assert "preference" in body_dict
+        preference = body_dict["preference"]
+        assert "automation_handoff" in preference
+        assert preference["automation_handoff"]["handoff_point"] == "root_cause"
+        assert preference["automation_handoff"]["target"] == "cursor_background_agent"
+
+    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
+    def test_post_without_automation_handoff(self, mock_post: MagicMock) -> None:
+        """Test that POST request works when automation_handoff is not provided (optional field)"""
+        # Setup the mock
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        # Request data without automation_handoff
+        request_data = {
+            "repositories": [
+                {
+                    "organization_id": self.org.id,
+                    "integration_id": "111",
+                    "provider": "github",
+                    "owner": "getsentry",
+                    "name": "sentry",
+                    "external_id": "123456",
+                }
+            ]
+        }
+
+        # Make the request
+        response = self.client.post(self.url, data=request_data)
+
+        # Assert the response is successful
+        assert response.status_code == 204
+
+        # Assert that the mock was called
+        mock_post.assert_called_once()
+
+    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
+    def test_post_with_null_automation_handoff(self, mock_post: MagicMock) -> None:
+        """Test that POST request correctly handles null automation_handoff"""
+        # Setup the mock
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        # Request data with null automation_handoff
+        request_data = {
+            "repositories": [
+                {
+                    "organization_id": self.org.id,
+                    "integration_id": "111",
+                    "provider": "github",
+                    "owner": "getsentry",
+                    "name": "sentry",
+                    "external_id": "123456",
+                }
+            ],
+            "automation_handoff": None,
+        }
+
+        # Make the request
+        response = self.client.post(self.url, data=request_data)
+
+        # Assert the response is successful
+        assert response.status_code == 204
+
+        # Assert that the mock was called
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+
+        # Verify the request body has null automation_handoff
+        body_dict = orjson.loads(kwargs["data"])
+        assert body_dict["preference"]["automation_handoff"] is None
+
+    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
+    def test_post_with_invalid_automation_handoff_handoff_point(self, mock_post: MagicMock) -> None:
+        """Test that POST request fails with invalid handoff_point value"""
+        # Request data with invalid handoff_point
+        request_data = {
+            "repositories": [
+                {
+                    "organization_id": self.org.id,
+                    "integration_id": "111",
+                    "provider": "github",
+                    "owner": "getsentry",
+                    "name": "sentry",
+                    "external_id": "123456",
+                }
+            ],
+            "automation_handoff": {
+                "handoff_point": "invalid_handoff_point",
+                "target": "cursor_background_agent",
+            },
+        }
+
+        # Make the request
+        response = self.client.post(self.url, data=request_data)
+
+        # Should fail with a 400 error for invalid request data
+        assert response.status_code == 400
+
+        # The post to Seer should not be called since validation fails
+        mock_post.assert_not_called()
+
+    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
+    def test_post_with_invalid_automation_handoff_target(self, mock_post: MagicMock) -> None:
+        """Test that POST request fails with invalid target value"""
+        # Request data with invalid target
+        request_data = {
+            "repositories": [
+                {
+                    "organization_id": self.org.id,
+                    "integration_id": "111",
+                    "provider": "github",
+                    "owner": "getsentry",
+                    "name": "sentry",
+                    "external_id": "123456",
+                }
+            ],
+            "automation_handoff": {
+                "handoff_point": "root_cause",
+                "target": "invalid_target",
+            },
+        }
+
+        # Make the request
+        response = self.client.post(self.url, data=request_data)
+
+        # Should fail with a 400 error for invalid request data
+        assert response.status_code == 400
+
+        # The post to Seer should not be called since validation fails
+        mock_post.assert_not_called()
+
+    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
+    @patch(
+        "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
+        return_value=[],
+    )
+    def test_get_with_automation_handoff(
+        self, mock_get_autofix_repos: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Test that GET method correctly returns automation_handoff in the response"""
+        from sentry.seer.endpoints.project_seer_preferences import (
+            SeerAutomationHandoffConfiguration,
+        )
+
+        # Create preference with automation_handoff
+        project_preference_with_handoff = SeerProjectPreference(
+            organization_id=self.org.id,
+            project_id=self.project.id,
+            repositories=[self.repo_definition],
+            automation_handoff=SeerAutomationHandoffConfiguration(
+                handoff_point="root_cause",
+                target="cursor_background_agent",
+            ),
+        )
+
+        response_data = PreferenceResponse(
+            preference=project_preference_with_handoff, code_mapping_repos=[]
+        ).dict()
+
+        # Setup the mock
+        mock_response = Mock()
+        mock_response.json.return_value = response_data
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        # Make the request
+        response = self.client.get(self.url)
+
+        # Assert the response
+        assert response.status_code == 200
+        assert "preference" in response.data
+        assert "automation_handoff" in response.data["preference"]
+        assert response.data["preference"]["automation_handoff"]["handoff_point"] == "root_cause"
+        assert (
+            response.data["preference"]["automation_handoff"]["target"] == "cursor_background_agent"
+        )

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -299,6 +299,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             "automation_handoff": {
                 "handoff_point": "root_cause",
                 "target": "cursor_background_agent",
+                "integration_id": 123,
             },
         }
 
@@ -322,37 +323,6 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert "automation_handoff" in preference
         assert preference["automation_handoff"]["handoff_point"] == "root_cause"
         assert preference["automation_handoff"]["target"] == "cursor_background_agent"
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
-    def test_post_without_automation_handoff(self, mock_post: MagicMock) -> None:
-        """Test that POST request works when automation_handoff is not provided (optional field)"""
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_post.return_value = mock_response
-
-        # Request data without automation_handoff
-        request_data = {
-            "repositories": [
-                {
-                    "organization_id": self.org.id,
-                    "integration_id": "111",
-                    "provider": "github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                    "external_id": "123456",
-                }
-            ]
-        }
-
-        # Make the request
-        response = self.client.post(self.url, data=request_data)
-
-        # Assert the response is successful
-        assert response.status_code == 204
-
-        # Assert that the mock was called
-        mock_post.assert_called_once()
 
     @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
     def test_post_with_null_automation_handoff(self, mock_post: MagicMock) -> None:
@@ -392,36 +362,6 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert body_dict["preference"]["automation_handoff"] is None
 
     @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
-    def test_post_with_invalid_automation_handoff_handoff_point(self, mock_post: MagicMock) -> None:
-        """Test that POST request fails with invalid handoff_point value"""
-        # Request data with invalid handoff_point
-        request_data = {
-            "repositories": [
-                {
-                    "organization_id": self.org.id,
-                    "integration_id": "111",
-                    "provider": "github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                    "external_id": "123456",
-                }
-            ],
-            "automation_handoff": {
-                "handoff_point": "invalid_handoff_point",
-                "target": "cursor_background_agent",
-            },
-        }
-
-        # Make the request
-        response = self.client.post(self.url, data=request_data)
-
-        # Should fail with a 400 error for invalid request data
-        assert response.status_code == 400
-
-        # The post to Seer should not be called since validation fails
-        mock_post.assert_not_called()
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.requests.post")
     def test_post_with_invalid_automation_handoff_target(self, mock_post: MagicMock) -> None:
         """Test that POST request fails with invalid target value"""
         # Request data with invalid target
@@ -439,6 +379,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             "automation_handoff": {
                 "handoff_point": "root_cause",
                 "target": "invalid_target",
+                "integration_id": 123,
             },
         }
 
@@ -472,6 +413,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             automation_handoff=SeerAutomationHandoffConfiguration(
                 handoff_point="root_cause",
                 target="cursor_background_agent",
+                integration_id=123,
             ),
         )
 


### PR DESCRIPTION
add optional `automation_handoff` field to seer project preference endpoint on backend.