### PR TITLE
ref: NuqsTestingAdapter

### DIFF
--- a/tests/js/sentry-test/nuqsTestingAdapter.spec.tsx
+++ b/tests/js/sentry-test/nuqsTestingAdapter.spec.tsx
@@ -1,0 +1,104 @@
+import {parseAsString, useQueryState} from 'nuqs';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+describe('SentryNuqsTestingAdapter', () => {
+  it('reads search params from router location', async () => {
+    function TestComponent() {
+      const [search] = useQueryState('query', parseAsString);
+      return <div>Search: {search ?? 'empty'}</div>;
+    }
+
+    const {router} = render(<TestComponent />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/test',
+          query: {query: 'hello'},
+        },
+      },
+    });
+
+    expect(screen.getByText('Search: hello')).toBeInTheDocument();
+
+    // Navigate to a new location with different search params
+    router.navigate('/test?query=world');
+
+    expect(await screen.findByText('Search: world')).toBeInTheDocument();
+  });
+
+  it('updates router location when nuqs state changes', async () => {
+    function TestComponent() {
+      const [search, setSearch] = useQueryState('query', parseAsString);
+      return (
+        <div>
+          <div>Search: {search ?? 'empty'}</div>
+          <button onClick={() => setSearch('updated')}>Update</button>
+        </div>
+      );
+    }
+
+    const {router} = render(<TestComponent />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/test',
+          query: {query: 'initial'},
+        },
+      },
+    });
+
+    expect(screen.getByText('Search: initial')).toBeInTheDocument();
+
+    // Click button to update search param via nuqs
+    await userEvent.click(screen.getByRole('button', {name: 'Update'}));
+
+    // Wait for navigation to complete
+    await screen.findByText('Search: updated');
+
+    // Verify the router location was updated
+    await waitFor(() => {
+      expect(router.location.search).toContain('query=updated');
+    });
+  });
+
+  it('handles multiple query params', () => {
+    function TestComponent() {
+      const [foo] = useQueryState('foo', parseAsString);
+      const [bar] = useQueryState('bar', parseAsString);
+      return (
+        <div>
+          <div>Foo: {foo ?? 'empty'}</div>
+          <div>Bar: {bar ?? 'empty'}</div>
+        </div>
+      );
+    }
+
+    render(<TestComponent />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/test',
+          query: {foo: 'value1', bar: 'value2'},
+        },
+      },
+    });
+
+    expect(screen.getByText('Foo: value1')).toBeInTheDocument();
+    expect(screen.getByText('Bar: value2')).toBeInTheDocument();
+  });
+
+  it('handles missing query params', () => {
+    function TestComponent() {
+      const [search] = useQueryState('query', parseAsString);
+      return <div>Search: {search ?? 'empty'}</div>;
+    }
+
+    render(<TestComponent />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/test',
+        },
+      },
+    });
+
+    expect(screen.getByText('Search: empty')).toBeInTheDocument();
+  });
+});

