### PR TITLE
fix(aci): Fix bug where issue detail links weren't working

### DIFF
--- a/static/app/views/alerts/pathnames.tsx
+++ b/static/app/views/alerts/pathnames.tsx
@@ -1,21 +1,16 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
-const ALERTS_BASE_PATHNAME = '/issues/alerts';
+const ALERTS_BASE_PATHNAME = 'issues/alerts';
 
 export function makeAlertsPathname({
   path,
   organization,
-  useLegacyBasePath = true,
 }: {
   organization: Organization;
   path: '/' | `/${string}/`;
-  useLegacyBasePath?: boolean;
 }) {
-  let basePath = '';
-  if (useLegacyBasePath) {
-    basePath = ALERTS_BASE_PATHNAME;
-  }
-
-  return normalizeUrl(`/organizations/${organization.slug}${basePath}${path}`);
+  return normalizeUrl(
+    `/organizations/${organization.slug}/${ALERTS_BASE_PATHNAME}${path}`
+  );
 }

--- a/static/app/views/alerts/pathnames.tsx
+++ b/static/app/views/alerts/pathnames.tsx
@@ -1,16 +1,21 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
-const ALERTS_BASE_PATHNAME = 'issues/alerts';
+const ALERTS_BASE_PATHNAME = '/issues/alerts';
 
 export function makeAlertsPathname({
   path,
   organization,
+  useLegacyBasePath = true,
 }: {
   organization: Organization;
   path: '/' | `/${string}/`;
+  useLegacyBasePath?: boolean;
 }) {
-  return normalizeUrl(
-    `/organizations/${organization.slug}/${ALERTS_BASE_PATHNAME}${path}`
-  );
+  let basePath = '';
+  if (useLegacyBasePath) {
+    basePath = ALERTS_BASE_PATHNAME;
+  }
+
+  return normalizeUrl(`/organizations/${organization.slug}${basePath}${path}`);
 }

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -9,6 +9,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar/sidebar';
 
@@ -63,11 +64,7 @@ export function getDetectorDetails({
     return {
       detectorType: 'metric_alert',
       detectorId,
-      detectorPath: makeAlertsPathname({
-        path: `/monitors/${detectorId}/`,
-        organization,
-        useLegacyBasePath: false,
-      }),
+      detectorPath: makeMonitorDetailsPathname(organization.slug, detectorId, 'monitors'),
       description: t(
         'This issue was created by a metric alert detector. View the detector details to learn more.'
       ),


### PR DESCRIPTION
# Description
We were previously only check for alertRule information, but if we create a monitor only using the new api, there isn't a back reference to it. This will look at the occurrence and ensure it's a metric issue, then determine if it's a legacy or new alert before constructing the link, it prefers the legacy routing for now.