### PR TITLE
fix(sub v3): Show limited subscription details to non-billing users

### DIFF
--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -203,7 +203,7 @@ class OnDemandBudgets extends Component<Props> {
       return this.renderNotEnabled();
     }
 
-    if (!hasPaymentSource && !subscription.onDemandInvoicedManual) {
+    if (!hasPaymentSource) {
       return this.renderNeedsPaymentSource();
     }
 

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -116,45 +116,6 @@ describe('OnDemandBudgets', () => {
     expect(await screen.findByText('Stripe')).toBeInTheDocument();
   });
 
-  it('allows VC partner accounts to set up on-demand budget without credit card', () => {
-    const subscription = SubscriptionFixture({
-      plan: 'am3_business',
-      planTier: PlanTier.AM3,
-      isFree: false,
-      isTrial: false,
-      supportsOnDemand: true,
-      organization,
-      partner: {
-        externalId: 'x123x',
-        name: 'VC Org',
-        partnership: {
-          id: 'VC',
-          displayName: 'VC',
-          supportNote: '',
-        },
-        isActive: true,
-      },
-      onDemandBudgets: {
-        enabled: false,
-        budgetMode: OnDemandBudgetMode.SHARED,
-        sharedMaxBudget: 0,
-        onDemandSpendUsed: 0,
-      },
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    const isVCPartner = subscription.partner?.partnership?.id === 'VC';
-    createWrapper({
-      subscription,
-      onDemandEnabled: true,
-      hasPaymentSource: isVCPartner,
-    });
-
-    // Should show Set Up Pay-as-you-go button instead of Add Credit Card
-    expect(screen.getByText('Set Up Pay-as-you-go')).toBeInTheDocument();
-    expect(screen.queryByText('Add Credit Card')).not.toBeInTheDocument();
-  });
-
   it('renders initial on-demand budget setup state', () => {
     const subscription = SubscriptionFixture({
       plan: 'am1_business',

--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -29,7 +29,12 @@ function getCards(organization: Organization, subscription: Subscription) {
   const cards: React.ReactNode[] = [];
   const isTrialOrFreePlan =
     isTrialPlan(subscription.plan) || isDeveloperPlan(subscription.planDetails);
+
+  // the organization can use PAYG
   const canUsePayg = supportsPayg(subscription);
+
+  // the user can update the PAYG budget
+  const canUpdatePayg = canUsePayg && hasBillingPerms;
 
   if (subscription.canSelfServe && !isTrialOrFreePlan && hasBillingPerms) {
     cards.push(
@@ -41,9 +46,7 @@ function getCards(organization: Organization, subscription: Subscription) {
     );
   }
 
-  const canUpdatePayg = canUsePayg && hasBillingPerms;
-
-  if (canUpdatePayg) {
+  if (canUsePayg) {
     cards.push(
       <PaygCard key="payg" subscription={subscription} organization={organization} />
     );

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
@@ -26,6 +26,28 @@ describe('PaygCard', () => {
     resetMockDate();
   });
 
+  it('renders set/edit button for users with billing perms', () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+    });
+    render(<PaygCard organization={organization} subscription={subscription} />);
+    expect(screen.getByRole('button', {name: 'Set limit'})).toBeInTheDocument();
+  });
+
+  it('does not render set/edit button for users without billing perms', () => {
+    const diffOrg = OrganizationFixture({
+      access: [],
+    });
+    const subscription = SubscriptionFixture({
+      organization: diffOrg,
+      plan: 'am3_team',
+    });
+    render(<PaygCard organization={diffOrg} subscription={subscription} />);
+    expect(screen.queryByRole('button', {name: 'Set limit'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Edit limit'})).not.toBeInTheDocument();
+  });
+
   it('renders for plan with no budget modes', async () => {
     const subscription = SubscriptionFixture({
       organization,

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
@@ -1,6 +1,9 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {
+  InvoicedSubscriptionFixture,
+  SubscriptionFixture,
+} from 'getsentry-test/fixtures/subscription';
 import {
   render,
   renderGlobalModal,
@@ -169,5 +172,46 @@ describe('PaygCard', () => {
 
     // closes inline edit
     expect(screen.getByRole('heading', {name: 'Pay-as-you-go'})).toBeInTheDocument();
+  });
+
+  it('enables edit button for present payment source', () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+    });
+    render(<PaygCard organization={organization} subscription={subscription} />);
+    expect(screen.getByRole('button', {name: 'Set limit'})).toBeEnabled();
+  });
+
+  it('disables edit button if no payment source', () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team', // we should never have a paid plan without a payment source IRL, but for testing purposes
+      paymentSource: null,
+    });
+    render(<PaygCard organization={organization} subscription={subscription} />);
+    expect(screen.getByRole('button', {name: 'Set limit'})).toBeDisabled();
+  });
+
+  it('enables edit button for self-serve partner accounts', () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+      paymentSource: null,
+      isSelfServePartner: true,
+    });
+    render(<PaygCard organization={organization} subscription={subscription} />);
+    expect(screen.getByRole('button', {name: 'Set limit'})).toBeEnabled();
+  });
+
+  it('enables edit button for manually invoiced PAYG', () => {
+    const subscription = InvoicedSubscriptionFixture({
+      organization,
+      plan: 'am3_business_ent',
+      paymentSource: null,
+      onDemandInvoicedManual: true,
+    });
+    render(<PaygCard organization={organization} subscription={subscription} />);
+    expect(screen.getByRole('button', {name: 'Set limit'})).toBeEnabled();
   });
 });

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -41,6 +41,11 @@ function PaygCard({
   subscription: Subscription;
 }) {
   const hasBillingPerms = hasBillingAccess(organization);
+  const hasPaymentSource = !!(
+    subscription.paymentSource ||
+    subscription.isSelfServePartner ||
+    subscription.onDemandInvoicedManual
+  );
   const api = useApi();
   const theme = useTheme();
   const paygBudget = parseOnDemandBudgetsFromSubscription(subscription);
@@ -200,6 +205,12 @@ function PaygCard({
                 {hasBillingPerms && (
                   <Button
                     size="xs"
+                    disabled={!hasPaymentSource}
+                    title={
+                      hasPaymentSource
+                        ? undefined
+                        : t('You must add a payment method to edit the limit')
+                    }
                     onClick={() => {
                       handleEditPayg(false);
                     }}

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -121,7 +121,7 @@ function PaygCard({
         window.location.pathname + window.location.search
       );
     }
-  }, [handleEditPayg, hasBillingPerms]);
+  }, [handleEditPayg]);
 
   return (
     <SubscriptionHeaderCard

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
@@ -32,7 +32,7 @@ describe('edit on-demand budget', () => {
     });
   });
 
-  it('allows VC partner accounts to edit on-demand budget without payment source', () => {
+  it('allows self-serve partner accounts to edit on-demand budget without payment source', () => {
     const subscription = SubscriptionFixture({
       plan: 'am3_business',
       planTier: PlanTier.AM3,
@@ -41,16 +41,7 @@ describe('edit on-demand budget', () => {
       supportsOnDemand: true,
       organization: onDemandOrg,
       paymentSource: null,
-      partner: {
-        externalId: 'x123x',
-        name: 'VC Org',
-        partnership: {
-          id: 'VC',
-          displayName: 'VC',
-          supportNote: '',
-        },
-        isActive: true,
-      },
+      isSelfServePartner: true,
       onDemandBudgets: {
         enabled: true,
         budgetMode: OnDemandBudgetMode.SHARED,

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
@@ -66,9 +66,11 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
   }
 
   const onDemandEnabled = subscription.planDetails.allowOnDemand;
-  // VC partner accounts don't require a payment source (i.e. credit card) since they make all payments via VC
-  const isVCPartner = subscription.partner?.partnership?.id === 'VC';
-  const hasPaymentSource = !!subscription.paymentSource || isVCPartner;
+  const hasPaymentSource = !!(
+    subscription.paymentSource ||
+    subscription.isSelfServePartner ||
+    subscription.onDemandInvoicedManual
+  );
   const hasOndemandBudgets =
     hasOnDemandBudgetsFeature(organization, subscription) &&
     Boolean(subscription.onDemandBudgets);

--- a/static/gsApp/views/subscriptionPage/onDemandSummary.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSummary.tsx
@@ -239,7 +239,7 @@ class OnDemandSummary extends Component<Props, State> {
       return this.renderNotEnabled();
     }
 
-    if (!hasPaymentSource && !subscription.onDemandInvoicedManual) {
+    if (!hasPaymentSource) {
       return this.renderNeedsPaymentSource();
     }
 

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
@@ -61,6 +61,7 @@ describe('SubscriptionHeader', () => {
     hasPaygCard: boolean;
     organization: Organization;
   }) {
+    const hasBillingPerms = organization.access?.includes('org:billing');
     await screen.findByRole('heading', {name: 'Subscription'});
 
     if (hasNextBillCard) {
@@ -83,15 +84,21 @@ describe('SubscriptionHeader', () => {
 
     if (hasPaygCard) {
       await screen.findByRole('heading', {name: 'Pay-as-you-go'});
-      screen.getByRole('button', {name: 'Set limit'});
+
+      if (hasBillingPerms) {
+        expect(screen.getByRole('button', {name: 'Set limit'})).toBeInTheDocument();
+      } else {
+        expect(screen.queryByRole('button', {name: 'Set limit'})).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', {name: 'Edit limit'})
+        ).not.toBeInTheDocument();
+      }
     } else {
       expect(
         screen.queryByRole('heading', {name: 'Pay-as-you-go'})
       ).not.toBeInTheDocument();
       expect(screen.queryByRole('button', {name: 'Set limit'})).not.toBeInTheDocument();
     }
-
-    const hasBillingPerms = organization.access?.includes('org:billing');
 
     // all subscriptions have links card
     if (hasBillingPerms) {
@@ -240,7 +247,7 @@ describe('SubscriptionHeader', () => {
     });
   });
 
-  it('renders new header cards for self-serve customers and user without billing perms', async () => {
+  it('renders new header cards for self-serve free customers and user without billing perms', async () => {
     const organization = OrganizationFixture({
       features: ['subscriptions-v3'],
     });
@@ -257,6 +264,26 @@ describe('SubscriptionHeader', () => {
       hasNextBillCard: false,
       hasBillingInfoCard: false,
       hasPaygCard: false,
+    });
+  });
+
+  it('renders new header cards for self-serve paid customers and user without billing perms', async () => {
+    const organization = OrganizationFixture({
+      features: ['subscriptions-v3'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+    render(
+      <SubscriptionHeader organization={organization} subscription={subscription} />
+    );
+    await assertNewHeaderCards({
+      organization,
+      hasNextBillCard: false,
+      hasBillingInfoCard: false,
+      hasPaygCard: true,
     });
   });
 

--- a/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
@@ -76,8 +76,12 @@ describe('UsageOverview', () => {
     expect(screen.getByRole('columnheader', {name: 'Product'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Total usage'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Reserved'})).toBeInTheDocument();
-    expect(screen.queryByText('Reserved spend')).not.toBeInTheDocument();
-    expect(screen.queryByText('Pay-as-you-go spend')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: 'Reserved spend'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: 'Pay-as-you-go spend'})
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('button', {name: 'View usage history'})
     ).not.toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -111,7 +111,6 @@ function ReservedUsageBar({percentUsed}: {percentUsed: number}) {
 }
 
 function UsageOverviewTable({subscription, organization, usageData}: UsageOverviewProps) {
-  const hasBillingPerms = organization.access.includes('org:billing');
   const navigate = useNavigate();
   const location = useLocation();
   const [openState, setOpenState] = useState<Partial<Record<AddOnCategory, boolean>>>({});
@@ -273,7 +272,6 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
       },
     ].filter(
       column =>
-        (hasBillingPerms || !column.key.endsWith('Spend')) &&
         (subscription.canSelfServe ||
           !column.key.endsWith('Spend') ||
           ((subscription.onDemandInvoiced || subscription.onDemandInvoicedManual) &&
@@ -281,7 +279,6 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
         (hasAnyPotentialOrActiveProductTrial || column.key !== 'trialInfo')
     );
   }, [
-    hasBillingPerms,
     subscription.planDetails,
     subscription.productTrials,
     subscription.canSelfServe,


### PR DESCRIPTION
<img width="2293" height="1045" alt="Screenshot 2025-10-31 at 1 21 50 PM" src="https://github.com/user-attachments/assets/b5a2fa11-393f-4691-990a-40ad6f7e31af" />

- Any user on self-serve org can see reserved spend and PAYG spend columns
- Any user on self-serve org can see a read-only version of the PAYG card
- Adds back payment source check for PAYG edit