### PR TITLE
feat(issues): GA case insensitive project slug lookup

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -435,8 +435,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:statistical-detectors-rca-spans-only", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Allow organizations to configure all symbol sources.
     manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
-    # Enable case-insensitive project slug lookup for qualified short ID bulk queries
-    manager.add("organizations:group-case-insensitive-short-id-lookup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable tracking of tombstone hits. When enabled, the feature increments the times_seen column and updates the last_seen timestamp
     manager.add("organizations:grouptombstones-hit-counter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -21,7 +21,7 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from snuba_sdk import Column, Condition, Op
 
-from sentry import eventstore, eventtypes, features, options, tagstore
+from sentry import eventstore, eventtypes, options, tagstore
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
@@ -370,32 +370,27 @@ class GroupManager(BaseManager["Group"]):
         groups = list(base_group_queryset.filter(short_id_lookup))
         group_lookup: set[int] = {group.short_id for group in groups}
 
-        organization = Organization.objects.get_from_cache(id=organization_id)
-        has_insensitive_lookup = features.has(
-            "organizations:group-case-insensitive-short-id-lookup", organization
-        )
-
         # If any requested short_ids are missing after the exact slug match,
         # fallback to a case-insensitive slug lookup to handle legacy/mixed-case slugs.
-        if has_insensitive_lookup:
-            missing_by_slug = defaultdict(list)
-            for sid in short_ids:
-                if sid.short_id not in group_lookup:
-                    missing_by_slug[sid.project_slug].append(sid.short_id)
+        # Handles legacy project slugs that may not be entirely lowercase.
+        missing_by_slug = defaultdict(list)
+        for sid in short_ids:
+            if sid.short_id not in group_lookup:
+                missing_by_slug[sid.project_slug].append(sid.short_id)
 
-            if len(missing_by_slug) > 0:
-                ci_short_id_lookup = reduce(
-                    or_,
-                    [
-                        Q(project__slug__iexact=slug, short_id__in=sids)
-                        for slug, sids in missing_by_slug.items()
-                    ],
-                )
+        if len(missing_by_slug) > 0:
+            ci_short_id_lookup = reduce(
+                or_,
+                [
+                    Q(project__slug__iexact=slug, short_id__in=sids)
+                    for slug, sids in missing_by_slug.items()
+                ],
+            )
 
-                fallback_groups = list(base_group_queryset.filter(ci_short_id_lookup))
+            fallback_groups = list(base_group_queryset.filter(ci_short_id_lookup))
 
-                groups.extend(fallback_groups)
-                group_lookup.update(group.short_id for group in fallback_groups)
+            groups.extend(fallback_groups)
+            group_lookup.update(group.short_id for group in fallback_groups)
 
         for short_id in short_ids:
             if short_id.short_id not in group_lookup:

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -170,7 +170,6 @@ class GroupTest(TestCase, SnubaTestCase):
                 group.organization.id, [group_short_id, group_2_short_id]
             )
 
-    @with_feature("organizations:group-case-insensitive-short-id-lookup")
     def test_by_qualified_short_id_bulk_case_insensitive_project_slug(self) -> None:
         project = self.create_project(slug="mixedcaseslug")
         group = self.create_group(project=project, short_id=project.next_short_id())


### PR DESCRIPTION
Fixes discover searches for `issue:PROJECT-123` when the project slug isn't entirely lowercase.
