### PR TITLE
chore(slack): option to log failing unfurl payloads

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -11,11 +11,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from slack_sdk.errors import SlackApiError
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import all_silo_endpoint
-from sentry.auth.superuser import SUPERUSER_ORG_ID
 from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
@@ -271,7 +270,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
                 )
             except SlackApiError as e:
                 lifecycle.add_extras(logger_params)
-                if organization_id == SUPERUSER_ORG_ID:
+                if options.get("slack.log-unfurl-payload", False):
                     lifecycle.add_extra("unfurls", payload["unfurls"])
                 lifecycle.record_failure(e)
                 return False

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -643,6 +643,8 @@ register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 # Debug values are used for the Notification Debug CLI
 register("slack.debug-workspace", flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("slack.debug-channel", flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Log unfurl payloads for debugging
+register("slack.log-unfurl-payload", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Issue Summary on Alerts (timeout in seconds)
 register("alerts.issue_summary_timeout", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
The logic to log the unfurls is somehow never being hit. Change it to use an option so it will be logged.