### PR TITLE
feat: Consolidate adjacent traces & move next to search

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
@@ -37,26 +37,36 @@ export function TraceLinkNavigationButton({
       : currentTraceStartTimestamp + LINKED_TRACE_MAX_DURATION; // Latest end time of next trace (+ 1h)
 
   const {
-    available: isPreviousTraceAvailable,
-    id: previousTraceSpanId,
-    trace: previousTraceId,
-    isLoading: isPreviousTraceLoading,
-  } = useFindAdjacentTrace({
-    direction: 'previous',
-    adjacentTraceEndTimestamp: currentTraceStartTimestamp,
-    adjacentTraceStartTimestamp: linkedTraceWindowTimestamp,
-    attributes,
-  });
+    adjacentTraceEndTimestamp,
+    adjacentTraceStartTimestamp,
+    iconDirection,
+    ariaLabel,
+  } = useMemo(() => {
+    if (direction === 'previous') {
+      return {
+        adjacentTraceEndTimestamp: currentTraceStartTimestamp,
+        adjacentTraceStartTimestamp: linkedTraceWindowTimestamp,
+        iconDirection: 'left' as const,
+        ariaLabel: t('Previous Trace'),
+      };
+    }
+    return {
+      adjacentTraceEndTimestamp: linkedTraceWindowTimestamp,
+      adjacentTraceStartTimestamp: currentTraceStartTimestamp,
+      iconDirection: 'right' as const,
+      ariaLabel: t('Next Trace'),
+    };
+  }, [direction, currentTraceStartTimestamp, linkedTraceWindowTimestamp]);
 
   const {
-    available: isNextTraceAvailable,
-    id: nextTraceSpanId,
-    trace: nextTraceId,
-    isLoading: isNextTraceLoading,
+    available: isTraceAvailable,
+    id: traceSpanId,
+    trace: traceId,
+    isLoading: isTraceLoading,
   } = useFindAdjacentTrace({
-    direction: 'next',
-    adjacentTraceEndTimestamp: linkedTraceWindowTimestamp,
-    adjacentTraceStartTimestamp: currentTraceStartTimestamp,
+    direction,
+    adjacentTraceEndTimestamp,
+    adjacentTraceStartTimestamp,
     attributes,
   });
 
@@ -74,45 +84,21 @@ export function TraceLinkNavigationButton({
     });
   }
 
-  if (direction === 'previous') {
-    return (
-      <LinkButton
-        size="xs"
-        icon={<IconChevron direction="left" />}
-        aria-label={t('Previous Trace')}
-        onClick={() => closeSpanDetailsDrawer()}
-        disabled={!previousTraceId || isPreviousTraceLoading || !isPreviousTraceAvailable}
-        to={getTraceDetailsUrl({
-          traceSlug: previousTraceId ?? '',
-          spanId: previousTraceSpanId,
-          dateSelection,
-          timestamp: linkedTraceWindowTimestamp,
-          location,
-          organization,
-        })}
-      />
-    );
-  }
-
-  if (direction === 'next') {
-    return (
-      <LinkButton
-        size="xs"
-        icon={<IconChevron direction="right" />}
-        aria-label={t('Next Trace')}
-        onClick={closeSpanDetailsDrawer}
-        disabled={!nextTraceId || isNextTraceLoading || !isNextTraceAvailable}
-        to={getTraceDetailsUrl({
-          traceSlug: nextTraceId ?? '',
-          spanId: nextTraceSpanId,
-          dateSelection,
-          timestamp: linkedTraceWindowTimestamp,
-          location,
-          organization,
-        })}
-      />
-    );
-  }
-
-  return null;
+  return (
+    <LinkButton
+      size="xs"
+      icon={<IconChevron direction={iconDirection} />}
+      aria-label={ariaLabel}
+      onClick={closeSpanDetailsDrawer}
+      disabled={!traceId || isTraceLoading || !isTraceAvailable}
+      to={getTraceDetailsUrl({
+        traceSlug: traceId ?? '',
+        spanId: traceSpanId,
+        dateSelection,
+        timestamp: linkedTraceWindowTimestamp,
+        location,
+        organization,
+      })}
+    />
+  );
 }

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
@@ -86,17 +86,14 @@ export function TraceLinkNavigationButton({
   ) {
     return (
       <StyledTooltip
-        position="right"
+        position="top"
         delay={400}
         isHoverable
-        title={tct(
-          `This links to the previous trace within the same session. To learn more, [link:read the docs].`,
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
-            ),
-          }
-        )}
+        title={tct(`Go to the previous trace of the same session. [link:Learn More]`, {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+          ),
+        })}
       >
         <TraceLink
           color="gray500"