--- a/tests/js/sentry-test/nuqsTestingAdapter.tsx
+++ b/tests/js/sentry-test/nuqsTestingAdapter.tsx
@@ -64,7 +64,7 @@ export function SentryNuqsTestingAdapter({
         // Navigate to the new location using Sentry's navigate
         // We need to construct the full path with the search string
         const newPath = queryString
-          ? `${location.pathname}?${queryString}`
+          ? `${location.pathname}${queryString}`
           : location.pathname;
 
         // The navigate function from TestRouter already wraps this in act()

--- a/tests/js/sentry-test/nuqsTestingAdapter.tsx
+++ b/tests/js/sentry-test/nuqsTestingAdapter.tsx
@@ -1,0 +1,94 @@
+import {useCallback, useMemo, type ReactElement, type ReactNode} from 'react';
+import {unstable_createAdapterProvider as createAdapterProvider} from 'nuqs/adapters/custom';
+import type {unstable_AdapterInterface as AdapterInterface} from 'nuqs/adapters/custom';
+import type {OnUrlUpdateFunction} from 'nuqs/adapters/testing';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+type SentryNuqsTestingAdapterProps = {
+  children: ReactNode;
+  /**
+   * Default options to pass to nuqs
+   */
+  defaultOptions?: {
+    clearOnDefault?: boolean;
+    scroll?: boolean;
+    shallow?: boolean;
+  };
+  /**
+   * A function that will be called whenever the URL is updated.
+   * Connect that to a spy in your tests to assert the URL updates.
+   */
+  onUrlUpdate?: OnUrlUpdateFunction;
+};
+
+/**
+ * Custom nuqs adapter component for Sentry that reads location from our
+ * useLocation hook instead of maintaining its own internal state.
+ *
+ * This ensures nuqs uses the same location source as the rest of the
+ * application during tests.
+ */
+export function SentryNuqsTestingAdapter({
+  children,
+  defaultOptions,
+  onUrlUpdate,
+}: SentryNuqsTestingAdapterProps): ReactElement {
+  // Create a hook that nuqs will call to get the adapter interface
+  // This hook needs to be defined inside a component that has access to location/navigate
+  const useSentryAdapter = useCallback(
+    (_watchKeys: string[]): AdapterInterface => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const location = useLocation();
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const navigate = useNavigate();
+
+      // Get search params from the current location
+      const searchParams = new URLSearchParams(location.search || '');
+
+      const updateUrl: AdapterInterface['updateUrl'] = (search, options) => {
+        const newSearchParams = new URLSearchParams(search);
+        const queryString = newSearchParams.toString();
+
+        // Call the onUrlUpdate callback if provided
+        onUrlUpdate?.({
+          searchParams: new URLSearchParams(search), // make a copy
+          queryString,
+          options,
+        });
+
+        // Navigate to the new location using Sentry's navigate
+        // We need to construct the full path with the search string
+        const newPath = queryString
+          ? `${location.pathname}?${queryString}`
+          : location.pathname;
+
+        // The navigate function from TestRouter already wraps this in act()
+        navigate(newPath, {replace: options.history === 'replace'});
+      };
+
+      const getSearchParamsSnapshot = () => {
+        // Always read from the current location
+        return new URLSearchParams(location.search || '');
+      };
+
+      return {
+        searchParams,
+        updateUrl,
+        getSearchParamsSnapshot,
+        rateLimitFactor: 0, // No throttling in tests
+        autoResetQueueOnUpdate: true, // Reset update queue after each update
+      };
+    },
+    [onUrlUpdate]
+  );
+
+  // Create the adapter provider (memoized to prevent remounting)
+  const AdapterProvider = useMemo(
+    () => createAdapterProvider(useSentryAdapter),
+    [useSentryAdapter]
+  );
+
+  return <AdapterProvider defaultOptions={defaultOptions}>{children}</AdapterProvider>;
+}

--- a/tests/js/sentry-test/nuqsTestingAdapter.tsx
+++ b/tests/js/sentry-test/nuqsTestingAdapter.tsx
@@ -1,5 +1,8 @@
 import {useCallback, useMemo, type ReactElement, type ReactNode} from 'react';
-import {unstable_createAdapterProvider as createAdapterProvider} from 'nuqs/adapters/custom';
+import {
+  unstable_createAdapterProvider as createAdapterProvider,
+  renderQueryString,
+} from 'nuqs/adapters/custom';
 import type {unstable_AdapterInterface as AdapterInterface} from 'nuqs/adapters/custom';
 import type {OnUrlUpdateFunction} from 'nuqs/adapters/testing';
 
@@ -49,7 +52,7 @@ export function SentryNuqsTestingAdapter({
 
       const updateUrl: AdapterInterface['updateUrl'] = (search, options) => {
         const newSearchParams = new URLSearchParams(search);
-        const queryString = newSearchParams.toString();
+        const queryString = renderQueryString(newSearchParams);
 
         // Call the onUrlUpdate callback if provided
         onUrlUpdate?.({


### PR DESCRIPTION
Continued from
- https://github.com/getsentry/sentry/pull/101616

This PR creates a `SentryNuqsTestingAdapter` that uses our `useLocation` and `useNavigate` hooks to interface with nuqs in tests so that it uses our testing router as the source of truth 