### PR TITLE
fix(Jira): Updates Jira integration to generically handle non JSON responses

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -1000,10 +1000,10 @@ class JiraIntegration(IssueSyncIntegration):
         """
         logging_context = {
             "exception_type": type(exc).__name__,
-            "request_body": str(exc.json),
+            "request_body": str(exc.json) if isinstance(exc, ApiError) else None,
         }
 
-        if not exc.json:
+        if isinstance(exc, ApiError) and not exc.json:
             logger.warning("sentry.jira.raise_error.non_json_error_response", extra=logging_context)
             raise IntegrationConfigurationError(
                 "Something went wrong while communicating with Jira"

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -50,7 +50,6 @@ from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationProviderError,
 )
 from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
@@ -999,25 +998,26 @@ class JiraIntegration(IssueSyncIntegration):
         This is because the majority of Jira errors we receive are external
         configuration problems, like required fields missing.
         """
+        logging_context = {
+            "exception_type": type(exc).__name__,
+            "request_body": str(exc.json),
+        }
+
+        if not exc.json:
+            logger.warning("sentry.jira.raise_error.non_json_error_response", extra=logging_context)
+            raise IntegrationConfigurationError(
+                "Something went wrong while communicating with Jira"
+            ) from exc
+
         if isinstance(exc, ApiInvalidRequestError):
-            if exc.json:
-                error_fields = self.error_fields_from_json(exc.json)
-                if error_fields is not None:
-                    raise IntegrationFormError(error_fields).with_traceback(sys.exc_info()[2])
+            error_fields = self.error_fields_from_json(exc.json)
+            if error_fields is not None:
+                raise IntegrationFormError(error_fields).with_traceback(sys.exc_info()[2])
 
             logger.warning(
-                "sentry.jira.raise_error.api_invalid_request_error",
-                extra={
-                    "exception_type": type(exc).__name__,
-                    "request_body": str(exc.json),
-                },
+                "sentry.jira.raise_error.generic_api_invalid_error", extra=logging_context
             )
             raise IntegrationConfigurationError(exc.text) from exc
-        elif isinstance(exc, ApiError):
-            if "Product Unavailable" in exc.text or "Page Unavailable" in exc.text:
-                raise IntegrationProviderError(
-                    "Something went wrong while communicating with Jira"
-                ) from exc
 
         super().raise_error(exc, identity=identity)
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -23,7 +23,6 @@ from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationError,
     IntegrationFormError,
-    IntegrationProviderError,
 )
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
@@ -797,7 +796,8 @@ class RegionJiraIntegrationTest(APITestCase):
         )
         installation = self.integration.get_installation(self.organization.id)
         with pytest.raises(
-            IntegrationProviderError, match="Something went wrong while communicating with Jira"
+            IntegrationConfigurationError,
+            match="Something went wrong while communicating with Jira",
         ):
             installation.create_issue(
                 {
@@ -826,7 +826,8 @@ class RegionJiraIntegrationTest(APITestCase):
         )
         installation = self.integration.get_installation(self.organization.id)
         with pytest.raises(
-            IntegrationProviderError, match="Something went wrong while communicating with Jira"
+            IntegrationConfigurationError,
+            match="Something went wrong while communicating with Jira",
         ):
             installation.create_issue(
                 {

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -85,9 +85,7 @@ class JiraSearchEndpointTest(APITestCase):
         for field in ("externalIssue", "parent"):
             resp = self.client.get(f"{path}?field={field}&query=test")
             assert resp.status_code == 400
-            assert resp.data == {
-                "detail": "Error Communicating with Jira (HTTP 500): unknown error"
-            }
+            assert resp.data == {"detail": "Something went wrong while communicating with Jira"}
 
     @responses.activate
     def test_assignee_search(self) -> None:


### PR DESCRIPTION
In multiple contexts, Jira returns non-JSON responses when an integration is configured incorrectly. This typically happens when the atlassian site is inaccessible for some reason (like pending site deletion for example).

This treats all error responses with HTML/non-JSON responses as configuration errors which should be handled as halts in the calling code already.
