### PR TITLE
feat(aci): Add environment labels to cron checkin timeline

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -47,7 +47,6 @@ type DetectorListTableProps = {
   isSuccess: boolean;
   queryCount: string;
   sort: Sort | undefined;
-  renderVisualization?: (detector: Detector) => React.ReactNode;
 };
 
 function LoadingSkeletons() {
@@ -101,7 +100,6 @@ function DetectorListTable({
   sort,
   queryCount,
   allResultsVisible,
-  renderVisualization,
 }: DetectorListTableProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
@@ -147,8 +145,8 @@ function DetectorListTable({
   const timelineWidth = useDebouncedValue(containerWidth, 1000);
   const timeWindowConfig = useTimeWindowConfig({timelineWidth});
 
+  const {additionalColumns = [], renderVisualization} = useMonitorViewContext();
   const hasVisualization = defined(renderVisualization);
-  const {additionalColumns = []} = useMonitorViewContext();
 
   return (
     <TableContainer>

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -73,8 +73,7 @@ export default function DetectorsList() {
   const location = useLocation();
   const navigate = useNavigate();
   const {selection, isReady} = usePageFilters();
-  const {detectorFilter, assigneeFilter, renderVisualization, emptyState} =
-    useMonitorViewContext();
+  const {detectorFilter, assigneeFilter, emptyState} = useMonitorViewContext();
 
   const {
     sort: sorts,
@@ -180,7 +179,6 @@ export default function DetectorsList() {
                   sort={sort}
                   queryCount={hitsInt > maxHitsInt ? `${maxHits}+` : hits}
                   allResultsVisible={allResultsVisible()}
-                  renderVisualization={renderVisualization}
                 />
               )}
             </VisuallyCompleteWithData>

--- a/static/app/views/detectors/list/cron.spec.tsx
+++ b/static/app/views/detectors/list/cron.spec.tsx
@@ -108,6 +108,9 @@ describe('CronDetectorsList', () => {
     // Name
     expect(within(row).getByText('Cron Detector')).toBeInTheDocument();
 
+    // Environment name
+    expect(within(row).getByText('production')).toBeInTheDocument();
+
     // Timeline visualization should render ticks once stats load
     expect(await screen.findAllByTestId('monitor-checkin-tick')).not.toHaveLength(0);
     expect(monitorStatsRequest).toHaveBeenCalled();

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -2,21 +2,27 @@ import {useCallback, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlaceholder';
 import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
 import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {fadeIn} from 'sentry/styles/animations';
 import type {CronDetector, Detector} from 'sentry/types/workflowEngine/detectors';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {HeaderCell} from 'sentry/views/detectors/components/detectorListTable';
 import DetectorsList from 'sentry/views/detectors/list';
 import {
   MonitorViewContext,
   useMonitorViewContext,
+  type MonitorListAdditionalColumn,
   type MonitorViewContextValue,
+  type RenderVisualizationParams,
 } from 'sentry/views/detectors/monitorViewContext';
 import {CronsLandingPanel} from 'sentry/views/insights/crons/components/cronsLandingPanel';
+import MonitorEnvironmentLabel from 'sentry/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel';
 import {
   checkInStatusPrecedent,
   statusToText,
@@ -45,23 +51,24 @@ function VisualizationCell({detector}: {detector: CronDetector}) {
       borderLeft="muted"
       height="100%"
     >
-      <Stack gap="lg" width="100%" ref={elementRef}>
+      <Stack gap="sm" width="100%" ref={elementRef}>
         {cronEnvironments.map(environment => {
           if (isPending) {
             return <CheckInPlaceholder key={environment.name} />;
           }
           return (
-            <CheckInTimeline
-              key={environment.name}
-              statusLabel={statusToText}
-              statusStyle={tickStyle}
-              statusPrecedent={checkInStatusPrecedent}
-              timeWindowConfig={timeWindowConfig}
-              bucketedData={selectCheckInData(
-                monitorStats?.[cronId] ?? [],
-                environment.name
-              )}
-            />
+            <TimelineFadeIn key={environment.name}>
+              <CheckInTimeline
+                statusLabel={statusToText}
+                statusStyle={tickStyle}
+                statusPrecedent={checkInStatusPrecedent}
+                timeWindowConfig={timeWindowConfig}
+                bucketedData={selectCheckInData(
+                  monitorStats?.[cronId] ?? [],
+                  environment.name
+                )}
+              />
+            </TimelineFadeIn>
           );
         })}
       </Stack>
@@ -69,10 +76,53 @@ function VisualizationCell({detector}: {detector: CronDetector}) {
   );
 }
 
+const ADDITIONAL_COLUMNS: MonitorListAdditionalColumn[] = [
+  {
+    id: 'environment-label',
+    columnWidth: '120px',
+    renderHeaderCell: () => (
+      <HeaderCell data-column-name="environment-label" sort={undefined} />
+    ),
+    renderCell: (detector: Detector) => {
+      if (detector.type !== 'monitor_check_in_failure') {
+        return null;
+      }
+      return (
+        <SimpleTable.RowCell data-column-name="environment-label" alignSelf="start">
+          <Stack gap="sm" width="100%">
+            {detector.dataSources[0].queryObj.environments.map(environment => {
+              return (
+                <Text density="compressed" key={environment.name}>
+                  <MonitorEnvironmentLabel
+                    monitorEnv={environment}
+                    key={environment.name}
+                  />
+                </Text>
+              );
+            })}
+          </Stack>
+        </SimpleTable.RowCell>
+      );
+    },
+  },
+];
+
 export default function CronDetectorsList() {
   const parentContext = useMonitorViewContext();
 
-  const renderVisualization = useCallback((detector: Detector) => {
+  const renderVisualization = useCallback(({detector}: RenderVisualizationParams) => {
+    if (!detector) {
+      return (
+        <Cell
+          data-column-name="visualization"
+          padding="lg 0"
+          borderLeft="muted"
+          height="100%"
+        >
+          <CheckInPlaceholder />
+        </Cell>
+      );
+    }
     if (detector.type === 'monitor_check_in_failure') {
       return <VisualizationCell detector={detector} />;
     }
@@ -86,6 +136,7 @@ export default function CronDetectorsList() {
       renderVisualization,
       showTimeRangeSelector: true,
       emptyState: <CronsLandingPanel />,
+      additionalColumns: ADDITIONAL_COLUMNS,
     }),
     [parentContext, renderVisualization]
   );
@@ -99,4 +150,10 @@ export default function CronDetectorsList() {
 
 const Cell = styled(SimpleTable.RowCell)`
   z-index: 4;
+`;
+
+const TimelineFadeIn = styled('div')`
+  width: 100%;
+  opacity: 0;
+  animation: ${fadeIn} 1s ease-out forwards;
 `;

--- a/static/app/views/detectors/list/uptime.tsx
+++ b/static/app/views/detectors/list/uptime.tsx
@@ -7,7 +7,7 @@ import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlace
 import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
 import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import type {Detector, UptimeDetector} from 'sentry/types/workflowEngine/detectors';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import DetectorsList from 'sentry/views/detectors/list';
@@ -15,6 +15,7 @@ import {
   MonitorViewContext,
   useMonitorViewContext,
   type MonitorViewContextValue,
+  type RenderVisualizationParams,
 } from 'sentry/views/detectors/monitorViewContext';
 import {
   checkStatusPrecedent,
@@ -63,7 +64,19 @@ function VisualizationCell({detector}: {detector: UptimeDetector}) {
 export default function UptimeDetectorsList() {
   const parentContext = useMonitorViewContext();
 
-  const renderVisualization = useCallback((detector: Detector) => {
+  const renderVisualization = useCallback(({detector}: RenderVisualizationParams) => {
+    if (!detector) {
+      return (
+        <Cell
+          data-column-name="visualization"
+          padding="lg 0"
+          borderLeft="muted"
+          height="100%"
+        >
+          <CheckInPlaceholder />
+        </Cell>
+      );
+    }
     if (detector.type === 'uptime_domain_failure') {
       return <VisualizationCell detector={detector} />;
     }

--- a/static/app/views/detectors/monitorViewContext.tsx
+++ b/static/app/views/detectors/monitorViewContext.tsx
@@ -2,13 +2,31 @@ import {createContext, useContext} from 'react';
 
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 
+export interface MonitorListAdditionalColumn {
+  id: string;
+  renderCell: (detector: Detector) => React.ReactNode;
+  renderHeaderCell: () => React.ReactNode;
+  /** Width of the column, defaults to auto */
+  columnWidth?: string;
+  renderPendingCell?: () => React.ReactNode;
+}
+
+export interface RenderVisualizationParams {
+  detector: Detector | null;
+}
+
 export interface MonitorViewContextValue {
   automationsLinkPrefix: string;
   monitorsLinkPrefix: string;
+  /**
+   * Additional columns to render after the default columns and before the visualization column.
+   * These appear to the right of the default columns and to the left of the visualization.
+   */
+  additionalColumns?: MonitorListAdditionalColumn[];
   assigneeFilter?: string;
   detectorFilter?: DetectorType;
   emptyState?: React.ReactNode;
-  renderVisualization?: (detector: Detector) => React.ReactNode;
+  renderVisualization?: (params: RenderVisualizationParams) => React.ReactNode;
   showTimeRangeSelector?: boolean;
 }
 
@@ -19,6 +37,7 @@ const DEFAULT_MONITOR_VIEW_CONTEXT: MonitorViewContextValue = {
   detectorFilter: undefined,
   showTimeRangeSelector: false,
   emptyState: null,
+  additionalColumns: [],
 };
 
 export const MonitorViewContext = createContext<MonitorViewContextValue>(


### PR DESCRIPTION
Adds an `additionalColumns` config to the monitor view context to allow for the addition of monitor labels in the crons view (or extra data for future types).

<img width="877" height="387" alt="CleanShot 2025-10-31 at 10 56 43" src="https://github.com/user-attachments/assets/8385c8d6-a6ca-4f87-861e-ea4a30c74e97" />
