### PR TITLE
fix(ai-insights): Persist timestamp of trace in URL

### DIFF
--- a/static/app/views/insights/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/agents/components/tracesTable.tsx
@@ -240,7 +240,9 @@ const BodyCell = memo(function BodyCell({
         <span>
           <TraceIdButton
             priority="link"
-            onClick={() => openTraceViewDrawer(dataRow.traceId)}
+            onClick={() =>
+              openTraceViewDrawer(dataRow.traceId, undefined, dataRow.timestamp / 1000)
+            }
           >
             {dataRow.traceId.slice(0, 8)}
           </TraceIdButton>

--- a/static/app/views/insights/agents/hooks/useAITrace.tsx
+++ b/static/app/views/insights/agents/hooks/useAITrace.tsx
@@ -15,7 +15,6 @@ import {
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
-import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
 
 interface UseAITraceResult {
   error: boolean;
@@ -23,18 +22,17 @@ interface UseAITraceResult {
   nodes: AITraceSpanNode[];
 }
 
-export function useAITrace(traceSlug: string): UseAITraceResult {
+export function useAITrace(traceSlug: string, timestamp?: number): UseAITraceResult {
   const [nodes, setNodes] = useState<AITraceSpanNode[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
 
   const api = useApi();
   const organization = useOrganization();
-  const queryParams = useTraceQueryParams();
 
   const trace = useTrace({
     traceSlug,
-    timestamp: queryParams.timestamp,
+    timestamp,
     additionalAttributes: [
       SpanFields.GEN_AI_AGENT_NAME,
       SpanFields.GEN_AI_FUNCTION_ID,

--- a/static/app/views/insights/agents/hooks/useNodeDetailsLink.tsx
+++ b/static/app/views/insights/agents/hooks/useNodeDetailsLink.tsx
@@ -57,7 +57,11 @@ export function useNodeDetailsLink({
   return getTraceDetailsUrl({
     source,
     organization,
-    location,
+    location: {
+      ...location,
+      // Do not forward all query params to the trace view
+      query: {},
+    },
     traceSlug,
     spanId,
     targetId,

--- a/static/app/views/insights/agents/hooks/useUrlTraceDrawer.tsx
+++ b/static/app/views/insights/agents/hooks/useUrlTraceDrawer.tsx
@@ -1,8 +1,10 @@
 import {useCallback} from 'react';
-import {parseAsString, useQueryState} from 'nuqs';
 
 import useDrawer from 'sentry/components/globalDrawer';
-import {DrawerUrlParams} from 'sentry/views/insights/agents/utils/urlParams';
+import {
+  DrawerUrlParams,
+  useTraceDrawerQueryState,
+} from 'sentry/views/insights/agents/utils/urlParams';
 
 export function useUrlTraceDrawer() {
   const {
@@ -12,19 +14,11 @@ export function useUrlTraceDrawer() {
     panelRef,
   } = useDrawer();
 
-  const [selectedTrace, setSelectedTrace] = useQueryState(
-    DrawerUrlParams.SELECTED_TRACE,
-    parseAsString.withOptions({history: 'replace'})
-  );
-
-  const [_, setSelectedSpan] = useQueryState(
-    DrawerUrlParams.SELECTED_SPAN,
-    parseAsString.withOptions({history: 'replace'})
-  );
+  const [traceDrawerQueryState, setTraceDrawerQueryState] = useTraceDrawerQueryState();
 
   const removeQueryParams = useCallback(() => {
-    setSelectedTrace(null);
-  }, [setSelectedTrace]);
+    setTraceDrawerQueryState(null);
+  }, [setTraceDrawerQueryState]);
 
   const closeDrawer = useCallback(() => {
     removeQueryParams();
@@ -36,22 +30,33 @@ export function useUrlTraceDrawer() {
       renderer: Parameters<typeof baseOpenDrawer>[0],
       options?: Parameters<typeof baseOpenDrawer>[1] & {
         spanId?: string;
+        timestamp?: number;
         traceSlug?: string;
       }
     ) => {
       const {
         traceSlug: optionsTraceSlug,
         spanId: optionsSpanId,
+        timestamp: optionsTimestamp,
         onClose,
         ariaLabel,
         ...rest
       } = options || {};
 
       if (optionsTraceSlug) {
-        setSelectedTrace(optionsTraceSlug);
+        setTraceDrawerQueryState({
+          traceId: optionsTraceSlug,
+        });
       }
       if (optionsSpanId) {
-        setSelectedSpan(optionsSpanId);
+        setTraceDrawerQueryState({
+          spanId: optionsSpanId,
+        });
+      }
+      if (optionsTimestamp) {
+        setTraceDrawerQueryState({
+          timestamp: optionsTimestamp,
+        });
       }
 
       return baseOpenDrawer(renderer, {
@@ -66,7 +71,7 @@ export function useUrlTraceDrawer() {
         },
       });
     },
-    [baseOpenDrawer, setSelectedTrace, setSelectedSpan, removeQueryParams]
+    [baseOpenDrawer, setTraceDrawerQueryState, removeQueryParams]
   );
 
   return {
@@ -74,6 +79,6 @@ export function useUrlTraceDrawer() {
     closeDrawer,
     isDrawerOpen,
     panelRef,
-    drawerUrlState: {trace: selectedTrace},
+    drawerUrlState: traceDrawerQueryState,
   };
 }

--- a/static/app/views/insights/agents/hooks/useUrlTraceDrawer.tsx
+++ b/static/app/views/insights/agents/hooks/useUrlTraceDrawer.tsx
@@ -43,21 +43,11 @@ export function useUrlTraceDrawer() {
         ...rest
       } = options || {};
 
-      if (optionsTraceSlug) {
-        setTraceDrawerQueryState({
-          traceId: optionsTraceSlug,
-        });
-      }
-      if (optionsSpanId) {
-        setTraceDrawerQueryState({
-          spanId: optionsSpanId,
-        });
-      }
-      if (optionsTimestamp) {
-        setTraceDrawerQueryState({
-          timestamp: optionsTimestamp,
-        });
-      }
+      setTraceDrawerQueryState({
+        traceId: optionsTraceSlug,
+        spanId: optionsSpanId,
+        timestamp: optionsTimestamp,
+      });
 
       return baseOpenDrawer(renderer, {
         ...rest,

--- a/static/app/views/insights/agents/utils/urlParams.tsx
+++ b/static/app/views/insights/agents/utils/urlParams.tsx
@@ -1,10 +1,31 @@
+import {parseAsInteger, parseAsString, useQueryStates} from 'nuqs';
+
 export enum DrawerUrlParams {
   SELECTED_SPAN = 'span',
   SELECTED_TRACE = 'trace',
+  TIMESTAMP = 'trace-timestamp',
 }
 
 export enum TableUrlParams {
   CURSOR = 'tableCursor',
   SORT_FIELD = 'field',
   SORT_ORDER = 'order',
+}
+
+export function useTraceDrawerQueryState() {
+  return useQueryStates(
+    {
+      traceId: parseAsString,
+      spanId: parseAsString,
+      timestamp: parseAsInteger,
+    },
+    {
+      history: 'replace',
+      urlKeys: {
+        traceId: DrawerUrlParams.SELECTED_TRACE,
+        spanId: DrawerUrlParams.SELECTED_SPAN,
+        timestamp: DrawerUrlParams.TIMESTAMP,
+      },
+    }
+  );
 }

--- a/static/app/views/insights/aiGenerations/views/components/generationsTable.tsx
+++ b/static/app/views/insights/aiGenerations/views/components/generationsTable.tsx
@@ -70,7 +70,6 @@ export function GenerationsTable() {
       search: query,
       fields: [
         SpanFields.TRACE,
-        SpanFields.TIMESTAMP,
         SpanFields.SPAN_ID,
         SpanFields.SPAN_STATUS,
         SpanFields.SPAN_DESCRIPTION,

--- a/static/app/views/insights/aiGenerations/views/components/generationsTable.tsx
+++ b/static/app/views/insights/aiGenerations/views/components/generationsTable.tsx
@@ -10,6 +10,7 @@ import {
   type GridColumnOrder,
 } from 'sentry/components/tables/gridEditable';
 import TimeSince from 'sentry/components/timeSince';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
 import {getShortEventId} from 'sentry/utils/events';
 import {useTraceViewDrawer} from 'sentry/views/insights/agents/components/drawer';
 import {HeadSortCell} from 'sentry/views/insights/agents/components/headSortCell';
@@ -69,6 +70,7 @@ export function GenerationsTable() {
       search: query,
       fields: [
         SpanFields.TRACE,
+        SpanFields.TIMESTAMP,
         SpanFields.SPAN_ID,
         SpanFields.SPAN_STATUS,
         SpanFields.SPAN_DESCRIPTION,
@@ -96,7 +98,11 @@ export function GenerationsTable() {
             <Button
               priority="link"
               onClick={() => {
-                openTraceViewDrawer(dataRow.trace, dataRow.span_id);
+                openTraceViewDrawer(
+                  dataRow.trace,
+                  dataRow.span_id,
+                  getTimeStampFromTableDateField(dataRow.timestamp)
+                );
               }}
             >
               {getShortEventId(dataRow.span_id)}


### PR DESCRIPTION
Persist trace timestamp in URL to allow opening traces that do not match the currently selected time period.
Simplify url param handling using `useQueryStates`.