### PR TITLE
fix(logs): update withoutLoggingSupport to remove platforms which support logs

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -379,7 +379,7 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging
-export const withoutLoggingSupport: Set<PlatformKey> = new Set(['elixir', 'unity']);
+export const withoutLoggingSupport: Set<PlatformKey> = new Set(['elixir']);
 
 // List of platforms that have metrics onboarding checklist content
 export const withMetricsOnboarding: Set<PlatformKey> = new Set([

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -382,7 +382,6 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 export const withoutLoggingSupport: Set<PlatformKey> = new Set([
   'elixir',
   'unity',
-  'unreal',
 ]);
 
 // List of platforms that have metrics onboarding checklist content

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -379,10 +379,7 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging
-export const withoutLoggingSupport: Set<PlatformKey> = new Set([
-  'elixir',
-  'unity',
-]);
+export const withoutLoggingSupport: Set<PlatformKey> = new Set(['elixir', 'unity']);
 
 // List of platforms that have metrics onboarding checklist content
 export const withMetricsOnboarding: Set<PlatformKey> = new Set([

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -382,7 +382,7 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 export const withoutLoggingSupport: Set<PlatformKey> = new Set([
   'elixir',
   'unity',
-  'unreal'
+  'unreal',
 ]);
 
 // List of platforms that have metrics onboarding checklist content

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -383,11 +383,8 @@ export const withoutLoggingSupport: Set<PlatformKey> = new Set([
   'cocoa-objc',
   'cocoa-swift',
   'elixir',
-  'dotnet',
   'php-symfony',
   'unity',
-  'unreal',
-  'native',
 ]);
 
 // List of platforms that have metrics onboarding checklist content

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -380,11 +380,9 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging
 export const withoutLoggingSupport: Set<PlatformKey> = new Set([
-  'cocoa-objc',
-  'cocoa-swift',
   'elixir',
-  'php-symfony',
   'unity',
+  'unreal'
 ]);
 
 // List of platforms that have metrics onboarding checklist content


### PR DESCRIPTION
Removed 'cocoa', 'dotnet',  'symfony', 'unity', 'unreal' and 'native' from the withoutLoggingSupport set, since they have all been released:

- **cocoa**
  - https://github.com/getsentry/sentry-cocoa/releases/tag/8.54.0
- **dotnet**
  - https://github.com/getsentry/sentry-dotnet/releases/tag/5.14.0
- **symfony**
  - https://github.com/getsentry/sentry-symfony/releases/tag/5.4.0
- **unity**
  - https://github.com/getsentry/sentry-unity/releases/tag/4.0.0-beta.4
- **unreal**
  - https://github.com/getsentry/sentry-unreal/releases/tag/1.2.0-beta.1
- **native**
  - https://github.com/getsentry/sentry-native/releases/tag/0.11.1