### PR TITLE
fix(deletions): Switch to bulk deletions for GroupHistory

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING, Any
 
+from sentry import options
+
 if TYPE_CHECKING:
     from sentry.db.models.base import Model
     from sentry.deletions.base import BaseDeletionTask
@@ -64,7 +66,10 @@ def load_defaults(manager: DeletionTaskManager) -> None:
     manager.register(models.GroupEnvironment, BulkModelDeletionTask)
     manager.register(models.GroupHash, defaults.GroupHashDeletionTask)
     manager.register(models.GroupHashMetadata, BulkModelDeletionTask)
-    manager.register(models.GroupHistory, defaults.GroupHistoryDeletionTask)
+    if options.get("deletions.group-history.use-bulk-deletion"):
+        manager.register(models.GroupHistory, defaults.GroupHistoryDeletionTask)
+    else:
+        manager.register(models.GroupHistory, BulkModelDeletionTask)
     manager.register(models.GroupLink, BulkModelDeletionTask)
     manager.register(models.GroupMeta, BulkModelDeletionTask)
     manager.register(models.GroupRedirect, BulkModelDeletionTask)

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -67,9 +67,9 @@ def load_defaults(manager: DeletionTaskManager) -> None:
     manager.register(models.GroupHash, defaults.GroupHashDeletionTask)
     manager.register(models.GroupHashMetadata, BulkModelDeletionTask)
     if options.get("deletions.group-history.use-bulk-deletion"):
-        manager.register(models.GroupHistory, defaults.GroupHistoryDeletionTask)
-    else:
         manager.register(models.GroupHistory, BulkModelDeletionTask)
+    else:
+        manager.register(models.GroupHistory, defaults.GroupHistoryDeletionTask)
     manager.register(models.GroupLink, BulkModelDeletionTask)
     manager.register(models.GroupMeta, BulkModelDeletionTask)
     manager.register(models.GroupRedirect, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/grouphistory.py
+++ b/src/sentry/deletions/defaults/grouphistory.py
@@ -1,3 +1,4 @@
+from sentry import options
 from sentry.deletions.base import ModelDeletionTask
 from sentry.models.grouphistory import GroupHistory
 
@@ -22,6 +23,10 @@ class GroupHistoryDeletionTask(ModelDeletionTask[GroupHistory]):
             return super().chunk()
 
         for group_id in group_ids:
+            if options.get("deletions.group-history.delete-all-at-once"):
+                self.model.objects.filter(group_id=group_id).delete()
+                continue
+
             # Delete history records for a single group in chunks of 100
             queryset = self.model.objects.filter(group_id=group_id)
             while True:

--- a/src/sentry/deletions/defaults/grouphistory.py
+++ b/src/sentry/deletions/defaults/grouphistory.py
@@ -1,4 +1,3 @@
-from sentry import options
 from sentry.deletions.base import ModelDeletionTask
 from sentry.models.grouphistory import GroupHistory
 
@@ -23,10 +22,6 @@ class GroupHistoryDeletionTask(ModelDeletionTask[GroupHistory]):
             return super().chunk()
 
         for group_id in group_ids:
-            if options.get("deletions.group-history.delete-all-at-once"):
-                self.model.objects.filter(group_id=group_id).delete()
-                continue
-
             # Delete history records for a single group in chunks of 100
             queryset = self.model.objects.filter(group_id=group_id)
             while True:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -343,6 +343,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "deletions.group-history.use-bulk-deletion",
+    default=False,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "cleanup.abort_execution",


### PR DESCRIPTION
This is how it used to be before #76608. Now that we have fixed the circular relationship (#102470) I believe we should give this approach another attempt.

Fixes [SENTRY-5BX2](https://sentry.sentry.io/issues/6993998110/):

For posterity:
```
OperationalError
canceling statement due to user request

SQL: SELECT "sentry_grouphistory"."id" AS "id" FROM "sentry_grouphistory" WHERE "sentry_grouphistory"."group_id" = %s ORDER BY 1 ASC LIMIT 100
```

The group in question has only been seen 4 times yet it has 905,729 rows of group history. This is caused by the priority of the group changing back and forth between high and medium priority. We're investigating the root cause of it.