### PR TITLE
feat(dashboards): ensure backend only accepts linked dashboards attached to a field

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -966,6 +966,17 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             ):
                 return
 
+            # check if the linked dashboard appears in the fields of the query
+            if not any(
+                field in query.fields
+                for field in [
+                    linked_dashboard.get("field") for linked_dashboard in linked_dashboards
+                ]
+            ):
+                raise serializers.ValidationError(
+                    "Linked dashboard does not appear in the fields of the query"
+                )
+
             for link_data in linked_dashboards:
                 field = link_data.get("field")
                 dashboard_id = link_data.get("dashboard_id")

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -967,7 +967,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                 return
 
             # check if the linked dashboard appears in the fields of the query
-            if len(linked_dashboards) > 0 and not any(
+            if not all(
                 field in query.fields
                 for field in [
                     linked_dashboard.get("field") for linked_dashboard in linked_dashboards

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -967,7 +967,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                 return
 
             # check if the linked dashboard appears in the fields of the query
-            if not any(
+            if len(linked_dashboards) > 0 and not any(
                 field in query.fields
                 for field in [
                     linked_dashboard.get("field") for linked_dashboard in linked_dashboards


### PR DESCRIPTION
The frontend should only allow a linked dashboard that appear in the list of fields associated with the widget, but in case it somehow doesn't this PR adds a check against that in the backend. This prevents extra linked dashboards in the DB that would be hard to delete