### PR TITLE
chore(preprod): clean up opening modals

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -14,6 +14,7 @@ import {t, tn} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {openAlternativeIconsInsightModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
+import {openMinifyLocalizedStringsModal} from 'sentry/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal';
 import {openOptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
 import type {
   FileSavingsResultGroup,
@@ -39,6 +40,7 @@ export function formatUpside(percentage: number): string {
 const INSIGHTS_WITH_MORE_INFO_MODAL = [
   'image_optimization',
   'alternate_icons_optimization',
+  'localized_strings_minify',
 ];
 
 const DEFAULT_ITEMS_PER_PAGE = 20;
@@ -71,6 +73,8 @@ export function AppSizeInsightsSidebarRow({
       openAlternativeIconsInsightModal();
     } else if (insight.key === 'image_optimization') {
       openOptimizeImagesModal(platform);
+    } else if (insight.key === 'localized_strings_minify') {
+      openMinifyLocalizedStringsModal();
     }
   };
 

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -16,6 +16,7 @@ import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {openAlternativeIconsInsightModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
 import {openMinifyLocalizedStringsModal} from 'sentry/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal';
 import {openOptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
+import {openStripDebugSymbolsModal} from 'sentry/views/preprod/buildDetails/main/insights/stripDebugSymbolsModal';
 import type {
   FileSavingsResultGroup,
   OptimizableImageFile,
@@ -41,6 +42,7 @@ const INSIGHTS_WITH_MORE_INFO_MODAL = [
   'image_optimization',
   'alternate_icons_optimization',
   'localized_strings_minify',
+  'strip_binary',
 ];
 
 const DEFAULT_ITEMS_PER_PAGE = 20;
@@ -75,6 +77,8 @@ export function AppSizeInsightsSidebarRow({
       openOptimizeImagesModal(platform);
     } else if (insight.key === 'localized_strings_minify') {
       openMinifyLocalizedStringsModal();
+    } else if (insight.key === 'strip_binary') {
+      openStripDebugSymbolsModal();
     }
   };
 

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -39,15 +39,15 @@ export function formatUpside(percentage: number): string {
   return `~0%`;
 }
 
-const INSIGHTS_WITH_MORE_INFO_MODAL = [
-  'image_optimization',
-  'alternate_icons_optimization',
-  'main_binary_exported_symbols',
-  'localized_strings_minify',
-  'strip_binary',
-];
-
 const DEFAULT_ITEMS_PER_PAGE = 20;
+
+const MODAL_HANDLERS: Record<string, (platform?: Platform) => void> = {
+  alternate_icons_optimization: () => openAlternativeIconsInsightModal(),
+  image_optimization: platform => openOptimizeImagesModal(platform),
+  main_binary_exported_symbols: () => openMainBinaryExportedSymbolsModal(),
+  localized_strings_minify: () => openMinifyLocalizedStringsModal(),
+  strip_binary: () => openStripDebugSymbolsModal(),
+};
 
 export function AppSizeInsightsSidebarRow({
   insight,
@@ -63,7 +63,7 @@ export function AppSizeInsightsSidebarRow({
   platform?: Platform;
 }) {
   const theme = useTheme();
-  const shouldShowTooltip = INSIGHTS_WITH_MORE_INFO_MODAL.includes(insight.key);
+  const shouldShowTooltip = insight.key in MODAL_HANDLERS;
   const [currentPage, setCurrentPage] = useState(0);
 
   const totalPages = Math.ceil(insight.files.length / itemsPerPage);
@@ -73,17 +73,7 @@ export function AppSizeInsightsSidebarRow({
   const showPagination = insight.files.length > itemsPerPage;
 
   const handleOpenModal = () => {
-    if (insight.key === 'alternate_icons_optimization') {
-      openAlternativeIconsInsightModal();
-    } else if (insight.key === 'image_optimization') {
-      openOptimizeImagesModal(platform);
-    } else if (insight.key === 'main_binary_exported_symbols') {
-      openMainBinaryExportedSymbolsModal();
-    } else if (insight.key === 'localized_strings_minify') {
-      openMinifyLocalizedStringsModal();
-    } else if (insight.key === 'strip_binary') {
-      openStripDebugSymbolsModal();
-    }
+    MODAL_HANDLERS[insight.key]?.(platform);
   };
 
   const handlePageChange = (newPage: number) => {

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -14,6 +14,7 @@ import {t, tn} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {openAlternativeIconsInsightModal} from 'sentry/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal';
+import {openMainBinaryExportedSymbolsModal} from 'sentry/views/preprod/buildDetails/main/insights/mainBinaryExportedSymbolsModal';
 import {openMinifyLocalizedStringsModal} from 'sentry/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal';
 import {openOptimizeImagesModal} from 'sentry/views/preprod/buildDetails/main/insights/optimizeImagesModal';
 import {openStripDebugSymbolsModal} from 'sentry/views/preprod/buildDetails/main/insights/stripDebugSymbolsModal';
@@ -41,6 +42,7 @@ export function formatUpside(percentage: number): string {
 const INSIGHTS_WITH_MORE_INFO_MODAL = [
   'image_optimization',
   'alternate_icons_optimization',
+  'main_binary_exported_symbols',
   'localized_strings_minify',
   'strip_binary',
 ];
@@ -75,6 +77,8 @@ export function AppSizeInsightsSidebarRow({
       openAlternativeIconsInsightModal();
     } else if (insight.key === 'image_optimization') {
       openOptimizeImagesModal(platform);
+    } else if (insight.key === 'main_binary_exported_symbols') {
+      openMainBinaryExportedSymbolsModal();
     } else if (insight.key === 'localized_strings_minify') {
       openMinifyLocalizedStringsModal();
     } else if (insight.key === 'strip_binary') {

--- a/static/app/views/preprod/buildDetails/main/insights/mainBinaryExportedSymbolsModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/mainBinaryExportedSymbolsModal.tsx
@@ -1,0 +1,77 @@
+import {openInsightInfoModal} from 'sentry/actionCreators/modal';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Heading} from 'sentry/components/core/text/heading';
+import {t, tct} from 'sentry/locale';
+import {InlineCode} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
+
+function getMainBinaryExportedSymbolsContent() {
+  return (
+    <Flex direction="column" gap="2xl">
+      <Flex direction="column" gap="xl">
+        <Flex direction="column" gap="md">
+          <Heading as="h3" size="md">
+            {t('Main Binary Export Metadata')}
+          </Heading>
+          <Text>
+            {tct(
+              '[bold:What it is]: Binaries that act as entrypoints for your app, such as your main app binary or watchOS app binary, are not linked against by other binaries. This means the export trie information is unnecessary and can be removed.',
+              {bold: <strong />}
+            )}
+          </Text>
+          <Text>
+            {tct(
+              '[bold:How to fix]: Maintain a minimal allowlist so only required entry points stay exported.',
+              {bold: <strong />}
+            )}
+          </Text>
+        </Flex>
+
+        <Flex direction="column" gap="md">
+          <ol>
+            <li>
+              <Text>
+                {tct('Create a text file in your project, for example [path]', {
+                  path: <InlineCode>Config/ExportedSymbols.txt</InlineCode>,
+                })}
+              </Text>
+            </li>
+            <li>
+              <Text>
+                {tct('Add [main] on its own line', {
+                  main: <InlineCode>_main</InlineCode>,
+                  mh: <InlineCode>__mh_execute_header</InlineCode>,
+                  dlsym: <InlineCode>dlsym</InlineCode>,
+                })}
+              </Text>
+            </li>
+            <li>
+              <Text>
+                {t('If you rely on other dynamic lookups, list those symbols too')}
+              </Text>
+            </li>
+            <li>
+              <Text>
+                {tct('In Xcode, set [setting] to the new file’s path', {
+                  setting: (
+                    <strong>
+                      {t('Build Settings → Linking → Exported Symbols File')}
+                    </strong>
+                  ),
+                })}
+              </Text>
+            </li>
+          </ol>
+          <Text>{t('Xcode now limits the export trie to just that allowlist')}</Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}
+
+export function openMainBinaryExportedSymbolsModal() {
+  openInsightInfoModal({
+    title: t('Main binary export metadata'),
+    children: getMainBinaryExportedSymbolsContent(),
+  });
+}

--- a/static/app/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal.tsx
@@ -1,0 +1,142 @@
+import {openInsightInfoModal} from 'sentry/actionCreators/modal';
+import {CodeBlock} from 'sentry/components/core/code';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Heading} from 'sentry/components/core/text/heading';
+import {t, tct} from 'sentry/locale';
+import {
+  CodeBlockWrapper,
+  InlineCode,
+} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
+
+const COMMENT_EXAMPLE = `/* Title for the expired code alert. */
+"code_expired" = "Code Expired";`;
+
+const STRIP_STRINGS_SCRIPT = `#!/usr/bin/env python3
+import json
+import os
+import subprocess
+
+
+def minify(file_path: str) -> None:
+    subprocess.run(["plutil", "-convert", "json", file_path], check=True)
+
+    with open(file_path, "r", encoding="utf-8") as source:
+        data = json.load(source)
+
+    with open(file_path, "w", encoding="utf-8") as target:
+        for key, value in data.items():
+            target.write(f'"{key}" = "{value}";\\n')
+
+
+for root, _, files in os.walk(os.environ["BUILT_PRODUCTS_DIR"], followlinks=True):
+    for filename in files:
+        if filename.endswith(".strings"):
+            path = os.path.join(root, filename)
+            print(f"Minifying {path}")
+            minify(path)`;
+
+function getMinifyLocalizedStringsContent() {
+  return (
+    <Flex direction="column" gap="2xl">
+      <Text>
+        {t(
+          'Xcode localized string bundles often ship with translator comments, whitespace, and legacy encodings that the runtime never reads. Trimming that excess reduces download size without touching what users see.'
+        )}
+      </Text>
+
+      <Flex direction="column" gap="xl">
+        <Flex direction="column" gap="md">
+          <Heading as="h3" size="md">
+            {t('Option 1: Keep the format lean')}
+          </Heading>
+          <ul>
+            <li>
+              <Text>
+                {tct(
+                  'Encode localized strings as plain text ([example]), not binary plists. Set [setting] ([key]) to [value] in Xcode.',
+                  {
+                    example: <InlineCode>"key" = "value";</InlineCode>,
+                    setting: <InlineCode>Strings File Output Encoding</InlineCode>,
+                    key: <InlineCode>STRINGS_FILE_OUTPUT_ENCODING</InlineCode>,
+                    value: <InlineCode>UTF-8</InlineCode>,
+                  }
+                )}
+              </Text>
+            </li>
+          </ul>
+        </Flex>
+
+        <Flex direction="column" gap="md">
+          <Heading as="h3" size="md">
+            {t('Option 2: Strip comments automatically')}
+          </Heading>
+          <Text>
+            {t(
+              'String files can have comments that ship with the bundle. They help during translation but take space in production. A typical comment may look like:'
+            )}
+          </Text>
+          <CodeBlockWrapper>
+            <CodeBlock language="text" filename="Localizable.strings">
+              {COMMENT_EXAMPLE}
+            </CodeBlock>
+          </CodeBlockWrapper>
+          <Text>
+            {t(
+              'You can automatically strip comments by adding a Run Script build phase that converts each `.strings` file to JSON, rewrites it without comments, and leaves a compact UTF-8 file behind:'
+            )}
+          </Text>
+          <ol>
+            <li>
+              <Text>
+                {tct(
+                  'In Xcode, open [menu] and add a new Run Script phase after the localized resources step.',
+                  {
+                    menu: (
+                      <InlineCode>Build Phases → + → New Run Script Phase</InlineCode>
+                    ),
+                  }
+                )}
+              </Text>
+            </li>
+            <li>
+              <Text>
+                {tct(
+                  'Point the shell to your Python 3 binary (for Homebrew on Apple Silicon: [binary]).',
+                  {binary: <InlineCode>/opt/homebrew/bin/python3</InlineCode>}
+                )}
+              </Text>
+            </li>
+            <li>
+              <Text>
+                {t('Paste the script below and commit your annotated originals.')}
+              </Text>
+            </li>
+          </ol>
+          <Text>
+            {t(
+              'The script converts each `.strings` file to JSON, rewrites it without comments, and leaves a compact UTF-8 file behind.'
+            )}
+          </Text>
+          <CodeBlockWrapper>
+            <CodeBlock language="python" filename="minify_strings.py">
+              {STRIP_STRINGS_SCRIPT}
+            </CodeBlock>
+          </CodeBlockWrapper>
+          <Text>
+            {t(
+              'This script strips comments and blank lines after the files are generated, so keep the original annotated copies under version control for translators.'
+            )}
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}
+
+export function openMinifyLocalizedStringsModal() {
+  openInsightInfoModal({
+    title: t('Minify localized strings'),
+    children: getMinifyLocalizedStringsContent(),
+  });
+}

--- a/static/app/views/preprod/buildDetails/main/insights/stripDebugSymbolsModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/stripDebugSymbolsModal.tsx
@@ -1,0 +1,113 @@
+import {openInsightInfoModal} from 'sentry/actionCreators/modal';
+import {Alert} from 'sentry/components/core/alert';
+import {CodeBlock} from 'sentry/components/core/code';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Heading} from 'sentry/components/core/text/heading';
+import {t} from 'sentry/locale';
+import {CodeBlockWrapper} from 'sentry/views/preprod/buildDetails/main/insights/insightInfoModal';
+
+const STRIP_SINGLE_BINARY = `strip -rSTx AppBinary -o AppBinaryStripped`;
+
+const STRIP_BUILD_SCRIPT = `#!/bin/bash
+set -e
+
+if [ "Release" != "\${CONFIGURATION}" ]; then
+  echo "Skipping symbol stripping for \${CONFIGURATION} build."
+  exit 0
+fi
+
+APP_DIR_PATH="\${BUILT_PRODUCTS_DIR}/\${EXECUTABLE_FOLDER_PATH}"
+echo "Stripping main binary: \${APP_DIR_PATH}/\${EXECUTABLE_NAME}"
+strip -rSTx "\${APP_DIR_PATH}/\${EXECUTABLE_NAME}"
+
+APP_FRAMEWORKS_DIR="\${APP_DIR_PATH}/Frameworks"
+if [ -d "\${APP_FRAMEWORKS_DIR}" ]; then
+  find "\${APP_FRAMEWORKS_DIR}" -maxdepth 2 -mindepth 2 -type f -perm -111 -exec bash -c '
+    codesign -v -R="anchor apple" "$1" &> /dev/null || strip -rSTx "$1"
+  ' _ {} \\;
+fi`;
+
+const DSYM_INPUT_FILE =
+  '${DWARF_DSYM_FOLDER_PATH}/${EXECUTABLE_NAME}.app.dSYM/\\\nContents/Resources/DWARF/${EXECUTABLE_NAME}';
+
+function getStripDebugSymbolsContent() {
+  return (
+    <Flex direction="column" gap="2xl">
+      <Text>
+        {t(
+          'Debug info and symbols are only used during development and should not be shipped to users.'
+        )}
+      </Text>
+
+      <Flex direction="column" gap="xl">
+        <Flex direction="column" gap="md">
+          <Heading as="h3" size="md">
+            {t('How to fix')}
+          </Heading>
+          <Text>
+            {t(
+              'Strip symbols from release builds and instead rely on separate dSYM files for crash reporters.'
+            )}
+          </Text>
+          <Alert type="warning">
+            {t(
+              'Stripping symbols before creating a dSYM breaks crash symbolication. Confirm your release build still produces and uploads dSYMs (or another crash reporter has them) before stripping.'
+            )}
+          </Alert>
+          <Text>
+            {t(
+              'In Xcode, ensure your release configuration sets the Debug Information Format build setting to DWARF with dSYM.'
+            )}
+          </Text>
+          <Text>
+            {t('You can manually strip a compiled binary with the strip command:')}
+          </Text>
+          <CodeBlockWrapper>
+            <CodeBlock language="bash" filename="strip.sh">
+              {STRIP_SINGLE_BINARY}
+            </CodeBlock>
+          </CodeBlockWrapper>
+        </Flex>
+
+        <Flex direction="column" gap="md">
+          <Heading as="h3" size="md">
+            {t('Automate stripping after build')}
+          </Heading>
+          <Alert type="warning">
+            {t(
+              'This script will strip the main app binary along with any binaries in the Frameworks/ directory. This is a sample script that may require adjustments for your project.'
+            )}
+          </Alert>
+          <Text>
+            {t(
+              'Add a Run Script phase that skips non-release builds and leaves Apple-signed frameworks untouched:'
+            )}
+          </Text>
+          <CodeBlockWrapper>
+            <CodeBlock language="bash" filename="strip_debug_symbols.sh">
+              {STRIP_BUILD_SCRIPT}
+            </CodeBlock>
+          </CodeBlockWrapper>
+          <Text>
+            {t(
+              'Because Xcode generates dSYMs from the unstripped binary, list the dSYM as an Input File so the script runs after Xcode finishes generating it:'
+            )}
+          </Text>
+          <CodeBlockWrapper>
+            <CodeBlock language="bash" filename="RunScript.inputfiles">
+              {DSYM_INPUT_FILE}
+            </CodeBlock>
+          </CodeBlockWrapper>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}
+
+export function openStripDebugSymbolsModal() {
+  openInsightInfoModal({
+    title: t('Strip debug symbols'),
+    children: getStripDebugSymbolsContent(),
+  });
+}


### PR DESCRIPTION
refactoring how we do modal opening, less verbose

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
