### PR TITLE
feat(dashboards): delete dashboard link when you delete/change a field

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -788,47 +788,49 @@ function Visualize({error, setError}: VisualizeProps) {
                               }}
                             />
                           )}
-                          {hasDrillDownFlows && isTableWidget && (
-                            <Button
-                              borderless
-                              icon={<IconLink />}
-                              aria-label={t('Link field')}
-                              size="zero"
-                              onClick={() => {
-                                openLinkToDashboardModal({
-                                  onLink: dashboardId => {
-                                    if (
-                                      fields[index]?.kind === FieldValueKind.FIELD &&
-                                      fields[index]?.field
-                                    ) {
-                                      const newLinkedDashboards: LinkedDashboard[] = [
-                                        ...linkedDashboards,
-                                        {dashboardId, field: fields[index].field},
-                                      ];
-                                      dispatch({
-                                        type: BuilderStateAction.SET_LINKED_DASHBOARDS,
-                                        payload: newLinkedDashboards,
-                                      });
-                                    }
-                                  },
-                                  currentLinkedDashboard: linkedDashboards.find(
-                                    linkedDashboard => {
+                          {hasDrillDownFlows &&
+                            isTableWidget &&
+                            fields[index]?.kind === FieldValueKind.FIELD && (
+                              <Button
+                                borderless
+                                icon={<IconLink />}
+                                aria-label={t('Link field')}
+                                size="zero"
+                                onClick={() => {
+                                  openLinkToDashboardModal({
+                                    onLink: dashboardId => {
                                       if (
                                         fields[index]?.kind === FieldValueKind.FIELD &&
                                         fields[index]?.field
                                       ) {
-                                        return (
-                                          linkedDashboard.field === fields[index].field
-                                        );
+                                        const newLinkedDashboards: LinkedDashboard[] = [
+                                          ...linkedDashboards,
+                                          {dashboardId, field: fields[index].field},
+                                        ];
+                                        dispatch({
+                                          type: BuilderStateAction.SET_LINKED_DASHBOARDS,
+                                          payload: newLinkedDashboards,
+                                        });
                                       }
-                                      return false;
-                                    }
-                                  ),
-                                  source,
-                                });
-                              }}
-                            />
-                          )}
+                                    },
+                                    currentLinkedDashboard: linkedDashboards.find(
+                                      linkedDashboard => {
+                                        if (
+                                          fields[index]?.kind === FieldValueKind.FIELD &&
+                                          fields[index]?.field
+                                        ) {
+                                          return (
+                                            linkedDashboard.field === fields[index].field
+                                          );
+                                        }
+                                        return false;
+                                      }
+                                    ),
+                                    source,
+                                  });
+                                }}
+                              />
+                            )}
                           <Button
                             borderless
                             icon={<IconDelete />}

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -380,6 +380,13 @@ function useWidgetBuilderState(): {
         }
         case BuilderStateAction.SET_FIELDS: {
           setFields(action.payload, options);
+          const remainingKindFields = action.payload.filter(
+            field => field.kind === FieldValueKind.FIELD
+          );
+          const remainingLinkedDashboards = linkedDashboards?.filter(linkedDashboard =>
+            remainingKindFields.some(field => field.field === linkedDashboard.field)
+          );
+          setLinkedDashboards(remainingLinkedDashboards, options);
 
           const isRemoved = action.payload.length < (fields?.length ?? 0);
           if (
@@ -593,6 +600,7 @@ function useWidgetBuilderState(): {
       fields,
       yAxis,
       displayType,
+      linkedDashboards,
       query,
       sort,
       dataset,


### PR DESCRIPTION
1. Remove associated dashboard link in frontend state when you delete or change an associated column, closes BROWSE-69
2. Don't allow users to link from a non-field column, closes BROWSE-98