### PR TITLE
fix(optionsautomator): Add missing defaults

### DIFF
--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -119,6 +119,9 @@ def configoptions(
     """
 
     from sentry import options
+    from sentry.options import load_defaults
+
+    load_defaults()
 
     ctx.obj["dry_run"] = dry_run
     ctx.obj["timestamp"] = timestamp


### PR DESCRIPTION
When calling configoptions it was otherwise causing a key error on the recently changed object store.

