### PR TITLE
fix(relocation) Fix task binding for noop task

### DIFF
--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -1665,7 +1665,7 @@ def completed(uuid: str) -> None:
 
 
 @instrumented_task(
-    name="sentry.relocation.completed",
+    name="sentry.relocation.noop",
     namespace=relocation_tasks,
     processing_deadline_duration=FAST_TIME_LIMIT,
     silo_mode=SiloMode.REGION,


### PR DESCRIPTION
When I added a noop task to relocations to fix typing/call errors I bound the noop task overtop of the `completed` task which resulted in the completed task no longer running.