### PR TITLE
chore(dynamic-sampling): set timeout for boost_low_volume_projects to 20min

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -85,7 +85,7 @@ OrgProjectVolumes = tuple[OrganizationId, ProjectId, int, DecisionKeepCount, Dec
 @instrumented_task(
     name="sentry.dynamic_sampling.tasks.boost_low_volume_projects",
     namespace=telemetry_experience_tasks,
-    processing_deadline_duration=15 * 60 + 5,
+    processing_deadline_duration=20 * 60 + 5,
     retry=Retry(times=5, delay=5),
     silo_mode=SiloMode.REGION,
 )


### PR DESCRIPTION
- Job runs every 10 minutes, this means the jobs will overlap
- The queries that control which orgs are balanced are sorted in ascending order by org_id, so this should be somewhat consistent, giving us roughly the same 10 minute cadence after the first job overruns

Contributes to TET-1147