### PR TITLE
chore(preprod): Unify labels across size content

### DIFF
--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import React, {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
@@ -17,6 +17,7 @@ import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDeta
 import {
   formattedDownloadSize,
   formattedInstallSize,
+  getLabels,
   getPlatformIconFromPlatform,
 } from 'sentry/views/preprod/utils/labelUtils';
 
@@ -39,12 +40,16 @@ export function PreprodBuildsTable({
   projectSlug,
   hasSearchQuery,
 }: PreprodBuildsTableProps) {
+  const labels = useMemo(
+    () => getLabels(builds[0]?.app_info?.platform ?? undefined),
+    [builds]
+  );
   const header = (
     <SimpleTable.Header>
       <SimpleTable.HeaderCell>{t('App')}</SimpleTable.HeaderCell>
       <SimpleTable.HeaderCell>{t('Build')}</SimpleTable.HeaderCell>
-      <SimpleTable.HeaderCell>{t('Install Size')}</SimpleTable.HeaderCell>
-      <SimpleTable.HeaderCell>{t('Download Size')}</SimpleTable.HeaderCell>
+      <SimpleTable.HeaderCell>{labels.installSizeLabel}</SimpleTable.HeaderCell>
+      <SimpleTable.HeaderCell>{labels.downloadSizeLabel}</SimpleTable.HeaderCell>
       <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>
     </SimpleTable.Header>
   );

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -19,6 +19,7 @@ import {
 import {
   formattedDownloadSize,
   formattedInstallSize,
+  getLabels,
   getPlatformIconFromPlatform,
   getReadablePlatformLabel,
 } from 'sentry/views/preprod/utils/labelUtils';
@@ -32,7 +33,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
   const {buildDetails, projectId} = props;
   const organization = useOrganization();
   const theme = useTheme();
-
+  const labels = getLabels(buildDetails.app_info?.platform ?? undefined);
   const breadcrumbs: Crumb[] = [
     {
       to: '#',
@@ -95,18 +96,22 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
             </Tooltip>
           )}
           {isSizeInfoCompleted(buildDetails.size_info) && (
-            <Tooltip title={t('Install size')}>
+            <Tooltip title={labels.installSizeDescription}>
               <Flex gap="sm" align="center">
                 <IconCode size="sm" color="gray300" />
-                <Text>{formattedInstallSize(buildDetails)}</Text>
+                <Text style={{textDecoration: 'underline dotted'}}>
+                  {formattedInstallSize(buildDetails)}
+                </Text>
               </Flex>
             </Tooltip>
           )}
           {isSizeInfoCompleted(buildDetails.size_info) && (
-            <Tooltip title={t('Download size')}>
+            <Tooltip title={labels.downloadSizeDescription}>
               <Flex gap="sm" align="center">
                 <IconDownload size="sm" color="gray300" />
-                <Text>{formattedDownloadSize(buildDetails)}</Text>
+                <Text style={{textDecoration: 'underline dotted'}}>
+                  {formattedDownloadSize(buildDetails)}
+                </Text>
               </Flex>
             </Tooltip>
           )}

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -99,9 +99,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
             <Tooltip title={labels.installSizeDescription}>
               <Flex gap="sm" align="center">
                 <IconCode size="sm" color="gray300" />
-                <Text style={{textDecoration: 'underline dotted'}}>
-                  {formattedInstallSize(buildDetails)}
-                </Text>
+                <Text underline="dotted">{formattedInstallSize(buildDetails)}</Text>
               </Flex>
             </Tooltip>
           )}
@@ -109,9 +107,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
             <Tooltip title={labels.downloadSizeDescription}>
               <Flex gap="sm" align="center">
                 <IconDownload size="sm" color="gray300" />
-                <Text style={{textDecoration: 'underline dotted'}}>
-                  {formattedDownloadSize(buildDetails)}
-                </Text>
+                <Text underline="dotted">{formattedDownloadSize(buildDetails)}</Text>
               </Flex>
             </Tooltip>
           )}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -38,6 +38,7 @@ import type {
   SizeAnalysisComparisonResults,
   SizeComparisonApiResponse,
 } from 'sentry/views/preprod/types/appSizeTypes';
