### PR TITLE
test(gsAdmin): fix flaky changeBalanceAction test in CI

### DIFF
--- a/static/gsAdmin/components/changeBalanceAction.spec.tsx
+++ b/static/gsAdmin/components/changeBalanceAction.spec.tsx
@@ -183,7 +183,12 @@ describe('BalanceChangeAction', () => {
     await userEvent.type(creditInput, '10');
     await waitFor(() => expect(creditInput).toHaveValue(10));
 
-    await userEvent.click(submitButton);
+    // Wait for button to be enabled before clicking
+    await waitFor(() => expect(submitButton).toBeEnabled());
+
+    // Disable pointer-events check to avoid false positive in CI
+    // where modal overlay may still be settling during initialization
+    await userEvent.click(submitButton, {pointerEventsCheck: 0});
 
     // Wait for form to be re-enabled after error
     // Don't rely on error message text as the Form component shows different messages


### PR DESCRIPTION
The PR I merged recently https://github.com/getsentry/sentry/pull/100807 introduced a flaky frontend test:

```
Summary of all failing tests
 FAIL  static/gsAdmin/components/changeBalanceAction.spec.tsx
  ● BalanceChangeAction › re-enables form after error

    Unable to perform pointer interaction as the element inherits `pointer-events: none`:

    DIV  <-- This element declared `pointer-events: none`
     DIV
      DIV
       SECTION
        FORM
         DIV
          BUTTON(label=Submit)  <-- Asserted pointer events here

      184 |     await waitFor(() => expect(creditInput).toHaveValue(10));
      185 |
    > 186 |     await userEvent.click(submitButton);
          |     ^
      187 |
      188 |     // Wait for form to be re-enabled after error
      189 |     // Don't rely on error message text as the Form component shows different messages

      at Object.assertPointerEvents (node_modules/.pnpm/@testing-library+user-event@14.6.1_@testing-library+dom@10.4.0/node_modules/@testing-library/user-event/dist/cjs/utils/pointer/cssPointerEvents.js:47:15)
      at Object.enter (node_modules/.pnpm/@testing-library+user-event@14.6.1_@testing-library+dom@10.4.0/node_modules/@testing-library/user-event/dist/cjs/system/pointer/pointer.js:52:34)
      at PointerHost.move (node_modules/.pnpm/@testing-library+user-event@14.6.1_@testing-library+dom@10.4.0/node_modules/@testing-library/user-event/dist/cjs/system/pointer/index.js:53:85)
      at pointerAction (node_modules/.pnpm/@testing-library+user-event@14.6.1_@testing-library+dom@10.4.0/node_modules/@testing-library/user-event/dist/cjs/pointer/index.js:59:39)
      at Object.pointer (node_modules/.pnpm/@testing-library+user-event@14.6.1_@testing-library+dom@10.4.0/node_modules/@testing-library/user-event/dist/cjs/pointer/index.js:27:15)
      at Object.asyncWrapper (node_modules/.pnpm/@testing-library+react@16.2.0_@testing-library+dom@10.4.0_@types+react-dom@19.2.0_@type_011f94990cdc27509fa142ae9e3c3bf5/node_modules/@testing-library/react/dist/pure.js:88:22)
      at Object.<anonymous> (static/gsAdmin/components/changeBalanceAction.spec.tsx:186:5)


Test Suites: 1 failed, 407 passed, 408 total
Tests:       1 failed, 1 skipped, 3040 passed, 3042 total
Snapshots:   2 passed, 2 total
Time:        266.043 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```

This PR should hopefully address this flakiness by:
1. waiting for button to be enabled
2. and by disabling the pointer-events check (similarly done in https://github.com/getsentry/sentry/pull/95798)
