### PR TITLE
feat: translate boolean filters differently

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -200,7 +200,7 @@ class TranslationVisitor(NodeVisitor):
             return term
 
         _, parsed_key, _, _, _ = children
-        flattened_parsed_key = []
+        flattened_parsed_key: list[str] = []
         _flatten(parsed_key, flattened_parsed_key)
         flattened_parsed_key_str = "".join(flattened_parsed_key)
         if flattened_parsed_key_str:
@@ -219,11 +219,11 @@ class TranslationVisitor(NodeVisitor):
             return term
 
         negation, parsed_key, sep, boolean_val = children
-        flattened_parsed_key = []
+        flattened_parsed_key: list[str] = []
         _flatten(parsed_key, flattened_parsed_key)
         flattened_parsed_key_str = "".join(flattened_parsed_key)
 
-        flattened_parsed_val = []
+        flattened_parsed_val: list[str] = []
         _flatten(boolean_val, flattened_parsed_val)
         flattened_parsed_val_str = "".join(flattened_parsed_val)
         if (
@@ -280,7 +280,7 @@ class ArithmeticTranslationVisitor(NodeVisitor):
 
 
 def translate_query(query: str):
-    flattened_query = []
+    flattened_query: list[str] = []
 
     tree = event_search_grammar.parse(query)
     parsed = TranslationVisitor().visit(tree)
@@ -342,7 +342,7 @@ def translate_equations(equations):
 
     for equation in equations:
 
-        flattened_equation = []
+        flattened_equation: list[str] = []
 
         # strip equation prefix
         if arithmetic.is_equation(equation):

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -41,6 +41,14 @@ COLUMNS_TO_DROP = (
 FIELDS_TO_DROP = ("total.count",)
 
 
+def _flatten(seq, flattened_list):
+    for item in seq:
+        if isinstance(item, list):
+            _flatten(item, flattened_list)
+        else:
+            flattened_list.append(item)
+
+
 def format_percentile_term(term):
     function, args, alias = fields.parse_function(term)
 
@@ -186,6 +194,54 @@ class TranslationVisitor(NodeVisitor):
 
         return children or node.text
 
+    def visit_numeric_filter(self, node, children):
+        term, did_update = search_term_switcheroo(node.text)
+        if did_update:
+            return term
+
+        _, parsed_key, _, _, _ = children
+        flattened_parsed_key = []
+        _flatten(parsed_key, flattened_parsed_key)
+        flattened_parsed_key_str = "".join(flattened_parsed_key)
+        if flattened_parsed_key_str:
+            if (
+                not flattened_parsed_key_str.startswith("tags[")
+                and flattened_parsed_key_str not in SPAN_ATTRIBUTE_DEFINITIONS
+            ):
+                new_parsed_key = [f"tags[{flattened_parsed_key_str},number]"]
+                children[1] = new_parsed_key
+
+        return children or node.text
+
+    def visit_boolean_filter(self, node, children):
+        term, did_update = search_term_switcheroo(node.text)
+        if did_update:
+            return term
+
+        negation, parsed_key, sep, boolean_val = children
+        flattened_parsed_key = []
+        _flatten(parsed_key, flattened_parsed_key)
+        flattened_parsed_key_str = "".join(flattened_parsed_key)
+
+        flattened_parsed_val = []
+        _flatten(boolean_val, flattened_parsed_val)
+        flattened_parsed_val_str = "".join(flattened_parsed_val)
+        if (
+            flattened_parsed_key_str
+            and not flattened_parsed_key_str.startswith("tags[")
+            and flattened_parsed_key_str not in SPAN_ATTRIBUTE_DEFINITIONS
+        ):
+            if flattened_parsed_val_str in ["0", "1"]:
+                new_parsed_key = [f"tags[{flattened_parsed_key_str},number]"]
+                children[1] = new_parsed_key
+
+                return children or node.text
+
+            if negation == "":
+                return f"(tags[{flattened_parsed_key_str},number]:{flattened_parsed_val_str} OR {flattened_parsed_key_str}:{flattened_parsed_val_str})"
+
+        return children or node.text
+
     def visit_text_filter(self, node, children):
         term, did_update = search_term_switcheroo(node.text)
         if did_update:
@@ -226,16 +282,9 @@ class ArithmeticTranslationVisitor(NodeVisitor):
 def translate_query(query: str):
     flattened_query = []
 
-    def _flatten(seq):
-        for item in seq:
-            if isinstance(item, list):
-                _flatten(item)
-            else:
-                flattened_query.append(item)
-
     tree = event_search_grammar.parse(query)
     parsed = TranslationVisitor().visit(tree)
-    _flatten(parsed)
+    _flatten(parsed, flattened_query)
 
     return apply_is_segment_condition("".join(flattened_query))
 
@@ -306,18 +355,10 @@ def translate_equations(equations):
             translated_equations.append(equation)
             continue
 
-        # function to flatten the parsed + updated equation
-        def _flatten(seq):
-            for item in seq:
-                if isinstance(item, list):
-                    _flatten(item)
-                else:
-                    flattened_equation.append(item)
-
         tree = arithmetic.arithmetic_grammar.parse(arithmetic_equation)
         translation_visitor = ArithmeticTranslationVisitor()
         parsed = translation_visitor.visit(tree)
-        _flatten(parsed)
+        _flatten(parsed, flattened_equation)
 
         # record dropped fields and equations and skip these translations
         if len(translation_visitor.dropped_fields) > 0:

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -15,6 +15,18 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "(avg(span.duration):<10 OR span.duration:11) AND is_transaction:1",
         ),
         pytest.param(
+            "foo:10 OR transaction.duration:11",
+            "(tags[foo,number]:10 OR span.duration:11) AND is_transaction:1",
+        ),
+        pytest.param(
+            "foo:1 OR transaction.duration:11",
+            "(tags[foo,number]:1 OR span.duration:11) AND is_transaction:1",
+        ),
+        pytest.param(
+            "foo:true OR transaction.duration:11",
+            "((tags[foo,number]:true OR foo:true) OR span.duration:11) AND is_transaction:1",
+        ),
+        pytest.param(
             "has:transaction.duration OR has:measurements.lcp",
             "(has:span.duration OR has:measurements.lcp) AND is_transaction:1",
         ),


### PR DESCRIPTION
Booleans were always string tags in the transactions dataset, but with EAP can be
number or string. We're trying to handle this case.