### PR TITLE
chore(grouping): Add new stacktrace rules file

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -1,0 +1,489 @@
+## * The default configuration of stacktrace grouping enhancers
+
+# iOS known apps
+family:native package:/var/containers/Bundle/Application/**          +app
+family:native package:/private/var/containers/Bundle/Application/**  +app
+
+# iOS apps in simulator
+family:native package:**/Developer/CoreSimulator/Devices/**          +app
+family:native package:**/Containers/Bundle/Application/**            +app
+
+# well known path components for mac paths
+family:native package:**.app/Contents/**                             +app
+family:native package:/Users/**                                      +app
+
+# Unreal Engine
+
+## UE internal fatal log message handling
+
+family:native stack.function:UE::Logging::Private::BasicFatalLog     v+app -app ^-app
+
+## UE internal assertion handling
+family:native stack.function:FDebug::CheckVerifyFailedImpl*                                             v+app -app ^-app
+stack.function:*::Impl::ExecCheckImplInternal | [ stack.function:FDebug::CheckVerifyFailedImpl ]        -app
+stack.function:FDebug::CheckVerifyFailedImpl2 | [ stack.function:FDebug::CheckVerifyFailedImpl2V ]      -app
+
+## UE internal ensure handling
+
+### UE 5.2 and older
+family:native stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse                  v+app -app ^-app
+category:indirection | [ stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse ]     -app
+
+### UE 5.3
+family:native stack.function:DispatchCheckVerify*                          v+app -app ^-app
+
+### UE 5.4 and newer
+family:native stack.function:UE::Assert::Private::ExecCheckImplInternal*   v+app -app ^-app
+
+## UE SDK USentrySubsystem event capturing
+family:native stack.function:USentrySubsystem::CaptureMessage*             v+app -app ^-app
+family:native stack.function:USentrySubsystem::CaptureMessageWithScope*    v+app -app ^-app
+family:native stack.function:USentrySubsystem::CaptureEvent*               v+app -app ^-app
+family:native stack.function:USentrySubsystem::CaptureEventWithScope*      v+app -app ^-app
+family:native stack.function:USentrySubsystem::*execCapture*               v+app -app ^-app
+
+# known well locations for unix paths
+family:native package:/lib/**                                        -app
+family:native package:/usr/lib/**                                    -app
+family:native path:/usr/local/lib/**                                 -app
+family:native path:/usr/local/Cellar/**                              -app
+family:native package:linux-gate.so*                                 -app
+
+# rust common modules/functions
+family:native function:std::*                                     -app
+family:native function:core::*                                    -app
+family:native function:alloc::*                                   -app
+family:native function:__rust_*                                   -app
+family:native function:rust_begin_unwind                          -app
+
+# rust borders
+family:native function:std::panicking::begin_panic                ^-group -group ^-app -app
+family:native function:core::panicking::begin_panic               ^-group -group ^-app -app
+family:native function:failure::backtrace::Backtrace::new         ^-group -group ^-app -app
+family:native function:error_chain::make_backtrace                ^-group -group ^-app -app
+family:native function:std::panicking::panic_fmt                  ^-app -app
+family:native function:core::panicking::panic_fmt                 ^-app -app
+
+# C++ borders
+family:native function:_CxxThrowException                         ^-group -group ^-app -app
+family:native function:__cxa_throw                                ^-group -group ^-app -app
+family:native function:__assert_rtn                               ^-group -group ^-app -app
+
+# Objective-C
+family:native function:_NSRaiseError                              ^-group -group ^-app -app
+family:native function:_mh_execute_header                         -group -app
+
+# Breakpad
+family:native function:google_breakpad::*                         -app -group
+family:native function:google_breakpad::ExceptionHandler::SignalHandler ^-group -group
+family:native function:google_breakpad::ExceptionHandler::WriteMinidumpWithException ^-group -group
+
+# Support frameworks that are not in-app
+family:native package:**/Frameworks/libswift*.dylib                  -app
+family:native package:**/Frameworks/KSCrash.framework/**             -app
+family:native package:**/Frameworks/SentrySwift.framework/**         -app
+family:native package:**/Frameworks/Sentry.framework/**              -app
+
+# Needed for versions < sentry-cocoa 7.0.0 and static linking.
+# Before sentry-cocoa 7.0.0, we marked all packages located inside the application bundle as inApp.
+# Since 7.0.0, the Cocoa SKD only marks the main executable as inApp. This change doesn't impact
+# applications using static libraries, as when using static libraries, all of them end up in the
+# main executable.
+family:native function:kscm_*                                     -app -group
+family:native function:sentrycrashcm_*                            -app -group
+family:native function:kscrash_*                                  -app -group
+family:native function:*sentrycrash_*                             -app -group
+family:native function:"?[[]KSCrash*"                             -app -group
+family:native function:"?[[]RNSentry*"                            -app -group
+family:native function:"__*[[]Sentry*"                            -app -group
+
+# Projects shipping their own class called "SentryFoo" can then easily override this in their
+# own grouping enhancers.
+family:native function:"?[[]Sentry*"                              -app -group
+
+# Mark Dart Flutter Android stacktraces in-app by default, further not in-app rules are applied afterwards below
+family:native stack.package:/data/app/** stack.abs_path:**/*.dart +app
+# Dart/Flutter stacktraces that are not in-app
+family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
+family:javascript module:**/packages/flutter/** -app
+family:native stack.abs_path:**/packages/flutter/** -app
+family:native stack.abs_path:lib/ui/hooks.dart -app
+family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
+# sentry-dart SDK frames are not in app
+stack.abs_path:package:sentry/** -app -group
+stack.abs_path:package:sentry_flutter/** -app -group
+# other sentry-dart packages that are non in app
+stack.abs_path:package:sentry_logging/** -app -group
+stack.abs_path:package:sentry_dio/** -app -group
+stack.abs_path:package:sentry_file/** -app -group
+stack.abs_path:package:sentry_hive/** -app -group
+stack.abs_path:package:sentry_isar/** -app -group
+stack.abs_path:package:sentry_sqflite/** -app -group
+stack.abs_path:package:sentry_drift/** -app -group
+stack.abs_path:package:sentry_isar/** -app
+stack.abs_path:package:sentry_link/** -app
+stack.abs_path:package:sentry_firebase_remote_config/** -app
+# .pub-cache is the node_modules equivalent for Dart
+family:native stack.abs_path:**/.pub-cache/** -app
+
+# Categorization of frames
+family:native package:"/System/Library/Frameworks/**" category=system
+family:native package:"C:/Windows/**" category=system
+family:native package:/usr/lib/** category=system
+family:native function:memset category=system
+family:native function:memcpy category=system
+family:native function:__memcpy category=system
+family:native function:memcmp category=system
+family:native package:CoreFoundation category=system
+family:native package:Foundation category=system
+family:native package:CFNetwork category=system
+family:native package:IOKit category=system
+family:native package:QuartzCore category=system
+family:native package:IOMobileFramebuffer category=system
+family:native package:libobjc* category=system
+family:native package:libsystem* category=system
+family:native package:/system/** category=system
+family:native package:/vendor/** category=system
+module:dalvik.system.* category=system
+module:com.android.* category=system
+family:native package:libdispatch.dylib category=system
+family:native package:WebKit category=system
+family:native package:**/libart.so category=system
+package:/apex/com.android.*/lib*/** category=system
+
+# (Presumably) preinstalled stuff on Lenovo Android devices
+module:com.lenovo.lsf.* category=system
+module:com.lenovo.payplus.* category=system
+
+family:native function:boost::* category=std
+family:native function:std::* category=std
+module:java.* category=std
+# common crypto library on android
+module:com.google.crypto.* category=std
+module:com.google.android.* category=std
+module:javax.crypto.* category=std
+
+module:android.database.* category=std
+module:androidx.* category=std
+module:android.* category=std
+module:android.os.* category=system
+
+family:native package:UIKit category=ui
+family:native package:UIKitCore category=ui
+family:native package:SwiftUI category=ui
+family:native package:AttributeGraph category=ui
+family:native package:CoreAutoLayout category=ui
+family:native package:GraphicsServices category=ui
+family:native function:"-\[NSISEngine*" category=ui  # auto-layout engine
+module:android.view.* category=ui
+module:android.text.* category=ui
+module:android.widget.* category=ui
+module:android.app.Dialog category=ui
+module:androidx.*.widget.* category=ui
+module:com.google.android.material.* category=ui
+category:ui function:handleMessage category=indirection
+category:ui function:run category=indirection
+
+family:native function:art::jit::* category=runtime
+
+family:native package:/system/lib/libmedia.so category=av
+family:native package:/System/lib/libaudioclient.so category=av
+family:native package:AudioToolbox* category=av
+family:native package:libAudioToolboxUtility.dylib category=av
+
+family:native function:std::_* category=internals
+family:native function:__swift_* category=internals
+family:native function:block_destroy_helper* category=internals
+family:native function:*_block_invoke* app:no category=internals
+
+family:native package:/usr/lib/system/** function:start category=threadbase
+family:native package:libdyld.dylib function:start category=threadbase
+family:native package:UIKitCore function:UIApplicationMain category=threadbase
+family:native function:wWinMain category=threadbase
+family:native function:invoke_main category=threadbase
+family:native function:BaseThreadInitThunk category=threadbase
+family:native function:RtlUserThreadStart category=threadbase
+family:native function:thread_start category=threadbase
+family:native function:_pthread_start category=threadbase
+family:native function:__pthread_start category=threadbase
+family:native function:_pthread_body category=threadbase
+family:native function:_dispatch_worker_thread2 category=threadbase
+family:native function:start_wqthread category=threadbase
+family:native function:_pthread_wqthread category=threadbase
+family:native function:boost::*::thread_proxy category=threadbase
+family:native package:/usr/lib/system/libsystem_pthread.dylib function:"<unknown>" category=threadbase
+module:android.os.AsyncTask* function:call category=threadbase
+family:native package:UIKit function:UIApplicationMain category=threadbase
+module:java.util.concurrent.ThreadPoolExecutor* function:runWorker category=threadbase
+module:android.os.* function:call category=threadbase
+module:android.app.ActivityThread function:main category=threadbase
+module:android.view.View function:layout category=threadbase
+module:android.os.Looper function:loop category=threadbase
+family:native function:TppWorkerThread category=threadbase
+family:native function:TppWorkpExecuteCallback category=threadbase
+family:native function:RtlpTpWorkCallback category=threadbase
+module:android.os.Handler function:dispatchMessage category=threadbase
+module:android.os.Handler function:handleCallback category=threadbase
+module:android.app.ActivityThread* function:handleMessage category=threadbase
+
+family:native package:"**/libsystem_malloc.dylib" category=malloc
+family:native function:malloc category=malloc
+family:native function:malloc_base category=malloc
+family:native function:RtlpAllocateHeapInternal category=malloc
+family:native function:std::*::allocator_traits* category=malloc
+
+family:native function:*::operator()* category=indirection
+family:native function:*<lambda>* category=indirection
+family:native function:destructor' category=indirection
+family:native function:__dynamic_cast category=indirection
+family:native function:boost::function* category=indirection
+family:native function:boost::_bi::* category=indirection
+family:native function:boost::detail::function::functor_manager* category=indirection
+family:native function:Array.subscript.* category=indirection
+module:java.lang.reflect.* category=indirection
+module:java.lang.Class function:getMethod category=indirection
+module:androidx.work.impl.utils.ForceStopRunnable category=indirection
+
+family:native function:"*::\\{dtor\\}" category=dtor
+family:native function:"destructor'" category=dtor
+
+family:native function:exit category=shutdown
+family:native function:RtlExitUserProcess category=shutdown
+family:native function:ExitProcessImplementation category=shutdown
+family:native function:RtlExitUserThread category=shutdown
+
+family:native function:RtlpExecuteHandlerForException category=handler
+family:native function:_sigtramp category=handler
+family:native function:DispatchHookW category=handler
+family:native function:execute_onexit_table category=handler
+
+family:native function:abort category=throw
+family:native function:raise category=throw
+family:native function:std::terminate category=throw
+family:native function:RtlExitUserThread category=throw
+family:native function:TppRaiseInvalidParameter category=throw
+family:native function:_CxxThrowException category=throw
+family:native function:RaiseException category=throw
+family:native function:RaiseComPlusException category=throw
+family:native function:_CFThrowFormattedException category=throw
+family:native function:objc_exception_throw category=throw
+family:native function:AG::precondition_failure* category=throw
+
+family:native package:"C:/WINDOWS/system32/DriverStore/**" category=driver
+family:native package:"/System/Library/Extensions/AppleIntel*GraphicsGLDriver.bundle/**" category=driver
+family:native function:*CUDA* category=driver
+family:native package:**/nvcuda.dll category=driver
+family:native package:"C:/Program Files/NVIDIA Corporation/**" category=driver
+family:native package:/System/Library/Extensions/GeForceGLDriver.bundle/** category=driver
+family:native package:/System/Library/Extensions/AMDRadeon*/** category=driver
+family:native package:/System/Library/PrivateFrameworks/GPUSupport.framework/** category=driver
+family:native package:libGPUSupportMercury.dylib category=driver
+family:native package:AGXGLDriver category=driver
+
+family:native function:RtlFreeHeap category=free
+family:native function:RtlFreeUnicodeString category=free
+family:native function:std::_Deallocate category=free
+family:native function:free category=free
+family:native function:objc_release category=free
+family:native function:_swift_release_dealloc category=free
+family:native function:_CFRelease category=free
+
+family:native package:C:/Windows/SYSTEM32/OPENGL32.dll category=gl
+family:native package:/System/Library/Frameworks/OpenGL.framework/** category=gl
+family:native package:OpenGLES category=gl
+family:native package:GLEngine category=gl
+family:native package:/system/lib/libEGL.so category=gl
+family:native package:**/libGLES*.so category=gl
+family:native package:**/libESXGLES*.so category=gl
+family:native package:/system/lib/libskia.so category=gl
+# Not a graphics library but we've seen it be interchangeable with OpenGL in stacktraces.
+family:native package:/System/Library/Frameworks/OpenCL.framework/** category=gl
+
+family:native package:"/System/Library/PrivateFrameworks/GPUSupport.framework/**" function:gpusGenerateCrashLog* category=telemetry
+family:native function:gpusKillClientExt category=telemetry
+family:native function:crashpad::* category=telemetry
+# Presumably some chinese user-tracking SDK. Wraps activity creation in Android.
+module:cn.gundam.sdk.* category=telemetry
+
+# No app actually uses this. This appears to be some type of framework that
+# comes up as part of some "Lenovo ID" activity (user login prompt?). Not
+# entirely sure if any of that is linked into the app, it's probably something
+# preinstalled on Lenovo devices.
+module:com.lenovo.payplus.analytics.* category=telemetry
+package:"**/libBugly.so" category=telemetry
+
+family:native function:dlopen category=load
+family:native function:dladdr category=load
+family:native function:ImageLoaderMachO::findClosestSymbol category=load
+family:native package:/system/lib/libnativeloader.so function:android::OpenNativeLibrary category=load
+module:java.lang.System function:loadLibrary category=load
+module:java.lang.Runtime function:loadLibrary* category=load
+
+family:native function:pthread_mutex_lock category=lock
+
+# Ignore driver frame if it is directly calling another driver frame. This
+# removes a lot of noise from the stack especially if most of the called frames
+# failed symbolication, stack scanning was done or to paper over differences in
+# driver versions.
+category:driver | [ category:driver ] category=internals
+
+# Only group by top-level GL operaton, not any helper functions it may have called.
+
+[ category:gl ] | category:gl category=internals
+[ category:av ] | category:av  category=internals
+
+# Only group by top-level malloc op, not any helper function it may have called.
+[ category:malloc ] | category:malloc category=internals
+
+# abort() and exception raising is technically the culprit for crashes, but not
+# the thing we want to show.
+category:throw ^-group
+
+# On Windows, _purecall internally aborts when the function pointer is invalid.
+# We want to treat this the same as a segfault happening before calling
+# _purecall.
+[ function:_purecall ] | category:throw category=internals
+
+# raise() called by abort() should only group by abort()
+[ category:throw ] | category:throw category=internals
+
+# Frames from the OS should never be considered in-app
+category:system -app
+
+# Thread bases such as `main()` are just noise and are called by noise.
+category:threadbase -group v-group
+
+# handler frames typically call code for crash reporting, so the frames below
+# are noise and do not represent the actual crash. We usually expect something to
+# be above handler frames that represents the actual crash. The stackwalker
+# has a bug where it cannot walk past _sigtramp on OS X but that is expected to
+# be fixed eventually.
+category:handler ^-group -group
+
+# Crash reporting tools are noise that can occur outside of signal handlers
+# too, apparently (Apple's GPUSupport module)
+category:telemetry -group
+
+category:indirection -group
+category:internals -group
+category:threadbase v-group -group
+
+# system frames starting with underscore are likely garbage
+# unsymbolicated system frames are likely system frames starting with underscore
+# _purecall is an exception as it is often the only important frame in a block of system frames
+family:native category:system function:_* !function:_purecall category=internals
+family:native category:system function:"<unknown>" category=internals
+family:native function:_INTERNAL* category=internals
+
+
+# We should be able to write this, but unfortunately sentry-cocoa 6.x is so
+# buggy with detecting compiler-generated code that we have decided to go with a
+# list of function name patterns instead:
+# path:"<compiler-generated>" category=internals
+
+family:native function:closure category=internals
+family:native function:Collection.map<T> category=internals
+family:native function:Array.subscript.getter category=internals
+family:native function:Array._getElement category=internals
+family:native function:_ArrayBuffer._nativeTypeChecked.getter category=internals
+family:native function:range category=internals
+family:native function:@callee_guaranteed category=internals
+
+# frames with .cold.1 are probably hotpaths vs slow paths but not relevant for grouping
+# e.g., two callstacks that should group together:
+#   foo -> bar
+#   foo -> foo.cold.1 -> bar
+family:native function:*.cold.1 category=indirection
+
+# System frame wedged between two other frames is just noise.
+[ !category:system ] | category:system | [ !category:system ] category=indirection
+
+# TODO: multi-category / category inheritance
+[ category:free ]       | category:system  category=internals
+[ category:system ]     | category:system  category=internals
+[ category:std ]        | category:system  category=internals
+[ category:std ]        | category:std     category=internals
+[ category:ui ]         | category:ui      category=internals
+[ category:ui ]         | category:system  category=internals
+[ category:internals ]  | category:system  category=internals
+[ category:internals ]  | category:ui      category=internals
+[ category:load ]       | category:system  category=internals
+[ category:load ]       | category:load    category=internals
+[ category:throw ]      | category:system  category=internals
+[ category:runtime ]    | category:system  category=internals
+[ category:runtime ]    | category:runtime category=internals
+[ category:dtor ]       | category:dtor    category=internals
+
+
+# SDK specific rules
+
+## general
+path:**/vendor/**        -app
+
+## python
+path:**/site-packages/** -app
+path:**/dist-packages/** -app
+
+## js
+path:**/node_modules/** -app
+module:unpkg/** -app
+path:**https://unpkg.com/** -app
+path:**https://cdnjs.cloudflare.com/** -app
+path:**https://cdn.jsdelivr.net/** -app
+path:**https://esm.run/** -app
+family:javascript function:reportError ^-app -app
+
+### transpilers and polyfills are just noise, be more aggressive
+module:@babel/** -app -group
+module:core-js/** -app -group
+module:regenerator-runtime/** -app -group
+module:tslib/** -app -group
+
+## react-native
+### babel
+family:javascript function:_callSuper -app -group
+
+## node
+function:runMicrotasks -app -group
+function:queueMicrotask -app -group
+function:processTicksAndRejections -app -group
+function:runNextTicks -app -group
+function:nextTick -app -group
+
+## go
+path:**/go/pkg/mod/** -app
+
+## java
+module:akka.* category=framework
+module:com.fasterxml.* category=framework
+module:com.microsoft.* category=framework
+module:com.sun.* category=framework
+module:feign.* category=framework
+module:io.opentelemetry.* category=framework
+module:io.sentry.* category=framework -group
+module:jdk.* category=framework
+module:oauth.* category=framework
+module:org.apache.* category=framework
+module:org.glassfish.* category=framework
+module:org.jboss.* category=framework
+module:org.jdesktop.* category=framework
+module:org.postgresql.* category=framework
+module:org.springframework.* category=framework
+module:org.web3j.* category=framework
+module:reactor.core.* category=framework
+module:scala.* category=framework
+module:sun.* category=framework
+
+category:framework -app
+
+## kotlin
+module:kotlin.* -app
+module:kotlinx.* -app
+module:io.ktor.* -app
+module:io.netty.* -app
+
+# Telemetry - we don't care about other telemetry providers, just adds noise
+# TODO(neel) can look at language specific telemetry lib stacktraces
+module:newrelic -app -group
+path:**/*newrelic*/** -app -group
+path:**/*LogRocket*/** -app -group

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -70,4 +70,5 @@ register_grouping_config(
     id=FALL_2025_GROUPING_CONFIG,
     base="newstyle:2023-01-11",
     initial_context={},
+    enhancements_base="all-platforms:2025-11-21",
 )


### PR DESCRIPTION
This adds a new stacktrace rules file, and uses it in the new grouping config. The new file is an exact replica of the current stacktrace rules file, with any changes to come in future PRs rather than here, so that it'll be easier to see what those changes actually are.