### PR TITLE
ui2: mutate user options if enforce flag is set

### DIFF
--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -51,7 +51,7 @@ export interface User extends Omit<AvatarUser, 'options'> {
     clock24Hours: boolean;
     defaultIssueEvent: 'recommended' | 'latest' | 'oldest';
     language: string;
-    prefersChonkUI: boolean;
+    prefersChonkUI: boolean | undefined;
     prefersIssueDetailsStreamlinedUI: boolean | null;
     prefersNextjsInsightsOverview: boolean;
     stacktraceOrder: StacktraceOrder;

--- a/tests/js/fixtures/user.ts
+++ b/tests/js/fixtures/user.ts
@@ -17,7 +17,7 @@ export function UserFixture(params: Partial<User> = {}): User {
       stacktraceOrder: -1,
       prefersIssueDetailsStreamlinedUI: true,
       prefersNextjsInsightsOverview: false,
-      prefersChonkUI: false,
+      prefersChonkUI: undefined,
     },
     ip_address: '127.0.0.1',
     hasPasswordAuth: true,


### PR DESCRIPTION
If organization has chonk-ui-enforce flag and user prefersChonkUI is not set to false, opt in user options to use UI2.

If we don't opt users in, then we cannot track the rollout progress as the values will not be updated