### PR TITLE
chore(explore): migrate page params hooks to query params

### DIFF
--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -18,7 +18,6 @@ import type {Organization, SavedQuery} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useSetExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
 import {useSetQueryParamsSavedQuery} from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -48,19 +47,7 @@ function SaveQueryModal({
   const [isSaving, setIsSaving] = useState(false);
   const [starred, setStarred] = useState(true);
 
-  const setExplorePageParams = useSetExplorePageParams();
   const setQueryParamsSavedQuery = useSetQueryParamsSavedQuery();
-
-  const updatePageIdAndTitle = useCallback(
-    (id: string, title: string) => {
-      if (traceItemDataset === TraceItemDataset.LOGS) {
-        setQueryParamsSavedQuery(id, title);
-      } else if (traceItemDataset === TraceItemDataset.SPANS) {
-        setExplorePageParams({id, title});
-      }
-    },
-    [setExplorePageParams, setQueryParamsSavedQuery, traceItemDataset]
-  );
 
   const onSave = useCallback(async () => {
     try {
@@ -68,7 +55,7 @@ function SaveQueryModal({
       addLoadingMessage(t('Saving query...'));
       const {id} = await saveQuery(name, initialName === undefined ? starred : undefined);
       if (initialName === undefined) {
-        updatePageIdAndTitle(id, name);
+        setQueryParamsSavedQuery(id, name);
       }
       addSuccessMessage(t('Query saved successfully'));
       if (defined(source)) {
@@ -99,7 +86,7 @@ function SaveQueryModal({
     saveQuery,
     name,
     starred,
-    updatePageIdAndTitle,
+    setQueryParamsSavedQuery,
     closeModal,
     organization,
     initialName,

--- a/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
@@ -18,7 +18,7 @@ export interface GroupBy {
   groupBy: string;
 }
 
-export function isBaseVisualize(value: any): value is BaseVisualize {
+function isBaseVisualize(value: any): value is BaseVisualize {
   return (
     defined(value) &&
     typeof value === 'object' &&
@@ -105,23 +105,6 @@ export function getAggregateFieldsFromLocation(
   }
 
   return aggregateFields;
-}
-
-export function updateLocationWithAggregateFields(
-  location: Location,
-  aggregateFields: Array<GroupBy | BaseVisualize> | null | undefined
-) {
-  if (defined(aggregateFields)) {
-    location.query.aggregateField = aggregateFields.flatMap(aggregateField => {
-      if (isBaseVisualize(aggregateField)) {
-        const visualizes = Visualize.fromJSON(aggregateField);
-        return visualizes.map(visualize => JSON.stringify(visualize.toJSON()));
-      }
-      return [JSON.stringify(aggregateField)];
-    });
-  } else if (aggregateFields === null) {
-    delete location.query.aggregateField;
-  }
 }
 
 function parseGroupByOrBaseVisualize(

--- a/static/app/views/explore/contexts/pageParamsContext/aggregateSortBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/aggregateSortBys.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 
@@ -54,20 +53,4 @@ function validateSorts(
       groupBys.includes(sortBy.field) ||
       visualizes.some(visualize => visualize.yAxis === sortBy.field)
   );
-}
-
-export function updateLocationWithAggregateSortBys(
-  location: Location,
-  sortBys: Sort[] | null | undefined
-) {
-  if (defined(sortBys)) {
-    location.query.aggregateSort = sortBys.map(sortBy =>
-      sortBy.kind === 'desc' ? `-${sortBy.field}` : sortBy.field
-    );
-
-    // make sure to clear the cursor every time the query is updated
-    delete location.query.cursor;
-  } else if (sortBys === null) {
-    delete location.query.aggregateSort;
-  }
 }

--- a/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/dataset.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {defined} from 'sentry/utils';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 
@@ -23,15 +22,4 @@ function parseDataset(rawDataset: string | undefined) {
   }
 
   return undefined;
-}
-
-export function updateLocationWithDataset(
-  location: Location,
-  dataset: DiscoverDatasets | null | undefined
-) {
-  if (defined(dataset)) {
-    location.query.dataset = dataset;
-  } else if (dataset === null) {
-    delete location.query.dataset;
-  }
 }

--- a/static/app/views/explore/contexts/pageParamsContext/fields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/fields.tsx
@@ -1,7 +1,6 @@
 import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import {decodeList} from 'sentry/utils/queryString';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -36,17 +35,6 @@ export function getFieldsFromLocation(
   }
 
   return defaultFields(organization);
-}
-
-export function updateLocationWithFields(
-  location: Location,
-  fields: string[] | undefined | null
-) {
-  if (defined(fields)) {
-    location.query.field = fields;
-  } else if (fields === null) {
-    delete location.query.field;
-  }
 }
 
 export function isDefaultFields(location: Location): boolean {

--- a/static/app/views/explore/contexts/pageParamsContext/id.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/id.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {defined} from 'sentry/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 
 export function defaultId(): undefined {
@@ -9,12 +8,4 @@ export function defaultId(): undefined {
 
 export function getIdFromLocation(location: Location) {
   return decodeScalar(location.query.id);
-}
-
-export function updateLocationWithId(location: Location, id: string | null | undefined) {
-  if (defined(id)) {
-    location.query.id = id;
-  } else if (id === null) {
-    delete location.query.id;
-  }
 }

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -3,20 +3,16 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {
-  PageParamsProvider,
-  useExplorePageParams,
-  useSetExplorePageParams,
-} from 'sentry/views/explore/contexts/pageParamsContext';
+import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {
   DEFAULT_VISUALIZATION,
   DEFAULT_VISUALIZATION_AGGREGATE,
   DEFAULT_VISUALIZATION_FIELD,
-  Visualize,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {
+  useQueryParams,
+  useSetQueryParams,
   useSetQueryParamsAggregateSortBys,
   useSetQueryParamsFields,
   useSetQueryParamsGroupBys,
@@ -25,6 +21,7 @@ import {
   useSetQueryParamsSortBys,
   useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
@@ -51,8 +48,8 @@ describe('defaults', () => {
 });
 
 describe('PageParamsProvider', () => {
-  let pageParams: ReturnType<typeof useExplorePageParams>;
-  let setPageParams: ReturnType<typeof useSetExplorePageParams>;
+  let queryParams: ReturnType<typeof useQueryParams>;
+  let setQueryParams: ReturnType<typeof useSetQueryParams>;
   let setFields: ReturnType<typeof useSetQueryParamsFields>;
   let setGroupBys: ReturnType<typeof useSetQueryParamsGroupBys>;
   let setMode: ReturnType<typeof useSetQueryParamsMode>;
@@ -62,8 +59,8 @@ describe('PageParamsProvider', () => {
   let setVisualizes: ReturnType<typeof useSetQueryParamsVisualizes>;
 
   function Component() {
-    pageParams = useExplorePageParams();
-    setPageParams = useSetExplorePageParams();
+    queryParams = useQueryParams();
+    setQueryParams = useSetQueryParams();
     setFields = useSetQueryParamsFields();
     setGroupBys = useSetQueryParamsGroupBys();
     setMode = useSetQueryParamsMode();
@@ -82,12 +79,11 @@ describe('PageParamsProvider', () => {
     );
 
     act(() =>
-      setPageParams({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp'],
+      setQueryParams({
+        fields: ['id', 'timestamp', 'span.op'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
@@ -108,9 +104,8 @@ describe('PageParamsProvider', () => {
       </Wrapper>
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: undefined,
         fields: [
           'id',
           'span.op',
@@ -121,9 +116,9 @@ describe('PageParamsProvider', () => {
         ],
         mode: Mode.SAMPLES,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
         aggregateSortBys: [{field: 'count(span.duration)', kind: 'desc'}],
-        aggregateFields: [{groupBy: ''}, new Visualize('count(span.duration)')],
+        aggregateFields: [{groupBy: ''}, new VisualizeFunction('count(span.duration)')],
       })
     );
   });
@@ -133,17 +128,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setFields(['id', 'span.op', 'timestamp']));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
         fields: ['id', 'span.op', 'timestamp'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -156,18 +150,24 @@ describe('PageParamsProvider', () => {
 
     act(() => setGroupBys(['browser.name', 'sdk.name']));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time', 'browser.name', 'sdk.name'],
+        fields: [
+          'id',
+          'timestamp',
+          'span.op',
+          'span.self_time',
+          'browser.name',
+          'sdk.name',
+        ],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'browser.name'},
           {groupBy: 'sdk.name'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -180,16 +180,15 @@ describe('PageParamsProvider', () => {
 
     act(() => setGroupBys([]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
           {groupBy: ''},
@@ -203,17 +202,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setGroupBys(['']));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: ''},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -226,17 +224,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setMode(Mode.AGGREGATE));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -254,23 +251,22 @@ describe('PageParamsProvider', () => {
           yAxes: ['count(span.self_time)'],
         },
       ],
-      sampleSortBys: null,
+      sortBys: null,
       aggregateSortBys: null,
     });
 
     act(() => setMode(Mode.SAMPLES));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: ''},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -281,9 +277,9 @@ describe('PageParamsProvider', () => {
   it('updates fields with managed group bys', () => {
     renderTestComponent({
       mode: Mode.AGGREGATE,
-      sampleSortBys: null,
+      sortBys: null,
       aggregateSortBys: null,
-      fields: ['id', 'timestamp'],
+      fields: ['id', 'timestamp', 'span.description'],
       aggregateFields: [
         {groupBy: 'span.description'},
         {groupBy: ''},
@@ -296,18 +292,24 @@ describe('PageParamsProvider', () => {
 
     act(() => setGroupBys(['sdk.name', 'sdk.version']));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time', 'sdk.name', 'sdk.version'],
+        fields: [
+          'id',
+          'timestamp',
+          'span.description',
+          'span.self_time',
+          'sdk.name',
+          'sdk.version',
+        ],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
           {groupBy: 'sdk.version'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -320,17 +322,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setQuery('foo:bar'));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: 'foo:bar',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -343,17 +344,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setSortBys([{field: 'id', kind: 'desc'}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
-        sampleSortBys: [{field: 'id', kind: 'desc'}],
+        sortBys: [{field: 'id', kind: 'desc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -366,17 +366,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setSortBys([{field: 'span.op', kind: 'desc'}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        sortBys: [{field: 'span.op', kind: 'desc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -398,20 +397,19 @@ describe('PageParamsProvider', () => {
 
     act(() => setAggregateSortBys([{field: 'max(span.duration)', kind: 'desc'}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'max(span.duration)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('min(span.self_time)', {
+          new VisualizeFunction('min(span.self_time)', {
             chartType: ChartType.AREA,
           }),
-          new Visualize('max(span.duration)', {
+          new VisualizeFunction('max(span.duration)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -433,20 +431,19 @@ describe('PageParamsProvider', () => {
 
     act(() => setAggregateSortBys([{field: 'avg(span.duration)', kind: 'desc'}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('min(span.self_time)', {
+          new VisualizeFunction('min(span.self_time)', {
             chartType: ChartType.AREA,
           }),
-          new Visualize('max(span.duration)', {
+          new VisualizeFunction('max(span.duration)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -468,17 +465,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setAggregateSortBys([{field: 'sdk.name', kind: 'desc'}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'sdk.name', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'sdk.name', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -500,17 +496,16 @@ describe('PageParamsProvider', () => {
 
     act(() => setAggregateSortBys([{field: 'sdk.version', kind: 'desc'}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'sdk.name', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
         ],
@@ -523,15 +518,17 @@ describe('PageParamsProvider', () => {
 
     act(() => setVisualizes([]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.duration)', kind: 'desc'}],
-        aggregateFields: [{groupBy: 'span.op'}, new Visualize('count(span.duration)')],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new VisualizeFunction('count(span.duration)'),
+        ],
       })
     );
   });
@@ -552,23 +549,22 @@ describe('PageParamsProvider', () => {
       ])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        dataset: DiscoverDatasets.SPANS,
-        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time', 'span.duration'],
         mode: Mode.AGGREGATE,
         query: '',
-        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
         aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize('count(span.self_time)', {
+          new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
-          new Visualize('avg(span.duration)', {
+          new VisualizeFunction('avg(span.duration)', {
             chartType: ChartType.LINE,
           }),
-          new Visualize('avg(span.self_time)', {
+          new VisualizeFunction('avg(span.self_time)', {
             chartType: ChartType.LINE,
           }),
         ],
@@ -583,9 +579,9 @@ describe('PageParamsProvider', () => {
       setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time', 'span.duration'],
       })
     );
 
@@ -598,17 +594,17 @@ describe('PageParamsProvider', () => {
       ])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time', 'span.duration'],
       })
     );
 
     act(() => setVisualizes([{yAxes: ['count(span.self_time)']}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        fields: ['id', 'timestamp', 'span.self_time'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
       })
     );
   });
@@ -620,9 +616,9 @@ describe('PageParamsProvider', () => {
       setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time', 'span.duration'],
       })
     );
 
@@ -630,7 +626,7 @@ describe('PageParamsProvider', () => {
       setFields(['id', 'timestamp', 'span.self_time', 'span.duration', 'span.duration'])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration', 'span.duration'],
       })
@@ -638,7 +634,7 @@ describe('PageParamsProvider', () => {
 
     act(() => setVisualizes([{yAxes: ['count(span.self_time)']}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
       })
@@ -652,9 +648,9 @@ describe('PageParamsProvider', () => {
       setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time', 'span.duration'],
       })
     );
 
@@ -668,7 +664,7 @@ describe('PageParamsProvider', () => {
       ])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time'],
       })
@@ -682,7 +678,7 @@ describe('PageParamsProvider', () => {
       ])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
       })
@@ -694,7 +690,7 @@ describe('PageParamsProvider', () => {
 
     act(() => setFields(['id', 'timestamp', 'span.self_time', 'span.duration']));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
       })
@@ -704,7 +700,7 @@ describe('PageParamsProvider', () => {
       setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
       })
@@ -712,7 +708,7 @@ describe('PageParamsProvider', () => {
 
     act(() => setVisualizes([{yAxes: ['count(span.self_time)']}]));
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
       })
@@ -731,9 +727,16 @@ describe('PageParamsProvider', () => {
       {organization}
     );
 
-    expect(pageParams).toEqual(
+    expect(queryParams).toEqual(
       expect.objectContaining({
-        fields: ['id', 'span.name', 'span.duration', 'timestamp'],
+        fields: [
+          'id',
+          'span.name',
+          'span.description',
+          'span.duration',
+          'transaction',
+          'timestamp',
+        ],
       })
     );
   });

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -1,61 +1,33 @@
 import type React from 'react';
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import type {Location} from 'history';
+import {createContext, useEffect, useMemo, useState} from 'react';
 
-import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
-import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   defaultId,
   getIdFromLocation,
-  updateLocationWithId,
 } from 'sentry/views/explore/contexts/pageParamsContext/id';
 
-import type {AggregateField, GroupBy} from './aggregateFields';
+import type {AggregateField} from './aggregateFields';
 import {
   defaultAggregateFields,
   getAggregateFieldsFromLocation,
-  isBaseVisualize,
   isGroupBy,
   isVisualize,
-  updateLocationWithAggregateFields,
 } from './aggregateFields';
 import {
   defaultAggregateSortBys,
   getAggregateSortBysFromLocation,
-  updateLocationWithAggregateSortBys,
 } from './aggregateSortBys';
-import {
-  defaultDataset,
-  getDatasetFromLocation,
-  updateLocationWithDataset,
-} from './dataset';
-import {
-  defaultFields,
-  getFieldsFromLocation,
-  isDefaultFields,
-  updateLocationWithFields,
-} from './fields';
-import {defaultMode, getModeFromLocation, Mode, updateLocationWithMode} from './mode';
-import {defaultQuery, getQueryFromLocation, updateLocationWithQuery} from './query';
-import {
-  defaultSortBys,
-  getSortBysFromLocation,
-  updateLocationWithSortBys,
-} from './sortBys';
-import {defaultTitle, getTitleFromLocation, updateLocationWithTitle} from './title';
-import type {BaseVisualize, Visualize} from './visualizes';
+import {defaultDataset, getDatasetFromLocation} from './dataset';
+import {defaultFields, getFieldsFromLocation, isDefaultFields} from './fields';
+import {defaultMode, getModeFromLocation, Mode} from './mode';
+import {defaultQuery, getQueryFromLocation} from './query';
+import {defaultSortBys, getSortBysFromLocation} from './sortBys';
+import {defaultTitle, getTitleFromLocation} from './title';
+import type {Visualize} from './visualizes';
 
 interface ReadablePageParamsOptions {
   aggregateFields: AggregateField[];
@@ -110,18 +82,6 @@ class ReadablePageParams {
   get visualizes(): Visualize[] {
     return this._visualizes;
   }
-}
-
-interface WritablePageParams {
-  aggregateFields?: Array<GroupBy | BaseVisualize> | null;
-  aggregateSortBys?: Sort[] | null;
-  dataset?: DiscoverDatasets | null;
-  fields?: string[] | null;
-  id?: string | null;
-  mode?: Mode | null;
-  query?: string | null;
-  sampleSortBys?: Sort[] | null;
-  title?: string | null;
 }
 
 function defaultPageParams(): ReadablePageParams {
@@ -228,246 +188,4 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
   }, [pageParams, managedFields, setManagedFields]);
 
   return <PageParamsContext value={pageParamsContextValue}>{children}</PageParamsContext>;
-}
-
-function useExploreAutoFields(): Set<string> {
-  const contextValue = useContext(PageParamsContext);
-  return contextValue.managedFields;
-}
-
-function useSetExploreAutoFields(): (managedFields: Set<string>) => void {
-  const contextValue = useContext(PageParamsContext);
-  return contextValue.setManagedFields;
-}
-
-export function useExplorePageParams(): ReadablePageParams {
-  const contextValue = useContext(PageParamsContext);
-  return contextValue.pageParams;
-}
-
-export function newExploreTarget(
-  location: Location,
-  pageParams: WritablePageParams
-): Location {
-  const target = {...location, query: {...location.query}};
-  updateLocationWithAggregateFields(target, pageParams.aggregateFields);
-  updateLocationWithAggregateSortBys(target, pageParams.aggregateSortBys);
-  updateLocationWithDataset(target, pageParams.dataset);
-  updateLocationWithFields(target, pageParams.fields);
-  updateLocationWithMode(target, pageParams.mode);
-  updateLocationWithQuery(target, pageParams.query);
-  updateLocationWithSortBys(target, pageParams.sampleSortBys);
-  updateLocationWithTitle(target, pageParams.title);
-  updateLocationWithId(target, pageParams.id);
-  return target;
-}
-
-function findAllFields(
-  readablePageParams: ReadablePageParams,
-  writablePageParams: WritablePageParams
-): {
-  addedFields: Set<string>;
-  removedFields: Set<string>;
-} {
-  if (!defined(writablePageParams.fields)) {
-    return {
-      addedFields: new Set<string>(),
-      removedFields: new Set<string>(),
-    };
-  }
-
-  const curFields: Map<string, number> = readablePageParams.fields.reduce(
-    (fields, field) => {
-      const count = fields.get(field) || 0;
-      fields.set(field, count + 1);
-      return fields;
-    },
-    new Map<string, number>()
-  );
-  const newFields: Map<string, number> = writablePageParams.fields.reduce(
-    (fields, field) => {
-      const count = fields.get(field) || 0;
-      fields.set(field, count + 1);
-      return fields;
-    },
-    new Map<string, number>()
-  );
-
-  const addedFields = new Set<string>();
-  const removedFields = new Set<string>();
-
-  function checkField(_count: number, field: string) {
-    const curCount = curFields.get(field) || 0;
-    const newCount = newFields.get(field) || 0;
-    if (curCount > newCount) {
-      removedFields.add(field);
-    } else if (curCount < newCount) {
-      addedFields.add(field);
-    }
-  }
-
-  curFields.forEach(checkField);
-  newFields.forEach(checkField);
-
-  return {addedFields, removedFields};
-}
-
-/**
- * Get a count of all the fields that are referenced else where in the query.
- * This is useful to compute the changes (added/removed references) that will
- * be used to determine if a field should be managed and added to the table.
- */
-function findAllFieldRefs(
-  readablePageParams: ReadablePageParams,
-  writablePageParams: WritablePageParams
-): {
-  curRefs: Map<string, number>;
-  newRefs: Map<string, number>;
-} {
-  const curRefs: Map<string, number> = new Map();
-  const newRefs: Map<string, number> = new Map();
-
-  const readableVisualizeFields = readablePageParams.aggregateFields
-    .filter<Visualize>(isVisualize)
-    .map(visualize => visualize.yAxis)
-    .map(yAxis => parseFunction(yAxis)?.arguments?.[0])
-    .filter<string>(defined);
-
-  readableVisualizeFields.forEach(field => {
-    const count = curRefs.get(field) || 0;
-    curRefs.set(field, count + 1);
-  });
-
-  const writableVisualizeFields =
-    // null means to clear it so make sure to handle it correctly
-    writablePageParams.aggregateFields === null
-      ? []
-      : writablePageParams.aggregateFields
-          ?.filter<BaseVisualize>(isBaseVisualize)
-          ?.flatMap(visualize => visualize.yAxes)
-          ?.map(yAxis => parseFunction(yAxis)?.arguments?.[0])
-          ?.filter<string>(defined);
-
-  // if visualize fields aren't set on the writable page params, it means
-  // it didn't change, so we fall back to using the fields from the readable
-  // page params
-  (writableVisualizeFields ?? readableVisualizeFields).forEach(field => {
-    const count = newRefs.get(field) || 0;
-    newRefs.set(field, count + 1);
-  });
-
-  return {curRefs, newRefs};
-}
-
-function deriveUpdatedAutoFields(
-  managedFields: Set<string>,
-  readablePageParams: ReadablePageParams,
-  writablePageParams: WritablePageParams
-): {
-  updatedFields?: string[];
-  updatedManagedFields?: Set<string>;
-} {
-  // null means to clear it, when this happens we should stop managing all fields
-  if (writablePageParams.fields === null) {
-    return {
-      updatedManagedFields: new Set(),
-    };
-  }
-
-  const {curRefs, newRefs} = findAllFieldRefs(readablePageParams, writablePageParams);
-
-  const allFields = new Set<string>([...curRefs.keys(), ...newRefs.keys()]);
-
-  // if the writable fields is undefined, it means we're not changing it
-  // so we should infer it from the readable fields
-  const fields = writablePageParams.fields ?? readablePageParams.fields;
-
-  const fieldsToAdd = new Set<string>();
-  const fieldsToDelete = new Set<string>();
-  const updatedManagedFields = new Set(managedFields);
-
-  allFields.forEach(field => {
-    const curCount = curRefs.get(field) || 0;
-    const newCount = newRefs.get(field) || 0;
-
-    if (
-      newCount > curCount &&
-      !updatedManagedFields.has(field) &&
-      !fields.includes(field)
-    ) {
-      // found a field that
-      // 1. isn't in the list of fields
-      // 2. isn't being managed
-      // 3. a new reference was found
-      // this means we should start managing the field
-      updatedManagedFields.add(field);
-      fieldsToAdd.add(field);
-    } else if (curCount > 0 && newCount <= 0 && updatedManagedFields.has(field)) {
-      // found a field that
-      // 1. is being managed
-      // 2. all references have been removed
-      updatedManagedFields.delete(field);
-      fieldsToDelete.add(field);
-    }
-  });
-
-  const {removedFields} = findAllFields(readablePageParams, writablePageParams);
-
-  // when a field is intentionally removed, it should no longer be managed
-  removedFields.forEach(field => {
-    updatedManagedFields.delete(field);
-    fieldsToDelete.delete(field);
-  });
-
-  let updatedFields: string[] | undefined = undefined;
-
-  if (fieldsToAdd.size || fieldsToDelete.size) {
-    updatedFields = fields.filter(field => {
-      const keep = !fieldsToDelete.has(field);
-      if (!keep) {
-        // it's possible the user manually added a duplicate of the field,
-        // but we want to only delete 1 instance of the field
-        fieldsToDelete.delete(field);
-      }
-      return keep;
-    });
-    updatedFields.push(...fieldsToAdd);
-  }
-
-  return {
-    updatedFields,
-    updatedManagedFields,
-  };
-}
-
-export function useSetExplorePageParams(): (
-  writablePageParams: WritablePageParams
-) => void {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const managedFields = useExploreAutoFields();
-  const setManagedFields = useSetExploreAutoFields();
-  const readablePageParams = useExplorePageParams();
-
-  return useCallback(
-    (writablePageParams: WritablePageParams) => {
-      const {updatedFields, updatedManagedFields} = deriveUpdatedAutoFields(
-        managedFields,
-        readablePageParams,
-        writablePageParams
-      );
-
-      if (defined(updatedManagedFields)) {
-        setManagedFields(updatedManagedFields);
-      }
-
-      if (defined(updatedFields)) {
-        writablePageParams.fields = updatedFields;
-      }
-
-      const target = newExploreTarget(location, writablePageParams);
-      navigate(target);
-    },
-    [location, navigate, readablePageParams, managedFields, setManagedFields]
-  );
 }

--- a/static/app/views/explore/contexts/pageParamsContext/mode.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/mode.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {defined} from 'sentry/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 
 export enum Mode {
@@ -18,18 +17,4 @@ export function getModeFromLocation(location: Location): Mode {
     return Mode.AGGREGATE;
   }
   return defaultMode();
-}
-
-export function updateLocationWithMode(
-  location: Location,
-  mode: Mode | null | undefined
-) {
-  if (defined(mode)) {
-    location.query.mode = mode;
-
-    // make sure to clear the cursor every time the query is updated
-    delete location.query.cursor;
-  } else if (mode === null) {
-    delete location.query.mode;
-  }
 }

--- a/static/app/views/explore/contexts/pageParamsContext/query.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/query.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {defined} from 'sentry/utils';
 import {decodeQuery} from 'sentry/utils/discover/eventView';
 
 export function defaultQuery(): string {
@@ -9,18 +8,4 @@ export function defaultQuery(): string {
 
 export function getQueryFromLocation(location: Location) {
   return decodeQuery(location);
-}
-
-export function updateLocationWithQuery(
-  location: Location,
-  query: string | null | undefined
-) {
-  if (defined(query)) {
-    location.query.query = query;
-
-    // make sure to clear the cursor every time the query is updated
-    delete location.query.cursor;
-  } else if (query === null) {
-    delete location.query.query;
-  }
 }

--- a/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
@@ -37,22 +36,6 @@ export function getSortBysFromLocation(location: Location, fields: string[]): So
   }
 
   return defaultSortBys(fields);
-}
-
-export function updateLocationWithSortBys(
-  location: Location,
-  sortBys: Sort[] | null | undefined
-) {
-  if (defined(sortBys)) {
-    location.query.sort = sortBys.map(sortBy =>
-      sortBy.kind === 'desc' ? `-${sortBy.field}` : sortBy.field
-    );
-
-    // make sure to clear the cursor every time the query is updated
-    delete location.query.cursor;
-  } else if (sortBys === null) {
-    delete location.query.sort;
-  }
 }
 
 export function formatSort(sort: Sort): string {

--- a/static/app/views/explore/contexts/pageParamsContext/title.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/title.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {defined} from 'sentry/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 
 export function defaultTitle(): string | undefined {
@@ -9,15 +8,4 @@ export function defaultTitle(): string | undefined {
 
 export function getTitleFromLocation(location: Location) {
   return decodeScalar(location.query.title);
-}
-
-export function updateLocationWithTitle(
-  location: Location,
-  title: string | null | undefined
-) {
-  if (defined(title)) {
-    location.query.title = title;
-  } else if (title === null) {
-    delete location.query.title;
-  }
 }

--- a/static/app/views/explore/hooks/useTab.tsx
+++ b/static/app/views/explore/hooks/useTab.tsx
@@ -3,8 +3,8 @@ import {useCallback, useMemo} from 'react';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {useExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
 import {updateNullableLocation} from 'sentry/views/explore/queryParams/location';
 import {getTargetWithReadableQueryParams} from 'sentry/views/explore/spans/spansQueryParams';
 
@@ -19,7 +19,7 @@ export enum Tab {
 export function useTab(): [Mode | Tab, (tab: Mode | Tab) => void] {
   const location = useLocation();
   const navigate = useNavigate();
-  const pageParams = useExplorePageParams();
+  const mode = useQueryParamsMode();
 
   const table = decodeScalar(location.query[SPANS_TABLE_KEY]);
 
@@ -28,7 +28,7 @@ export function useTab(): [Mode | Tab, (tab: Mode | Tab) => void] {
     // short term, we avoid introducing/removing any fields on the
     // query. So we continue using the existing `mode` value and
     // coalesce it with the `tab` value` to create a single tab.
-    if (pageParams.mode === Mode.AGGREGATE) {
+    if (mode === Mode.AGGREGATE) {
       return Mode.AGGREGATE;
     }
 
@@ -40,7 +40,7 @@ export function useTab(): [Mode | Tab, (tab: Mode | Tab) => void] {
     }
 
     return Tab.SPAN;
-  }, [table, pageParams.mode]);
+  }, [table, mode]);
 
   const setTab = useCallback(
     (newTab: Mode | Tab) => {

--- a/static/app/views/explore/spans/spansExport.spec.tsx
+++ b/static/app/views/explore/spans/spansExport.spec.tsx
@@ -1,12 +1,19 @@
+import type {ReactNode} from 'react';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {downloadAsCsv} from 'sentry/views/discover/utils';
 import {SpansExport} from 'sentry/views/explore/spans/spansExport';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 
 jest.mock('sentry/views/discover/utils', () => ({
   downloadAsCsv: jest.fn(),
 }));
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
+}
 
 describe('SpansExport', () => {
   const {organization} = initializeOrg({
@@ -49,7 +56,7 @@ describe('SpansExport', () => {
         aggregatesTableResult={aggregatesTableResult}
         spansTableResult={spansTableResult}
       />,
-      {organization}
+      {organization, additionalWrapper: Wrapper}
     );
     expect(screen.getByText('Export')).toBeInTheDocument();
   });
@@ -62,7 +69,7 @@ describe('SpansExport', () => {
         aggregatesTableResult={aggregatesTableResult}
         spansTableResult={spansTableResult}
       />,
-      {organization}
+      {organization, additionalWrapper: Wrapper}
     );
 
     const exportButton = screen.getByText('Export');
@@ -91,9 +98,7 @@ describe('SpansExport', () => {
         aggregatesTableResult={aggregatesTableResult}
         spansTableResult={spansTableResult}
       />,
-      {
-        organization,
-      }
+      {organization, additionalWrapper: Wrapper}
     );
 
     const exportButton = screen.getByText('Export');
@@ -115,7 +120,7 @@ describe('SpansExport', () => {
         aggregatesTableResult={aggregatesTableResult}
         spansTableResult={spansTableResult}
       />,
-      {organization}
+      {organization, additionalWrapper: Wrapper}
     );
 
     const exportButton = screen.getByText('Export');
@@ -146,7 +151,7 @@ describe('SpansExport', () => {
         aggregatesTableResult={aggregatesTableResult}
         spansTableResult={spansTableResult}
       />,
-      {organization}
+      {organization, additionalWrapper: Wrapper}
     );
 
     const exportButton = screen.getByText('Export');

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -45,7 +45,6 @@ import SchemaHintsList, {
 } from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
 import {ChartSelectionProvider} from 'sentry/views/explore/components/suspectTags/chartSelectionContext';
-import {useSetExplorePageParams} from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
@@ -63,6 +62,7 @@ import {
   useQueryParamsMode,
   useQueryParamsQuery,
   useQueryParamsVisualizes,
+  useSetQueryParams,
   useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {ExploreCharts} from 'sentry/views/explore/spans/charts';
@@ -187,7 +187,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
   const mode = useQueryParamsMode();
   const fields = useQueryParamsFields();
   const query = useQueryParamsQuery();
-  const setExplorePageParams = useSetExplorePageParams();
+  const setQueryParams = useSetQueryParams();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
 
   const organization = useOrganization();
@@ -225,7 +225,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
         const existingFields = new Set(fields);
         const newColumns = suggestedColumns.filter(col => !existingFields.has(col));
 
-        setExplorePageParams({
+        setQueryParams({
           query: newQuery,
           fields: newColumns.length ? [...fields, ...newColumns] : undefined,
         });
@@ -266,7 +266,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
       oldSearch,
       query,
       setCaseInsensitive,
-      setExplorePageParams,
+      setQueryParams,
       stringSecondaryAliases,
       stringTags,
     ]

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -31,7 +31,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
-import {newExploreTarget} from 'sentry/views/explore/contexts/pageParamsContext';
 import type {GroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -52,6 +51,7 @@ import type {
 import {getLogsUrlFromSavedQueryUrl} from 'sentry/views/explore/logs/utils';
 import type {ReadableExploreQueryParts} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {getTargetWithReadableQueryParams} from 'sentry/views/explore/spans/spansQueryParams';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 import {isChartType} from 'sentry/views/insights/common/components/chart';
@@ -393,11 +393,11 @@ export function viewSamplesTarget({
     yAxes: visualizes.map(visualize => visualize.yAxis),
   });
 
-  return newExploreTarget(location, {
+  return getTargetWithReadableQueryParams(location, {
     mode: Mode.SAMPLES,
     fields: newFields,
     query: newSearch.formatString(),
-    sampleSortBys: newSortBys,
+    sortBys: newSortBys,
   });
 }
 


### PR DESCRIPTION
The last 2 hooks using page params are useExplorePageParams and useSetExplorePageParams. Time to get off them and onto the respective query params hooks.