### PR TITLE
feat(preprod): Change app name to be normal text and app id to be code block in size status check

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -137,7 +137,7 @@ def _format_artifact_summary(
         else:
             artifact_url = get_preprod_artifact_url(artifact)
 
-        name_text = f"[`{app_name}`<br>{app_id}]({artifact_url})"
+        name_text = f"[{app_name}<br>`{app_id}`]({artifact_url})"
 
         # Configuration
         configuration_text = (

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -196,8 +196,8 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         assert title == "Size Analysis"
         assert subtitle == "1 app analyzed, 1 app processing"
         # Should have two rows - main app shows sizes, watch shows processing
-        assert "com.example.app" in summary
-        assert "`-- (Watch)`" in summary
+        assert "`com.example.app`" in summary
+        assert "-- (Watch)" in summary
         assert "1.0 MB" in summary  # Main app completed
         assert "Processing..." in summary  # Watch app processing
 
@@ -428,8 +428,8 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert title == "Size Analysis"
         assert subtitle == "2 apps analyzed"
         # Should have two rows - main app and watch app
-        assert "com.example.app" in summary  # Both main and watch show app_id
-        assert "`-- (Watch)`" in summary  # Watch app label
+        assert "`com.example.app`" in summary  # Both main and watch show app_id
+        assert "-- (Watch)" in summary  # Watch app label
         assert "1.0 MB" in summary  # Main app download
         assert "524.3 KB" in summary  # Watch app download
         assert "2.1 MB" in summary  # Main app install
@@ -438,9 +438,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         main_row_idx = None
         watch_row_idx = None
         for i, line in enumerate(lines):
-            if "com.example.app" in line and "(Watch)" not in line:
+            if "`com.example.app`" in line and "(Watch)" not in line:
                 main_row_idx = i
-            elif "`-- (Watch)`" in line:
+            elif "-- (Watch)" in line:
                 watch_row_idx = i
         assert main_row_idx is not None
         assert watch_row_idx is not None
@@ -486,8 +486,8 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert title == "Size Analysis"
         assert subtitle == "2 apps analyzed"
         # Should have two rows - main app and dynamic feature
-        assert "com.example.android" in summary  # Main app and dynamic feature both show app_id
-        assert "`-- (Dynamic Feature)`" in summary  # Dynamic feature label
+        assert "`com.example.android`" in summary  # Main app and dynamic feature both show app_id
+        assert "-- (Dynamic Feature)" in summary  # Dynamic feature label
         assert "4.2 MB" in summary  # Main app download (note: rounds to 4.2 not 4.0)
         assert "1.0 MB" in summary  # Dynamic feature download
         assert "8.4 MB" in summary  # Main app install


### PR DESCRIPTION
Flips this to be a code snippet for the app id and normal text for the app name:
<img width="264" height="126" alt="Screenshot 2025-11-04 at 10 50 17 AM" src="https://github.com/user-attachments/assets/266c4768-5e53-4cf1-b32f-8986d9e1b7b4" />
