### PR TITLE
feat(user-options): store seer last used solution action

### DIFF
--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -69,7 +69,7 @@ class UserOptionsSerializer(serializers.Serializer[UserOption]):
     prefersIssueDetailsStreamlinedUI = serializers.BooleanField(required=False)
     prefersNextjsInsightsOverview = serializers.BooleanField(required=False)
     prefersChonkUI = serializers.BooleanField(required=False)
-    autofixLastUsedSolutionAction = serializers.ChoiceField(
+    autofixLastUsedRootCauseAction = serializers.ChoiceField(
         choices=(
             ("seer_solution", _("Seer Solution")),
             ("cursor_background_agent", _("Cursor Background Agent")),
@@ -246,7 +246,7 @@ class UserDetailsEndpoint(UserEndpoint):
             "prefersIssueDetailsStreamlinedUI": "prefers_issue_details_streamlined_ui",
             "prefersNextjsInsightsOverview": "prefers_nextjs_insights_overview",
             "prefersChonkUI": "prefers_chonk_ui",
-            "autofixLastUsedSolutionAction": "autofix_last_used_solution_action",
+            "autofixLastUsedRootCauseAction": "autofix_last_used_root_cause_action",
         }
 
         options_result = serializer_options.validated_data

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -69,6 +69,13 @@ class UserOptionsSerializer(serializers.Serializer[UserOption]):
     prefersIssueDetailsStreamlinedUI = serializers.BooleanField(required=False)
     prefersNextjsInsightsOverview = serializers.BooleanField(required=False)
     prefersChonkUI = serializers.BooleanField(required=False)
+    autofixLastUsedSolutionAction = serializers.ChoiceField(
+        choices=(
+            ("seer_solution", _("Seer Solution")),
+            ("cursor_background_agent", _("Cursor Background Agent")),
+        ),
+        required=False,
+    )
 
 
 class BaseUserSerializer(CamelSnakeModelSerializer[User]):
@@ -239,6 +246,7 @@ class UserDetailsEndpoint(UserEndpoint):
             "prefersIssueDetailsStreamlinedUI": "prefers_issue_details_streamlined_ui",
             "prefersNextjsInsightsOverview": "prefers_nextjs_insights_overview",
             "prefersChonkUI": "prefers_chonk_ui",
+            "autofixLastUsedSolutionAction": "autofix_last_used_solution_action",
         }
 
         options_result = serializer_options.validated_data

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -75,6 +75,7 @@ class _UserOptions(TypedDict):
     prefersIssueDetailsStreamlinedUI: bool | None
     prefersNextjsInsightsOverview: bool
     prefersChonkUI: bool
+    autofixLastUsedSolutionAction: str | None
 
 
 class UserSerializerResponseOptional(TypedDict, total=False):
@@ -220,6 +221,7 @@ class UserSerializer(Serializer):
                     "prefers_issue_details_streamlined_ui"
                 ),
                 "prefersChonkUI": options.get("prefers_chonk_ui", False),
+                "autofixLastUsedSolutionAction": options.get("autofix_last_used_solution_action"),
             }
 
             d["flags"] = {"newsletter_consent_prompt": bool(obj.flags.newsletter_consent_prompt)}

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -75,7 +75,7 @@ class _UserOptions(TypedDict):
     prefersIssueDetailsStreamlinedUI: bool | None
     prefersNextjsInsightsOverview: bool
     prefersChonkUI: bool
-    autofixLastUsedSolutionAction: str | None
+    autofixLastUsedRootCauseAction: str | None
 
 
 class UserSerializerResponseOptional(TypedDict, total=False):
@@ -221,7 +221,9 @@ class UserSerializer(Serializer):
                     "prefers_issue_details_streamlined_ui"
                 ),
                 "prefersChonkUI": options.get("prefers_chonk_ui", False),
-                "autofixLastUsedSolutionAction": options.get("autofix_last_used_solution_action"),
+                "autofixLastUsedRootCauseAction": options.get(
+                    "autofix_last_used_root_cause_action"
+                ),
             }
 
             d["flags"] = {"newsletter_consent_prompt": bool(obj.flags.newsletter_consent_prompt)}

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -50,6 +50,7 @@ class UserDetailsGetTest(UserDetailsTest):
         assert not resp.data["options"]["clock24Hours"]
         assert not resp.data["options"]["prefersIssueDetailsStreamlinedUI"]
         assert not resp.data["options"]["prefersChonkUI"]
+        assert resp.data["options"]["autofixLastUsedSolutionAction"] is None
 
     def test_superuser_simple(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
@@ -235,6 +236,36 @@ class UserDetailsUpdateTest(UserDetailsTest):
             "me",
         )
         assert resp.data["options"]["prefersNextjsInsightsOverview"] is True
+
+    def test_user_options_autofix_last_used_solution_action_seer(self) -> None:
+        resp = self.get_success_response(
+            "me", options={"autofixLastUsedSolutionAction": "seer_solution"}
+        )
+
+        # Verify saved in UserOption
+        option = UserOption.objects.get(user=self.user, key="autofix_last_used_solution_action")
+        assert option.value == "seer_solution"
+
+        # Verify returned in response
+        assert resp.data["options"]["autofixLastUsedSolutionAction"] == "seer_solution"
+
+    def test_user_options_autofix_last_used_solution_action_cursor(self) -> None:
+        resp = self.get_success_response(
+            "me", options={"autofixLastUsedSolutionAction": "cursor_background_agent"}
+        )
+
+        # Verify saved in UserOption
+        option = UserOption.objects.get(user=self.user, key="autofix_last_used_solution_action")
+        assert option.value == "cursor_background_agent"
+
+        # Verify returned in response
+        assert resp.data["options"]["autofixLastUsedSolutionAction"] == "cursor_background_agent"
+
+    def test_user_options_autofix_invalid_choice(self) -> None:
+        # Verify invalid values are rejected with 400 error
+        self.get_error_response(
+            "me", options={"autofixLastUsedSolutionAction": "invalid_option"}, status_code=400
+        )
 
 
 @control_silo_test

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -50,7 +50,7 @@ class UserDetailsGetTest(UserDetailsTest):
         assert not resp.data["options"]["clock24Hours"]
         assert not resp.data["options"]["prefersIssueDetailsStreamlinedUI"]
         assert not resp.data["options"]["prefersChonkUI"]
