### PR TITLE
fix(cleanup): Selection of GroupHistory should not order by

### DIFF
--- a/src/sentry/deletions/defaults/grouphistory.py
+++ b/src/sentry/deletions/defaults/grouphistory.py
@@ -22,11 +22,9 @@ class GroupHistoryDeletionTask(ModelDeletionTask[GroupHistory]):
             return super().chunk()
 
         for group_id in group_ids:
-            # Delete history records for a single group in chunks of 100
             queryset = self.model.objects.filter(group_id=group_id)
             while True:
-                # Get IDs for the first 100 records
-                chunk_ids = list(queryset.order_by("id").values_list("id", flat=True)[:100])
+                chunk_ids = list(queryset.values_list("id", flat=True)[:10000])
                 if not chunk_ids:
                     break
                 # Delete records for these IDs

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -343,7 +343,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-
 register(
     "cleanup.abort_execution",
     default=False,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -343,6 +343,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+
 register(
     "cleanup.abort_execution",
     default=False,


### PR DESCRIPTION
Ordering by would required a `group_id` & `id` index which we don't have. We're about to delete all rows, thus, we don't need to sort it.

Fixes [SENTRY-5BX2](https://sentry.sentry.io/issues/6993998110/):

For posterity:
```
OperationalError
canceling statement due to user request

SQL: SELECT "sentry_grouphistory"."id" AS "id" FROM "sentry_grouphistory" WHERE "sentry_grouphistory"."group_id" = %s ORDER BY 1 ASC LIMIT 100
```

The group in question has only been seen 4 times yet it has 905,729 rows of group history. This is caused by the priority of the group changing back and forth between high and medium priority. We're investigating the root cause of it.