### PR TITLE
feat(ai-consent): Skip consent screen for issue summary

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -46,7 +46,8 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const orgNeedsGenAiAcknowledgement =
     !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged &&
     (isSummaryEnabled || isAutofixEnabled) &&
-    areAiFeaturesAllowed;
+    areAiFeaturesAllowed &&
+    !organization.features.includes('gen-ai-consent-flow-removal');
 
   return {
     hasSummary,

--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -46,8 +46,7 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const orgNeedsGenAiAcknowledgement =
     !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged &&
     (isSummaryEnabled || isAutofixEnabled) &&
-    areAiFeaturesAllowed &&
-    !organization.features.includes('gen-ai-consent-flow-removal');
+    areAiFeaturesAllowed;
 
   return {
     hasSummary,

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -143,8 +143,8 @@ describe('SeerSection', () => {
         url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
           setupAcknowledgement: {
-            orgHasAcknowledged: false, // Has not consented
-            userHasAcknowledged: false,
+            orgHasAcknowledged: true,
+            userHasAcknowledged: true,
           },
           integration: {ok: true, reason: null},
           githubWriteIntegration: {ok: true, repos: []},

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -133,6 +133,44 @@ describe('SeerSection', () => {
       expect(screen.getByRole('button', {name: 'Fix with Seer'})).toBeInTheDocument();
     });
 
+    it('shows issue summary and "Fix with Seer" when consent flow is removed and there is no autofix quota', async () => {
+      const orgWithConsentFlowRemoved = OrganizationFixture({
+        hideAiFeatures: false,
+        features: ['gen-ai-features', 'gen-ai-consent-flow-removal'],
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
+        body: AutofixSetupFixture({
+          setupAcknowledgement: {
+            orgHasAcknowledged: false, // Has not consented
+            userHasAcknowledged: false,
+          },
+          integration: {ok: true, reason: null},
+          githubWriteIntegration: {ok: true, repos: []},
+          billing: {hasAutofixQuota: false},
+        }),
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/summarize/`,
+        method: 'POST',
+        body: {whatsWrong: 'Test summary', possibleCause: 'You did it wrong'},
+      });
+
+      render(<SeerSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+        organization: orgWithConsentFlowRemoved,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/initial guess/i)).toBeInTheDocument();
+      // Should show issue summary
+      expect(await screen.findByText('You did it wrong')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Fix with Seer'})).toBeInTheDocument();
+    });
+
     it('shows "Find Root Cause" even when autofix needs setup', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -16,6 +16,7 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import useOrganization from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
@@ -105,6 +106,9 @@ export default function SeerSection({
   const issueTypeDoesntHaveSeer =
     !issueTypeConfig.autofix && !issueTypeConfig.issueSummary;
 
+  const organization = useOrganization();
+  const removeConsentFlow = organization.features.includes('gen-ai-consent-flow-removal');
+
   if (
     (!aiConfig.areAiFeaturesAllowed || issueTypeDoesntHaveSeer) &&
     !aiConfig.hasResources
@@ -140,7 +144,8 @@ export default function SeerSection({
       preventCollapse={!hasStreamlinedUI}
     >
       <SeerSectionContainer>
-        {(aiConfig.orgNeedsGenAiAcknowledgement || !aiConfig.hasAutofixQuota) &&
+        {(aiConfig.orgNeedsGenAiAcknowledgement ||
+          (!removeConsentFlow && !aiConfig.hasAutofixQuota)) &&
         !aiConfig.isAutofixSetupLoading ? (
           <SeerWelcomeEntrypoint />
         ) : aiConfig.hasAutofix || aiConfig.hasSummary ? (


### PR DESCRIPTION
Changes gated with the flag `gen-ai-consent-flow-removal`

Before: If org has not given consent, or has not purchased Seer, a placeholder was shown:

<img width="328" height="370" alt="CleanShot 2025-11-04 at 09 14 27" src="https://github.com/user-attachments/assets/b618a231-8e2a-4df6-9f80-3e7ac3412697" />

After: Issue summary is fetched and displayed for all orgs, regardless of whether or not they have consented or paid for Seer.

<img width="336" height="207" alt="CleanShot 2025-11-04 at 09 13 51" src="https://github.com/user-attachments/assets/ab18e01c-636b-44b8-a33f-b49a945c896a" />