+import {getLabels} from 'sentry/views/preprod/utils/labelUtils';
 
 export function SizeCompareMainContent() {
   const organization = useOrganization();
@@ -122,10 +123,14 @@ export function SizeCompareMainContent() {
       installSizeDiff / size_metric_diff_item.base_install_size;
     const downloadSizePercentage =
       downloadSizeDiff / size_metric_diff_item.base_download_size;
+
+    const labels = getLabels(
+      sizeComparisonQuery.data?.head_build_details.app_info?.platform ?? undefined
+    );
     // Calculate metrics
     const metrics = [
       {
-        title: t('Install Size'),
+        title: labels.installSizeLabel,
         head: size_metric_diff_item.head_install_size,
         base: size_metric_diff_item.base_install_size,
         diff:
@@ -135,7 +140,7 @@ export function SizeCompareMainContent() {
         icon: IconCode,
       },
       {
-        title: t('Download Size'),
+        title: labels.downloadSizeLabel,
         head: size_metric_diff_item.head_download_size,
         base: size_metric_diff_item.base_download_size,
         diff:
@@ -147,7 +152,7 @@ export function SizeCompareMainContent() {
     ];
 
     return metrics;
-  }, [comparisonDataQuery.data]);
+  }, [comparisonDataQuery.data, sizeComparisonQuery.data]);
 
   // Filter diff items based on the toggle and search query
   const filteredDiffItems = useMemo(() => {

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -10,58 +10,19 @@ import {IconClock, IconFile, IconJson, IconLink, IconMobile} from 'sentry/icons'
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {getFormat, getFormattedDate, getUtcToSystem} from 'sentry/utils/dates';
-import {unreachable} from 'sentry/utils/unreachable';
 import {openInstallModal} from 'sentry/views/preprod/components/installModal';
 import {
   BuildDetailsSizeAnalysisState,
   type BuildDetailsAppInfo,
   type BuildDetailsSizeInfo,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
-import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import {
+  getLabels,
   getPlatformIconFromPlatform,
   getReadableArtifactTypeLabel,
   getReadableArtifactTypeTooltip,
   getReadablePlatformLabel,
 } from 'sentry/views/preprod/utils/labelUtils';
-
-interface Labels {
-  appId: string;
-  buildConfiguration: string;
-  downloadSize: string;
-  installSize: string;
-  installSizeText: string;
-  installUnavailableTooltip: string;
-}
-
-function getLabels(platform: Platform | undefined): Labels {
-  switch (platform) {
-    case 'android':
-      return {
-        installSizeText: t('Uncompressed Size'),
-        appId: t('Package name'),
-        installSize: t('Size on disk not including AOT DEX'),
-        downloadSize: t('Bytes transferred over the network'),
-        buildConfiguration: t('Build configuration'),
-        installUnavailableTooltip: t('This app cannot be installed.'),
-      };
-    case 'ios':
-    case 'macos':
-    case undefined:
-      return {
-        installSizeText: t('Install Size'),
-        appId: t('Bundle identifier'),
-        installSize: t('Unencrypted install size'),
-        downloadSize: t('Bytes transferred over the network'),
-        buildConfiguration: t('Build configuration'),
-        installUnavailableTooltip: t(
-          'Code signature must be valid for this app to be installed.'
-        ),
-      };
-    default:
-      return unreachable(platform);
-  }
-}
 
 interface BuildDetailsSidebarAppInfoProps {
   appInfo: BuildDetailsAppInfo;
@@ -91,16 +52,16 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
         props.sizeInfo.state === BuildDetailsSizeAnalysisState.COMPLETED && (
           <Flex gap="sm">
             <Flex direction="column" gap="xs" flex={1}>
-              <Tooltip title={labels.installSize} position="left">
-                <Heading as="h4">{labels.installSizeText}</Heading>
+              <Tooltip title={labels.installSizeDescription} position="left">
+                <Heading as="h4">{labels.installSizeLabel}</Heading>
               </Tooltip>
               <Text size="md">
                 {formatBytesBase10(props.sizeInfo.install_size_bytes)}
               </Text>
             </Flex>
             <Flex direction="column" gap="xs" flex={1}>
-              <Tooltip title={labels.downloadSize} position="left">
-                <Heading as="h4">{t('Download Size')}</Heading>
+              <Tooltip title={labels.downloadSizeDescription} position="left">
+                <Heading as="h4">{labels.downloadSizeLabel}</Heading>
               </Tooltip>
               <Text size="md">
                 {formatBytesBase10(props.sizeInfo.download_size_bytes)}

--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -1,4 +1,6 @@
+import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import {unreachable} from 'sentry/utils/unreachable';
 import {
   BuildDetailsArtifactType,
   isSizeInfoCompleted,
@@ -43,18 +45,59 @@ export function getReadableArtifactTypeTooltip(
   artifactType: BuildDetailsArtifactType | null
 ): string {
   if (artifactType === null) {
-    return 'Unknown';
+    return t('Unknown');
   }
 
   switch (artifactType) {
     case BuildDetailsArtifactType.XCARCHIVE:
-      return 'XCode application archive';
+      return t('XCode application archive');
     case BuildDetailsArtifactType.AAB:
-      return 'Android app bundle';
+      return t('Android app bundle');
     case BuildDetailsArtifactType.APK:
-      return 'Android application package';
+      return t('Android application package');
     default:
       throw new Error(`Unknown artifact type: ${artifactType}`);
+  }
+}
+
+interface Labels {
+  appId: string;
+  buildConfiguration: string;
+  downloadSizeDescription: string;
+  downloadSizeLabel: string;
+  installSizeDescription: string;
+  installSizeLabel: string;
+  installUnavailableTooltip: string;
+}
+
+export function getLabels(platform: Platform | undefined): Labels {
+  switch (platform) {
+    case 'android':
+      return {
+        installSizeLabel: t('Uncompressed size'),
+        downloadSizeLabel: t('Download size'),
+        appId: t('Package name'),
+        installSizeDescription: t('Uncompressed size on disk not including AOT DEX'),
+        downloadSizeDescription: t('Bytes transferred over the network'),
+        buildConfiguration: t('Build configuration'),
+        installUnavailableTooltip: t('This app cannot be installed.'),
+      };
+    case 'ios':
+    case 'macos':
+    case undefined:
+      return {
+        installSizeLabel: t('Install Size'),
+        appId: t('Bundle identifier'),
+        installSizeDescription: t('Unencrypted install size'),
+        downloadSizeDescription: t('Bytes transferred over the network'),
+        downloadSizeLabel: t('Download size'),
+        buildConfiguration: t('Build configuration'),
+        installUnavailableTooltip: t(
+          'Code signature must be valid for this app to be installed.'
+        ),
+      };
+    default:
+      return unreachable(platform);
   }
 }
 


### PR DESCRIPTION
Noticed some varying usages of install/download size floating around, as well as some incorrect usages of "install size" for Android (should be "uncompressed size"). 

Updated to share some existing helpers we had in place. 

Also adds a dotted underline to install/download size to indicate you can hover for a tooltip per Dan's suggestion.

<img width="779" height="408" alt="Screenshot 2025-11-04 at 11 02 15 AM" src="https://github.com/user-attachments/assets/f0dbe554-76c8-49de-a832-43488f8eb742" />

Resolves EME-591