### PR TITLE
fix(issues): Increase top tag total value with empty keys

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -751,9 +751,9 @@ class SnubaTagStorage(TagStorage):
 
             # Increase the count of the key by the count of empty values
             for keyobj in keys_with_counts:
-                stats: dict[str, Any] | None = empty_stats_map.get(keyobj.key)
-                if stats and stats.get("count", 0) > 0:
-                    keyobj.count = (keyobj.count or 0) + stats["count"]
+                empty_stats: dict[str, Any] | None = empty_stats_map.get(keyobj.key)
+                if empty_stats and empty_stats.get("count", 0) > 0:
+                    keyobj.count = (keyobj.count or 0) + empty_stats["count"]
 
         for keyobj in keys_with_counts:
             key = keyobj.key

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -751,7 +751,7 @@ class SnubaTagStorage(TagStorage):
 
             # Increase the count of the key by the count of empty values
             for keyobj in keys_with_counts:
-                stats = empty_stats_map.get(keyobj.key)
+                stats: dict[str, Any] | None = empty_stats_map.get(keyobj.key)
                 if stats and stats.get("count", 0) > 0:
                     keyobj.count = (keyobj.count or 0) + stats["count"]
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -749,6 +749,12 @@ class SnubaTagStorage(TagStorage):
                 ]
                 values_by_key[k] = {vk: vd for vk, vd in sorted_items}
 
+            # Increase the count of the key by the count of empty values
+            for keyobj in keys_with_counts:
+                stats = empty_stats_map.get(keyobj.key)
+                if stats and stats.get("count", 0) > 0:
+                    keyobj.count = (keyobj.count or 0) + stats["count"]
+
         for keyobj in keys_with_counts:
             key = keyobj.key
             values = values_by_key.get(key, dict())

--- a/tests/sentry/issues/endpoints/test_group_tags.py
+++ b/tests/sentry/issues/endpoints/test_group_tags.py
@@ -341,6 +341,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         values = {v["value"] for v in response.data[0]["topValues"]}
         assert values == {"", "bar"}
         assert response.data[0]["topValues"][0]["count"] == 1
+        assert response.data[0]["totalValues"] == 2
 
     def test_include_empty_values_in_all_tags_with_feature(self) -> None:
         event = self.store_event(
@@ -378,6 +379,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
         foo = next((t for t in response.data if t["key"] == "foo"), None)
         assert foo is not None
         assert {v["value"] for v in foo["topValues"]} == {"", "bar"}
+        assert foo["totalValues"] == 2
 
     def test_flags(self) -> None:
         event1 = self.store_event(


### PR DESCRIPTION
In #102049 added the empty tags, but noticing the total values no longer makes sense. Increases the total count when empty values is active

part of https://linear.app/getsentry/issue/RTC-1181/