### PR TITLE
fix(dashboards): Use stored global filter tag instead of fetching filter tag collection

### DIFF
--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -24,16 +24,13 @@ import {
 
 function NumericFilterSelector({
   globalFilter,
-  searchBarData,
   onRemoveFilter,
   onUpdateFilter,
 }: GenericFilterSelectorProps) {
-  const filterKeys = useMemo(() => searchBarData.getFilterKeys(), [searchBarData]);
-
   // Parse global filter condition to retrieve initial state
   const globalFilterTokens = useMemo(
-    () => parseFilterValue(globalFilter.value, filterKeys, globalFilter),
-    [filterKeys, globalFilter]
+    () => parseFilterValue(globalFilter.value, globalFilter),
+    [globalFilter]
   );
 
   const globalFilterToken = globalFilterTokens ? globalFilterTokens[0] : null;
@@ -150,7 +147,6 @@ function NumericFilterSelector({
                         stagedFilterValue,
                         stagedFilterOperator,
                         globalFilterToken,
-                        filterKeys,
                         globalFilter
                       );
                       onUpdateFilter({

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -91,22 +91,18 @@ export function newNumericFilterQuery(
     token: filterToken,
   });
   if (!cleanedValue) return '';
-  const filterWithNewValue = modifyFilterValue(
-    filterToken.text,
-    filterToken,
-    cleanedValue
-  );
+  const newFilterValue = modifyFilterValue(filterToken.text, filterToken, cleanedValue);
 
-  const newFilterTokens = parseFilterValue(filterWithNewValue, globalFilter);
-  const filterTokenWithNewValue = newFilterTokens?.[0];
-  if (!filterTokenWithNewValue) {
+  const newFilterTokens = parseFilterValue(newFilterValue, globalFilter);
+  const newFilterToken = newFilterTokens?.[0];
+  if (!newFilterToken) {
     return '';
   }
 
   // Update the operator of the filter
   const newFilterQuery = modifyFilterOperatorQuery(
-    filterWithNewValue,
-    filterTokenWithNewValue,
+    newFilterValue,
+    newFilterToken,
     newOperator,
     false
   );

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -10,7 +10,7 @@ import {
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
-import type {Tag, TagCollection} from 'sentry/types/group';
+import type {Tag} from 'sentry/types/group';
 import {getFieldDefinition, type FieldDefinition} from 'sentry/utils/fields';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
 
@@ -37,14 +37,15 @@ export function getFieldDefinitionForDataset(
 
 export function parseFilterValue(
   filterValue: string,
-  filterKeys: TagCollection,
   globalFilter: GlobalFilter
 ): Array<TokenResult<Token.FILTER>> {
   const parsedResult = parseQueryBuilderValue(
     filterValue,
     () => getFieldDefinitionForDataset(globalFilter.tag, globalFilter.dataset),
     {
-      filterKeys,
+      filterKeys: {
+        [globalFilter.tag.key]: globalFilter.tag,
+      },
     }
   );
   if (!parsedResult) {
@@ -76,7 +77,6 @@ export function newNumericFilterQuery(
   newValue: string,
   newOperator: TermOperator,
   filterToken: TokenResult<Token.FILTER>,
-  filterKeys: TagCollection,
   globalFilter: GlobalFilter
 ) {
   // Update the value of the filter
@@ -97,7 +97,7 @@ export function newNumericFilterQuery(
     cleanedValue
   );
 
-  const newFilterTokens = parseFilterValue(filterWithNewValue, filterKeys, globalFilter);
+  const newFilterTokens = parseFilterValue(filterWithNewValue, globalFilter);
   const filterTokenWithNewValue = newFilterTokens?.[0];
   if (!filterTokenWithNewValue) {
     return '';


### PR DESCRIPTION
When parsing a particular filter value, it is unnecessary to pass the entire filter tag collection of a dataset into the parse function. Instead, we can pass in the tag definition of the global filter.