### PR TITLE
fix: moment deprecated date formatting

### DIFF
--- a/static/app/utils/getDaysSinceDate.spec.tsx
+++ b/static/app/utils/getDaysSinceDate.spec.tsx
@@ -14,4 +14,16 @@ describe('getDaysSinceDate', () => {
   it('simple test', () => {
     expect(getDaysSinceDate('2022-05-11')).toBe(26);
   });
+  it('deprecated date format', () => {
+    expect(getDaysSinceDate('Thu May 11 2022')).toBe(26);
+  });
+  it('iso string', () => {
+    expect(getDaysSinceDate('2022-05-11T17:19:18.307Z')).toBe(26);
+  });
+  it('iso string 23:59', () => {
+    expect(getDaysSinceDate('2022-05-11T23:59:59.900Z')).toBe(26);
+  });
+  it('iso string 00:00', () => {
+    expect(getDaysSinceDate('2022-05-11T00:00:00.100Z')).toBe(26);
+  });
 });

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -83,7 +83,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
     );
     localStorage.setItem(
       `billing-status-last-shown-date-${organization.id}`,
-      'Mon Jun 06 2022' // MOCK_TODAY
+      '2022-06-06T05:09:33.000Z' // MOCK_TODAY
     );
   });
 
@@ -97,7 +97,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
     ).toBe('errors-replays-spans-profileDuration');
     expect(
       localStorage.getItem(`billing-status-last-shown-date-${organization.id}`)
-    ).toBe('Mon Jun 06 2022');
+    ).toBe('2022-06-06T05:09:33.000Z');
   }
 
   it('should render for multiple categories', async () => {
@@ -399,7 +399,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
     assertLocalStorageStateAfterAutoOpen();
   });
 
-  it('should auto open the alert when more than a day has passed', async () => {
+  it('should auto open the alert when more than a day has passed (deprecated date format)', async () => {
     localStorage.setItem(
       `billing-status-last-shown-date-${organization.id}`,
       'Sun Jun 05 2022'
@@ -409,10 +409,30 @@ describe('PrimaryNavigationQuotaExceeded', () => {
     assertLocalStorageStateAfterAutoOpen();
   });
 
-  it('should auto open the alert when the last shown date is before the current usage cycle started', async () => {
+  it('should auto open the alert when the last shown date is before the current usage cycle started (deprecated date format)', async () => {
     localStorage.setItem(
       `billing-status-last-shown-date-${organization.id}`,
       'Sun May 29 2022'
+    ); // last seen before current usage cycle started, so alert should show even though categories haven't changed
+    render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+    expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
+    assertLocalStorageStateAfterAutoOpen();
+  });
+
+  it('should auto open the alert when more than a day has passed (ISO date format)', async () => {
+    localStorage.setItem(
+      `billing-status-last-shown-date-${organization.id}`,
+      '2022-06-05T15:00:32.000Z'
+    ); // more than a day, so alert should show even though categories haven't changed
+    render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+    expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
+    assertLocalStorageStateAfterAutoOpen();
+  });
+
+  it('should auto open the alert when the last shown date is before the current usage cycle started (ISO date format))', async () => {
+    localStorage.setItem(
+      `billing-status-last-shown-date-${organization.id}`,
+      '2022-05-29T05:09:33.000Z'
     ); // last seen before current usage cycle started, so alert should show even though categories haven't changed
     render(<PrimaryNavigationQuotaExceeded organization={organization} />);
     expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -210,9 +210,7 @@ function PrimaryNavigationQuotaExceeded({organization}: {organization: Organizat
     organization,
     daysToSnooze:
       -1 *
-      getDaysSinceDate(
-        subscription?.onDemandPeriodEnd ?? moment().utc().toDate().toDateString()
-      ),
+      getDaysSinceDate(subscription?.onDemandPeriodEnd ?? moment().utc().toISOString()),
     isDismissed: isSnoozedForCurrentPeriod,
     options: {
       enabled: promptsToCheck.length > 0,

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -260,7 +260,7 @@ function PrimaryNavigationQuotaExceeded({organization}: {organization: Organizat
       );
       localStorage.setItem(
         `billing-status-last-shown-date-${organization.id}`,
-        moment().utc().toDate().toDateString()
+        moment().utc().toISOString()
       );
     }
   }, [


### PR DESCRIPTION
This fixes the following console.warn that we are getting in prod:

```
 Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments:
```

We were passing a deprecated date format to `getDaysSinceDate()`: `moment().utc().toDate().toDateString()`. I have replaced it with an ISO date string.
