### PR TITLE
chore(prevent): Unnest the returned data for prevent ai config

### DIFF
--- a/src/sentry/prevent/endpoints/pr_review_github_config.py
+++ b/src/sentry/prevent/endpoints/pr_review_github_config.py
@@ -61,7 +61,7 @@ class OrganizationPreventGitHubConfigEndpoint(OrganizationEndpoint):
 
         response_data: dict[str, Any] = deepcopy(PREVENT_AI_CONFIG_DEFAULT)
         if config:
-            response_data["organization"][git_organization_name] = config.data
+            response_data["organization"] = config.data
 
         return Response(response_data, status=200)
 
@@ -103,6 +103,6 @@ class OrganizationPreventGitHubConfigEndpoint(OrganizationEndpoint):
         )
 
         response_data: dict[str, Any] = deepcopy(PREVENT_AI_CONFIG_DEFAULT)
-        response_data["organization"][git_organization_name] = request.data
+        response_data["organization"] = request.data
 
         return Response(response_data, status=200)

--- a/tests/sentry/prevent/endpoints/test_pr_review_config.py
+++ b/tests/sentry/prevent/endpoints/test_pr_review_config.py
@@ -66,7 +66,7 @@ class OrganizationPreventGitHubConfigTest(APITestCase):
 
         resp = self.client.get(self.url)
         assert resp.status_code == 200
-        assert resp.data["organization"][self.git_org] == VALID_ORG_CONFIG
+        assert resp.data["organization"] == VALID_ORG_CONFIG
 
     def test_get_returns_404_when_integration_not_found(self):
         """Test GET endpoint returns 404 when GitHub integration doesn't exist."""
@@ -88,7 +88,7 @@ class OrganizationPreventGitHubConfigTest(APITestCase):
         """Test PUT endpoint creates a new configuration entry."""
         resp = self.client.put(self.url, data=VALID_ORG_CONFIG, format="json")
         assert resp.status_code == 200
-        assert resp.data["organization"][self.git_org] == VALID_ORG_CONFIG
+        assert resp.data["organization"] == VALID_ORG_CONFIG
 
         config = PreventAIConfiguration.objects.get(
             organization_id=self.org.id, integration_id=self.integration.id
@@ -191,8 +191,6 @@ class OrganizationPreventGitHubConfigTest(APITestCase):
         resp = self.client.get(self.url)
         assert resp.status_code == 200
         assert (
-            resp.data["organization"][self.git_org]["repo_overrides"]["my-repo"]["bug_prediction"][
-                "sensitivity"
-            ]
+            resp.data["organization"]["repo_overrides"]["my-repo"]["bug_prediction"]["sensitivity"]
             == "high"
         )


### PR DESCRIPTION
The returned data was nested at the github org name, which used to be needed but in the current state of things is not necessary. Update the return values accordingly.

