### PR TITLE
ref(uptime): Always create seat during assignment to track over-quota monitors

### DIFF
--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -28,6 +28,7 @@ from sentry.conf.types.kafka_definition import get_topic_codec
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.models.group import Group, GroupStatus
+from sentry.quotas.base import SeatAssignmentResult
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
@@ -859,7 +860,9 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch("sentry.uptime.autodetect.result_handler.logger") as onboarding_logger,
             mock.patch(
                 "sentry.uptime.autodetect.result_handler.update_uptime_detector",
-                side_effect=UptimeMonitorNoSeatAvailable(None),
+                side_effect=UptimeMonitorNoSeatAvailable(
+                    SeatAssignmentResult(assignable=False, reason="Testing")
+                ),
             ),
             self.tasks(),
             self.feature(features),

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -219,11 +219,15 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         assert detector.enabled is True
 
     @mock.patch(
+        "sentry.quotas.backend.assign_seat",
+        return_value=1,  # Outcome.RATE_LIMITED (anything != Outcome.ACCEPTED)
+    )
+    @mock.patch(
         "sentry.quotas.backend.check_assign_seat",
         return_value=SeatAssignmentResult(assignable=False, reason="Assignment failed in test"),
     )
     def test_status_enable_no_seat_assignment(
-        self, _mock_check_assign_seat: mock.MagicMock
+        self, _mock_check_assign_seat: mock.MagicMock, _mock_assign_seat: mock.MagicMock
     ) -> None:
         detector = self.create_uptime_detector(enabled=False)
         resp = self.get_error_response(

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.quotas.base import SeatAssignmentResult
 from sentry.uptime.endpoints.validators import MAX_REQUEST_SIZE_BYTES
 from sentry.uptime.models import get_uptime_subscription
 from sentry.uptime.types import (
@@ -10,6 +9,7 @@ from sentry.uptime.types import (
     DEFAULT_RECOVERY_THRESHOLD,
     UptimeMonitorMode,
 )
+from sentry.utils.outcomes import Outcome
 from sentry.workflow_engine.models import Detector
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
@@ -303,10 +303,10 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             )
 
     @mock.patch(
-        "sentry.quotas.backend.check_assign_seat",
-        return_value=SeatAssignmentResult(assignable=False, reason="Testing"),
+        "sentry.quotas.backend.assign_seat",
+        return_value=Outcome.RATE_LIMITED,
     )
-    def test_no_seat_assignment(self, _mock_check_assign_seat: mock.MagicMock) -> None:
+    def test_no_seat_assignment(self, _mock_assign_seat: mock.MagicMock) -> None:
         resp = self.get_success_response(
             self.organization.slug,
             self.project.slug,


### PR DESCRIPTION
Changed enable_uptime_detector to call assign_seat() first instead of
check_assign_seat(). This ensures we create a seat assignment record
in the database even when over quota, allowing the system to track
which monitors are consuming quota.

Previously, check_assign_seat() would bail early without creating any
records. Now assign_seat() creates the seat (possibly marked as
over-quota), and if it fails, we disable the detector and call
check_assign_seat() to get the reason for the failure.

Updated UptimeMonitorNoSeatAvailable to always require a
SeatAssignmentResult (removed Optional[None]).