### PR TITLE
chore(replay): Reduce EAP [EVENT PARSE FAIL] log volume

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -342,11 +342,12 @@ def parse_trace_item(
     try:
         return as_trace_item(context, event_type, event)
     except (AttributeError, KeyError, TypeError, ValueError) as e:
-        logger.warning(
-            "[EVENT PARSE FAIL] Could not transform breadcrumb to trace-item",
-            exc_info=e,
-            extra={"event": event},
-        )
+        if random.random() < 0.01:
+            logger.warning(
+                "[EVENT PARSE FAIL] Could not transform breadcrumb to trace-item",
+                exc_info=e,
+                extra={"event": event},
+            )
         return None
 
 


### PR DESCRIPTION
Per https://sentry.slack.com/archives/C04KGFNHCN7/p1761856620697399

Log volume from the event_parser with warning message "[EVENT PARSE FAIL] Could not transform breadcrumb to trace-item" has increased substantially since Oct 29. Let's reduce the volume by sampling at 1% for now.

<img width="1185" height="307" alt="Screenshot 2025-10-31 at 12 41 31 PM" src="https://github.com/user-attachments/assets/cba6721a-e67b-43fd-b128-4a3b43181f17" />
