### PR TITLE
feat(analytics): Add Seer access tracking to Issue Details Viewed event

### DIFF
--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,3 +1,4 @@
+import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 import {ConfigFixture} from 'sentry-fixture/config';
 import {EnvironmentsFixture} from 'sentry-fixture/environments';
 import {EventFixture} from 'sentry-fixture/event';
@@ -148,6 +149,10 @@ describe('groupDetails', () => {
     MockApiClient.addMockResponse({
       url: `/projects/${defaultInit.organization.slug}/${project.slug}/`,
       body: project,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/autofix/setup/`,
+      body: AutofixSetupFixture({}),
     });
   });
 

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -19,7 +19,6 @@ import {featureFlagDrawerPlatforms} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
-import {DataCategory} from 'sentry/types/core';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {GroupStatus, IssueCategory, IssueType} from 'sentry/types/group';
@@ -526,29 +525,6 @@ function useTrackView({
   const user = useUser();
   const hasStreamlinedUI = useHasStreamlinedUI();
 
-  // Calculate Seer access properties
-  const hasSeerAccess = hasAutofixQuota;
-
-  // Check if there's an active trial for SEER_AUTOFIX
-  const hasActiveAutofixTrial =
-    organization.productTrials?.some(trial => {
-      if (trial.category !== DataCategory.SEER_AUTOFIX || !trial.isStarted) {
-        return false;
-      }
-      // Check if trial hasn't expired
-      if (trial.endDate) {
-        const endDate = new Date(trial.endDate);
-        return endDate > new Date();
-      }
-      return false;
-    }) ?? false;
-
-  const seerAccessType = hasSeerAccess
-    ? hasActiveAutofixTrial
-      ? 'trial'
-      : 'purchased'
-    : undefined;
-
   useRouteAnalyticsEventNames('issue_details.viewed', 'Issue Details: Viewed');
   useRouteAnalyticsParams({
     ...getAnalyticsDataForGroup(group),
@@ -569,8 +545,7 @@ function useTrackView({
       user?.options?.prefersIssueDetailsStreamlinedUI === null,
     org_streamline_only: organization.streamlineOnly ?? undefined,
     has_streamlined_ui: hasStreamlinedUI,
-    has_seer_access: hasSeerAccess,
-    seer_access_type: seerAccessType,
+    has_seer_access: hasAutofixQuota,
   });
   // Set default values for properties that may be updated in subcomponents.
   // Must be separate from the above values, otherwise the actual values filled in


### PR DESCRIPTION
## Description

Adds `has_seer_access` property to the "Issue Details: Viewed" analytics event to track whether the viewer's organization has access to Seer.

This helps measure the breadth of automations usage across organizations viewing issues.

## Changes

### New Analytics Property

- **`has_seer_access`** (boolean): Whether the organization has Seer access (based on available Seer quota)
  - `true` - Organization has Seer access (trial or purchased)
  - `false` - Organization does not have Seer access

### Implementation Details

1. Added `useAiConfig` hook to get `hasAutofixQuota` from the backend
2. The `hasAutofixQuota` value comes from the `/autofix/setup/` endpoint which checks if the organization has Seer quota
3. Pass `hasAutofixQuota` to the analytics tracking function
4. Added `has_seer_access` property to the analytics event parameters
5. Added test mock for the autofix setup endpoint to fix failing tests

## Testing

- ✅ All 14 tests in `groupDetails.spec.tsx` pass locally
- ✅ Code passes linting checks
- [ ] Manual testing: View issue details page and verify analytics event includes `has_seer_access` property

## Related

Fixes AIML-1431