### PR TITLE
fix(ui): moment deprecated date formatting in `getFormattedTimestamp()`

### DIFF
--- a/static/app/utils/date/getFormattedTimestamp.tsx
+++ b/static/app/utils/date/getFormattedTimestamp.tsx
@@ -4,17 +4,13 @@ import {t} from 'sentry/locale';
 import getDuration from 'sentry/utils/duration/getDuration';
 
 const timeFormat = 'HH:mm:ss';
-const timeDateFormat = `ll ${timeFormat}`;
 
 const getRelativeTime = (
   parsedTime: ReturnType<typeof moment>,
   parsedTimeToCompareWith: ReturnType<typeof moment>,
   displayRelativeTime?: boolean
 ) => {
-  // ll is necessary here, otherwise moment(x).from will throw an error
-  const formattedTime = moment(parsedTime.format(timeDateFormat));
-  const formattedTimeToCompareWith = parsedTimeToCompareWith.format(timeDateFormat);
-  const timeDiff = Math.abs(formattedTime.diff(formattedTimeToCompareWith));
+  const timeDiff = Math.abs(parsedTime.diff(parsedTimeToCompareWith));
 
   const shortRelativeTime = getDuration(Math.round(timeDiff / 1000), 0, true).replace(
     /\s/g,


### PR DESCRIPTION
This fixes the following console.warn that we are getting in prod:

```
 Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments:
```

`getRelativeTime()` is passed 2 `moment` objects that are formatted into a non-standard date string, that is used to re-create another `moment` object. We can use the `moment` arguments directly instead.
