### PR TITLE
perf(dashboards): Lazily compute trailing items for columns

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -307,21 +307,21 @@ function Visualize({error, setError}: VisualizeProps) {
           return {
             label: prettifyTagKey(column),
             value: column,
-            trailingItems: <TypeBadge kind={classifyTagKey(column)} />,
+            trailingItems: () => <TypeBadge kind={classifyTagKey(column)} />,
           };
         }),
       ...Object.values(stringSpanTags).map(tag => {
         return {
           label: tag.name,
           value: tag.key,
-          trailingItems: <TypeBadge kind={FieldKind.TAG} />,
+          trailingItems: () => <TypeBadge kind={FieldKind.TAG} />,
         };
       }),
       ...Object.values(numericSpanTags).map(tag => {
         return {
           label: prettifyTagKey(tag.name),
           value: tag.key,
-          trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+          trailingItems: () => <TypeBadge kind={FieldKind.MEASUREMENT} />,
         };
       }),
     ];
@@ -482,7 +482,7 @@ function Visualize({error, setError}: VisualizeProps) {
                       ? getAggregateValueKey(option.value.meta.name)
                       : option.value.meta.name,
                   label: option.value.meta.name,
-                  trailingItems:
+                  trailingItems: () =>
                     renderTag(option.value.kind, option.value.meta.name) ?? null,
                 }));
 
@@ -508,10 +508,8 @@ function Visualize({error, setError}: VisualizeProps) {
                           label: option.value.meta.name,
                           value: option.value.meta.name,
                           textValue: option.value.meta.name,
-                          trailingItems: renderTag(
-                            option.value.kind,
-                            option.value.meta.name
-                          ),
+                          trailingItems: () =>
+                            renderTag(option.value.kind, option.value.meta.name),
                         }))
                         .sort(_sortFn),
                     ];
@@ -528,14 +526,15 @@ function Visualize({error, setError}: VisualizeProps) {
                           label: option.value.meta.name,
                           value: option.value.meta.name,
                           textValue: option.value.meta.name,
-                          trailingItems: renderTag(
-                            option.value.kind,
-                            option.value.meta.name,
-                            option.value.kind !== FieldValueKind.FUNCTION &&
-                              option.value.kind !== FieldValueKind.EQUATION
-                              ? option.value.meta.dataType
-                              : undefined
-                          ),
+                          trailingItems: () =>
+                            renderTag(
+                              option.value.kind,
+                              option.value.meta.name,
+                              option.value.kind !== FieldValueKind.FUNCTION &&
+                                option.value.kind !== FieldValueKind.EQUATION
+                                ? option.value.meta.dataType
+                                : undefined
+                            ),
                         }))
                         .sort(_sortFn),
                     ];


### PR DESCRIPTION
The same PR as https://github.com/getsentry/sentry/pull/101819, but now it's for the _column_ options. Exactly the same idea, and pretty good performance improvement. This punts the performance penalty to the dropdown component, but that's still better, since we can virtualize there.

**Before:**
<img width="271" height="133" alt="Screenshot 2025-10-30 at 4 07 09 PM" src="https://github.com/user-attachments/assets/3a31ed2f-6cb1-4bd7-9d13-1e1725fe27b5" />

**After:**
<img width="237" height="126" alt="Screenshot 2025-10-30 at 4 08 31 PM" src="https://github.com/user-attachments/assets/c757d3e9-0503-411f-8612-b204859076d5" />
