### PR TITLE
ref(sdk): Change "Unexpected navigation redirect" to use logging

### DIFF
--- a/static/app/views/nav/useRedirectNavV2Routes.tsx
+++ b/static/app/views/nav/useRedirectNavV2Routes.tsx
@@ -37,12 +37,9 @@ function useLogUnexpectedNavigationRedirect({shouldRedirect}: {shouldRedirect: b
 
   useEffect(() => {
     if (shouldRedirect && lastKnownRoute !== routeString) {
-      Sentry.captureMessage('Unexpected navigation redirect', {
-        level: 'warning',
-        tags: {
-          last_known_route: lastKnownRoute,
-          route: routeString,
-        },
+      Sentry.logger.warn('Unexpected navigation redirect', {
+        last_known_route: lastKnownRoute,
+        route: routeString,
       });
     }
   }, [lastKnownRoute, shouldRedirect, routeString]);


### PR DESCRIPTION
This PR changes the `captureMessage` call to use logging instead. **Feel free to close this if you want to keep it as an issue!**

Some reasons you may want to keep it as an issue:

* You need/want issue workflow (e.g. assignment)
* You need an associated stacktrace
* You want a guaranteed replay with the issue
