### PR TITLE
bug(suspect commits): lock duration should match task duration

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -41,7 +41,7 @@ DEBOUNCE_PR_COMMENT_CACHE_KEY = lambda pullrequest_id: f"pr-comment-{pullrequest
 DEBOUNCE_PR_COMMENT_LOCK_KEY = lambda pullrequest_id: f"queue_comment_task:{pullrequest_id}"
 PR_COMMENT_TASK_TTL = timedelta(minutes=5).total_seconds()
 PR_COMMENT_WINDOW = 14  # days
-
+TASK_DURATION_S = 90
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.tasks.process_commit_context",
     namespace=issues_tasks,
-    processing_deadline_duration=90,
+    processing_deadline_duration=TASK_DURATION_S,
     retry=Retry(times=5, delay=5),
     silo_mode=SiloMode.REGION,
 )
@@ -72,7 +72,9 @@ def process_commit_context(
     Will check if the suspect commit author can be auto-assigned.
     """
     lock = locks.get(
-        f"process-commit-context:{group_id}", duration=90, name="process_commit_context"
+        f"process-commit-context:{group_id}",
+        duration=TASK_DURATION_S,
+        name="process_commit_context",
     )
     try:
         with lock.acquire():

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -32,7 +32,7 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
-from sentry.taskworker.retry import NoRetriesRemainingError, Retry, retry_task
+from sentry.taskworker.retry import NoRetriesRemainingError, Retry
 from sentry.utils import metrics
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.sdk import set_current_event_project
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
     name="sentry.tasks.process_commit_context",
     namespace=issues_tasks,
     processing_deadline_duration=90,
-    retry=Retry(times=5, on=(ApiError,)),
+    retry=Retry(times=5, delay=5),
     silo_mode=SiloMode.REGION,
 )
 def process_commit_context(
@@ -72,7 +72,7 @@ def process_commit_context(
     Will check if the suspect commit author can be auto-assigned.
     """
     lock = locks.get(
-        f"process-commit-context:{group_id}", duration=10, name="process_commit_context"
+        f"process-commit-context:{group_id}", duration=90, name="process_commit_context"
     )
     try:
         with lock.acquire():
@@ -129,7 +129,7 @@ def process_commit_context(
                 )
             except ApiError:
                 metrics.incr("tasks.process_commit_context_all_frames.retry")
-                retry_task()
+                raise
 
             if not blame or not installation:
                 metrics.incr("tasks.process_commit_context_all_frames.no_blame_found")

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -197,7 +197,7 @@ def process_suspect_commits(
     This is the task behind SuspectCommitStrategy.RELEASE_BASED
     """
     lock = locks.get(
-        f"process-suspect-commits:{group_id}", duration=10, name="process_suspect_commits"
+        f"process-suspect-commits:{group_id}", duration=90, name="process_suspect_commits"
     )
     try:
         with lock.acquire():

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -28,6 +28,7 @@ PREFERRED_GROUP_OWNERS = 2
 PREFERRED_GROUP_OWNER_AGE = timedelta(days=7)
 MIN_COMMIT_SCORE = 2
 DEBOUNCE_CACHE_KEY = lambda group_id: f"process-suspect-commits-{group_id}"
+TASK_DURATION_S = 90
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +180,7 @@ def _process_suspect_commits(
 @instrumented_task(
     name="sentry.tasks.process_suspect_commits",
     namespace=issues_tasks,
-    processing_deadline_duration=90,
+    processing_deadline_duration=TASK_DURATION_S,
     retry=Retry(times=5, delay=5),
     silo_mode=SiloMode.REGION,
 )
@@ -197,7 +198,9 @@ def process_suspect_commits(
     This is the task behind SuspectCommitStrategy.RELEASE_BASED
     """
     lock = locks.get(
-        f"process-suspect-commits:{group_id}", duration=90, name="process_suspect_commits"
+        f"process-suspect-commits:{group_id}",
+        duration=TASK_DURATION_S,
+        name="process_suspect_commits",
     )
     try:
         with lock.acquire():

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from datetime import timezone as datetime_timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
 import responses
 from django.utils import timezone
 
@@ -36,7 +35,6 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
-from sentry.taskworker.retry import NoRetriesRemainingError, RetryError
 from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
@@ -813,77 +811,18 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
     @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
-        side_effect=ApiError("Unknown API error"),
-    )
-    def test_retry_on_bad_api_error(
-        self, mock_get_commit_context: MagicMock, mock_process_suspect_commits: MagicMock
-    ) -> None:
-        """
-        A failure case where the integration hits an unknown API error.
-        The task should be retried.
-        """
-        with self.tasks():
-            assert not GroupOwner.objects.filter(group=self.event.group).exists()
-            event_frames = get_frame_paths(self.event)
-            with pytest.raises(RetryError):
-                process_commit_context(
-                    event_id=self.event.event_id,
-                    event_platform=self.event.platform,
-                    event_frames=event_frames,
-                    group_id=self.event.group_id,
-                    project_id=self.event.project_id,
-                    sdk_name="sentry.python",
-                )
-
-        assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        assert not mock_process_suspect_commits.called
-
-    @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
-    @patch(
-        "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
         side_effect=ApiError("File not found", code=404),
     )
-    def test_no_retry_on_expected_api_error(
+    def test_no_retry_on_non_retryable_api_error(
         self, mock_get_commit_context, mock_process_suspect_commits
     ):
         """
-        A failure case where the integration hits an a 404 error.
-        This type of failure should immediately bail.
+        A failure case where the integration hits a 404 error.
+        This type of failure should immediately bail with no retries.
         """
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
             event_frames = get_frame_paths(self.event)
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
-                sdk_name="sentry.python",
-            )
-
-        assert not GroupOwner.objects.filter(group=self.event.group).exists()
-        mock_process_suspect_commits.assert_not_called()
-
-    @patch("sentry.tasks.commit_context.retry_task")
-    @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
-    @patch(
-        "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
-        side_effect=ApiError("Unknown API error"),
-    )
-    def test_no_fall_back_on_max_retries(
-        self, mock_get_commit_context, mock_process_suspect_commits, mock_retry_task
-    ):
-        """
-        A failure case where the integration hits an unknown API error a fifth time.
-        After 5 retries, the task should bail.
-        """
-        mock_retry_task.side_effect = NoRetriesRemainingError()
-
-        with self.tasks():
-            assert not GroupOwner.objects.filter(group=self.event.group).exists()
-            event_frames = get_frame_paths(self.event)
-
             process_commit_context(
                 event_id=self.event.event_id,
                 event_platform=self.event.platform,


### PR DESCRIPTION
The task duration for both suspect commit tasks used to be 10s, when we bumped it to 90s we didn't make the same adjustment to the lock TTL, so we get errors like [this](https://sentry.sentry.io/issues/6944665117).

The lock was expiring before the task had completed. With these changes, the lock will be held for the entire duration the task could possibly run. But, tasks that finish early still release the lock immediately, and if a task is killed at the deadline, the lock expires at the same time.

Fixes SENTRY-5AP2