### PR TITLE
feat(timeseries): Add `topEvents` support for Logs and Trace Metrics

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -38,6 +38,7 @@ from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.utils import DATASET_LABELS, RPC_DATASETS
 from sentry.utils.snuba import SnubaTSResult
 
@@ -49,6 +50,7 @@ TOP_EVENTS_DATASETS = {
     spans_metrics,
     Spans,
     OurLogs,
+    TraceMetrics,
     errors,
     transactions,
 }
@@ -138,7 +140,10 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                 if dataset not in TOP_EVENTS_DATASETS:
                     raise ParseError(detail=f"{dataset} doesn't support topEvents yet")
 
-            metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}
+            metrics_enhanced = dataset in {
+                metrics_performance,
+                metrics_enhanced_performance,
+            }
             use_rpc = dataset in RPC_DATASETS
 
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -34,6 +34,7 @@ from sentry.snuba import (
     spans_metrics,
     transactions,
 )
+from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
@@ -47,6 +48,7 @@ TOP_EVENTS_DATASETS = {
     metrics_enhanced_performance,
     spans_metrics,
     Spans,
+    OurLogs,
     errors,
     transactions,
 }

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -3,7 +3,9 @@ from datetime import timedelta
 from django.urls import reverse
 
 from sentry.testutils.helpers.datetime import before_now
-from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+from tests.snuba.api.endpoints.test_organization_events import (
+    OrganizationEventsEndpointTestBase,
+)
 from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import (
     AnyConfidence,
     build_expected_timeseries,
@@ -12,7 +14,9 @@ from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import 
 any_confidence = AnyConfidence()
 
 
-class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpointTestBase):
+class OrganizationEventsStatsOurlogsMetricsEndpointTest(
+    OrganizationEventsEndpointTestBase
+):
     endpoint = "sentry-api-0-organization-events-timeseries"
 
     def setUp(self) -> None:
@@ -34,7 +38,9 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             features = {"organizations:ourlogs": True}
         features.update(self.features)
         with self.feature(features):
-            return self.client.get(self.url if url is None else url, data=data, format="json")
+            return self.client.get(
+                self.url if url is None else url, data=data, format="json"
+            )
 
     def test_count(self) -> None:
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -85,6 +91,89 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             "valueType": "integer",
             "valueUnit": None,
             "interval": 3_600_000,
+        }
+
+    def test_top_events(self) -> None:
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo"},
+                    timestamp=self.start + timedelta(minutes=1),
+                    attributes={"environment": {"string_value": "prod"}},
+                ),
+                self.create_ourlog(
+                    {"body": "foo"},
+                    timestamp=self.start + timedelta(minutes=1),
+                    attributes={"environment": {"string_value": "dev"}},
+                ),
+                self.create_ourlog(
+                    {"body": "foo"},
+                    timestamp=self.start + timedelta(minutes=1),
+                    attributes={"environment": {"string_value": "prod"}},
+                ),
+                self.create_ourlog(
+                    {"body": "foo"},
+                    timestamp=self.start + timedelta(minutes=1),
+                    attributes={"environment": {"string_value": "dev"}},
+                ),
+            ]
+        )
+
+        self.end = self.start + timedelta(minutes=6)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "groupBy": ["environment"],
+                "project": self.project.id,
+                "dataset": "logs",
+                "excludeOther": 0,
+                "topEvents": 2,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "logs",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeSeries"]) == 2
+
+        timeseries = response.data["timeSeries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["yAxis"] == "count()"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 60_000, [0, 2, 0, 0, 0, 0], ignore_accuracy=True
+        )
+        assert timeseries["groupBy"] == [{"key": "environment", "value": "prod"}]
+        assert timeseries["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeSeries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["yAxis"] == "count()"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 60_000, [0, 2, 0, 0, 0, 0], ignore_accuracy=True
+        )
+        assert timeseries["groupBy"] == [{"key": "environment", "value": "dev"}]
+        assert timeseries["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
         }
 
     def test_zerofill(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -3,9 +3,7 @@ from datetime import timedelta
 from django.urls import reverse
 
 from sentry.testutils.helpers.datetime import before_now
-from tests.snuba.api.endpoints.test_organization_events import (
-    OrganizationEventsEndpointTestBase,
-)
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import (
     AnyConfidence,
     build_expected_timeseries,
@@ -14,9 +12,7 @@ from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import 
 any_confidence = AnyConfidence()
 
 
-class OrganizationEventsStatsOurlogsMetricsEndpointTest(
-    OrganizationEventsEndpointTestBase
-):
+class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpointTestBase):
     endpoint = "sentry-api-0-organization-events-timeseries"
 
     def setUp(self) -> None:
@@ -38,9 +34,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(
             features = {"organizations:ourlogs": True}
         features.update(self.features)
         with self.feature(features):
-            return self.client.get(
-                self.url if url is None else url, data=data, format="json"
-            )
+            return self.client.get(self.url if url is None else url, data=data, format="json")
 
     def test_count(self) -> None:
         event_counts = [6, 0, 6, 3, 0, 3]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
@@ -1,0 +1,81 @@
+from datetime import timedelta
+
+from django.urls import reverse
+
+from sentry.testutils.helpers.datetime import before_now
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import (
+    AnyConfidence,
+    build_expected_timeseries,
+)
+
+any_confidence = AnyConfidence()
+
+
+class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpointTestBase):
+    endpoint = "sentry-api-0-organization-events-timeseries"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.start = self.day_ago = before_now(days=1).replace(
+            hour=10, minute=0, second=0, microsecond=0
+        )
+        self.end = self.start + timedelta(hours=6)
+        self.two_days_ago = self.day_ago - timedelta(days=1)
+
+        self.url = reverse(
+            self.endpoint,
+            kwargs={"organization_id_or_slug": self.project.organization.slug},
+        )
+
+    def _do_request(self, data, url=None, features=None):
+        return self.client.get(self.url if url is None else url, data=data, format="json")
+
+    def test_simple(self) -> None:
+        metric_values = [6, 0, 6, 3, 0, 3]
+
+        trace_metrics = []
+        for hour, value in enumerate(metric_values):
+            trace_metrics.extend(
+                [
+                    self.create_trace_metric(
+                        "foo",
+                        value,
+                        "counter",
+                        timestamp=self.start + timedelta(hours=hour),
+                    )
+                ]
+            )
+        self.store_trace_metrics(trace_metrics)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "sum(value)",
+                "query": "metric.name:foo",
+                "project": self.project.id,
+                "dataset": "tracemetrics",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "tracemetrics",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["yAxis"] == "sum(value)"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 3_600_000, metric_values, ignore_accuracy=True
+        )
+        assert timeseries["meta"] == {
+            "dataScanned": "full",
+            "valueType": "number",
+            "valueUnit": None,
+            "interval": 3_600_000,
+        }


### PR DESCRIPTION
Right now, neither logs not trace metrics support the `topEvents` parameter. I couldn't find any technical reason for this, they're just omitted from the allowlist. I added some basic tests and turned on `topEvents` for those datasets, and it seems to work fine.

1. Is there any specific reason those datasets aren't allowed to use `topEvents` that I'm missing? I think they're just RPC datasets same as spans, so I'm not sure why they wouldn't
2. How much test coverage does this need? Span `topEvents` has a _lot_ of cases, but I'm not sure if they're needed here
