### PR TITLE
chore(feedback): Adjust padding around feedback summary area

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -101,7 +101,7 @@ const SummaryContainer = styled('div')`
 `;
 
 const SummaryIconContainer = styled('div')`
-  padding: ${p => p.theme.space.xl};
+  padding: ${p => p.theme.space.md};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
 `;


### PR DESCRIPTION
This adjusts the padding around the disclosure widget, inside the feedback summary box. Before there was enough padding that my example summary would take up more lines, and the 4 categories at the bottom would wrap too, now we're saving some space to prevent as much line-wrapping, and it looks even better imo.

**Before:**
<img width="404" height="216" alt="before" src="https://github.com/user-attachments/assets/9168e8ad-24a8-450e-b35e-afdcd48d362c" />

**After:**
<img width="404" height="176" alt="after" src="https://github.com/user-attachments/assets/dd481c94-547a-4190-b126-467c85b452f4" />
