### PR TITLE
fix(tracemetrics): Overlapped groupbys accidentally get box-shadow

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -103,14 +103,20 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
 
       // Update box-shadow directly on DOM elements (prevents re-renders)
       const shouldShowShadow = hasOverflow && !isScrolledFullyRight;
-      const stickyCells = tableElement.querySelectorAll<HTMLElement>(
-        '[data-sticky-column="true"]'
-      );
-      stickyCells.forEach(cell => {
-        cell.style.boxShadow = shouldShowShadow
-          ? '-2px 0px 4px -1px rgba(0, 0, 0, 0.1)'
-          : 'none';
-      });
+      tableElement
+        .querySelectorAll<HTMLElement>('[data-sticky-column="true"]')
+        .forEach(cell => {
+          cell.style.boxShadow = shouldShowShadow
+            ? '-2px 0px 4px -1px rgba(0, 0, 0, 0.1)'
+            : 'none';
+        });
+      tableElement
+        .querySelectorAll<HTMLElement>('[data-sticky-column="false"]')
+        .forEach(cell => {
+          if (cell.style.boxShadow !== 'none') {
+            cell.style.boxShadow = 'none';
+          }
+        });
     };
 
     // Throttle scroll handler to avoid calling this too often
@@ -164,7 +170,7 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
             <StickyCompatibleStyledHeaderCell
               key={i}
               divider={!isLastColumn(i)}
-              data-sticky-column={isLastColumn(i) ? 'true' : undefined}
+              data-sticky-column={isLastColumn(i) ? 'true' : 'false'}
               isSticky={isLastColumn(i)}
               sort={direction}
               handleSortClick={updateSort}
@@ -192,7 +198,7 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
                 <StickyCompatibleStyledRowCell
                   key={j}
                   hasPadding
-                  data-sticky-column={isLastColumn(j) ? 'true' : undefined}
+                  data-sticky-column={isLastColumn(j) ? 'true' : 'false'}
                   isSticky={isLastColumn(j)}
                   offset={j === 0 ? firstColumnOffset : '0px'}
                 >


### PR DESCRIPTION
There's some weird race condition where the CSS styles are accidentally applying to the penultimate column and not getting cleaned up. This just cleans up the other columns to make sure we aren't setting a box shadow when unnecessary.

There's a possibility of a better fix here but for now it's okay.