### PR TITLE
chore(preprod): remove % savings from individual insights (eme-570)

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -47,10 +47,6 @@ describe('AppSizeInsightsSidebarRow', () => {
     expect(screen.getByText(/-\s*256\s*KB/i)).toBeInTheDocument();
     // logo.png shows 128 KB in both main row and HEIC row
     expect(screen.getAllByText(/-\s*128\s*KB/i)).toHaveLength(2);
-    expect(screen.getByText('(-7.5%)')).toBeInTheDocument();
-    expect(screen.getByText('(-4%)')).toBeInTheDocument();
-    // logo.png has (-2%) savings (main and HEIC)
-    expect(screen.getAllByText('(-2%)')).toHaveLength(2);
   });
 
   it('calls onToggleExpanded when clicking the toggle button', async () => {
@@ -102,13 +98,10 @@ describe('AppSizeInsightsSidebarRow', () => {
 
     // Should show max savings in main row (300 KB appears twice: main row + HEIC row)
     expect(screen.getAllByText(/-300\s*KB/i)).toHaveLength(2);
-    // (-10%) appears in main row and HEIC row
-    expect(screen.getAllByText('(-10%)')).toHaveLength(2);
 
     // Should show both optimization options with app-relative percentages
     expect(screen.getByText('Optimize:')).toBeInTheDocument();
     expect(screen.getByText(/-200\s*KB/i)).toBeInTheDocument();
-    expect(screen.getByText('(-6.7%)')).toBeInTheDocument();
 
     expect(screen.getByText('Convert to HEIC:')).toBeInTheDocument();
   });

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -207,14 +207,9 @@ function FileRow({file}: {file: ProcessedInsightFile}) {
       <Text size="sm" ellipsis style={{flex: 1}}>
         {file.path}
       </Text>
-      <Flex align="center" gap="sm">
-        <Text variant="primary" bold size="sm" tabular>
-          -{formatBytesBase10(file.savings)}
-        </Text>
-        <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>
-          ({formatUpside(file.percentage / 100)})
-        </Text>
-      </Flex>
+      <Text variant="primary" bold size="sm" tabular>
+        -{formatBytesBase10(file.savings)}
+      </Text>
     </Flex>
   );
 }
@@ -242,14 +237,9 @@ function DuplicateGroupFileRow({
         <Text size="sm" ellipsis style={{flex: 1}} bold>
           {group.name}
         </Text>
-        <Flex align="center" gap="sm">
-          <Text variant="primary" bold size="sm" tabular>
-            -{formatBytesBase10(file.savings)}
-          </Text>
-          <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>
-            ({formatUpside(file.percentage / 100)})
-          </Text>
-        </Flex>
+        <Text variant="primary" bold size="sm" tabular>
+          -{formatBytesBase10(file.savings)}
+        </Text>
       </Flex>
       <Flex direction="column" gap="xs" padding="xs sm">
         {group.files.map((duplicateFile, index) => (
@@ -350,9 +340,6 @@ function OptimizableImageFileRow({
           <Text variant="primary" bold size="sm" tabular>
             -{formatBytesBase10(maxSavings)}
           </Text>
-          <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>
-            ({formatUpside(file.percentage / 100)})
-          </Text>
         </Flex>
       </Flex>
       <Flex direction="column" gap="xs" padding="xs sm">
@@ -370,15 +357,6 @@ function OptimizableImageFileRow({
             >
               -{formatBytesBase10(originalFile.minify_savings)}
             </Text>
-            <Text
-              size="xs"
-              variant="muted"
-              tabular
-              align="right"
-              style={{minWidth: '64px'}}
-            >
-              ({formatUpside(file.data.minifyPercentage / 100)})
-            </Text>
           </Flex>
         )}
         {hasHeicSavings && (
@@ -394,15 +372,6 @@ function OptimizableImageFileRow({
               style={{minWidth: '80px'}}
             >
               -{formatBytesBase10(originalFile.conversion_savings)}
-            </Text>
-            <Text
-              size="xs"
-              variant="muted"
-              tabular
-              align="right"
-              style={{minWidth: '64px'}}
-            >
-              ({formatUpside(file.data.conversionPercentage / 100)})
             </Text>
           </Flex>
         )}


### PR DESCRIPTION

<img width="671" height="614" alt="image" src="https://github.com/user-attachments/assets/66b9453e-b664-4928-9240-e38754f56e43" />

<img width="669" height="489" alt="image" src="https://github.com/user-attachments/assets/de5178af-afc8-4cf1-b32e-aef7f7fddcff" />

<img width="677" height="319" alt="image" src="https://github.com/user-attachments/assets/1a19e09d-eab8-4e4e-8bc1-35df853f7476" />

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
