### PR TITLE
ref(sdk): Update sentry sdk to 2.43.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "sentry-protos>=0.4.2",
     "sentry-redis-tools>=0.5.0",
     "sentry-relay>=0.9.17",
-    "sentry-sdk[http2]>=2.42.0",
+    "sentry-sdk[http2]>=2.43.0",
     "sentry-usage-accountant>=0.0.10",
     # remove once there are no unmarked transitive dependencies on setuptools
     "setuptools>=70.0.0",

--- a/src/sentry/metrics/sentry_sdk.py
+++ b/src/sentry/metrics/sentry_sdk.py
@@ -1,7 +1,7 @@
 from random import random
 from typing import Any
 
-from sentry_sdk import _metrics as metrics
+from sentry_sdk import metrics
 
 from .base import MetricsBackend, Tags
 

--- a/tests/sentry/metrics/test_dualwrite.py
+++ b/tests/sentry/metrics/test_dualwrite.py
@@ -35,7 +35,7 @@ def test_dualwrite_distribution(distribution, timing):
     distribution.assert_not_called()
 
 
-@mock.patch("sentry_sdk._metrics.count")
+@mock.patch("sentry_sdk.metrics.count")
 @mock.patch("datadog.dogstatsd.base.DogStatsd.increment")
 @thread_leak_allowlist(reason="datadog dualwrite metrics", issue=98803)
 def test_dualwrite_experimental_backend(dogstatsd_incr, sentry_sdk_incr):
@@ -57,7 +57,7 @@ def test_dualwrite_experimental_backend(dogstatsd_incr, sentry_sdk_incr):
     sentry_sdk_incr.assert_not_called()
 
 
-@mock.patch("sentry_sdk._metrics.gauge")
+@mock.patch("sentry_sdk.metrics.gauge")
 @mock.patch("datadog.dogstatsd.base.DogStatsd.gauge")
 @thread_leak_allowlist(reason="datadog dualwrite metrics", issue=98803)
 def test_dualwrite_experimental_backend_rollout_disabled(dogstatsd_gauge, sentry_sdk_gauge):

--- a/tests/sentry/metrics/test_sentry_sdk.py
+++ b/tests/sentry/metrics/test_sentry_sdk.py
@@ -10,7 +10,7 @@ class TestSentrySDKMetricsBackend:
     def backend(self):
         return SentrySDKMetricsBackend(prefix="test.", experimental_sample_rate=1.0)
 
-    @mock.patch("sentry_sdk._metrics.count")
+    @mock.patch("sentry_sdk.metrics.count")
     def test_incr(self, mock_count, backend):
         with mock.patch.object(backend, "_should_send", return_value=True):
             backend.incr("foo", tags={"x": "y"}, amount=2, unit="count")
@@ -22,7 +22,7 @@ class TestSentrySDKMetricsBackend:
             attributes={"x": "y"},
         )
 
-    @mock.patch("sentry_sdk._metrics.count")
+    @mock.patch("sentry_sdk.metrics.count")
     def test_incr_no_unit(self, mock_count, backend):
         with mock.patch.object(backend, "_should_send", return_value=True):
             backend.incr("foo", tags={"x": "y"}, amount=2)
@@ -34,7 +34,7 @@ class TestSentrySDKMetricsBackend:
             attributes={"x": "y"},
         )
 
-    @mock.patch("sentry_sdk._metrics.gauge")
+    @mock.patch("sentry_sdk.metrics.gauge")
     def test_gauge(self, mock_gauge, backend):
         with mock.patch.object(backend, "_should_send", return_value=True):
             backend.gauge("bar", value=42.0, tags={"x": "y"}, unit="bytes")
@@ -46,7 +46,7 @@ class TestSentrySDKMetricsBackend:
             attributes={"x": "y"},
         )
 
-    @mock.patch("sentry_sdk._metrics.distribution")
+    @mock.patch("sentry_sdk.metrics.distribution")
     def test_distribution(self, mock_distribution, backend):
         with mock.patch.object(backend, "_should_send", return_value=True):
             backend.distribution("baz", value=100.0, tags={"x": "y"}, unit="millisecond")
@@ -58,7 +58,7 @@ class TestSentrySDKMetricsBackend:
             attributes={"x": "y"},
         )
 
-    @mock.patch("sentry_sdk._metrics.count")
+    @mock.patch("sentry_sdk.metrics.count")
     def test_incr_with_instance(self, mock_count, backend):
         with mock.patch.object(backend, "_should_send", return_value=True):
             backend.incr("foo", instance="web", tags={"x": "y"}, amount=1)
@@ -76,13 +76,13 @@ class TestSentrySDKMetricsBackend:
     def test_event_noop(self, backend):
         backend.event("title", "message")
 
-    @mock.patch("sentry_sdk._metrics.count")
+    @mock.patch("sentry_sdk.metrics.count")
     def test_incr_sampling(self, mock_count):
         backend = SentrySDKMetricsBackend(prefix="test.", experimental_sample_rate=0.0)
         backend.incr("foo", amount=1)
         mock_count.assert_not_called()
 
-    @mock.patch("sentry_sdk._metrics.count")
+    @mock.patch("sentry_sdk.metrics.count")
     def test_incr_deny_list(self, mock_count):
         backend = SentrySDKMetricsBackend(
             prefix="test.", experimental_sample_rate=1.0, deny_list=["test.denied"]

--- a/uv.lock
+++ b/uv.lock
@@ -2157,7 +2157,7 @@ requires-dist = [
     { name = "sentry-protos", specifier = ">=0.4.2" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.17" },
-    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.42.0" },
+    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.43.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "simplejson", specifier = ">=3.17.6" },
@@ -2389,14 +2389,14 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.42.0"
+version = "2.43.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.42.0-py2.py3-none-any.whl", hash = "sha256:1a7986e638306ff158f52dd47d9480a4055e6c289388caa90628acb2563fe7bd" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.43.0-py2.py3-none-any.whl", hash = "sha256:4aacafcf1756ef066d359ae35030881917160ba7f6fc3ae11e0e58b09edc2d5d" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!-- Describe your PR here. -->

Use `sentry_sdk.metrics` instead of `sentry_sdk._metrics`, as the namespace is updated in https://github.com/getsentry/sentry-python/pull/5035.
