### PR TITLE
fix(dashboards): Lift `AnimatePresence`

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -158,7 +158,7 @@ function WidgetBuilderV2({
   }, [isPreviewDraggable]);
 
   return (
-    <Fragment>
+    <AnimatePresence>
       {isOpen && (
         <Fragment>
           <Global
@@ -169,80 +169,72 @@ function WidgetBuilderV2({
             `}
           />
           <Backdrop style={{opacity: 0.5, pointerEvents: 'auto'}} />
-          <AnimatePresence>
-            {isOpen && (
-              <WidgetBuilderProvider>
-                <CustomMeasurementsProvider
-                  organization={organization}
-                  selection={selection}
+          <WidgetBuilderProvider>
+            <CustomMeasurementsProvider organization={organization} selection={selection}>
+              <TraceItemAttributeProviderFromDataset>
+                <ContainerWithoutSidebar
+                  style={
+                    hasValidNav
+                      ? isMediumScreen
+                        ? {
+                            left: 0,
+                            top: `${dimensions.height ?? 0}px`,
+                            willChange: 'top',
+                          }
+                        : {
+                            left: `${dimensions.width ?? 0}px`,
+                            top: 0,
+                            willChange: 'left',
+                          }
+                      : undefined
+                  }
                 >
-                  <TraceItemAttributeProviderFromDataset>
-                    <ContainerWithoutSidebar
-                      style={
-                        hasValidNav
-                          ? isMediumScreen
-                            ? {
-                                left: 0,
-                                top: `${dimensions.height ?? 0}px`,
-                                willChange: 'top',
-                              }
-                            : {
-                                left: `${dimensions.width ?? 0}px`,
-                                top: 0,
-                                willChange: 'left',
-                              }
-                          : undefined
-                      }
-                    >
-                      <WidgetBuilderContainer>
-                        <SlideoutContainer>
-                          <WidgetBuilderSlideout
-                            isOpen={isOpen}
-                            onClose={() => {
-                              onClose();
-                              setTranslate(DEFAULT_WIDGET_DRAG_POSITIONING);
-                            }}
-                            onSave={onSave}
-                            onQueryConditionChange={setQueryConditionsValid}
-                            dashboard={dashboard}
+                  <WidgetBuilderContainer>
+                    <SlideoutContainer>
+                      <WidgetBuilderSlideout
+                        onClose={() => {
+                          onClose();
+                          setTranslate(DEFAULT_WIDGET_DRAG_POSITIONING);
+                        }}
+                        onSave={onSave}
+                        onQueryConditionChange={setQueryConditionsValid}
+                        dashboard={dashboard}
+                        dashboardFilters={dashboardFilters}
+                        setIsPreviewDraggable={setIsPreviewDraggable}
+                        isWidgetInvalid={!queryConditionsValid}
+                        openWidgetTemplates={openWidgetTemplates}
+                        setOpenWidgetTemplates={setOpenWidgetTemplates}
+                        onDataFetched={handleWidgetDataFetched}
+                        thresholdMetaState={thresholdMetaState}
+                      />
+                    </SlideoutContainer>
+                    {(!isSmallScreen || isPreviewDraggable) && (
+                      <DndContext
+                        onDragEnd={handleDragEnd}
+                        onDragMove={handleDragMove}
+                        collisionDetection={closestCorners}
+                      >
+                        <SurroundingWidgetContainer>
+                          <WidgetPreviewContainer
                             dashboardFilters={dashboardFilters}
-                            setIsPreviewDraggable={setIsPreviewDraggable}
+                            dashboard={dashboard}
+                            dragPosition={translate}
+                            isDraggable={isPreviewDraggable}
                             isWidgetInvalid={!queryConditionsValid}
-                            openWidgetTemplates={openWidgetTemplates}
-                            setOpenWidgetTemplates={setOpenWidgetTemplates}
                             onDataFetched={handleWidgetDataFetched}
-                            thresholdMetaState={thresholdMetaState}
+                            openWidgetTemplates={openWidgetTemplates}
                           />
-                        </SlideoutContainer>
-                        {(!isSmallScreen || isPreviewDraggable) && (
-                          <DndContext
-                            onDragEnd={handleDragEnd}
-                            onDragMove={handleDragMove}
-                            collisionDetection={closestCorners}
-                          >
-                            <SurroundingWidgetContainer>
-                              <WidgetPreviewContainer
-                                dashboardFilters={dashboardFilters}
-                                dashboard={dashboard}
-                                dragPosition={translate}
-                                isDraggable={isPreviewDraggable}
-                                isWidgetInvalid={!queryConditionsValid}
-                                onDataFetched={handleWidgetDataFetched}
-                                openWidgetTemplates={openWidgetTemplates}
-                              />
-                            </SurroundingWidgetContainer>
-                          </DndContext>
-                        )}
-                      </WidgetBuilderContainer>
-                    </ContainerWithoutSidebar>
-                  </TraceItemAttributeProviderFromDataset>
-                </CustomMeasurementsProvider>
-              </WidgetBuilderProvider>
-            )}
-          </AnimatePresence>
+                        </SurroundingWidgetContainer>
+                      </DndContext>
+                    )}
+                  </WidgetBuilderContainer>
+                </ContainerWithoutSidebar>
+              </TraceItemAttributeProviderFromDataset>
+            </CustomMeasurementsProvider>
+          </WidgetBuilderProvider>
         </Fragment>
       )}
-    </Fragment>
+    </AnimatePresence>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -69,7 +69,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -109,7 +108,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -146,7 +144,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -184,7 +181,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -216,7 +212,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -257,7 +252,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -301,7 +295,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -341,7 +334,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -388,7 +380,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -426,7 +417,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -458,7 +448,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -489,7 +478,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -514,7 +502,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -539,7 +526,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -568,7 +554,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />
@@ -609,7 +594,6 @@ describe('WidgetBuilderSlideout', () => {
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
-          isOpen
           openWidgetTemplates={false}
           setOpenWidgetTemplates={jest.fn()}
         />

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -56,7 +56,6 @@ import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibr
 type WidgetBuilderSlideoutProps = {
   dashboard: DashboardDetails;
   dashboardFilters: DashboardFilters;
-  isOpen: boolean;
   isWidgetInvalid: boolean;
   onClose: () => void;
   onQueryConditionChange: (valid: boolean) => void;
@@ -69,7 +68,6 @@ type WidgetBuilderSlideoutProps = {
 };
 
 function WidgetBuilderSlideout({
-  isOpen,
   onClose,
   onSave,
   onQueryConditionChange,
@@ -205,7 +203,7 @@ function WidgetBuilderSlideout({
 
   return (
     <SlideOverPanel
-      collapsed={!isOpen}
+      collapsed={false}
       slidePosition="left"
       data-test-id="widget-slideout"
       transitionProps={animationTransitionSettings}


### PR DESCRIPTION
There's a bug in the current Widget Builder where it doesn't animate out on close anymore. This happens because the `isOpen` conditional is _above_ `AnimatePresence`. Then the builder closes, the `AnimatePresence` is unmounted, and it doesn't run the animation.
Instead, it needs to be lifted higher.

I also removed what looked like redundant `isOpen` conditionals and props. There was an `isOpen` nested under another `isOpen` that looks redundant, and an `isOpen` prop that isn't needed since it's never `false`.

This PR is best enjoyed with whitespace turned off.