### PR TITLE
fix(tracemetrics): Queries using incorrect method of merging filters

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -4,7 +4,6 @@ import type {NewQuery} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {
@@ -86,11 +85,11 @@ function useMetricAggregatesTableImp({
   }, [groupBys, visualize.yAxis]);
 
   const query = useMemo(() => {
-    const currentSearch = new MutableSearch(`metric.name:${metricName}`);
+    const baseQuery = `metric.name:${metricName}`;
     if (!searchQuery.isEmpty()) {
-      currentSearch.addStringFilter(searchQuery.formatString());
+      return `${baseQuery} (${searchQuery.formatString()})`;
     }
-    return currentSearch.formatString();
+    return baseQuery;
   }, [metricName, searchQuery]);
 
   const eventView = useMemo(() => {

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -7,7 +7,6 @@ import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import type {RPCQueryExtras} from 'sentry/views/explore/hooks/useProgressiveQuery';
@@ -85,11 +84,11 @@ function useMetricSamplesTableImpl({
   const sortBys = useQueryParamsSortBys();
 
   const query = useMemo(() => {
-    const currentSearch = new MutableSearch(`metric.name:${metricName}`);
+    const baseQuery = `metric.name:${metricName}`;
     if (!searchQuery.isEmpty()) {
-      currentSearch.addStringFilter(searchQuery.formatString());
+      return `${baseQuery} (${searchQuery.formatString()})`;
     }
-    return currentSearch.formatString();
+    return baseQuery;
   }, [metricName, searchQuery]);
 
   // Calculate adjusted datetime values with ingestion delay applied

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
@@ -60,16 +60,16 @@ function useMetricTimeseriesImpl({
   const sortBys = useQueryParamsAggregateSortBys();
 
   const search = useMemo(() => {
-    const currentSearch = new MutableSearch(`metric.name:${traceMetric.name}`);
+    const baseQuery = `metric.name:${traceMetric.name}`;
     if (!searchQuery.isEmpty()) {
-      currentSearch.addStringFilter(searchQuery.formatString());
+      return `${baseQuery} (${searchQuery.formatString()})`;
     }
-    return currentSearch;
+    return baseQuery;
   }, [traceMetric.name, searchQuery]);
 
   const timeseriesResult = useSortedTimeSeries(
     {
-      search,
+      search: new MutableSearch(search),
       yAxis: [visualize.yAxis],
       interval,
       fields: [...groupBys, visualize.yAxis],


### PR DESCRIPTION
The existing implementation was buggy because it was just concatenating the filters together as a string filter. Instead, we need to encapsulate the metric query with parens and put the user query inside those.