### PR TITLE
feat(dashboards): Use Motion design tokens for animation

### DIFF
--- a/static/app/components/core/principles/motion/motion.mdx
+++ b/static/app/components/core/principles/motion/motion.mdx
@@ -59,6 +59,21 @@ const theme = useTheme();
 theme.motion.smooth.moderate;
 ```
 
+If you need to use the tokens with [Framer Motion](https://motion.dev) you can access the Bézier curve control points values and durations directly.
+
+```jsx
+const theme = useTheme();
+
+<motion.div
+  animate={{opacity: 0}}
+  transition={{
+    type: 'tween',
+    ease: theme.motionControlPoints.enter,
+    duration: theme.motionDurations.slow,
+  }}
+></motion.div>;
+```
+
 ## Easing
 
 The easing curve of an animation drastically changes our perception of it. These easing tokens have been chosen to provide snappy, natural motion to interactions.

--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -11,15 +11,15 @@ const LEFT_SIDE_PANEL_WIDTH = '40vw';
 const PANEL_HEIGHT = '50vh';
 
 const OPEN_STYLES = {
-  bottom: {opacity: 1, x: 0, y: 0},
-  right: {opacity: 1, x: 0, y: 0},
-  left: {opacity: 1, x: 0, y: 0},
+  bottom: {transform: 'translateX(0) translateY(0)', opacity: 1},
+  right: {transform: 'translateX(0) translateY(0)', opacity: 1},
+  left: {transform: 'translateX(0) translateY(0)', opacity: 1},
 };
 
 const COLLAPSED_STYLES = {
-  bottom: {opacity: 0, x: 0, y: PANEL_HEIGHT},
-  right: {opacity: 0, x: PANEL_WIDTH, y: 0},
-  left: {opacity: 0, x: '-100%', y: 0},
+  bottom: {transform: `translateX(0) translateY(${PANEL_HEIGHT})`, opacity: 0},
+  right: {transform: `translateX(${PANEL_WIDTH}) translateY(0)`, opacity: 0},
+  left: {transform: `translateX(-${PANEL_WIDTH}) translateY(0)`, opacity: 0},
 };
 
 type SlideOverPanelProps = {

--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
-import {css} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion, type Transition} from 'framer-motion';
 
@@ -49,6 +49,8 @@ function SlideOverPanel({
   panelWidth,
   ref,
 }: SlideOverPanelProps) {
+  const theme = useTheme();
+
   useEffect(() => {
     if (!collapsed && onOpen) {
       onOpen();
@@ -69,9 +71,9 @@ function SlideOverPanel({
       exit={collapsedStyle}
       slidePosition={slidePosition}
       transition={{
-        type: 'spring',
-        stiffness: 1000,
-        damping: 50,
+        type: 'tween',
+        ease: theme.motionControlPoints.enter,
+        duration: theme.motionDurations.slow,
         ...transitionProps,
       }}
       role="complementary"

--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -11,15 +11,15 @@ const LEFT_SIDE_PANEL_WIDTH = '40vw';
 const PANEL_HEIGHT = '50vh';
 
 const OPEN_STYLES = {
-  bottom: {transform: 'translateX(0) translateY(0)', opacity: 1},
-  right: {transform: 'translateX(0) translateY(0)', opacity: 1},
-  left: {transform: 'translateX(0) translateY(0)', opacity: 1},
+  bottom: {opacity: 1, x: 0, y: 0},
+  right: {opacity: 1, x: 0, y: 0},
+  left: {opacity: 1, x: 0, y: 0},
 };
 
 const COLLAPSED_STYLES = {
-  bottom: {transform: `translateX(0) translateY(${PANEL_HEIGHT})`, opacity: 0},
-  right: {transform: `translateX(${PANEL_WIDTH}) translateY(0)`, opacity: 0},
-  left: {transform: `translateX(-${PANEL_WIDTH}) translateY(0)`, opacity: 0},
+  bottom: {opacity: 0, x: 0, y: PANEL_HEIGHT},
+  right: {opacity: 0, x: PANEL_WIDTH, y: 0},
+  left: {opacity: 0, x: '-100%', y: 0},
 };
 
 type SlideOverPanelProps = {

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -252,20 +252,42 @@ const generateTokens = (colors: Colors) => ({
   },
 });
 
-const generateMotion = () => {
-  return {
-    smooth: withDuration('cubic-bezier(0.72, 0, 0.16, 1)'),
-    snap: withDuration('cubic-bezier(0.8, -0.4, 0.5, 1)'),
-    enter: withDuration('cubic-bezier(0.24, 1, 0.32, 1)'),
-    exit: withDuration('cubic-bezier(0.64, 0, 0.8, 0)'),
-  };
+type Curve = 'smooth' | 'snap' | 'enter' | 'exit';
+type ControlPoints = [number, number, number, number];
+
+const BEZIER_CONTROL_POINTS: Record<Curve, ControlPoints> = {
+  smooth: [0.72, 0, 0.16, 1],
+  snap: [0.8, -0.4, 0.5, 1],
+  enter: [0.24, 1, 0.32, 1],
+  exit: [0.64, 0, 0.8, 0],
+};
+
+function formatBezierCurve(points: ControlPoints): string {
+  return `cubic-bezier(${points.join(', ')})`;
+}
+
+type AnimationDuration = 'fast' | 'moderate' | 'slow';
+
+const MOTION_DURATIONS: Record<AnimationDuration, number> = {
+  fast: 0.12,
+  moderate: 0.16,
+  slow: 0.24,
 };
 
 const withDuration = (easing: string) => {
   return {
-    fast: `120ms ${easing}`,
-    moderate: `160ms ${easing}`,
-    slow: `240ms ${easing}`,
+    fast: `${MOTION_DURATIONS.fast}s ${easing}`,
+    moderate: `${MOTION_DURATIONS.moderate}s ${easing}`,
+    slow: `${MOTION_DURATIONS.slow}s ${easing}`,
+  };
+};
+
+const generateMotion = () => {
+  return {
+    smooth: withDuration(formatBezierCurve(BEZIER_CONTROL_POINTS.smooth)),
+    snap: withDuration(formatBezierCurve(BEZIER_CONTROL_POINTS.snap)),
+    enter: withDuration(formatBezierCurve(BEZIER_CONTROL_POINTS.enter)),
+    exit: withDuration(formatBezierCurve(BEZIER_CONTROL_POINTS.exit)),
   };
 };
 
@@ -1152,6 +1174,8 @@ const commonTheme = {
 
   space,
   motion: generateMotion(),
+  motionControlPoints: BEZIER_CONTROL_POINTS,
+  motionDurations: MOTION_DURATIONS,
 
   // Icons
   iconSizes,

--- a/static/app/views/dashboards/widgetBuilder/components/common/animationSettings.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/common/animationSettings.tsx
@@ -1,6 +1,0 @@
-import type {MotionNodeAnimationOptions} from 'framer-motion';
-
-export const animationTransitionSettings: MotionNodeAnimationOptions['transition'] = {
-  type: 'tween',
-  duration: 0.5,
-};

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -332,9 +332,9 @@ export function WidgetPreviewContainer({
   };
 
   const animatedProps: MotionNodeAnimationOptions = {
-    initial: {opacity: 0, transform: 'translateX(100%) translateY(0)'},
-    animate: {opacity: 1, transform: 'translateX(0) translateY(0)'},
-    exit: {opacity: 0, transform: 'translateX(100%) translateY(0)'},
+    initial: {opacity: 0, x: '100%', y: 0},
+    animate: {opacity: 1, x: 0, y: 0},
+    exit: {opacity: 0, x: '100%', y: 0},
     transition: transitionSettings,
   };
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -25,7 +25,6 @@ import {
   type DashboardFilters,
   type Widget,
 } from 'sentry/views/dashboards/types';
-import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import {
   DEFAULT_WIDGET_DRAG_POSITIONING,
   DRAGGABLE_PREVIEW_HEIGHT_PX,
@@ -43,6 +42,7 @@ import {
   useWidgetBuilderContext,
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {useWidgetBuilderTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderAnimationSettings';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
@@ -269,6 +269,7 @@ export function WidgetPreviewContainer({
   const organization = useOrganization();
   const location = useLocation();
   const theme = useTheme();
+  const transitionSettings = useWidgetBuilderTransitionSettings();
   const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.sm})`);
   // if small screen and draggable, enable dragging
   const isDragEnabled = isSmallScreen && isDraggable;
