### PR TITLE
feat(aci): Add cron checkin timeline to monitors list page

### DIFF
--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -56,7 +56,7 @@ export function PreprodBuildsTable({
       <SimpleTable.Row key={build.id}>
         <FullRowLink to={linkUrl}>
           <InteractionStateLayer />
-          <SimpleTable.RowCell justify="flex-start">
+          <SimpleTable.RowCell justify="start">
             {build.app_info?.name || build.app_info?.app_id ? (
               <Flex direction="column" gap="xs">
                 <Flex align="center" gap="sm">
@@ -90,7 +90,7 @@ export function PreprodBuildsTable({
             ) : null}
           </SimpleTable.RowCell>
 
-          <SimpleTable.RowCell justify="flex-start">
+          <SimpleTable.RowCell justify="start">
             <Flex direction="column" gap="xs">
               <Flex align="center" gap="xs">
                 {build.app_info?.version !== null && (

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -1,6 +1,6 @@
-import type {ComponentProps, CSSProperties, HTMLAttributes, RefObject} from 'react';
-import type {Theme} from '@emotion/react';
+import type {ComponentProps, HTMLAttributes, RefObject} from 'react';
 import {css} from '@emotion/react';
+import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
@@ -81,24 +81,14 @@ function Row({children, variant = 'default', ...props}: RowProps) {
 
 function RowCell({
   children,
-  className,
-  justify,
   ...props
 }: ComponentProps<typeof Flex> & {
   children: React.ReactNode;
-  className?: string;
-  justify?: CSSProperties['justifyContent'];
 }) {
   return (
-    <StyledRowCell
-      {...props}
-      className={className}
-      role="cell"
-      align="center"
-      justify={justify}
-    >
+    <Flex role="cell" align="center" overflow="hidden" padding="lg xl" {...props}>
       {children}
-    </StyledRowCell>
+    </Flex>
   );
 }
 
@@ -124,11 +114,6 @@ const StyledPanelHeader = styled('div')`
   grid-column: 1 / -1;
 `;
 
-const StyledRowCell = styled(Flex)`
-  overflow: hidden;
-  padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
-`;
-
 const StyledRow = styled('div', {
   shouldForwardProp: prop => prop !== 'variant',
 })<{variant?: 'default' | 'faded'}>`
@@ -145,7 +130,7 @@ const StyledRow = styled('div', {
   ${p =>
     p.variant === 'faded' &&
     css`
-      ${StyledRowCell}, {
+      [role='cell'] {
         opacity: 0.8;
       }
     `}

--- a/static/app/views/detectors/components/details/common/openPeriodIssues.tsx
+++ b/static/app/views/detectors/components/details/common/openPeriodIssues.tsx
@@ -105,7 +105,7 @@ function OpenPeriodsSubTable({groupId, onZoom}: OpenPeriodsSubTableProps) {
             <SimpleTable.RowCell>
               <Duration seconds={seconds} abbreviation />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell justify="flex-end">
+            <SimpleTable.RowCell justify="end">
               <Button size="xs" onClick={() => onZoom(openPeriodStart, openPeriodEnd)}>
                 {t('Zoom')}
               </Button>
@@ -134,7 +134,7 @@ function OpenPeriodsSubTableSkeleton() {
           <SimpleTable.RowCell>
             <Placeholder height="20px" width="50%" />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell justify="flex-end">
+          <SimpleTable.RowCell justify="end">
             <Placeholder height="24px" width="48px" />
           </SimpleTable.RowCell>
         </SimpleTable.Row>

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -6,6 +6,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils';
 import {DetectorLink} from 'sentry/views/detectors/components/detectorLink';
 import {DetectorListConnectedAutomations} from 'sentry/views/detectors/components/detectorListConnectedAutomations';
 import {DetectorAssigneeCell} from 'sentry/views/detectors/components/detectorListTable/detectorAssigneeCell';
@@ -15,9 +16,15 @@ interface DetectorListRowProps {
   detector: Detector;
   onSelect: (id: string) => void;
   selected: boolean;
+  renderVisualization?: (detector: Detector) => React.ReactNode;
 }
 
-export function DetectorListRow({detector, selected, onSelect}: DetectorListRowProps) {
+export function DetectorListRow({
+  detector,
+  selected,
+  onSelect,
+  renderVisualization,
+}: DetectorListRowProps) {
   return (
     <DetectorSimpleTableRow
       variant={detector.enabled ? 'default' : 'faded'}
@@ -48,6 +55,7 @@ export function DetectorListRow({detector, selected, onSelect}: DetectorListRowP
       <SimpleTable.RowCell data-column-name="connected-automations">
         <DetectorListConnectedAutomations automationIds={detector.workflowIds} />
       </SimpleTable.RowCell>
+      {defined(renderVisualization) && renderVisualization(detector)}
     </DetectorSimpleTableRow>
   );
 }

--- a/static/app/views/detectors/list/cron.spec.tsx
+++ b/static/app/views/detectors/list/cron.spec.tsx
@@ -1,0 +1,128 @@
+import {CronDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+  type RouterConfig,
+} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import CronDetectorsList from 'sentry/views/detectors/list/cron';
+
+describe('CronDetectorsList', () => {
+  const organization = OrganizationFixture({
+    features: ['workflow-engine-ui'],
+  });
+
+  const initialRouterConfig: RouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/detectors/crons/`,
+    },
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/1/',
+      body: UserFixture(),
+    });
+
+    // Ensure a project is selected for queries
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}));
+
+    // Make elements report a non-zero size so timelines compute rollups and fetch
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        return 800;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 50;
+      },
+    });
+  });
+
+  it('displays empty state when no cron monitors are found', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [],
+    });
+
+    render(<CronDetectorsList />, {organization, initialRouterConfig});
+
+    // Should show text for onboarding state
+    expect(await screen.findByText('Monitor Your Cron Jobs')).toBeInTheDocument();
+  });
+
+  it('loads cron monitors, renders timeline, and updates on time selection', async () => {
+    // Detectors list returns a single cron monitor
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [CronDetectorFixture({name: 'Cron Detector'})],
+    });
+
+    // Monitor stats for the cron monitor id "uuid-foo"
+    const nowSec = Math.floor(Date.now() / 1000);
+    const monitorStatsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/monitors-stats/',
+      body: {
+        'uuid-foo': [
+          [
+            nowSec - 3600,
+            {
+              production: {
+                ok: 1,
+                error: 0,
+                missed: 0,
+                timeout: 0,
+                in_progress: 0,
+                unknown: 0,
+              },
+            },
+          ],
+        ],
+      },
+    });
+
+    const {router} = render(<CronDetectorsList />, {organization, initialRouterConfig});
+
+    // Page header/title and detector row
+    expect(await screen.findByText('Cron Monitors')).toBeInTheDocument();
+    const row = await screen.findByTestId('detector-list-row');
+    expect(row).toBeInTheDocument();
+
+    expect(screen.getByRole('columnheader', {name: /Name/})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Last Issue'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Assignee'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Alerts'})).toBeInTheDocument();
+
+    // Name
+    expect(within(row).getByText('Cron Detector')).toBeInTheDocument();
+
+    // Timeline visualization should render ticks once stats load
+    expect(await screen.findAllByTestId('monitor-checkin-tick')).not.toHaveLength(0);
+    expect(monitorStatsRequest).toHaveBeenCalled();
+
+    // Time range selector should be present
+    const timeTrigger = screen.getByTestId('page-filter-timerange-selector');
+    await userEvent.click(timeTrigger);
+    await userEvent.click(await screen.findByRole('option', {name: 'Last hour'}));
+
+    // Should update the stats period to 1h
+    await waitFor(() => {
+      expect(router.location.query.statsPeriod).toBe('1h');
+    });
+
+    // Updating stats period should cause the monitor stats request to refetch
+    expect(monitorStatsRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -1,20 +1,102 @@
+import {useCallback, useMemo, useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {Stack} from '@sentry/scraps/layout';
+
+import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlaceholder';
+import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
+import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import type {CronDetector, Detector} from 'sentry/types/workflowEngine/detectors';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useDimensions} from 'sentry/utils/useDimensions';
 import DetectorsList from 'sentry/views/detectors/list';
 import {
   MonitorViewContext,
   useMonitorViewContext,
+  type MonitorViewContextValue,
 } from 'sentry/views/detectors/monitorViewContext';
+import {CronsLandingPanel} from 'sentry/views/insights/crons/components/cronsLandingPanel';
+import {
+  checkInStatusPrecedent,
+  statusToText,
+  tickStyle,
+} from 'sentry/views/insights/crons/utils';
+import {selectCheckInData} from 'sentry/views/insights/crons/utils/selectCheckInData';
+import {useMonitorStats} from 'sentry/views/insights/crons/utils/useMonitorStats';
+
+function VisualizationCell({detector}: {detector: CronDetector}) {
+  const cronId = detector.dataSources[0].queryObj.id;
+  const cronEnvironments = detector.dataSources[0].queryObj.environments;
+
+  const elementRef = useRef<HTMLDivElement>(null);
+  const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
+  const timelineWidth = useDebouncedValue(containerWidth, 1000);
+  const timeWindowConfig = useTimeWindowConfig({timelineWidth});
+  const {data: monitorStats, isPending} = useMonitorStats({
+    monitors: [detector.dataSources[0].queryObj.id],
+    timeWindowConfig,
+  });
+
+  return (
+    <Cell
+      data-column-name="visualization"
+      padding="lg 0"
+      borderLeft="muted"
+      height="100%"
+    >
+      <Stack gap="lg" width="100%" ref={elementRef}>
+        {cronEnvironments.map(environment => {
+          if (isPending) {
+            return <CheckInPlaceholder key={environment.name} />;
+          }
+          return (
+            <CheckInTimeline
+              key={environment.name}
+              statusLabel={statusToText}
+              statusStyle={tickStyle}
+              statusPrecedent={checkInStatusPrecedent}
+              timeWindowConfig={timeWindowConfig}
+              bucketedData={selectCheckInData(
+                monitorStats?.[cronId] ?? [],
+                environment.name
+              )}
+            />
+          );
+        })}
+      </Stack>
+    </Cell>
+  );
+}
 
 export default function CronDetectorsList() {
   const parentContext = useMonitorViewContext();
 
+  const renderVisualization = useCallback((detector: Detector) => {
+    if (detector.type === 'monitor_check_in_failure') {
+      return <VisualizationCell detector={detector} />;
+    }
+    return null;
+  }, []);
+
+  const contextValue = useMemo<MonitorViewContextValue>(
+    () => ({
+      ...parentContext,
+      detectorFilter: 'monitor_check_in_failure',
+      renderVisualization,
+      showTimeRangeSelector: true,
+      emptyState: <CronsLandingPanel />,
+    }),
+    [parentContext, renderVisualization]
+  );
+
   return (
-    <MonitorViewContext.Provider
-      value={{
-        ...parentContext,
-        detectorFilter: 'monitor_check_in_failure',
-      }}
-    >
+    <MonitorViewContext.Provider value={contextValue}>
       <DetectorsList />
     </MonitorViewContext.Provider>
   );
 }
+
+const Cell = styled(SimpleTable.RowCell)`
+  z-index: 4;
+`;

--- a/static/app/views/detectors/monitorViewContext.tsx
+++ b/static/app/views/detectors/monitorViewContext.tsx
@@ -1,12 +1,15 @@
 import {createContext, useContext} from 'react';
 
-import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
+import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 
-interface MonitorViewContextValue {
+export interface MonitorViewContextValue {
   automationsLinkPrefix: string;
   monitorsLinkPrefix: string;
   assigneeFilter?: string;
   detectorFilter?: DetectorType;
+  emptyState?: React.ReactNode;
+  renderVisualization?: (detector: Detector) => React.ReactNode;
+  showTimeRangeSelector?: boolean;
 }
 
 const DEFAULT_MONITOR_VIEW_CONTEXT: MonitorViewContextValue = {
@@ -14,6 +17,8 @@ const DEFAULT_MONITOR_VIEW_CONTEXT: MonitorViewContextValue = {
   automationsLinkPrefix: 'monitors/alerts',
   assigneeFilter: undefined,
   detectorFilter: undefined,
+  showTimeRangeSelector: false,
+  emptyState: null,
 };
 
 export const MonitorViewContext = createContext<MonitorViewContextValue>(

--- a/static/app/views/insights/crons/utils/useMonitorStats.tsx
+++ b/static/app/views/insights/crons/utils/useMonitorStats.tsx
@@ -56,6 +56,7 @@ export function useMonitorStats(
     {
       staleTime: 0,
       enabled: enabled && rollupConfig.totalBuckets > 0,
+      retry: false,
       ...options,
     }
   );

--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -148,7 +148,7 @@ export function SizeCompareItemDiffTable({diffItems}: SizeCompareItemDiffTablePr
                 {changeTypeLabel}
               </ChangeTag>
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell justify="flex-start" style={{minWidth: 0}}>
+            <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
               <Tooltip
                 title={
                   diffItem.path ? (

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -88,7 +88,7 @@ type LocationConfig = {
   query?: Record<string, string | number | string[]>;
 };
 
-type RouterConfig = {
+export type RouterConfig = {
   /**
    * Child routes
    */


### PR DESCRIPTION
Uses the context to render a custom component in the visualization column. Also uses the overlay which allows you to select a time range by clicking and dragging.

<img width="1517" height="442" alt="CleanShot 2025-10-29 at 11 35 26" src="https://github.com/user-attachments/assets/5f6465bb-f7d5-47a1-aebf-44a1ffa43b08" />


