### PR TITLE
feat(aci): Add metric to track AlertRule usage in APIs

### DIFF
--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -28,6 +28,10 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.receivers.rule_snooze import _update_workflow_engine_models
+from sentry.workflow_engine.utils.legacy_metric_tracking import (
+    report_used_legacy_models,
+    track_alert_endpoint_execution,
+)
 
 
 def can_edit_alert_rule(organization, request):
@@ -275,6 +279,18 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[AlertRule]):
         "POST": ApiPublishStatus.PRIVATE,
     }
     rule_field = "alert_rule"
+
+    @track_alert_endpoint_execution("sentry-api-0-metric-rule-snooze")
+    def post(self, request: Request, project: Project, rule: AlertRule) -> Response:
+        # Mark that we're using legacy AlertRule models
+        report_used_legacy_models()
+        return super().post(request, project, rule)
+
+    @track_alert_endpoint_execution("sentry-api-0-metric-rule-snooze")
+    def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:
+        # Mark that we're using legacy AlertRule models
+        report_used_legacy_models()
+        return super().delete(request, project, rule)
 
     def fetch_rule_list(self, project: Project) -> BaseQuerySet[AlertRule]:
         queryset = AlertRule.objects.fetch_for_project(project=project)

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -280,13 +280,13 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[AlertRule]):
     }
     rule_field = "alert_rule"
 
-    @track_alert_endpoint_execution("sentry-api-0-metric-rule-snooze")
+    @track_alert_endpoint_execution("POST", "sentry-api-0-metric-rule-snooze")
     def post(self, request: Request, project: Project, rule: AlertRule) -> Response:
         # Mark that we're using legacy AlertRule models
         report_used_legacy_models()
         return super().post(request, project, rule)
 
-    @track_alert_endpoint_execution("sentry-api-0-metric-rule-snooze")
+    @track_alert_endpoint_execution("DELETE", "sentry-api-0-metric-rule-snooze")
     def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:
         # Mark that we're using legacy AlertRule models
         report_used_legacy_models()

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -8,6 +8,7 @@ from sentry.incidents.models.incident import IncidentActivity
 from sentry.interfaces.user import EventUserApiContext
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
 class IncidentActivitySerializerResponse(TypedDict):
@@ -33,6 +34,9 @@ class IncidentActivitySerializer(Serializer):
         return {item: {"user": user_lookup.get(str(item.user_id))} for item in item_list}
 
     def serialize(self, obj, attrs, user, **kwargs) -> IncidentActivitySerializerResponse:
+        # Mark that we're using legacy IncidentActivity models (which depend on Incident -> AlertRule)
+        report_used_legacy_models()
+
         incident = obj.incident
 
         return {

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -52,6 +52,7 @@ from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
 from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 logger = logging.getLogger(__name__)
 
@@ -339,6 +340,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         },
         examples=MetricAlertExamples.GET_METRIC_ALERT_RULE,
     )
+    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def get(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
         """
@@ -365,6 +367,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         },
         examples=MetricAlertExamples.UPDATE_METRIC_ALERT_RULE,
     )
+    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def put(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
         """
@@ -394,6 +397,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
+    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def delete(
         self, request: Request, organization: Organization, alert_rule: AlertRule

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -340,7 +340,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         },
         examples=MetricAlertExamples.GET_METRIC_ALERT_RULE,
     )
-    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rule-details")
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def get(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
         """
@@ -367,7 +367,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         },
         examples=MetricAlertExamples.UPDATE_METRIC_ALERT_RULE,
     )
-    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rule-details")
+    @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def put(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
         """
@@ -397,7 +397,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rule-details")
+    @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def delete(
         self, request: Request, organization: Organization, alert_rule: AlertRule

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -250,7 +250,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @track_alert_endpoint_execution("sentry-api-0-organization-combined-rules")
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-combined-rules")
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches metric, issue, crons, and uptime alert rules for an organization
@@ -641,7 +641,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         },
         examples=MetricAlertExamples.LIST_METRIC_ALERT_RULES,  # TODO: make
     )
