### PR TITLE
ref(replay): update messaging for mobile replay summaries

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -38,6 +38,15 @@ export default function Ai() {
   const project = useProjectFromId({project_id: replayRecord?.project_id});
   const analyticsArea = useAnalyticsArea();
 
+  const isVideoReplay = replay?.isVideoReplay();
+
+  // for mobile replays, each segment is 5s, so show a different message to avoid confusion.
+  const replayTooLongMessage = isVideoReplay
+    ? t(
+        'Note: this replay has many video segments, so we might not be summarizing the full replay.'
+      )
+    : t('Note: this replay is very long, so we might not be summarizing all of it.');
+
   const {
     summaryData,
     isPending: isSummaryPending,
@@ -219,13 +228,7 @@ export default function Ai() {
       <StyledTabItemContainer>
         <OverflowBody>
           <ChapterList timeRanges={summaryData.data.time_ranges} />
-          {segmentCount > 100 && (
-            <Subtext>
-              {t(
-                `Note: this replay is very long, so we might not be summarizing all of it.`
-              )}
-            </Subtext>
-          )}
+          {segmentCount > 100 && <Subtext>{replayTooLongMessage}</Subtext>}
         </OverflowBody>
       </StyledTabItemContainer>
     </Wrapper>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -38,14 +38,9 @@ export default function Ai() {
   const project = useProjectFromId({project_id: replayRecord?.project_id});
   const analyticsArea = useAnalyticsArea();
 
-  const isVideoReplay = replay?.isVideoReplay();
-
-  // for mobile replays, each segment is 5s, so show a different message to avoid confusion.
-  const replayTooLongMessage = isVideoReplay
-    ? t(
-        'Note: this replay has many video segments, so we might not be summarizing the full replay.'
-      )
-    : t('Note: this replay is very long, so we might not be summarizing all of it.');
+  const replayTooLongMessage = t(
+    'While in beta phase, we only summarize a small portion of the replay.'
+  );
 
   const {
     summaryData,


### PR DESCRIPTION
for mobile replays, each segment is 5s. showing a message about the replay being too long is confusing, so update the wording shown.

best fix would be to summarize > 100 segments for mobile replays since that's only 500 seconds = 8 minutes. 