### PR TITLE
feat(issue-summary): Remove seer organization consent requirement

### DIFF
--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -31,7 +31,7 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
         return None
     if not group.organization.get_option("sentry:enable_seer_enhanced_alerts", default=True):
         return None
-    if not get_seer_org_acknowledgement(org_id=group.organization.id):
+    if not get_seer_org_acknowledgement(group.organization):
         return None
 
     from sentry import quotas

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -553,7 +553,7 @@ def trigger_autofix(
     if group.organization.get_option("sentry:hide_ai_features"):
         return _respond_with_error("AI features are disabled for this organization.", 403)
 
-    if not get_seer_org_acknowledgement(org_id=group.organization.id):
+    if not get_seer_org_acknowledgement(group.organization):
         return _respond_with_error(
             "Seer has not been enabled for this organization. Please open an issue at sentry.io/issues and set up Seer.",
             403,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -351,7 +351,9 @@ def get_issue_summary(
     if group.organization.get_option("sentry:hide_ai_features"):
         return {"detail": "AI features are disabled for this organization."}, 403
 
-    if not get_seer_org_acknowledgement(group.organization.id):
+    if not features.has(
+        "organizations:gen-ai-consent-flow-removal", group.organization
+    ) and not get_seer_org_acknowledgement(group.organization.id):
         return {"detail": "AI Autofix has not been acknowledged by the organization."}, 403
 
     cache_key = get_issue_summary_cache_key(group.id)

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -351,9 +351,7 @@ def get_issue_summary(
     if group.organization.get_option("sentry:hide_ai_features"):
         return {"detail": "AI features are disabled for this organization."}, 403
 
-    if not features.has(
-        "organizations:gen-ai-consent-flow-removal", group.organization
-    ) and not get_seer_org_acknowledgement(group.organization.id):
+    if not get_seer_org_acknowledgement(group.organization):
         return {"detail": "AI Autofix has not been acknowledged by the organization."}, 403
 
     cache_key = get_issue_summary_cache_key(group.id)

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -144,10 +144,12 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 "repos": repos,
             }
 
-        user_acknowledgement = get_seer_user_acknowledgement(user_id=request.user.id, org_id=org.id)
+        user_acknowledgement = get_seer_user_acknowledgement(
+            user_id=request.user.id, organization=org
+        )
         org_acknowledgement = True
         if not user_acknowledgement:  # If the user has acknowledged, the org must have too.
-            org_acknowledgement = get_seer_org_acknowledgement(org_id=org.id)
+            org_acknowledgement = get_seer_org_acknowledgement(org)
 
         has_autofix_quota: bool = quotas.backend.has_available_reserved_budget(
             org_id=org.id, data_category=DataCategory.SEER_AUTOFIX

--- a/src/sentry/seer/endpoints/group_autofix_update.py
+++ b/src/sentry/seer/endpoints/group_autofix_update.py
@@ -43,7 +43,7 @@ class GroupAutofixUpdateEndpoint(GroupAiEndpoint):
                 data={"error": "You must be authenticated to use this endpoint"},
             )
 
-        if not get_seer_org_acknowledgement(org_id=group.organization.id):
+        if not get_seer_org_acknowledgement(group.organization):
             return Response(
                 status=403,
                 data={

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -203,7 +203,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "AI features are disabled for this organization."}, status=403
             )
-        if not get_seer_org_acknowledgement(organization.id):
+        if not get_seer_org_acknowledgement(organization):
             return Response(
                 {"detail": "Seer has not been acknowledged by the organization."}, status=403
             )
@@ -244,7 +244,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "AI features are disabled for this organization."}, status=403
             )
-        if not get_seer_org_acknowledgement(organization.id):
+        if not get_seer_org_acknowledgement(organization):
             return Response(
                 {"detail": "Seer has not been acknowledged by the organization."}, status=403
             )

--- a/src/sentry/seer/endpoints/organization_seer_explorer_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_update.py
@@ -47,7 +47,7 @@ class OrganizationSeerExplorerUpdateEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "AI features are disabled for this organization."}, status=403
             )
