### PR TITLE
feat(ui): Add Copy Raw Stacktrace button to issue details

### DIFF
--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -66,6 +66,7 @@ export function Exception({
         title={t('Stack Trace')}
         type={EntryType.EXCEPTION}
         projectSlug={projectSlug}
+        event={event}
         eventId={event.id}
         platform={event.platform ?? 'other'}
         hasMinified={!!data.values?.some(value => value.rawStacktrace)}

--- a/static/app/components/events/interfaces/stackTrace.tsx
+++ b/static/app/components/events/interfaces/stackTrace.tsx
@@ -70,6 +70,7 @@ export function StackTrace({projectSlug, event, data, groupingCurrentLevel}: Pro
       <TraceEventDataSection
         type={EntryType.STACKTRACE}
         projectSlug={projectSlug}
+        event={event}
         eventId={event.id}
         platform={platform}
         stackTraceNotFound={stackTraceNotFound}

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -332,6 +332,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
         <TraceEventDataSection
           type={SectionKey.THREADS}
           projectSlug={projectSlug}
+          event={event}
           eventId={event.id}
           title={hasMoreThanOneThread ? t('Thread Stack Trace') : t('Stack Trace')}
           platform={platform}

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -337,6 +337,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
           title={hasMoreThanOneThread ? t('Thread Stack Trace') : t('Stack Trace')}
           platform={platform}
           isNestedSection={hasMoreThanOneThread}
+          activeThreadId={activeThread?.id}
           hasMinified={
             !!exception?.values?.find(value => value.rawStacktrace) ||
             !!activeThread?.rawStacktrace

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -249,19 +249,21 @@ export function TraceEventDataSection({
 
     const rawStacktraces = stacktraceEntries.map(entry => {
       if (entry.type === EntryType.EXCEPTION) {
-        return entry.data.values
-          ?.map(exception =>
-            displayRawContent({
-              data: exception.stacktrace,
-              platform: exception.stacktrace?.frames?.[0]?.platform ?? platform,
-              exception,
-              hasSimilarityEmbeddingsFeature: false,
-              includeLocation: true,
-              rawTrace: true,
-            })
-          )
-          .filter(Boolean)
-          .join('\n\n');
+        return (
+          entry.data.values
+            ?.map(exception =>
+              displayRawContent({
+                data: exception.stacktrace,
+                platform: exception.stacktrace?.frames?.[0]?.platform ?? platform,
+                exception,
+                hasSimilarityEmbeddingsFeature: false,
+                includeLocation: true,
+                rawTrace: true,
+              })
+            )
+            .filter(Boolean)
+            .join('\n\n') ?? ''
+        );
       }
       if (entry.type === EntryType.STACKTRACE) {
         return displayRawContent({

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -434,9 +434,7 @@ export function TraceEventDataSection({
                 icon={<IconCopy />}
                 onClick={handleCopyRawStacktrace}
                 aria-label={t('Copy Raw Stacktrace')}
-              >
-                {t('Copy Raw Stacktrace')}
-              </Button>
+              />
             </Tooltip>
             {displayOptions.includes('raw-stack-trace') && nativePlatform && (
               <LinkButton

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -428,14 +428,13 @@ export function TraceEventDataSection({
                 </SegmentedControl>
               </Tooltip>
             )}
-            <Tooltip title={t('Copy raw stacktrace to clipboard')}>
-              <Button
-                size="xs"
-                icon={<IconCopy />}
-                onClick={handleCopyRawStacktrace}
-                aria-label={t('Copy Raw Stacktrace')}
-              />
-            </Tooltip>
+            <Button
+              size="xs"
+              icon={<IconCopy />}
+              onClick={handleCopyRawStacktrace}
+              aria-label={t('Copy Raw Stacktrace')}
+              title={t('Copy raw stacktrace to clipboard')}
+            />
             {displayOptions.includes('raw-stack-trace') && nativePlatform && (
               <LinkButton
                 size="xs"


### PR DESCRIPTION
Users would like to copy the raw stacktrace but find it annoying to have to switch to "raw stacktrace" view to do so. "Copy to clipboard" above on issue details page isn't obvious and also copies the entire issue, which they may not want.

- Adds a "Copy Raw Stacktrace" button inline with other stacktrace control options
- Reuses logic from the existing copy / display raw stacktrace functionality
- Passes event to necessary components so we have access to it


Generated with Claude code with a few iterations. prompt:
```
add a button to issue details streamlined next to "most relevant" / "full stack trace" called "Copy Raw Stacktrace"
```
context: https://sentry.slack.com/archives/CDXAKMGTU/p1762210622219059


<img width="220" height="85" alt="Screenshot 2025-11-03 at 10 02 59 PM" src="https://github.com/user-attachments/assets/9fa4e560-f6cf-4d57-8cef-8f8b0b540397" />
<img width="882" height="109" alt="Screenshot 2025-11-03 at 10 02 57 PM" src="https://github.com/user-attachments/assets/a260f338-0678-4677-adf7-d9b9cf55a393" />
