### PR TITLE
fix(sub v3): header card overflow

### DIFF
--- a/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
-import {Text} from 'sentry/components/core/text';
 import {IconList, IconSubscribed, IconTimer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -25,29 +24,26 @@ function LinksCard({organization}: {organization: Organization}) {
                 priority="link"
                 icon={<IconList />}
                 to="/settings/billing/receipts/"
+                size="xs"
               >
-                <Text size="sm" variant="accent">
-                  {t('View all receipts')}
-                </Text>
+                {t('View all receipts')}
               </LinkButton>
               <LinkButton
                 priority="link"
                 icon={<IconTimer />}
                 to="/settings/billing/activity-logs/"
+                size="xs"
               >
-                <Text size="sm" variant="accent">
-                  {t('View activity')}
-                </Text>
+                {t('View activity')}
               </LinkButton>
               {hasSpendNotifications && (
                 <LinkButton
                   priority="link"
                   icon={<IconSubscribed />}
                   to="/settings/billing/notifications/"
+                  size="xs"
                 >
-                  <Text size="sm" variant="accent">
-                    {t('Manage spend notifications')}
-                  </Text>
+                  {t('Manage spend notifications')}
                 </LinkButton>
               )}
             </Fragment>
@@ -56,10 +52,9 @@ function LinksCard({organization}: {organization: Organization}) {
               priority="link"
               icon={<IconTimer />}
               to="/settings/billing/activity-logs/"
+              size="xs"
             >
-              <Text size="sm" variant="accent">
-                {t('View activity')}
-              </Text>
+              {t('View activity')}
             </LinkButton>
           )}
         </Flex>,

--- a/static/gsApp/views/subscriptionPage/headerCards/nextBillCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/nextBillCard.tsx
@@ -75,7 +75,14 @@ function NextBillCard({
   return (
     <SubscriptionHeaderCard
       sections={[
-        <Flex justify="between" align="start" key="title" width="100%">
+        <Flex
+          justify="between"
+          align="start"
+          key="title"
+          width="100%"
+          wrap="wrap"
+          gap="sm"
+        >
           <Heading as="h2" size="lg">
             {t('Next bill')}
           </Heading>

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -189,14 +189,7 @@ function PaygCard({
               </Flex>,
             ]
           : [
-              <Flex
-                justify="between"
-                align="start"
-                key="title"
-                width="100%"
-                wrap="wrap"
-                gap="sm"
-              >
+              <Flex justify="between" align="start" key="title" width="100%" gap="sm">
                 <Heading as="h2" size="lg">
                   {displayBudgetName(subscription.planDetails, {title: true})}
                 </Heading>

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -157,7 +157,7 @@ function PaygCard({
                     }}
                   />
                 </Currency>
-                <Flex justify="between" align="center">
+                <Flex justify="between" align="center" gap="xl sm" wrap="wrap">
                   <Flex gap="sm" align="center">
                     <Button priority="primary" onClick={() => handleSubmit()}>
                       {t('Save')}

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -189,7 +189,14 @@ function PaygCard({
               </Flex>,
             ]
           : [
-              <Flex justify="between" align="start" key="title" width="100%">
+              <Flex
+                justify="between"
+                align="start"
+                key="title"
+                width="100%"
+                wrap="wrap"
+                gap="sm"
+              >
                 <Heading as="h2" size="lg">
                   {displayBudgetName(subscription.planDetails, {title: true})}
                 </Heading>


### PR DESCRIPTION
At certain breakpoints, the PAYG pricing link in the edit state and the date tag for Next Bill would overflow their respective cards:
<img width="502" height="240" alt="Screenshot 2025-10-31 at 10 54 43 AM" src="https://github.com/user-attachments/assets/f09c3075-3e19-47bb-be6d-c4253c802d30" />


This PR fixes these to handle overflow:
<img width="440" height="226" alt="Screenshot 2025-10-31 at 10 55 03 AM" src="https://github.com/user-attachments/assets/4fc8a256-6614-4316-b941-936a3fef958f" />

 
This PR also removes unnecessary `Text` usage in the links card.
