### PR TITLE
fix(explore): Saved query actions are cut off by table overflow

### DIFF
--- a/static/app/components/savedEntityTable.tsx
+++ b/static/app/components/savedEntityTable.tsx
@@ -211,6 +211,7 @@ SavedEntityTable.CellActions = function CellActions({items}: {items: MenuItemPro
       items={items}
       position="bottom-end"
       size="sm"
+      strategy="fixed"
     />
   );
 };


### PR DESCRIPTION
Switch the dropdown to a "fixed" strategy, so it opens over the table, which otherwise cuts it off.

**Before:**
<img width="179" height="191" alt="Screenshot 2025-10-31 at 3 50 03 PM" src="https://github.com/user-attachments/assets/c24c1421-36e8-4c19-88d8-82a9a02a8224" />

**After:**
<img width="245" height="240" alt="Screenshot 2025-10-31 at 3 50 19 PM" src="https://github.com/user-attachments/assets/a78e0160-6ef8-45c6-a3ee-1acec9c46344" />
