### PR TITLE
fix(replay): Fix overflow on replay snippets inside issues views

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -87,6 +87,7 @@ const PlayerContainer = styled(FluidHeight)`
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
     min-height: ${REPLAY_LOADING_HEIGHT + 16}px;
   }
+  overflow: unset;
 `;
 
 const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`

--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -196,7 +196,6 @@ const PlayerPanel = styled('div')`
   gap: ${space(1)};
   flex-direction: column;
   flex-grow: 1;
-  overflow: hidden;
   height: 100%;
 `;
 
@@ -208,6 +207,7 @@ const PreviewPlayerContainer = styled(FluidHeight)<{isSidebarOpen: boolean}>`
   gap: ${space(2)};
   background: ${p => p.theme.background};
   height: unset;
+  overflow: unset;
 
   :fullscreen {
     padding: ${space(1)};

--- a/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.tsx
@@ -90,6 +90,7 @@ const PlayerContainer = styled(FluidHeight)`
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
     min-height: ${REPLAY_LOADING_HEIGHT_LARGE}px;
   }
+  overflow: unset;
 `;
 
 const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`


### PR DESCRIPTION
| | Issue Details |
| --- | --- |
| Before | <img width="676" height="124" alt="Screenshot 2025-11-03 at 10 59 15 AM" src="https://github.com/user-attachments/assets/7c7e8d82-9d82-48ef-826e-95230ef60341" /> |
| After | <img width="713" height="124" alt="Screenshot 2025-11-03 at 10 59 07 AM" src="https://github.com/user-attachments/assets/ed8cf0a4-1349-40da-b094-8bbbe87dfb20" />

| | Issues > Replays |
| --- | --- |
| Before | <img width="661" height="107" alt="Screenshot 2025-11-03 at 10 58 35 AM" src="https://github.com/user-attachments/assets/0d2179ea-9295-4c9d-9131-e56e3effc423" /> |
| After | <img width="661" height="107" alt="Screenshot 2025-11-03 at 10 58 47 AM" src="https://github.com/user-attachments/assets/3a70cb6b-00bf-4efb-ba23-a7fcb191e38f" /> |


