### PR TITLE
fix(settings): Remove double slash from OTLP endpoint URL

### DIFF
--- a/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
@@ -55,12 +55,12 @@ export function OtlpTab({
     <Fragment>
       <FieldGroup
         label={t('OTLP Endpoint')}
-        help={t('This is the base OTLP endpoint.')}
+        help={t('The base OTLP endpoint for your project.')}
         inline={false}
         flexibleControlStateSize
       >
         <TextCopyInput aria-label={t('OTLP Endpoint')}>
-          {`${integrationEndpoint}/otlp`}
+          {`${integrationEndpoint}otlp`}
         </TextCopyInput>
       </FieldGroup>
       {showOtlpLogs && (


### PR DESCRIPTION
<img width="508" height="100" alt="image" src="https://github.com/user-attachments/assets/c8f2cde8-4393-46c4-b211-842c6c68846b" />

The usage of `/otlp` creates a double slash in the endpoint, fixing that.
