### PR TITLE
chore(replay): fix typo in api docs..?

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -24,7 +24,7 @@ This document is structured by resource with each resource having actions that c
     Default: 7d
     Members: + s + m + h + d + w
   - start (optional, string) - ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`)
-  - end (optional, string) - ISO 8601 format. Required if `start` is set.
+  - end (optional, string) - ISO 8601 format.
   - per_page (optional, number)
     Default: 10
   - offset (optional, number)


### PR DESCRIPTION
I was working with this endpoint, and it seems to work fine with only a `start` parameter... although wanted to clarify 😀