### PR TITLE
feat(billing): add transactions to retentions UI

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -642,6 +642,7 @@ describe('CustomerOverview', () => {
     const organization = OrganizationFixture({});
     const subscription = SubscriptionFixture({
       organization,
+      plan: 'am3_f',
     });
 
     subscription.planDetails = {

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -5,10 +5,12 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import Form from 'sentry/components/forms/form';
+import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import useApi from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
+import {hasCategoryFeature} from 'getsentry/utils/dataCategory';
 
 type Props = {
   onSuccess: () => void;
@@ -28,12 +30,6 @@ function UpdateRetentionSettingsModal({
 }: ModalProps) {
   const api = useApi();
 
-  const [spansStandard, setSpansStandard] = useState<number | null | string>(
-    subscription.categories.spans?.retention?.standard ?? null
-  );
-  const [spansDownsampled, setSpansDownsampled] = useState<number | null | string>(
-    subscription.categories.spans?.retention?.downsampled ?? null
-  );
   const [logBytesStandard, setLogBytesStandard] = useState<number | null | string>(
     subscription.categories.logBytes?.retention?.standard ?? null
   );
@@ -41,19 +37,48 @@ function UpdateRetentionSettingsModal({
     subscription.categories.logBytes?.retention?.downsampled ?? null
   );
 
+  const [transactionsStandard, setTransactionsStandard] = useState<
+    number | null | string
+  >(subscription.categories.transactions?.retention?.standard ?? null);
+  const [transactionsDownsampled, setTransactionsDownsampled] = useState<
+    number | null | string
+  >(subscription.categories.transactions?.retention?.downsampled ?? null);
+
+  const [spansStandard, setSpansStandard] = useState<number | null | string>(
+    subscription.categories.spans?.retention?.standard ?? null
+  );
+  const [spansDownsampled, setSpansDownsampled] = useState<number | null | string>(
+    subscription.categories.spans?.retention?.downsampled ?? null
+  );
+
   const onSubmit = () => {
-    const data = {
-      retentions: {
-        spans: {
-          standard: Number(spansStandard),
-          downsampled: spansDownsampled === '' ? null : Number(spansDownsampled),
-        },
-        logBytes: {
-          standard: Number(logBytesStandard),
-          downsampled: logBytesDownsampled === '' ? null : Number(logBytesDownsampled),
-        },
-      },
-    };
+    const retentions: Partial<
+      Record<DataCategory, {downsampled: number | null; standard: number}>
+    > = {};
+
+    if (hasCategoryFeature(DataCategory.LOG_BYTE, subscription, organization)) {
+      retentions.logBytes = {
+        standard: Number(logBytesStandard),
+        downsampled: logBytesDownsampled === '' ? null : Number(logBytesDownsampled),
+      };
+    }
+
+    if (hasCategoryFeature(DataCategory.TRANSACTIONS, subscription, organization)) {
+      retentions.transactions = {
+        standard: Number(transactionsStandard),
+        downsampled:
+          transactionsDownsampled === '' ? null : Number(transactionsDownsampled),
+      };
+    }
+
+    if (hasCategoryFeature(DataCategory.SPANS, subscription, organization)) {
+      retentions.spans = {
+        standard: Number(spansStandard),
+        downsampled: spansDownsampled === '' ? null : Number(spansDownsampled),
+      };
+    }
+
+    const data = {retentions};
 
     api.request(`/_admin/${organization.slug}/retention-settings/`, {
       method: 'POST',
@@ -85,32 +110,58 @@ function UpdateRetentionSettingsModal({
         </div>
         <br />
         <Form onSubmit={onSubmit} submitLabel="Update Settings" onCancel={closeModal}>
-          <NumberField
-            name="spansStandard"
-            label="Spans Standard"
-            defaultValue={spansStandard}
-            onChange={setSpansStandard}
-            required
-          />
-          <NumberField
-            name="spansDownsampled"
-            label="Spans Downsampled"
-            defaultValue={spansDownsampled}
-            onChange={setSpansDownsampled}
-          />
-          <NumberField
-            name="logBytesStandard"
-            label="Logs Standard"
-            defaultValue={logBytesStandard}
-            onChange={setLogBytesStandard}
-            required
-          />
-          <NumberField
-            name="logBytesDownsampled"
-            label="Logs Downsampled"
-            defaultValue={logBytesDownsampled}
-            onChange={setLogBytesDownsampled}
-          />
+          {hasCategoryFeature(DataCategory.LOG_BYTE, subscription, organization) && (
+            <Fragment>
+              <NumberField
+                name="logBytesStandard"
+                label="Logs Standard"
+                defaultValue={logBytesStandard}
+                onChange={setLogBytesStandard}
+                required
+              />
+              <NumberField
+                name="logBytesDownsampled"
+                label="Logs Downsampled"
+                defaultValue={logBytesDownsampled}
+                onChange={setLogBytesDownsampled}
+              />
+            </Fragment>
+          )}
+
+          {hasCategoryFeature(DataCategory.TRANSACTIONS, subscription, organization) && (
+            <Fragment>
+              <NumberField
+                name="transactionsStandard"
+                label="Transactions Standard"
+                defaultValue={transactionsStandard}
+                onChange={setTransactionsStandard}
+              />
+              <NumberField
+                name="transactionsDownsampled"
+                label="Transactions Downsampled"
+                defaultValue={transactionsDownsampled}
+                onChange={setTransactionsDownsampled}
+              />
+            </Fragment>
+          )}
+
+          {hasCategoryFeature(DataCategory.SPANS, subscription, organization) && (
+            <Fragment>
+              <NumberField
+                name="spansStandard"
+                label="Spans Standard"
+                defaultValue={spansStandard}
+                onChange={setSpansStandard}
+                required
+              />
+              <NumberField
+                name="spansDownsampled"
+                label="Spans Downsampled"
+                defaultValue={spansDownsampled}
+                onChange={setSpansDownsampled}
+              />
+            </Fragment>
+          )}
         </Form>
       </Body>
     </Fragment>

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -135,6 +135,7 @@ function UpdateRetentionSettingsModal({
                 label="Transactions Standard"
                 defaultValue={transactionsStandard}
                 onChange={setTransactionsStandard}
+                required
               />
               <NumberField
                 name="transactionsDownsampled"

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -793,6 +793,7 @@ export function getReservedBudgetCategoryForAddOn(addOnCategory: AddOnCategory) 
 export const RETENTION_SETTINGS_CATEGORIES = new Set([
   DataCategory.SPANS,
   DataCategory.LOG_BYTE,
+  DataCategory.TRANSACTIONS,
 ]);
 
 export function getCredits({


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/102095

This allows Transactions retention settings to be updated for pre-AM3 plans
