### PR TITLE
fix(logs): Disable logs query if no trace id in issue details

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -41,7 +41,7 @@ export function OurlogsSection({
       source="state"
       freeze={traceId ? {traceId} : undefined}
     >
-      <LogsPageDataProvider>
+      <LogsPageDataProvider disabled={!traceId}>
         <OurlogsSectionContent event={event} group={group} project={project} />
       </LogsPageDataProvider>
     </LogsQueryParamsProvider>
@@ -80,7 +80,7 @@ function OurlogsSectionContent({
             source="state"
             freeze={traceId ? {traceId} : undefined}
           >
-            <LogsPageDataProvider>
+            <LogsPageDataProvider disabled={!traceId}>
               <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
                 <OurlogsDrawer
                   group={group}

--- a/static/app/views/explore/contexts/logs/logsPageData.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageData.tsx
@@ -21,16 +21,19 @@ export const useLogsPageData = _useLogsPageData;
 
 export function LogsPageDataProvider({
   children,
+  allowHighFidelity,
+  disabled,
 }: {
   children: React.ReactNode;
+  allowHighFidelity?: boolean;
   disabled?: boolean;
 }) {
   const organization = useOrganization();
   const feature = isLogsEnabled(organization);
   const highFidelity = useLogsQueryHighFidelity();
   const infiniteLogsQueryResult = useInfiniteLogsQuery({
-    disabled: !feature,
-    highFidelity,
+    disabled: disabled || !feature,
+    highFidelity: allowHighFidelity && highFidelity,
   });
   const value = useMemo(() => {
     return {

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -81,7 +81,7 @@ export default function LogsContent() {
           <Layout.Page>
             <LogsHeader />
             <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-              <LogsPageDataProvider>
+              <LogsPageDataProvider allowHighFidelity>
                 {defined(onboardingProject) ? (
                   <LogsTabOnboarding
                     organization={organization}


### PR DESCRIPTION
If there is no trace id in the issue details, we should not fire the logs query to save some work.