### PR TITLE
feat(settings): Add base OTLP endpoint

### DIFF
--- a/static/app/views/settings/project/projectKeys/credentials/index.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/index.tsx
@@ -258,6 +258,7 @@ function ProjectKeyCredentials({
       case 'otlp':
         return (
           <OtlpTab
+            integrationEndpoint={data.dsn.integration}
             logsEndpoint={data.dsn.otlp_logs}
             tracesEndpoint={data.dsn.otlp_traces}
             publicKey={data.public}

--- a/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
@@ -8,6 +8,7 @@ import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 
 interface OtlpTabProps {
+  integrationEndpoint: string;
   logsEndpoint: string;
   publicKey: string;
   showOtlpLogs: boolean;
@@ -21,6 +22,7 @@ export function OtlpTab({
   publicKey,
   showOtlpLogs,
   showOtlpTraces,
+  integrationEndpoint,
 }: OtlpTabProps) {
   // Build the OTEL collector config example
   const buildCollectorConfig = useMemo(() => {
@@ -51,6 +53,16 @@ export function OtlpTab({
 
   return (
     <Fragment>
+      <FieldGroup
+        label={t('OTLP Endpoint')}
+        help={t('This is the base OTLP endpoint.')}
+        inline={false}
+        flexibleControlStateSize
+      >
+        <TextCopyInput aria-label={t('OTLP Endpoint')}>
+          {`${integrationEndpoint}/otlp`}
+        </TextCopyInput>
+      </FieldGroup>
       {showOtlpLogs && (
         <Fragment>
           <FieldGroup


### PR DESCRIPTION
Add a base OTLP endpoint to the setting page. This would be something like `https://o0.ingest.sentry.io/api/0/integration/otlp` compared to `https://o0.ingest.sentry.io/api/0/integration/otlp/v1/traces` (the traces specific endpoint).

This helps us for use cases like Neon that require you to only pass in a base OTLP endpoint: https://neon.com/docs/guides/opentelemetry