### PR TITLE
feat(logs): Configure on demand from product trial banner

### DIFF
--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -26,6 +26,7 @@ import titleCase from 'getsentry/utils/titleCase';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 
 function shouldUseOnDemandCta(category: DataCategory): boolean {
+  // TODO: other categories that use on demand is still missing here
   return category === DataCategory.LOG_BYTE;
 }
 

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -6,7 +6,6 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -26,7 +25,7 @@ import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
 import titleCase from 'getsentry/utils/titleCase';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 
-function doesCategoryUseOnDemand(category: DataCategory): boolean {
+function shouldUseOnDemandCta(category: DataCategory): boolean {
   return category === DataCategory.LOG_BYTE;
 }
 
@@ -62,7 +61,7 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
 
   const isPaid = subscription.planDetails?.price > 0;
   const hasBillingRole = organization.access?.includes('org:billing');
-  const categoryUsesOnDemand = doesCategoryUseOnDemand(trial.category);
+  const categoryUsesOnDemand = shouldUseOnDemandCta(trial.category);
 
   let alertText: string | null = null;
   let alertHeader: string | null = null;
@@ -121,7 +120,9 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
         subscription.planDetails.budgetTerm
       );
 
-      const eventTypes: EventType[] = [DATA_CATEGORY_INFO.log_byte.singular as EventType];
+      const eventTypes: EventType[] = [
+        getCategoryInfoFromPlural(trial.category)!.singular as EventType,
+      ];
       alertButton = (
         <AddEventsCTA
           organization={organization}


### PR DESCRIPTION
For logs specifically, instead of prompting the user to upgrade plans. We should check if they are already on a paid plan and prompt them to configure their on demand/payg budgets instead.

<table>
<tr>
 <td>Users with billing role
 <td>
<img width="1051" height="71" alt="image" src="https://github.com/user-attachments/assets/b0786640-f074-4831-8bbe-3bfc0524d63c" />
<tr>
 <td>Users without billing role
 <td>
<img width="1066" height="71" alt="image" src="https://github.com/user-attachments/assets/a003a2ce-6c7c-44b8-93c8-133ceb136c1c" />
</table>

Closes LOGS-413