### PR TITLE
ref(onboarding): Split native onboarding docs

### DIFF
--- a/static/app/gettingStartedDocs/native/native/index.tsx
+++ b/static/app/gettingStartedDocs/native/native/index.tsx
@@ -1,0 +1,11 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+
+import {onboarding} from './onboarding';
+
+const docs: Docs = {
+  onboarding,
+  crashReportOnboarding: CrashReportWebApiOnboarding,
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/native/native/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/native/native/onboarding.spec.tsx
@@ -1,10 +1,10 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from './qt';
+import docs from '.';
 
-describe('getting started with native-qt', () => {
-  it('renders gradle docs correctly', () => {
+describe('getting started with native', () => {
+  it('renders docs correctly', () => {
     renderWithOnboardingLayout(docs);
 
     // Renders main headings

--- a/static/app/gettingStartedDocs/native/native/onboarding.tsx
+++ b/static/app/gettingStartedDocs/native/native/onboarding.tsx
@@ -1,18 +1,15 @@
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
-  Docs,
   DocsParams,
   OnboardingConfig,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getConsoleExtensions} from 'sentry/components/onboarding/gettingStartedDoc/utils/consoleExtensions';
-import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import {getVerifySnippet} from 'sentry/gettingStartedDocs/native/native/utils';
 import {t, tct} from 'sentry/locale';
 
-type Params = DocsParams;
-
-const getConfigureSnippet = (params: Params) => `
+const getConfigureSnippet = (params: DocsParams) => `
 #include <sentry.h>
 
 int main(void) {
@@ -31,14 +28,7 @@ int main(void) {
   sentry_close();
 }`;
 
-const getVerifySnippet = () => `
-sentry_capture_event(sentry_value_new_message_event(
-  /*   level */ SENTRY_LEVEL_INFO,
-  /*  logger */ "custom",
-  /* message */ "It works!"
-));`;
-
-const onboarding: OnboardingConfig = {
+export const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
@@ -119,10 +109,3 @@ const onboarding: OnboardingConfig = {
     ...([getConsoleExtensions(params)].filter(Boolean) as OnboardingStep[]),
   ],
 };
-
-const docs: Docs = {
-  onboarding,
-  crashReportOnboarding: CrashReportWebApiOnboarding,
-};
-
-export default docs;

--- a/static/app/gettingStartedDocs/native/native/utils.tsx
+++ b/static/app/gettingStartedDocs/native/native/utils.tsx
@@ -1,0 +1,6 @@
+export const getVerifySnippet = () => `
+sentry_capture_event(sentry_value_new_message_event(
+  /*   level */ SENTRY_LEVEL_INFO,
+  /*  logger */ "custom",
+  /* message */ "It works!"
+));`;

--- a/static/app/gettingStartedDocs/native/qt/index.tsx
+++ b/static/app/gettingStartedDocs/native/qt/index.tsx
@@ -1,0 +1,11 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+
+import {onboarding} from './onboarding';
+
+const docs: Docs = {
+  onboarding,
+  crashReportOnboarding: CrashReportWebApiOnboarding,
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/native/qt/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/native/qt/onboarding.spec.tsx
@@ -1,10 +1,10 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from './native';
+import docs from '.';
 
-describe('getting started with native', () => {
-  it('renders docs correctly', () => {
+describe('getting started with native-qt', () => {
+  it('renders gradle docs correctly', () => {
     renderWithOnboardingLayout(docs);
 
     // Renders main headings

--- a/static/app/gettingStartedDocs/native/qt/onboarding.tsx
+++ b/static/app/gettingStartedDocs/native/qt/onboarding.tsx
@@ -1,16 +1,13 @@
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
-  Docs,
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import {getVerifySnippet} from 'sentry/gettingStartedDocs/native/native/utils';
 import {t, tct} from 'sentry/locale';
 
-type Params = DocsParams;
-
-const getConfigureSnippet = (params: Params) => `
+const getConfigureSnippet = (params: DocsParams) => `
 #include <QtWidgets>
 #include <sentry.h>
 
@@ -33,14 +30,7 @@ int main(int argc, char *argv[])
     return app.exec();
 }`;
 
-const getVerifySnippet = () => `
-sentry_capture_event(sentry_value_new_message_event(
-  /*   level */ SENTRY_LEVEL_INFO,
-  /*  logger */ "custom",
-  /* message */ "It works!"
-));`;
-
-const onboarding: OnboardingConfig = {
+export const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
@@ -118,10 +108,3 @@ const onboarding: OnboardingConfig = {
     },
   ],
 };
-
-const docs: Docs = {
-  onboarding,
-  crashReportOnboarding: CrashReportWebApiOnboarding,
-};
-
-export default docs;


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms