### PR TITLE
fix(spans-migration): account for case sensitive boolean values

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -239,9 +239,9 @@ class TranslationVisitor(NodeVisitor):
 
             flattened_parsed_val_num = None
             if negation == "":
-                if flattened_parsed_val_str == "true":
+                if flattened_parsed_val_str.lower() == "true":
                     flattened_parsed_val_num = "1"
-                elif flattened_parsed_val_str == "false":
+                elif flattened_parsed_val_str.lower() == "false":
                     flattened_parsed_val_num = "0"
                 return f"(tags[{flattened_parsed_key_str},number]:{flattened_parsed_val_num if flattened_parsed_val_num is not None else flattened_parsed_val_str} OR {flattened_parsed_key_str}:{flattened_parsed_val_str})"
 

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -189,7 +189,7 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
         DashboardWidgetQuery.objects.bulk_create(new_widget_queries)
 
         widget.widget_type = DashboardWidgetTypes.SPANS
-        widget.dataset_source = DatasetSourcesTypes.SPAN_MIGRATION_VERSION_4.value
+        widget.dataset_source = DatasetSourcesTypes.SPAN_MIGRATION_VERSION_5.value
         widget.changed_reason = dropped_fields_info
         widget.save()
 

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -136,6 +136,10 @@ class DatasetSourcesTypes(Enum):
     Dataset modified by the transaction -> span migration version 4 (fixing boolean bug)
     """
     SPAN_MIGRATION_VERSION_4 = 10
+    """
+    Dataset modified by the transaction -> span migration version 5 (fixing boolean bug again)
+    """
+    SPAN_MIGRATION_VERSION_5 = 11
 
     @classmethod
     def as_choices(cls):

--- a/tests/sentry/explore/translation/test_dashboards_translation.py
+++ b/tests/sentry/explore/translation/test_dashboards_translation.py
@@ -96,7 +96,7 @@ class DashboardTranslationTestCase(TestCase):
         # Assert widget type and dataset source are set correctly
         assert transaction_widget.widget_type == DashboardWidgetTypes.SPANS
         assert (
-            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_4.value
+            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_5.value
         )
 
         assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()
@@ -741,7 +741,7 @@ class DashboardRestoreTransactionWidgetTestCase(TestCase):
         # Verify translation occurred
         assert transaction_widget.widget_type == DashboardWidgetTypes.SPANS
         assert (
-            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_4.value
+            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_5.value
         )
         assert transaction_widget.widget_snapshot is not None
 


### PR DESCRIPTION
i pushed a fix yesterday for the boolean filter logic but forgot to account for case insensitivity 🤦‍♀️ 
So i'm fixing that and planning to run the migration again with this new version.
