### PR TITLE
fix(explore): Runtime error on stringTags.hasOwnProperty

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -81,7 +81,7 @@ export function useEAPSpanSearchQueryBuilderProps(props: EAPSpanSearchQueryBuild
 
   const numberAttributes = numberTags;
   const stringAttributes = useMemo(() => {
-    if (stringTags.hasOwnProperty(SpanFields.RELEASE)) {
+    if (SpanFields.RELEASE in stringTags) {
       return {
         ...stringTags,
         ...STATIC_SEMVER_TAGS,

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -217,7 +217,7 @@ function useFilterKeySections(
       ...itemTypeToFilterKeySections(itemType).map(section => {
         return {
           ...section,
-          children: section.children.filter(key => stringAttributes.hasOwnProperty(key)),
+          children: section.children.filter(key => key in stringAttributes),
         };
       }),
       {

--- a/static/app/views/explore/hooks/useExploreSuggestedAttribute.tsx
+++ b/static/app/views/explore/hooks/useExploreSuggestedAttribute.tsx
@@ -13,21 +13,21 @@ export function useExploreSuggestedAttribute({
 }: UseExploreSuggestedAttributeOptions) {
   return useCallback(
     (key: string): string | null => {
-      if (stringAttributes.hasOwnProperty(key)) {
+      if (key in stringAttributes) {
         return key;
       }
 
-      if (numberAttributes.hasOwnProperty(key)) {
+      if (key in numberAttributes) {
         return key;
       }
 
       const explicitStringAttribute = `tags[${key},string]`;
-      if (stringAttributes.hasOwnProperty(explicitStringAttribute)) {
+      if (explicitStringAttribute in stringAttributes) {
         return explicitStringAttribute;
       }
 
       const explicitNumberAttribute = `tags[${key},number]`;
-      if (numberAttributes.hasOwnProperty(explicitNumberAttribute)) {
+      if (explicitNumberAttribute in numberAttributes) {
         return explicitNumberAttribute;
       }
 

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -39,10 +39,7 @@ export function useGroupByFields({
         .map(([_, tag]) => optionFromTag(tag, traceItemType)),
       ...groupBys
         .filter(
-          groupBy =>
-            groupBy &&
-            !numberTags.hasOwnProperty(groupBy) &&
-            !stringTags.hasOwnProperty(groupBy)
+          groupBy => groupBy && !(groupBy in numberTags) && !(groupBy in stringTags)
         )
         .map(groupBy =>
           optionFromTag({key: groupBy, name: groupBy, kind: FieldKind.TAG}, traceItemType)

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -50,10 +50,7 @@ export function ColumnEditorModal({
   const tags: Array<SelectOption<string>> = useMemo(() => {
     let allTags = [
       ...columns
-        .filter(
-          column =>
-            !stringTags.hasOwnProperty(column) && !numberTags.hasOwnProperty(column)
-        )
+        .filter(column => !(column in stringTags) && !(column in numberTags))
         .map(column => {
           const kind = classifyTagKey(column);
           const label = prettifyTagKey(column);

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -564,11 +564,11 @@ export function findSuggestedColumns(
     }
 
     const isStringAttribute = key.startsWith('!')
-      ? attributes.stringAttributes.hasOwnProperty(key.slice(1))
-      : attributes.stringAttributes.hasOwnProperty(key);
+      ? key.slice(1) in attributes.stringAttributes
+      : key in attributes.stringAttributes;
     const isNumberAttribute = key.startsWith('!')
-      ? attributes.numberAttributes.hasOwnProperty(key.slice(1))
-      : attributes.numberAttributes.hasOwnProperty(key);
+      ? key.slice(1) in attributes.numberAttributes
+      : key in attributes.numberAttributes;
 
     // guard against unknown keys and aggregate keys
     if (!isStringAttribute && !isNumberAttribute) {
@@ -628,7 +628,7 @@ function isSimpleFilter(
 
   // all number attributes are considered non trivial because they
   // almost always match on a range of values
-  if (attributes.numberAttributes.hasOwnProperty(key)) {
+  if (key in attributes.numberAttributes) {
     return false;
   }
 


### PR DESCRIPTION
- FIXES: [ISSUE](https://sentry.sentry.io/issues/6982212742/?alert_rule_id=14828501&alert_type=issue&notification_uuid=742f16fe-594e-465f-ba05-6850ea60d796&project=11276&referrer=slack), it's reproducible
- stringTags has the correct type `TagCollection` since we always add hardcoded entries, never null/undefined
- Seems like a runtime issue where the `stringTags` loses prototype, event though it's declared as a Record<...> initially
- fwiw I repaced all key checks for tags on the page with `'key in obj'`