### PR TITLE
feat(design): Add dotted underline variant to Text component

### DIFF
--- a/static/app/components/core/text/styles.tsx
+++ b/static/app/components/core/text/styles.tsx
@@ -12,6 +12,10 @@ export function getTextDecoration(p: TextProps<any> | HeadingProps) {
   }
   if (p.underline) {
     decorations.push('underline');
+
+    if (p.underline === 'dotted') {
+      decorations.push('dotted');
+    }
   }
   return decorations.join(' ');
 }

--- a/static/app/components/core/text/text.mdx
+++ b/static/app/components/core/text/text.mdx
@@ -102,6 +102,7 @@ Text components support various typography options including bold, italic, under
     <Text bold>Bold text</Text>
     <Text italic>Italic text</Text>
     <Text underline>Underlined text</Text>
+    <Text underline="dotted">Dotted underlined text</Text>
     <Text strikethrough>Strikethrough text</Text>
     <Text bold italic underline>
       Bold italic underlined text
@@ -112,6 +113,7 @@ Text components support various typography options including bold, italic, under
 <Text bold>Bold text</Text>
 <Text italic>Italic text</Text>
 <Text underline>Underlined text</Text>
+<Text underline="dotted">Dotted underlined text</Text>
 <Text strikethrough>Strikethrough text</Text>
 <Text bold italic underline>
   Bold italic underlined text

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -68,10 +68,10 @@ export interface BaseTextProps {
   textWrap?: 'wrap' | 'nowrap' | 'balance' | 'pretty' | 'stable';
 
   /**
-   * Determines if the text should be underlined.
-   * @default false
+   * Determines how text should be underlined.
+   * @default undefined
    */
-  underline?: boolean;
+  underline?: boolean | 'dotted';
 
   /**
    * Uppercase the text.


### PR DESCRIPTION
Suggested from a designer recently to use `dotted` underline when text shows a tooltip. This adds `'dotted'` as a literal type to `underline` and supports showing as dotted. Added a sample to stories too.

<img width="883" height="645" alt="Screenshot 2025-11-04 at 11 20 37 AM" src="https://github.com/user-attachments/assets/e5ff0edd-29cf-42f8-a85a-0b428058e35f" />
