### PR TITLE
chore(dynamic-sampling): add count metric for project counts, by measure

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -311,6 +311,12 @@ def query_project_counts_by_org(
     else:
         granularity = Granularity(60)
 
+    metrics.incr(
+        "dynamic_sampling.query_project_counts_by_org.count",
+        amount=len(org_ids),
+        tags={"measure": str(measure.value)},
+    )
+
     org_ids = list(org_ids)
     project_ids = list(
         Project.objects.filter(organization_id__in=org_ids, status=ObjectStatus.ACTIVE).values_list(


### PR DESCRIPTION
- Add a metric to count how many orgs run the project counts on spans vs transactions

Contributes to TET-1342