### PR TITLE
fix(dashboards): Ensure custom tag options are displayed when adding global filters

### DIFF
--- a/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
@@ -24,11 +24,6 @@ describe('AddFilter', () => {
       name: 'Unsupported Function',
       kind: FieldKind.FUNCTION,
     },
-    'unsupported.measurement': {
-      key: 'unsupported.measurement',
-      name: 'Unsupported Measurement',
-      kind: FieldKind.MEASUREMENT,
-    },
   };
 
   const getSearchBarData = (_: WidgetType): SearchBarData => ({
@@ -91,9 +86,6 @@ describe('AddFilter', () => {
     // Unsupported filter keys should not be included in the options
     expect(
       screen.queryByText(mockFilterKeys['unsupported.function']!.key)
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(mockFilterKeys['unsupported.measurement']!.key)
     ).not.toBeInTheDocument();
   });
 

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -76,7 +76,7 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
     ? Object.entries(filterKeys).flatMap(([_, tag]) => {
         const fieldDefinition = getFieldDefinitionForDataset(tag, selectedDataset);
         const valueType = fieldDefinition?.valueType;
-        if (!valueType || UNSUPPORTED_FIELD_VALUE_TYPES.includes(valueType)) {
+        if (valueType && UNSUPPORTED_FIELD_VALUE_TYPES.includes(valueType)) {
           return [];
         }
         fieldDefinitionMap.set(tag.key, fieldDefinition);
@@ -127,8 +127,9 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
 
             let defaultFilterValue = '';
             const fieldDefinition = fieldDefinitionMap.get(selectedFilterKey.key) ?? null;
+            const valueType = fieldDefinition?.valueType;
 
-            if (fieldDefinition?.valueType !== FieldValueType.STRING) {
+            if (valueType && valueType !== FieldValueType.STRING) {
               defaultFilterValue = getInitialFilterText(
                 selectedFilterKey.key,
                 fieldDefinition,


### PR DESCRIPTION
Custom tags were being filtered out from the tag options when adding global filters. This PR handles the case where these custom tags don't have value types.

Fixes [DAIN-1057](https://linear.app/getsentry/issue/DAIN-1057/fix-bug-where-custom-tags-arent-shown-when-adding-global-filters)