### PR TITLE
bug(preprod): Add empty insights content

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -325,12 +325,10 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
             onToggleCategory={handleToggleCategory}
           />
         )}
-        {processedInsights.length > 0 && (
-          <AppSizeInsights
-            processedInsights={processedInsights}
-            platform={validatedPlatform(buildDetailsData?.app_info?.platform)}
-          />
-        )}
+        <AppSizeInsights
+          processedInsights={processedInsights}
+          platform={validatedPlatform(buildDetailsData?.app_info?.platform)}
+        />
       </Stack>
     </Flex>
   );

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -35,6 +35,7 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
     setSearchParams(newParams);
   }, [searchParams, setSearchParams]);
 
+  const hasInsights = processedInsights.length > 0;
   // Only show top 5 insights, show the rest in the sidebar
   const topInsights = processedInsights.slice(0, 5);
 
@@ -50,9 +51,11 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
         <Heading as="h2" size="lg">
           {t('Top insights')}
         </Heading>
-        <Button size="sm" icon={<IconSettings />} onClick={openSidebar}>
-          {t('View insight details')}
-        </Button>
+        {hasInsights && (
+          <Button size="sm" icon={<IconSettings />} onClick={openSidebar}>
+            {t('View insight details')}
+          </Button>
+        )}
       </Flex>
       <Flex
         direction="column"
@@ -91,6 +94,19 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
             </Flex>
           </Flex>
         ))}
+        {!hasInsights && (
+          <Flex
+            padding="lg"
+            radius="md"
+            background="primary"
+            align="center"
+            justify="center"
+          >
+            <Text size="sm" bold>
+              {t('No insights found')}
+            </Text>
+          </Flex>
+        )}
       </Flex>
 
       <AppSizeInsightsSidebar

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -103,7 +103,7 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
             justify="center"
           >
             <Text size="sm" bold>
-              {t('No insights found')}
+              {t('Your app looks good! No insights were found.')}
             </Text>
           </Flex>
         )}


### PR DESCRIPTION
Adds empty insights content when no insights available.

Before
<img width="1076" height="723" alt="Screenshot 2025-11-03 at 1 52 45 PM" src="https://github.com/user-attachments/assets/33a5357d-5961-4990-821d-fcf34dbfe6c4" />

After
<img width="1065" height="755" alt="Screenshot 2025-11-03 at 1 43 50 PM" src="https://github.com/user-attachments/assets/046d56d4-dc17-4cad-a462-ef20b1aa64b7" />

Resolves EME-584