### PR TITLE
fix(widget-builder): Expose numeric attributes for grouping

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -7,7 +7,7 @@ import {waitFor} from 'sentry-test/reactTestingLibrary';
 import type {Client} from 'sentry/api';
 import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES, FieldKind} from 'sentry/utils/fields';
+import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
 import {WidgetType} from 'sentry/views/dashboards/types';
 
@@ -63,28 +63,5 @@ describe('SpansConfig', () => {
         })
       );
     });
-  });
-
-  it('returns the string tags as group by options', () => {
-    const mockTags = {
-      ['transaction']: {
-        name: 'transaction',
-        key: 'transaction',
-        kind: FieldKind.TAG,
-      },
-      ['platform']: {
-        name: 'platform',
-        key: 'platform',
-        kind: FieldKind.TAG,
-      },
-      ['span.duration']: {
-        name: 'span.duration',
-        key: 'span.duration',
-        kind: FieldKind.MEASUREMENT,
-      },
-    };
-    const groupByOptions = SpansConfig.getGroupByFieldOptions!(organization, mockTags);
-
-    expect(Object.keys(groupByOptions)).toEqual(['tag:transaction', 'tag:platform']);
   });
 });

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -273,15 +273,6 @@ function getPrimaryFieldOptions(
   return {...baseFieldOptions, ...spanTags};
 }
 
-function _isNotNumericTag(option: FieldValueOption) {
-  // Filter out numeric tags from primary options, they only show up in
-  // the parameter fields for aggregate functions
-  if ('dataType' in option.value.meta) {
-    return option.value.meta.dataType !== 'number';
-  }
-  return true;
-}
-
 function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryFieldValue) {
   // Allow for unknown values to be used for aggregate functions
   // This supports showing the tag value even if it's not in the current
@@ -383,10 +374,7 @@ function getGroupByFieldOptions(
   );
   const yAxisFilter = filterYAxisOptions();
 
-  // The only options that should be returned as valid group by options
-  // are string tags
-  const filterGroupByOptions = (option: FieldValueOption) =>
-    _isNotNumericTag(option) && !yAxisFilter(option);
+  const filterGroupByOptions = (option: FieldValueOption) => !yAxisFilter(option);
 
   return pickBy(primaryFieldOptions, filterGroupByOptions);
 }


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/102230, the main explore page exposes
numeric attributes for grouping so Dashboards should remove this filter and show the same
values.