### PR TITLE
chore(Replay): Add Count and Size to Span

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -402,15 +402,35 @@ def _largest_attr(ti: TraceItem) -> tuple[str, int]:
     return name, anyv.ByteSize()
 
 
+def _attr_stats(ti: TraceItem) -> tuple[int, int]:
+    if not ti.attributes:
+        return (0, 0)
+    count = len(ti.attributes)
+    total_size = sum(v.ByteSize() for v in ti.attributes.values())
+    return (count, total_size)
+
+
 @sentry_sdk.trace
 def emit_trace_items_to_eap(trace_items: list[TraceItem]) -> None:
+    # Get largest attribute across trace items
     largest_attribute = max(
         ((ti, *_largest_attr(ti)) for ti in trace_items),
         key=lambda t: t[2],
         default=None,
     )
 
+    # Get total attribute count and size
+    total_attr_count = 0
+    total_attr_size_bytes = 0
+    for ti in trace_items:
+        c, s = _attr_stats(ti)
+        total_attr_count += c
+        total_attr_size_bytes += s
+
     with sentry_sdk.start_span(op="process", name="write_trace_items") as span:
+        span.set_data("attribute_count_total", total_attr_count)
+        span.set_data("attribute_size_total_bytes", total_attr_size_bytes)
+
         if largest_attribute:
             ti, name, size = largest_attribute
             span.set_data("largest_attr_trace_id", ti.trace_id)


### PR DESCRIPTION
The current span does not give enough context into this issue: https://sentry.sentry.io/issues/6779186130/?notification_uuid=238718bc-7dc9-4044-ab0a-d9c9816741f9&project=1&referrer=regression_activity-email 

Thus, we add the number of attributes and total size to the span.

Relates to: REPLAY-807