### PR TITLE
fix(frontend): make the "loading obnoxious amount of JS" banner mobile friendly

### DIFF
--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -523,6 +523,18 @@ table.table.key-value {
     overflow: hidden;
     border-radius: 50%;
   }
+
+  @media (max-width: 500px) {
+    width: 90vw;
+    margin-left: -45vw;
+
+    .loading-message {
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      padding: 0 1rem;
+      box-sizing: border-box;
+    }
+  }
 }
 
 .theme-dark .loading.triangle .loading-indicator {


### PR DESCRIPTION
The CSS is hardcoding the width to be 500px which overflows on mobile devices. Adds a `@media (max-width: 500px)` media query to add custom sizing for those screens.

<img width="427" height="435" alt="Screenshot 2025-10-30 at 10 35 17 AM" src="https://github.com/user-attachments/assets/84aecca1-c1b1-4b58-8b74-abe8dd70f335" />
