### PR TITLE
feat(preprod): Wire up frontend for Android proguard mapping missing

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -211,6 +211,30 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   const missingDsymBinaries =
     buildDetailsData?.app_info?.apple_app_info?.missing_dsym_binaries;
 
+  const missingProguardMapping =
+    buildDetailsData?.app_info?.android_app_info?.has_proguard_mapping === false;
+
+  const getAlertMessage = () => {
+    if (missingDsymBinaries && missingDsymBinaries.length > 0) {
+      if (missingDsymBinaries?.length === 1) {
+        return t(
+          'Missing debug symbols for some binaries (%s). Those binaries will not have a detailed breakdown.',
+          missingDsymBinaries[0]
+        );
+      }
+      return t(
+        'Missing debug symbols for some binaries (%s and others). Those binaries will not have a detailed breakdown.',
+        missingDsymBinaries[0]
+      );
+    }
+
+    if (missingProguardMapping) {
+      return t('Missing proguard mapping. Dex will not have a detailed breakdown.');
+    }
+
+    return undefined;
+  };
+
   // Filter data based on search query and categories
   const filteredRoot = filterTreemapElement(
     appSizeData.treemap.root,
@@ -234,7 +258,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
             root={filteredTreemapData.root}
             searchQuery={searchQuery || ''}
             unfilteredRoot={appSizeData.treemap.root}
-            missingDsymBinaries={missingDsymBinaries}
+            alertMessage={getAlertMessage()}
             onSearchChange={value => setSearchQuery(value || undefined)}
           />
         ) : (
@@ -249,7 +273,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
         root={filteredTreemapData.root}
         searchQuery={searchQuery || ''}
         unfilteredRoot={appSizeData.treemap.root}
-        missingDsymBinaries={missingDsymBinaries}
+        alertMessage={getAlertMessage()}
         onSearchChange={value => setSearchQuery(value || undefined)}
       />
     ) : (

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -22,7 +22,7 @@ import {filterTreemapElement} from 'sentry/views/preprod/utils/treemapFiltering'
 interface AppSizeTreemapProps {
   root: TreemapElement | null;
   searchQuery: string;
-  missingDsymBinaries?: string[];
+  alertMessage?: string;
   onSearchChange?: (query: string) => void;
   unfilteredRoot?: TreemapElement;
 }
@@ -30,12 +30,12 @@ interface AppSizeTreemapProps {
 function FullscreenModalContent({
   unfilteredRoot,
   initialSearch,
-  missingDsymBinaries,
+  alertMessage,
   onSearchChange,
 }: {
   initialSearch: string;
   unfilteredRoot: TreemapElement;
-  missingDsymBinaries?: string[];
+  alertMessage?: string;
   onSearchChange?: (query: string) => void;
 }) {
   const [localSearch, setLocalSearch] = useState(initialSearch);
@@ -74,7 +74,7 @@ function FullscreenModalContent({
         <AppSizeTreemap
           root={filteredRoot}
           searchQuery={localSearch}
-          missingDsymBinaries={missingDsymBinaries}
+          alertMessage={alertMessage}
         />
       </Container>
     </Flex>
@@ -83,7 +83,7 @@ function FullscreenModalContent({
 
 export function AppSizeTreemap(props: AppSizeTreemapProps) {
   const theme = useTheme();
-  const {root, searchQuery, unfilteredRoot, missingDsymBinaries, onSearchChange} = props;
+  const {root, searchQuery, unfilteredRoot, alertMessage, onSearchChange} = props;
   const appSizeCategoryInfo = getAppSizeCategoryInfo(theme);
   const renderingContext = useContext(ChartRenderingContext);
   const isFullscreen = renderingContext?.isFullscreen ?? false;
@@ -314,24 +314,9 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     },
   };
 
-  const hasMissingDsyms = missingDsymBinaries && missingDsymBinaries.length > 0;
-
-  const getBinariesMessage = () => {
-    if (missingDsymBinaries?.length === 1) {
-      return t(
-        'Missing debug symbols for some binaries (%s). Those binaries will not have a detailed breakdown.',
-        missingDsymBinaries[0]
-      );
-    }
-    return t(
-      'Missing debug symbols for some binaries (%s and others). Those binaries will not have a detailed breakdown.',
-      missingDsymBinaries![0]
-    );
-  };
-
   return (
     <Flex direction="column" gap="sm" height="100%" width="100%">
-      {hasMissingDsyms && <Alert type="warning">{getBinariesMessage()}</Alert>}
+      {alertMessage && <Alert type="warning">{alertMessage}</Alert>}
       <Container
         height="100%"
         width="100%"
@@ -379,7 +364,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
                     <FullscreenModalContent
                       unfilteredRoot={unfilteredRoot}
                       initialSearch={searchQuery}
-                      missingDsymBinaries={missingDsymBinaries}
+                      alertMessage={alertMessage}
                       onSearchChange={onSearchChange}
                     />
                   ) : (
@@ -387,7 +372,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
                       <AppSizeTreemap
                         root={root}
                         searchQuery={searchQuery}
-                        missingDsymBinaries={missingDsymBinaries}
+                        alertMessage={alertMessage}
                       />
                     </Container>
                   ),

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -9,6 +9,7 @@ export interface BuildDetailsApiResponse {
 }
 
 export interface BuildDetailsAppInfo {
+  android_app_info?: AndroidAppInfo | null;
   app_id?: string | null;
   apple_app_info?: AppleAppInfo | null;
   artifact_type?: BuildDetailsArtifactType | null;
@@ -24,6 +25,10 @@ export interface BuildDetailsAppInfo {
 
 interface AppleAppInfo {
   missing_dsym_binaries?: string[];
+}
+
+interface AndroidAppInfo {
+  has_proguard_mapping?: boolean;
 }
 
 export interface BuildDetailsVcsInfo {


### PR DESCRIPTION
Adds missing proguard mappings warning message if `has_proguard_mapping === false`. Refactors the warning message for missing dsyms to better interface with a generic `alertMessage` we'll pass to the `AppSizeTreemap` component.

<img width="1499" height="704" alt="Screenshot 2025-10-30 at 4 20 18 PM" src="https://github.com/user-attachments/assets/9a51d1a1-b1de-42b7-99d7-d199d8b9fd25" />

Resolves EME-508
