### PR TITLE
fix(typing): Type src/sentry/integrations/source_code_management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,7 +451,7 @@ module = [
     "sentry.integrations.slack.threads.*",
     "sentry.integrations.slack.unfurl.*",
     "sentry.integrations.slack.views.*",
-    "sentry.integrations.source_code_management.repository",
+    "sentry.integrations.source_code_management.*",
     "sentry.integrations.utils.sync",
     "sentry.integrations.vsts.actions.*",
     "sentry.integrations.vsts.handlers.*",

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -20,7 +20,7 @@ SOURCE_CODE_ISSUE_HALT_PATTERNS = {
 
 
 class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegration, ABC):
-    def record_event(self, event: SCMIntegrationInteractionType):
+    def record_event(self, event: SCMIntegrationInteractionType) -> SCMIntegrationInteractionEvent:
         return SCMIntegrationInteractionEvent(
             interaction_type=event,
             provider_key=self.model.provider,
@@ -35,7 +35,7 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
         params: Mapping[str, Any],
         lifecycle: EventLifecycle,
         page_number_limit: int | None = None,
-    ):
+    ) -> tuple[str, list[tuple[str, str | int]]]:
         try:
             repos = self.get_repositories(page_number_limit=page_number_limit)
         except ApiError as exc:
@@ -67,7 +67,7 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
 
     def get_repository_choices(
         self, group: Group | None, params: Mapping[str, Any], page_number_limit: int | None = None
-    ):
+    ) -> tuple[str, list[tuple[str, str | int]]]:
         """
         Returns the default repository and a set/subset of repositories of associated with the installation
         """
@@ -87,9 +87,10 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
         # Now that we're outside the lifecycle, we can raise the user facing error
         if user_facing_error:
             raise user_facing_error
+        assert False, "Unreachable"
 
     # TODO(saif): Make private and move all usages over to `get_defaults`
-    def get_project_defaults(self, project_id):
+    def get_project_defaults(self, project_id: int | str) -> dict[str, str]:
         if not self.org_integration:
             return {}
 
@@ -97,7 +98,7 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
             str(project_id), {}
         )
 
-    def create_default_repo_choice(self, default_repo):
+    def create_default_repo_choice(self, default_repo: str) -> tuple[str, str]:
         """
         Helper method for get_repository_choices
         Returns the choice for the default repo in a tuple to be added to the list of repository choices

--- a/src/sentry/integrations/source_code_management/language_parsers.py
+++ b/src/sentry/integrations/source_code_management/language_parsers.py
@@ -76,7 +76,9 @@ class LanguageParser(ABC):
         return functions
 
     @classmethod
-    def _get_function_name_conditions(cls, stackframe_level: int, function_names: list[str]):
+    def _get_function_name_conditions(
+        cls, stackframe_level: int, function_names: list[str]
+    ) -> list[Condition]:
         """
         For some languages we need a special case of matching both for the function name itself and for
         {function_prefix} + the function name, because sometimes Snuba stores the function name as
@@ -103,7 +105,9 @@ class LanguageParser(ABC):
         return function_name_conditions
 
     @classmethod
-    def _get_function_name_functions(cls, stackframe_level: int, function_names: list[str]):
+    def _get_function_name_functions(
+        cls, stackframe_level: int, function_names: list[str]
+    ) -> list[Function]:
         """
         This is used in the multi_if. We need to account for the special cases in some languages order to
         properly fetch the function name -- "className+{function_prefix}+functionName" or simply "functionName" depending

--- a/src/sentry/integrations/source_code_management/search.py
+++ b/src/sentry/integrations/source_code_management/search.py
@@ -24,7 +24,7 @@ from sentry.organizations.services.organization import RpcOrganization
 T = TypeVar("T", bound=SourceCodeIssueIntegration)
 
 
-class SourceCodeSearchSerializer(serializers.Serializer):
+class SourceCodeSearchSerializer(serializers.Serializer[dict[str, str]]):
     field = serializers.CharField(required=True)
     query = serializers.CharField(required=True)
 
@@ -66,7 +66,7 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
         event: SCMIntegrationInteractionType,
         organization_id: int,
         integration_id: int,
-    ):
+    ) -> SCMIntegrationInteractionEvent:
         # XXX (mifu67): self.integration_provider is None for the GithubSharedSearchEndpoint,
         # which is used by both GitHub and GitHub Enterprise.
         provider_name = (

--- a/src/sentry/integrations/source_code_management/webhook.py
+++ b/src/sentry/integrations/source_code_management/webhook.py
@@ -18,7 +18,7 @@ class SCMWebhook(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def __call__(self, event: Mapping[str, Any], **kwargs) -> None:
+    def __call__(self, event: Mapping[str, Any], **kwargs: Any) -> None:
         raise NotImplementedError
 
     @abstractmethod


### PR DESCRIPTION
Pretty simple addition of types. `get_repository_choices` has a weird command flow that requires an assert for mypy to recognize that a path is unreachable, but I feel confident in the correctness there.
