### PR TITLE
feat(aci): Add checkin timeline to uptime monitors page

### DIFF
--- a/static/app/views/detectors/list/uptime.spec.tsx
+++ b/static/app/views/detectors/list/uptime.spec.tsx
@@ -1,0 +1,126 @@
+import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+  type RouterConfig,
+} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import UptimeDetectorsList from 'sentry/views/detectors/list/uptime';
+
+describe('UptimeDetectorsList', () => {
+  const organization = OrganizationFixture({
+    features: ['workflow-engine-ui'],
+  });
+
+  const initialRouterConfig: RouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/detectors/uptime/`,
+    },
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/1/',
+      body: UserFixture(),
+    });
+
+    // Ensure a project is selected for queries
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}));
+
+    // Make elements report a non-zero size so timelines compute rollups and fetch
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        return 800;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 50;
+      },
+    });
+  });
+
+  it('displays header when no uptime monitors are found', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [],
+    });
+
+    render(<UptimeDetectorsList />, {organization, initialRouterConfig});
+
+    // Page heading/title
+    expect(await screen.findByText('Uptime Monitors')).toBeInTheDocument();
+    // No rows present
+    expect(screen.queryByTestId('detector-list-row')).not.toBeInTheDocument();
+  });
+
+  it('loads uptime monitors, renders timeline, and updates on time selection', async () => {
+    // Detectors list returns a single uptime monitor
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [UptimeDetectorFixture({name: 'Uptime Detector', id: 'uptime-1'})],
+    });
+
+    // Monitor stats for the uptime detector id "uptime-1"
+    const nowSec = Math.floor(Date.now() / 1000);
+    const monitorStatsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/uptime-stats/',
+      body: {
+        'uptime-1': [
+          [
+            nowSec - 3600,
+            {
+              success: 1,
+              failure: 0,
+              failure_incident: 0,
+              missed_window: 0,
+            },
+          ],
+        ],
+      },
+    });
+
+    const {router} = render(<UptimeDetectorsList />, {organization, initialRouterConfig});
+
+    // Page header/title and detector row
+    expect(await screen.findByText('Uptime Monitors')).toBeInTheDocument();
+    const row = await screen.findByTestId('detector-list-row');
+    expect(row).toBeInTheDocument();
+
+    expect(screen.getByRole('columnheader', {name: /Name/})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Last Issue'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Assignee'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Alerts'})).toBeInTheDocument();
+
+    // Name
+    expect(within(row).getByText('Uptime Detector')).toBeInTheDocument();
+
+    // Timeline visualization should render ticks once stats load
+    expect(await screen.findAllByTestId('monitor-checkin-tick')).not.toHaveLength(0);
+    expect(monitorStatsRequest).toHaveBeenCalled();
+
+    // Time range selector should be present
+    const timeTrigger = screen.getByTestId('page-filter-timerange-selector');
+    await userEvent.click(timeTrigger);
+    await userEvent.click(await screen.findByRole('option', {name: 'Last hour'}));
+
+    // Should update the stats period to 1h
+    await waitFor(() => {
+      expect(router.location.query.statsPeriod).toBe('1h');
+    });
+
+    // Updating stats period should cause the monitor stats request to refetch
+    expect(monitorStatsRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/static/app/views/detectors/list/uptime.tsx
+++ b/static/app/views/detectors/list/uptime.tsx
@@ -1,20 +1,92 @@
+import {useCallback, useMemo, useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+
+import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlaceholder';
+import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
+import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import type {Detector, UptimeDetector} from 'sentry/types/workflowEngine/detectors';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useDimensions} from 'sentry/utils/useDimensions';
 import DetectorsList from 'sentry/views/detectors/list';
 import {
   MonitorViewContext,
   useMonitorViewContext,
+  type MonitorViewContextValue,
 } from 'sentry/views/detectors/monitorViewContext';
+import {
+  checkStatusPrecedent,
+  statusToText,
+  tickStyle,
+} from 'sentry/views/insights/uptime/timelineConfig';
+import {useUptimeMonitorStats} from 'sentry/views/insights/uptime/utils/useUptimeMonitorStats';
+
+function VisualizationCell({detector}: {detector: UptimeDetector}) {
+  const uptimeDetectorId = detector.id;
+
+  const elementRef = useRef<HTMLDivElement>(null);
+  const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
+  const timelineWidth = useDebouncedValue(containerWidth, 1000);
+  const timeWindowConfig = useTimeWindowConfig({timelineWidth});
+
+  const {data: uptimeStats, isPending} = useUptimeMonitorStats({
+    detectorIds: [uptimeDetectorId],
+    timeWindowConfig,
+  });
+
+  return (
+    <Cell
+      data-column-name="visualization"
+      padding="lg 0"
+      borderLeft="muted"
+      height="100%"
+    >
+      <Flex width="100%" height="100%" ref={elementRef} align="center">
+        {isPending ? (
+          <CheckInPlaceholder />
+        ) : (
+          <CheckInTimeline
+            statusLabel={statusToText}
+            statusStyle={tickStyle}
+            statusPrecedent={checkStatusPrecedent}
+            timeWindowConfig={timeWindowConfig}
+            bucketedData={uptimeStats?.[uptimeDetectorId] ?? []}
+          />
+        )}
+      </Flex>
+    </Cell>
+  );
+}
 
 export default function UptimeDetectorsList() {
   const parentContext = useMonitorViewContext();
 
+  const renderVisualization = useCallback((detector: Detector) => {
+    if (detector.type === 'uptime_domain_failure') {
+      return <VisualizationCell detector={detector} />;
+    }
+    return null;
+  }, []);
+
+  const contextValue = useMemo<MonitorViewContextValue>(
+    () => ({
+      ...parentContext,
+      detectorFilter: 'uptime_domain_failure',
+      renderVisualization,
+      showTimeRangeSelector: true,
+    }),
+    [parentContext, renderVisualization]
+  );
+
   return (
-    <MonitorViewContext.Provider
-      value={{
-        ...parentContext,
-        detectorFilter: 'uptime_domain_failure',
-      }}
-    >
+    <MonitorViewContext.Provider value={contextValue}>
       <DetectorsList />
     </MonitorViewContext.Provider>
   );
 }
+
+const Cell = styled(SimpleTable.RowCell)`
+  z-index: 4;
+`;


### PR DESCRIPTION
Similar to the one for crons

<img width="1483" height="391" alt="CleanShot 2025-10-29 at 15 51 04" src="https://github.com/user-attachments/assets/e9c628b0-b635-478a-a1d1-d9eab3a99877" />
