### PR TITLE
fix(codecov): Fix sentry app links

### DIFF
--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -29,7 +29,7 @@ function OrgFooterMessage() {
                 'Installing the [githubAppLink:GitHub Application] will require admin approval.',
                 {
                   githubAppLink: (
-                    <ExternalLink openInNewTab href="https://github.com/apps/sentry-io" />
+                    <ExternalLink openInNewTab href="https://github.com/apps/sentry" />
                   ),
                 }
               )}
@@ -38,7 +38,7 @@ function OrgFooterMessage() {
         )}
       </Grid>
       <LinkButton
-        href="https://github.com/apps/sentry-io/installations/select_target"
+        href="https://github.com/apps/sentry/installations/select_target"
         size="xs"
         icon={<IconAdd />}
         external

--- a/static/app/views/prevent/coverage/coverage.tsx
+++ b/static/app/views/prevent/coverage/coverage.tsx
@@ -123,7 +123,7 @@ const LayoutGap = styled('div')`
 //         <Prereq>
 //           <PrereqMainText>{t('Install the GitHub Sentry App')}</PrereqMainText>
 //           <PrereqSubText>
-//             <Link to="https://github.com/apps/sentry-io">{t('Install the app')}</Link>
+//             <Link to="https://github.com/apps/sentry">{t('Install the app')}</Link>
 //             {t(
 //               " on your GitHub org in your Sentry org. You will need to be an Owner of your GitHub organization to fully configure the integration. Note: Once linked, a GitHub org/account can't be connected to another Sentry org."
 //             )}

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -27,7 +27,7 @@ const INSTRUCTIONS_TEXT = {
     "You need to install the Sentry App on your GitHub organization as an admin. If you're not an admin, you will need to make sure your GitHub organization admins approve the installation of the Sentry App on GitHub."
   ),
   mainCTA: t('Add installation'),
-  mainCTALink: 'https://github.com/apps/sentry-io',
+  mainCTALink: 'https://github.com/apps/sentry',
 } as const;
 
 export default function TestsPreOnboardingPage() {


### PR DESCRIPTION
Looks like the sentry app was renamed so the slug formerly at `sentry-io` is just at `sentry`. Fix in these links that show up on the Codecov pages
