### PR TITLE
chore(jira): Catch Jira HTML error

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -963,7 +963,11 @@ class JiraIntegration(IssueSyncIntegration):
         if not jira_project:
             raise IntegrationFormError({"project": ["Jira project is required"]})
 
-        meta = client.get_create_meta_for_project(jira_project)
+        try:
+            meta = client.get_create_meta_for_project(jira_project)
+        except ApiError as e:
+            self.raise_error(e)
+
         if not meta:
             raise IntegrationConfigurationError(
                 "Could not fetch issue create configuration from Jira."


### PR DESCRIPTION
After looking at the [sentry issue](https://sentry.sentry.io/issues/6919607524/?query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D%20integration_name%3Ajira&referrer=issue-stream&sort=date) closer, I was catching at the wrong place so I think this should actually work this time.