### PR TITLE
motion: add first class framer support

### DIFF
--- a/static/app/components/core/principles/motion/motion.mdx
+++ b/static/app/components/core/principles/motion/motion.mdx
@@ -50,13 +50,33 @@ On an otherwise static page, any motion will draw user attention. For this reaso
 
 # Token Reference
 
-Motion tokens for CSS are exposed under the `theme.motion` namespace as pairs of easing and duration values.
+Motion tokens are exposed under the `theme.motion` namespace and support both CSS and Framer Motion usage patterns.
 
 ```js
 const theme = useTheme();
-
 // motion[easing][duration]
 theme.motion.smooth.moderate;
+```
+
+## Framer Motion
+
+For Framer Motion animations, use the `framer` namespace which provides transition objects ready to use with Framer Motion components:
+
+```tsx
+import {useTheme} from '@emotion/react';
+import {motion} from 'framer-motion';
+
+function AnimatedComponent() {
+  const theme = useTheme();
+
+  return (
+    <motion.div
+      initial={{opacity: 0, y: -16}}
+      animate={{opacity: 1, y: 0}}
+      transition={theme.motion.framer.enter.fast}
+    />
+  );
+}
 ```
 
 ## Easing

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -10,6 +10,7 @@
 import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import color from 'color';
+import type {Transition} from 'framer-motion';
 
 // palette generated via: https://gka.github.io/palettes/#colors=444674,69519A,E1567C,FB7D46,F2B712|steps=20|bez=1|coL=1
 const CHART_PALETTE = [
@@ -252,22 +253,71 @@ const generateTokens = (colors: Colors) => ({
   },
 });
 
-const generateMotion = () => {
-  return {
-    smooth: withDuration('cubic-bezier(0.72, 0, 0.16, 1)'),
-    snap: withDuration('cubic-bezier(0.8, -0.4, 0.5, 1)'),
-    enter: withDuration('cubic-bezier(0.24, 1, 0.32, 1)'),
-    exit: withDuration('cubic-bezier(0.64, 0, 0.8, 0)'),
-  };
+type MotionName = 'smooth' | 'snap' | 'enter' | 'exit';
+type MotionDuration = 'fast' | 'moderate' | 'slow';
+
+type MotionDefinition = Record<MotionDuration, string>;
+
+const motionDurations: Record<MotionDuration, number> = {
+  fast: 120,
+  moderate: 160,
+  slow: 240,
 };
 
-const withDuration = (easing: string) => {
-  return {
-    fast: `120ms ${easing}`,
-    moderate: `160ms ${easing}`,
-    slow: `240ms ${easing}`,
-  };
+const motionCurves: Record<MotionName, [number, number, number, number]> = {
+  smooth: [0.72, 0, 0.16, 1],
+  snap: [0.8, -0.4, 0.5, 1],
+  enter: [0.24, 1, 0.32, 1],
+  exit: [0.64, 0, 0.8, 0],
 };
+
+const withDuration = (
+  durations: Record<MotionDuration, number>,
+  easing: [number, number, number, number]
+): [MotionDefinition, Record<MotionDuration, Transition>] => {
+  const motion: MotionDefinition = {
+    fast: `${durations.fast}ms cubic-bezier(${easing.join(', ')})`,
+    moderate: `${durations.moderate}ms cubic-bezier(${easing.join(', ')})`,
+    slow: `${durations.slow}ms cubic-bezier(${easing.join(', ')})`,
+  };
+
+  const framerMotion: Record<MotionDuration, Transition> = {
+    fast: {
+      duration: durations.fast / 1000,
+      ease: easing,
+    },
+    moderate: {
+      duration: durations.moderate / 1000,
+      ease: easing,
+    },
+    slow: {
+      duration: durations.slow / 1000,
+      ease: easing,
+    },
+  };
+
+  return [motion, framerMotion];
+};
+
+function generateMotion() {
+  const [smoothMotion, smoothFramer] = withDuration(motionDurations, motionCurves.smooth);
+  const [snapMotion, snapFramer] = withDuration(motionDurations, motionCurves.snap);
+  const [enterMotion, enterFramer] = withDuration(motionDurations, motionCurves.enter);
+  const [exitMotion, exitFramer] = withDuration(motionDurations, motionCurves.exit);
+
+  return {
+    smooth: smoothMotion,
+    snap: snapMotion,
+    enter: enterMotion,
+    exit: exitMotion,
+    framer: {
+      smooth: smoothFramer,
+      snap: snapFramer,
+      enter: enterFramer,
+      exit: exitFramer,
+    },
+  };
+}
 
 const generateThemeAliases = (colors: Colors) => ({
   /**


### PR DESCRIPTION
Add first class framer motion support to theme. 

@gggritso I'll let you experiment with the transition definition for the drawer animation and we'll figure out if we can modify one of our current definitions or introduce a brand new one, but I'd like to defer that until we see what the desired transition would look like.