### PR TITLE
feat(dashboards): Between operator for numeric global filters

### DIFF
--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -31,11 +31,13 @@ import {
 } from 'sentry/views/dashboards/globalFilter/utils';
 import type {GlobalFilter} from 'sentry/views/dashboards/types';
 
-type BetweenOperator = 'between';
-export type Operator = TermOperator | BetweenOperator;
+enum CustomOperator {
+  BETWEEN = 'between',
+}
+export type Operator = TermOperator | CustomOperator;
 
 function getOperatorLabel(operator: Operator) {
-  if (operator === 'between') {
+  if (operator === CustomOperator.BETWEEN) {
     return t('between');
   }
   return OP_LABELS[operator];
@@ -181,7 +183,7 @@ function useBetweenOperatorFilter(
 
   return {
     operatorOptions: [] as Array<SelectOption<Operator>>,
-    stagedOperator: 'between' as Operator,
+    stagedOperator: CustomOperator.BETWEEN,
     setStagedOperator: () => {},
     stagedValue: '',
     setStagedValue: () => {},
@@ -240,9 +242,7 @@ function NumericFilterSelector({
   const operatorOptions = [
     ...nativeFilter.operatorOptions,
     {
-      textValue: 'between',
-      label: t('between'),
-      value: 'between' as Operator,
+      value: CustomOperator.BETWEEN,
     },
   ];
 
@@ -252,7 +252,7 @@ function NumericFilterSelector({
     label: getOperatorLabel(option.value),
     textValue: getOperatorLabel(option.value),
     onClick: () => {
-      if (option.value === 'between') {
+      if (option.value === CustomOperator.BETWEEN) {
         setStagedIsNativeOperator(false);
       } else {
         setStagedIsNativeOperator(true);

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -83,12 +83,6 @@ function useNativeOperatorFilter(
     globalFilterToken?.value?.text || ''
   );
 
-  const currentFilterToken = useMemo(() => {
-    const reconstructedQuery = `${globalFilter.tag.key}:${stagedFilterOperator}${stagedFilterValue}`;
-    const parsed = parseFilterValue(reconstructedQuery, globalFilter);
-    return parsed[0] || globalFilterToken;
-  }, [stagedFilterOperator, stagedFilterValue, globalFilter, globalFilterToken]);
-
   const hasStagedChanges =
     stagedFilterOperator !== globalFilterOperator ||
     stagedFilterValue !== globalFilterToken?.value?.text;
@@ -117,7 +111,7 @@ function useNativeOperatorFilter(
 
   const isValidValue = isValidNumericFilterValue(
     stagedFilterValue,
-    currentFilterToken,
+    globalFilterToken,
     globalFilter
   );
 
@@ -125,7 +119,7 @@ function useNativeOperatorFilter(
     return newNumericFilterQuery(
       stagedFilterValue,
       stagedFilterOperator,
-      currentFilterToken,
+      globalFilterToken,
       globalFilter
     );
   };

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -9,7 +9,7 @@ import {Text} from '@sentry/scraps/text';
 import {Button} from 'sentry/components/core/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {getOperatorInfo} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
-import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {OP_LABELS as NATIVE_OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {
   TermOperator,
   Token,
@@ -36,11 +36,14 @@ enum CustomOperator {
 }
 export type Operator = TermOperator | CustomOperator;
 
-function getOperatorLabel(operator: Operator) {
-  if (operator === CustomOperator.BETWEEN) {
-    return t('between');
-  }
-  return OP_LABELS[operator];
+const OPERATOR_LABELS: Partial<Record<Operator, string>> = {
+  [CustomOperator.BETWEEN]: t('between'),
+  [TermOperator.GREATER_THAN_EQUAL]: '\u2265',
+  [TermOperator.LESS_THAN_EQUAL]: '\u2264',
+};
+
+export function getOperatorLabel(operator: Operator): string {
+  return OPERATOR_LABELS[operator] ?? NATIVE_OP_LABELS[operator as TermOperator];
 }
 
 interface NumericFilterState {

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -46,6 +46,8 @@ export function getOperatorLabel(operator: Operator): string {
   return OPERATOR_LABELS[operator] ?? NATIVE_OP_LABELS[operator as TermOperator];
 }
 
+const FILTER_QUERY_SEPARATOR = ' ';
+
 interface NumericFilterState {
   buildFilterQuery: () => string;
   hasStagedChanges: boolean;
@@ -191,7 +193,9 @@ function useBetweenOperatorFilter(
     renderSelectorTrigger,
     isValidValue,
     buildFilterQuery: () =>
-      lowerBound.buildFilterQuery() + ' ' + upperBound.buildFilterQuery(),
+      lowerBound.buildFilterQuery() +
+      FILTER_QUERY_SEPARATOR +
+      upperBound.buildFilterQuery(),
   };
 }
 
@@ -201,7 +205,7 @@ function NumericFilterSelector({
   onUpdateFilter,
 }: GenericFilterSelectorProps) {
   const globalFilterQueries = useMemo(
-    () => globalFilter.value.split(' '),
+    () => globalFilter.value.split(FILTER_QUERY_SEPARATOR),
     [globalFilter]
   );
 

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -216,8 +216,8 @@ function NumericFilterSelector({
 
   const nativeFilterToken = useMemo(() => {
     if (isNativeOperator) {
-      const [firstQuery] = globalFilterQueries;
-      const tokens = parseFilterValue(firstQuery!, globalFilter);
+      const firstQuery = globalFilterQueries[0] ?? '';
+      const tokens = parseFilterValue(firstQuery, globalFilter);
       return tokens?.[0];
     }
     const tokens = parseFilterValue(`${globalFilter.tag.key}:>100`, globalFilter);

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -34,7 +34,7 @@ import type {GlobalFilter} from 'sentry/views/dashboards/types';
 enum CustomOperator {
   BETWEEN = 'between',
 }
-export type Operator = TermOperator | CustomOperator;
+type Operator = TermOperator | CustomOperator;
 
 const OPERATOR_LABELS: Partial<Record<Operator, string>> = {
   [CustomOperator.BETWEEN]: t('between'),

--- a/static/app/views/dashboards/globalFilter/numericFilterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelectorTrigger.tsx
@@ -12,7 +12,7 @@ type NumericFilterSelectorTriggerProps = {
   globalFilterValue: string;
 };
 
-function FilterSelectorTrigger({
+function NumericFilterSelectorTrigger({
   globalFilter,
   globalFilterOperator,
   globalFilterValue,
@@ -29,7 +29,33 @@ function FilterSelectorTrigger({
   );
 }
 
-export default FilterSelectorTrigger;
+const LESS_THAN_EQUAL = '\u2264';
+
+type BetweenFilterSelectorTriggerProps = {
+  globalFilter: GlobalFilter;
+  lowerBound: string;
+  upperBound: string;
+};
+
+function BetweenFilterSelectorTrigger({
+  globalFilter,
+  lowerBound,
+  upperBound,
+}: BetweenFilterSelectorTriggerProps) {
+  const {tag} = globalFilter;
+
+  return (
+    <ButtonLabelWrapper>
+      <TextOverflow>
+        <FilterValueWrapper>{lowerBound}</FilterValueWrapper> {LESS_THAN_EQUAL}{' '}
+        {prettifyTagKey(tag.key)} {LESS_THAN_EQUAL}{' '}
+        <FilterValueWrapper>{upperBound}</FilterValueWrapper>
+      </TextOverflow>
+    </ButtonLabelWrapper>
+  );
+}
+
+export {NumericFilterSelectorTrigger, BetweenFilterSelectorTrigger};
 
 const ButtonLabelWrapper = styled('span')`
   width: 100%;

--- a/static/app/views/dashboards/globalFilter/numericFilterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelectorTrigger.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
-import type {TermOperator} from 'sentry/components/searchSyntax/parser';
+import {TermOperator} from 'sentry/components/searchSyntax/parser';
 import TextOverflow from 'sentry/components/textOverflow';
 import {prettifyTagKey} from 'sentry/utils/fields';
+import {getOperatorLabel} from 'sentry/views/dashboards/globalFilter/numericFilterSelector';
 import type {GlobalFilter} from 'sentry/views/dashboards/types';
 
 type NumericFilterSelectorTriggerProps = {
@@ -22,14 +22,12 @@ function NumericFilterSelectorTrigger({
   return (
     <ButtonLabelWrapper>
       <TextOverflow>
-        {prettifyTagKey(tag.key)} {OP_LABELS[globalFilterOperator]}{' '}
+        {prettifyTagKey(tag.key)} {getOperatorLabel(globalFilterOperator)}{' '}
         <FilterValueWrapper>{globalFilterValue}</FilterValueWrapper>
       </TextOverflow>
     </ButtonLabelWrapper>
   );
 }
-
-const LESS_THAN_EQUAL = '\u2264';
 
 type BetweenFilterSelectorTriggerProps = {
   globalFilter: GlobalFilter;
@@ -43,12 +41,13 @@ function BetweenFilterSelectorTrigger({
   upperBound,
 }: BetweenFilterSelectorTriggerProps) {
   const {tag} = globalFilter;
+  const operatorLabel = getOperatorLabel(TermOperator.LESS_THAN_EQUAL);
 
   return (
     <ButtonLabelWrapper>
       <TextOverflow>
-        <FilterValueWrapper>{lowerBound}</FilterValueWrapper> {LESS_THAN_EQUAL}{' '}
-        {prettifyTagKey(tag.key)} {LESS_THAN_EQUAL}{' '}
+        <FilterValueWrapper>{lowerBound}</FilterValueWrapper> {operatorLabel}{' '}
+        {prettifyTagKey(tag.key)} {operatorLabel}{' '}
         <FilterValueWrapper>{upperBound}</FilterValueWrapper>
       </TextOverflow>
     </ButtonLabelWrapper>


### PR DESCRIPTION
- Adds a custom between operator for numeric global filters
- Adds unicode characters to label operators like '=>' and '<=' 
- Cleans up numeric filter logic

Fixes [DAIN-1040](https://linear.app/getsentry/issue/DAIN-1040/add-between-operator-to-numeric-filters)