### PR TITLE
Do reprocessing using objectstore

### DIFF
--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from objectstore_client import Client, ClientBuilder, ClientError, MetricsBackend, TimeToLive
 from objectstore_client.metrics import Tags
 
-from sentry.utils import metrics
+from sentry.utils import metrics as sentry_metrics
 
 __all__ = ["get_attachments_client", "Client", "ClientBuilder", "ClientError"]
 
@@ -17,13 +17,13 @@ class SentryMetricsBackend(MetricsBackend):
         value: int | float = 1,
         tags: Tags | None = None,
     ) -> None:
-        metrics.incr(name, int(value), tags=tags)
+        sentry_metrics.incr(name, int(value), tags=tags)
 
     def gauge(self, name: str, value: int | float, tags: Tags | None = None) -> None:
         """
         Sets a gauge metric to the given value.
         """
-        metrics.gauge(name, value, tags=tags)
+        sentry_metrics.gauge(name, value, tags=tags)
 
     def distribution(
         self,
@@ -32,7 +32,7 @@ class SentryMetricsBackend(MetricsBackend):
         tags: Tags | None = None,
         unit: str | None = None,
     ) -> None:
-        metrics.distribution(name, value, tags=tags, unit=unit)
+        sentry_metrics.distribution(name, value, tags=tags, unit=unit)
 
 
 def get_attachments_client() -> ClientBuilder:

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -94,7 +94,10 @@ from django.db import router
 from sentry import models, nodestore, options
 from sentry.attachments import CachedAttachment, attachment_cache, store_attachments_for_event
 from sentry.deletions.defaults.group import DIRECT_GROUP_RELATED_MODELS
-from sentry.models.eventattachment import EventAttachment
+from sentry.models.eventattachment import V2_PREFIX, EventAttachment
+from sentry.models.project import Project
+from sentry.objectstore import get_attachments_client
+from sentry.options.rollout import in_random_rollout
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.services.eventstore.processing import event_processing_store
@@ -214,13 +217,15 @@ def reprocess_event(project_id: int, event_id: str, start_time: float) -> None:
     # Step 1: Copy attachments into attachment cache. Note that we can only
     # consider minidumps because filestore just stays as-is after reprocessing
     # (we simply update group_id on the EventAttachment models in post_process)
+    project = Project.objects.get_from_cache(id=project_id)
     cache_key = cache_key_for_event(data)
     attachment_objects = []
     for attachment_id, attachment in enumerate(attachments):
