### PR TITLE
feat(ai-consent): Add issue summary to drawer

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -46,7 +46,8 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const orgNeedsGenAiAcknowledgement =
     !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged &&
     (isSummaryEnabled || isAutofixEnabled) &&
-    areAiFeaturesAllowed;
+    areAiFeaturesAllowed &&
+    !organization.features.includes('gen-ai-consent-flow-removal');
 
   return {
     hasSummary,

--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -46,8 +46,7 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const orgNeedsGenAiAcknowledgement =
     !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged &&
     (isSummaryEnabled || isAutofixEnabled) &&
-    areAiFeaturesAllowed &&
-    !organization.features.includes('gen-ai-consent-flow-removal');
+    areAiFeaturesAllowed;
 
   return {
     hasSummary,

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -8,7 +8,7 @@ import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {Flex} from 'sentry/components/core/layout';
+import {Flex, Stack} from 'sentry/components/core/layout';
 import {ExternalLink, Link} from 'sentry/components/core/link';
 import {DateTime} from 'sentry/components/dateTime';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
@@ -47,6 +47,30 @@ const AiSetupDataConsent = HookOrDefault({
   hookName: 'component:ai-setup-data-consent',
   defaultComponent: () => <div data-test-id="ai-setup-data-consent" />,
 });
+
+function WelcomeScreen({
+  group,
+  project,
+  event,
+}: {
+  event: Event;
+  group: Group;
+  project: Project;
+}) {
+  const organization = useOrganization();
+  const skipConsentFlow = organization.features.includes('gen-ai-consent-flow-removal');
+
+  return (
+    <Stack gap="2xl">
+      {skipConsentFlow && (
+        <StyledCard>
+          <GroupSummary group={group} event={event} project={project} />
+        </StyledCard>
+      )}
+      <AiSetupDataConsent groupId={group.id} />
+    </Stack>
+  );
+}
 
 export function SeerDrawer({group, project, event}: SeerDrawerProps) {
   const organization = useOrganization();
@@ -296,7 +320,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
             <Placeholder height="15rem" />
           </PlaceholderStack>
         ) : showWelcomeScreen ? (
-          <AiSetupDataConsent groupId={group.id} />
+          <WelcomeScreen group={group} project={project} event={event} />
         ) : (
           <Fragment>
             <SeerNotices


### PR DESCRIPTION
When `gen-ai-consent-flow-removal` is enabled, renders the full issue summary at the top of the drawer, above the promo content.

Before:

<img width="869" height="785" alt="CleanShot 2025-11-04 at 10 38 10" src="https://github.com/user-attachments/assets/5de15a58-53c7-49e5-bd63-aad9930829b5" />


After:

<img width="874" height="1049" alt="CleanShot 2025-11-04 at 10 32 17" src="https://github.com/user-attachments/assets/f7649ed7-d88d-4d45-81ab-189b26d99fb7" />
