### PR TITLE
feat(tracemetrics): Try out sample rate and timing

### DIFF
--- a/src/sentry/metrics/sentry_sdk.py
+++ b/src/sentry/metrics/sentry_sdk.py
@@ -47,6 +47,9 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
+        if sample_rate:
+            metric_attributes["sentry.client_sample_rate"] = sample_rate
+
         metrics.count(
             full_key,
             amount,
@@ -63,7 +66,29 @@ class SentrySDKMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         stacklevel: int = 0,
     ) -> None:
-        pass
+
+        full_key = self._get_key(key)
+        if not self._should_send(full_key):
+            return
+
+        if not self._should_sample(sample_rate):
+            return
+
+        metric_attributes = dict(tags) if tags else {}
+        if instance:
+            metric_attributes["instance"] = instance
+
+        if sample_rate:
+            metric_attributes["sentry.client_sample_rate"] = sample_rate
+
+        metric_attributes["is_timing"] = True
+
+        metrics.gauge(
+            full_key,
+            value,
+            unit="millisecond",  # MetricUnit
+            attributes=metric_attributes,
+        )
 
     def gauge(
         self,
@@ -85,6 +110,9 @@ class SentrySDKMetricsBackend(MetricsBackend):
         metric_attributes = dict(tags) if tags else {}
         if instance:
             metric_attributes["instance"] = instance
+
+        if sample_rate:
+            metric_attributes["sentry.client_sample_rate"] = sample_rate
 
         metrics.gauge(
             full_key,
@@ -113,6 +141,9 @@ class SentrySDKMetricsBackend(MetricsBackend):
         metric_attributes = dict(tags) if tags else {}
         if instance:
             metric_attributes["instance"] = instance
+
+        if sample_rate:
+            metric_attributes["sentry.client_sample_rate"] = sample_rate
 
         metrics.distribution(
             full_key,

--- a/src/sentry/metrics/sentry_sdk.py
+++ b/src/sentry/metrics/sentry_sdk.py
@@ -83,10 +83,10 @@ class SentrySDKMetricsBackend(MetricsBackend):
 
         metric_attributes["is_timing"] = True
 
-        metrics.gauge(
+        metrics.distribution(
             full_key,
             value,
-            unit="millisecond",  # MetricUnit
+            unit="millisecond",
             attributes=metric_attributes,
         )
 

--- a/src/sentry/metrics/sentry_sdk.py
+++ b/src/sentry/metrics/sentry_sdk.py
@@ -47,7 +47,7 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate:
+        if sample_rate != 1.0:
             metric_attributes["sentry.client_sample_rate"] = sample_rate
 
         metrics.count(
@@ -78,7 +78,7 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate:
+        if sample_rate != 1.0:
             metric_attributes["sentry.client_sample_rate"] = sample_rate
 
         metric_attributes["is_timing"] = True
@@ -111,7 +111,7 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate:
+        if sample_rate != 1.0:
             metric_attributes["sentry.client_sample_rate"] = sample_rate
 
         metrics.gauge(
@@ -142,7 +142,7 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate:
+        if sample_rate != 1.0:
             metric_attributes["sentry.client_sample_rate"] = sample_rate
 
         metrics.distribution(

--- a/tests/sentry/metrics/test_sentry_sdk.py
+++ b/tests/sentry/metrics/test_sentry_sdk.py
@@ -70,8 +70,17 @@ class TestSentrySDKMetricsBackend:
             attributes={"x": "y", "instance": "web"},
         )
 
-    def test_timing_noop(self, backend):
-        backend.timing("foo", 42.0)
+    @mock.patch("sentry_sdk.metrics.gauge")
+    def test_timing(self, mock_gauge, backend):
+        with mock.patch.object(backend, "_should_send", return_value=True):
+            backend.timing("foo", 42.0, tags={"x": "y"})
+
+        mock_gauge.assert_called_once_with(
+            "test.foo",
+            42.0,
+            unit="millisecond",
+            attributes={"x": "y", "is_timing": True},
+        )
 
     def test_event_noop(self, backend):
         backend.event("title", "message")
@@ -92,3 +101,65 @@ class TestSentrySDKMetricsBackend:
 
         backend.incr("allowed.metric", amount=1)
         mock_count.assert_called_once()
+
+    @mock.patch("sentry_sdk.metrics.count")
+    def test_incr_with_sample_rate(self, mock_count, backend):
+        with (
+            mock.patch.object(backend, "_should_send", return_value=True),
+            mock.patch.object(backend, "_should_sample", return_value=True),
+        ):
+            backend.incr("foo", tags={"x": "y"}, amount=2, sample_rate=0.5)
+
+        mock_count.assert_called_once_with(
+            "test.foo",
+            2,
+            unit=None,
+            attributes={"x": "y", "sentry.client_sample_rate": 0.5},
+        )
+
+    @mock.patch("sentry_sdk.metrics.gauge")
+    def test_gauge_with_sample_rate(self, mock_gauge, backend):
+        with (
+            mock.patch.object(backend, "_should_send", return_value=True),
+            mock.patch.object(backend, "_should_sample", return_value=True),
+        ):
+            backend.gauge("bar", value=42.0, tags={"x": "y"}, sample_rate=0.25, unit="bytes")
+
+        mock_gauge.assert_called_once_with(
+            "test.bar",
+            42.0,
+            unit="bytes",
+            attributes={"x": "y", "sentry.client_sample_rate": 0.25},
+        )
+
+    @mock.patch("sentry_sdk.metrics.distribution")
+    def test_distribution_with_sample_rate(self, mock_distribution, backend):
+        with (
+            mock.patch.object(backend, "_should_send", return_value=True),
+            mock.patch.object(backend, "_should_sample", return_value=True),
+        ):
+            backend.distribution(
+                "baz", value=100.0, tags={"x": "y"}, sample_rate=0.1, unit="millisecond"
+            )
+
+        mock_distribution.assert_called_once_with(
+            "test.baz",
+            100.0,
+            unit="millisecond",
+            attributes={"x": "y", "sentry.client_sample_rate": 0.1},
+        )
+
+    @mock.patch("sentry_sdk.metrics.gauge")
+    def test_timing_with_sample_rate(self, mock_gauge, backend):
+        with (
+            mock.patch.object(backend, "_should_send", return_value=True),
+            mock.patch.object(backend, "_should_sample", return_value=True),
+        ):
+            backend.timing("foo", 42.0, tags={"x": "y"}, sample_rate=0.75)
+
+        mock_gauge.assert_called_once_with(
+            "test.foo",
+            42.0,
+            unit="millisecond",
+            attributes={"x": "y", "sentry.client_sample_rate": 0.75, "is_timing": True},
+        )

--- a/tests/sentry/metrics/test_sentry_sdk.py
+++ b/tests/sentry/metrics/test_sentry_sdk.py
@@ -70,12 +70,12 @@ class TestSentrySDKMetricsBackend:
             attributes={"x": "y", "instance": "web"},
         )
 
-    @mock.patch("sentry_sdk.metrics.gauge")
-    def test_timing(self, mock_gauge, backend):
+    @mock.patch("sentry_sdk.metrics.distribution")
+    def test_timing(self, mock_distribution, backend):
         with mock.patch.object(backend, "_should_send", return_value=True):
             backend.timing("foo", 42.0, tags={"x": "y"})
 
-        mock_gauge.assert_called_once_with(
+        mock_distribution.assert_called_once_with(
             "test.foo",
             42.0,
             unit="millisecond",
@@ -149,15 +149,15 @@ class TestSentrySDKMetricsBackend:
             attributes={"x": "y", "sentry.client_sample_rate": 0.1},
         )
 
-    @mock.patch("sentry_sdk.metrics.gauge")
-    def test_timing_with_sample_rate(self, mock_gauge, backend):
+    @mock.patch("sentry_sdk.metrics.distribution")
+    def test_timing_with_sample_rate(self, mock_distribution, backend):
         with (
             mock.patch.object(backend, "_should_send", return_value=True),
             mock.patch.object(backend, "_should_sample", return_value=True),
         ):
             backend.timing("foo", 42.0, tags={"x": "y"}, sample_rate=0.75)
 
-        mock_gauge.assert_called_once_with(
+        mock_distribution.assert_called_once_with(
             "test.foo",
             42.0,
             unit="millisecond",


### PR DESCRIPTION
### Summary
This adds sample rate code and allows 'timing' to be sent (as a gauge, but for us it doesn't matter functionally).
