### PR TITLE
tests(tracemetrics): Require metric type to be specified

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -10,7 +10,7 @@ from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from io import BytesIO
-from typing import Any, TypedDict, Union
+from typing import Any, Literal, TypedDict, Union
 from unittest import mock
 from urllib.parse import urlencode
 from uuid import UUID, uuid4
@@ -3480,6 +3480,7 @@ class TraceMetricsTestCase(BaseTestCase, TraceItemTestCase):
         self,
         metric_name: str,
         metric_value: float,
+        metric_type: Literal["counter", "distribution", "gauge"],
         organization: Organization | None = None,
         project: Project | None = None,
         timestamp: datetime | None = None,
@@ -3505,7 +3506,10 @@ class TraceMetricsTestCase(BaseTestCase, TraceItemTestCase):
 
         attributes_proto = {
             "sentry.metric_name": AnyValue(string_value=metric_name),
+            "sentry.metric_type": AnyValue(string_value=metric_type),
             "sentry.value": AnyValue(double_value=metric_value),
+            f"sentry._internal.cooccuring.name.{metric_name}": AnyValue(bool_value=True),
+            f"sentry._internal.cooccuring.type.{metric_type}": AnyValue(bool_value=True),
         }
 
         if attributes:

--- a/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
@@ -23,7 +23,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
 
         trace_metrics = [
             self.create_trace_metric(
-                metric_name, metric_value, timestamp=self.start + timedelta(hours=i)
+                metric_name, metric_value, "counter", timestamp=self.start + timedelta(hours=i)
             )
             for metric_name in ["foo", "bar"]
             for i, metric_value in enumerate(metric_values)
@@ -53,7 +53,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         for _ in range(36):
             metrics.append(
                 self.create_trace_metric(
-                    "test_metric", 1.0, timestamp=self.start + timedelta(hours=0)
+                    "test_metric", 1.0, "counter", timestamp=self.start + timedelta(hours=0)
                 )
             )
         self.store_trace_metrics(metrics)

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -10,8 +10,8 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_simple(self) -> None:
         trace_metrics = [
-            self.create_trace_metric("foo", 1),
-            self.create_trace_metric("bar", 2),
+            self.create_trace_metric("foo", 1, "counter"),
+            self.create_trace_metric("bar", 2, "counter"),
         ]
         self.store_trace_metrics(trace_metrics)
 
@@ -35,8 +35,8 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_simple_aggregation(self) -> None:
         trace_metrics = [
-            self.create_trace_metric("foo", 1),
-            self.create_trace_metric("bar", 2),
+            self.create_trace_metric("foo", 1, "counter"),
+            self.create_trace_metric("bar", 2, "counter"),
         ]
         self.store_trace_metrics(trace_metrics)
 
@@ -59,7 +59,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
     def test_per_minute_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
         for _ in range(6):
-            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
+            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0, "counter")])
 
         response = self.do_request(
             {
@@ -81,7 +81,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
     def test_per_second_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
         for _ in range(6):
-            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0)])
+            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0, "counter")])
 
         response = self.do_request(
             {
@@ -104,12 +104,8 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_per_second_formula_with_counter_metric_type(self) -> None:
         counter_metrics = [
-            self.create_trace_metric(
-                "request_count", 5.0, attributes={"sentry.metric_type": "counter"}
-            ),
-            self.create_trace_metric(
-                "request_count", 3.0, attributes={"sentry.metric_type": "counter"}
-            ),
+            self.create_trace_metric("request_count", 5.0, "counter"),
+            self.create_trace_metric("request_count", 3.0, "counter"),
         ]
         self.store_trace_metrics(counter_metrics)
 
@@ -128,8 +124,8 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_per_second_formula_with_gauge_metric_type(self) -> None:
         gauge_metrics = [
-            self.create_trace_metric("cpu_usage", 75.0, attributes={"sentry.metric_type": "gauge"}),
-            self.create_trace_metric("cpu_usage", 80.0, attributes={"sentry.metric_type": "gauge"}),
+            self.create_trace_metric("cpu_usage", 75.0, "gauge"),
+            self.create_trace_metric("cpu_usage", 80.0, "gauge"),
         ]
         self.store_trace_metrics(gauge_metrics)
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -815,6 +815,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
             self.create_trace_metric(
                 metric_name="http.request.duration",
                 metric_value=123.45,
+                metric_type="distribution",
                 organization=self.organization,
                 project=self.project,
                 attributes={
@@ -826,6 +827,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
             self.create_trace_metric(
                 metric_name="http.request.duration",
                 metric_value=234.56,
+                metric_type="distribution",
                 organization=self.organization,
                 project=self.project,
                 attributes={
@@ -856,6 +858,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
             self.create_trace_metric(
                 metric_name="http.request.duration",
                 metric_value=100.0,
+                metric_type="distribution",
                 organization=self.organization,
                 project=self.project,
                 attributes={
@@ -866,6 +869,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
             self.create_trace_metric(
                 metric_name="database.query.duration",
                 metric_value=50.0,
+                metric_type="distribution",
                 organization=self.organization,
                 project=self.project,
                 attributes={
@@ -897,6 +901,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
             self.create_trace_metric(
                 metric_name="custom.metric",
                 metric_value=100.0,
+                metric_type="distribution",
                 organization=self.organization,
                 project=self.project,
                 attributes={
@@ -1916,11 +1921,13 @@ class OrganizationTraceItemAttributeValuesEndpointTraceMetricsTest(
             self.create_trace_metric(
                 metric_name="http.request.duration",
                 metric_value=123.45,
+                metric_type="distribution",
                 attributes={"http.method": "GET"},
             ),
             self.create_trace_metric(
                 metric_name="http.request.duration",
                 metric_value=234.56,
+                metric_type="distribution",
                 attributes={"http.method": "POST"},
             ),
         ]


### PR DESCRIPTION
When writing tests, we should make metric type mandatory.