-    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rules")
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rules")
     def get(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         Return a list of active metric alert rules bound to an organization.
@@ -669,7 +669,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         },
         examples=MetricAlertExamples.CREATE_METRIC_ALERT_RULE,
     )
-    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rules")
+    @track_alert_endpoint_execution("POST", "sentry-api-0-organization-alert-rules")
     def post(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         Create a new metric alert rule for the given organization.

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -81,6 +81,7 @@ from sentry.uptime.types import (
 from sentry.utils.cursors import Cursor, StringCursor
 from sentry.workflow_engine.models import Detector, DetectorState
 from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +250,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @track_alert_endpoint_execution("sentry-api-0-organization-combined-rules")
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches metric, issue, crons, and uptime alert rules for an organization
@@ -639,6 +641,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         },
         examples=MetricAlertExamples.LIST_METRIC_ALERT_RULES,  # TODO: make
     )
+    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rules")
     def get(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         Return a list of active metric alert rules bound to an organization.
@@ -666,6 +669,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         },
         examples=MetricAlertExamples.CREATE_METRIC_ALERT_RULE,
     )
+    @track_alert_endpoint_execution("sentry-api-0-organization-alert-rules")
     def post(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         Create a new metric alert rule for the given organization.

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -39,7 +39,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
-    @track_alert_endpoint_execution("sentry-api-0-organization-incident-details")
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-details")
     def get(self, request: Request, organization, incident) -> Response:
         """
         Fetch an Incident.
@@ -50,7 +50,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return Response(data)
 
-    @track_alert_endpoint_execution("sentry-api-0-organization-incident-details")
+    @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-incident-details")
     def put(self, request: Request, organization: Organization, incident) -> Response:
         serializer = IncidentSerializer(data=request.data)
         if serializer.is_valid():

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -11,6 +11,7 @@ from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSeri
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.models.organization import Organization
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 
 class IncidentSerializer(serializers.Serializer):
@@ -38,6 +39,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
+    @track_alert_endpoint_execution("sentry-api-0-organization-incident-details")
     def get(self, request: Request, organization, incident) -> Response:
         """
         Fetch an Incident.
@@ -48,6 +50,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return Response(data)
 
+    @track_alert_endpoint_execution("sentry-api-0-organization-incident-details")
     def put(self, request: Request, organization: Organization, incident) -> Response:
         serializer = IncidentSerializer(data=request.data)
         if serializer.is_valid():

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -33,7 +33,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
-    @track_alert_endpoint_execution("sentry-api-0-organization-incident-index")
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-index")
     def get(self, request: Request, organization: Organization) -> Response:
         """
         List Incidents that a User can access within an Organization

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -20,6 +20,7 @@ from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import ensure_aware
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 from .utils import parse_team_params
 
@@ -32,6 +33,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
+    @track_alert_endpoint_execution("sentry-api-0-organization-incident-index")
     def get(self, request: Request, organization: Organization) -> Response:
         """
         List Incidents that a User can access within an Organization

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -10,6 +10,7 @@ from sentry.incidents.endpoints.organization_alert_rule_details import (
     remove_alert_rule,
     update_alert_rule,
 )
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 
 @region_silo_endpoint
@@ -21,6 +22,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
 
+    @track_alert_endpoint_execution("sentry-api-0-project-alert-rule-details")
     def get(self, request: Request, project, alert_rule) -> Response:
         """
         Fetch a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.
@@ -29,6 +31,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         """
         return fetch_alert_rule(request, project.organization, alert_rule)
 
+    @track_alert_endpoint_execution("sentry-api-0-project-alert-rule-details")
     def put(self, request: Request, project, alert_rule) -> Response:
         """
         Update a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.
@@ -37,6 +40,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         """
         return update_alert_rule(request, project.organization, alert_rule)
 
+    @track_alert_endpoint_execution("sentry-api-0-project-alert-rule-details")
     def delete(self, request: Request, project, alert_rule) -> Response:
         """
         Delete a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -22,7 +22,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    @track_alert_endpoint_execution("sentry-api-0-project-alert-rule-details")
+    @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rule-details")
     def get(self, request: Request, project, alert_rule) -> Response:
         """
         Fetch a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.
@@ -31,7 +31,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         """
         return fetch_alert_rule(request, project.organization, alert_rule)
 
-    @track_alert_endpoint_execution("sentry-api-0-project-alert-rule-details")
+    @track_alert_endpoint_execution("PUT", "sentry-api-0-project-alert-rule-details")
     def put(self, request: Request, project, alert_rule) -> Response:
         """
         Update a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.
@@ -40,7 +40,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         """
         return update_alert_rule(request, project.organization, alert_rule)
 
-    @track_alert_endpoint_execution("sentry-api-0-project-alert-rule-details")
+    @track_alert_endpoint_execution("DELETE", "sentry-api-0-project-alert-rule-details")
     def delete(self, request: Request, project, alert_rule) -> Response:
         """
         Delete a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -24,7 +24,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
     }
     permission_classes = (ProjectAlertRulePermission,)
 
