### PR TITLE
fix(dashboards): Global filter selector should not store single values in an array

### DIFF
--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -70,7 +70,7 @@ describe('FilterSelector', () => {
 
     expect(mockOnUpdateFilter).toHaveBeenCalledWith({
       ...mockGlobalFilter,
-      value: 'browser:[chrome]',
+      value: 'browser:chrome',
     });
   });
 

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -98,17 +98,17 @@ function FilterSelector({
     setActiveFilterValues(opts);
 
     // Build filter condition string
-    const filterValue = () => {
-      if (opts.length === 0) {
-        return '';
-      }
-      const mutableSearch = new MutableSearch('');
-      return mutableSearch.addFilterValueList(tag.key, opts).toString();
-    };
+    const mutableSearch = new MutableSearch('');
 
+    let filterValue = '';
+    if (opts.length === 1) {
+      filterValue = mutableSearch.addFilterValue(tag.key, opts[0]!).toString();
+    } else if (opts.length > 1) {
+      filterValue = mutableSearch.addFilterValueList(tag.key, opts).toString();
+    }
     onUpdateFilter({
       ...globalFilter,
-      value: filterValue(),
+      value: filterValue,
     });
   };
 


### PR DESCRIPTION
If only one option is selected in a global filter, the filter query should not be created as an array. Instead, it should omit the array brackets and pass it in as is. This avoids errors when setting boolean values where they're expected to be passed in as single values.

Fixes [DAIN-1060](https://linear.app/getsentry/issue/DAIN-1060/cachehit-boolean-filter-breaks-query)