### PR TITLE
feat(tracemetrics): Make aggregate table scrollable with sticky column

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -364,6 +364,7 @@ function CellAction({
       >
         {cellActions?.length ? (
           <DropdownMenu
+            usePortal
             items={cellActions}
             strategy="fixed"
             size="sm"

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -1,6 +1,7 @@
-import {useMemo} from 'react';
-import {useTheme} from '@emotion/react';
+import {useEffect, useMemo, useRef} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import throttle from 'lodash/throttle';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -37,8 +38,8 @@ interface AggregatesTabProps {
 }
 
 export function AggregatesTab({metricName}: AggregatesTabProps) {
-  const theme = useTheme();
   const topEvents = useTopEvents();
+  const tableRef = useRef<HTMLDivElement>(null);
 
   const {result, eventView, fields} = useMetricAggregatesTable({
     enabled: Boolean(metricName),
@@ -87,11 +88,59 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
     return index === fields.length - 1;
   };
 
+  // Detect horizontal scroll to conditionally show sticky column shadow
+  useEffect(() => {
+    const tableElement = tableRef.current;
+    if (!tableElement) {
+      return undefined;
+    }
+
+    const checkScroll = () => {
+      const {scrollWidth, clientWidth, scrollLeft} = tableElement;
+      const hasOverflow = scrollWidth > clientWidth;
+      // Check if scrolled all the way to the right, use < 1 as threshold to account for precision issues
+      const isScrolledFullyRight = Math.abs(scrollLeft + clientWidth - scrollWidth) < 1;
+
+      // Update box-shadow directly on DOM elements (prevents re-renders)
+      const shouldShowShadow = hasOverflow && !isScrolledFullyRight;
+      const stickyCells = tableElement.querySelectorAll<HTMLElement>(
+        '[data-sticky-column="true"]'
+      );
+      stickyCells.forEach(cell => {
+        cell.style.boxShadow = shouldShowShadow
+          ? '-2px 0px 4px -1px rgba(0, 0, 0, 0.1)'
+          : 'none';
+      });
+    };
+
+    // Throttle scroll handler to avoid calling this too often
+    const throttledCheckScroll = throttle(checkScroll, 100, {
+      leading: true,
+      trailing: true,
+    });
+
+    // Check on mount and when content changes
+    checkScroll();
+
+    // Listen to scroll events with throttled handler
+    tableElement.addEventListener('scroll', throttledCheckScroll);
+
+    // Use ResizeObserver to check when table size changes
+    const resizeObserver = new ResizeObserver(throttledCheckScroll);
+    resizeObserver.observe(tableElement);
+
+    return () => {
+      tableElement.removeEventListener('scroll', throttledCheckScroll);
+      throttledCheckScroll.cancel();
+      resizeObserver.disconnect();
+    };
+  }, [result.data, fields.length]);
+
   return (
-    <StickyCompatibleSimpleTable style={tableStyle}>
+    <StickyCompatibleSimpleTable ref={tableRef} style={tableStyle}>
       {result.isPending && <TransparentLoadingMask />}
 
-      <StyledSimpleTableHeader style={{zIndex: 2}}>
+      <StickyCompatibleStyledHeader>
         {fields.map((field, i) => {
           let label = field;
           const tag = stringTags?.[field] ?? numberTags?.[field] ?? null;
@@ -112,35 +161,23 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
           }
 
           return (
-            <StyledSimpleTableHeaderCell
+            <StickyCompatibleStyledHeaderCell
               key={i}
               divider={!isLastColumn(i)}
-              style={{
-                justifyContent: func ? 'flex-end' : 'flex-start',
-                padding: '0 4px',
-
-                // Sticky styles for last column
-                ...(isLastColumn(i) && {
-                  position: 'sticky',
-                  right: 0,
-                  background: theme.bodyBackground,
-                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.05)',
-                  height: '100%',
-                }),
-                zIndex: 2,
-              }}
+              data-sticky-column={isLastColumn(i) ? 'true' : undefined}
+              isSticky={isLastColumn(i)}
               sort={direction}
               handleSortClick={updateSort}
             >
               <Tooltip showOnlyOnOverflow title={label}>
                 {label}
               </Tooltip>
-            </StyledSimpleTableHeaderCell>
+            </StickyCompatibleStyledHeaderCell>
           );
         })}
-      </StyledSimpleTableHeader>
+      </StickyCompatibleStyledHeader>
 
-      <StyledSimpleTableBody style={{overflow: 'unset'}}>
+      <StickyCompatibleTableBody>
         {result.isError ? (
           <SimpleTable.Empty>
             <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
@@ -152,22 +189,12 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
                 <StyledTopResultsIndicator count={topEvents} index={i} />
               )}
               {fields.map((field, j) => (
-                <StyledSimpleTableRowCell
+                <StickyCompatibleStyledRowCell
                   key={j}
                   hasPadding
-                  style={{
-                    paddingLeft: j === 0 ? firstColumnOffset : '0px',
-                    ...(isLastColumn(j) && {
-                      position: 'sticky',
-                      right: 0,
-                      zIndex: 1,
-                      justifySelf: 'end',
-                      width: '100%',
-                      background: theme.background,
-                      boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-                      height: '100%',
-                    }),
-                  }}
+                  data-sticky-column={isLastColumn(j) ? 'true' : undefined}
+                  isSticky={isLastColumn(j)}
+                  offset={j === 0 ? firstColumnOffset : '0px'}
                 >
                   <FieldRenderer
                     column={columns[j]}
@@ -175,7 +202,7 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
                     unit={getMetricsUnit(meta, field)}
                     meta={meta}
                   />
-                </StyledSimpleTableRowCell>
+                </StickyCompatibleStyledRowCell>
               ))}
             </SimpleTable.Row>
           ))
@@ -190,11 +217,53 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
             </EmptyStateWarning>
           </SimpleTable.Empty>
         )}
-      </StyledSimpleTableBody>
+      </StickyCompatibleTableBody>
     </StickyCompatibleSimpleTable>
   );
 }
 
 const StickyCompatibleSimpleTable = styled(StyledSimpleTable)`
   overflow: auto;
+`;
+
+const StickyCompatibleTableBody = styled(StyledSimpleTableBody)`
+  overflow: unset;
+`;
+
+const StickyCompatibleStyledHeader = styled(StyledSimpleTableHeader)`
+  z-index: 2;
+`;
+
+const StickyCompatibleStyledHeaderCell = styled(StyledSimpleTableHeaderCell)<{
+  isSticky: boolean;
+}>`
+  justify-content: ${p => (p.isSticky ? 'flex-end' : 'flex-start')};
+  padding: 0 4px;
+  ${p =>
+    p.isSticky &&
+    css`
+      position: sticky;
+      right: 0;
+      background: ${p.theme.bodyBackground};
+      height: 100%;
+      z-index: 2;
+    `};
+`;
+
+const StickyCompatibleStyledRowCell = styled(StyledSimpleTableRowCell)<{
+  isSticky: boolean;
+  offset: string;
+}>`
+  padding-left: ${p => p.offset};
+  ${p =>
+    p.isSticky &&
+    css`
+      position: sticky;
+      right: 0;
+      background: ${p.theme.background};
+      height: 100%;
+      z-index: 1;
+      justify-self: end;
+      width: 100%;
+    `};
 `;

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -57,7 +57,7 @@ export const StyledSimpleTableHeaderCell = styled(SimpleTable.HeaderCell)`
 export const StyledSimpleTableBody = styled('div')`
   position: relative;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   min-height: 0;
   display: grid;
   grid-template-columns: subgrid;

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -57,7 +57,7 @@ export const StyledSimpleTableHeaderCell = styled(SimpleTable.HeaderCell)`
 export const StyledSimpleTableBody = styled('div')`
   position: relative;
   overflow-y: auto;
-  overflow-x: auto;
+  overflow-x: hidden;
   min-height: 0;
   display: grid;
   grid-template-columns: subgrid;


### PR DESCRIPTION
Makes the aggregate table scrollable, meanwhile keeping the last column (the aggregate) sticky. I needed to override some styles to make it work for this component and added an effect that checks to conditionally apply the box shadow styling when the sticky column starts to overlap other coumns.


https://github.com/user-attachments/assets/1406439c-d90a-4c7d-9aae-96377a747382

