### PR TITLE
feat(dashboards): render any linkable cell in blue

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -401,6 +401,12 @@ function CellAction({
                     e.preventDefault();
                   }
                 }}
+                hasLinks={
+                  // TODO - hack, ideally we don't directly access the DOM and use a ref instead, ideally we can determin if the cell type has a link
+                  !!document
+                    .getElementById(triggerProps.id ?? '')
+                    ?.getElementsByTagName('a')?.[0]
+                }
               >
                 {children}
               </ActionMenuTriggerV2>
@@ -479,10 +485,10 @@ const ActionMenuTrigger = styled(Button)`
   }
 `;
 
-const ActionMenuTriggerV2 = styled('div')`
+const ActionMenuTriggerV2 = styled('div')<{hasLinks?: boolean}>`
   a,
   span {
-    color: ${p => p.theme.textColor};
+    color: ${p => (p.hasLinks ? p.theme.linkColor : p.theme.textColor)};
   }
   :hover {
     cursor: pointer;


### PR DESCRIPTION
To make it super obvious that a cell contains a link, we can render it as blue
<img width="360" height="238" alt="image" src="https://github.com/user-attachments/assets/536516ab-d7fe-4c11-b3f3-80fe8b1bc0ac" />

Note, were directly accessing the DOM here as it's consistent with how we grab aTags in the click handler. I think we should eventually update this, perhaps the cell renderer also returns a `hasLink` boolean which is gets passed into the `CellAction` component.
