### PR TITLE
feat(aci): add counts to connected automation list pagination

### DIFF
--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -10,10 +10,11 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import AutomationTitleCell from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {parseCursor} from 'sentry/utils/cursor';
 import {useAutomationsQuery} from 'sentry/views/automations/hooks';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 
@@ -92,6 +93,25 @@ export function ConnectedAutomationsList({
   );
 
   const pageLinks = getResponseHeader?.('Link');
+  const totalCount = getResponseHeader?.('X-Hits');
+  const totalCountInt = totalCount ? parseInt(totalCount, 10) : 0;
+
+  const paginationCaption = useMemo(() => {
+    if (!automations || automations.length === 0 || isLoading || limit === null) {
+      return undefined;
+    }
+
+    const currentCursor = parseCursor(cursor);
+    const offset = currentCursor?.offset ?? 0;
+    const startCount = offset * limit + 1;
+    const endCount = startCount + automations.length - 1;
+
+    return tct('[start]-[end] of [total]', {
+      start: startCount.toLocaleString(),
+      end: endCount.toLocaleString(),
+      total: totalCountInt.toLocaleString(),
+    });
+  }, [automations, isLoading, cursor, limit, totalCountInt]);
 
   return (
     <Container {...props}>
@@ -151,7 +171,13 @@ export function ConnectedAutomationsList({
             </SimpleTable.Row>
           ))}
       </SimpleTableWithColumns>
-      {limit === null ? null : <Pagination onCursor={onCursor} pageLinks={pageLinks} />}
+      {limit && totalCountInt > limit && (
+        <Pagination
+          onCursor={onCursor}
+          pageLinks={pageLinks}
+          caption={paginationCaption}
+        />
+      )}
     </Container>
   );
 }

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -171,11 +171,11 @@ export function ConnectedAutomationsList({
             </SimpleTable.Row>
           ))}
       </SimpleTableWithColumns>
-      {limit && totalCountInt > limit && (
+      {limit && (
         <Pagination
           onCursor={onCursor}
           pageLinks={pageLinks}
-          caption={paginationCaption}
+          caption={totalCountInt > limit ? paginationCaption : null}
         />
       )}
     </Container>

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -1,9 +1,9 @@
+import {useState} from 'react';
+
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
 
 type Props = {
@@ -11,11 +11,7 @@ type Props = {
 };
 
 export function DetectorDetailsAutomations({detector}: Props) {
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const cursor =
-    typeof location.query.cursor === 'string' ? location.query.cursor : undefined;
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
 
   return (
     <Section title={t('Connected Alerts')}>
@@ -23,15 +19,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
         <ConnectedAutomationsList
           automationIds={detector.workflowIds}
           cursor={cursor}
-          onCursor={newCursor => {
-            navigate({
-              pathname: location.pathname,
-              query: {
-                ...location.query,
-                cursor: newCursor,
-              },
-            });
-          }}
+          onCursor={setCursor}
         />
       </ErrorBoundary>
     </Section>


### PR DESCRIPTION
hides the pagination if there aren't multiple pages

<img width="992" height="647" alt="Screenshot 2025-10-29 at 1 44 45 PM" src="https://github.com/user-attachments/assets/d70c01b7-d5e9-4f7f-986b-1ec8c130dddc" />


updates to the connected detector list will come in the next PR, the related components could use some refactoring so I want to split it up