### PR TITLE
chore(jira): Add halts for the weird jira html errors

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -50,6 +50,7 @@ from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
+    IntegrationProviderError,
 )
 from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
@@ -1013,6 +1014,12 @@ class JiraIntegration(IssueSyncIntegration):
                 },
             )
             raise IntegrationConfigurationError(exc.text) from exc
+        elif isinstance(exc, ApiError):
+            if "Product Unavailable" in exc.text or "Page Unavailable" in exc.text:
+                raise IntegrationProviderError(
+                    "Something went wrong while communicating with Jira"
+                ) from exc
+
         super().raise_error(exc, identity=identity)
 
     def sync_assignee_outbound(

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -24,6 +24,7 @@ from sentry.shared_integrations.exceptions import (
     ApiUnauthorized,
     IntegrationConfigurationError,
     IntegrationFormError,
+    IntegrationProviderError,
     IntegrationResourceNotFoundError,
 )
 from sentry.silo.base import region_silo_function
@@ -185,6 +186,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 InvalidIdentity,
                 ApiUnauthorized,
                 IntegrationResourceNotFoundError,
+                IntegrationProviderError,
             ) as e:
                 # Most of the time, these aren't explicit failures, they're
                 # some misconfiguration of an issue field - typically Jira.

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -23,6 +23,7 @@ from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
+    IntegrationProviderError,
 )
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
@@ -759,6 +760,64 @@ class RegionJiraIntegrationTest(APITestCase):
         )
         installation = self.integration.get_installation(self.organization.id)
         with pytest.raises(IntegrationConfigurationError):
+            installation.create_issue(
+                {
+                    "title": "example summary",
+                    "description": "example bug report",
+                    "issuetype": "1",
+                    "project": "10000",
+                }
+            )
+
+    @responses.activate
+    def test_create_issue_product_unavailable_error(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/createmeta",
+            body=StubService.get_stub_json("jira", "createmeta_response.json"),
+            content_type="json",
+        )
+        # Simulate Jira returning an HTML "Product Unavailable" error page
+        responses.add(
+            responses.POST,
+            "https://example.atlassian.net/rest/api/2/issue",
+            status=503,
+            body='<!DOCTYPE html>\n<html lang="en">\n    <head>\n        <title>Atlassian Cloud Notifications - Product Unavailable</title>\n    </head>\n    <body>\n        <h1>Jira has been deactivated</h1>\n    </body>\n</html>',
+            content_type="text/html",
+        )
+        installation = self.integration.get_installation(self.organization.id)
+        with pytest.raises(
+            IntegrationProviderError, match="Something went wrong while communicating with Jira"
+        ):
+            installation.create_issue(
+                {
+                    "title": "example summary",
+                    "description": "example bug report",
+                    "issuetype": "1",
+                    "project": "10000",
+                }
+            )
+
+    @responses.activate
+    def test_create_issue_page_unavailable_error(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/createmeta",
+            body=StubService.get_stub_json("jira", "createmeta_response.json"),
+            content_type="json",
+        )
+        # Simulate Jira returning an HTML "Page Unavailable" error
+        responses.add(
+            responses.POST,
+            "https://example.atlassian.net/rest/api/2/issue",
+            status=503,
+            body='<!DOCTYPE html>\n<html lang="en">\n    <head>\n        <title>Page Unavailable</title>\n    </head>\n    <body>\n        <h1>Page Unavailable</h1>\n    </body>\n</html>',
+            content_type="text/html",
+        )
+        installation = self.integration.get_installation(self.organization.id)
+        with pytest.raises(
+            IntegrationProviderError, match="Something went wrong while communicating with Jira"
+        ):
             installation.create_issue(
                 {
                     "title": "example summary",


### PR DESCRIPTION
It seems like Jira is spitting out weird HTML as a part of an incident they're having. Based off the [logs](https://console.cloud.google.com/logs/query;query=resource.labels.container_name%3D%22sentry%22%0AjsonPayload.event%20%3D%20%22integrations.slo.failure%22%0AjsonPayload.interaction_type%20%3D%20%22create_external_issue%22%0AjsonPayload.integration_name%20%3D%20%22jira%22;summaryFields=:false:32:beginning;cursorTimestamp=2025-10-29T18:26:39.211416822Z;startTime=2025-10-29T00:34:00.000Z;endTime=2025-10-29T19:46:00.000Z?project=internal-sentry&rapt=AEjHL4PcyLdjEFbjSpfiFEr1poUsMouQKcsYYdgPNxw_ic1GsrQhekgtF_olJbF2AjsTy4dlx8SEBK-fSIfU08IA7XTWJX0PcCYo08VULprys6FDjGASXJE) and [sentry issues ](https://sentry.sentry.io/issues/6919103098/events/b1ace4212551432dae9d70862a4f8882/)we're seeing, record these weird errors as halts.