@@ -111,7 +108,7 @@ export function TraceLinkNavigationButton({
           })}
         >
           <IconChevron direction="left" />
-          <TraceLinkText>{t('Go to Previous Trace')}</TraceLinkText>
+          <TraceLinkText>{t('Previous Trace')}</TraceLinkText>
         </TraceLink>
       </StyledTooltip>
     );
@@ -120,17 +117,14 @@ export function TraceLinkNavigationButton({
   if (direction === 'next' && !isNextTraceLoading && nextTraceId && nextTraceSpanId) {
     return (
       <StyledTooltip
-        position="left"
+        position="top"
         delay={400}
         isHoverable
-        title={tct(
-          `This links to the next trace within the same session. To learn more, [link:read the docs].`,
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
-            ),
-          }
-        )}
+        title={tct(`Go to the next trace of the same session. [link:Learn More]`, {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+          ),
+        })}
       >
         <TraceLink
           color="gray500"
@@ -144,30 +138,17 @@ export function TraceLinkNavigationButton({
             organization,
           })}
         >
-          <TraceLinkText>{t('Go to Next Trace')}</TraceLinkText>
+          <TraceLinkText>{t('Next Trace')}</TraceLinkText>
           <IconChevron direction="right" />
         </TraceLink>
       </StyledTooltip>
     );
   }
 
-  // If there's no linked trace, let's render a placeholder for now to avoid layout shifts
-  // We should reconsider the place where we render these buttons, to avoid reducing the
-  // waterfall height permanently
-  return <TraceLinkNavigationButtonPlaceHolder />;
+  return null;
 }
