### PR TITLE
fix(uptime): Aggregate timeseries data instead of overwriting

### DIFF
--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -200,7 +200,9 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
 
             for bucket, data_point in zip(timeseries.buckets, timeseries.data_points):
                 value = int(data_point.data) if data_point.data_present else 0
-                formatted_data[subscription_id][bucket.seconds][status] = value
+                # Add to existing value instead of overwriting, since multiple timeseries
+                # may contribute to the same status (e.g., success with different incident_status values)
+                formatted_data[subscription_id][bucket.seconds][status] += value
 
         final_data: dict[str, list[tuple[int, dict[str, int]]]] = {}
         for subscription_id, timestamps in formatted_data.items():


### PR DESCRIPTION
The uptime stats endpoint was missing OK checks before and after downtime
because Snuba returns separate timeseries for each (check_status,
incident_status) combination. When processing these timeseries, the code was
overwriting values instead of aggregating them, causing checks with
NO_INCIDENT status to be erased by empty buckets from IN_INCIDENT timeseries.

Changed the value assignment to use addition (+=) so that success checks from
both incident states are properly aggregated into the final timeline.