### PR TITLE
chore(preprod): Improve no results content on comparison page

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -1,6 +1,10 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout/stack';
+import {Text} from '@sentry/scraps/text';
+
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Flex} from 'sentry/components/core/layout/flex';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -42,9 +46,15 @@ type Sort = {
 
 interface SizeCompareItemDiffTableProps {
   diffItems: DiffItem[];
+  disableHideSmallChanges: () => void;
+  originalItemCount: number;
 }
 
-export function SizeCompareItemDiffTable({diffItems}: SizeCompareItemDiffTableProps) {
+export function SizeCompareItemDiffTable({
+  diffItems,
+  originalItemCount,
+  disableHideSmallChanges,
+}: SizeCompareItemDiffTableProps) {
   // Sort by diff initially
   const [sort, setSort] = useState<Sort>({
     field: 'size_diff',
@@ -120,7 +130,18 @@ export function SizeCompareItemDiffTable({diffItems}: SizeCompareItemDiffTablePr
         ))}
       </SimpleTableHeader>
       {sortedDiffItems.length === 0 && (
-        <SimpleTable.Empty>{t('No items changed')}</SimpleTable.Empty>
+        <SimpleTable.Empty>
+          <Stack gap="lg" align="center" justify="center">
+            <Text size="lg" variant="muted" bold>
+              {t('No results found')}
+            </Text>
+            {originalItemCount > 0 && (
+              <Button priority="primary" onClick={disableHideSmallChanges}>
+                {t('Show all changes')}
+              </Button>
+            )}
+          </Stack>
+        </SimpleTable.Empty>
       )}
       {sortedDiffItems.map((diffItem, index) => {
         let changeTypeLabel: string;

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -360,9 +360,8 @@ export function SizeCompareMainContent() {
         <Flex direction="column" gap="0">
           <Flex align="center" justify="between" padding="xl">
             <Flex align="center" gap="sm">
-              <Heading as="h2">{t('Items Changed:')}</Heading>
-              <Heading as="h2" variant="muted">
-                {filteredDiffItems.length}
+              <Heading as="h2">
+                {t('Items Changed: %s', comparisonDataQuery.data?.diff_items.length)}
               </Heading>
             </Flex>
             <Flex align="center" gap="sm">
@@ -403,7 +402,7 @@ export function SizeCompareMainContent() {
                   />
                 </InputGroup>
                 <Flex align="center" gap="lg" wrap="nowrap">
-                  <Text wrap="nowrap">{t('Hide small changes (< 500B)')}</Text>
+                  <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
                   <Switch
                     checked={hideSmallChanges}
                     size="sm"
@@ -415,7 +414,11 @@ export function SizeCompareMainContent() {
                   />
                 </Flex>
               </Flex>
-              <SizeCompareItemDiffTable diffItems={filteredDiffItems} />
+              <SizeCompareItemDiffTable
+                diffItems={filteredDiffItems}
+                originalItemCount={comparisonDataQuery.data?.diff_items.length ?? 0}
+                disableHideSmallChanges={() => setHideSmallChanges(!hideSmallChanges)}
+              />
             </Stack>
           )}
         </Flex>


### PR DESCRIPTION
Worked with Dan on the copy here:
- Updates filter to be more concise
- Adds richer empty state with button to turn off the hide small changes filter
- Lock the Items changed: X value to be the original items, indicating that things did change in all cases

Resolves EME-485

Before
<img width="1500" height="470" alt="Screenshot 2025-10-30 at 1 56 55 PM" src="https://github.com/user-attachments/assets/7dc8b731-0383-436f-97c6-d4a35a960d58" />


After:
<img width="1486" height="433" alt="Screenshot 2025-10-30 at 2 00 58 PM" src="https://github.com/user-attachments/assets/c3a645ee-722a-43f0-b952-8645856340b3" />