-
-export function TraceLinkNavigationButtonPlaceHolder() {
-  return <PlaceHolderText>&nbsp;</PlaceHolderText>;
-}
-
-const PlaceHolderText = styled('span')`
-  padding: ${space(0.5)} ${space(0.5)};
-  visibility: hidden;
-`;
 
 const StyledTooltip = styled(Tooltip)`
-  padding: ${space(0.5)} ${space(0.5)};
   text-decoration: underline dotted
     ${p => (p.disabled ? p.theme.gray300 : p.theme.gray300)};
 `;

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+
+import {ButtonBar} from '@sentry/scraps/button';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
+import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
+import {TraceLinkNavigationButton} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton';
+
+export function TraceLinksNavigation({
+  rootEventResults,
+  source,
+}: {
+  rootEventResults: TraceRootEventQueryResults;
+  source: string;
+}) {
+  const organization = useOrganization();
+  const showLinkedTraces =
+    organization?.features.includes('trace-view-linked-traces') &&
+    // Don't show the linked traces buttons when the waterfall is embedded in the replay
+    // detail page, as it already contains all traces of the replay session.
+    source !== 'replay';
+
+  if (!showLinkedTraces) {
+    return null;
+  }
+
+  return (
+    <TraceLinksNavigationContainer>
+      {isTraceItemDetailsResponse(rootEventResults.data) &&
+        rootEventResults.data.timestamp && (
+          <Tooltip
+            position="top"
+            delay={400}
+            isHoverable
+            title={tct(
+              `Go to the previous or next trace of the same session. [link:Learn More]`,
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+                ),
+              }
+            )}
+          >
+            <ButtonBar merged gap="0">
+              <TraceLinkNavigationButton
+                direction="previous"
+                attributes={rootEventResults.data.attributes}
+                currentTraceStartTimestamp={
+                  new Date(rootEventResults.data.timestamp).getTime() / 1000
+                }
+              />
+              <TraceLinkNavigationButton
+                direction="next"
+                attributes={rootEventResults.data.attributes}
+                currentTraceStartTimestamp={
+                  new Date(rootEventResults.data.timestamp).getTime() / 1000
+                }
+              />
+            </ButtonBar>
+          </Tooltip>
+        )}
+    </TraceLinksNavigationContainer>
+  );
+}
+
+const TraceLinksNavigationContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
+`;

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
@@ -1,11 +1,8 @@
-import styled from '@emotion/styled';
-
 import {ButtonBar} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
@@ -25,51 +22,44 @@ export function TraceLinksNavigation({
     // detail page, as it already contains all traces of the replay session.
     source !== 'replay';
 
-  if (!showLinkedTraces) {
+  if (
+    !showLinkedTraces ||
+    !isTraceItemDetailsResponse(rootEventResults.data) ||
+    !rootEventResults.data.timestamp
+  ) {
     return null;
   }
 
   return (
-    <TraceLinksNavigationContainer>
-      {isTraceItemDetailsResponse(rootEventResults.data) &&
-        rootEventResults.data.timestamp && (
-          <Tooltip
-            position="top"
-            delay={400}
-            isHoverable
-            title={tct(
-              `Go to the previous or next trace of the same session. [link:Learn More]`,
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
-                ),
-              }
-            )}
-          >
-            <ButtonBar merged gap="0">
-              <TraceLinkNavigationButton
-                direction="previous"
-                attributes={rootEventResults.data.attributes}
-                currentTraceStartTimestamp={
-                  new Date(rootEventResults.data.timestamp).getTime() / 1000
-                }
-              />
-              <TraceLinkNavigationButton
-                direction="next"
-                attributes={rootEventResults.data.attributes}
-                currentTraceStartTimestamp={
-                  new Date(rootEventResults.data.timestamp).getTime() / 1000
-                }
-              />
-            </ButtonBar>
-          </Tooltip>
-        )}
-    </TraceLinksNavigationContainer>
+    <Tooltip
+      position="top"
+      delay={400}
+      isHoverable
+      title={tct(
+        `Go to the previous or next trace of the same session. [link:Learn More]`,
+        {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+          ),
+        }
+      )}
+    >
+      <ButtonBar merged gap="0">
+        <TraceLinkNavigationButton
+          direction="previous"
+          attributes={rootEventResults.data.attributes}
+          currentTraceStartTimestamp={
+            new Date(rootEventResults.data.timestamp).getTime() / 1000
+          }
+        />
+        <TraceLinkNavigationButton
+          direction="next"
+          attributes={rootEventResults.data.attributes}
+          currentTraceStartTimestamp={
+            new Date(rootEventResults.data.timestamp).getTime() / 1000
+          }
+        />
+      </ButtonBar>
+    </Tooltip>
   );
 }
-
-const TraceLinksNavigationContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  gap: ${space(0.5)};
-`;

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindLinkedTraces.ts
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindLinkedTraces.ts
@@ -6,61 +6,111 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {ConnectedTraceConnection} from './traceLinkNavigationButton';
 
 /**
- * Find the next trace by looking using the spans endpoint to query for a trace
- * linking to the current trace as its previous trace.
+ * Find an adjacent trace (next or previous) by querying the spans endpoint.
+ * For 'next' traces: looks for a trace linking to the current trace as its previous trace.
+ * For 'previous' traces: looks for the trace specified in the previous_trace attribute.
  */
