### PR TITLE
fix(tracemetrics): Handle unset default per second argument

### DIFF
--- a/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
@@ -15,13 +15,13 @@ import {
   isDefaultFields,
 } from 'sentry/views/explore/logs/logsQueryParams';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
-import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface LogsLocationQueryParamsProviderProps {
   children: ReactNode;
   // Will override the frozen params from the location if the key is provided.
-  frozenParams?: Partial<ReadableQueryParams>;
+  frozenParams?: Partial<ReadableQueryParamsOptions>;
 }
 
 export function LogsLocationQueryParamsProvider({
@@ -40,7 +40,7 @@ export function LogsLocationQueryParamsProvider({
 
   const readableQueryParams = useMemo(
     () =>
-      frozenParams ? {..._readableQueryParams, ...frozenParams} : _readableQueryParams,
+      frozenParams ? _readableQueryParams.replace(frozenParams) : _readableQueryParams,
     [_readableQueryParams, frozenParams]
   );
 

--- a/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
@@ -13,12 +13,15 @@ import {defaultCursor} from 'sentry/views/explore/queryParams/cursor';
 import {defaultGroupBys} from 'sentry/views/explore/queryParams/groupBy';
 import {defaultMode} from 'sentry/views/explore/queryParams/mode';
 import {defaultQuery} from 'sentry/views/explore/queryParams/query';
-import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {
+  ReadableQueryParams,
+  type ReadableQueryParamsOptions,
+} from 'sentry/views/explore/queryParams/readableQueryParams';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface LogsStateQueryParamsProviderProps {
   children: ReactNode;
-  frozenParams?: Partial<ReadableQueryParams>;
+  frozenParams?: Partial<ReadableQueryParamsOptions>;
 }
 
 export function LogsStateQueryParamsProvider({
@@ -65,7 +68,7 @@ export function LogsStateQueryParamsProvider({
 
   const readableQueryParams = useMemo(
     () =>
-      frozenParams ? {..._readableQueryParams, ...frozenParams} : _readableQueryParams,
+      frozenParams ? _readableQueryParams.replace(frozenParams) : _readableQueryParams,
     [_readableQueryParams, frozenParams]
   );
 

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -1,3 +1,4 @@
+import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {
   TraceMetricKnownFieldKey,
   type TraceMetricFieldKey,
@@ -36,3 +37,102 @@ export const HiddenTraceMetricSearchFields: TraceMetricFieldKey[] = [
 export const HiddenTraceMetricGroupByFields: TraceMetricFieldKey[] = [
   ...HiddenTraceMetricSearchFields,
 ];
+
+export const OPTIONS_BY_TYPE: Record<string, Array<SelectOption<string>>> = {
+  counter: [
+    {
+      label: 'per_second',
+      value: 'per_second',
+    },
+    {
+      label: 'per_minute',
+      value: 'per_minute',
+    },
+    {
+      label: 'sum',
+      value: 'sum',
+    },
+  ],
+  distribution: [
+    {
+      label: 'p50',
+      value: 'p50',
+    },
+    {
+      label: 'p75',
+      value: 'p75',
+    },
+    {
+      label: 'p90',
+      value: 'p90',
+    },
+    {
+      label: 'p95',
+      value: 'p95',
+    },
+    {
+      label: 'p99',
+      value: 'p99',
+    },
+    {
+      label: 'avg',
+      value: 'avg',
+    },
+    {
+      label: 'min',
+      value: 'min',
+    },
+    {
+      label: 'max',
+      value: 'max',
+    },
+    {
+      label: 'sum',
+      value: 'sum',
+    },
+    {
+      label: 'count',
+      value: 'count',
+    },
+    {
+      label: 'per_second',
+      value: 'per_second',
+    },
+    {
+      label: 'per_minute',
+      value: 'per_minute',
+    },
+  ],
+  gauge: [
+    {
+      label: 'min',
+      value: 'min',
+    },
+    {
+      label: 'max',
+      value: 'max',
+    },
+    {
+      label: 'avg',
+      value: 'avg',
+    },
+    {
+      label: 'last',
+      value: 'last',
+    },
+    {
+      label: 'per_second',
+      value: 'per_second',
+    },
+    {
+      label: 'per_minute',
+      value: 'per_minute',
+    },
+  ],
+};
+
+export const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
+  counter: 'per_second',
+  distribution: 'p75',
+  gauge: 'avg',
+};

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -135,9 +135,9 @@ function defaultSortBys(): Sort[] {
 }
 
 function defaultAggregateFields(): AggregateField[] {
-  return [new VisualizeFunction('per_second()')];
+  return [new VisualizeFunction('per_second(value)')];
 }
 
 function defaultAggregateSortBys(): Sort[] {
-  return [{field: 'per_second()', kind: 'desc'}];
+  return [{field: 'per_second(value)', kind: 'desc'}];
 }

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -1,113 +1,11 @@
-import {useEffect} from 'react';
-
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
-import {defined} from 'sentry/utils';
-import usePrevious from 'sentry/utils/usePrevious';
+import {OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   useMetricVisualize,
   useSetMetricVisualize,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
-
-const OPTIONS_BY_TYPE: Record<string, Array<{label: string; value: string}>> = {
-  counter: [
-    {
-      label: 'per_second',
-      value: 'per_second',
-    },
-    {
-      label: 'per_minute',
-      value: 'per_minute',
-    },
-    {
-      label: 'sum',
-      value: 'sum',
-    },
-  ],
-  distribution: [
-    {
-      label: 'p50',
-      value: 'p50',
-    },
-    {
-      label: 'p75',
-      value: 'p75',
-    },
-    {
-      label: 'p90',
-      value: 'p90',
-    },
-    {
-      label: 'p95',
-      value: 'p95',
-    },
-    {
-      label: 'p99',
-      value: 'p99',
-    },
-    {
-      label: 'avg',
-      value: 'avg',
-    },
-    {
-      label: 'min',
-      value: 'min',
-    },
-    {
-      label: 'max',
-      value: 'max',
-    },
-    {
-      label: 'sum',
-      value: 'sum',
-    },
-    {
-      label: 'count',
-      value: 'count',
-    },
-    {
-      label: 'per_second',
-      value: 'per_second',
-    },
-    {
-      label: 'per_minute',
-      value: 'per_minute',
-    },
-  ],
-  gauge: [
-    {
-      label: 'min',
-      value: 'min',
-    },
-    {
-      label: 'max',
-      value: 'max',
-    },
-    {
-      label: 'avg',
-      value: 'avg',
-    },
-    {
-      label: 'last',
-      value: 'last',
-    },
-    {
-      label: 'per_second',
-      value: 'per_second',
-    },
-    {
-      label: 'per_minute',
-      value: 'per_minute',
-    },
-  ],
-};
-
-const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
-  counter: 'per_second',
-  distribution: 'p75',
-  gauge: 'avg',
-};
 
 function getFunctionArguments(functionName: string, traceMetric: TraceMetric): string {
   if (functionName === 'per_second' || functionName === 'per_minute') {
@@ -119,29 +17,6 @@ function getFunctionArguments(functionName: string, traceMetric: TraceMetric): s
 export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
-  const previousType = usePrevious(traceMetric.type);
-
-  useEffect(() => {
-    if (
-      defined(previousType) &&
-      previousType !== traceMetric.type &&
-      defined(DEFAULT_YAXIS_BY_TYPE[traceMetric.type]) &&
-      // Don't reset aggregate function if it's already set to a non-default value
-      // This prevents overriding saved query aggregate functions
-      visualize.parsedFunction?.name === DEFAULT_YAXIS_BY_TYPE[previousType]
-    ) {
-      const defaultFunction = DEFAULT_YAXIS_BY_TYPE[traceMetric.type];
-      if (defaultFunction) {
-        const functionArgs = getFunctionArguments(defaultFunction, traceMetric);
-        setVisualize(
-          visualize.replace({
-            yAxis: `${defaultFunction}(${functionArgs})`,
-            chartType: undefined, // Reset chart type to let determineDefaultChartType decide
-          })
-        );
-      }
-    }
-  }, [setVisualize, visualize, traceMetric.type, previousType, traceMetric]);
 
   return (
     <CompactSelect

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -1,0 +1,166 @@
+import type {ReactNode} from 'react';
+
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {
+  MultiMetricsQueryParamsProvider,
+  useMultiMetricsQueryParams,
+} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <MultiMetricsQueryParamsProvider>{children}</MultiMetricsQueryParamsProvider>;
+}
+
+describe('MultiMetricsQueryParamsProvider', () => {
+  it('sets defaults', () => {
+    const {result} = renderHookWithProviders(() => useMultiMetricsQueryParams(), {
+      additionalWrapper: Wrapper,
+    });
+
+    expect(result.current).toEqual([
+      {
+        metric: {name: '', type: ''},
+        queryParams: new ReadableQueryParams({
+          extrapolate: true,
+          mode: Mode.AGGREGATE,
+          query: '',
+
+          cursor: '',
+          fields: ['id', 'timestamp'],
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+
+          aggregateCursor: '',
+          aggregateFields: [new VisualizeFunction('per_second(value)')],
+          aggregateSortBys: [{field: 'per_second(value)', kind: 'desc'}],
+        }),
+        removeMetric: expect.any(Function),
+        setQueryParams: expect.any(Function),
+        setTraceMetric: expect.any(Function),
+      },
+    ]);
+  });
+
+  it('updates to compatible aggregate when changing metrics', () => {
+    const {result} = renderHookWithProviders(() => useMultiMetricsQueryParams(), {
+      additionalWrapper: Wrapper,
+    });
+
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'counter'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'foo', type: 'counter'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('per_second(value,counter)')],
+        }),
+      }),
+    ]);
+
+    act(() => result.current[0]!.setTraceMetric({name: 'bar', type: 'gauge'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'bar', type: 'gauge'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('per_second(value,gauge)')],
+        }),
+      }),
+    ]);
+
+    act(() => result.current[0]!.setTraceMetric({name: 'qux', type: 'distribution'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'qux', type: 'distribution'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('per_second(value,distribution)')],
+        }),
+      }),
+    ]);
+  });
+
+  it('updates incompatible aggregate when changing metrics', () => {
+    const {result} = renderHookWithProviders(() => useMultiMetricsQueryParams(), {
+      additionalWrapper: Wrapper,
+    });
+
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'counter'}));
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [new VisualizeFunction('sum(value)')],
+        })
+      )
+    );
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'foo', type: 'counter'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('sum(value)')],
+        }),
+      }),
+    ]);
+
+    act(() => result.current[0]!.setTraceMetric({name: 'qux', type: 'gauge'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'qux', type: 'gauge'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('avg(value)')],
+        }),
+      }),
+    ]);
+
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [new VisualizeFunction('last(value)')],
+        })
+      )
+    );
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'qux', type: 'gauge'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('last(value)')],
+        }),
+      }),
+    ]);
+
+    act(() => result.current[0]!.setTraceMetric({name: 'bar', type: 'distribution'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'bar', type: 'distribution'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('p75(value)')],
+        }),
+      }),
+    ]);
+
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [new VisualizeFunction('p99(value)')],
+        })
+      )
+    );
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'bar', type: 'distribution'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('p99(value)')],
+        }),
+      }),
+    ]);
+
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'counter'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'foo', type: 'counter'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('per_second(value,counter)')],
+        }),
+      }),
+    ]);
+  });
+});

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -153,13 +153,12 @@ export function getMetricsUrlFromSavedQueryUrl({
 
     return {
       ...defaultQuery,
-      queryParams: {
-        ...defaultQuery.queryParams,
+      queryParams: defaultQuery.queryParams.replace({
         mode: queryItem.mode,
         query: queryItem.query,
         aggregateFields,
         aggregateSortBys: decodeSorts(queryItem.orderby) || [],
-      },
+      }),
     };
   });
 

--- a/static/app/views/explore/queryParams/readableQueryParams.ts
+++ b/static/app/views/explore/queryParams/readableQueryParams.ts
@@ -59,4 +59,20 @@ export class ReadableQueryParams {
     this.id = options.id;
     this.title = options.title;
   }
+
+  replace(options: Partial<ReadableQueryParamsOptions>) {
+    return new ReadableQueryParams({
+      aggregateCursor: options.aggregateCursor ?? this.aggregateCursor,
+      aggregateFields: options.aggregateFields ?? this.aggregateFields,
+      aggregateSortBys: options.aggregateSortBys ?? this.aggregateSortBys,
+      cursor: options.cursor ?? this.cursor,
+      extrapolate: options.extrapolate ?? this.extrapolate,
+      fields: options.fields ?? this.fields,
+      mode: options.mode ?? this.mode,
+      query: options.query ?? this.query,
+      sortBys: options.sortBys ?? this.sortBys,
+      id: options.id ?? this.id,
+      title: options.title ?? this.title,
+    });
+  }
 }


### PR DESCRIPTION
By default the per second argument is unset. This does 2 things

1. ensure it is set by default
2. when the aggregation changes, ensure it updates the aggregation as needed