### PR TITLE
fix(spans-migration): migrated widgets changing dataset source to default

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1025,12 +1025,10 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         widget.dataset_source = new_dataset_source
         widget.detail = {"layout": data.get("layout", prev_layout)}
 
-        if (
-            new_dataset_source == DatasetSourcesTypes.USER.value
-            and widget.widget_type == DashboardWidgetTypes.SPANS
-        ):
-            widget.changed_reason = None
-
+        if widget.widget_type == DashboardWidgetTypes.SPANS:
+            if new_dataset_source == DatasetSourcesTypes.USER.value:
+                widget.changed_reason = None
+        # we don't want to reset dataset source for spans widgets in case they are part of the migration
         elif widget.widget_type not in [
             DashboardWidgetTypes.DISCOVER,
             DashboardWidgetTypes.TRANSACTION_LIKE,

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1031,7 +1031,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         ):
             widget.changed_reason = None
 
-        if widget.widget_type not in [
+        elif widget.widget_type not in [
             DashboardWidgetTypes.DISCOVER,
             DashboardWidgetTypes.TRANSACTION_LIKE,
             DashboardWidgetTypes.ERROR_EVENTS,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -25,6 +25,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetQueryOnDemand,
     DashboardWidgetTypes,
 )
+from sentry.models.dashboard_widget import DatasetSourcesTypes as DashboardWidgetDatasetSourcesTypes
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
@@ -1771,7 +1772,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             dashboard=new_dashboard,
             title="Spans widget",
             widget_type=DashboardWidgetTypes.SPANS,
-            dataset_source=DatasetSourcesTypes.UNKNOWN.value,
+            dataset_source=DashboardWidgetDatasetSourcesTypes.SPAN_MIGRATION_VERSION_1.value,
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             changed_reason=[
                 {
@@ -1793,6 +1794,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "widgetType": "spans",
                     "datasetSource": "user",
                     "displayType": "line",
+                    "changedReason": spans_widget.changed_reason,
                     "queries": [
                         {
                             "name": "Errors",
@@ -1811,6 +1813,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][0]["changedReason"] is None
         spans_widget.refresh_from_db()
         assert spans_widget.changed_reason is None
+        assert spans_widget.dataset_source == DashboardWidgetDatasetSourcesTypes.USER.value
 
     def test_remove_widgets(self) -> None:
         data = {


### PR DESCRIPTION
We had added some validation in the backend for changing the `dataset_source` and the `changed_reason` fields when a migrated widget has been saved by the user. There was some issues with that because the condition after would be true and and also alter the `dataset_source` to something we didn't want. I've fixed this issue so that the other condition doesn't touch spans widgets for the sake of this migration.
