### PR TITLE
feat(aci): add hits to workflow group history response header

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -131,6 +131,8 @@ def fetch_workflow_groups_paginated(
     return cast(
         CursorResult[Group],
         OffsetPaginator(
-            qs, order_by=("-count", "-last_triggered"), on_results=convert_results
-        ).get_result(per_page, cursor),
+            qs,
+            order_by=("-count", "-last_triggered"),
+            on_results=convert_results,
+        ).get_result(per_page, cursor, count_hits=True),
     )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -96,6 +96,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
             self.user,
             WorkflowGroupHistorySerializer(),
         )
+        assert resp["X-Hits"] == "4"
 
         resp = self.get_success_response(
             self.organization.slug,
@@ -118,6 +119,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
             self.user,
             WorkflowGroupHistorySerializer(),
         )
+        assert resp["X-Hits"] == "4"
 
     def test_invalid_dates_error(self) -> None:
         self.get_error_response(


### PR DESCRIPTION
adds X-Hits and X-Max-Hits to the response headers so that we know how many objects the full query contains, even if the response itself is paginated, so we can display the count in the UI in the pagination caption