### PR TITLE
fix(ourlog): Rename logs cell action from 'search..' to 'add to filter'

### DIFF
--- a/static/app/views/explore/logs/useLogAttributesTreeActions.tsx
+++ b/static/app/views/explore/logs/useLogAttributesTreeActions.tsx
@@ -58,7 +58,7 @@ export function useLogAttributesTreeActions({embedded}: {embedded: boolean}) {
     const items: MenuItemProps[] = [
       {
         key: 'search-for-value',
-        label: t('Search for this value'),
+        label: t('Add to filter'),
         onAction: () => addSearchFilter(content),
       },
       {


### PR DESCRIPTION
As described.

Closes LOGS-427

