### PR TITLE
feat(producer): Replace confluent_kafka.Producer with ConfluentProducer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "rfc3339-validator>=0.1.2",
     "rfc3986-validator>=0.1.1",
     # [end] jsonschema format validators
-    "sentry-arroyo>=2.30.0",
+    "sentry-arroyo>=2.31.2",
     "sentry-forked-email-reply-parser>=0.5.12.post1",
     "sentry-kafka-schemas>=2.1.11",
     "sentry-ophio>=1.1.3",

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -52,11 +52,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
             self.__producers[topic] = get_confluent_producer(
                 build_kafka_producer_configuration(default_config=cluster_options)
             )
-            # fallback to confluent_kafka Producer if not rolled out
-            if self.__producers[topic] is None:
-                self.__producers[topic] = Producer(
-                    build_kafka_producer_configuration(default_config=cluster_options)
-                )
 
         return self.__producers[topic]
 

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -20,6 +20,7 @@ from sentry.eventstream.snuba import KW_SKIP_SEMANTIC_PARTITIONING, SnubaProtoco
 from sentry.eventstream.types import EventStreamEventType
 from sentry.killswitches import killswitch_matches_context
 from sentry.utils import json
+from sentry.utils.confluent_producer import get_confluent_producer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
@@ -48,9 +49,14 @@ class KafkaEventStream(SnubaProtocolEventStream):
             cluster_options = get_kafka_producer_cluster_options(cluster_name)
             cluster_options["client.id"] = "sentry.eventstream.kafka"
             # XXX(markus): We should use `sentry.utils.arroyo_producer.get_arroyo_producer`.
