### PR TITLE
feat(aci): use new detector chart for test org

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -213,6 +213,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:more-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable higher limit for workflows
     manager.add("organizations:more-workflows", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Generate charts using detector/open period payload
+    manager.add("organizations:new-metric-issue-charts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Extract on demand metrics
     manager.add("organizations:on-demand-metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Extract on demand metrics (experimental features)

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -62,6 +62,9 @@ from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.users.services.user_option import RpcUserOption, user_option_service
 from sentry.utils.email import MessageBuilder, get_email_addresses
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializerResponse,
+)
 from sentry.workflow_engine.models.incident_groupopenperiod import IncidentGroupOpenPeriod
 
 EMAIL_STATUS_DISPLAY = {TriggerStatus.ACTIVE: "Fired", TriggerStatus.RESOLVED: "Resolved"}
@@ -509,6 +512,7 @@ def generate_incident_trigger_email_context(
     trigger_threshold: float | None,
     user: User | RpcUser | None = None,
     notification_uuid: str | None = None,
+    detector_serialized_response: DetectorSerializerResponse | None = None,
 ) -> dict[str, Any]:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
@@ -562,6 +566,7 @@ def generate_incident_trigger_email_context(
                 open_period_context=open_period_context,
                 size=ChartSize({"width": 600, "height": 200}),
                 subscription=subscription,
+                detector_serialized_response=detector_serialized_response,
             )
         except Exception:
             logging.exception("Error while attempting to build_metric_alert_chart")
@@ -682,6 +687,7 @@ def email_users(
     targets: list[tuple[int, str]],
     project: Project,
     notification_uuid: str | None = None,
+    detector_serialized_response: DetectorSerializerResponse | None = None,
 ) -> list[int]:
     users = user_service.get_many_by_id(ids=[user_id for user_id, _ in targets])
     sent_to_users = []
@@ -704,6 +710,7 @@ def email_users(
             trigger_threshold=alert_context.alert_threshold,
             user=user,
             notification_uuid=notification_uuid,
+            detector_serialized_response=detector_serialized_response,
         )
         build_message(email_context, trigger_status, user_id).send_async(to=[email])
         sent_to_users.append(user_id)

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -134,6 +134,7 @@ def fetch_metric_issue_open_periods(
     time_period: Mapping[str, str],
     user: User | RpcUser | None = None,
 ) -> list[Any]:
+    detector_id = open_period_identifier
     try:
         if features.has(
             "organizations:workflow-engine-single-process-metric-issues",
@@ -147,23 +148,33 @@ def fetch_metric_issue_open_periods(
                 # open_period_identifier is a metric detector ID -> get the alert rule ID
                 open_period_identifier = alert_rule_detector.alert_rule_id
 
-        resp = client.get(
-            auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
-            user=user,
-            path=f"/organizations/{organization.slug}/incidents/",
-            # TODO(iamrajjoshi): Use the correct endpoint and update the params
-            params={
-                "alertRule": open_period_identifier,
-                "expand": "activities",
-                "includeSnapshots": True,
-                "project": -1,
-                **time_period,
-            },
-        )
+        if organization.slug == "mf-test-n7":
+            resp = client.get(
+                auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
+                user=user,
+                path=f"/organizations/{organization.slug}/open-periods/",
+                params={
+                    "detectorId": detector_id,
+                    **time_period,
+                },
+            )
+        else:
+            resp = client.get(
+                auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
+                user=user,
+                path=f"/organizations/{organization.slug}/incidents/",
+                params={
+                    "alertRule": open_period_identifier,
+                    "expand": "activities",
+                    "includeSnapshots": True,
+                    "project": -1,
+                    **time_period,
+                },
+            )
         # TODO (mifu67): temporary log that I'm going to remove after debugging. Get the data for old and new
-        if organization.slug == "sentry" or organization.slug == "demo":
+        if organization.slug == "mf-test-n7":
             logger.info(
-                "fetching metric issue incidents",
+                "fetching metric issue open periods",
                 extra={
                     "organization_id": organization.id,
                     "open_period_id": open_period_identifier,

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -24,6 +24,9 @@ from sentry.integrations.messaging.metrics import (
 )
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializerResponse,
+)
 
 from ..utils import logger
 
@@ -36,6 +39,7 @@ def send_incident_alert_notification(
     open_period_context: OpenPeriodContext,
     alert_rule_serialized_response: AlertRuleSerializerResponse | None,
     incident_serialized_response: DetailedIncidentSerializerResponse | None,
+    detector_serialized_response: DetectorSerializerResponse | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     chart_url = None
@@ -53,6 +57,7 @@ def send_incident_alert_notification(
                 open_period_context=open_period_context,
                 selected_incident_serialized=incident_serialized_response,
                 subscription=metric_issue_context.subscription,
+                detector_serialized_response=detector_serialized_response,
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -54,6 +54,9 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.open_period import open_period_start_for_group
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializerResponse,
+)
 from sentry.workflow_engine.models.action import Action
 
 _logger = logging.getLogger(__name__)
@@ -193,6 +196,7 @@ def _build_notification_payload(
     open_period_context: OpenPeriodContext,
     alert_rule_serialized_response: AlertRuleSerializerResponse | None,
     incident_serialized_response: DetailedIncidentSerializerResponse | None,
+    detector_serialized_response: DetectorSerializerResponse | None,
     notification_uuid: str | None,
 ) -> tuple[str, str]:
     chart_url = None
@@ -210,6 +214,7 @@ def _build_notification_payload(
                 open_period_context=open_period_context,
                 selected_incident_serialized=incident_serialized_response,
                 subscription=metric_issue_context.subscription,
+                detector_serialized_response=detector_serialized_response,
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)
@@ -410,6 +415,7 @@ def send_incident_alert_notification(
     open_period_context: OpenPeriodContext,
     alert_rule_serialized_response: AlertRuleSerializerResponse | None,
     incident_serialized_response: DetailedIncidentSerializerResponse | None,
+    detector_serialized_response: DetectorSerializerResponse | None = None,
     notification_uuid: str | None = None,
 ) -> bool:
     # Make sure organization integration is still active:
@@ -435,6 +441,7 @@ def send_incident_alert_notification(
         alert_rule_serialized_response=alert_rule_serialized_response,
         incident_serialized_response=incident_serialized_response,
         notification_uuid=notification_uuid,
+        detector_serialized_response=detector_serialized_response,
     )
 
     # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -6,6 +6,7 @@ from django.contrib.postgres.constraints import ExclusionConstraint
 from django.contrib.postgres.fields import DateTimeRangeField
 from django.contrib.postgres.fields.ranges import RangeBoundary, RangeOperators
 from django.db import models, router, transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from sentry import options
@@ -155,7 +156,9 @@ def get_open_periods_for_group(
         date_started__gte=query_start,
     ).order_by("-date_started")
     if query_end:
-        group_open_periods = group_open_periods.filter(date_ended__lte=query_end)
+        group_open_periods = group_open_periods.filter(
+            Q(date_ended__lte=query_end) | Q(date_ended__isnull=True)
+        )
 
     return group_open_periods[:limit]
 

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
@@ -13,6 +13,7 @@ from sentry.models.project import Project
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
     get_alert_rule_serializer,
     get_detailed_incident_serializer,
+    get_detector_serializer,
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseMetricAlertHandler
@@ -49,6 +50,7 @@ class DiscordMetricAlertHandler(BaseMetricAlertHandler):
             raise ValueError("Open period not found")
 
         alert_rule_serialized_response = get_alert_rule_serializer(detector)
+        detector_serialized_response = get_detector_serializer(detector)
         incident_serialized_response = get_detailed_incident_serializer(open_period)
 
         logger.info(
@@ -67,4 +69,5 @@ class DiscordMetricAlertHandler(BaseMetricAlertHandler):
             notification_uuid=notification_uuid,
             alert_rule_serialized_response=alert_rule_serialized_response,
             incident_serialized_response=incident_serialized_response,
+            detector_serialized_response=detector_serialized_response,
         )

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
@@ -18,6 +18,7 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
     get_alert_rule_serializer,
     get_detailed_incident_serializer,
+    get_detector_serializer,
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseMetricAlertHandler
@@ -54,6 +55,7 @@ class EmailMetricAlertHandler(BaseMetricAlertHandler):
             raise ValueError("Open period not found")
 
         alert_rule_serialized_response = get_alert_rule_serializer(detector)
+        detector_serialized_response = get_detector_serializer(detector)
         incident_serialized_response = get_detailed_incident_serializer(open_period)
 
         recipients = list(
@@ -77,6 +79,7 @@ class EmailMetricAlertHandler(BaseMetricAlertHandler):
             alert_context=alert_context,
             alert_rule_serialized_response=alert_rule_serialized_response,
             incident_serialized_response=incident_serialized_response,
+            detector_serialized_response=detector_serialized_response,
             trigger_status=trigger_status,
             targets=targets,
             project=project,

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
@@ -14,6 +14,7 @@ from sentry.models.project import Project
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
     get_alert_rule_serializer,
     get_detailed_incident_serializer,
+    get_detector_serializer,
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseMetricAlertHandler
@@ -46,6 +47,7 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
             raise ValueError("Open period not found")
 
         alert_rule_serialized_response = get_alert_rule_serializer(detector)
+        detector_serialized_response = get_detector_serializer(detector)
         incident_serialized_response = get_detailed_incident_serializer(open_period)
 
         logger.info(
@@ -66,4 +68,5 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
             notification_uuid=notification_uuid,
             alert_rule_serialized_response=alert_rule_serialized_response,
             incident_serialized_response=incident_serialized_response,
+            detector_serialized_response=detector_serialized_response,
         )

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/utils.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/utils.py
@@ -12,6 +12,10 @@ from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineIncidentSerializer,
 )
 from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializer,
+    DetectorSerializerResponse,
+)
 from sentry.workflow_engine.models import Detector
 
 
@@ -19,6 +23,12 @@ def get_alert_rule_serializer(detector: Detector) -> AlertRuleSerializerResponse
     return serialize(detector, None, WorkflowEngineDetectorSerializer())
 
 
+def get_detector_serializer(detector: Detector) -> DetectorSerializerResponse:
+    return serialize(detector, None, DetectorSerializer())
+
+
+# TODO(mifu67): These take an open period, get the incident, and call the incident
+# serializer on the incident. They will need to be replaced.
 def get_detailed_incident_serializer(
     open_period: GroupOpenPeriod,
 ) -> DetailedIncidentSerializerResponse:

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any
+from datetime import datetime
+from typing import Any, TypedDict
 
 from django.db.models import Count
 
@@ -20,6 +21,29 @@ from sentry.workflow_engine.models import (
     DetectorGroup,
     DetectorWorkflow,
 )
+
+
+class DetectorSerializerResponseOptional(TypedDict, total=False):
+    owner: str | None
+    createdById: str | None
+    alertRuleId: int | None
+    ruleId: int | None
+    latestGroup: dict | None
+
+
+class DetectorSerializerResponse(DetectorSerializerResponseOptional):
+    id: str
+    projectId: str
+    name: str
+    type: str
+    workflowIds: list[str]
+    dateCreated: datetime
+    dateUpdated: datetime
+    dataSources: list[dict]
+    conditionGroup: dict
+    config: dict
+    enabled: bool
+    openIssues: int
 
 
 @register(Detector)

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -18,13 +18,18 @@ from sentry.incidents.endpoints.serializers.incident import (
     DetailedIncidentSerializer,
     DetailedIncidentSerializerResponse,
 )
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.incidents.models.incident import Incident, IncidentActivityType, IncidentStatus
 from sentry.incidents.typings.metric_detector import AlertContext, OpenPeriodContext
+from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.models import DetectorGroup
 
 now = "2022-05-16T20:00:00"
 frozen_time = f"{now}Z"
@@ -171,3 +176,37 @@ class FetchOpenPeriodsTest(TestCase):
         assert created_activity_resp["incidentIdentifier"] == str(incident.identifier)
         assert created_activity_resp["type"] == IncidentActivityType.CREATED.value
         assert created_activity_resp["dateCreated"] == created_activity.date_added
+
+    @freeze_time(frozen_time)
+    @with_feature("organizations:incidents")
+    @with_feature("organizations:new-metric-issue-charts")
+    @with_feature("organizations:workflow-engine-single-process-metric-issues")
+    def test_use_open_period_serializer(self) -> None:
+        detector = self.create_detector(project=self.project)
+        group = self.create_group(type=MetricIssue.type_id, priority=PriorityLevel.HIGH)
+
+        # Link detector to group
+        DetectorGroup.objects.create(detector=detector, group=group)
+
+        group_open_period = GroupOpenPeriod.objects.get(group=group)
+
+        opened_gopa = GroupOpenPeriodActivity.objects.create(
+            date_added=group_open_period.date_added,
+            group_open_period=group_open_period,
+            type=OpenPeriodActivityType.OPENED,
+            value=group.priority,
+        )
+
+        time_period = incident_date_range(
+            60, group_open_period.date_started, group_open_period.date_ended
+        )
+
+        chart_data = fetch_metric_issue_open_periods(self.organization, detector.id, time_period)
+
+        assert chart_data[0]["id"] == str(group_open_period.id)
+        assert chart_data[0]["start"] == group_open_period.date_started
+
+        activities = chart_data[0]["activities"]
+        assert activities[0]["id"] == str(opened_gopa.id)
+        assert activities[0]["type"] == OpenPeriodActivityType(opened_gopa.type).to_str()
+        assert activities[0]["value"] == PriorityLevel(group.priority).to_str()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -16,6 +16,7 @@ from sentry.notifications.notification_action.metric_alert_registry import Disco
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
     get_alert_rule_serializer,
     get_detailed_incident_serializer,
+    get_detector_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
@@ -81,6 +82,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context=open_period_context,
             alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
             incident_serialized_response=get_detailed_incident_serializer(self.open_period),
+            detector_serialized_response=get_detector_serializer(self.detector),
             notification_uuid=notification_uuid,
         )
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -16,6 +16,7 @@ from sentry.notifications.notification_action.metric_alert_registry import Email
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
     get_alert_rule_serializer,
     get_detailed_incident_serializer,
+    get_detector_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
@@ -81,6 +82,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             alert_context=alert_context,
             alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
             incident_serialized_response=get_detailed_incident_serializer(self.open_period),
+            detector_serialized_response=get_detector_serializer(self.detector),
             trigger_status=TriggerStatus.ACTIVE,
             targets=[(self.user.id, self.user.email)],
             project=self.detector.project,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -16,6 +16,7 @@ from sentry.notifications.notification_action.metric_alert_registry import Slack
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
     get_alert_rule_serializer,
     get_detailed_incident_serializer,
+    get_detector_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
@@ -84,6 +85,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             open_period_context=open_period_context,
             alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
             incident_serialized_response=get_detailed_incident_serializer(self.open_period),
+            detector_serialized_response=get_detector_serializer(self.detector),
             notification_uuid=notification_uuid,
         )
 


### PR DESCRIPTION
Set up flow for using detector/open period data to generate notification charts. Hide this behind a feature flag so we can test.