### PR TITLE
fix(widget-viewer): Remove portal from widget viewer actions

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -364,7 +364,6 @@ function CellAction({
       >
         {cellActions?.length ? (
           <DropdownMenu
-            usePortal
             items={cellActions}
             strategy="fixed"
             size="sm"


### PR DESCRIPTION
Fixes an issue where the portal'd dropdown menu doesn't open over the modal in dashboard widget viewer tables, making the tables seemingly uninteractable.