### PR TITLE
fix(tracemetrics): Remove global simple table changes

### DIFF
--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -122,9 +122,6 @@ const StyledPanelHeader = styled('div')`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1 / -1;
-  position: sticky;
-  top: 0;
-  z-index: 2;
 `;
 
 const StyledRowCell = styled(Flex)`

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -69,6 +69,8 @@ export const StyledSimpleTableBody = styled('div')`
 export const StyledSimpleTableHeader = styled(SimpleTable.Header)`
   height: 33px;
   z-index: unset;
+  position: sticky;
+  top: 0;
 `;
 
 export const StickyTableRow = styled(SimpleTable.Row)<{


### PR DESCRIPTION
### Summary
Accidentally put it in the internal 'StyledPanelHeader' instead of the locally styled one
