### PR TITLE
fix(aci): remove unused/unserializable field from open period serializer

### DIFF
--- a/src/sentry/web/frontend/debug/charts/metric_alert_charts.py
+++ b/src/sentry/web/frontend/debug/charts/metric_alert_charts.py
@@ -203,7 +203,6 @@ open_periods = {
             "id": "551505189",  # this ID renders on the vertical line indicating the beginning of an open period
             "start": "2022-04-21T20:29:34.982805Z",
             "end": None,
-            "duration": None,
             "isOpen": True,
             "lastChecked": "2022-05-01T20:28:00Z",
             "activities": [

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Mapping
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
@@ -20,7 +20,6 @@ class GroupOpenPeriodResponse(TypedDict):
     id: str
     start: datetime
     end: datetime | None
-    duration: timedelta | None
     isOpen: bool
     lastChecked: datetime
     activities: list[GroupOpenPeriodActivityResponse] | None
@@ -66,7 +65,6 @@ class GroupOpenPeriodSerializer(Serializer):
             id=str(obj.id),
             start=obj.date_started,
             end=obj.date_ended,
-            duration=obj.date_ended - obj.date_started if obj.date_ended else None,
             isOpen=obj.date_ended is None,
             lastChecked=get_last_checked_for_open_period(obj.group),
             activities=attrs.get("activities"),

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -63,7 +63,6 @@ class OrganizationOpenPeriodsTest(APITestCase):
         open_period = response.data[0]
         assert open_period["start"] == self.group.first_seen
         assert open_period["end"] is None
-        assert open_period["duration"] is None
         assert open_period["isOpen"] is True
         assert len(open_period["activities"]) == 1
         assert open_period["activities"][0] == {
@@ -99,7 +98,6 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["id"] == str(self.group_open_period.id)
         assert resp["start"] == self.group.first_seen
         assert resp["end"] is None
-        assert resp["duration"] is None
         assert resp["isOpen"] is True
         assert resp["lastChecked"] >= last_checked
         assert resp["activities"][0] == {
@@ -139,7 +137,6 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["id"] == str(open_period.id)
         assert resp["start"] == self.group.first_seen
         assert resp["end"] == resolved_time
-        assert resp["duration"] == resolved_time - self.group.first_seen
         assert resp["isOpen"] is False
         assert resp["lastChecked"].replace(second=0, microsecond=0) == activity.datetime.replace(
             second=0, microsecond=0
@@ -225,7 +222,6 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["id"] == str(open_period2.id)
         assert resp["start"] == unresolved_time
         assert resp["end"] == second_resolved_time
-        assert resp["duration"] == second_resolved_time - unresolved_time
         assert resp["isOpen"] is False
         assert resp["lastChecked"].replace(second=0, microsecond=0) == second_resolved_time.replace(
             second=0, microsecond=0
@@ -247,7 +243,6 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp2["id"] == str(open_period.id)
         assert resp2["start"] == self.group.first_seen
         assert resp2["end"] == resolved_time
-        assert resp2["duration"] == resolved_time - self.group.first_seen
         assert resp2["isOpen"] is False
         assert resp2["lastChecked"].replace(second=0, microsecond=0) == resolved_time.replace(
             second=0, microsecond=0
@@ -321,7 +316,6 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["id"] == str(open_period.id)
         assert resp["start"] == unresolved_time
         assert resp["end"] == second_resolved_time
-        assert resp["duration"] == second_resolved_time - unresolved_time
         assert resp["isOpen"] is False
         assert resp["lastChecked"].replace(second=0, microsecond=0) == second_resolved_time.replace(
             second=0, microsecond=0


### PR DESCRIPTION
We were returning `duration` as timedelta, which is not a serializable type. Since we aren't using the field anyway, remove it.

Fixes: [SENTRY_5BXC](https://sentry.sentry.io/issues/6994952122/events/3907c6992124474fbc0f2aa3e9db5c9e/)
Fixes: [SENTRY-5BXD](https://sentry.sentry.io/issues/6994952158/events/4033371a7dc346ba81409f3e70e36d94/)