### PR TITLE
fix(ui): set loading indicator background to transparent

### DIFF
--- a/static/app/components/loadingIndicator.stories.tsx
+++ b/static/app/components/loadingIndicator.stories.tsx
@@ -1,6 +1,8 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import * as Storybook from 'sentry/stories';
 
+import NegativeSpaceContainer from './container/negativeSpaceContainer';
+
 export default Storybook.story('LoadingIndicator', story => {
   story('Default', () => (
     <div>
@@ -8,13 +10,19 @@ export default Storybook.story('LoadingIndicator', story => {
         Setting custom size on <Storybook.JSXProperty name="size" value={24} /> will cause
         the border width to scale proportionally with the size of the loading indicator.
       </p>
-      <Storybook.SideBySide>
-        <LoadingIndicator />
-        <LoadingIndicator size={48} />
-        <LoadingIndicator size={24} />
-      </Storybook.SideBySide>
+      <NegativeSpaceContainer>
+        <Storybook.SideBySide>
+          <LoadingIndicator />
+          <LoadingIndicator size={48} />
+          <LoadingIndicator size={24} />
+        </Storybook.SideBySide>
+      </NegativeSpaceContainer>
     </div>
   ));
 
-  story('Loading text', () => <LoadingIndicator>Loading...</LoadingIndicator>);
+  story('Loading text', () => (
+    <NegativeSpaceContainer>
+      <LoadingIndicator>Loading...</LoadingIndicator>
+    </NegativeSpaceContainer>
+  ));
 });

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -135,7 +135,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
     }
 
     .loading .loading-indicator {
-      background: ${theme.tokens.background.primary};
+      background: transparent;
     }
 
     color: ${theme.textColor};
@@ -157,7 +157,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
     }
     /*this updates styles set by shared-components.less to match our theme*/
     .theme-dark .loading .loading-indicator {
-      background: ${theme.tokens.background.primary};
+      background: transparent;
     }
     .theme-dark .loading.triangle .loading-indicator {
       background: #fff;


### PR DESCRIPTION
so that it inherits the color from the parent container for cases where we don't render it on a primary background

| before | after |
|--------|--------|
| <img width="1150" height="513" alt="Screenshot 2025-11-03 at 10 35 32" src="https://github.com/user-attachments/assets/0468c8e9-8a98-4869-8d66-38963dad10f6" /> | <img width="1168" height="500" alt="Screenshot 2025-11-03 at 10 35 10" src="https://github.com/user-attachments/assets/43b9bc67-c3a0-48a5-a407-fccad8a8a81c" /> |
