### PR TITLE
chore(feedback): Set feedback summaries/categories feature badge to new

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -75,7 +75,7 @@ export default function FeedbackSummaryCategories() {
           }
         >
           <Flex gap="xs" align="center">
-            {t('Summary')} <FeatureBadge type="beta" />
+            {t('Summary')} <FeatureBadge type="new" />
           </Flex>
         </Disclosure.Title>
         <Disclosure.Content>


### PR DESCRIPTION
Feedback summaries and categories were GA'd 2 weeks ago under the "beta" badge. Let's change the feature badge to "new".

Before
<img width="401" height="200" alt="Screenshot 2025-11-03 at 9 11 22 AM" src="https://github.com/user-attachments/assets/0a7c2878-85ad-453a-88d5-883245f85ab3" />


After

<img width="401" height="199" alt="Screenshot 2025-11-03 at 9 10 29 AM" src="https://github.com/user-attachments/assets/eb99d8f3-a37e-45f8-a9f0-a7f7996a2b8e" />
