### PR TITLE
feat(consumer): add option for configuring JoinProfiler sample rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3625,3 +3625,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Sets the sample rate for profiles collected via the JoinProfiler arroyo strategy
+# TODO: add the JoinProfiler arroyo strategy
+register(
+    "consumer.join.profiling.rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3632,5 +3632,5 @@ register(
     "consumer.join.profiling.rate",
     type=Float,
     default=0.0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/102140 I'm adding a custom arroyo strategy to profile the `join()` method on our consumers. This option will be used to configure the profiling sample rate for the `consumer.join` transaction by adding it to our [profiles_sampler](https://github.com/getsentry/sentry/blob/master/src/sentry/utils/sdk.py#L206-L208) function.