@@ -334,7 +335,7 @@ export function WidgetPreviewContainer({
     initial: {opacity: 0, x: '100%', y: 0},
     animate: {opacity: 1, x: 0, y: 0},
     exit: {opacity: 0, x: '100%', y: 0},
-    transition: animationTransitionSettings,
+    transition: transitionSettings,
   };
 
   return (

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -332,9 +332,9 @@ export function WidgetPreviewContainer({
   };
 
   const animatedProps: MotionNodeAnimationOptions = {
-    initial: {opacity: 0, x: '100%', y: 0},
-    animate: {opacity: 1, x: 0, y: 0},
-    exit: {opacity: 0, x: '100%', y: 0},
+    initial: {opacity: 0, transform: 'translateX(100%) translateY(0)'},
+    animate: {opacity: 1, transform: 'translateX(0) translateY(0)'},
+    exit: {opacity: 0, transform: 'translateX(100%) translateY(0)'},
     transition: transitionSettings,
   };
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -27,7 +27,6 @@ import {
   type DashboardFilters,
   type Widget,
 } from 'sentry/views/dashboards/types';
-import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
 import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
@@ -49,6 +48,7 @@ import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hook
 import {useDisableTransactionWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useDisableTransactionWidget';
 import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {useSegmentSpanWidgetState} from 'sentry/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState';
+import {useWidgetBuilderTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderAnimationSettings';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
@@ -90,6 +90,7 @@ function WidgetBuilderSlideout({
   const [error, setError] = useState<Record<string, any>>({});
   const theme = useTheme();
   const isEditing = useIsEditingWidget();
+  const transitionSettings = useWidgetBuilderTransitionSettings();
   const source = useDashboardWidgetSource();
   const {cacheBuilderState} = useCacheBuilderState();
   const {setSegmentSpanBuilderState} = useSegmentSpanWidgetState();
@@ -208,7 +209,7 @@ function WidgetBuilderSlideout({
       collapsed={!isOpen}
       slidePosition="left"
       data-test-id="widget-slideout"
-      transitionProps={animationTransitionSettings}
+      transitionProps={transitionSettings}
     >
       <SlideoutHeaderWrapper>
         <Breadcrumbs crumbs={breadcrumbs} />

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderAnimationSettings.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderAnimationSettings.tsx
@@ -1,0 +1,12 @@
+import {useTheme} from '@emotion/react';
+import type {Transition} from 'framer-motion';
+
+export function useWidgetBuilderTransitionSettings(): Transition {
+  const theme = useTheme();
+
+  return {
+    type: 'tween',
+    ease: theme.motionControlPoints.snap,
+    duration: 0.5, // TODO: Introduce a slower value
+  };
+}


### PR DESCRIPTION
EDIT: I removed some unrelated changes!

~Change 1: Using `transform` for animations. According to my profiling, animating `x`, `y`, and `opacity` together in Framer Motion uses `requestAnimationFrame`! When the main thread is busy (which is very often with the Widget Builder), this causes jittery animations. Yuck. Instead, I'm transitioning `transform` directly, as per the Framer documentation. This delegates the transition straight to the compositor, which is way better! I applied this change to both the Widget Builder _and_ the whole slideout panel.~

Using the motion Design Tokens. Scraps specifies the correct bezier curves and durations that we should use. I added some theme configuration that allows using the tokens in a Framer Motion context, by exporting the raw values. Then I dropped them in.

1. Is this one of the intended uses for these tokens? Do we need different tokens for large UI animations, like opening panels?
1. The way I exported the values is a bit gross. What would be good names for these tokens?
2. `motion.snap.slow` is _way too fast_ for large panels, like the Widget Builder. Can we get another token, or should I use a custom value?
