### PR TITLE
feat(Replay): Add Function to Query EAP for Replay Details

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -361,6 +361,7 @@ def as_trace_item(
     # Extend the attributes with the replay_id to make it queryable by replay_id after we
     # eventually use the trace_id in its rightful position.
     trace_item_context["attributes"]["replay_id"] = context["replay_id"]
+    trace_item_context["attributes"]["segment_id"] = context["segment_id"]
 
     return new_trace_item(
         {

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3794,6 +3794,8 @@ class ReplayEAPTestCase(BaseTestCase):
         assert response.status_code == 200
 
         for replay in replays:
+            # Reverse the ids here since these are stored in little endian in Clickhouse
+            # and end up reversed.
             replay.item_id = replay.item_id[::-1]
 
 

--- a/tests/sentry/replays/endpoints/test_organization_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_details.py
@@ -10,60 +10,6 @@ REPLAYS_FEATURES = {"organizations:session-replay": True}
 
 
 class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
-    def test_query_replay_instance_eap_calls_eap_query(self) -> None:
-        """Ensure query_replay_instance_eap calls eap_read.query with correct arguments."""
-        import datetime
-        from unittest.mock import patch
-
-        from sentry.replays.endpoints.organization_replay_details import query_replay_instance_eap
-
-        project_ids = [123]
-        replay_id = "abc123"
-        start = datetime.datetime(2025, 1, 1, 0, 0, tzinfo=datetime.UTC)
-        end = datetime.datetime(2025, 1, 2, 0, 0, tzinfo=datetime.UTC)
-        organization_id = 42
-        referrer = "test.referrer"
-
-        with patch("sentry.replays.lib.eap.read.query") as mock_query:
-            mock_query.return_value = "mocked"
-            result = query_replay_instance_eap(
-                project_ids=project_ids,
-                replay_id=replay_id,
-                start=start,
-                end=end,
-                organization_id=organization_id,
-                referrer=referrer,
-            )
-            assert result == "mocked"
-            assert mock_query.call_count == 1
-
-            args, kwargs = mock_query.call_args
-            snuba_query = args[0]
-            assert snuba_query.match.name == "replays"
-
-            select_cols = [col.name for col in snuba_query.select]
-            assert "replay_id" in select_cols
-            assert "project_id" in select_cols
-            assert "timestamp" in select_cols
-            assert "segment_id" in select_cols
-            assert "is_archived" in select_cols
-
-            settings = args[1]
-            assert settings["attribute_types"]["replay_id"] == str
-            assert settings["attribute_types"]["project_id"] == int
-            assert settings["attribute_types"]["timestamp"] == int
-            assert settings["attribute_types"]["segment_id"] == int
-            assert settings["attribute_types"]["is_archived"] == int
-            assert settings["default_limit"] == 1
-            assert settings["default_offset"] == 0
-
-            request_meta = args[2]
-            assert request_meta["organization_id"] == organization_id
-            assert request_meta["project_ids"] == project_ids
-            assert request_meta["referrer"] == referrer
-            assert request_meta["cogs_category"] == "replays"
-            assert request_meta["trace_item_type"] == "replay"
-
     endpoint = "sentry-api-0-organization-replay-details"
 
     def setUp(self) -> None:

--- a/tests/sentry/replays/endpoints/test_organization_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_details.py
@@ -10,6 +10,60 @@ REPLAYS_FEATURES = {"organizations:session-replay": True}
 
 
 class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
+    def test_query_replay_instance_eap_calls_eap_query(self) -> None:
+        """Ensure query_replay_instance_eap calls eap_read.query with correct arguments."""
+        import datetime
+        from unittest.mock import patch
+
+        from sentry.replays.endpoints.organization_replay_details import query_replay_instance_eap
+
+        project_ids = [123]
+        replay_id = "abc123"
+        start = datetime.datetime(2025, 1, 1, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 1, 2, 0, 0, tzinfo=datetime.UTC)
+        organization_id = 42
+        referrer = "test.referrer"
+
+        with patch("sentry.replays.lib.eap.read.query") as mock_query:
+            mock_query.return_value = "mocked"
+            result = query_replay_instance_eap(
+                project_ids=project_ids,
+                replay_id=replay_id,
+                start=start,
+                end=end,
+                organization_id=organization_id,
+                referrer=referrer,
+            )
+            assert result == "mocked"
+            assert mock_query.call_count == 1
+
+            args, kwargs = mock_query.call_args
+            snuba_query = args[0]
+            assert snuba_query.match.name == "replays"
+
+            select_cols = [col.name for col in snuba_query.select]
+            assert "replay_id" in select_cols
+            assert "project_id" in select_cols
+            assert "timestamp" in select_cols
+            assert "segment_id" in select_cols
+            assert "is_archived" in select_cols
+
+            settings = args[1]
+            assert settings["attribute_types"]["replay_id"] == str
+            assert settings["attribute_types"]["project_id"] == int
+            assert settings["attribute_types"]["timestamp"] == int
+            assert settings["attribute_types"]["segment_id"] == int
+            assert settings["attribute_types"]["is_archived"] == int
+            assert settings["default_limit"] == 1
+            assert settings["default_offset"] == 0
+
+            request_meta = args[2]
+            assert request_meta["organization_id"] == organization_id
+            assert request_meta["project_ids"] == project_ids
+            assert request_meta["referrer"] == referrer
+            assert request_meta["cogs_category"] == "replays"
+            assert request_meta["trace_item_type"] == "replay"
+
     endpoint = "sentry-api-0-organization-replay-details"
 
     def setUp(self) -> None:

--- a/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
+++ b/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
@@ -99,8 +99,9 @@ class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
         assert isinstance(res2, dict)
         assert res1.get("data") is not None
         assert res2.get("data") is not None
-        assert len(res1["data"]) > 0, f"res1 returned no data: {res1}"
-        assert len(res2["data"]) > 0, f"res2 returned no data: {res2}"
+
+        assert len(res1["data"]) == 1, f"Expected 1 row for replay_id1, got {len(res1['data'])}"
+        assert len(res2["data"]) == 1, f"Expected 1 row for replay_id2, got {len(res2['data'])}"
 
         assert res1["data"][0]["replay_id"] == replay_id1
         assert res2["data"][0]["replay_id"] == replay_id2

--- a/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
+++ b/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
@@ -1,0 +1,86 @@
+import datetime
+from uuid import uuid4
+
+from sentry.replays.endpoints.organization_replay_details import query_replay_instance_eap
+from sentry.testutils.cases import ReplayEAPTestCase, TestCase
+
+
+class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
+    def test_eap_replay_query(self) -> None:
+        replay_id1 = uuid4().hex
+        replay_id2 = uuid4().hex
+        now = datetime.datetime.now(datetime.UTC)
+
+        replay1 = self.create_eap_replay(
+            replay_id=replay_id1,
+            timestamp=now,
+            segment_id=0,
+            replay_start_timestamp=int(now.timestamp()),
+            count_error_events=5,
+            count_warning_events=2,
+            count_info_events=1,
+            click_is_dead=0,
+            click_is_rage=0,
+            is_archived=0,
+        )
+        replay2 = self.create_eap_replay(
+            replay_id=replay_id2,
+            timestamp=now,
+            segment_id=0,
+            replay_start_timestamp=int(now.timestamp()),
+            count_error_events=3,
+            count_warning_events=1,
+            count_info_events=0,
+            click_is_dead=0,
+            click_is_rage=0,
+            is_archived=0,
+        )
+
+        self.store_replays_eap([replay1, replay2])
+
+        start = now - datetime.timedelta(minutes=5)
+        end = now + datetime.timedelta(minutes=5)
+        organization_id = self.organization.id
+        project_ids = [self.project.id]
+
+        res1 = query_replay_instance_eap(
+            project_ids=project_ids,
+            replay_ids=[replay_id1],
+            start=start,
+            end=end,
+            request_user_id=self.user.id,
+            organization_id=organization_id,
+        )
+        res2 = query_replay_instance_eap(
+            project_ids=project_ids,
+            replay_ids=[replay_id2],
+            start=start,
+            end=end,
+            request_user_id=self.user.id,
+            organization_id=organization_id,
+        )
+
+        assert isinstance(res1, dict)
+        assert isinstance(res2, dict)
+        assert res1.get("data") is not None
+        assert res2.get("data") is not None
+        assert len(res1["data"]) > 0, f"res1 returned no data: {res1}"
+        assert len(res2["data"]) > 0, f"res2 returned no data: {res2}"
+
+        assert res1["data"][0]["replay_id"] == replay_id1
+        assert res2["data"][0]["replay_id"] == replay_id2
+
+        replay1_data = res1["data"][0]
+        assert "count_segments" in replay1_data
+        assert "count_errors" in replay1_data
+        assert "is_archived" in replay1_data
+        assert "started_at" in replay1_data
+        assert "finished_at" in replay1_data
+
+        assert replay1_data["count_errors"] == 5
+        assert replay1_data["count_warnings"] == 2
+        assert replay1_data["count_segments"] == 1
+
+        replay2_data = res2["data"][0]
+        assert replay2_data["count_errors"] == 3
+        assert replay2_data["count_warnings"] == 1


### PR DESCRIPTION
Adding helper function to allow for query EAP for replay details and added unit test for function. This helper function is not being called yet (planning on adding a flag to gate)

Relates to: REPLAY-824