### PR TITLE
fix(tracemetrics): Pass along usePortal for dropdowns in metrics

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -328,11 +328,13 @@ export enum ActionTriggerType {
 
 type Props = React.PropsWithoutRef<Omit<CellActionsOpts, 'to'>> & {
   triggerType?: ActionTriggerType;
+  usePortalOnDropdown?: boolean;
 };
 
 function CellAction({
   triggerType = ActionTriggerType.BOLD_HOVER,
   allowActions,
+  usePortalOnDropdown,
   ...props
 }: Props) {
   const organization = useOrganization();
@@ -364,6 +366,7 @@ function CellAction({
       >
         {cellActions?.length ? (
           <DropdownMenu
+            usePortal={usePortalOnDropdown}
             items={cellActions}
             strategy="fixed"
             size="sm"

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -16,8 +16,8 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
-import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
 import type EventView from 'sentry/utils/discover/eventView';
+import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
 import type {
   Aggregation,
   Column,

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -10,6 +10,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import {parseFunction} from 'sentry/utils/discover/fields';
+import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMetricAggregatesTable';
@@ -47,7 +48,10 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
     metricName,
   });
 
-  const columns = useMemo(() => eventView.getColumns(), [eventView]);
+  const columns = useMemo(
+    () => decodeColumnOrder(eventView.fields, result.meta),
+    [eventView, result.meta]
+  );
   const sorts = useQueryParamsAggregateSortBys();
   const setSorts = useSetQueryParamsAggregateSortBys();
   const groupBys = useQueryParamsGroupBys();
@@ -207,6 +211,7 @@ export function AggregatesTab({metricName}: AggregatesTabProps) {
                     data={row}
                     unit={getMetricsUnit(meta, field)}
                     meta={meta}
+                    usePortalOnDropdown
                   />
                 </StickyCompatibleStyledRowCell>
               ))}

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -42,9 +42,16 @@ interface FieldProps {
   meta: MetaType;
   column?: TableColumn<keyof TableDataRow>;
   unit?: string;
+  usePortalOnDropdown?: boolean;
 }
 
-export function FieldRenderer({data, meta, unit, column}: FieldProps) {
+export function FieldRenderer({
+  data,
+  meta,
+  unit,
+  column,
+  usePortalOnDropdown,
+}: FieldProps) {
   const userQuery = useQueryParamsQuery();
   const setUserQuery = useSetQueryParamsQuery();
 
@@ -56,6 +63,7 @@ export function FieldRenderer({data, meta, unit, column}: FieldProps) {
       column={column}
       userQuery={userQuery}
       setUserQuery={setUserQuery}
+      usePortalOnDropdown={usePortalOnDropdown}
     />
   );
 }
@@ -90,6 +98,7 @@ export function MultiQueryFieldRenderer({
 interface BaseFieldProps extends FieldProps {
   setUserQuery: (query: string) => void;
   userQuery: string;
+  usePortalOnDropdown?: boolean;
 }
 
 function BaseExploreFieldRenderer({
@@ -99,6 +108,7 @@ function BaseExploreFieldRenderer({
   column,
   userQuery,
   setUserQuery,
+  usePortalOnDropdown,
 }: BaseFieldProps) {
   const location = useLocation();
   const organization = useOrganization();
@@ -188,6 +198,7 @@ function BaseExploreFieldRenderer({
         setUserQuery(query.formatString());
       }}
       allowActions={ALLOWED_CELL_ACTIONS}
+      usePortalOnDropdown={usePortalOnDropdown}
     >
       {rendered}
     </CellAction>


### PR DESCRIPTION
We need to pass down usePortal because of the z-index shenanigans we're doing for overlapping values on small screens/sizes of the table. If we don't do this, the contents could be overlapped by other cell icons that require sticky styling.

I also changed a `getColumns` call to `decodeColumnOrder` because at the moment, `getColumns` wasn't respecting the aggregates type, so the resulting dropdown was aligned to the wrong side of the column.