### PR TITLE
fix(billing): Remove upgrade prompt for Business plan users on trial ended banner

### DIFF
--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -20,7 +20,7 @@ import AddEventsCTA, {type EventType} from 'getsentry/components/addEventsCTA';
 import ProductTrialTag from 'getsentry/components/productTrial/productTrialTag';
 import StartTrialButton from 'getsentry/components/startTrialButton';
 import type {ProductTrial, Subscription} from 'getsentry/types';
-import {UsageAction} from 'getsentry/utils/billing';
+import {isBizPlanFamily, UsageAction} from 'getsentry/utils/billing';
 import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
 import titleCase from 'getsentry/utils/titleCase';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
@@ -178,10 +178,20 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
     }
   } else if (daysLeft < 0 && daysLeft >= -7 && trial.isStarted) {
     alertHeader = t('%s Trial', titleCase(getProductName(trial.category)));
-    alertText = t(
-      'Your unlimited %s trial ended. Keep using more by upgrading your plan.',
-      getProductName(product ?? trial.category)
-    );
+
+    if (isPaid && isBizPlanFamily(subscription.planDetails)) {
+      // For Business plan users, just say the trial ended without upgrade prompt
+      alertText = t(
+        'Your unlimited %s trial ended.',
+        getProductName(product ?? trial.category)
+      );
+    } else {
+      // For free and Team plan users, show the upgrade prompt
+      alertText = t(
+        'Your unlimited %s trial ended. Keep using more by upgrading your plan.',
+        getProductName(product ?? trial.category)
+      );
+    }
 
     alertButton =
       isPaid && !hasBillingRole ? (


### PR DESCRIPTION

Closes https://linear.app/getsentry/issue/BIL-1508/update-product-trial-ended-copy

When product trials end, users on paid Business plans were incorrectly seeing "Keep using more by upgrading your plan" which was confusing since they're already on a Business plan.

This change updates the trial ended banner to show different messages based on the user's plan:
- Business plan users: "Your unlimited [Product] trial ended." (no upgrade prompt)
- Team plan users: "Your unlimited [Product] trial ended. Keep using more by upgrading your plan." (shows upgrade prompt)
- Free plan users: "Your unlimited [Product] trial ended. Keep using more by upgrading your plan." (shows upgrade prompt)

The button behavior remains unchanged (Request Upgrade / Update Plan based on billing role), only the message text is updated for Business plan users.

This fix ensures Business plan users see appropriate messaging without confusing upgrade prompts, while Team plan users are still encouraged to upgrade to Business.
