### PR TITLE
fix: allow more query intervals in organization projects

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -63,6 +63,7 @@ STATUS_LABELS = {
 }
 
 STATS_PERIOD_CHOICES = {
+    "90d": StatsPeriod(90, timedelta(days=1)),
     "30d": StatsPeriod(30, timedelta(hours=24)),
     "14d": StatsPeriod(14, timedelta(hours=24)),
     "7d": StatsPeriod(7, timedelta(hours=24)),

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -28,7 +28,9 @@ from sentry.models.team import Team
 from sentry.search.utils import tokenize_query
 from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
 
-ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
+ERR_INVALID_STATS_PERIOD = (
+    "Invalid stats_period. Valid choices are '', '1h', '24h', '7d', '14d', '30d', and '90d'"
+)
 
 DATASETS = {
     "": discover,  # in case they pass an empty query string fall back on default
@@ -72,7 +74,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
         """
         stats_period = request.GET.get("statsPeriod")
         collapse = request.GET.getlist("collapse", [])
-        if stats_period not in (None, "", "1h", "24h", "7d", "14d", "30d"):
+        if stats_period not in (None, "", "1h", "24h", "7d", "14d", "30d", "90d"):
             return Response(
                 {"error": {"params": {"stats_period": {"message": ERR_INVALID_STATS_PERIOD}}}},
                 status=400,


### PR DESCRIPTION
- During an admin task I saw this in _admin -  a 400 error from the API for the 90d query interval
<img width="1249" height="243" alt="image" src="https://github.com/user-attachments/assets/e637ac26-b052-4c83-9fe6-f12d8dd92bb1" />

- We may not want to do this for some reason, but I don't know of any explicit reason not to do this. If we don't want to do this, we should handle it better