### PR TITLE
feat(seer-autofix): remember last used rca action

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -35,9 +35,8 @@ import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
-import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 import {AutofixTimeline} from './autofixTimeline';
@@ -262,8 +261,6 @@ function AutofixRootCauseDisplay({
 }: AutofixRootCauseProps) {
   const cause = causes[0];
   const organization = useOrganization();
-  const user = useUser();
-  const {mutate: mutateUserOptions} = useMutateUserOptions();
   const iconFocusRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLDivElement | null>(null);
   const [solutionText, setSolutionText] = useState('');
@@ -279,7 +276,9 @@ function AutofixRootCauseDisplay({
     runId
   );
 
-  const preferredAction = user.options.autofixLastUsedRootCauseAction || 'seer_solution';
+  const [preferredAction, setPreferredAction] = useLocalStorageState<
+    'seer_solution' | 'cursor_background_agent'
+  >('autofix:rootCauseActionPreference', 'seer_solution');
 
   const handleSelectDescription = () => {
     if (descriptionRef.current) {
@@ -300,7 +299,7 @@ function AutofixRootCauseDisplay({
     }
 
     // Save user preference
-    mutateUserOptions({autofixLastUsedRootCauseAction: 'seer_solution'});
+    setPreferredAction('seer_solution');
 
     const instruction = solutionText.trim();
 
@@ -335,7 +334,7 @@ function AutofixRootCauseDisplay({
     }
 
     // Save user preference
-    mutateUserOptions({autofixLastUsedRootCauseAction: 'cursor_background_agent'});
+    setPreferredAction('cursor_background_agent');
 
     // Show immediate loading toast
     addLoadingMessage(t('Launching %s...', cursorIntegration.name));

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -303,6 +303,7 @@ function AutofixRootCauseDisplay({
     mutateUserOptions({autofixLastUsedRootCauseAction: 'seer_solution'});
 
     const instruction = solutionText.trim();
+
     if (instruction) {
       selectRootCause({
         cause_id: cause.id,
@@ -319,7 +320,7 @@ function AutofixRootCauseDisplay({
     trackAnalytics('autofix.root_cause.find_solution', {
       organization,
       group_id: groupId,
-      instruction_provided: solutionText.trim().length > 0,
+      instruction_provided: instruction.length > 0,
     });
   };
 

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -57,7 +57,6 @@ export interface User extends Omit<AvatarUser, 'options'> {
     stacktraceOrder: StacktraceOrder;
     theme: 'system' | 'light' | 'dark';
     timezone: string;
-    autofixLastUsedRootCauseAction?: 'seer_solution' | 'cursor_background_agent';
   };
   permissions: Set<string>;
   authenticators?: UserEnrolledAuthenticator[];

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -57,6 +57,7 @@ export interface User extends Omit<AvatarUser, 'options'> {
     stacktraceOrder: StacktraceOrder;
     theme: 'system' | 'light' | 'dark';
     timezone: string;
+    autofixLastUsedRootCauseAction?: 'seer_solution' | 'cursor_background_agent';
   };
   permissions: Set<string>;
   authenticators?: UserEnrolledAuthenticator[];

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -1,6 +1,7 @@
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {PriorityLevel} from 'sentry/types/group';
 import type {IntegrationType} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
 import type {Broadcast} from 'sentry/types/system';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 import type {CommonGroupAnalyticsData} from 'sentry/utils/events';
@@ -65,6 +66,15 @@ interface SetPriorityParams extends CommonGroupAnalyticsData {
 
 export type IssueEventParameters = {
   'actionable_items.expand_clicked': ActionableItemDebugParam;
+  'autofix.coding_agent.launch_from_root_cause': {
+    group_id: string;
+    organization: Organization;
+  };
+  'autofix.root_cause.find_solution': {
+    group_id: string;
+    instruction_provided: boolean;
+    organization: Organization;
+  };
   'autofix.setup_modal_viewed': {
     groupId: string;
     projectId: string;
@@ -437,6 +447,9 @@ export type IssueEventParameters = {
 type IssueEventKey = keyof IssueEventParameters;
 
 export const issueEventMap: Record<IssueEventKey, string | null> = {
+  'autofix.coding_agent.launch_from_root_cause':
+    'Autofix: Coding Agent Launch From Root Cause',
+  'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',
   'breadcrumbs.issue_details.change_time_display': 'Breadcrumb Time Display Toggled',
   'breadcrumbs.issue_details.drawer_opened': 'Breadcrumb Drawer Opened',


### PR DESCRIPTION
Remember a user's last used root cause card action in the user options

<img width="914" height="322" alt="CleanShot 2025-10-30 at 21 18 27@2x" src="https://github.com/user-attachments/assets/bcfe843a-f707-4f39-a3eb-e020e66e66e4" />
<img width="772" height="360" alt="CleanShot 2025-10-30 at 21 16 51@2x" src="https://github.com/user-attachments/assets/862572cc-86c8-4228-9901-a341e750c138" />

Will still show [Find Solution] if you don't have any integrations configured.

Paired with #102400 