-        with sentry_sdk.start_span(op="reprocess_event._copy_attachment_into_cache") as span:
+        with sentry_sdk.start_span(op="reprocess_event._maybe_copy_attachment_into_cache") as span:
             span.set_data("attachment_id", attachment.id)
             attachment_objects.append(
-                _copy_attachment_into_cache(
+                _maybe_copy_attachment_into_cache(
+                    project=project,
                     attachment_id=attachment_id,
                     attachment=attachment,
                     cache_key=cache_key,
@@ -390,40 +395,63 @@ def buffered_delete_old_primary_hash(
         )
 
 
-def _copy_attachment_into_cache(
-    attachment_id: int, attachment: EventAttachment, cache_key: str, cache_timeout: int
+def _maybe_copy_attachment_into_cache(
+    project: Project,
+    attachment_id: int,
+    attachment: EventAttachment,
+    cache_key: str,
+    cache_timeout: int,
 ) -> CachedAttachment:
-    with attachment.getfile() as fp:
-        chunk_index = 0
-        size = 0
-        while True:
-            chunk = fp.read(settings.SENTRY_REPROCESSING_ATTACHMENT_CHUNK_SIZE)
-            if not chunk:
-                break
+    stored_id = None
+    chunks = None
 
-            size += len(chunk)
+    if in_random_rollout("objectstore.enable_for.attachments"):
+        blob_path = attachment.blob_path or ""
+        if blob_path.startswith(V2_PREFIX):
+            # in case the attachment is already stored in objectstore, there is nothing to do
+            stored_id = blob_path.removeprefix(V2_PREFIX)
+        else:
+            # otherwise, we store it in objectstore
+            with attachment.getfile() as fp:
+                stored_id = (
+                    get_attachments_client()
+                    .for_project(project.organization_id, project.id)
+                    .put(fp)
+                )
 
-            attachment_cache.set_chunk(
-                key=cache_key,
-                id=attachment_id,
-                chunk_index=chunk_index,
-                chunk_data=chunk,
-                timeout=cache_timeout,
-            )
-            chunk_index += 1
+    else:
+        # when not using objectstore, store chunks in the attachment cache
+        with attachment.getfile() as fp:
+            chunk_index = 0
+            size = 0
+            while True:
+                chunk = fp.read(settings.SENTRY_REPROCESSING_ATTACHMENT_CHUNK_SIZE)
+                if not chunk:
+                    break
 
-    assert size == attachment.size
+                size += len(chunk)
+
+                attachment_cache.set_chunk(
+                    key=cache_key,
+                    id=attachment_id,
+                    chunk_index=chunk_index,
+                    chunk_data=chunk,
+                    timeout=cache_timeout,
+                )
+                chunk_index += 1
+
+        assert size == attachment.size
+        chunks = chunk_index
 
     return CachedAttachment(
         key=cache_key,
         id=attachment_id,
         name=attachment.name,
-        # XXX: Not part of eventattachment model, but not strictly
-        # necessary for processing
-        content_type=None,
+        content_type=attachment.content_type,
         type=attachment.type,
-        chunks=chunk_index,
-        size=size,
+        size=attachment.size,
+        stored_id=stored_id,
+        chunks=chunks,
     )
 
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from sentry.attachments import attachment_cache
+from sentry.attachments import get_attachments_for_event
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.event_manager import EventManager
 from sentry.grouping.enhancer import EnhancementsConfig
@@ -29,7 +29,6 @@ from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
-from sentry.utils.cache import cache_key_for_event
 
 pytestmark = [requires_snuba]
 
@@ -384,8 +383,7 @@ def test_attachments_and_userfeedback(
         extra.setdefault("processing_counter", 0)
         extra["processing_counter"] += 1
 
-        cache_key = cache_key_for_event(data)
-        attachments = attachment_cache.get(cache_key)
+        attachments = get_attachments_for_event(data)
         extra.setdefault("attachments", []).append([attachment.type for attachment in attachments])
 
         return data

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_with_objectstore_initial.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_with_objectstore_initial.pysnap
@@ -1,0 +1,548 @@
+---
+created: '2025-11-04T11:37:39.383601+00:00'
+creator: sentry
+source: tests/symbolicator/test_minidump_full.py
+---
+contexts:
+  device:
+    arch: x86
+    type: device
+  os:
+    name: Windows
+    type: os
+    version: 10.0.14393
+debug_meta:
+  images:
+  - candidates:
+    - download:
+        status: notfound
+      source: sentry:project
+      source_name: Sentry
+    code_file: C:\projects\breakpad-tools\windows\Release\crash.exe
+    code_id: 5ab380779000
+    debug_file: C:\projects\breakpad-tools\windows\Release\crash.pdb
+    debug_id: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
+    debug_status: missing
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x2a0000'
+    image_size: 36864
+    type: pe
+    unwind_status: missing
+  - code_file: C:\Windows\System32\dbghelp.dll
+    code_id: 57898e12145000
+    debug_file: dbghelp.pdb
+    debug_id: 9c2a902b-6fdf-40ad-8308-588a41d572a0-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70850000'
+    image_size: 1331200
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\msvcp140.dll
+    code_id: 589abc846c000
+    debug_file: msvcp140.i386.pdb
+    debug_id: bf5257f7-8c26-43dd-9bb7-901625e1136a-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x709a0000'
+    image_size: 442368
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\apphelp.dll
+    code_id: 57898eeb92000
+    debug_file: apphelp.pdb
+    debug_id: 8daf7773-372f-460a-af38-944e193f7e33-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70a10000'
+    image_size: 598016
+    type: pe
+    unwind_status: unused
+  - candidates:
+    - download:
+        status: notfound
+      source: sentry:project
+      source_name: Sentry
+    code_file: C:\Windows\System32\dbgcore.dll
+    code_id: 57898dab25000
+    debug_file: dbgcore.pdb
+    debug_id: aec7ef2f-df4b-4642-a471-4c3e5fe8760a-1
+    debug_status: missing
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70b70000'
+    image_size: 151552
+    type: pe
+    unwind_status: missing
+  - code_file: C:\Windows\System32\VCRUNTIME140.dll
+    code_id: 589abc7714000
+    debug_file: vcruntime140.i386.pdb
+    debug_id: 0ed80a50-ecda-472b-86a4-eb6c833f8e1b-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70c60000'
+    image_size: 81920
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\CRYPTBASE.dll
+    code_id: 57899141a000
+    debug_file: cryptbase.pdb
+    debug_id: 147c51fb-7ca1-408f-85b5-285f2ad6f9c5-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73ba0000'
+    image_size: 40960
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\sspicli.dll
+    code_id: 59bf30e31f000
+    debug_file: wsspicli.pdb
+    debug_id: 51e432b1-0450-4b19-8ed1-6d4335f9f543-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73bb0000'
+    image_size: 126976
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\advapi32.dll
+    code_id: 5a49bb7677000
+    debug_file: advapi32.pdb
+    debug_id: 0c799483-b549-417d-8433-4331852031fe-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73c70000'
+    image_size: 487424
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\msvcrt.dll
+    code_id: 57899155be000
+    debug_file: msvcrt.pdb
+    debug_id: 6f6409b3-d520-43c7-9b2f-62e00bfe761c-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73cf0000'
+    image_size: 778240
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\sechost.dll
+    code_id: 598942c741000
+    debug_file: sechost.pdb
+    debug_id: 6f6a05dd-0a80-478b-a419-9b88703bf75b-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x74450000'
+    image_size: 266240
+    type: pe
+    unwind_status: unused
+  - candidates:
+    - download:
+        status: notfound
+      source: sentry:project
+      source_name: Sentry
+    code_file: C:\Windows\System32\kernel32.dll
+    code_id: 590285e9e0000
+    debug_file: wkernel32.pdb
+    debug_id: d3474559-96f7-47d6-bf43-c176b2171e68-1
+    debug_status: missing
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x75050000'
+    image_size: 917504
+    type: pe
+    unwind_status: missing
+  - code_file: C:\Windows\System32\bcryptPrimitives.dll
+    code_id: 59b0df8f5a000
+    debug_file: bcryptprimitives.pdb
+    debug_id: 287b19c3-9209-4a2b-bb8f-bcc37f411b11-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x75130000'
+    image_size: 368640
+    type: pe
+    unwind_status: unused
+  - candidates:
+    - download:
+        status: notfound
+      source: sentry:project
+      source_name: Sentry
+    code_file: C:\Windows\System32\rpcrt4.dll
+    code_id: 5a49bb75c1000
+    debug_file: wrpcrt4.pdb
+    debug_id: ae131c67-27a7-4fa1-9916-b5a4aef41190-1
+    debug_status: missing
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x75810000'
+    image_size: 790528
+    type: pe
+    unwind_status: missing
+  - code_file: C:\Windows\System32\ucrtbase.dll
+    code_id: 59bf2b5ae0000
+    debug_file: ucrtbase.pdb
+    debug_id: 6bedcbce-0a3a-40e9-8040-81c2c8c6cc2f-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x758f0000'
+    image_size: 917504
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\KERNELBASE.dll
+    code_id: 59bf2bcf1a1000
+    debug_file: wkernelbase.pdb
+    debug_id: 8462294a-c645-402d-ac82-a4e95f61ddf9-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x76db0000'
+    image_size: 1708032
+    type: pe
+    unwind_status: unused
+  - candidates:
+    - download:
+        status: notfound
+      source: sentry:project
+      source_name: Sentry
+    code_file: C:\Windows\System32\ntdll.dll
+    code_id: 59b0d8f3183000
+    debug_file: wntdll.pdb
+    debug_id: 971f98e5-ce60-41ff-b2d7-235bbeb34578-1
+    debug_status: missing
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x77170000'
+    image_size: 1585152
+    type: pe
+    unwind_status: missing
+errors:
+- image_path: C:\projects\breakpad-tools\windows\Release\crash.exe
+  image_uuid: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
+  message: None
+  type: native_missing_dsym
+exception:
+  values:
+  - mechanism:
+      handled: false
+      synthetic: true
+      type: minidump
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f44'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f79'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x750662c4'
+        lineno: null
+        package: C:\Windows\System32\kernel32.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x2a2d97'
+        lineno: null
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: null
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x2a3435'
+        lineno: null
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: null
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x7584e9c0'
+        lineno: null
+        package: C:\Windows\System32\rpcrt4.dll
+        symbol: null
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x70b7ae40'
+        lineno: null
+        package: C:\Windows\System32\dbgcore.dll
+        symbol: null
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x7584e9c0'
+        lineno: null
+        package: C:\Windows\System32\rpcrt4.dll
+        symbol: null
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x2a28d0'
+        lineno: null
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x2a2a3d'
+        lineno: null
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: null
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x10ff670'
+        ebx: '0xfe5000'
+        ecx: '0x10ff670'
+        edi: '0x13bfd78'
+        edx: '0x7'
+        eflags: '0x10246'
+        eip: '0x2a2a3d'
+        esi: '0x759c6314'
+        esp: '0x10ff644'
+    thread_id: 1636
+    type: EXCEPTION_ACCESS_VIOLATION_WRITE
+    value: 'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'
+stacktrace: null
+threads:
+  values:
+  - crashed: true
+    id: 1636
+    raw_stacktrace: null
+    stacktrace: null
+  - id: 3580
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f44'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f79'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x750662c4'
+        lineno: null
+        package: C:\Windows\System32\kernel32.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771e016c'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x159faa4'
+        ebx: '0x13b0990'
+        ecx: '0x0'
+        edi: '0x13b4af0'
+        edx: '0x0'
+        eflags: '0x216'
+        eip: '0x771e016c'
+        esi: '0x13b4930'
+        esp: '0x159f900'
+  - id: 2600
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f44'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f79'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x750662c4'
+        lineno: null
+        package: C:\Windows\System32\kernel32.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771e016c'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x169fb98'
+        ebx: '0x13b0990'
+        ecx: '0x0'
+        edi: '0x13b7c28'
+        edx: '0x0'
+        eflags: '0x202'
+        eip: '0x771e016c'
+        esi: '0x13b7a68'
+        esp: '0x169f9f4'
+  - id: 2920
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771df3dc'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x179f2b8'
+        ebx: '0x17b1aa0'
+        ecx: '0x0'
+        edi: '0x17b1a90'
+        edx: '0x0'
+        eflags: '0x206'
+        eip: '0x771df3dc'
+        esi: '0x2cc'
+        esp: '0x179f2ac'

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_with_objectstore_reprocessed.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_with_objectstore_reprocessed.pysnap
@@ -1,0 +1,495 @@
+---
+created: '2025-11-04T11:37:40.008090+00:00'
+creator: sentry
+source: tests/symbolicator/test_minidump_full.py
+---
+contexts:
+  device:
+    arch: x86
+    type: device
+  os:
+    name: Windows
+    type: os
+    version: 10.0.14393
+debug_meta:
+  images:
+  - arch: x86
+    candidates:
+    - debug:
+        status: ok
+      download:
+        features:
+          has_debug_info: true
+          has_sources: false
+          has_symbols: true
+          has_unwind_info: true
+        status: ok
+      location: sentry://project_debug_file/x
+      source: sentry:project
+      source_name: Sentry
+      unwind:
+        status: ok
+    code_file: C:\projects\breakpad-tools\windows\Release\crash.exe
+    code_id: 5ab380779000
+    debug_file: C:\projects\breakpad-tools\windows\Release\crash.pdb
+    debug_id: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
+    debug_status: found
+    features:
+      has_debug_info: true
+      has_sources: false
+      has_symbols: true
+      has_unwind_info: true
+    image_addr: '0x2a0000'
+    image_size: 36864
+    type: pe
+    unwind_status: found
+  - code_file: C:\Windows\System32\dbghelp.dll
+    code_id: 57898e12145000
+    debug_file: dbghelp.pdb
+    debug_id: 9c2a902b-6fdf-40ad-8308-588a41d572a0-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70850000'
+    image_size: 1331200
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\msvcp140.dll
+    code_id: 589abc846c000
+    debug_file: msvcp140.i386.pdb
+    debug_id: bf5257f7-8c26-43dd-9bb7-901625e1136a-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x709a0000'
+    image_size: 442368
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\apphelp.dll
+    code_id: 57898eeb92000
+    debug_file: apphelp.pdb
+    debug_id: 8daf7773-372f-460a-af38-944e193f7e33-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70a10000'
+    image_size: 598016
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\dbgcore.dll
+    code_id: 57898dab25000
+    debug_file: dbgcore.pdb
+    debug_id: aec7ef2f-df4b-4642-a471-4c3e5fe8760a-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70b70000'
+    image_size: 151552
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\VCRUNTIME140.dll
+    code_id: 589abc7714000
+    debug_file: vcruntime140.i386.pdb
+    debug_id: 0ed80a50-ecda-472b-86a4-eb6c833f8e1b-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x70c60000'
+    image_size: 81920
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\CRYPTBASE.dll
+    code_id: 57899141a000
+    debug_file: cryptbase.pdb
+    debug_id: 147c51fb-7ca1-408f-85b5-285f2ad6f9c5-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73ba0000'
+    image_size: 40960
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\sspicli.dll
+    code_id: 59bf30e31f000
+    debug_file: wsspicli.pdb
+    debug_id: 51e432b1-0450-4b19-8ed1-6d4335f9f543-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73bb0000'
+    image_size: 126976
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\advapi32.dll
+    code_id: 5a49bb7677000
+    debug_file: advapi32.pdb
+    debug_id: 0c799483-b549-417d-8433-4331852031fe-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73c70000'
+    image_size: 487424
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\msvcrt.dll
+    code_id: 57899155be000
+    debug_file: msvcrt.pdb
+    debug_id: 6f6409b3-d520-43c7-9b2f-62e00bfe761c-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x73cf0000'
+    image_size: 778240
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\sechost.dll
+    code_id: 598942c741000
+    debug_file: sechost.pdb
+    debug_id: 6f6a05dd-0a80-478b-a419-9b88703bf75b-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x74450000'
+    image_size: 266240
+    type: pe
+    unwind_status: unused
+  - candidates:
+    - download:
+        status: notfound
+      source: sentry:project
+      source_name: Sentry
+    code_file: C:\Windows\System32\kernel32.dll
+    code_id: 590285e9e0000
+    debug_file: wkernel32.pdb
+    debug_id: d3474559-96f7-47d6-bf43-c176b2171e68-1
+    debug_status: missing
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x75050000'
+    image_size: 917504
+    type: pe
+    unwind_status: missing
+  - code_file: C:\Windows\System32\bcryptPrimitives.dll
+    code_id: 59b0df8f5a000
+    debug_file: bcryptprimitives.pdb
+    debug_id: 287b19c3-9209-4a2b-bb8f-bcc37f411b11-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x75130000'
+    image_size: 368640
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\rpcrt4.dll
+    code_id: 5a49bb75c1000
+    debug_file: wrpcrt4.pdb
+    debug_id: ae131c67-27a7-4fa1-9916-b5a4aef41190-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x75810000'
+    image_size: 790528
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\ucrtbase.dll
+    code_id: 59bf2b5ae0000
+    debug_file: ucrtbase.pdb
+    debug_id: 6bedcbce-0a3a-40e9-8040-81c2c8c6cc2f-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x758f0000'
+    image_size: 917504
+    type: pe
+    unwind_status: unused
+  - code_file: C:\Windows\System32\KERNELBASE.dll
+    code_id: 59bf2bcf1a1000
+    debug_file: wkernelbase.pdb
+    debug_id: 8462294a-c645-402d-ac82-a4e95f61ddf9-1
+    debug_status: unused
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x76db0000'
+    image_size: 1708032
+    type: pe
+    unwind_status: unused
+  - candidates:
+    - download:
+        status: notfound
+      source: sentry:project
+      source_name: Sentry
+    code_file: C:\Windows\System32\ntdll.dll
+    code_id: 59b0d8f3183000
+    debug_file: wntdll.pdb
+    debug_id: 971f98e5-ce60-41ff-b2d7-235bbeb34578-1
+    debug_status: missing
+    features:
+      has_debug_info: false
+      has_sources: false
+      has_symbols: false
+      has_unwind_info: false
+    image_addr: '0x77170000'
+    image_size: 1585152
+    type: pe
+    unwind_status: missing
+errors: []
+exception:
+  values:
+  - mechanism:
+      handled: false
+      synthetic: true
+      type: minidump
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f44'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f79'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x750662c4'
+        lineno: null
+        package: C:\Windows\System32\kernel32.dll
+        symbol: null
+        trust: cfi
+      - data:
+          orig_in_app: -1
+          symbolicator_status: symbolicated
+        function: __scrt_common_main_seh
+        in_app: false
+        instruction_addr: '0x2a2d96'
+        lineno: 283
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: __scrt_common_main_seh
+        trust: cfi
+      - data:
+          orig_in_app: -1
+          symbolicator_status: symbolicated
+        function: main
+        in_app: false
+        instruction_addr: '0x2a2a3d'
+        lineno: 35
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: main
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x10ff670'
+        ebx: '0xfe5000'
+        ecx: '0x10ff670'
+        edi: '0x13bfd78'
+        edx: '0x7'
+        eflags: '0x10246'
+        eip: '0x2a2a3d'
+        esi: '0x759c6314'
+        esp: '0x10ff644'
+    thread_id: 1636
+    type: EXCEPTION_ACCESS_VIOLATION_WRITE
+    value: 'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'
+stacktrace: null
+threads:
+  values:
+  - crashed: true
+    id: 1636
+    raw_stacktrace: null
+    stacktrace: null
+  - id: 3580
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f44'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f79'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x750662c4'
+        lineno: null
+        package: C:\Windows\System32\kernel32.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771e016c'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x159faa4'
+        ebx: '0x13b0990'
+        ecx: '0x0'
+        edi: '0x13b4af0'
+        edx: '0x0'
+        eflags: '0x216'
+        eip: '0x771e016c'
+        esi: '0x13b4930'
+        esp: '0x159f900'
+  - id: 2600
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f44'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771d0f79'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x750662c4'
+        lineno: null
+        package: C:\Windows\System32\kernel32.dll
+        symbol: null
+        trust: fp
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771e016c'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x169fb98'
+        ebx: '0x13b0990'
+        ecx: '0x0'
+        edi: '0x13b7c28'
+        edx: '0x0'
+        eflags: '0x202'
+        eip: '0x771e016c'
+        esi: '0x13b7a68'
+        esp: '0x169f9f4'
+  - id: 2920
+    raw_stacktrace: null
+    stacktrace:
+      frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        function: null
+        in_app: false
+        instruction_addr: '0x771df3dc'
+        lineno: null
+        package: C:\Windows\System32\ntdll.dll
+        symbol: null
+        trust: context
+      registers:
+        eax: '0x0'
+        ebp: '0x179f2b8'
+        ebx: '0x17b1aa0'
+        ecx: '0x0'
+        edi: '0x17b1a90'
+        edx: '0x0'
+        eflags: '0x206'
+        eip: '0x771df3dc'
+        esi: '0x2cc'
+        esp: '0x179f2ac'


### PR DESCRIPTION
Depending on the rollout feature flag, this will now use objectstore-stored attachments when doing reprocessing.