### PR TITLE
chore(replay): Add org & proj context to event parser log

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -341,11 +341,11 @@ def parse_trace_item(
 ) -> TraceItem | None:
     try:
         return as_trace_item(context, event_type, event)
-    except (AttributeError, KeyError, TypeError, ValueError) as e:
+    except (AttributeError, KeyError, TypeError, ValueError):
         if random.random() < 0.01:
             logger.warning(
                 "[EVENT PARSE FAIL] Could not transform breadcrumb to trace-item",
-                exc_info=e,
+                exc_info=True,
                 extra={
                     "organization_id": context["organization_id"],
                     "project_id": context["project_id"],

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -346,7 +346,11 @@ def parse_trace_item(
             logger.warning(
                 "[EVENT PARSE FAIL] Could not transform breadcrumb to trace-item",
                 exc_info=e,
-                extra={"event": event},
+                extra={
+                    "organization_id": context["organization_id"],
+                    "project_id": context["project_id"],
+                    "event": event,
+                },
             )
         return None
 


### PR DESCRIPTION
We have a high volume of "[EVENT PARSE FAIL] Could not transform breadcrumb to trace-item" logs. Let's add some org and proj context to find out if it's a specific customer that caused the increase in volume. Also, let's change exc_info=e to exc_info=True as this matches the other log in the file.