### PR TITLE
fix(dashboards): Remove weird permanent scroll bar on "All Dashboards" table

### DIFF
--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -323,8 +323,6 @@ function DashboardTable({
   return (
     <GridEditable
       data={dashboards ?? []}
-      // necessary for edit access dropdown
-      bodyStyle={{overflow: 'scroll'}}
       columnOrder={columnOrder}
       columnSortBy={[]}
       grid={{


### PR DESCRIPTION
The current table _always_ has horizontal and vertical scrollbars! e.g.,

<img width="265" height="290" alt="Screenshot 2025-10-31 at 3 43 07 PM" src="https://github.com/user-attachments/assets/b53cafe0-352e-4a01-b02b-27e4c1c73485" />

The always-on overflow was added to allow users to scroll through the table if they [expand a column too far](https://github.com/getsentry/sentry/pull/92630) but as far as I can tell, it's not necessary, I can scroll just fine when the columns are expanded. Maybe something changed? The "Access" control, also works fine since the dropdown was [changed to a fixed strategy](https://github.com/getsentry/sentry/pull/98519/).

NOTE: This only appears when using a non-trackpad mouse (i.e., not a Magic Mouse, and not a laptop trackpad)

<img width="357" height="418" alt="Screenshot 2025-10-31 at 3 43 26 PM" src="https://github.com/user-attachments/assets/bc83f773-988e-47b9-ab69-f524310cdc2b" />
