### PR TITLE
ref(grouping): Reorder exception grouping components

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -411,6 +411,9 @@ class ExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponen
         """
         Convert to a dictionary, first rearranging the values so they show up in the order we want
         in grouping info.
+
+        TODO: Once we're fully transitioned off of the `newstyle:2023-01-11` config, this method can
+        be deleted
         """
         ordered_values: Any = []
 

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -55,12 +55,10 @@ register_grouping_config(
     id="newstyle:2023-01-11",
     # There's no `base` argument here because this config is based on `BASE_STRATEGY`. To base a
     # config on a previous config, include its `id` value as the value for `base` here.
-    #
-    # There's nothing in the initial context because this config uses all the default values. If we
-    # change grouping behavior in a future config, it should be gated by a config feature, that
-    # feature should be defaulted to False in the base config, and then the `initial_context` in the
-    # new config is where we'd flip it to True.
-    initial_context={},
+    initial_context={
+        # Shim to preserve hash values, since they're order-dependent
+        "use_legacy_exception_subcomponent_order": True,
+    },
     enhancements_base="all-platforms:2023-01-11",
     fingerprinting_bases=["javascript@2024-02-02"],
 )

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -613,10 +613,14 @@ def single_exception(
             )
 
         values: list[ExceptionGroupingComponentChildren] = []
-        if ns_error_component is not None:
-            values = [stacktrace_component, type_component, ns_error_component, value_component]
-        else:
-            values = [stacktrace_component, type_component, value_component]
+
+        # TODO: Once we're fully transitioned off of the `newstyle:2023-01-11` config, the code here
+        # (and the option controlling it) can be deleted
+        if context.get("use_legacy_exception_subcomponent_order"):
+            if ns_error_component is not None:
+                values = [stacktrace_component, type_component, ns_error_component, value_component]
+            else:
+                values = [stacktrace_component, type_component, value_component]
 
         exception_components_by_variant[variant_name] = ExceptionGroupingComponent(
             values=values, frame_counts=stacktrace_component.frame_counts

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -614,6 +614,11 @@ def single_exception(
 
         values: list[ExceptionGroupingComponentChildren] = []
 
+        if ns_error_component is not None:
+            values = [type_component, value_component, ns_error_component, stacktrace_component]
+        else:
+            values = [type_component, value_component, stacktrace_component]
+
         # TODO: Once we're fully transitioned off of the `newstyle:2023-01-11` config, the code here
         # (and the option controlling it) can be deleted
         if context.get("use_legacy_exception_subcomponent_order"):

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 
+from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.component import (
     BaseGroupingComponent,
     ChainedExceptionGroupingComponent,
@@ -12,6 +13,7 @@ from sentry.grouping.component import (
     StacktraceGroupingComponent,
     ThreadsGroupingComponent,
 )
+from sentry.grouping.strategies.configurations import FALL_2025_GROUPING_CONFIG
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
 
@@ -379,3 +381,28 @@ class ComponentTest(TestCase):
             "value", recursive=True, only_contributing=True
         )
         assert not contributing_error_value_component
+
+    # TODO: Once we're fully transitioned off of the `newstyle:2023-01-11` config, this test can
+    # be deleted
+    def test_configs_put_exception_subcomponents_in_expected_order(self) -> None:
+        self.event.data["exception"]["values"][0]["stacktrace"] = {"frames": []}
+
+        self.project.update_option("sentry:grouping_config", DEFAULT_GROUPING_CONFIG)
+        variants = self.event.get_grouping_variants()
+        exception_component = variants["app"].root_component.values[0]
+        assert isinstance(exception_component, ExceptionGroupingComponent)
+        assert [subcomponent.id for subcomponent in exception_component.values] == [
+            "stacktrace",
+            "type",
+            "value",
+        ]
+
+        self.project.update_option("sentry:grouping_config", FALL_2025_GROUPING_CONFIG)
+        variants = self.event.get_grouping_variants()
+        exception_component = variants["app"].root_component.values[0]
+        assert isinstance(exception_component, ExceptionGroupingComponent)
+        assert [subcomponent.id for subcomponent in exception_component.values] == [
+            "stacktrace",
+            "type",
+            "value",
+        ]


### PR DESCRIPTION
Currently, [we rearrange exception grouping components' subcomponents](https://github.com/getsentry/sentry/blob/fe370946425756ade9846ed15e1aef25343db0a1/src/sentry/grouping/component.py#L410-L424) before displaying them in grouping info, so that they show up in the order we want. (Specifically, we move the stacktrace last so that even if it's long, you can still see the exception type and value without scrolling.)

Now that we're introducing a new grouping config, we can change the underlying order, so that no rearranging is required. (This requires a new config because hash values are order-dependent, so changing the order of the components will result in new hash values.) This PR makes the change, while preserving the current order under a new `use_legacy_exception_subcomponent_order` grouping config option, which is set to `True` in the current default config. A follow-up PR will turn the option off in the new grouping config.