-            self.__producers[topic] = Producer(
+            self.__producers[topic] = get_confluent_producer(
                 build_kafka_producer_configuration(default_config=cluster_options)
             )
+            # fallback to confluent_kafka Producer if not rolled out
+            if self.__producers[topic] is None:
+                self.__producers[topic] = Producer(
+                    build_kafka_producer_configuration(default_config=cluster_options)
+                )
 
         return self.__producers[topic]
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -629,6 +629,10 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Rollout configuration for Arroyo ConfluentProducer
+# Controls the rollout of individual Kafka producers by name
+register("arroyo.producer.confluent-producer-rollout", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)
 register("analytics.options", default={}, flags=FLAG_NOSTORE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -631,7 +631,12 @@ register(
 
 # Rollout configuration for Arroyo ConfluentProducer
 # Controls the rollout of individual Kafka producers by name
-register("arroyo.producer.confluent-producer-rollout", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register(
+    "arroyo.producer.confluent-producer-rollout",
+    type=Dict,
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)

--- a/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
@@ -14,6 +14,7 @@ from confluent_kafka import Producer
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.utils import kafka_config, metrics
+from sentry.utils.confluent_producer import get_confluent_producer
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,10 @@ class SimpleProduceStep(ProcessingStep[KafkaPayload]):
         snuba_metrics = kafka_config.get_topic_definition(output_topic)
         producer_config = kafka_config.get_kafka_producer_cluster_options(snuba_metrics["cluster"])
         producer_config["client.id"] = "sentry.sentry_metrics.multiprocess"
-        self.__producer = Producer(producer_config)
+        self.__producer = get_confluent_producer(producer_config)
+        # fallback to confluent_kafka Producer if not rolled out
+        if self.__producer is None:
+            self.__producer = Producer(producer_config)
         self.__producer_topic = snuba_metrics["real_topic_name"]
 
         self.__commit = CommitOffsets(commit_function)

--- a/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
@@ -10,7 +10,6 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import Commit, FilteredPayload, Message, Partition, Value
-from confluent_kafka import Producer
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.utils import kafka_config, metrics
@@ -30,9 +29,6 @@ class SimpleProduceStep(ProcessingStep[KafkaPayload]):
         producer_config = kafka_config.get_kafka_producer_cluster_options(snuba_metrics["cluster"])
         producer_config["client.id"] = "sentry.sentry_metrics.multiprocess"
         self.__producer = get_confluent_producer(producer_config)
-        # fallback to confluent_kafka Producer if not rolled out
-        if self.__producer is None:
-            self.__producer = Producer(producer_config)
         self.__producer_topic = snuba_metrics["real_topic_name"]
 
         self.__commit = CommitOffsets(commit_function)

--- a/src/sentry/sentry_metrics/consumers/indexer/slicing_router.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/slicing_router.py
@@ -20,6 +20,7 @@ from sentry.sentry_metrics.consumers.indexer.routing_producer import (
     RoutingPayload,
 )
 from sentry.utils import kafka_config
+from sentry.utils.confluent_producer import get_confluent_producer
 
 
 class SlicingConfigurationException(Exception):
@@ -112,8 +113,12 @@ class SlicingRouter(MessageRouter):
             producer_config["client.id"] = (
                 f"sentry.sentry_metrics.slicing_router.{current_sliceable}.{current_slice_id}"
             )
+            producer = get_confluent_producer(producer_config)
+            # fallback to confluent_kafka Producer if not rolled out
+            if producer is None:
+                producer = Producer(producer_config)
             self.__slice_to_producer[current_slice_id] = MessageRoute(
-                producer=Producer(producer_config),
+                producer=producer,
                 topic=Topic(configuration["topic"]),
             )
         # All logical partitions should be routed to a slice ID that's present in the slice

--- a/src/sentry/sentry_metrics/consumers/indexer/slicing_router.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/slicing_router.py
@@ -114,9 +114,6 @@ class SlicingRouter(MessageRouter):
                 f"sentry.sentry_metrics.slicing_router.{current_sliceable}.{current_slice_id}"
             )
             producer = get_confluent_producer(producer_config)
-            # fallback to confluent_kafka Producer if not rolled out
-            if producer is None:
-                producer = Producer(producer_config)
             self.__slice_to_producer[current_slice_id] = MessageRoute(
                 producer=producer,
                 topic=Topic(configuration["topic"]),

--- a/src/sentry/utils/confluent_producer.py
+++ b/src/sentry/utils/confluent_producer.py
@@ -24,8 +24,9 @@ def get_confluent_producer(
     name = configuration.get("client.id")
 
     # f"sentry.sentry_metrics.slicing_router.{current_sliceable}.{current_slice_id}"
-    if name.startswith("sentry.sentry_metrics.slicing_router"):
-        name = "sentry.sentry_metrics.slicing_router"
+    if name is not None and isinstance(name, str):
+        if name.startswith("sentry.sentry_metrics.slicing_router"):
+            name = "sentry.sentry_metrics.slicing_router"
 
     if rollout_config.get(name, False):
         return ConfluentProducer(configuration)

--- a/src/sentry/utils/confluent_producer.py
+++ b/src/sentry/utils/confluent_producer.py
@@ -22,6 +22,11 @@ def get_confluent_producer(
     """
     rollout_config = options.get("arroyo.producer.confluent-producer-rollout", {})
     name = configuration.get("client.id")
+
+    # f"sentry.sentry_metrics.slicing_router.{current_sliceable}.{current_slice_id}"
+    if name.startswith("sentry.sentry_metrics.slicing_router"):
+        name = "sentry.sentry_metrics.slicing_router"
+
     if rollout_config.get(name, False):
         return ConfluentProducer(configuration)
     return None

--- a/src/sentry/utils/confluent_producer.py
+++ b/src/sentry/utils/confluent_producer.py
@@ -30,4 +30,4 @@ def get_confluent_producer(
 
     if rollout_config.get(name, False):
         return ConfluentProducer(configuration)
-    return None
+    return Producer(configuration)

--- a/src/sentry/utils/confluent_producer.py
+++ b/src/sentry/utils/confluent_producer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from arroyo.backends.kafka import ConfluentProducer
+from confluent_kafka import Producer
+
+from sentry import options
+
+
+def get_confluent_producer(
+    configuration: dict[str, Any],
+) -> Producer:
+    """
+    Get a confluent_kafka Producer for a given configuration.
+
+    Args:
+        configuration: The configuration for the confluent_kafka Producer
+
+    Returns:
+        confluent_kafka Producer
+    """
+    rollout_config = options.get("arroyo.producer.confluent-producer-rollout", {})
+    name = configuration.get("client.id")
+    if rollout_config.get(name, False):
+        return ConfluentProducer(configuration)
+    return None

--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from arroyo.backends.kafka import build_kafka_producer_configuration
-from confluent_kafka import Producer
 
 from sentry.utils.confluent_producer import get_confluent_producer
 
@@ -15,9 +14,6 @@ class KafkaPublisher:
         self.producer = get_confluent_producer(
             build_kafka_producer_configuration(default_config=connection)
         )
-        # fallback to confluent_kafka Producer if not rolled out
-        if self.producer is None:
-            self.producer = Producer(build_kafka_producer_configuration(default_config=connection))
         self.asynchronous = asynchronous
 
     def publish(self, channel: str, value: str, key: str | None = None) -> None:

--- a/tests/sentry/sentry_metrics/consumers/test_slicing_router.py
+++ b/tests/sentry/sentry_metrics/consumers/test_slicing_router.py
@@ -20,6 +20,7 @@ from sentry.sentry_metrics.consumers.indexer.slicing_router import (
     _validate_slicing_config,
     _validate_slicing_consumer_config,
 )
+from sentry.testutils.helpers.options import override_options
 
 KAFKA_SNUBA_GENERIC_METRICS = "snuba-generic-metrics"
 
@@ -78,6 +79,7 @@ def setup_slicing() -> Generator[None]:
 
 
 @pytest.mark.parametrize("org_id", [1, 127, 128, 256, 257])
+@override_options({"arroyo.producer.confluent-producer-rollout": {}})
 def test_with_slicing(metrics_message, setup_slicing) -> None:
     """
     With partitioning settings, the SlicingRouter should route to the correct topic
@@ -94,6 +96,7 @@ def test_with_slicing(metrics_message, setup_slicing) -> None:
         assert False, "unexpected org_id"
 
 
+@override_options({"arroyo.producer.confluent-producer-rollout": {}})
 def test_with_no_org_in_routing_header(setup_slicing) -> None:
     """
     With partitioning settings, the SlicingRouter should route to the correct topic

--- a/tests/sentry/utils/test_confluent_producer.py
+++ b/tests/sentry/utils/test_confluent_producer.py
@@ -1,0 +1,43 @@
+from arroyo.backends.kafka import ConfluentProducer
+from confluent_kafka import Producer
+
+from sentry.testutils.helpers.options import override_options
+from sentry.utils.confluent_producer import get_confluent_producer
+
+
+@override_options({"arroyo.producer.confluent-producer-rollout": {"test_producer": True}})
+def test_get_confluent_producer() -> None:
+    configuration = {
+        "bootstrap.servers": "localhost:9092",
+        "client.id": "test_producer",
+    }
+
+    producer = get_confluent_producer(configuration)
+    assert producer is not None
+
+    assert isinstance(producer, Producer)
+    assert isinstance(producer, ConfluentProducer)
+
+    for attrs in Producer.__dict__.keys():
+        assert hasattr(producer, attrs)
+
+
+@override_options({"arroyo.producer.confluent-producer-rollout": {"test_producer": False}})
+def test_get_confluent_producer_not_rolled_out() -> None:
+    configuration = {
+        "bootstrap.servers": "localhost:9092",
+        "client.id": "test_producer",
+    }
+
+    producer = get_confluent_producer(configuration)
+    assert producer is None
+
+
+@override_options({"arroyo.producer.confluent-producer-rollout": {}})
+def test_get_confluent_producer_no_client_id() -> None:
+    configuration = {
+        "bootstrap.servers": "localhost:9092",
+    }
+
+    producer = get_confluent_producer(configuration)
+    assert producer is None

--- a/tests/sentry/utils/test_confluent_producer.py
+++ b/tests/sentry/utils/test_confluent_producer.py
@@ -30,7 +30,8 @@ def test_get_confluent_producer_not_rolled_out() -> None:
     }
 
     producer = get_confluent_producer(configuration)
-    assert producer is None
+    assert isinstance(producer, Producer)
+    assert not isinstance(producer, ConfluentProducer)
 
 
 @override_options({"arroyo.producer.confluent-producer-rollout": {}})
@@ -40,4 +41,5 @@ def test_get_confluent_producer_no_client_id() -> None:
     }
 
     producer = get_confluent_producer(configuration)
-    assert producer is None
+    assert isinstance(producer, Producer)
+    assert not isinstance(producer, ConfluentProducer)

--- a/uv.lock
+++ b/uv.lock
@@ -2150,7 +2150,7 @@ requires-dist = [
     { name = "requests-oauthlib", specifier = ">=1.2.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.2" },
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
-    { name = "sentry-arroyo", specifier = ">=2.30.0" },
+    { name = "sentry-arroyo", specifier = ">=2.31.2" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
     { name = "sentry-kafka-schemas", specifier = ">=2.1.11" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
@@ -2242,13 +2242,13 @@ dev = [
 
 [[package]]
 name = "sentry-arroyo"
-version = "2.30.0"
+version = "2.31.2"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "confluent-kafka", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.30.0-py3-none-any.whl", hash = "sha256:c3107951443432fbc929eb810b06525f8fcdfe1ed95d4b92bfb9a6260b658322" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.31.2-py3-none-any.whl", hash = "sha256:e00196f91c7b8f8989cc93f2460160991efbd872f3adbf1b983de403189322c1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Now that `ConfluentProducer` is released in `getsentry/arroyo`, bump `sentry-arroyo` to `2.31.2` and slowly rolling out  `ConfluentProducer` to replace `confluent_kafka.Producer` in order to record produce metrics.

Refs STREAM-549