### PR TITLE
feat(stacktrace): Strip away relative segments before copy to clipboard

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -411,7 +411,11 @@ function CopyFrameLink({event, frame}: CopyFrameLinkProps) {
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    copy(filePath.replace(/^(\.\/)?(\.\.\/)*/g, ''), {
+
+    // Strip away relative path segments to make it easier for editors to actually find the file (like VSCode cmd+p)
+    const cleanedFilepath = filePath.replace(/^(\.\/)?(\.\.\/)*/g, '')
+
+    copy(cleanedFilepath, {
       successMessage: t('File path copied to clipboard'),
       errorMessage: t('Failed to copy file path'),
     });

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -413,7 +413,7 @@ function CopyFrameLink({event, frame}: CopyFrameLinkProps) {
     e.stopPropagation();
 
     // Strip away relative path segments to make it easier for editors to actually find the file (like VSCode cmd+p)
-    const cleanedFilepath = filePath.replace(/^(\.\/)?(\.\.\/)*/g, '')
+    const cleanedFilepath = filePath.replace(/^(\.\/)?(\.\.\/)*/g, '');
 
     copy(cleanedFilepath, {
       successMessage: t('File path copied to clipboard'),

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -411,7 +411,7 @@ function CopyFrameLink({event, frame}: CopyFrameLinkProps) {
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    copy(filePath, {
+    copy(filePath.replace(/^(\.\/)?(\.\.\/)*/g, ''), {
       successMessage: t('File path copied to clipboard'),
       errorMessage: t('Failed to copy file path'),
     });


### PR DESCRIPTION
Strips away all relative segments from filepath in stack trace before copying to clipboard.