-    @track_alert_endpoint_execution("sentry-api-0-project-alert-rules")
+    @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rules")
     def get(self, request: Request, project) -> HttpResponseBase:
         """
         Fetches metric alert rules for a project - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
@@ -32,7 +32,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
         alert_rules = AlertRule.objects.fetch_for_project(project)
         return self.fetch_metric_alert(request, project.organization, alert_rules)
 
-    @track_alert_endpoint_execution("sentry-api-0-project-alert-rules")
+    @track_alert_endpoint_execution("POST", "sentry-api-0-project-alert-rules")
     def post(self, request: Request, project) -> HttpResponseBase:
         """
         Create an alert rule - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -12,6 +12,7 @@ from sentry.incidents.endpoints.organization_alert_rule_index import (
     create_metric_alert,
 )
 from sentry.incidents.models.alert_rule import AlertRule
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 
 @region_silo_endpoint
@@ -23,6 +24,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
     }
     permission_classes = (ProjectAlertRulePermission,)
 
+    @track_alert_endpoint_execution("sentry-api-0-project-alert-rules")
     def get(self, request: Request, project) -> HttpResponseBase:
         """
         Fetches metric alert rules for a project - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
@@ -30,6 +32,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleIndexMixin):
         alert_rules = AlertRule.objects.fetch_for_project(project)
         return self.fetch_metric_alert(request, project.organization, alert_rules)
 
+    @track_alert_endpoint_execution("sentry-api-0-project-alert-rules")
     def post(self, request: Request, project) -> HttpResponseBase:
         """
         Create an alert rule - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -35,6 +35,7 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 logger = logging.getLogger(__name__)
 
@@ -254,6 +255,9 @@ class AlertRuleSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> AlertRuleSerializerResponse:
+        # Mark that we're using legacy AlertRule models
+        report_used_legacy_models()
+
         from sentry.incidents.endpoints.utils import translate_threshold
         from sentry.incidents.logic import translate_aggregate_field
 
@@ -464,6 +468,8 @@ class CombinedRuleSerializer(Serializer):
     ) -> MutableMapping[Any, Any]:
         updated_attrs = {**attrs}
         if isinstance(obj, AlertRule):
+            # Mark that we're using legacy AlertRule models
+            report_used_legacy_models()
             updated_attrs["type"] = "alert_rule"
         elif isinstance(obj, Rule):
             updated_attrs["type"] = "rule"

--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger.py
@@ -6,6 +6,7 @@ from django.db.models import prefetch_related_objects
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.endpoints.utils import translate_threshold
 from sentry.incidents.models.alert_rule import AlertRuleTrigger, AlertRuleTriggerAction
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
 @register(AlertRuleTrigger)
@@ -29,6 +30,9 @@ class AlertRuleTriggerSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
+        # Mark that we're using legacy AlertRuleTrigger models
+        report_used_legacy_models()
+
         return {
             "id": str(obj.id),
             "alertRuleId": str(obj.alert_rule_id),

--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -2,6 +2,7 @@ import logging
 
 from sentry.api.serializers import Serializer, register
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,9 @@ def get_input_channel_id(action_type, target_identifier=None):
 class AlertRuleTriggerActionSerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs):
