### PR TITLE
ref(sdk): Change "Gen AI span missing cost calculation" to use logging

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -133,21 +133,15 @@ function getAISpanAttributes({
 
   // Check for missing cost calculation and emit Sentry error
   if (model && (!totalCosts || Number(totalCosts) === 0)) {
-    Sentry.captureMessage('Gen AI span missing cost calculation', {
-      level: 'warning',
-      tags: {
-        feature: 'agent-monitoring',
-        span_type: 'gen_ai',
-        has_model: 'true',
-        has_cost: 'false',
-        span_operation: op || 'unknown',
-        model: model.toString(),
-      },
-      extra: {
-        total_costs: totalCosts,
-        span_operation: op,
-        attributes,
-      },
+    Sentry.logger.warn('Gen AI span missing cost calculation', {
+      feature: 'agent-monitoring',
+      span_type: 'gen_ai',
+      has_model: 'true',
+      has_cost: 'false',
+      span_operation: op || 'unknown',
+      model: model.toString(),
+      total_costs: totalCosts,
+      attributes,
     });
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -61,11 +61,13 @@ function parseAIMessages(messages: string): AIMessage[] | string {
           message !== null && Boolean(message.content)
       );
   } catch (error) {
-    Sentry.captureMessage('Error parsing ai.prompt.messages', {
-      extra: {
-        error,
-      },
-    });
+    try {
+      Sentry.captureException(
+        new Error('Error parsing ai.prompt.messages', {cause: error})
+      );
+    } catch {
+      // ignore errors with browsers that don't support `cause`
+    }
     return messages;
   }
 }
@@ -89,11 +91,13 @@ function transformInputMessages(inputMessages: string) {
     }
     return JSON.stringify(result);
   } catch (error) {
-    Sentry.captureMessage('Error parsing ai.input_messages', {
-      extra: {
-        error,
-      },
-    });
+    try {
+      Sentry.captureException(
+        new Error('Error parsing ai.input_messages', {cause: error})
+      );
+    } catch {
+      // ignore errors with browsers that don't support `cause`
+    }
     return undefined;
   }
 }
@@ -115,11 +119,11 @@ function transformPrompt(prompt: string) {
     }
     return JSON.stringify(result);
   } catch (error) {
-    Sentry.captureMessage('Error parsing ai.prompt', {
-      extra: {
-        error,
-      },
-    });
+    try {
+      Sentry.captureException(new Error('Error parsing ai.prompt', {cause: error}));
+    } catch {
+      // ignore errors with browsers that don't support `cause`
+    }
     return undefined;
   }
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -61,13 +61,11 @@ function parseAIMessages(messages: string): AIMessage[] | string {
           message !== null && Boolean(message.content)
       );
   } catch (error) {
-    try {
-      Sentry.captureException(
-        new Error('Error parsing ai.prompt.messages', {cause: error})
-      );
-    } catch {
-      // ignore errors with browsers that don't support `cause`
-    }
+    Sentry.captureMessage('Error parsing ai.prompt.messages', {
+      extra: {
+        error,
+      },
+    });
     return messages;
   }
 }
@@ -91,13 +89,11 @@ function transformInputMessages(inputMessages: string) {
     }
     return JSON.stringify(result);
   } catch (error) {
-    try {
-      Sentry.captureException(
-        new Error('Error parsing ai.input_messages', {cause: error})
-      );
-    } catch {
-      // ignore errors with browsers that don't support `cause`
-    }
+    Sentry.captureMessage('Error parsing ai.input_messages', {
+      extra: {
+        error,
+      },
+    });
     return undefined;
   }
 }
@@ -119,11 +115,11 @@ function transformPrompt(prompt: string) {
     }
     return JSON.stringify(result);
   } catch (error) {
-    try {
-      Sentry.captureException(new Error('Error parsing ai.prompt', {cause: error}));
-    } catch {
-      // ignore errors with browsers that don't support `cause`
-    }
+    Sentry.captureMessage('Error parsing ai.prompt', {
+      extra: {
+        error,
+      },
+    });
     return undefined;
   }
 }


### PR DESCRIPTION
This PR changes the `captureMessage` call to use logging instead. **Feel free to close this if you want to keep it as an issue!**

Some reasons you may want to keep it as an issue:

* You need/want issue workflow (e.g. assignment)
* You need an associated stacktrace
* You want a guaranteed replay with the issue
