### PR TITLE
fix(auth): Handle missing WebAuthn session state gracefully

### DIFF
--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -97,3 +97,15 @@ class U2FInterfaceTest(TestCase):
         _, kwargs = mock_state.call_args
         assert kwargs.get("state") == "state"
         assert "webauthn_authentication_state" not in self.request.session
+
+    def test_validate_response_missing_session_state(self) -> None:
+        self.test_try_enroll_webauthn()
+        mock_state = Mock()
+        self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
+
+        # Session state is missing (e.g., session expired)
+        assert "webauthn_authentication_state" not in self.request.session
+
+        # Should return False without calling authenticate_complete
+        assert not self.u2f.validate_response(self.request, None, self.response)
+        mock_state.assert_not_called()


### PR DESCRIPTION
When the webauthn_authentication_state is missing from the session (e.g., due to session expiration), bail early and return False instead of passing None to authenticate_complete(), which causes a TypeError when it tries to access state["challenge"].

This change treats missing session state the same as any other authentication failure, returning a proper 403 instead of crashing with a 500 error.

Fixes [RTC-1246: TypeError: 'NoneType' object is not subscriptable](https://linear.app/getsentry/issue/RTC-1246/typeerror-nonetype-object-is-not-subscriptable)
Fixes SENTRY-3Z4D
Fixes SENTRY-3Z4B