### PR TITLE
chore(preprod): add minify localized string instruction (EME-506)

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -14,6 +14,7 @@ import {t, tn} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {openAlternativeIconsInsightModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
+import {openMinifyLocalizedStringsModal} from 'sentry/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal';
 import {openOptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
 import type {
   FileSavingsResultGroup,
@@ -39,6 +40,7 @@ export function formatUpside(percentage: number): string {
 const INSIGHTS_WITH_MORE_INFO_MODAL = [
   'image_optimization',
   'alternate_icons_optimization',
+  'localized_strings_minify',
 ];
 
 const DEFAULT_ITEMS_PER_PAGE = 20;
@@ -71,6 +73,8 @@ export function AppSizeInsightsSidebarRow({
       openAlternativeIconsInsightModal();
     } else if (insight.key === 'image_optimization') {
       openOptimizeImagesModal(platform);
+    } else if (insight.key === 'localized_strings_minify') {
+      openMinifyLocalizedStringsModal();
     }
   };
 

--- a/static/app/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal.tsx
@@ -1,0 +1,142 @@
+import {openInsightInfoModal} from 'sentry/actionCreators/modal';
+import {CodeBlock} from 'sentry/components/core/code';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Heading} from 'sentry/components/core/text/heading';
+import {t, tct} from 'sentry/locale';
+import {
+  CodeBlockWrapper,
+  InlineCode,
+} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
+
+const COMMENT_EXAMPLE = `/* Title for the expired code alert. */
+"code_expired" = "Code Expired";`;
+
+const STRIP_STRINGS_SCRIPT = `#!/usr/bin/env python3
+import json
+import os
+import subprocess
+
+
+def minify(file_path: str) -> None:
+    subprocess.run(["plutil", "-convert", "json", file_path], check=True)
+
+    with open(file_path, "r", encoding="utf-8") as source:
+        data = json.load(source)
+
+    with open(file_path, "w", encoding="utf-8") as target:
+        for key, value in data.items():
+            target.write(f'"{key}" = "{value}";\\n')
+
+
+for root, _, files in os.walk(os.environ["BUILT_PRODUCTS_DIR"], followlinks=True):
+    for filename in files:
+        if filename.endswith(".strings"):
+            path = os.path.join(root, filename)
+            print(f"Minifying {path}")
+            minify(path)`;
+
+function getMinifyLocalizedStringsContent() {
+  return (
+    <Flex direction="column" gap="2xl">
+      <Text>
+        {t(
+          'Xcode localized string bundles often ship with translator comments, whitespace, and legacy encodings that the runtime never reads. Trimming that excess reduces download size without touching what users see.'
+        )}
+      </Text>
+
+      <Flex direction="column" gap="xl">
+        <Flex direction="column" gap="md">
+          <Heading as="h3" size="md">
+            {t('Option 1: Keep the format lean')}
+          </Heading>
+          <ul>
+            <li>
+              <Text>
+                {tct(
+                  'Encode localized strings as plain text ([example]), not binary plists. Set [setting] ([key]) to [value] in Xcode.',
+                  {
+                    example: <InlineCode>"key" = "value";</InlineCode>,
+                    setting: <InlineCode>Strings File Output Encoding</InlineCode>,
+                    key: <InlineCode>STRINGS_FILE_OUTPUT_ENCODING</InlineCode>,
+                    value: <InlineCode>UTF-8</InlineCode>,
+                  }
+                )}
+              </Text>
+            </li>
+          </ul>
+        </Flex>
+
+        <Flex direction="column" gap="md">
+          <Heading as="h3" size="md">
+            {t('Option 2: Strip comments automatically')}
+          </Heading>
+          <Text>
+            {t(
+              'String files can have comments that ship with the bundle. They help during translation but take space in production. A typical comment may look like:'
+            )}
+          </Text>
+          <CodeBlockWrapper>
+            <CodeBlock language="text" filename="Localizable.strings">
+              {COMMENT_EXAMPLE}
+            </CodeBlock>
+          </CodeBlockWrapper>
+          <Text>
+            {t(
+              'You can automatically strip comments by adding a Run Script build phase that converts each `.strings` file to JSON, rewrites it without comments, and leaves a compact UTF-8 file behind:'
+            )}
+          </Text>
+          <ol>
+            <li>
+              <Text>
+                {tct(
+                  'In Xcode, open [menu] and add a new Run Script phase after the localized resources step.',
+                  {
+                    menu: (
+                      <InlineCode>Build Phases → + → New Run Script Phase</InlineCode>
+                    ),
+                  }
+                )}
+              </Text>
+            </li>
+            <li>
+              <Text>
+                {tct(
+                  'Point the shell to your Python 3 binary (for Homebrew on Apple Silicon: [binary]).',
+                  {binary: <InlineCode>/opt/homebrew/bin/python3</InlineCode>}
+                )}
+              </Text>
+            </li>
+            <li>
+              <Text>
+                {t('Paste the script below and commit your annotated originals.')}
+              </Text>
+            </li>
+          </ol>
+          <Text>
+            {t(
+              'The script converts each `.strings` file to JSON, rewrites it without comments, and leaves a compact UTF-8 file behind.'
+            )}
+          </Text>
+          <CodeBlockWrapper>
+            <CodeBlock language="python" filename="minify_strings.py">
+              {STRIP_STRINGS_SCRIPT}
+            </CodeBlock>
+          </CodeBlockWrapper>
+          <Text>
+            {t(
+              'This script strips comments and blank lines after the files are generated, so keep the original annotated copies under version control for translators.'
+            )}
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}
+
+export function openMinifyLocalizedStringsModal() {
+  openInsightInfoModal({
+    title: t('Minify localized strings'),
+    children: getMinifyLocalizedStringsContent(),
+  });
+}


### PR DESCRIPTION
add modal to include instructions for minifying strings
<img width="828" height="787" alt="image" src="https://github.com/user-attachments/assets/bf60c826-02a0-40b9-84c2-bc0950ccc28b" />


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
