### PR TITLE
ref(uptime): Remove remove_uptime_subscription_if_unused

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -30,8 +30,8 @@ from sentry.uptime.models import (
 )
 from sentry.uptime.subscriptions.subscriptions import (
     check_and_update_regions,
+    delete_uptime_subscription,
     disable_uptime_detector,
-    remove_uptime_subscription_if_unused,
 )
 from sentry.uptime.subscriptions.tasks import (
     send_uptime_config_deletion,
@@ -249,7 +249,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             detector = get_detector(subscription, prefetch_workflow_data=True)
         except Detector.DoesNotExist:
             # Nothing to do if there's an orphaned uptime subscription
-            remove_uptime_subscription_if_unused(subscription)
+            delete_uptime_subscription(subscription)
             return
 
         organization = detector.project.organization

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -529,20 +529,7 @@ def delete_uptime_detector(detector: Detector):
     quotas.backend.remove_seat(DataCategory.UPTIME, detector)
     detector.update(status=ObjectStatus.PENDING_DELETION)
     RegionScheduledDeletion.schedule(detector, days=0)
-    remove_uptime_subscription_if_unused(uptime_subscription)
-
-
-def remove_uptime_subscription_if_unused(uptime_subscription: UptimeSubscription):
-    """
-    Determines if an uptime subscription is no longer used by any detectors and removes it if so
-    """
-    # If the uptime subscription is no longer used, we also remove it.
-    has_active_detector = Detector.objects.filter(
-        data_sources__source_id=str(uptime_subscription.id),
-        status=ObjectStatus.ACTIVE,
-    ).exists()
-    if not has_active_detector:
-        delete_uptime_subscription(uptime_subscription)
+    delete_uptime_subscription(uptime_subscription)
 
 
 def is_url_auto_monitored_for_project(project: Project, url: str) -> bool:

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -215,13 +215,13 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             self.feature(features),
             mock.patch("sentry.remote_subscriptions.consumers.result_consumer.logger") as logger,
             mock.patch(
-                "sentry.uptime.consumers.results_consumer.remove_uptime_subscription_if_unused"
-            ) as mock_remove_uptime_subscription_if_unused,
+                "sentry.uptime.consumers.results_consumer.delete_uptime_subscription"
+            ) as mock_delete_uptime_subscription,
         ):
             # Does not produce an error
             self.send_result(result)
             assert not logger.exception.called
-            mock_remove_uptime_subscription_if_unused.assert_called_with(self.subscription)
+            mock_delete_uptime_subscription.assert_called_with(self.subscription)
 
     def test_no_create_issues_option(self) -> None:
         self.detector.config.update({"downtime_threshold": 1, "recovery_threshold": 1})

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -32,7 +32,6 @@ from sentry.uptime.subscriptions.subscriptions import (
     enable_uptime_detector,
     get_auto_monitored_detectors_for_project,
     is_url_auto_monitored_for_project,
-    remove_uptime_subscription_if_unused,
     update_uptime_detector,
     update_uptime_subscription,
 )
@@ -843,32 +842,6 @@ class DeleteUptimeDetectorTest(UptimeTestCase):
         with pytest.raises(UptimeSubscription.DoesNotExist):
             uptime_subscription.refresh_from_db()
         mock_remove_seat.assert_called_with(DataCategory.UPTIME, detector)
-
-
-class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
-    def test_remove(self) -> None:
-        uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
-        with self.tasks():
-            remove_uptime_subscription_if_unused(uptime_sub)
-
-        with pytest.raises(UptimeSubscription.DoesNotExist):
-            uptime_sub.refresh_from_db()
-
-    def test_keep(self) -> None:
-        detector = create_uptime_detector(
-            self.project,
-            self.environment,
-            url="https://sentry.io",
-            interval_seconds=3600,
-            timeout_ms=1000,
-            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
-        )
-        uptime_subscription = get_uptime_subscription(detector)
-
-        with self.tasks():
-            remove_uptime_subscription_if_unused(uptime_subscription)
-
-        assert UptimeSubscription.objects.filter(id=uptime_subscription.id).exists()
 
 
 class IsUrlMonitoredForProjectTest(UptimeTestCase):


### PR DESCRIPTION
We don't need this since the relationship for detectors to uptime_subscription's is 1:1. This only adds confusion and possibly potential bugs.