### PR TITLE
fix(spans-migration): boolean filters migrated incorrectly

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -237,8 +237,13 @@ class TranslationVisitor(NodeVisitor):
 
                 return children or node.text
 
+            flattened_parsed_val_num = None
             if negation == "":
-                return f"(tags[{flattened_parsed_key_str},number]:{flattened_parsed_val_str} OR {flattened_parsed_key_str}:{flattened_parsed_val_str})"
+                if flattened_parsed_val_str == "true":
+                    flattened_parsed_val_num = "1"
+                elif flattened_parsed_val_str == "false":
+                    flattened_parsed_val_num = "0"
+                return f"(tags[{flattened_parsed_key_str},number]:{flattened_parsed_val_num if flattened_parsed_val_num is not None else flattened_parsed_val_str} OR {flattened_parsed_key_str}:{flattened_parsed_val_str})"
 
         return children or node.text
 

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -189,7 +189,7 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
         DashboardWidgetQuery.objects.bulk_create(new_widget_queries)
 
         widget.widget_type = DashboardWidgetTypes.SPANS
-        widget.dataset_source = DatasetSourcesTypes.SPAN_MIGRATION_VERSION_3.value
+        widget.dataset_source = DatasetSourcesTypes.SPAN_MIGRATION_VERSION_4.value
         widget.changed_reason = dropped_fields_info
         widget.save()
 

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -132,6 +132,10 @@ class DatasetSourcesTypes(Enum):
     Dataset modified by the transaction -> span migration version 3
     """
     SPAN_MIGRATION_VERSION_3 = 9
+    """
+    Dataset modified by the transaction -> span migration version 4 (fixing boolean bug)
+    """
+    SPAN_MIGRATION_VERSION_4 = 10
 
     @classmethod
     def as_choices(cls):

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -23,8 +23,12 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "(tags[foo,number]:1 OR span.duration:11) AND is_transaction:1",
         ),
         pytest.param(
+            "!foo:true OR transaction.duration:11",
+            "(!foo:true OR span.duration:11) AND is_transaction:1",
+        ),
+        pytest.param(
             "foo:true OR transaction.duration:11",
-            "((tags[foo,number]:true OR foo:true) OR span.duration:11) AND is_transaction:1",
+            "((tags[foo,number]:1 OR foo:true) OR span.duration:11) AND is_transaction:1",
         ),
         pytest.param(
             "has:transaction.duration OR has:measurements.lcp",

--- a/tests/sentry/explore/translation/test_dashboards_translation.py
+++ b/tests/sentry/explore/translation/test_dashboards_translation.py
@@ -96,7 +96,7 @@ class DashboardTranslationTestCase(TestCase):
         # Assert widget type and dataset source are set correctly
         assert transaction_widget.widget_type == DashboardWidgetTypes.SPANS
         assert (
-            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_3.value
+            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_4.value
         )
 
         assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()
@@ -741,7 +741,7 @@ class DashboardRestoreTransactionWidgetTestCase(TestCase):
         # Verify translation occurred
         assert transaction_widget.widget_type == DashboardWidgetTypes.SPANS
         assert (
-            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_3.value
+            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_4.value
         )
         assert transaction_widget.widget_snapshot is not None
 


### PR DESCRIPTION
the boolean filters initially were being turned into number tags and string tags with an `or` condition however the number tags had a string value which was causing errors in the frontend. I've changed it to be 1 or 0 for true or false. I've also made the overhead changes in order to run the migration again (which is what the changes to the script is doing).
