### PR TITLE
fix(config): Hook up to new prevent ai config apis

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -9,7 +9,6 @@ import type {WidgetType} from 'sentry/views/dashboards/types';
 import type {Actor, Avatar, ObjectStatus, Scope} from './core';
 import type {ExternalTeam} from './integrations';
 import type {OnboardingTaskStatus} from './onboarding';
-import type {PreventAIConfig} from './prevent';
 import type {Project} from './project';
 import type {Relay} from './relay';
 import type {User} from './user';
@@ -114,7 +113,6 @@ export interface Organization extends OrganizationSummary {
   };
   orgRole?: string;
   planSampleRate?: number | null;
-  preventAiConfigGithub?: PreventAIConfig;
 }
 
 export interface Team {

--- a/static/app/types/prevent.tsx
+++ b/static/app/types/prevent.tsx
@@ -17,13 +17,8 @@ export interface PreventAIFeatureConfigsByName {
   vanilla: PreventAIFeatureConfig; // "vanilla" basic ai pr review
 }
 
-export interface PreventAIOrgConfig {
+export interface PreventAIConfig {
   org_defaults: PreventAIFeatureConfigsByName;
   repo_overrides: Record<string, PreventAIFeatureConfigsByName>;
-}
-
-export interface PreventAIConfig {
-  default_org_config: PreventAIOrgConfig;
-  github_organizations: Record<string, PreventAIOrgConfig>;
   schema_version: string;
 }

--- a/static/app/types/prevent.tsx
+++ b/static/app/types/prevent.tsx
@@ -22,3 +22,5 @@ export interface PreventAIConfig {
   repo_overrides: Record<string, PreventAIFeatureConfigsByName>;
   schema_version: string;
 }
+
+export const PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT = 'v1';

--- a/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.spec.tsx
@@ -1,0 +1,108 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {usePreventAIGitHubConfig} from './usePreventAIConfig';
+
+describe('usePreventAIGitHubConfig', () => {
+  const org = OrganizationFixture({slug: 'test-org'});
+  const gitOrgName = 'octo-corp';
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetches config from API correctly', async () => {
+    const configResponse = {
+      default_org_config: {
+        org_defaults: {
+          vanilla: {enabled: true, sensitivity: 'medium'},
+          test_generation: {enabled: false, sensitivity: 'low'},
+          bug_prediction: {enabled: false, sensitivity: 'high'},
+        },
+        repo_overrides: {
+          'repo-123': {
+            vanilla: {enabled: false, sensitivity: 'high'},
+            test_generation: {enabled: true, sensitivity: 'critical'},
+            bug_prediction: {enabled: false, sensitivity: 'medium'},
+          },
+        },
+        schema_version: 'v1',
+      },
+      organization: {
+        'octo-corp': {
+          org_defaults: {
+            vanilla: {enabled: false, sensitivity: 'low'},
+            test_generation: {enabled: true, sensitivity: 'medium'},
+            bug_prediction: {enabled: true, sensitivity: 'high'},
+          },
+          repo_overrides: {},
+          schema_version: 'v1',
+        },
+      },
+      schema_version: 'v1',
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/prevent/ai/github/config/${gitOrgName}/`,
+      body: configResponse,
+    });
+
+    const {result} = renderHookWithProviders(
+      () => usePreventAIGitHubConfig({gitOrgName}),
+      {
+        organization: org,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(result.current.data).toMatchObject(configResponse);
+    expect(result.current.isError).toBeFalsy();
+  });
+
+  it('sets isError when API fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/prevent/ai/github/config/${gitOrgName}/`,
+      statusCode: 500,
+    });
+
+    const {result} = renderHookWithProviders(
+      () => usePreventAIGitHubConfig({gitOrgName}),
+      {
+        organization: org,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('uses correct API URL for different org', async () => {
+    const diffOrg = OrganizationFixture({slug: 'diff-org'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/diff-org/prevent/ai/github/config/${gitOrgName}/`,
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(
+      () => usePreventAIGitHubConfig({gitOrgName}),
+      {
+        organization: diffOrg,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(result.current.isError).toBeFalsy();
+  });
+});

--- a/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.spec.tsx
@@ -2,6 +2,8 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT} from 'sentry/types/prevent';
+
 import {usePreventAIGitHubConfig} from './usePreventAIConfig';
 
 describe('usePreventAIGitHubConfig', () => {
@@ -27,7 +29,7 @@ describe('usePreventAIGitHubConfig', () => {
             bug_prediction: {enabled: false, sensitivity: 'medium'},
           },
         },
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
       },
       organization: {
         'octo-corp': {
@@ -37,10 +39,10 @@ describe('usePreventAIGitHubConfig', () => {
             bug_prediction: {enabled: true, sensitivity: 'high'},
           },
           repo_overrides: {},
-          schema_version: 'v1',
+          schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         },
       },
-      schema_version: 'v1',
+      schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
     };
 
     MockApiClient.addMockResponse({

--- a/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.tsx
@@ -1,0 +1,25 @@
+import type {PreventAIConfig} from 'sentry/types/prevent';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface UsePreventAIGitHubConfigOptions {
+  gitOrgName: string;
+}
+
+interface UsePreventAIGitHubConfigResult {
+  default_org_config: PreventAIConfig;
+  schema_version: string;
+  organization?: Record<string, PreventAIConfig>;
+}
+
+export function usePreventAIGitHubConfig({gitOrgName}: UsePreventAIGitHubConfigOptions) {
+  const organization = useOrganization();
+
+  return useApiQuery<UsePreventAIGitHubConfigResult, RequestError>(
+    [`/organizations/${organization.slug}/prevent/ai/github/config/${gitOrgName}/`],
+    {
+      staleTime: 30000,
+    }
+  );
+}

--- a/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.spec.tsx
@@ -1,6 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
-import {PreventAIConfigFixture} from 'sentry-fixture/prevent';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -9,9 +8,7 @@ import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {usePreventAIOrgs} from './usePreventAIOrgRepos';
 
 describe('usePreventAIOrgRepos', () => {
-  const mockOrg = OrganizationFixture({
-    preventAiConfigGithub: PreventAIConfigFixture(),
-  });
+  const mockOrg = OrganizationFixture();
 
   const mockResponse: OrganizationIntegration[] = [
     OrganizationIntegrationsFixture({

--- a/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
@@ -1,8 +1,9 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PreventAIConfigFixture} from 'sentry-fixture/prevent';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import * as organizationsActionCreator from 'sentry/actionCreators/organizations';
+import type {PreventAIConfig} from 'sentry/types/prevent';
 
 import {
   makePreventAIConfig,
@@ -10,270 +11,196 @@ import {
 } from './useUpdatePreventAIFeature';
 
 describe('useUpdatePreventAIFeature', () => {
-  const mockOrg = OrganizationFixture({
-    slug: 'test-sentry-slug',
-    preventAiConfigGithub: {
-      schema_version: 'v1',
-      github_organizations: {
-        'org-1': {
-          org_defaults: {
-            vanilla: {
-              enabled: false,
-              triggers: {on_command_phrase: false, on_ready_for_review: false},
-              sensitivity: 'medium',
-            },
-            test_generation: {
-              enabled: false,
-              triggers: {on_command_phrase: false, on_ready_for_review: false},
-            },
-            bug_prediction: {
-              enabled: false,
-              triggers: {on_command_phrase: false, on_ready_for_review: false},
-              sensitivity: 'medium',
-            },
-          },
-          repo_overrides: {},
-        },
-      },
-      default_org_config: {
-        org_defaults: {
-          vanilla: {
-            enabled: false,
-            triggers: {on_command_phrase: false, on_ready_for_review: false},
-            sensitivity: 'medium',
-          },
-          test_generation: {
-            enabled: false,
-            triggers: {on_command_phrase: false, on_ready_for_review: false},
-          },
-          bug_prediction: {
-            enabled: false,
-            triggers: {on_command_phrase: false, on_ready_for_review: false},
-            sensitivity: 'medium',
-          },
-        },
-        repo_overrides: {},
-      },
-    },
-  });
+  const organization = OrganizationFixture();
+  const config = PreventAIConfigFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    jest
-      .spyOn(organizationsActionCreator, 'updateOrganization')
-      .mockImplementation(() => {});
+    jest.resetAllMocks();
   });
 
-  it('calls API with correct params to enable a feature', async () => {
-    const mockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/${mockOrg.slug}/`,
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('enables a feature successfully via API', async () => {
+    const mockResp = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/ai/github/config/org-1/`,
       method: 'PUT',
-      body: {preventAiConfigGithub: mockOrg.preventAiConfigGithub},
+      body: config,
     });
+
     const {result} = renderHookWithProviders(() => useUpdatePreventAIFeature(), {
-      organization: mockOrg,
+      organization,
     });
 
     result.current.enableFeature({
       feature: 'vanilla',
       enabled: true,
-      orgId: 'org-1',
+      gitOrgName: 'org-1',
+      originalConfig: config,
       repoId: 'repo-1',
       trigger: {on_command_phrase: true},
     });
 
     await waitFor(() => {
-      expect(mockResponse).toHaveBeenCalled();
+      expect(mockResp).toHaveBeenCalled();
     });
+
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeUndefined();
   });
 
   it('sets error if API call fails', async () => {
-    const mockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/${mockOrg.slug}/`,
+    const mockResp = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/ai/github/config/org-1/`,
       method: 'PUT',
       statusCode: 400,
       body: {detail: 'fail'},
     });
 
     const {result} = renderHookWithProviders(() => useUpdatePreventAIFeature(), {
-      organization: mockOrg,
+      organization,
     });
 
     await expect(
       result.current.enableFeature({
         feature: 'vanilla',
         enabled: true,
-        orgId: 'org-1',
+        gitOrgName: 'org-1',
+        originalConfig: config,
         repoId: 'repo-1',
         trigger: {on_command_phrase: true},
       })
     ).rejects.toBeDefined();
 
     await waitFor(() => {
-      expect(mockResponse).toHaveBeenCalled();
+      expect(mockResp).toHaveBeenCalled();
     });
     expect(result.current.error).toBeDefined();
     expect(result.current.isLoading).toBe(false);
   });
 
-  it('throws if organization has no prevent AI config', async () => {
-    const orgNoConfig = {
-      ...OrganizationFixture(),
-      preventAiConfigGithub: undefined,
-    };
-    const {result} = renderHookWithProviders(() => useUpdatePreventAIFeature(), {
-      organization: orgNoConfig,
-    });
-
-    await expect(
-      result.current.enableFeature({
-        feature: 'vanilla',
-        enabled: true,
-        orgId: 'org-1',
-        repoId: 'repo-1',
-      })
-    ).rejects.toThrow('Organization has no AI Code Review config');
-  });
-
   describe('makePreventAIConfig', () => {
-    it('should update the correct feature config in org_defaults', () => {
-      const config = structuredClone(mockOrg.preventAiConfigGithub!);
-      const updatedConfig = makePreventAIConfig(config, {
+    it('updates org_defaults feature config', () => {
+      const original = structuredClone(config);
+      const updated = makePreventAIConfig(original, {
         feature: 'vanilla',
         enabled: true,
-        orgId: 'org-1',
+        gitOrgName: 'org-1',
+        originalConfig: config,
       });
-      expect(
-        updatedConfig.github_organizations?.['org-1']?.org_defaults?.vanilla?.enabled
-      ).toBe(true);
-      // Should not mutate original
-      expect(config.github_organizations?.['org-1']?.org_defaults?.vanilla?.enabled).toBe(
-        false
-      );
+      expect(updated.org_defaults?.vanilla?.enabled).toBe(true);
+      expect(original.org_defaults?.vanilla?.enabled).toBe(false);
     });
 
-    it('should update the correct feature config in repo_overrides', () => {
-      const config = structuredClone(mockOrg.preventAiConfigGithub!);
-      const updatedConfig = makePreventAIConfig(config, {
+    it('updates repo_overrides feature config', () => {
+      const original = structuredClone(config);
+      const updated = makePreventAIConfig(original, {
         feature: 'test_generation',
         enabled: true,
-        orgId: 'org-1',
+        gitOrgName: 'org-1',
+        originalConfig: config,
         repoId: 'repo-123',
         trigger: {on_command_phrase: true},
       });
+      expect(updated.repo_overrides?.['repo-123']?.test_generation?.enabled).toBe(true);
       expect(
-        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-123']
-          ?.test_generation?.enabled
+        updated.repo_overrides?.['repo-123']?.test_generation.triggers.on_command_phrase
       ).toBe(true);
-      expect(
-        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-123']
-          ?.test_generation.triggers.on_command_phrase
-      ).toBe(true);
-      // Should not mutate original
-      expect(config.github_organizations?.['org-1']?.repo_overrides).toEqual({});
+      expect(original.repo_overrides).toEqual({});
     });
 
-    it('should merge triggers', () => {
-      const config = structuredClone(mockOrg.preventAiConfigGithub!);
-      const updatedConfig = makePreventAIConfig(config, {
+    it('merges triggers', () => {
+      const original = structuredClone(config);
+      const updated = makePreventAIConfig(original, {
         feature: 'bug_prediction',
         enabled: false,
-        orgId: 'org-1',
+        gitOrgName: 'org-1',
+        originalConfig: config,
         repoId: 'repo-xyz',
         trigger: {on_ready_for_review: true},
       });
-      const feature =
-        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-xyz']
-          ?.bug_prediction;
+      const feature = updated.repo_overrides?.['repo-xyz']?.bug_prediction;
       expect(feature?.enabled).toBe(false);
       expect(feature?.triggers.on_ready_for_review).toBe(true);
     });
 
-    it('should update sensitivity', () => {
-      const config = structuredClone(mockOrg.preventAiConfigGithub!);
-      const updatedConfig = makePreventAIConfig(config, {
+    it('updates sensitivity', () => {
+      const original = structuredClone(config);
+      const updated = makePreventAIConfig(original, {
         feature: 'bug_prediction',
         enabled: true,
-        orgId: 'org-1',
+        gitOrgName: 'org-1',
+        originalConfig: config,
         repoId: 'repo-xyz',
         sensitivity: 'low',
       });
-      const feature =
-        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-xyz']
-          ?.bug_prediction;
+      const feature = updated.repo_overrides?.['repo-xyz']?.bug_prediction;
       expect(feature?.sensitivity).toBe('low');
     });
 
-    it('should delete repo override when use_org_defaults is enabled', () => {
-      const config = structuredClone(mockOrg.preventAiConfigGithub!);
-      if (config.github_organizations?.['org-1']?.repo_overrides) {
-        config.github_organizations['org-1'].repo_overrides['repo-123'] = {
-          vanilla: {
-            enabled: true,
-            triggers: {on_command_phrase: true, on_ready_for_review: false},
-            sensitivity: 'high',
+    it('deletes repo override when use_org_defaults is enabled', () => {
+      const localConfig = structuredClone(config);
+      const configWithOverride: PreventAIConfig = {
+        ...config,
+        repo_overrides: {
+          'repo-123': {
+            vanilla: {
+              enabled: true,
+              triggers: {on_command_phrase: true, on_ready_for_review: false},
+              sensitivity: 'high',
+            },
+            bug_prediction: {
+              enabled: true,
+              triggers: {on_command_phrase: true, on_ready_for_review: false},
+              sensitivity: 'high',
+            },
+            test_generation: {
+              enabled: true,
+              triggers: {on_command_phrase: true, on_ready_for_review: false},
+            },
           },
-          test_generation: {
-            enabled: true,
-            triggers: {on_command_phrase: false, on_ready_for_review: false},
-          },
-          bug_prediction: {
-            enabled: true,
-            triggers: {on_command_phrase: true, on_ready_for_review: true},
-            sensitivity: 'critical',
-          },
-        };
-      }
+        },
+      };
 
-      const updatedConfig = makePreventAIConfig(config, {
+      const updated = makePreventAIConfig(localConfig, {
         feature: 'use_org_defaults',
         enabled: true,
-        orgId: 'org-1',
+        gitOrgName: 'org-1',
+        originalConfig: configWithOverride,
         repoId: 'repo-123',
       });
 
-      // The repo override should be deleted
-      expect(
-        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-123']
-      ).toBeUndefined();
+      expect(updated.repo_overrides?.['repo-123']).toBeUndefined();
     });
 
-    it('should create repo override when use_org_defaults is disabled', () => {
-      const config = structuredClone(mockOrg.preventAiConfigGithub!);
-      // No repo override exists initially
-      expect(
-        config.github_organizations?.['org-1']?.repo_overrides?.['repo-456']
-      ).toBeUndefined();
+    it('creates repo override when use_org_defaults is disabled', () => {
+      const localConfig = structuredClone(config);
+      expect(localConfig.repo_overrides?.['repo-456']).toBeUndefined();
 
-      const updatedConfig = makePreventAIConfig(config, {
+      const updated = makePreventAIConfig(localConfig, {
         feature: 'use_org_defaults',
         enabled: false,
-        orgId: 'org-1',
+        gitOrgName: 'org-1',
+        originalConfig: config,
         repoId: 'repo-456',
       });
 
-      // A repo override should be created, cloned from org_defaults
-      const repoOverride =
-        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-456'];
+      const repoOverride = updated.repo_overrides?.['repo-456'];
       expect(repoOverride).toBeDefined();
-      expect(repoOverride).toEqual(
-        updatedConfig.github_organizations?.['org-1']?.org_defaults
-      );
-      // Should not mutate original
-      expect(
-        config.github_organizations?.['org-1']?.repo_overrides?.['repo-456']
-      ).toBeUndefined();
+      expect(repoOverride).toEqual(updated.org_defaults);
+      expect(localConfig.repo_overrides?.['repo-456']).toBeUndefined();
     });
 
-    it('should error if repo name is not provided when feature is use_org_defaults', () => {
-      const config = structuredClone(mockOrg.preventAiConfigGithub!);
+    it('throws if repo name is not provided when use_org_defaults', () => {
+      const localConfig = structuredClone(config);
       expect(() =>
-        makePreventAIConfig(config, {
+        makePreventAIConfig(localConfig, {
           feature: 'use_org_defaults',
           enabled: true,
-          orgId: 'org-1',
+          gitOrgName: 'org-1',
+          originalConfig: config,
         })
       ).toThrow('Repo name is required when feature is use_org_defaults');
     });

--- a/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
@@ -19,10 +19,6 @@ describe('useUpdatePreventAIFeature', () => {
     jest.resetAllMocks();
   });
 
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
   it('enables a feature successfully via API', async () => {
     const mockResp = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/prevent/ai/github/config/org-1/`,

--- a/static/app/views/prevent/preventAI/manageRepos.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageRepos.spec.tsx
@@ -11,22 +11,20 @@ describe('PreventAIManageRepos', () => {
     OrganizationIntegrationsFixture({
       id: 'integration-1',
       organizationId: 'org-1',
-      name: 'Org One',
+      name: 'org-1',
       externalId: 'ext-1',
       domainName: 'github.com/org-one',
     }),
     OrganizationIntegrationsFixture({
       id: 'integration-2',
       organizationId: 'org-2',
-      name: 'Org Two',
+      name: 'org-2',
       externalId: 'ext-2',
       domainName: 'github.com/org-two',
     }),
   ];
 
-  const organization = OrganizationFixture({
-    preventAiConfigGithub: PreventAIConfigFixture(),
-  });
+  const organization = OrganizationFixture();
 
   beforeEach(() => {
     MockApiClient.addMockResponse({
@@ -46,6 +44,11 @@ describe('PreventAIManageRepos', () => {
           name: 'org-two/repo-three',
         },
       ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/ai/github/config/org-1/`,
+      method: 'GET',
+      body: {default_org_config: PreventAIConfigFixture()},
     });
   });
 

--- a/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
@@ -6,6 +6,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {RepositoryStatus} from 'sentry/types/integrations';
 import type {OrganizationIntegration, Repository} from 'sentry/types/integrations';
 import type {PreventAIConfig} from 'sentry/types/prevent';
+import {PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT} from 'sentry/types/prevent';
 import ManageReposPanel, {
   getRepoConfig,
   type ManageReposPanelProps,
@@ -83,7 +84,7 @@ describe('ManageReposPanel', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
       body: {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         default_org_config: PreventAIConfigFixture(),
         organization: {
           'org-1': PreventAIConfigFixture(),
@@ -153,7 +154,7 @@ describe('ManageReposPanel', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
       body: {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         default_org_config: PreventAIConfigFixture(),
         organization: {
           'org-1': configWithOverride,
@@ -183,7 +184,7 @@ describe('ManageReposPanel', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
       body: {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         default_org_config: PreventAIConfigFixture(),
         organization: {
           'org-1': configWithOverride,
@@ -226,7 +227,7 @@ describe('ManageReposPanel', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
       body: {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         default_org_config: PreventAIConfigFixture(),
         organization: {
           'org-1': configWithOverride,
@@ -262,7 +263,7 @@ describe('ManageReposPanel', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
       body: {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         default_org_config: PreventAIConfigFixture(),
         organization: {
           'org-1': configWithOverride,
@@ -347,7 +348,7 @@ describe('ManageReposPanel', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
       body: {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         default_org_config: PreventAIConfigFixture(),
         organization: {
           'org-1': configWithOverride,
@@ -363,7 +364,7 @@ describe('ManageReposPanel', () => {
   describe('getRepoConfig', () => {
     it('returns org defaults when repoName is null', () => {
       const orgConfig: PreventAIConfig = {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         org_defaults: {
           bug_prediction: {
             enabled: true,
@@ -403,7 +404,7 @@ describe('ManageReposPanel', () => {
 
     it('returns repo override config when present', () => {
       const orgConfig: PreventAIConfig = {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         org_defaults: {
           bug_prediction: {
             enabled: true,
@@ -456,7 +457,7 @@ describe('ManageReposPanel', () => {
 
     it('returns org defaults when repo override is not present', () => {
       const orgConfig: PreventAIConfig = {
-        schema_version: 'v1',
+        schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
         org_defaults: {
           bug_prediction: {
             enabled: true,

--- a/tests/js/fixtures/prevent.ts
+++ b/tests/js/fixtures/prevent.ts
@@ -1,28 +1,25 @@
-import type {Sensitivity} from 'sentry/types/prevent';
+import type {PreventAIConfig, Sensitivity} from 'sentry/types/prevent';
 
-export function PreventAIConfigFixture() {
+export function PreventAIConfigFixture(): PreventAIConfig {
   return {
     schema_version: 'v1',
-    github_organizations: {},
-    default_org_config: {
-      org_defaults: {
-        bug_prediction: {
-          enabled: false,
-          triggers: {on_command_phrase: false, on_ready_for_review: false},
-          sensitivity: 'medium' as Sensitivity,
-        },
-        test_generation: {
-          enabled: false,
-          triggers: {on_command_phrase: false, on_ready_for_review: false},
-          sensitivity: 'medium' as Sensitivity,
-        },
-        vanilla: {
-          enabled: false,
-          triggers: {on_command_phrase: false, on_ready_for_review: false},
-          sensitivity: 'medium' as Sensitivity,
-        },
+    org_defaults: {
+      bug_prediction: {
+        enabled: false,
+        triggers: {on_command_phrase: false, on_ready_for_review: false},
+        sensitivity: 'medium' as Sensitivity,
       },
-      repo_overrides: {},
+      test_generation: {
+        enabled: false,
+        triggers: {on_command_phrase: false, on_ready_for_review: false},
+        sensitivity: 'medium' as Sensitivity,
+      },
+      vanilla: {
+        enabled: false,
+        triggers: {on_command_phrase: false, on_ready_for_review: false},
+        sensitivity: 'medium' as Sensitivity,
+      },
     },
+    repo_overrides: {},
   };
 }

--- a/tests/js/fixtures/prevent.ts
+++ b/tests/js/fixtures/prevent.ts
@@ -1,8 +1,9 @@
 import type {PreventAIConfig, Sensitivity} from 'sentry/types/prevent';
+import {PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT} from 'sentry/types/prevent';
 
 export function PreventAIConfigFixture(): PreventAIConfig {
   return {
-    schema_version: 'v1',
+    schema_version: PREVENT_AI_CONFIG_SCHEMA_VERSION_DEFAULT,
     org_defaults: {
       bug_prediction: {
         enabled: false,


### PR DESCRIPTION
We spun off isolated prevent AI apis for the get/put prevent ai config instead of using the existing spot within organization options so that we can allow members (not just admins) perform the update. Point the frontend to these new apis.
The pages are at https://sentry-gctlymwi8.sentry.dev/prevent/ai-code-review/home/ for feature flagged orgs (including sentry, codecov)