### PR TITLE
fix(sub v3): Usage Overview table tweaks

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -484,6 +484,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
 
   return (
     <GridEditable
+      resizable={false}
       bodyStyle={{
         borderTopLeftRadius: '0px',
         borderTopRightRadius: '0px',
@@ -498,7 +499,12 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
       columnSortBy={[]}
       grid={{
         renderHeadCell: column => {
-          return <Text>{column.name}</Text>;
+          const isSpendColumn = column.name.toLowerCase().endsWith('spend');
+          return (
+            <Container width="100%" justifySelf={isSpendColumn ? 'end' : 'start'}>
+              <Text align={isSpendColumn ? 'right' : 'left'}>{column.name}</Text>
+            </Container>
+          );
         },
         renderBodyCell: (column, row) => {
           const {

--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -499,7 +499,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
       columnSortBy={[]}
       grid={{
         renderHeadCell: column => {
-          const isSpendColumn = column.name.toLowerCase().endsWith('spend');
+          const isSpendColumn = column.key.toString().toLowerCase().endsWith('spend');
           return (
             <Container width="100%" justifySelf={isSpendColumn ? 'end' : 'start'}>
               <Text align={isSpendColumn ? 'right' : 'left'}>{column.name}</Text>


### PR DESCRIPTION
- Table shouldn't be resizable
- Right align spend column headers to align with body
<img width="1401" height="676" alt="Screenshot 2025-10-31 at 11 47 38 AM" src="https://github.com/user-attachments/assets/3d27c3f7-8633-4d38-977b-d21c4b2b8d48" />

Also closes https://linear.app/getsentry/issue/BIL-1717/align-spend-headers-to-the-right