### PR TITLE
fix(dynamic-sampling): use options instead of feature flags for switching b/w span and transaction based rebalancing

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1152,10 +1152,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         #       so we need to refactor this into an async task we can run and observe
         org_id = organization.id
         measure = SamplingMeasure.TRANSACTIONS
-        if options.get("dynamic-sampling.check_span_feature_flag") and features.has(
-            "organizations:dynamic-sampling-spans", organization
-        ):
-            measure = SamplingMeasure.SPANS
+        if options.get("dynamic-sampling.check_span_feature_flag"):
+            span_org_ids = options.get("dynamic-sampling.measure.spans") or []
+            if org_id in span_org_ids:
+                measure = SamplingMeasure.SPANS
 
         projects_with_tx_count_and_rates = []
         for chunk in query_project_counts_by_org(

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -133,38 +133,28 @@ def partition_by_measure(
 
     # Exclude orgs with project-mode sampling from the start. We know the
     # default is DynamicSamplingMode.ORGANIZATION.
-    orgs = [org for org, mode in modes.items() if mode != DynamicSamplingMode.PROJECT]
+    org_ids = {org.id for org, mode in modes.items() if mode != DynamicSamplingMode.PROJECT}
 
     if not options.get("dynamic-sampling.check_span_feature_flag"):
-        metrics.incr("dynamic_sampling.partition_by_measure.transactions", amount=len(orgs))
-        return {SamplingMeasure.TRANSACTIONS: [org.id for org in orgs]}
+        metrics.incr("dynamic_sampling.partition_by_measure.transactions", amount=len(org_ids))
+        return {SamplingMeasure.TRANSACTIONS: list(org_ids)}
 
-    spans = []
-    transactions = []
-
-    # Use batch feature flag check to avoid N+1 queries.
-    feature_results = features.batch_has_for_organizations(
-        "organizations:dynamic-sampling-spans", orgs
-    )
-    if feature_results is None:
-        metrics.incr("dynamic_sampling.partition_by_measure.transactions", amount=len(orgs))
-        logger.error("dynamic_sampling.partition_by_measure.features_none", extra={"orgs": orgs})
-        return {SamplingMeasure.TRANSACTIONS: [org.id for org in orgs]}
+    span_org_ids = set(options.get("dynamic-sampling.measure.spans")) or set()
+    transactions_org_ids = org_ids - span_org_ids
 
     logger.info(
-        "dynamic_sampling.partition_by_measure.batched_feature_check",
-        extra={"feature_results": feature_results},
+        "dynamic_sampling.partition_by_measure.options_check",
+        extra={"span_org_ids": span_org_ids},
     )
 
-    for org in orgs:
-        if feature_results.get(f"organization:{org.id}"):
-            spans.append(org.id)
-        else:
-            transactions.append(org.id)
-
-    metrics.incr("dynamic_sampling.partition_by_measure.spans", amount=len(spans))
-    metrics.incr("dynamic_sampling.partition_by_measure.transactions", amount=len(transactions))
-    return {SamplingMeasure.SPANS: spans, SamplingMeasure.TRANSACTIONS: transactions}
+    metrics.incr("dynamic_sampling.partition_by_measure.spans", amount=len(span_org_ids))
+    metrics.incr(
+        "dynamic_sampling.partition_by_measure.transactions", amount=len(transactions_org_ids)
+    )
+    return {
+        SamplingMeasure.SPANS: list(span_org_ids),
+        SamplingMeasure.TRANSACTIONS: list(transactions_org_ids),
+    }
 
 
 @instrumented_task(
@@ -190,10 +180,10 @@ def boost_low_volume_projects_of_org_with_query(org_id: OrganizationId) -> None:
         return
 
     measure = SamplingMeasure.TRANSACTIONS
-    if options.get("dynamic-sampling.check_span_feature_flag") and features.has(
-        "organizations:dynamic-sampling-spans", org
-    ):
-        measure = SamplingMeasure.SPANS
+    if options.get("dynamic-sampling.check_span_feature_flag"):
+        span_org_ids = options.get("dynamic-sampling.measure.spans") or []
+        if org_id in span_org_ids:
+            measure = SamplingMeasure.SPANS
 
     projects_with_tx_count_and_rates = fetch_projects_with_total_root_transaction_count_and_rates(
         org_ids=[org_id],

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -141,7 +141,7 @@ def partition_by_measure(
         metrics.incr(
             "dynamic_sampling.partition_by_measure.transactions", amount=len(filtered_org_ids)
         )
-        return {SamplingMeasure.TRANSACTIONS: list(filtered_org_ids)}
+        return {SamplingMeasure.TRANSACTIONS: sorted(filtered_org_ids)}
 
     span_org_ids = set(options.get("dynamic-sampling.measure.spans") or [])
     span_org_ids = span_org_ids & filtered_org_ids
@@ -157,8 +157,8 @@ def partition_by_measure(
         "dynamic_sampling.partition_by_measure.transactions", amount=len(transactions_org_ids)
     )
     return {
-        SamplingMeasure.SPANS: list(span_org_ids),
-        SamplingMeasure.TRANSACTIONS: list(transactions_org_ids),
+        SamplingMeasure.SPANS: sorted(span_org_ids),
+        SamplingMeasure.TRANSACTIONS: sorted(transactions_org_ids),
     }
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2182,6 +2182,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_MODIFIABLE_RATE,
 )
 
+# List of organization IDs that should be using spans for rebalancing in dynamic sampling.
+register(
+    "dynamic-sampling.measure.spans",
+    default=[],
+    type=Sequence,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # === Hybrid cloud subsystem options ===
 # UI rollout
 register(

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
@@ -287,9 +287,11 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
 class TestPartitionByMeasure(TestCase):
     def test_partition_by_measure_with_spans_feature(self) -> None:
         org = self.create_organization("test-org1")
-        with (
-            self.options({"dynamic-sampling.check_span_feature_flag": True}),
-            self.feature({"organizations:dynamic-sampling-spans": True}),
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": True,
+                "dynamic-sampling.measure.spans": [org.id],
+            }
         ):
             result = partition_by_measure([org.id])
             assert SamplingMeasure.SPANS in result
@@ -299,9 +301,11 @@ class TestPartitionByMeasure(TestCase):
 
     def test_partition_by_measure_without_spans_feature(self) -> None:
         org = self.create_organization("test-org1")
-        with (
-            self.options({"dynamic-sampling.check_span_feature_flag": True}),
-            self.feature({"organizations:dynamic-sampling-spans": False}),
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": True,
+                "dynamic-sampling.measure.spans": [],
+            }
         ):
             result = partition_by_measure([org.id])
             assert SamplingMeasure.SPANS in result
@@ -311,9 +315,11 @@ class TestPartitionByMeasure(TestCase):
 
     def test_partition_by_measure_with_span_feature_flag_disabled(self) -> None:
         org = self.create_organization("test-org1")
-        with (
-            self.options({"dynamic-sampling.check_span_feature_flag": False}),
-            self.feature({"organizations:dynamic-sampling-spans": True}),
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": False,
+                "dynamic-sampling.measure.spans": [org.id],
+            }
         ):
             result = partition_by_measure([org.id])
             assert SamplingMeasure.TRANSACTIONS in result


### PR DESCRIPTION
- Use an option with a list of orgs instead of feature flags because it's faster
- Should be in-memory and therefore significantly faster than feature flags
- We can do this because we do not expect large quantities of orgs to be added to this
- Previous batch-checking solution had high performance penalty despite multiple optimizations

Contributes to TET-1147