### PR TITLE
feat(preprod): add pagination to long insight results

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -111,15 +111,20 @@ export function AppSizeInsightsSidebar({
 
             <Flex flex={1} overflowY="auto" padding="xl">
               <Flex direction="column" gap="xl" width="100%">
-                {processedInsights.map(insight => (
-                  <AppSizeInsightsSidebarRow
-                    key={insight.key}
-                    insight={insight}
-                    isExpanded={expandedInsights.has(insight.key)}
-                    onToggleExpanded={() => toggleExpanded(insight.key)}
-                    platform={platform}
-                  />
-                ))}
+                {processedInsights.map(insight => {
+                  const isGroupedInsight =
+                    insight.key === 'duplicate_files' || insight.key === 'loose_images';
+                  return (
+                    <AppSizeInsightsSidebarRow
+                      key={insight.key}
+                      insight={insight}
+                      isExpanded={expandedInsights.has(insight.key)}
+                      onToggleExpanded={() => toggleExpanded(insight.key)}
+                      platform={platform}
+                      itemsPerPage={isGroupedInsight ? 10 : undefined}
+                    />
+                  );
+                })}
               </Flex>
             </Flex>
           </Flex>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -90,13 +90,7 @@ export function AppSizeInsightsSidebarRow({
         <Text variant="primary" size="md" bold>
           {insight.name}
         </Text>
-        <Flex
-          align="center"
-          gap="sm"
-          style={{
-            flexShrink: 0,
-          }}
-        >
+        <Flex align="center" gap="sm" shrink={0}>
           <Text size="sm" tabular>
             {t('Potential savings %s', formatBytesBase10(insight.totalSavings))}
           </Text>
@@ -204,11 +198,10 @@ function FileRow({file}: {file: ProcessedInsightFile}) {
       justify="between"
       gap="lg"
       padding="xs sm"
+      radius="sm"
+      overflow="hidden"
       style={{
-        borderRadius: '4px',
         minWidth: 0,
-        maxWidth: '100%',
-        overflow: 'hidden',
       }}
     >
       <Text size="sm" ellipsis style={{flex: 1}}>
@@ -240,11 +233,10 @@ function DuplicateGroupFileRow({
         justify="between"
         gap="lg"
         padding="xs sm"
+        radius="sm"
+        overflow="hidden"
         style={{
-          borderRadius: '4px',
           minWidth: 0,
-          maxWidth: '100%',
-          overflow: 'hidden',
         }}
       >
         <Text size="sm" ellipsis style={{flex: 1}} bold>
@@ -269,7 +261,8 @@ function DuplicateGroupFileRow({
               size="xs"
               variant="muted"
               tabular
-              style={{minWidth: '80px', textAlign: 'right'}}
+              align="right"
+              style={{minWidth: '80px'}}
             >
               {formatBytesBase10(duplicateFile.total_savings)}
             </Text>
@@ -335,20 +328,19 @@ function OptimizableImageFileRow({
         justify="between"
         gap="lg"
         padding="xs sm"
+        radius="sm"
+        overflow="hidden"
         style={{
-          borderRadius: '4px',
           minWidth: 0,
-          maxWidth: '100%',
-          overflow: 'hidden',
         }}
       >
-        <Flex align="center" gap="xs" style={{minWidth: 0, overflow: 'hidden'}}>
+        <Flex align="center" gap="xs" overflow="hidden" style={{minWidth: 0}}>
           <Text size="sm" ellipsis style={{flex: 1}}>
             {file.path}
           </Text>
           {hasMetadata && (
             <Tooltip title={tooltipContent} isHoverable skipWrapper>
-              <Flex align="center" style={{flexShrink: 0}}>
+              <Flex align="center" shrink={0}>
                 <IconFlag size="xs" color="subText" />
               </Flex>
             </Tooltip>
@@ -373,7 +365,8 @@ function OptimizableImageFileRow({
               size="xs"
               variant="primary"
               tabular
-              style={{minWidth: '80px', textAlign: 'right'}}
+              align="right"
+              style={{minWidth: '80px'}}
             >
               -{formatBytesBase10(originalFile.minify_savings)}
             </Text>
@@ -381,7 +374,8 @@ function OptimizableImageFileRow({
               size="xs"
               variant="muted"
               tabular
-              style={{minWidth: '64px', textAlign: 'right'}}
+              align="right"
+              style={{minWidth: '64px'}}
             >
               ({formatUpside(file.data.minifyPercentage / 100)})
             </Text>
@@ -396,7 +390,8 @@ function OptimizableImageFileRow({
               size="xs"
               variant="primary"
               tabular
-              style={{minWidth: '80px', textAlign: 'right'}}
+              align="right"
+              style={{minWidth: '80px'}}
             >
               -{formatBytesBase10(originalFile.conversion_savings)}
             </Text>
@@ -404,7 +399,8 @@ function OptimizableImageFileRow({
               size="xs"
               variant="muted"
               tabular
-              style={{minWidth: '64px', textAlign: 'right'}}
+              align="right"
+              style={{minWidth: '64px'}}
             >
               ({formatUpside(file.data.conversionPercentage / 100)})
             </Text>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -90,7 +90,7 @@ export function AppSizeInsightsSidebarRow({
         <Text variant="primary" size="md" bold>
           {insight.name}
         </Text>
-        <Flex align="center" gap="sm" shrink={0}>
+        <Flex align="center" gap="sm" style={{flexShrink: 0}}>
           <Text size="sm" tabular>
             {t('Potential savings %s', formatBytesBase10(insight.totalSavings))}
           </Text>
@@ -340,7 +340,7 @@ function OptimizableImageFileRow({
           </Text>
           {hasMetadata && (
             <Tooltip title={tooltipContent} isHoverable skipWrapper>
-              <Flex align="center" shrink={0}>
+              <Flex align="center" style={{flexShrink: 0}}>
                 <IconFlag size="xs" color="subText" />
               </Flex>
             </Tooltip>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -55,11 +55,12 @@ export function AppSizeInsightsSidebarRow({
   const shouldShowTooltip = INSIGHTS_WITH_MORE_INFO_MODAL.includes(insight.key);
   const [currentPage, setCurrentPage] = useState(0);
 
-  const totalPages = Math.ceil(insight.files.length / ITEMS_PER_PAGE);
+  const sortedFiles = [...insight.files].sort((a, b) => b.savings - a.savings);
+  const totalPages = Math.ceil(sortedFiles.length / ITEMS_PER_PAGE);
   const startIndex = currentPage * ITEMS_PER_PAGE;
   const endIndex = startIndex + ITEMS_PER_PAGE;
-  const currentFiles = insight.files.slice(startIndex, endIndex);
-  const showPagination = insight.files.length > ITEMS_PER_PAGE;
+  const currentFiles = sortedFiles.slice(startIndex, endIndex);
+  const showPagination = sortedFiles.length > ITEMS_PER_PAGE;
 
   const handleOpenModal = () => {
     if (insight.key === 'alternate_icons_optimization') {
@@ -114,7 +115,7 @@ export function AppSizeInsightsSidebarRow({
         )}
       </Stack>
 
-      {insight.files.length > 0 && (
+      {sortedFiles.length > 0 && (
         <Container paddingTop="md">
           <Button
             size="sm"
@@ -131,7 +132,7 @@ export function AppSizeInsightsSidebarRow({
             }
           >
             <Text variant="primary" size="md" bold>
-              {tn('%s file', '%s files', insight.files.length)}
+              {tn('%s file', '%s files', sortedFiles.length)}
             </Text>
           </Button>
 
@@ -149,7 +150,7 @@ export function AppSizeInsightsSidebarRow({
                 })}
               >
                 {currentFiles.map((file, fileIndex) => (
-                  <FileRow key={`${file.path}-${fileIndex}`} file={file} />
+                  <FileRow key={`${file.path}-${startIndex + fileIndex}`} file={file} />
                 ))}
               </Container>
 

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -17,6 +17,7 @@ type FileTypeData =
       originalFile: OptimizableImageFile;
     }
   | {fileType: 'strip_binary'; originalFile: StripBinaryFileInfo}
+  | {fileType: 'duplicate_files'; originalGroup: FileSavingsResultGroup}
   | {fileType: 'regular'; originalFile: FileSavingsResult};
 
 export interface ProcessedInsightFile {
@@ -247,18 +248,15 @@ export function processInsights(
         description: config.description,
         totalSavings: insight.total_savings,
         percentage: (insight.total_savings / totalSize) * 100,
-        files: groups.flatMap((group: FileSavingsResultGroup) => {
-          const files = Array.isArray(group?.files) ? group.files : [];
-          return files.map((file: FileSavingsResult) => ({
-            path: file.file_path,
-            savings: file.total_savings,
-            percentage: (file.total_savings / totalSize) * 100,
-            data: {
-              fileType: 'regular' as const,
-              originalFile: file,
-            },
-          }));
-        }),
+        files: groups.map((group: FileSavingsResultGroup) => ({
+          path: group.name,
+          savings: group.total_savings,
+          percentage: (group.total_savings / totalSize) * 100,
+          data: {
+            fileType: 'duplicate_files' as const,
+            originalGroup: group,
+          },
+        })),
       });
     }
   }
@@ -300,18 +298,15 @@ export function processInsights(
         description: config.description,
         totalSavings: insight.total_savings,
         percentage: (insight.total_savings / totalSize) * 100,
-        files: groups.flatMap((group: FileSavingsResultGroup) => {
-          const files = Array.isArray(group?.files) ? group.files : [];
-          return files.map((file: FileSavingsResult) => ({
-            path: file.file_path,
-            savings: file.total_savings,
-            percentage: (file.total_savings / totalSize) * 100,
-            data: {
-              fileType: 'regular' as const,
-              originalFile: file,
-            },
-          }));
-        }),
+        files: groups.map((group: FileSavingsResultGroup) => ({
+          path: group.name,
+          savings: group.total_savings,
+          percentage: (group.total_savings / totalSize) * 100,
+          data: {
+            fileType: 'duplicate_files' as const,
+            originalGroup: group,
+          },
+        })),
       });
     }
   }


### PR DESCRIPTION
Adds **client-side** pagination for insights with more than 20 results.

Note: I explicitly did not add this to the URL state since it's more for browsing and not something you'd expect to stay sticky if you reload the page or share as a link.

<img width="704" height="674" alt="Screenshot 2025-10-29 at 2 35 42 PM" src="https://github.com/user-attachments/assets/a4b5cd01-1119-4005-b6ef-d133554a4390" />

While I was at it, I fixed our duplicate files insight display to properly respect the API grouping, since this was causing the sort order to be wrong:

<img width="703" height="646" alt="Screenshot 2025-10-29 at 2 35 14 PM" src="https://github.com/user-attachments/assets/58d0d75b-416a-476d-b9b5-af69e8f20061" />

Resolves EME-477, EME-258, EME-505
