### PR TITLE
ref(deletions): Use the same transaction prefix

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -24,7 +24,7 @@ from sentry.silo.base import SiloLimit, SiloMode
 
 logger = logging.getLogger(__name__)
 
-TRANSACTION_NAME = "cleanup"
+TRANSACTION_PREFIX = "cleanup"
 
 if TYPE_CHECKING:
     from sentry.db.models.base import BaseModel
@@ -121,7 +121,9 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             return
 
         try:
-            with sentry_sdk.start_transaction(op="cleanup", name=TRANSACTION_NAME):
+            with sentry_sdk.start_transaction(
+                op="cleanup", name=f"{TRANSACTION_PREFIX}.multiprocess_worker"
+            ):
                 model = import_string(model_name)
                 task = deletions.get(
                     model=model,
@@ -224,7 +226,9 @@ def _cleanup(
     # Start transaction AFTER creating the multiprocessing pool to avoid
     # transaction context issues in child processes. This ensures only the
     # main process tracks the overall cleanup operation performance.
-    with sentry_sdk.start_transaction(op="cleanup", name=TRANSACTION_NAME) as transaction:
+    with sentry_sdk.start_transaction(
+        op="cleanup", name=f"{TRANSACTION_PREFIX}.main"
+    ) as transaction:
         try:
             # Check if cleanup should be aborted before starting
             if options.get("cleanup.abort_execution"):

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -24,6 +24,8 @@ from sentry.silo.base import SiloLimit, SiloMode
 
 logger = logging.getLogger(__name__)
 
+TRANSACTION_NAME = "cleanup"
+
 if TYPE_CHECKING:
     from sentry.db.models.base import BaseModel
 
@@ -119,7 +121,7 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             return
 
         try:
-            with sentry_sdk.start_transaction(op="cleanup", name="multiprocess_worker"):
+            with sentry_sdk.start_transaction(op="cleanup", name=TRANSACTION_NAME):
                 model = import_string(model_name)
                 task = deletions.get(
                     model=model,
@@ -222,7 +224,7 @@ def _cleanup(
     # Start transaction AFTER creating the multiprocessing pool to avoid
     # transaction context issues in child processes. This ensures only the
     # main process tracks the overall cleanup operation performance.
-    with sentry_sdk.start_transaction(op="cleanup", name="cleanup") as transaction:
+    with sentry_sdk.start_transaction(op="cleanup", name=TRANSACTION_NAME) as transaction:
         try:
             # Check if cleanup should be aborted before starting
             if options.get("cleanup.abort_execution"):


### PR DESCRIPTION
This allows errors within processes and the main script to report using the same transaction prefix.

This will help with not requiring multiple views and different alerts since we can use `transaction.contains("cleanup")`.