### PR TITLE
test(ui): Remove unused deprecated test router

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
@@ -1,8 +1,6 @@
 import {EventAttachmentFixture} from 'sentry-fixture/eventAttachment';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -13,17 +11,9 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
 describe('ScreenshotModal', () => {
-  let initialData: ReturnType<typeof initializeOrg>;
   const project = ProjectFixture();
 
   beforeEach(() => {
-    initialData = initializeOrg({
-      organization: OrganizationFixture(),
-      router: {
-        params: {groupId: 'group-id'},
-        location: {query: {types: 'event.screenshot'}},
-      },
-    });
     ProjectsStore.loadInitialData([project]);
     GroupStore.init();
   });
@@ -52,10 +42,7 @@ describe('ScreenshotModal', () => {
         downloadUrl="/testing/download-href"
         groupId="group-id"
         attachments={attachments}
-      />,
-      {
-        organization: initialData.organization,
-      }
+      />
     );
     expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
@@ -91,10 +78,7 @@ describe('ScreenshotModal', () => {
         attachments={attachments}
         downloadUrl="/testing/download-href"
         groupId="group-id"
-      />,
-      {
-        organization: initialData.organization,
-      }
+      />
     );
 
     expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
@@ -120,10 +104,7 @@ describe('ScreenshotModal', () => {
         eventAttachment={eventAttachment}
         downloadUrl="/testing/download-href"
         groupId="group-id"
-      />,
-      {
-        organization: initialData.organization,
-      }
+      />
     );
 
     expect(screen.getByText(eventAttachment.name)).toBeInTheDocument();

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
@@ -1,16 +1,9 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 
 describe('Breadcrumb Data SQL', () => {
-  const {organization} = initializeOrg({
-    router: {
-      location: {query: {project: '0'}},
-    },
-  });
-
   it('displays formatted SQL message', () => {
     render(
       <Sql
@@ -31,10 +24,7 @@ FOR
 UPDATE NOWAIT`,
         }}
         searchTerm=""
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     expect(screen.getByText('SELECT db.id, db.project_id,')).toBeInTheDocument();

--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -1,24 +1,12 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import TagFacets, {TAGS_FORMATTER} from 'sentry/components/group/tagFacets';
 
-const mockProject = ProjectFixture();
-const {organization} = initializeOrg({
-  organization: {},
-  projects: [mockProject],
-  router: {
-    routes: [],
-    location: {
-      pathname: '/organizations/org-slug/issues/1/',
-      query: {},
-    },
-  },
-});
-
 describe('Tag Facets', () => {
+  const organization = OrganizationFixture();
   const project = ProjectFixture();
   project.platform = 'android';
   const tags = ['os', 'device', 'release'];

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
@@ -36,7 +36,6 @@ describe('Modals -> AddDashboardWidgetModal', () => {
     organization: {
       features: ['performance-view', 'discover-query'],
     },
-    router: {},
     projects: [],
   });
   let mockQuery!: Widget['queries'][number];

--- a/static/app/components/timeRangeSelector/index.spec.tsx
+++ b/static/app/components/timeRangeSelector/index.spec.tsx
@@ -1,27 +1,13 @@
 import {ConfigFixture} from 'sentry-fixture/config';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import ConfigStore from 'sentry/stores/configStore';
 
-const {organization} = initializeOrg({
-  organization: {features: ['open-membership']},
-  projects: [
-    {id: '1', slug: 'project-1', isMember: true},
-    {id: '2', slug: 'project-2', isMember: true},
-    {id: '3', slug: 'project-3', isMember: false},
-  ],
-  router: {
-    location: {
-      pathname: '/organizations/org-slug/issues/',
-      query: {},
-    },
-    params: {},
-  },
-});
+const organization = OrganizationFixture({features: ['open-membership']});
 
 describe('TimeRangeSelector', () => {
   const onChange = jest.fn();

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -22,7 +22,6 @@ describe('getIssueFieldRenderer', () => {
   beforeEach(() => {
     context = initializeOrg({
       organization,
-      router: {},
       projects: [ProjectFixture()],
     });
     organization = context.organization;

--- a/static/app/utils/useCustomMeasurements.spec.tsx
+++ b/static/app/utils/useCustomMeasurements.spec.tsx
@@ -36,7 +36,6 @@ describe('useCustomMeasurements', () => {
     const {organization} = initializeOrg({
       organization: {features: ['dashboards-mep']},
       projects: [],
-      router: {},
     });
     const measurementsMetaMock = mockMeasurementsMeta();
     render(

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -78,7 +78,7 @@ describe('Dashboards > Dashboard', () => {
   let tagsMock: jest.Mock;
 
   beforeEach(() => {
-    initialData = initializeOrg({organization, router: {}, projects: []});
+    initialData = initializeOrg({organization, projects: []});
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/dashboards/widgets/`,
       method: 'POST',

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
@@ -1,4 +1,5 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {Widget} from 'sentry/views/dashboards/types';
@@ -39,9 +40,7 @@ describe('IssueWidgetQueries', () => {
     },
   };
 
-  const {organization} = initializeOrg({
-    router: {orgId: 'orgId'},
-  } as Parameters<typeof initializeOrg>[0]);
+  const organization = OrganizationFixture();
   const api = new MockApiClient();
 
   it('does an issue query and passes correct tableResults to child component', async () => {

--- a/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.spec.tsx
@@ -1,9 +1,9 @@
 import {duration} from 'moment-timezone';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render as baseRender, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
@@ -44,20 +44,7 @@ const mockReplay = ReplayReader.factory({
 });
 
 const render = (children: React.ReactElement, orgParams: Partial<Organization> = {}) => {
-  const {organization} = initializeOrg({
-    organization: {slug: mockOrgSlug, ...orgParams},
-    router: {
-      routes: [
-        {path: '/'},
-        {path: '/organizations/:orgId/issues/:groupId/'},
-        {path: 'replays/'},
-      ],
-      location: {
-        pathname: '/organizations/org-slug/replays/',
-        query: {},
-      },
-    },
-  });
+  const organization = OrganizationFixture({slug: mockOrgSlug, ...orgParams});
 
   return baseRender(children, {
     organization,

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -2,7 +2,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DATA_CATEGORY_INFO, DEFAULT_STATS_PERIOD} from 'sentry/constants';
@@ -28,11 +27,7 @@ describe('OrganizationStats', () => {
     },
   };
   const projects = ['1', '2', '3'].map(id => ProjectFixture({id, slug: `proj-${id}`}));
-  const {organization} = initializeOrg({
-    organization: {features: ['team-insights']},
-    projects,
-    router: undefined,
-  });
+  const organization = OrganizationFixture({features: ['team-insights']});
   const endpoint = `/organizations/${organization.slug}/stats_v2/`;
 
   let mockRequest: jest.Mock;
@@ -246,11 +241,10 @@ describe('OrganizationStats', () => {
    * Project Selection
    */
   it('renders default projects', async () => {
-    const newOrg = initializeOrg();
-    newOrg.organization.features = ['team-insights'];
-    OrganizationStore.onUpdate(newOrg.organization, {replace: true});
+    const newOrg = OrganizationFixture({features: ['team-insights']});
+    OrganizationStore.onUpdate(newOrg, {replace: true});
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     expect(await screen.findByText('All Projects')).toBeInTheDocument();
@@ -268,13 +262,12 @@ describe('OrganizationStats', () => {
   });
 
   it('renders with multiple projects selected', async () => {
-    const newOrg = initializeOrg();
-    newOrg.organization.features = ['team-insights'];
+    const newOrg = OrganizationFixture({features: ['team-insights']});
 
     const selectedProjects = [1, 2];
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
     act(() => PageFiltersStore.updateProjects(selectedProjects, []));
 
@@ -298,12 +291,11 @@ describe('OrganizationStats', () => {
   });
 
   it('renders with a single project selected', async () => {
-    const newOrg = initializeOrg();
-    newOrg.organization.features = ['team-insights'];
+    const newOrg = OrganizationFixture({features: ['team-insights']});
     const selectedProject = [1];
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
     act(() => PageFiltersStore.updateProjects(selectedProject, []));
 
@@ -328,10 +320,9 @@ describe('OrganizationStats', () => {
   });
 
   it('renders a project when its graph icon is clicked', async () => {
-    const newOrg = initializeOrg();
-    newOrg.organization.features = ['team-insights'];
+    const newOrg = OrganizationFixture({features: ['team-insights']});
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     expect(await screen.findByTestId('usage-stats-chart')).toBeInTheDocument();
@@ -347,11 +338,10 @@ describe('OrganizationStats', () => {
     const selectedProject = [1];
 
     for (const features of [['team-insights'], ['team-insights']]) {
-      const newOrg = initializeOrg();
-      newOrg.organization.features = features;
+      const newOrg = OrganizationFixture({features});
 
       render(<OrganizationStats />, {
-        organization: newOrg.organization,
+        organization: newOrg,
       });
       act(() => PageFiltersStore.updateProjects(selectedProject, []));
 
@@ -364,14 +354,12 @@ describe('OrganizationStats', () => {
    * Feature Flagging - Continuous Profiling
    */
   it('shows only profile duration category with continuous-profiling-stats feature', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights', 'continuous-profiling-stats'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights', 'continuous-profiling-stats'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -385,13 +373,11 @@ describe('OrganizationStats', () => {
   });
 
   it('shows both profile hours and profiles categories with continuous-profiling feature', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights', 'continuous-profiling'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights', 'continuous-profiling'],
     });
 
-    render(<OrganizationStats />, {organization: newOrg.organization});
+    render(<OrganizationStats />, {organization: newOrg});
 
     await userEvent.click(await screen.findByText('Category'));
 
@@ -404,14 +390,12 @@ describe('OrganizationStats', () => {
   });
 
   it('shows both profile hours without continuous-profiling feature', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -429,14 +413,12 @@ describe('OrganizationStats', () => {
   });
 
   it('shows only profile duration category when both profiling features are enabled', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights', 'continuous-profiling-stats', 'continuous-profiling'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights', 'continuous-profiling-stats', 'continuous-profiling'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -450,14 +432,12 @@ describe('OrganizationStats', () => {
   });
 
   it('shows only Profiles category without profiling features', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -471,14 +451,12 @@ describe('OrganizationStats', () => {
   });
 
   it('shows Seer categories when seer-billing feature flag is enabled', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights', 'seer-billing'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights', 'seer-billing'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -487,14 +465,12 @@ describe('OrganizationStats', () => {
   });
 
   it('does not show Seer categories when seer-billing feature flag is disabled', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -503,14 +479,12 @@ describe('OrganizationStats', () => {
   });
 
   it('shows Metrics category when tracemetrics-stats feature flag is enabled', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights', 'tracemetrics-enabled', 'tracemetrics-stats'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights', 'tracemetrics-enabled', 'tracemetrics-stats'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -518,14 +492,12 @@ describe('OrganizationStats', () => {
   });
 
   it('does not show Metrics category when tracemetrics-stats feature flag is disabled', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     await userEvent.click(await screen.findByText('Category'));
@@ -543,14 +515,12 @@ describe('OrganizationStats', () => {
   });
 
   it('shows estimation text when profile duration category is selected', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        features: ['team-insights', 'continuous-profiling-stats', 'continuous-profiling'],
-      },
+    const newOrg = OrganizationFixture({
+      features: ['team-insights', 'continuous-profiling-stats', 'continuous-profiling'],
     });
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
       initialRouterConfig: {
         location: {
           pathname: '/organizations/org-slug/stats/',
@@ -564,15 +534,13 @@ describe('OrganizationStats', () => {
   });
 
   it('denies access without project membership', async () => {
-    const newOrg = initializeOrg({
-      organization: {
-        openMembership: false,
-      },
+    const newOrg = OrganizationFixture({
+      openMembership: false,
     });
     act(() => ProjectsStore.loadInitialData([ProjectFixture({isMember: false})]));
 
     render(<OrganizationStats />, {
-      organization: newOrg.organization,
+      organization: newOrg,
     });
 
     expect(

--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -4,7 +4,6 @@ import {
   PreprodVcsInfoFullFixture,
 } from 'sentry-fixture/preprod';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {BuildDetailsSizeAnalysisState} from 'sentry/views/preprod/types/buildDetailsTypes';
@@ -12,15 +11,7 @@ import {BuildDetailsSizeAnalysisState} from 'sentry/views/preprod/types/buildDet
 import BuildDetails from './buildDetails';
 
 describe('BuildDetails', () => {
-  const {organization} = initializeOrg({
-    organization: OrganizationFixture(),
-    router: {
-      params: {
-        projectId: 'project-1',
-        artifactId: 'artifact-1',
-      },
-    },
-  });
+  const organization = OrganizationFixture();
 
   const initialRouterConfig = {
     location: {

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -43,11 +43,7 @@ describe('Loader Script Settings', () => {
       keyId: '1',
     };
 
-    const {organization, project} = initializeOrg({
-      router: {
-        params,
-      },
-    });
+    const {organization, project} = initializeOrg();
 
     const data = {
       ...ProjectKeysFixture()[0],


### PR DESCRIPTION
Removes routers that were defined but unused. Removes some use of initializeOrg in those files. If you're using the default organization fixture you don't really need to pass it around.
