### PR TITLE
feat(ai-insights): open traces drawer from conversation table

### DIFF
--- a/static/app/views/insights/agents/components/drawer.tsx
+++ b/static/app/views/insights/agents/components/drawer.tsx
@@ -105,7 +105,7 @@ const TraceViewDrawer = memo(function TraceViewDrawer({
   );
 });
 
-export function useTraceViewDrawer({onClose = undefined}: UseTraceViewDrawerProps) {
+export function useTraceViewDrawer({onClose}: UseTraceViewDrawerProps = {}) {
   const organization = useOrganization();
   const {openDrawer, isDrawerOpen, drawerUrlState, closeDrawer} = useUrlTraceDrawer();
 

--- a/static/app/views/insights/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/agents/components/tracesTable.tsx
@@ -232,7 +232,7 @@ const BodyCell = memo(function BodyCell({
 }) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const {openTraceViewDrawer} = useTraceViewDrawer({});
+  const {openTraceViewDrawer} = useTraceViewDrawer();
 
   switch (column.key) {
     case 'traceId':


### PR DESCRIPTION
Closes [TET-1282: AI Insights for Seer - display conversations instead of traces](https://linear.app/getsentry/issue/TET-1282/ai-insights-for-seer-display-conversations-instead-of-traces)

- Displays trace Ids in a separate column
- Clicking on a trace Id makes opens the trace drawer
https://github.com/user-attachments/assets/f52f8a93-a60f-417d-bcce-1bf76337c1cc

