### PR TITLE
fix(billing): Hide product trial CTAs for partner-managed subscriptions

### DIFF
--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -22,6 +22,7 @@ import StartTrialButton from 'getsentry/components/startTrialButton';
 import type {ProductTrial, Subscription} from 'getsentry/types';
 import {UsageAction} from 'getsentry/utils/billing';
 import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
+import {isDisabledByPartner} from 'getsentry/utils/partnerships';
 import titleCase from 'getsentry/utils/titleCase';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 
@@ -63,6 +64,12 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
   const isPaid = subscription.planDetails?.price > 0;
   const hasBillingRole = organization.access?.includes('org:billing');
   const categoryUsesOnDemand = shouldUseOnDemandCta(trial.category);
+
+  // Don't show trial CTAs for partner-managed subscriptions
+  // These organizations manage their billing through partners (Heroku, Vercel, GitHub, etc.)
+  if (isDisabledByPartner(subscription)) {
+    return null;
+  }
 
   let alertText: string | null = null;
   let alertHeader: string | null = null;

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -41,6 +41,7 @@ import {
   isByteCategory,
   isContinuousProfiling,
 } from 'getsentry/utils/dataCategory';
+import {isDisabledByPartner} from 'getsentry/utils/partnerships';
 import titleCase from 'getsentry/utils/titleCase';
 import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
 
@@ -545,6 +546,12 @@ export function getBestActionToIncreaseEventLimits(
 ) {
   const isPaidPlan = subscription.planDetails?.price > 0;
   const hasBillingPerms = organization.access?.includes('org:billing');
+
+  // Managed subscriptions should always request (can't self-serve via checkout)
+  // These organizations manage their billing through partners (Heroku, Vercel, GitHub, etc.)
+  if (isDisabledByPartner(subscription)) {
+    return UsageAction.REQUEST_ADD_EVENTS;
+  }
 
   // free orgs can increase event limits by trialing
   if (!isPaidPlan && subscription.canTrial) {


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1669/product-trial-cta-showing-link-to-checkout-in-managed-orgs

Organizations with partner-managed billing (Heroku, Vercel, GitHub) were incorrectly seeing "Update Plan" buttons with checkout links in product trial alerts. These organizations manage billing through their partner
platforms and cannot use Sentry's checkout flow.

This adds a check using `isDisabledByPartner()` to return early and not render trial CTAs for managed subscriptions.

I've also added something similar for `getBestActionToIncreaseEventLimits()`.