-        if not get_seer_org_acknowledgement(organization.id):
+        if not get_seer_org_acknowledgement(organization):
             return Response(
                 {"detail": "Seer has not been acknowledged by the organization."}, status=403
             )

--- a/src/sentry/seer/endpoints/organization_seer_setup_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_setup_check.py
@@ -55,11 +55,11 @@ class OrganizationSeerSetupCheck(OrganizationEndpoint):
 
         # Check consent
         user_acknowledgement = get_seer_user_acknowledgement(
-            user_id=request.user.id, org_id=organization.id
+            user_id=request.user.id, organization=organization
         )
         org_acknowledgement = True
         if not user_acknowledgement:  # If the user has acknowledged, the org must have too.
-            org_acknowledgement = get_seer_org_acknowledgement(org_id=organization.id)
+            org_acknowledgement = get_seer_org_acknowledgement(organization)
 
         return Response(
             {

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -294,7 +294,7 @@ def get_sentry_organization_ids(
 
 def get_organization_autofix_consent(*, org_id: int) -> dict:
     org: Organization = Organization.objects.get(id=org_id)
-    seer_org_acknowledgement = get_seer_org_acknowledgement(org_id=org.id)
+    seer_org_acknowledgement = get_seer_org_acknowledgement(org)
     github_extension_enabled = org_id in options.get("github-extension.enabled-orgs")
     return {
         "consent": seer_org_acknowledgement or github_extension_enabled,

--- a/src/sentry/seer/seer_setup.py
+++ b/src/sentry/seer/seer_setup.py
@@ -10,7 +10,8 @@ feature_name = "seer_autofix_setup_acknowledged"
 
 
 def get_seer_user_acknowledgement(user_id: int, organization: Organization) -> bool:
-    # If consent flow is removed via feature flag, always treat as acknowledged
+    # The consent requirement for generative AI features is being removed
+    # After GA, remove all calls to this function
     if features.has("organizations:gen-ai-consent-flow-removal", organization):
         return True
 
@@ -23,7 +24,8 @@ def get_seer_user_acknowledgement(user_id: int, organization: Organization) -> b
 
 
 def get_seer_org_acknowledgement(organization: Organization) -> bool:
-    # If consent flow is removed via feature flag, always treat as acknowledged
+    # The consent requirement for generative AI features is being removed
+    # After GA, remove all calls to this function
     if features.has("organizations:gen-ai-consent-flow-removal", organization):
         return True
 

--- a/src/sentry/seer/seer_setup.py
+++ b/src/sentry/seer/seer_setup.py
@@ -9,19 +9,27 @@ from sentry.users.services.user.model import RpcUser
 feature_name = "seer_autofix_setup_acknowledged"
 
 
-def get_seer_user_acknowledgement(user_id: int, org_id: int) -> bool:
+def get_seer_user_acknowledgement(user_id: int, organization: Organization) -> bool:
+    # If consent flow is removed via feature flag, always treat as acknowledged
+    if features.has("organizations:gen-ai-consent-flow-removal", organization):
+        return True
+
     return PromptsActivity.objects.filter(
         user_id=user_id,
         feature=feature_name,
-        organization_id=org_id,
+        organization_id=organization.id,
         project_id=0,
     ).exists()
 
 
-def get_seer_org_acknowledgement(org_id: int) -> bool:
+def get_seer_org_acknowledgement(organization: Organization) -> bool:
+    # If consent flow is removed via feature flag, always treat as acknowledged
+    if features.has("organizations:gen-ai-consent-flow-removal", organization):
+        return True
+
     return PromptsActivity.objects.filter(
         feature=feature_name,
-        organization_id=org_id,
+        organization_id=organization.id,
         project_id=0,
     ).exists()
 
@@ -32,7 +40,7 @@ def has_seer_access(
     return (
         features.has("organizations:gen-ai-features", organization, actor=actor)
         and not bool(organization.get_option("sentry:hide_ai_features"))
-        and get_seer_org_acknowledgement(org_id=organization.id)
+        and get_seer_org_acknowledgement(organization)
     )
 
 
@@ -45,7 +53,7 @@ def has_seer_access_with_detail(
     if organization.get_option("sentry:hide_ai_features"):
         return False, "AI features are disabled for this organization."
 
-    if not get_seer_org_acknowledgement(organization.id):
+    if not get_seer_org_acknowledgement(organization):
         return False, "Seer has not been acknowledged by the organization."
 
     return True, None

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1612,7 +1612,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     if lock.locked():
         return
 
-    seer_enabled = get_seer_org_acknowledgement(group.organization.id)
+    seer_enabled = get_seer_org_acknowledgement(group.organization)
     if not seer_enabled:
         return
 

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -66,7 +66,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert status_code == 200
         assert summary_data == convert_dict_key_case(existing_summary, snake_to_camel_case)
         mock_call_seer.assert_not_called()
-        mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
+        mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
     @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
     @patch("sentry.seer.autofix.issue_summary._get_event")
@@ -81,7 +81,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert status_code == 400
         assert summary_data == {"detail": "Could not find an event for the issue"}
         assert cache.get(f"ai-group-summary-v2:{self.group.id}") is None
-        mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
+        mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
     @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
     @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
@@ -123,7 +123,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_get_event.assert_called_once_with(self.group, self.user, provided_event_id=None)
         mock_get_trace_tree.assert_called_once()
         mock_call_seer.assert_called_once_with(self.group, serialized_event, {"trace": "tree"})
-        mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
+        mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
         # Check if the cache was set correctly
         cached_summary = cache.get(f"ai-group-summary-v2:{self.group.id}")
@@ -141,7 +141,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             assert summary_data == {
                 "detail": "AI Autofix has not been acknowledged by the organization."
             }
-            mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
+            mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
     @patch("sentry.seer.autofix.issue_summary.requests.post")
     @patch("sentry.seer.autofix.issue_summary._get_event")
@@ -185,7 +185,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_post.assert_called_once()
         payload = orjson.loads(mock_post.call_args_list[0].kwargs["data"])
         assert payload["trace_tree"] is None
-        mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
+        mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
         assert cache.get(f"ai-group-summary-v2:{self.group.id}") == expected_response_summary
 
@@ -242,7 +242,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             # Verify that _get_event and _call_seer were not called due to cache hit
             mock_get_event.assert_not_called()
             mock_call_seer.assert_not_called()
-            mock_get_acknowledgement.assert_called_with(self.group.organization.id)
+            mock_get_acknowledgement.assert_called_with(self.group.organization)
 
     @patch("sentry.seer.autofix.issue_summary._generate_summary")
     @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
@@ -338,7 +338,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 
         # Ensure generation was called directly
         mock_generate_summary.assert_called_once()
-        mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
+        mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
     @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
     @patch("sentry.seer.autofix.issue_summary.requests.post")
@@ -406,7 +406,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_generate_summary_core.assert_not_called()
         # Ensure cache was checked three times (once initially, once after lock failure, and once for hideAiFeatures check)
         assert mock_cache_get.call_count == 3
-        mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
+        mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
     @patch("sentry.seer.autofix.issue_summary.eventstore.backend.get_event_by_id")
     @patch("sentry.seer.autofix.issue_summary.serialize")

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -189,7 +189,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
 
         assert response.status_code == 403
         assert response.data == {"detail": "Seer has not been acknowledged by the organization."}
-        mock_get_seer_org_acknowledgement.assert_called_once_with(self.organization.id)
+        mock_get_seer_org_acknowledgement.assert_called_once_with(self.organization)
 
     def test_post_without_open_team_membership_returns_403(self) -> None:
         self.organization.flags.allow_joinleave = False


### PR DESCRIPTION
Behind a [feature flag](https://github.com/getsentry/sentry/pull/102514), removes the consent check in `seer_org_acknowledgement()`. This is part of the plan to remove the gen ai consent requirement for free features like issue/replay/feedback summaries and explore search.

Paid Seer features have a separate consent flow that happens when purchasing Seer. 