### PR TITLE
feat(seer-settings): add cursor background agent handoff setting

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
@@ -13,6 +13,7 @@ export function useUpdateProjectSeerPreferences(project: Project) {
       const payload: ProjectSeerPreferences = {
         repositories: data.repositories,
         automated_run_stopping_point: data.automated_run_stopping_point ?? 'root_cause',
+        automation_handoff: data.automation_handoff,
       };
       return api.requestPromise(
         `/projects/${organization.slug}/${project.slug}/seer/preferences/`,

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -311,7 +311,7 @@ export interface SeerRepoDefinition {
   provider_raw?: string;
 }
 
-export interface SeerAutomationHandoffConfiguration {
+interface SeerAutomationHandoffConfiguration {
   handoff_point: 'root_cause';
   target: 'cursor_background_agent';
 }

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -311,9 +311,15 @@ export interface SeerRepoDefinition {
   provider_raw?: string;
 }
 
+export interface SeerAutomationHandoffConfiguration {
+  handoff_point: 'root_cause';
+  target: 'cursor_background_agent';
+}
+
 export interface ProjectSeerPreferences {
   repositories: SeerRepoDefinition[];
   automated_run_stopping_point?: 'root_cause' | 'solution' | 'code_changes' | 'open_pr';
+  automation_handoff?: SeerAutomationHandoffConfiguration;
 }
 
 export const AUTOFIX_TTL_IN_DAYS = 30;

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -313,6 +313,7 @@ export interface SeerRepoDefinition {
 
 interface SeerAutomationHandoffConfiguration {
   handoff_point: 'root_cause';
+  integration_id: number;
   target: 'cursor_background_agent';
 }
 

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -310,7 +310,7 @@ describe('ProjectSeer', () => {
 
     // Find the select menu
     const select = await screen.findByRole('textbox', {
-      name: /Auto-Triggered Fixes/i,
+      name: /Auto-Trigger Fixes/i,
     });
 
     act(() => {
@@ -320,11 +320,14 @@ describe('ProjectSeer', () => {
     // Open the menu and select a new value
     await userEvent.click(select);
 
-    const option = await screen.findByText('Minimally Actionable and Above');
-    await userEvent.click(option);
+    const options = await screen.findAllByText('Minimally Actionable and Above');
+    await userEvent.click(options[0]);
 
-    const option2 = await screen.findByText('Highly Actionable and Above');
-    await userEvent.click(option2);
+    // Reopen the menu to select another value
+    await userEvent.click(select);
+
+    const options2 = await screen.findAllByText('Highly Actionable and Above');
+    await userEvent.click(options2[0]);
 
     // Form has saveOnBlur=true, so wait for the PUT request
     await waitFor(() => {

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -116,6 +116,14 @@ describe('ProjectSeer', () => {
       method: 'GET',
       body: seerPreferencesResponse,
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      method: 'GET',
+      body: {
+        integrations: [],
+      },
+    });
   });
 
   afterEach(() => {
@@ -157,7 +165,7 @@ describe('ProjectSeer', () => {
       expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          data: {
+          data: expect.objectContaining({
             automated_run_stopping_point: 'root_cause',
             repositories: [
               {
@@ -183,7 +191,7 @@ describe('ProjectSeer', () => {
                 branch_overrides: [],
               },
             ],
-          },
+          }),
         })
       );
     });
@@ -219,7 +227,7 @@ describe('ProjectSeer', () => {
       expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          data: {
+          data: expect.objectContaining({
             automated_run_stopping_point: 'root_cause',
             repositories: [
               {
@@ -234,7 +242,7 @@ describe('ProjectSeer', () => {
                 branch_overrides: [],
               },
             ],
-          },
+          }),
         })
       );
     });
@@ -267,10 +275,10 @@ describe('ProjectSeer', () => {
       expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          data: {
+          data: expect.objectContaining({
             automated_run_stopping_point: 'root_cause',
             repositories: [],
-          },
+          }),
         })
       );
     });
@@ -430,6 +438,7 @@ describe('ProjectSeer', () => {
         expect.objectContaining({
           data: expect.objectContaining({
             automated_run_stopping_point: 'code_changes',
+            repositories: expect.any(Array),
           }),
         })
       );

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -321,13 +321,19 @@ describe('ProjectSeer', () => {
     await userEvent.click(select);
 
     const options = await screen.findAllByText('Minimally Actionable and Above');
-    await userEvent.click(options[0]);
+    expect(options[0]).toBeDefined();
+    if (options[0]) {
+      await userEvent.click(options[0]);
+    }
 
     // Reopen the menu to select another value
     await userEvent.click(select);
 
     const options2 = await screen.findAllByText('Highly Actionable and Above');
-    await userEvent.click(options2[0]);
+    expect(options2[0]).toBeDefined();
+    if (options2[0]) {
+      await userEvent.click(options2[0]);
+    }
 
     // Form has saveOnBlur=true, so wait for the PUT request
     await waitFor(() => {

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -406,9 +406,9 @@ describe('ProjectSeer', () => {
 
     render(<ProjectSeer project={initialProject} />, {organization});
 
-    // Find the select menu for Stopping Point for Auto-Triggered Fixes
+    // Find the select menu for Where should Seer stop?
     const select = await screen.findByRole('textbox', {
-      name: /Stopping Point for Auto-Triggered Fixes/i,
+      name: /Where should Seer stop/i,
     });
 
     act(() => {
@@ -524,22 +524,23 @@ describe('ProjectSeer', () => {
       organization: orgWithCursorFeature,
     });
 
-    // Find the toggle for Hand off to Cursor Background Agent
-    const toggle = await screen.findByRole('checkbox', {
-      name: /Hand off to Cursor Background Agent/i,
+    // Find the select menu for Where should Seer stop?
+    const select = await screen.findByRole('textbox', {
+      name: /Where should Seer stop/i,
     });
-    expect(toggle).toBeInTheDocument();
-    expect(toggle).not.toBeChecked();
 
-    // Toggle it on
-    await userEvent.click(toggle);
+    act(() => {
+      select.focus();
+    });
 
-    // Form should call PUT for the project
+    // Open the menu and select 'Hand off to Cursor Background Agent'
+    await userEvent.click(select);
+    const cursorOption = await screen.findByText('Hand off to Cursor Background Agent');
+    await userEvent.click(cursorOption);
+
+    // Form has saveOnBlur=true, so wait for the PUT request
     await waitFor(() => {
-      expect(projectPutRequest).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({data: {automation_handoff: true}})
-      );
+      expect(projectPutRequest).toHaveBeenCalledTimes(1);
     });
 
     // Wait for the seer preferences POST to be called with automation_handoff


### PR DESCRIPTION
allow configuring of automation hand off to seer project settings as a field in the stopping point dropdown + reword it


<img width="2786" height="804" alt="CleanShot 2025-10-30 at 18 32 43@2x" src="https://github.com/user-attachments/assets/d591ecc9-17ac-41de-a649-f97cb848e24e" />

