### PR TITLE
chore(grouphistory): Stop using `prev_history`

### DIFF
--- a/src/sentry/deletions/defaults/grouphistory.py
+++ b/src/sentry/deletions/defaults/grouphistory.py
@@ -2,6 +2,7 @@ from sentry.deletions.base import ModelDeletionTask
 from sentry.models.grouphistory import GroupHistory
 
 
+# XXX: Once we remove prev_history from GroupHistory, we can simplify this to a regular BulkModelDeletionTask.
 class GroupHistoryDeletionTask(ModelDeletionTask[GroupHistory]):
     """
     Specialized deletion handling that operates per group

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -313,7 +313,6 @@ def record_group_history(
         user_id=user_id,
         team_id=team_id,
         status=status,
-        prev_history=prev_history,
         prev_history_date=prev_history.date_added if prev_history else None,
     )
 
@@ -352,7 +351,6 @@ def bulk_record_group_history(
                 team_id=team_id,
                 user_id=user_id,
                 status=status,
-                prev_history=get_prev_history(group, status),
                 prev_history_date=get_prev_history_date(group, status),
             )
             for group in groups

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1963,13 +1963,9 @@ class Factories:
         release: Release | None = None,
         user_id: int | None = None,
         team_id: int | None = None,
-        prev_history: GroupHistory | None = None,
+        prev_history_date: datetime | None = None,
         date_added: datetime | None = None,
     ) -> GroupHistory:
-        prev_history_date = None
-        if prev_history:
-            prev_history_date = prev_history.date_added
-
         kwargs = {}
         if date_added:
             kwargs["date_added"] = date_added
@@ -1981,7 +1977,6 @@ class Factories:
             user_id=user_id,
             team_id=team_id,
             status=status,
-            prev_history=prev_history,
             prev_history_date=prev_history_date,
             **kwargs,
         )

--- a/tests/sentry/core/endpoints/test_team_time_to_resolution.py
+++ b/tests/sentry/core/endpoints/test_team_time_to_resolution.py
@@ -32,7 +32,7 @@ class TeamTimeToResolutionTest(APITestCase):
             group1,
             GroupHistoryStatus.RESOLVED,
             user_id=self.user.id,
-            prev_history=gh1,
+            prev_history_date=gh1.date_added,
             date_added=before_now(days=2),
         )
 
@@ -47,7 +47,7 @@ class TeamTimeToResolutionTest(APITestCase):
             group2,
             GroupHistoryStatus.RESOLVED,
             user_id=self.user.id,
-            prev_history=gh2,
+            prev_history_date=gh2.date_added,
         )
         today = str(now().date())
         yesterday = str((now() - timedelta(days=1)).date())
@@ -72,7 +72,7 @@ class TeamTimeToResolutionTest(APITestCase):
             group2,
             GroupHistoryStatus.RESOLVED,
             user_id=self.user.id,
-            prev_history=gh2,
+            prev_history_date=gh2.date_added,
         )
 
         # making sure it doesnt bork anything
@@ -80,7 +80,7 @@ class TeamTimeToResolutionTest(APITestCase):
             group2,
             GroupHistoryStatus.DELETED,
             user_id=self.user.id,
-            prev_history=gh2,
+            prev_history_date=gh2.date_added,
         )
         # Make sure that if we have a `GroupHistory` row with no prev history then we don't crash.
         self.create_group_history(
@@ -114,7 +114,7 @@ class TeamTimeToResolutionTest(APITestCase):
             group1,
             GroupHistoryStatus.RESOLVED,
             user_id=self.user.id,
-            prev_history=gh1,
+            prev_history_date=gh1.date_added,
             date_added=before_now(days=2),
         )
 

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -135,7 +135,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         history_two = self.create_group_history(
             group=group,
             status=GroupHistoryStatus.RESOLVED,
-            prev_history=history_one,
+            prev_history_date=history_one.date_added,
         )
         other_history_one = self.create_group_history(
             group=other_group, status=GroupHistoryStatus.ONGOING
@@ -143,7 +143,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         other_history_two = self.create_group_history(
             group=other_group,
             status=GroupHistoryStatus.RESOLVED,
-            prev_history=other_history_one,
+            prev_history_date=other_history_one.date_added,
         )
         with self.tasks():
             delete_groups_for_project(

--- a/tests/sentry/models/test_grouphistory.py
+++ b/tests/sentry/models/test_grouphistory.py
@@ -78,10 +78,10 @@ class GetPrevHistoryTest(TestCase):
         prev_history = self.create_group_history(self.group, GroupHistoryStatus.UNRESOLVED)
         assert get_prev_history(self.group, GroupHistoryStatus.RESOLVED) == prev_history
         prev_history = self.create_group_history(
-            self.group, GroupHistoryStatus.RESOLVED, prev_history=prev_history
+            self.group, GroupHistoryStatus.RESOLVED, prev_history_date=prev_history.date_added
         )
         assert get_prev_history(self.group, GroupHistoryStatus.UNRESOLVED) == prev_history
         prev_history = self.create_group_history(
-            self.group, GroupHistoryStatus.UNRESOLVED, prev_history=prev_history
+            self.group, GroupHistoryStatus.UNRESOLVED, prev_history_date=prev_history.date_added
         )
         assert get_prev_history(self.group, GroupHistoryStatus.RESOLVED) == prev_history


### PR DESCRIPTION
While investigating #102470, I realized we don't actually use it for anything useful.

In order to delete the column, we first need to stop making use of it (see [docs](https://develop.sentry.dev/backend/application-domains/database-migrations/#deleting-columns) for instructions).

Next PR: #102672