### PR TITLE
feat(conduit): Add conduit demo task

### DIFF
--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -36,13 +36,13 @@ def generate_conduit_token(
         JWT token string
     """
     if issuer is None:
-        issuer = settings.CONDUIT_JWT_ISSUER
+        issuer = settings.CONDUIT_GATEWAY_JWT_ISSUER
     if audience is None:
-        audience = settings.CONDUIT_JWT_AUDIENCE
+        audience = settings.CONDUIT_GATEWAY_JWT_AUDIENCE
     if conduit_private_key is None:
-        conduit_private_key = settings.CONDUIT_PRIVATE_KEY
+        conduit_private_key = settings.CONDUIT_GATEWAY_PRIVATE_KEY
         if conduit_private_key is None:
-            raise ValueError("CONDUIT_PRIVATE_KEY not configured")
+            raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY not configured")
 
     now = int(time.time())
     exp = now + TOKEN_TTL_SEC

--- a/src/sentry/conduit/endpoints/organization_conduit_demo.py
+++ b/src/sentry/conduit/endpoints/organization_conduit_demo.py
@@ -3,6 +3,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -30,6 +31,8 @@ class OrganizationConduitDemoEndpoint(OrganizationEndpoint):
     owner = ApiOwner.INFRA_ENG
 
     def post(self, request: Request, organization: Organization) -> Response:
+        if not features.has("organizations:conduit-demo", organization, actor=request.user):
+            return Response(status=404)
         try:
             conduit_credentials = get_conduit_credentials(
                 organization.id,

--- a/src/sentry/conduit/endpoints/organization_conduit_demo.py
+++ b/src/sentry/conduit/endpoints/organization_conduit_demo.py
@@ -41,14 +41,7 @@ class OrganizationConduitDemoEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         # Kick off a task to stream data to Conduit
-        try:
-            stream_demo_data.delay(organization.id, conduit_credentials.channel_id)
-        except Exception as e:
-            sentry_sdk.capture_exception(e, level="warning")
-            return Response(
-                {"error": "Failed to start stream"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        stream_demo_data.delay(organization.id, conduit_credentials.channel_id)
         serializer = ConduitCredentialsResponseSerializer(
             {
                 "conduit": conduit_credentials._asdict(),

--- a/src/sentry/conduit/tasks.py
+++ b/src/sentry/conduit/tasks.py
@@ -1,0 +1,165 @@
+import datetime
+import logging
+import time
+from functools import partial
+from uuid import uuid4
+
+import requests
+from django.conf import settings
+from google.protobuf.struct_pb2 import Struct
+from google.protobuf.timestamp_pb2 import Timestamp
+from requests import Response
+from requests.exceptions import RequestException
+from sentry_protos.conduit.v1alpha.publish_pb2 import Phase, PublishRequest
+
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import conduit_tasks
+from sentry.utils import jwt
+from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
+
+logger = logging.getLogger(__name__)
+
+PUBLISH_REQUEST_TIMEOUT_SECONDS = 5
+PUBLISH_REQUEST_MAX_RETRIES = 5
+NUM_DELTAS = 100
+SEND_INTERVAL_SECONDS = 0.15
+JWT_EXPIRATION_SECONDS = 300  # 5 minutes
+TASK_PROCESSING_DEADLINE_SECONDS = 60 * 3  # 3 minutes
+
+
+@instrumented_task(
+    name="sentry.conduit.tasks.stream_demo_data",
+    namespace=conduit_tasks,
+    processing_deadline_duration=TASK_PROCESSING_DEADLINE_SECONDS,
+    silo_mode=SiloMode.REGION,
+)
+def stream_demo_data(org_id: int, channel_id: str) -> None:
+    """Asynchronously stream data to Conduit."""
+    token = generate_jwt(subject="demo")
+    logger.info(
+        "conduit.stream_demo_data.started", extra={"org_id": org_id, "channel_id": channel_id}
+    )
+    sequence = 0
+    start_publish_request = PublishRequest(
+        channel_id=channel_id,
+        message_id=str(uuid4()),
+        sequence=sequence,
+        client_timestamp=get_timestamp(),
+        phase=Phase.PHASE_START,
+    )
+    publish_data(org_id, start_publish_request, token)
+    sequence += 1
+
+    for i in range(NUM_DELTAS):
+        payload = Struct()
+        payload.update({"value": str(i)})
+        delta_publish_request = PublishRequest(
+            channel_id=channel_id,
+            message_id=str(uuid4()),
+            sequence=sequence,
+            client_timestamp=get_timestamp(),
+            phase=Phase.PHASE_DELTA,
+            payload=payload,
+        )
+        publish_data(org_id, delta_publish_request, token)
+        sequence += 1
+        time.sleep(SEND_INTERVAL_SECONDS)
+
+    end_publish_request = PublishRequest(
+        channel_id=channel_id,
+        message_id=str(uuid4()),
+        sequence=sequence,
+        client_timestamp=get_timestamp(),
+        phase=Phase.PHASE_END,
+    )
+    publish_data(org_id, end_publish_request, token)
+    logger.info(
+        "conduit.stream_demo_data.ended", extra={"org_id": org_id, "channel_id": channel_id}
+    )
+
+
+def generate_jwt(
+    subject: str, issuer: str | None = None, audience: str | None = None, secret: str | None = None
+) -> str:
+    """
+    Generate a JWT token for the Conduit publish API.
+
+    Uses HS256 algorithm with a 5 minute expiration.
+    """
+    if issuer is None:
+        issuer = settings.CONDUIT_PUBLISH_JWT_ISSUER
+    if audience is None:
+        audience = settings.CONDUIT_PUBLISH_JWT_AUDIENCE
+    if secret is None:
+        secret = settings.CONDUIT_PUBLISH_SECRET
+        if secret is None:
+            raise ValueError("CONDUIT_PUBLISH_SECRET not configured")
+    claims = {
+        "sub": subject,
+        "iss": issuer,
+        "aud": audience,
+        "exp": int(time.time()) + JWT_EXPIRATION_SECONDS,
+    }
+    return jwt.encode(claims, secret, algorithm="HS256")
+
+
+def should_retry_publish(attempt: int, exception: Exception) -> bool:
+    return attempt < PUBLISH_REQUEST_MAX_RETRIES and isinstance(exception, RequestException)
+
+
+publish_retry_policy = ConditionalRetryPolicy(
+    should_retry_publish,
+    exponential_delay(0.5),
+)
+
+
+def publish_data(
+    org_id: int,
+    publish_request: PublishRequest,
+    token: str,
+    publish_url: str | None = None,
+) -> Response:
+    """
+    Publish a protobuf message to Conduit with retries.
+
+    Retries up to 5 times with exponential backoff.
+    """
+    if publish_url is None:
+        publish_url = settings.CONDUIT_PUBLISH_URL
+    return publish_retry_policy(
+        partial(
+            _do_publish,
+            org_id=org_id,
+            publish_request=publish_request,
+            token=token,
+            publish_url=publish_url,
+        )
+    )
+
+
+def _do_publish(
+    org_id: int,
+    publish_request: PublishRequest,
+    token: str,
+    publish_url: str,
+) -> Response:
+    response = requests.post(
+        url=f"{publish_url}/publish/{org_id}/{publish_request.channel_id}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/x-protobuf",
+        },
+        data=publish_request.SerializeToString(),
+        timeout=PUBLISH_REQUEST_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    return response
+
+
+def get_timestamp(dt: datetime.datetime | None = None) -> Timestamp:
+    if dt is None:
+        dt = datetime.datetime.now(datetime.UTC)
+    timestamp = Timestamp()
+    timestamp.FromDatetime(dt)
+    return timestamp

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -827,6 +827,7 @@ TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 # Taskworkers need to import task modules to make tasks
 # accessible to the worker.
 TASKWORKER_IMPORTS: tuple[str, ...] = (
+    "sentry.conduit.tasks",
     "sentry.data_export.tasks",
     "sentry.debug_files.tasks",
     "sentry.deletions.tasks.hybrid_cloud",
@@ -3185,7 +3186,12 @@ if ngrok_host and SILO_DEVSERVER:
     SENTRY_OPTIONS["system.region-api-url-template"] = f"https://{{region}}.{ngrok_host}"
     SENTRY_FEATURES["system:multi-region"] = True
 
-CONDUIT_PRIVATE_KEY: str | None = os.getenv("CONDUIT_PRIVATE_KEY")
+CONDUIT_GATEWAY_PRIVATE_KEY: str | None = os.getenv("CONDUIT_GATEWAY_PRIVATE_KEY")
 CONDUIT_GATEWAY_URL: str = os.getenv("CONDUIT_GATEWAY_URL", "https://conduit.sentry.io")
-CONDUIT_JWT_ISSUER: str = os.getenv("CONDUIT_JWT_ISSUER", "sentry")
-CONDUIT_JWT_AUDIENCE: str = os.getenv("CONDUIT_JWT_AUDIENCE", "conduit")
+CONDUIT_GATEWAY_JWT_ISSUER: str = os.getenv("CONDUIT_GATEWAY_JWT_ISSUER", "sentry.io")
+CONDUIT_GATEWAY_JWT_AUDIENCE: str = os.getenv("CONDUIT_GATEWAY_JWT_AUDIENCE", "conduit")
+
+CONDUIT_PUBLISH_SECRET: str | None = os.getenv("CONDUIT_PUBLISH_SECRET")
+CONDUIT_PUBLISH_URL: str = os.getenv("CONDUIT_PUBLISH_URL", "http://127.0.0.1:9097")
+CONDUIT_PUBLISH_JWT_ISSUER: str = os.getenv("CONDUIT_PUBLISH_JWT_ISSUER", "sentry.io")
+CONDUIT_PUBLISH_JWT_AUDIENCE: str = os.getenv("CONDUIT_PUBLISH_JWT_AUDIENCE", "conduit")

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -611,6 +611,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:notification-platform", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:on-demand-gen-metrics-deprecation-prefill", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:on-demand-gen-metrics-deprecation-query-prefill", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enables Conduit demo endpoint and UI
+    manager.add("organizations:conduit-demo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -26,6 +26,11 @@ buffer_tasks = app.taskregistry.create_namespace(
     app_feature="errors",
 )
 
+conduit_tasks = app.taskregistry.create_namespace(
+    "conduit",
+    app_feature="conduit",
+)
+
 crons_tasks = app.taskregistry.create_namespace(
     "crons",
     app_feature="crons",

--- a/tests/sentry/conduit/test_auth.py
+++ b/tests/sentry/conduit/test_auth.py
@@ -86,9 +86,9 @@ def test_generate_conduit_token_uses_settings():
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
 
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_PRIVATE_KEY = RS256_KEY
-        mock_settings.CONDUIT_JWT_ISSUER = "test-issuer"
-        mock_settings.CONDUIT_JWT_AUDIENCE = "test-audience"
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "test-issuer"
+        mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "test-audience"
 
         token = generate_conduit_token(
             org_id,
@@ -111,7 +111,7 @@ def test_generate_conduit_token_raises_when_missing():
     """Should raise an error if the private key is not configured."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
-    with pytest.raises(ValueError, match="CONDUIT_PRIVATE_KEY not configured"):
+    with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY not configured"):
         generate_conduit_token(
             org_id,
             channel_id,
@@ -122,9 +122,9 @@ def test_get_conduit_credentials_returns_all_credentials():
     """Should return a url, token, and channel_id."""
     gateway_url = "https://conduit.example.com"
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_PRIVATE_KEY = RS256_KEY
-        mock_settings.CONDUIT_JWT_ISSUER = "sentry"
-        mock_settings.CONDUIT_JWT_AUDIENCE = "conduit"
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
+        mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
         mock_settings.CONDUIT_GATEWAY_URL = gateway_url
 
         org_id = 123
@@ -142,9 +142,9 @@ def test_get_conduit_credentials_uses_custom_url():
     """Should use provided gateway_url instead of settings."""
     gateway_url = "https://custom.conduit.io"
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_PRIVATE_KEY = RS256_KEY
-        mock_settings.CONDUIT_JWT_ISSUER = "sentry"
-        mock_settings.CONDUIT_JWT_AUDIENCE = "conduit"
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
+        mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
 
         org_id = 123
         result = get_conduit_credentials(org_id, gateway_url)
@@ -161,9 +161,9 @@ def test_get_conduit_credentials_token_is_valid():
     """Generated token should be decodable with correct claims."""
     gateway_url = "https://conduit.example.com"
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_PRIVATE_KEY = RS256_KEY
-        mock_settings.CONDUIT_JWT_ISSUER = "sentry"
-        mock_settings.CONDUIT_JWT_AUDIENCE = "conduit"
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
+        mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
         mock_settings.CONDUIT_GATEWAY_URL = gateway_url
 
         org_id = 123

--- a/tests/sentry/conduit/test_tasks.py
+++ b/tests/sentry/conduit/test_tasks.py
@@ -1,0 +1,308 @@
+import datetime
+import re
+from unittest.mock import patch
+from uuid import uuid4
+
+import jwt as pyjwt
+import pytest
+import responses
+from django.test import override_settings
+from requests.exceptions import RequestException
+from sentry_protos.conduit.v1alpha.publish_pb2 import Phase, PublishRequest
+
+from sentry.conduit.tasks import (
+    NUM_DELTAS,
+    PUBLISH_REQUEST_MAX_RETRIES,
+    _do_publish,
+    generate_jwt,
+    get_timestamp,
+    publish_data,
+    stream_demo_data,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+class GenerateJWTTest(TestCase):
+    @override_settings(
+        CONDUIT_PUBLISH_SECRET="test-secret",
+        CONDUIT_PUBLISH_JWT_ISSUER="test-issuer",
+        CONDUIT_PUBLISH_JWT_AUDIENCE="test-audience",
+    )
+    def test_generate_jwt_uses_settings(self):
+        """Test that generate_jwt uses settings when parameters are not provided."""
+        token = generate_jwt(subject="test-subject")
+
+        claims = pyjwt.decode(token, options={"verify_signature": False})
+
+        assert claims["sub"] == "test-subject"
+        assert claims["iss"] == "test-issuer"
+        assert claims["aud"] == "test-audience"
+        assert "exp" in claims
+
+    def test_generate_jwt_uses_provided_parameters(self):
+        """Test that generate_jwt uses parameters when provided."""
+        token = generate_jwt(
+            subject="test-subject",
+            issuer="custom-issuer",
+            audience="custom-audience",
+            secret="custom-secret",
+        )
+
+        claims = pyjwt.decode(token, options={"verify_signature": False})
+
+        assert claims["sub"] == "test-subject"
+        assert claims["iss"] == "custom-issuer"
+        assert claims["aud"] == "custom-audience"
+        assert "exp" in claims
+
+    def test_generate_jwt_raises_when_secret_missing(self):
+        """Test that generate_jwt raises ValueError when secret is not configured."""
+        with pytest.raises(ValueError) as context:
+            generate_jwt(subject="test-subject")
+
+        assert "CONDUIT_PUBLISH_SECRET not configured" in str(context.value)
+
+
+class GetTimestampTest(TestCase):
+    @freeze_time("2025-01-01T12:00:00Z")
+    def test_get_timestamp_uses_current_time(self):
+        """Test that get_timestamp generates a valid timestamp."""
+        timestamp = get_timestamp()
+
+        dt = timestamp.ToDatetime()
+        expected = datetime.datetime(2025, 1, 1, 12, 0, 0)
+        assert dt == expected
+
+    def test_get_timestamp_uses_provided_datetime(self):
+        """Test that get_timestamp uses provided datetime."""
+        custom_dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        timestamp = get_timestamp(custom_dt)
+
+        dt = timestamp.ToDatetime()
+        assert dt == custom_dt
+
+
+class PublishDataTest(TestCase):
+    @responses.activate
+    @override_settings(
+        CONDUIT_PUBLISH_SECRET="test-secret",
+        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    )
+    def test_publish_data_success(self):
+        """Test successful publish request."""
+        org_id = 123
+        channel_id = str(uuid4())
+        token = generate_jwt(subject="test")
+
+        publish_request = PublishRequest(
+            channel_id=channel_id,
+            message_id=str(uuid4()),
+            sequence=0,
+            client_timestamp=get_timestamp(),
+            phase=Phase.PHASE_START,
+        )
+
+        responses.add(
+            responses.POST,
+            f"http://localhost:9093/publish/{org_id}/{channel_id}",
+            status=200,
+        )
+
+        response = _do_publish(
+            org_id=org_id,
+            publish_request=publish_request,
+            token=token,
+            publish_url="http://localhost:9093",
+        )
+
+        assert response.status_code == 200
+        assert len(responses.calls) == 1
+
+        request = responses.calls[0].request
+        assert request.headers["Authorization"] == f"Bearer {token}"
+        assert request.headers["Content-Type"] == "application/x-protobuf"
+
+    @responses.activate
+    @override_settings(
+        CONDUIT_PUBLISH_SECRET="test-secret",
+        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    )
+    def test_publish_data_retry_on_failure(self):
+        """Test that publish_data retries on RequestException."""
+        org_id = 123
+        channel_id = str(uuid4())
+        token = generate_jwt(subject="test")
+
+        publish_request = PublishRequest(
+            channel_id=channel_id,
+            message_id=str(uuid4()),
+            sequence=0,
+            client_timestamp=get_timestamp(),
+            phase=Phase.PHASE_START,
+        )
+
+        # Fails twice, then succeeds
+        responses.add(
+            responses.POST,
+            f"http://localhost:9093/publish/{org_id}/{channel_id}",
+            status=500,
+        )
+        responses.add(
+            responses.POST,
+            f"http://localhost:9093/publish/{org_id}/{channel_id}",
+            status=500,
+        )
+        responses.add(
+            responses.POST,
+            f"http://localhost:9093/publish/{org_id}/{channel_id}",
+            status=200,
+        )
+
+        response = publish_data(
+            org_id=org_id,
+            publish_request=publish_request,
+            token=token,
+            publish_url="http://localhost:9093",
+        )
+
+        assert response.status_code == 200
+        assert len(responses.calls) == 3
+
+    @responses.activate
+    @override_settings(
+        CONDUIT_PUBLISH_SECRET="test-secret",
+        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    )
+    def test_publish_data_max_retries_exceeded(self):
+        """Test that publish_data raises after max retries."""
+        org_id = 123
+        channel_id = str(uuid4())
+        token = generate_jwt(subject="test")
+
+        publish_request = PublishRequest(
+            channel_id=channel_id,
+            message_id=str(uuid4()),
+            sequence=0,
+            client_timestamp=get_timestamp(),
+            phase=Phase.PHASE_START,
+        )
+
+        for _ in range(PUBLISH_REQUEST_MAX_RETRIES):
+            responses.add(
+                responses.POST,
+                f"http://localhost:9093/publish/{org_id}/{channel_id}",
+                status=500,
+            )
+
+        with pytest.raises(RequestException):
+            publish_data(
+                org_id=org_id,
+                publish_request=publish_request,
+                token=token,
+            )
+
+        assert len(responses.calls) == PUBLISH_REQUEST_MAX_RETRIES
+
+    @responses.activate
+    @override_settings(
+        CONDUIT_PUBLISH_SECRET="test-secret",
+        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    )
+    def test_publish_data_uses_custom_url(self):
+        """Test that publish_data uses provided publish_url."""
+        org_id = 123
+        channel_id = str(uuid4())
+        token = generate_jwt(subject="test")
+        custom_url = "http://custom.example.com"
+
+        publish_request = PublishRequest(
+            channel_id=channel_id,
+            message_id=str(uuid4()),
+            sequence=0,
+            client_timestamp=get_timestamp(),
+            phase=Phase.PHASE_START,
+        )
+
+        responses.add(
+            responses.POST,
+            f"{custom_url}/publish/{org_id}/{channel_id}",
+            status=200,
+        )
+
+        response = publish_data(
+            org_id=org_id,
+            publish_request=publish_request,
+            token=token,
+            publish_url=custom_url,
+        )
+
+        assert response.status_code == 200
+        assert len(responses.calls) == 1
+
+
+class StreamDemoDataTest(TestCase):
+    @responses.activate
+    @override_settings(
+        CONDUIT_PUBLISH_SECRET="test-secret",
+        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    )
+    @patch("sentry.conduit.tasks.time.sleep")
+    def test_stream_demo_data_sends_all_phases(self, mock_sleep):
+        """Test that stream_demo_data sends START, DELTA, and END phases."""
+        org_id = 123
+        channel_id = str(uuid4())
+
+        responses.add(
+            responses.POST,
+            re.compile(r"http://localhost:9093/publish/\d+/.+"),
+            status=200,
+        )
+
+        stream_demo_data(org_id=org_id, channel_id=channel_id)
+
+        assert len(responses.calls) == NUM_DELTAS + 2
+        assert mock_sleep.call_count == NUM_DELTAS
+
+    @responses.activate
+    @override_settings(
+        CONDUIT_PUBLISH_SECRET="test-secret",
+        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    )
+    @patch("sentry.conduit.tasks.time.sleep")
+    def test_stream_demo_data_stops_on_exhausted_retries(self, mock_sleep):
+        """Test that stream_demo_data stops streaming when a publish fails after max retries."""
+        org_id = 123
+        channel_id = str(uuid4())
+
+        # Fail after 10 successful requests
+        for _ in range(10):
+            responses.add(
+                responses.POST,
+                re.compile(r"http://localhost:9093/publish/\d+/.+"),
+                status=200,
+            )
+
+        for _ in range(PUBLISH_REQUEST_MAX_RETRIES):
+            responses.add(
+                responses.POST,
+                re.compile(r"http://localhost:9093/publish/\d+/.+"),
+                status=500,
+            )
+
+        with pytest.raises(RequestException):
+            stream_demo_data(org_id=org_id, channel_id=channel_id)
+
+        assert len(responses.calls) == 10 + PUBLISH_REQUEST_MAX_RETRIES

--- a/tests/sentry/conduit/test_tasks.py
+++ b/tests/sentry/conduit/test_tasks.py
@@ -13,7 +13,6 @@ from sentry_protos.conduit.v1alpha.publish_pb2 import Phase, PublishRequest
 from sentry.conduit.tasks import (
     NUM_DELTAS,
     PUBLISH_REQUEST_MAX_RETRIES,
-    _do_publish,
     generate_jwt,
     get_timestamp,
     publish_data,
@@ -111,7 +110,7 @@ class PublishDataTest(TestCase):
             status=200,
         )
 
-        response = _do_publish(
+        response = publish_data(
             org_id=org_id,
             publish_request=publish_request,
             token=token,


### PR DESCRIPTION
Adds a demo task to asynchronously generate data and send it to the Conduit Publish API. This serves as a reference implementation for publishing data to Conduit and enables our demo to actually work.

I also updated some of the setting names to be more precise to avoid confusion.

The next step is adding a frontend demo page that consumes the stream via the conduit client.