### PR TITLE
feat(codecov): Add stack trace line coverage legend and better indication

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -544,21 +544,18 @@ describe('Exception Content', () => {
         }
       );
 
-      // The frame should be expandable. Try to expand it if it's not already expanded
+      // The frame should be expanded
       const toggleButton = screen.queryByRole('button', {name: 'Toggle Context'});
-      if (toggleButton) {
-        const isCollapsed =
-          toggleButton.getAttribute('data-test-id') === 'toggle-button-collapsed';
-        if (isCollapsed) {
-          await userEvent.click(toggleButton);
-        }
-      }
+      expect(toggleButton).toBeInTheDocument();
+      expect(toggleButton).toHaveAttribute('data-test-id', 'toggle-button-expanded');
 
-      await screen.findByText('def func4():');
-
+      // The frame context and line coverage legend should be visible
+      expect(await screen.findByText('def func4():')).toBeInTheDocument();
       expect(await screen.findByText('Line covered by tests')).toBeInTheDocument();
-      expect(screen.getByText('Line uncovered by tests')).toBeInTheDocument();
-      expect(screen.getByText('Line partially covered by tests')).toBeInTheDocument();
+      expect(await screen.findByText('Line uncovered by tests')).toBeInTheDocument();
+      expect(
+        await screen.findByText('Line partially covered by tests')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -2,9 +2,11 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout/flex';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {StacktraceBanners} from 'sentry/components/events/interfaces/crashContent/exception/banners/stacktraceBanners';
+import {useLineCoverageContext} from 'sentry/components/events/interfaces/crashContent/exception/lineCoverageContext';
 import {
   prepareSourceMapDebuggerFrameInformation,
   useSourceMapDebuggerData,
@@ -26,6 +28,7 @@ import {
 } from 'sentry/views/issueDetails/streamline/foldSection';
 import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 
+import {LineCoverageLegend} from './lineCoverageLegend';
 import {Mechanism} from './mechanism';
 import {RelatedExceptions} from './relatedExceptions';
 import StackTrace from './stackTrace';
@@ -186,6 +189,7 @@ function InnerContent({
     ? exceptionIdx === values.length - 1
     : exceptionIdx === 0;
 
+  const {hasCoverageData} = useLineCoverageContext();
   return (
     <Fragment>
       <StyledPre>
@@ -201,9 +205,12 @@ function InnerContent({
       <ToggleExceptionButton
         {...{hiddenExceptions, toggleRelatedExceptions, values, exception}}
       />
-      {exception.mechanism && (
-        <Mechanism data={exception.mechanism} meta={meta?.[exceptionIdx]?.mechanism} />
-      )}
+      <Flex direction="row" justify="between">
+        {exception.mechanism && (
+          <Mechanism data={exception.mechanism} meta={meta?.[exceptionIdx]?.mechanism} />
+        )}
+        {hasCoverageData ? <LineCoverageLegend /> : null}
+      </Flex>
       <RelatedExceptions
         mechanism={exception.mechanism}
         allExceptions={values}
@@ -261,9 +268,6 @@ export function Content({
     num_exceptions: values?.length ?? 0,
   });
 
-  // Organization context may be unavailable for the shared event view, so we
-  // avoid using the `useOrganization` hook here and directly useContext
-  // instead.
   if (!values) {
     return null;
   }

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -205,12 +205,17 @@ function InnerContent({
       <ToggleExceptionButton
         {...{hiddenExceptions, toggleRelatedExceptions, values, exception}}
       />
-      <Flex direction="row" justify="between">
-        {exception.mechanism && (
-          <Mechanism data={exception.mechanism} meta={meta?.[exceptionIdx]?.mechanism} />
-        )}
-        {hasCoverageData ? <LineCoverageLegend /> : null}
-      </Flex>
+      {exception.mechanism || hasCoverageData ? (
+        <RowWrapper direction="row" justify="between">
+          {exception.mechanism && (
+            <Mechanism
+              data={exception.mechanism}
+              meta={meta?.[exceptionIdx]?.mechanism}
+            />
+          )}
+          {hasCoverageData ? <LineCoverageLegend /> : null}
+        </RowWrapper>
+      ) : null}
       <RelatedExceptions
         mechanism={exception.mechanism}
         allExceptions={values}
@@ -405,4 +410,8 @@ const StyledFoldSection = styled(FoldSection)`
     margin-left: ${p => p.theme.space.xl};
     margin-right: ${p => p.theme.space.xl};
   }
+`;
+
+const RowWrapper = styled(Flex)`
+  margin: ${p => p.theme.space.xl} 0 ${p => p.theme.space.xs} 0;
 `;

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -268,6 +268,8 @@ export function Content({
     num_exceptions: values?.length ?? 0,
   });
 
+  // Organization context may be unavailable for the shared event view, so we need
+  // to account for this possibility if we rely on the `useOrganization` hook.
   if (!values) {
     return null;
   }

--- a/static/app/components/events/interfaces/crashContent/exception/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/index.tsx
@@ -6,6 +6,7 @@ import type {Project} from 'sentry/types/project';
 import {StackView} from 'sentry/types/stacktrace';
 
 import {Content} from './content';
+import {LineCoverageProvider} from './lineCoverageContext';
 import RawContent from './rawContent';
 
 type Props = {
@@ -37,17 +38,19 @@ export function ExceptionContent({
           platform={event.platform}
         />
       ) : (
-        <Content
-          type={stackType}
-          stackView={stackView}
-          values={values}
-          projectSlug={projectSlug}
-          newestFirst={isNewestFramesFirst}
-          event={event}
-          groupingCurrentLevel={groupingCurrentLevel}
-          meta={meta}
-          threadId={threadId}
-        />
+        <LineCoverageProvider>
+          <Content
+            type={stackType}
+            stackView={stackView}
+            values={values}
+            projectSlug={projectSlug}
+            newestFirst={isNewestFramesFirst}
+            event={event}
+            groupingCurrentLevel={groupingCurrentLevel}
+            meta={meta}
+            threadId={threadId}
+          />
+        </LineCoverageProvider>
       )}
     </ErrorBoundary>
   );

--- a/static/app/components/events/interfaces/crashContent/exception/lineCoverageContext.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/lineCoverageContext.tsx
@@ -1,0 +1,22 @@
+import {createContext, useContext, useState} from 'react';
+
+export const LineCoverageContext = createContext<{
+  hasCoverageData: boolean;
+  setHasCoverageData: (hasCoverageData: boolean) => void;
+}>({
+  hasCoverageData: false,
+  setHasCoverageData: () => {},
+});
+
+export function LineCoverageProvider({children}: {children: React.ReactNode}) {
+  const [hasCoverageData, setHasCoverageData] = useState(false);
+  return (
+    <LineCoverageContext.Provider value={{hasCoverageData, setHasCoverageData}}>
+      {children}
+    </LineCoverageContext.Provider>
+  );
+}
+
+export const useLineCoverageContext = () => {
+  return useContext(LineCoverageContext);
+};

--- a/static/app/components/events/interfaces/crashContent/exception/lineCoverageContext.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/lineCoverageContext.tsx
@@ -1,5 +1,7 @@
 import {createContext, useContext, useState} from 'react';
 
+// This context is used to track whether any of the frames in the exception have line
+// coverage data to accurately display the line coverage legend if relevant.
 export const LineCoverageContext = createContext<{
   hasCoverageData: boolean;
   setHasCoverageData: (hasCoverageData: boolean) => void;

--- a/static/app/components/events/interfaces/crashContent/exception/lineCoverageContext.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/lineCoverageContext.tsx
@@ -2,7 +2,7 @@ import {createContext, useContext, useState} from 'react';
 
 // This context is used to track whether any of the frames in the exception have line
 // coverage data to accurately display the line coverage legend if relevant.
-export const LineCoverageContext = createContext<{
+const LineCoverageContext = createContext<{
   hasCoverageData: boolean;
   setHasCoverageData: (hasCoverageData: boolean) => void;
 }>({

--- a/static/app/components/events/interfaces/crashContent/exception/lineCoverageLegend.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/lineCoverageLegend.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+
+import {Flex} from 'sentry/components/core/layout/flex';
+
+export function LineCoverageLegend() {
+  return (
+    <Flex gap="2xl" align="center" direction="row">
+      <CoveredLine>Line covered by tests</CoveredLine>
+      <UncoveredLine>Line uncovered by tests</UncoveredLine>
+      <PartiallyCoveredLine>Line partially covered by tests</PartiallyCoveredLine>
+    </Flex>
+  );
+}
+
+const CoveredLine = styled('div')`
+  padding-right: ${p => p.theme.space.md};
+  border-right: 3px solid ${p => p.theme.tokens.content.success};
+  white-space: nowrap;
+`;
+
+const UncoveredLine = styled('div')`
+  padding-right: ${p => p.theme.space.md};
+  border-right: 3px solid ${p => p.theme.tokens.content.danger};
+  white-space: nowrap;
+`;
+
+const PartiallyCoveredLine = styled('div')`
+  padding-right: ${p => p.theme.space.md};
+  border-right: 3px dashed ${p => p.theme.tokens.content.warning};
+  white-space: nowrap;
+`;

--- a/static/app/components/events/interfaces/crashContent/exception/lineCoverageLegend.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/lineCoverageLegend.tsx
@@ -1,13 +1,15 @@
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout/flex';
+import {coverageText as COVERAGE_TEXT} from 'sentry/components/events/interfaces/frame/contextLineNumber';
+import {Coverage} from 'sentry/types/integrations';
 
 export function LineCoverageLegend() {
   return (
     <Flex gap="2xl" align="center" direction="row">
-      <CoveredLine>Line covered by tests</CoveredLine>
-      <UncoveredLine>Line uncovered by tests</UncoveredLine>
-      <PartiallyCoveredLine>Line partially covered by tests</PartiallyCoveredLine>
+      <CoveredLine>{COVERAGE_TEXT[Coverage.COVERED]}</CoveredLine>
+      <UncoveredLine>{COVERAGE_TEXT[Coverage.NOT_COVERED]}</UncoveredLine>
+      <PartiallyCoveredLine>{COVERAGE_TEXT[Coverage.PARTIAL]}</PartiallyCoveredLine>
     </Flex>
   );
 }

--- a/static/app/components/events/interfaces/crashContent/exception/lineCoverageLegend.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/lineCoverageLegend.tsx
@@ -6,7 +6,7 @@ import {Coverage} from 'sentry/types/integrations';
 
 export function LineCoverageLegend() {
   return (
-    <Flex gap="2xl" align="center" direction="row">
+    <Flex gap="2xl" align="center" direction="row" paddingBottom="md">
       <CoveredLine>{COVERAGE_TEXT[Coverage.COVERED]}</CoveredLine>
       <UncoveredLine>{COVERAGE_TEXT[Coverage.NOT_COVERED]}</UncoveredLine>
       <PartiallyCoveredLine>{COVERAGE_TEXT[Coverage.PARTIAL]}</PartiallyCoveredLine>

--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -98,16 +98,8 @@ export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
     }
   });
 
-  return (
-    <Wrapper>
-      <StyledPills>{pills}</StyledPills>
-    </Wrapper>
-  );
+  return <StyledPills>{pills}</StyledPills>;
 }
-
-const Wrapper = styled('div')`
-  margin: ${space(2)} 0 ${space(0.5)} 0;
-`;
 
 const iconStyle = (p: {theme: Theme}) => css`
   transition: 0.1s linear color;

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import keyBy from 'lodash/keyBy';
 
 import ClippedBox from 'sentry/components/clippedBox';
+import {useLineCoverageContext} from 'sentry/components/events/interfaces/crashContent/exception/lineCoverageContext';
 import {parseAssembly} from 'sentry/components/events/interfaces/utils';
 import {IconFlag} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -78,6 +79,10 @@ function Context({
   platform,
 }: Props) {
   const organization = useOrganization();
+  const {
+    hasCoverageData: issueHasCoverageData,
+    setHasCoverageData: setIssueHasCoverageData,
+  } = useLineCoverageContext();
 
   const {projects} = useProjects();
   const project = useMemo(
@@ -111,6 +116,9 @@ function Context({
 
   const hasCoverageData =
     !isLoadingCoverage && coverage?.status === CodecovStatusCode.COVERAGE_EXISTS;
+  if (hasCoverageData && !issueHasCoverageData) {
+    setIssueHasCoverageData(true);
+  }
 
   const [lineCoverage = [], hasCoverage] =
     hasCoverageData && coverage?.lineCoverage && !!activeLineNumber! && contextLines

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import keyBy from 'lodash/keyBy';
 
@@ -116,9 +116,12 @@ function Context({
 
   const hasCoverageData =
     !isLoadingCoverage && coverage?.status === CodecovStatusCode.COVERAGE_EXISTS;
-  if (hasCoverageData && !issueHasCoverageData) {
-    setIssueHasCoverageData(true);
-  }
+
+  useEffect(() => {
+    if (hasCoverageData && !issueHasCoverageData) {
+      setIssueHasCoverageData(true);
+    }
+  }, [hasCoverageData, issueHasCoverageData, setIssueHasCoverageData]);
 
   const [lineCoverage = [], hasCoverage] =
     hasCoverageData && coverage?.lineCoverage && !!activeLineNumber! && contextLines

--- a/static/app/components/events/interfaces/frame/contextLineNumber.tsx
+++ b/static/app/components/events/interfaces/frame/contextLineNumber.tsx
@@ -14,9 +14,9 @@ interface Props {
 }
 
 const coverageText: Record<Coverage, string | undefined> = {
-  [Coverage.NOT_COVERED]: t('Uncovered'),
-  [Coverage.COVERED]: t('Covered'),
-  [Coverage.PARTIAL]: t('Partially Covered'),
+  [Coverage.NOT_COVERED]: t('Line uncovered by tests'),
+  [Coverage.COVERED]: t('Line covered by tests'),
+  [Coverage.PARTIAL]: t('Line partially covered by tests'),
   [Coverage.NOT_APPLICABLE]: undefined,
 };
 const coverageClass: Record<Coverage, string | undefined> = {
@@ -63,24 +63,23 @@ const Wrapper = styled('div')`
     margin-right: ${space(1.5)};
     background: transparent;
     min-width: 58px;
-    border-right-style: solid;
-    border-right-color: transparent;
+    border-right: 3px solid transparent;
     user-select: none;
   }
 
   &.covered .line-number {
     background: ${p => p.theme.green100};
+    border-right: 3px solid ${p => p.theme.tokens.content.success};
   }
 
   &.uncovered .line-number {
     background: ${p => p.theme.red100};
-    border-right-color: ${p => p.theme.red300};
+    border-right: 3px solid ${p => p.theme.tokens.content.danger};
   }
 
   &.partial .line-number {
     background: ${p => p.theme.yellow100};
-    border-right-style: dashed;
-    border-right-color: ${p => p.theme.yellow300};
+    border-right: 3px dashed ${p => p.theme.tokens.content.warning};
   }
 
   &.active {

--- a/static/app/components/events/interfaces/frame/contextLineNumber.tsx
+++ b/static/app/components/events/interfaces/frame/contextLineNumber.tsx
@@ -13,7 +13,7 @@ interface Props {
   coverage?: Coverage;
 }
 
-const coverageText: Record<Coverage, string | undefined> = {
+export const coverageText: Record<Coverage, string | undefined> = {
   [Coverage.NOT_COVERED]: t('Line uncovered by tests'),
   [Coverage.COVERED]: t('Line covered by tests'),
   [Coverage.PARTIAL]: t('Line partially covered by tests'),


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1301/polish-codecov-covereduncovered-line-visuals-in-sentry-issues
Figma: https://www.figma.com/design/dHDWguapYO8kiWaMZl1GAE/CCMRG-1301?node-id=13-127&t=vLpCzeDAij3CQbHo-1

<img width="1112" height="640" alt="Screenshot 2025-10-30 at 3 25 48 PM" src="https://github.com/user-attachments/assets/eeb02a68-9a17-4b83-866a-1da8ea402cc7" />

- Adds new legend
- Changes hover tooltip text for line-by-line
- Added a context to intelligently handle when to show the legend based on whether any of the stack frames have code coverage data. I didn't want the legend to be there even when there was no coverage data.