+        # Mark that we're using legacy AlertRuleTriggerAction models
+        report_used_legacy_models()
+
         from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
 
         priority = (

--- a/src/sentry/incidents/endpoints/serializers/incident.py
+++ b/src/sentry/incidents/endpoints/serializers/incident.py
@@ -13,6 +13,7 @@ from sentry.incidents.endpoints.serializers.alert_rule import (
 from sentry.incidents.models.incident import Incident, IncidentActivity, IncidentProject
 from sentry.snuba.entity_subscription import apply_dataset_query_conditions
 from sentry.snuba.models import SnubaQuery
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
 class IncidentSerializerResponse(TypedDict):
@@ -76,6 +77,9 @@ class IncidentSerializer(Serializer):
         return results
 
     def serialize(self, obj, attrs, user, **kwargs) -> IncidentSerializerResponse:
+        # Mark that we're using legacy Incident models (which depend on AlertRule)
+        report_used_legacy_models()
+
         date_closed = obj.date_closed.replace(second=0, microsecond=0) if obj.date_closed else None
         return {
             "id": str(obj.id),

--- a/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
+++ b/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
@@ -1,0 +1,95 @@
+"""
+Utilities for tracking legacy AlertRule model usage in API endpoints.
+
+This module provides a decorator and reporting mechanism to track which endpoints
+are using legacy AlertRule models vs the new workflow engine models. This helps
+with migration progress tracking.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from contextvars import ContextVar
+from typing import Any, TypeVar
+
+from django.http import HttpResponseBase
+
+from sentry.utils import metrics
+
+# ContextVar to track whether legacy models were used in the current request context
+_legacy_models_used: ContextVar[bool] = ContextVar("legacy_models_used", default=False)
+
+T = TypeVar("T", bound=HttpResponseBase)
+
+
+def report_used_legacy_models() -> None:
+    """
+    Mark the current request context as having used legacy AlertRule models.
+
+    This should be called from:
+    - Serializers that serialize AlertRule or related models
+    - Endpoint logic that directly uses AlertRule models
+
+    The value is tracked in a ContextVar and will be read when the
+    track_alert_endpoint_execution decorator exits.
+    """
+    _legacy_models_used.set(True)
+
+
+def track_alert_endpoint_execution(
+    route_name: str,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """
+    Decorator to track execution of alert-related endpoints and report metrics.
+
+    This decorator:
+    1. Sets up a ContextVar context for tracking legacy model usage
+    2. Executes the endpoint method
+    3. Reports a metric with whether legacy models were used
+
+    Args:
+        route_name: Django route name for the endpoint (e.g.,
+                   "sentry-api-0-organization-alert-rule-details")
+
+    Usage:
+        @track_alert_endpoint_execution("sentry-api-0-organization-alert-rule-details")
+        def get(self, request: Request, organization: Organization) -> Response:
+            ...
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            # Reset the context var for this request
+            token = _legacy_models_used.set(False)
+
+            # Extract request object to get HTTP method
+            # The request is typically the second argument (after self)
+            request = None
+            if len(args) > 1 and hasattr(args[1], "method"):
+                request = args[1]
+
+            try:
+                # Execute the endpoint
+                response = func(*args, **kwargs)
+                return response
+            finally:
+                # Report the metric after execution
+                legacy_models = _legacy_models_used.get()
+                http_method = request.method if request else "UNKNOWN"
+
+                metrics.incr(
+                    "alert_endpoint.executed",
+                    tags={
+                        "endpoint": route_name,
+                        "method": http_method,
+                        "legacy_models": str(legacy_models).lower(),
+                    },
+                )
+                # Reset the context var
+                _legacy_models_used.reset(token)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
To keep an eye on remaining uses of AlertRule in our APIs, this adds a decorator for in-scope API endpoints that
logs a metric and tracks whether a marker method (`report_used_legacy_models`) was called during the execution.
This way, assuming we're properly annotated, we can dynamically know which percentage of requests use legacy model objects, which requests use them, what percent of endpoints are still using them, etc.
