### PR TITLE
fix(deletions): Delete seer matched group hash metadata first

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -272,7 +272,7 @@ def delete_group_hashes(
             # * Deleting the group hashes
             #
             # If we delete the metadata first, we will not need to update the columns before deleting them.
-            if options.get("deletions.group-hashes.delete-seer-matched-hashes"):
+            if options.get("deletions.group-hashes-metadata.update-seer-matched-grouphash-ids"):
                 GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).update(
                     seer_matched_grouphash=None
                 )

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -273,6 +273,8 @@ def delete_group_hashes(
             #
             # If we delete the metadata first, we will not need to update the columns before deleting them.
             GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
+            if options.get("deletions.group-hashes.delete-seer-matched-hashes"):
+                GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).delete()
             GroupHash.objects.filter(id__in=hash_ids).delete()
 
         iterations += 1

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -272,9 +272,11 @@ def delete_group_hashes(
             # * Deleting the group hashes
             #
             # If we delete the metadata first, we will not need to update the columns before deleting them.
-            GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
             if options.get("deletions.group-hashes.delete-seer-matched-hashes"):
-                GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).delete()
+                GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).update(
+                    seer_matched_grouphash=None
+                )
+            GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
             GroupHash.objects.filter(id__in=hash_ids).delete()
 
         iterations += 1

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -258,20 +258,12 @@ def delete_group_hashes(
             logger.warning("Error scheduling task to delete hashes from seer")
         finally:
             hash_ids = [gh[0] for gh in hashes_chunk]
-            # If we delete the grouphash metadata rows first we will not need to update the references to the other grouphashes.
-            # If we try to delete the group hashes first, then it will require the updating of the columns first.
-            #
-            # To understand this, let's say we have the following relationships:
-            # gh A -> ghm A -> no reference to another grouphash
-            # gh B -> ghm B -> gh C
-            # gh C -> ghm C -> gh A
-            #
-            # Deleting group hashes A, B & C (since they all point to the same group) will require:
-            # * Updating columns ghmB & ghmC to point to None
-            # * Deleting the group hash metadata rows
-            # * Deleting the group hashes
-            #
-            # If we delete the metadata first, we will not need to update the columns before deleting them.
+            # GroupHashMetadata rows can reference GroupHash rows via seer_matched_grouphash_id.
+            # Before deleting these GroupHash rows, we need to either:
+            # 1. Update seer_matched_grouphash to None first (to avoid foreign key constraint errors), OR
+            # 2. Delete the GroupHashMetadata rows entirely (they'll be deleted anyway)
+            # If we update the columns first, the deletion of the grouphash metadata rows will have less work to do,
+            # thus, improving the performance of the deletion.
             if options.get("deletions.group-hashes-metadata.update-seer-matched-grouphash-ids"):
                 GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).update(
                     seer_matched_grouphash=None

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -343,8 +343,8 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "deletions.group-hashes.delete-seer-matched-hashes",
-    default=True,
+    "deletions.group-hashes-metadata.update-seer-matched-grouphash-ids",
+    default=False,
     type=Bool,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -342,6 +342,12 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "deletions.group-hashes.delete-seer-matched-hashes",
+    default=True,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "deletions.group-history.use-bulk-deletion",

--- a/tests/sentry/deletions/test_grouphash.py
+++ b/tests/sentry/deletions/test_grouphash.py
@@ -1,8 +1,6 @@
 from unittest.mock import patch
 from uuid import uuid4
 
-import pytest
-
 from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
@@ -74,7 +72,6 @@ class DeleteGroupHashTest(TestCase):
         assert not GroupHashMetadata.objects.filter(grouphash_id=existing_grouphash.id).exists()
         assert not GroupHashMetadata.objects.filter(grouphash_id=new_grouphash.id).exists()
 
-    @pytest.mark.django_db
     def test_deleting_grouphash_matched_by_seer_after_unmerge(self) -> None:
         """
         Ensure that `seer_matched_grouphash` references aren't left dangling (and causing integrity
@@ -147,12 +144,3 @@ class DeleteGroupHashTest(TestCase):
         new_grouphash = GroupHash.objects.filter(hash=new_event.get_primary_hash()).first()
         assert new_grouphash and new_grouphash.metadata
         assert new_grouphash.metadata.seer_matched_grouphash is None
-
-    @pytest.mark.django_db
-    def test_deleting_grouphash_matched_by_seer_after_unmerge_with_update_seer_matched_grouphash_ids_disabled(
-        self,
-    ) -> None:
-        with self.options(
-            {"deletions.group-hashes-metadata.update-seer-matched-grouphash-ids": True}
-        ):
-            self.test_deleting_grouphash_matched_by_seer_after_unmerge()


### PR DESCRIPTION
When deleting a GroupHash row, all GroupHashMetadata rows pointing to it via `seer_matched_grouphash` need updating (see code):
https://github.com/getsentry/sentry/blob/698262018e6009759d8562e2da63be749df7c32d/src/sentry/models/grouphashmetadata.py#L115-L118

Before #101720, we would only delete GroupHash rows and that would time out because we would stomp queries longer than 30 seconds. In #101720 we added the deletion of the GroupHashMetadata rows but we should have also added the updating.

The new code will have these three stages:
```
GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).update(seer_matched_grouphash=None)
GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
GroupHash.objects.filter(id__in=hash_ids).delete()
```

Fixes [SENTRY-5ABJ](https://sentry.sentry.io/issues/6930113529/).

For posterity, this is the top of the stack trace:
```
OperationalError
canceling statement due to user request

SQL: UPDATE "sentry_grouphashmetadata" SET "seer_matched_grouphash_id" = NULL WHERE "sentry_grouphashmetadata"."seer_matched_grouphash_id" IN (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
```