-export function useFindNextTrace({
+export function useFindAdjacentTrace({
   direction,
   attributes,
-  nextTraceEndTimestamp,
-  nextTraceStartTimestamp,
+  adjacentTraceEndTimestamp,
+  adjacentTraceStartTimestamp,
 }: {
+  adjacentTraceEndTimestamp: number;
+  adjacentTraceStartTimestamp: number;
   attributes: TraceItemResponseAttribute[];
   direction: ConnectedTraceConnection;
-  nextTraceEndTimestamp: number;
-  nextTraceStartTimestamp: number;
-}): {isLoading: boolean; id?: string; trace?: string} {
-  const {currentTraceId, currentSpanId, projectId, environment} = useMemo(() => {
+}): {
+  available: boolean;
+  isLoading: boolean;
+  id?: string;
+  trace?: string;
+} {
+  const {
+    projectId,
+    environment,
+    currentTraceId,
+    currentSpanId,
+    adjacentTraceId,
+    adjacentTraceSpanId,
+    hasAdjacentTraceLink,
+    adjacentTraceSampled,
+  } = useMemo(() => {
+    let _projectId: number | undefined = undefined;
+    let _environment: string | undefined = undefined;
     let _currentTraceId: string | undefined;
     let _currentSpanId: string | undefined;
-    let _projectId: number | undefined;
-    let _environment: string | undefined;
+    let _adjacentTraceAttribute: TraceItemResponseAttribute | undefined = undefined;
 
-    for (const a of attributes) {
-      if (a.name === 'trace' && a.type === 'str') {
-        _currentTraceId = a.value;
-      } else if (a.name === 'transaction.span_id' && a.type === 'str') {
-        _currentSpanId = a.value;
-      } else if (a.name === 'project_id' && a.type === 'int') {
+    for (const a of attributes ?? []) {
+      if (a.name === 'project_id' && a.type === 'int') {
         _projectId = a.value;
       } else if (a.name === 'environment' && a.type === 'str') {
         _environment = a.value;
+      } else if (a.name === 'trace' && a.type === 'str') {
+        _currentTraceId = a.value;
+      } else if (a.name === 'transaction.span_id' && a.type === 'str') {
+        _currentSpanId = a.value;
+      } else if (a.name === 'previous_trace' && a.type === 'str') {
+        _adjacentTraceAttribute = a;
       }
     }
+
+    const _hasAdjacentTraceLink = typeof _adjacentTraceAttribute?.value === 'string';
+
+    // In case the attribute value does not conform to `[traceId]-[spanId]-[sampledFlag]`,
+    // the split operation will return an array with different length or unexpected contents.
+    // For cases where we only get partial, empty or too long arrays, we should be safe because we
+    // only take the first three elements. If any of the elements are empty or undefined, we'll
+    // disable the query (see below).
+    // Worst-case, we get invalid ids and query for those. Since we check for `isError` below,
+    // we handle that case gracefully. Likewise we handle the case of getting an empty result.
+    // So all in all, this should be safe and we don't have to do further validation on the
+    // attribute content.
+    const [_adjacentTraceId, _adjacentTraceSpanId, _adjacentTraceSampledFlag] =
+      _hasAdjacentTraceLink ? _adjacentTraceAttribute?.value.split('-') || [] : [];
+
     return {
-      currentTraceId: _currentTraceId,
-      currentSpanId: _currentSpanId,
       projectId: _projectId,
       environment: _environment,
+      currentTraceId: _currentTraceId,
+      currentSpanId: _currentSpanId,
+      hasAdjacentTraceLink: _hasAdjacentTraceLink,
+      adjacentTraceSampled: _adjacentTraceSampledFlag === '1',
+      adjacentTraceId: _adjacentTraceId,
+      adjacentTraceSpanId: _adjacentTraceSpanId,
     };
   }, [attributes]);
 
+  const searchQuery =
+    direction === 'next'
+      ? `sentry.previous_trace:${currentTraceId}-${currentSpanId}-1`
+      : `id:${adjacentTraceSpanId} trace:${adjacentTraceId}`;
+
+  const enabled =
+    direction === 'next'
+      ? !!projectId
+      : hasAdjacentTraceLink &&
+        adjacentTraceSampled &&
+        !!adjacentTraceSpanId &&
+        !!adjacentTraceId;
+
   const {data, isError, isPending} = useSpans(
     {
-      search: `sentry.previous_trace:${currentTraceId}-${currentSpanId}-1`,
+      search: searchQuery,
       fields: ['id', 'trace'],
       limit: 1,
-      enabled: direction === 'next' && !!projectId,
+      enabled,
       projectIds: projectId ? [projectId] : [],
       pageFilters: {
         environments: environment ? [environment] : [],
         projects: projectId ? [projectId] : [],
         datetime: {
-          start: nextTraceStartTimestamp
-            ? new Date(nextTraceStartTimestamp * 1000).toISOString()
+          start: adjacentTraceStartTimestamp
+            ? new Date(adjacentTraceStartTimestamp * 1000).toISOString()
             : '',
-          end: nextTraceEndTimestamp
-            ? new Date(nextTraceEndTimestamp * 1000).toISOString()
+          end: adjacentTraceEndTimestamp
+            ? new Date(adjacentTraceEndTimestamp * 1000).toISOString()
             : '',
           period: null,
           utc: true,
@@ -74,119 +124,30 @@ export function useFindNextTrace({
   const spanId = data?.[0]?.id;
   const traceId = data?.[0]?.trace;
 
-  const nextTraceData = useMemo(() => {
-    if (!spanId || !traceId || isError || isPending) {
+  return useMemo(() => {
+    if (direction === 'next') {
       return {
-        id: undefined,
-        trace: undefined,
+        id: spanId,
+        trace: traceId,
+        available: !!spanId && !!traceId && !isError,
         isLoading: isPending,
       };
     }
-    return {
-      id: spanId,
-      trace: traceId,
-      isLoading: false,
-    };
-  }, [spanId, traceId, isError, isPending]);
-
-  return nextTraceData;
-}
-
-export function useFindPreviousTrace({
-  direction,
-  attributes,
-  previousTraceEndTimestamp,
-  previousTraceStartTimestamp,
-}: {
-  attributes: TraceItemResponseAttribute[];
-  direction: ConnectedTraceConnection;
-  previousTraceEndTimestamp: number;
-  previousTraceStartTimestamp: number;
-}): {
-  available: boolean;
-  isLoading: boolean;
-  sampled: boolean;
-  id?: string;
-  trace?: string;
-} {
-  const {
-    projectId,
-    environment,
-    previousTraceId,
-    previousTraceSpanId,
-    hasPreviousTraceLink,
-    previousTraceSampled,
-  } = useMemo(() => {
-    let _projectId: number | undefined = undefined;
-    let _environment: string | undefined = undefined;
-    let _previousTraceAttribute: TraceItemResponseAttribute | undefined = undefined;
-
-    for (const a of attributes ?? []) {
-      if (a.name === 'project_id' && a.type === 'int') {
-        _projectId = a.value;
-      } else if (a.name === 'environment' && a.type === 'str') {
-        _environment = a.value;
-      } else if (a.name === 'previous_trace' && a.type === 'str') {
-        _previousTraceAttribute = a;
-      }
-    }
-
-    const _hasPreviousTraceLink = typeof _previousTraceAttribute?.value === 'string';
-
-    // In case the attribute value does not conform to `[traceId]-[spanId]-[sampledFlag]`,
-    // the split operation will return an array with different length or unexpected contents.
-    // For cases where we only get partial, empty or too long arrays, we should be safe because we
-    // only take the first three elements. If any of the elements are empty or undefined, we'll
-    // disable the query (see below).
-    // Worst-case, we get invalid ids and query for those. Since we check for `isError` below,
-    // we handle that case gracefully. Likewise we handle the case of getting an empty result.
-    // So all in all, this should be safe and we don't have to do further validation on the
-    // attribute content.
-    const [_previousTraceId, _previousTraceSpanId, _previousTraceSampledFlag] =
-      _hasPreviousTraceLink ? _previousTraceAttribute?.value.split('-') || [] : [];
 
     return {
-      projectId: _projectId,
-      environment: _environment,
-      hasPreviousTraceLink: _hasPreviousTraceLink,
-      previousTraceSampled: _previousTraceSampledFlag === '1',
-      previousTraceId: _previousTraceId,
-      previousTraceSpanId: _previousTraceSpanId,
+      trace: adjacentTraceId,
+      id: adjacentTraceSpanId,
+      available: !!data?.[0]?.id && !isError,
+      isLoading: isPending,
     };
-  }, [attributes]);
-
-  const {data, isError, isPending} = useSpans(
-    {
-      search: `id:${previousTraceSpanId} trace:${previousTraceId}`,
-      fields: ['id', 'trace'],
-      limit: 1,
-      enabled:
-        direction === 'previous' &&
-        hasPreviousTraceLink &&
-        previousTraceSampled &&
-        !!previousTraceSpanId &&
-        !!previousTraceId,
-      projectIds: projectId ? [projectId] : [],
-      pageFilters: {
-        environments: environment ? [environment] : [],
-        projects: projectId ? [projectId] : [],
-        datetime: {
-          start: new Date(previousTraceStartTimestamp * 1000).toISOString(),
-          end: new Date(previousTraceEndTimestamp * 1000).toISOString(),
-          period: null,
-          utc: true,
-        },
-      },
-      queryWithoutPageFilters: true,
-    },
-    `api.insights.trace-panel-${direction}-trace-link`
-  );
-
-  return {
-    trace: previousTraceId,
-    id: previousTraceSpanId,
-    available: !!data?.[0]?.id && !isError,
-    sampled: previousTraceSampled,
-    isLoading: isPending,
-  };
+  }, [
+    direction,
+    spanId,
+    traceId,
+    adjacentTraceId,
+    adjacentTraceSpanId,
+    data,
+    isError,
+    isPending,
+  ]);
 }

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -1,15 +1,11 @@
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
-import {space} from 'sentry/styles/space';
-import useOrganization from 'sentry/utils/useOrganization';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
-import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
 import {TraceContextVitals} from 'sentry/views/performance/newTraceDetails/traceContextVitals';
 import {TraceHeaderComponents} from 'sentry/views/performance/newTraceDetails/traceHeader/styles';
-import {TraceLinkNavigationButton} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceLayoutTabsConfig} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
 
@@ -52,9 +48,6 @@ export function TraceTabsAndVitals({
   const containerRef = useRef<HTMLDivElement>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const [containerWidth, setContainerWidth] = useState<number>();
-  const organization = useOrganization();
-
-  const showLinkedTraces = organization?.features.includes('trace-view-linked-traces');
 
   const onResize = useCallback(() => {
     if (containerRef.current) {
@@ -111,29 +104,6 @@ export function TraceTabsAndVitals({
           ))}
         </TabList>
       </Tabs>
-      {showLinkedTraces && (
-        <TraceLinksNavigationContainer>
-          {isTraceItemDetailsResponse(rootEventResults.data) &&
-            rootEventResults.data.timestamp && (
-              <Fragment>
-                <TraceLinkNavigationButton
-                  direction="previous"
-                  attributes={rootEventResults.data.attributes}
-                  currentTraceStartTimestamp={
-                    new Date(rootEventResults.data.timestamp).getTime() / 1000
-                  }
-                />
-                <TraceLinkNavigationButton
-                  direction="next"
-                  attributes={rootEventResults.data.attributes}
-                  currentTraceStartTimestamp={
-                    new Date(rootEventResults.data.timestamp).getTime() / 1000
-                  }
-                />
-              </Fragment>
-            )}
-        </TraceLinksNavigationContainer>
-      )}
       <TraceContextVitals
         rootEventResults={rootEventResults}
         tree={tree}
@@ -145,13 +115,4 @@ export function TraceTabsAndVitals({
 
 const StyledPlaceholder = styled(TraceHeaderComponents.StyledPlaceholder)`
   background-color: ${p => p.theme.purple100};
-`;
-
-const TraceLinksNavigationContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  gap: ${space(0.5)};
-  &:not(:last-child) {
-    margin-right: ${space(1)};
-  }
 `;

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -1,11 +1,15 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
+import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
+import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
 import {TraceContextVitals} from 'sentry/views/performance/newTraceDetails/traceContextVitals';
 import {TraceHeaderComponents} from 'sentry/views/performance/newTraceDetails/traceHeader/styles';
+import {TraceLinkNavigationButton} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceLayoutTabsConfig} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
 
@@ -48,6 +52,9 @@ export function TraceTabsAndVitals({
   const containerRef = useRef<HTMLDivElement>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const [containerWidth, setContainerWidth] = useState<number>();
+  const organization = useOrganization();
+
+  const showLinkedTraces = organization?.features.includes('trace-view-linked-traces');
 
   const onResize = useCallback(() => {
     if (containerRef.current) {
@@ -104,6 +111,29 @@ export function TraceTabsAndVitals({
           ))}
         </TabList>
       </Tabs>
+      {showLinkedTraces && (
+        <TraceLinksNavigationContainer>
+          {isTraceItemDetailsResponse(rootEventResults.data) &&
+            rootEventResults.data.timestamp && (
+              <Fragment>
+                <TraceLinkNavigationButton
+                  direction="previous"
+                  attributes={rootEventResults.data.attributes}
+                  currentTraceStartTimestamp={
+                    new Date(rootEventResults.data.timestamp).getTime() / 1000
+                  }
+                />
+                <TraceLinkNavigationButton
+                  direction="next"
+                  attributes={rootEventResults.data.attributes}
+                  currentTraceStartTimestamp={
+                    new Date(rootEventResults.data.timestamp).getTime() / 1000
+                  }
+                />
+              </Fragment>
+            )}
+        </TraceLinksNavigationContainer>
+      )}
       <TraceContextVitals
         rootEventResults={rootEventResults}
         tree={tree}
@@ -115,4 +145,13 @@ export function TraceTabsAndVitals({
 
 const StyledPlaceholder = styled(TraceHeaderComponents.StyledPlaceholder)`
   background-color: ${p => p.theme.purple100};
+`;
+
+const TraceLinksNavigationContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
+  &:not(:last-child) {
+    margin-right: ${space(1)};
+  }
 `;

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -1,6 +1,5 @@
 import type React from 'react';
 import {
-  Fragment,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -36,11 +35,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
-import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
-import {
-  TraceLinkNavigationButton,
-  TraceLinkNavigationButtonPlaceHolder,
-} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {TraceOpenInExploreButton} from 'sentry/views/performance/newTraceDetails/traceOpenInExploreButton';
 import {traceGridCssVariables} from 'sentry/views/performance/newTraceDetails/traceWaterfallStyles';
@@ -140,12 +134,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const forceRerender = useCallback(() => {
     flushSync(rerender);
   }, []);
-
-  const showLinkedTraces =
-    organization?.features.includes('trace-view-linked-traces') &&
-    // Don't show the linked traces buttons when the waterfall is embedded in the replay
-    // detail page, as it already contains all traces of the replay session.
-    props.source !== 'replay';
 
   useEffect(() => {
     trackAnalytics('performance_views.trace_view_v1_page_load', {
@@ -805,31 +793,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
           traceEventView={props.traceEventView}
         />
       </TraceGrid>
-      {showLinkedTraces && (
-        <TraceLinksNavigationContainer>
-          {isTraceItemDetailsResponse(props.rootEventResults.data) &&
-          props.rootEventResults.data.timestamp ? (
-            <Fragment>
-              <TraceLinkNavigationButton
-                direction="previous"
-                attributes={props.rootEventResults.data.attributes}
-                currentTraceStartTimestamp={
-                  new Date(props.rootEventResults.data.timestamp).getTime() / 1000
-                }
-              />
-              <TraceLinkNavigationButton
-                direction="next"
-                attributes={props.rootEventResults.data.attributes}
-                currentTraceStartTimestamp={
-                  new Date(props.rootEventResults.data.timestamp).getTime() / 1000
-                }
-              />
-            </Fragment>
-          ) : (
-            <TraceLinkNavigationButtonPlaceHolder />
-          )}
-        </TraceLinksNavigationContainer>
-      )}
     </Flex>
   );
 }
@@ -837,16 +800,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
 const TraceToolbar = styled('div')`
   display: flex;
   gap: ${space(1)};
-`;
-
-const TraceLinksNavigationContainer = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-
-  &:not(:empty) {
-    margin-top: ${space(1)};
-  }
 `;
 
 export const TraceGrid = styled('div')<{

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -35,6 +35,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
+import {TraceLinksNavigation} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {TraceOpenInExploreButton} from 'sentry/views/performance/newTraceDetails/traceOpenInExploreButton';
 import {traceGridCssVariables} from 'sentry/views/performance/newTraceDetails/traceWaterfallStyles';
@@ -728,6 +729,10 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     <Flex direction="column" flex={1}>
       <TraceToolbar>
         <TraceSearchInput onTraceSearch={onTraceSearch} organization={organization} />
+        <TraceLinksNavigation
+          rootEventResults={props.rootEventResults}
+          source={props.source}
+        />
         <TraceOpenInExploreButton
           trace_id={props.traceSlug}
           traceEventView={props.traceEventView}


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/getsentry/sentry/pull/96510. The new approach is that the buttons are close to the other interaction buttons, so the user doesn't have to go and find this at the very bottom of the page. Since the search and the "Open in Explore" are already trace related, the user doesn't have to switch "context" and the buttons wouldn't need any additional text in it, except the tooltip if users are curious what it is.

## Significant changes

- `useFindPreviousTrace` and `useFindNextTrace` have been consolidated into `useFindAdjacentTrace`, which reduces code duplication
- The tooltip has been moved to the outer most ButtonBar, since it wouldn't need a tooltip for each button
- A own component has been created for the Buttons so it can be easily moved around

## 📹

> The UI reacts a little slow in the GIF since my computer was a little low on resources at this point in time

![Kapture 2025-10-31 at 13 22 55](https://github.com/user-attachments/assets/ea0cf34b-fd8e-42d3-9239-72969fd33412)

