### PR TITLE
ref(explorer): remove use of message timestamp

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -91,7 +91,6 @@ describe('useSeerExplorer', () => {
           data: expect.objectContaining({
             query: 'Test query',
             insert_index: 0,
-            message_timestamp: expect.any(Number),
           }),
         })
       );

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -141,9 +141,6 @@ export const useSeerExplorer = () => {
         deletedFromIndex ?? (apiData?.session?.blocks.length || 0);
       const calculatedInsertIndex = insertIndex ?? effectiveMessageLength;
 
-      // Generate timestamp in seconds to match backend format
-      const timestamp = Date.now() / 1000;
-
       // Record current real blocks signature to know when to clear optimistic UI
       const baselineSignature = JSON.stringify(
         (apiData?.session?.blocks || []).map(b => [
@@ -154,8 +151,15 @@ export const useSeerExplorer = () => {
         ])
       );
 
+      // Generate deterministic block IDs matching backend logic
+      // Backend generates: `{prefix}-{index}-{content[:16].replace(' ', '-')}`
+      const generateBlockId = (prefix: string, content: string, index: number) => {
+        const contentPrefix = content.slice(0, 16).replace(/ /g, '-');
+        return `${prefix}-${index}-${contentPrefix}`;
+      };
+
       // Set optimistic UI: show user's message and a thinking placeholder,
-      // and hide all real blocks after the insert point. IDs mimic real pattern.
+      // and hide all real blocks after the insert point.
       const assistantContent =
         OPTIMISTIC_ASSISTANT_TEXTS[
           Math.floor(Math.random() * OPTIMISTIC_ASSISTANT_TEXTS.length)
@@ -164,8 +168,12 @@ export const useSeerExplorer = () => {
         insertIndex: calculatedInsertIndex,
         userQuery: query,
         baselineSignature,
-        userBlockId: `user-${timestamp}`,
-        assistantBlockId: `assistant-${timestamp}`,
+        userBlockId: generateBlockId('user', query, calculatedInsertIndex),
+        assistantBlockId: generateBlockId(
+          'loading',
+          assistantContent || '',
+          calculatedInsertIndex + 1
+        ),
         assistantContent: assistantContent || 'Thinking...',
       });
 
@@ -177,7 +185,6 @@ export const useSeerExplorer = () => {
             data: {
               query,
               insert_index: calculatedInsertIndex,
-              message_timestamp: timestamp,
               on_page_context: screenshot,
             },
           }


### PR DESCRIPTION
We had a hack where the frontend would send a timestamp to the backend to set the block ID, so that optimistic blocks would have the same ID as the real blocks that replaced them once polling completed. As part of introducing the SDK (https://github.com/getsentry/sentry/pull/102447), that hack was not pretty, so this PR uses a different approach to get a deterministic ID without sending an extra parameter.

Requires https://github.com/getsentry/seer/pull/3859 and https://github.com/getsentry/sentry/pull/102447
