### PR TITLE
fix(searchbar): Ensure unsaved page filters are passed into filter tag query

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -179,7 +179,7 @@ function Dashboard({
       GroupStore.reset();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [selection]);
 
   // Handle newWidget parsed from Add to Dashboard flows
   useEffect(() => {

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -158,8 +158,7 @@ function Dashboard({
   useEffect(() => {
     // Always load organization tags on dashboards
     loadOrganizationTags(api, organization.slug, selection);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selection]);
+  }, [api, organization.slug, selection]);
 
   // The operations in this effect should only run on mount/unmount
   useEffect(() => {

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -155,12 +155,15 @@ function Dashboard({
     );
   }, [api, organization.slug, selection.projects]);
 
+  useEffect(() => {
+    // Always load organization tags on dashboards
+    loadOrganizationTags(api, organization.slug, selection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selection]);
+
   // The operations in this effect should only run on mount/unmount
   useEffect(() => {
     window.addEventListener('resize', debouncedHandleResize);
-
-    // Always load organization tags on dashboards
-    loadOrganizationTags(api, organization.slug, selection);
 
     // Get member list data for issue widgets
     fetchMemberList();
@@ -179,7 +182,7 @@ function Dashboard({
       GroupStore.reset();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selection]);
+  }, []);
 
   // Handle newWidget parsed from Add to Dashboard flows
   useEffect(() => {


### PR DESCRIPTION
- Adds page filters to the dashboards use effect that fetches organization tags
- This ensures that all page filter changes (including unsaved changes) are passed into the tag fetching query

Fixes [BROWSE-99](https://linear.app/getsentry/issue/BROWSE-99/ensure-unsaved-page-filters-are-passed-into-filter-tag-query)