-        assert resp.data["options"]["autofixLastUsedSolutionAction"] is None
+        assert resp.data["options"]["autofixLastUsedRootCauseAction"] is None
 
     def test_superuser_simple(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
@@ -239,32 +239,32 @@ class UserDetailsUpdateTest(UserDetailsTest):
 
     def test_user_options_autofix_last_used_solution_action_seer(self) -> None:
         resp = self.get_success_response(
-            "me", options={"autofixLastUsedSolutionAction": "seer_solution"}
+            "me", options={"autofixLastUsedRootCauseAction": "seer_solution"}
         )
 
         # Verify saved in UserOption
-        option = UserOption.objects.get(user=self.user, key="autofix_last_used_solution_action")
+        option = UserOption.objects.get(user=self.user, key="autofix_last_used_root_cause_action")
         assert option.value == "seer_solution"
 
         # Verify returned in response
-        assert resp.data["options"]["autofixLastUsedSolutionAction"] == "seer_solution"
+        assert resp.data["options"]["autofixLastUsedRootCauseAction"] == "seer_solution"
 
     def test_user_options_autofix_last_used_solution_action_cursor(self) -> None:
         resp = self.get_success_response(
-            "me", options={"autofixLastUsedSolutionAction": "cursor_background_agent"}
+            "me", options={"autofixLastUsedRootCauseAction": "cursor_background_agent"}
         )
 
         # Verify saved in UserOption
-        option = UserOption.objects.get(user=self.user, key="autofix_last_used_solution_action")
+        option = UserOption.objects.get(user=self.user, key="autofix_last_used_root_cause_action")
         assert option.value == "cursor_background_agent"
 
         # Verify returned in response
-        assert resp.data["options"]["autofixLastUsedSolutionAction"] == "cursor_background_agent"
+        assert resp.data["options"]["autofixLastUsedRootCauseAction"] == "cursor_background_agent"
 
     def test_user_options_autofix_invalid_choice(self) -> None:
         # Verify invalid values are rejected with 400 error
         self.get_error_response(
-            "me", options={"autofixLastUsedSolutionAction": "invalid_option"}, status_code=400
+            "me", options={"autofixLastUsedRootCauseAction": "invalid_option"}, status_code=400
         )
 
 

--- a/tests/sentry/users/api/serializers/test_user.py
+++ b/tests/sentry/users/api/serializers/test_user.py
@@ -7,6 +7,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.users.api.serializers.user import DetailedSelfUserSerializer, DetailedUserSerializer
 from sentry.users.models.authenticator import Authenticator
 from sentry.users.models.user_avatar import UserAvatar
+from sentry.users.models.user_option import UserOption
 from sentry.users.models.useremail import UserEmail
 from sentry.users.models.userpermission import UserPermission
 
@@ -132,3 +133,15 @@ class DetailedSelfUserSerializerTest(TestCase):
         assert len(result["authenticators"]) == 1
         assert result["authenticators"][0]["id"] == str(self.auth.id)
         assert result["permissions"] == ["foo"]
+
+    def test_autofix_last_used_solution_action_serialization(self) -> None:
+        UserOption.objects.set_value(
+            user=self.user, key="autofix_last_used_solution_action", value="cursor_background_agent"
+        )
+
+        result = serialize(self.user, self.user, DetailedSelfUserSerializer())
+        assert result["options"]["autofixLastUsedSolutionAction"] == "cursor_background_agent"
+
+    def test_autofix_last_used_solution_action_not_set(self) -> None:
+        result = serialize(self.user, self.user, DetailedSelfUserSerializer())
+        assert result["options"]["autofixLastUsedSolutionAction"] is None

--- a/tests/sentry/users/api/serializers/test_user.py
+++ b/tests/sentry/users/api/serializers/test_user.py
@@ -136,12 +136,14 @@ class DetailedSelfUserSerializerTest(TestCase):
 
     def test_autofix_last_used_solution_action_serialization(self) -> None:
         UserOption.objects.set_value(
-            user=self.user, key="autofix_last_used_solution_action", value="cursor_background_agent"
+            user=self.user,
+            key="autofix_last_used_root_cause_action",
+            value="cursor_background_agent",
         )
 
         result = serialize(self.user, self.user, DetailedSelfUserSerializer())
-        assert result["options"]["autofixLastUsedSolutionAction"] == "cursor_background_agent"
+        assert result["options"]["autofixLastUsedRootCauseAction"] == "cursor_background_agent"
 
     def test_autofix_last_used_solution_action_not_set(self) -> None:
         result = serialize(self.user, self.user, DetailedSelfUserSerializer())
-        assert result["options"]["autofixLastUsedSolutionAction"] is None
+        assert result["options"]["autofixLastUsedRootCauseAction"] is None


### PR DESCRIPTION
Store a `autofixLastUsedRootCauseAction` field to remember a user's last used post-rca action when they have a coding agent integration configured.

paired with #102399 