### PR TITLE
fix(issues): Remove first/last seen for empty tag values

### DIFF
--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -131,8 +131,10 @@ class TagValueSerializerResponse(TagValueSerializerResponseOptional):
     name: str
     value: str
     count: int
-    lastSeen: str
-    firstSeen: str
+    # Empty values do not have last seen timestamps.
+    lastSeen: str | None
+    # Empty values do not have first seen timestamps.
+    firstSeen: str | None
 
 
 @register(GroupTagValue)


### PR DESCRIPTION
Helps fix an issue where this query gets too large on groups that have a lot of long tag keys. First/last seen isn't very interesting for tags when the tag is omitted.

fixes SENTRY-5BVA
part of https://linear.app/getsentry/issue/RTC-1181