### PR TITLE
fix(ui2): Align trailingItems and expand chevron in Alert

### DIFF
--- a/static/app/components/core/alert/alert.chonk.tsx
+++ b/static/app/components/core/alert/alert.chonk.tsx
@@ -25,7 +25,7 @@ interface ChonkAlertProps extends Omit<AlertProps, 'type'> {
 export const AlertPanel = chonkStyled('div')<ChonkAlertProps>`
   position: relative;
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: ${p => getAlertGridLayout(p)};
   padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   border-width: ${p => (p.system ? '0px 0px 1px 0px' : '1px')};
   border-style: solid;
@@ -41,6 +41,10 @@ export const AlertPanel = chonkStyled('div')<ChonkAlertProps>`
     text-decoration: underline;
   }
 `;
+
+function getAlertGridLayout(p: ChonkAlertProps) {
+  return `1fr ${p.trailingItems ? 'auto' : ''} ${p.expand ? 'min-content' : ''}`;
+}
 
 function makeChonkAlertTheme(props: ChonkAlertProps): SerializedStyles {
   const tokens = getChonkAlertTokens(props.type, props.theme!);

--- a/static/app/components/core/alert/alert.mdx
+++ b/static/app/components/core/alert/alert.mdx
@@ -173,7 +173,7 @@ Add interactive elements like buttons, links or badges to the right side of aler
 <Storybook.Demo>
   <Alert.Container>
     <Alert type="info" trailingItems={<Badge type="warning">Action Required</Badge>}>
-      This alert has a trailing bagde
+      This alert has a trailing badge
     </Alert>
     <Alert
       type="error"
@@ -189,6 +189,25 @@ Add interactive elements like buttons, links or badges to the right side of aler
       }
     >
       This alert has multiple trailing actions
+    </Alert>
+    <Alert
+      type="warning"
+      expand={
+        <div>
+          <p>This alert starts in an expanded state.</p>
+          <p>Users can still collapse it by clicking the chevron.</p>
+        </div>
+      }
+      trailingItems={
+        <Flex gap="sm">
+          <Badge type="warning">Action Required</Badge>
+          <Alert.Button priority="muted" icon={<IconEdit />}>
+            Edit
+          </Alert.Button>
+        </Flex>
+      }
+    >
+      This alert has multiple trailing items and can be expanded.
     </Alert>
   </Alert.Container>
 </Storybook.Demo>


### PR DESCRIPTION

<img width="828" height="422" alt="Screenshot 2025-10-30 at 11 23 21 AM" src="https://github.com/user-attachments/assets/f763d5a2-3320-498f-8e06-f92fce3c0725" />
