### PR TITLE
fix(sub v3): Set max width on billing info panels

### DIFF
--- a/static/gsApp/components/billingDetails/form.tsx
+++ b/static/gsApp/components/billingDetails/form.tsx
@@ -248,6 +248,7 @@ function BillingDetailsForm({
         wrapper={wrapper}
         submitLabel={submitLabel}
         fieldProps={fieldProps}
+        extraButton={extraButton}
       />
     );
   }

--- a/static/gsApp/components/billingDetails/legacyForm.tsx
+++ b/static/gsApp/components/billingDetails/legacyForm.tsx
@@ -40,6 +40,10 @@ type Props = {
    */
   wrapper: (children: any) => React.ReactElement;
   /**
+   * Extra button to render in the form footer.
+   */
+  extraButton?: React.ReactNode;
+  /**
    * Additional form field props.
    */
   fieldProps?: FieldGroupProps;
@@ -121,6 +125,7 @@ function LegacyBillingDetailsForm({
   isDetailed = true,
   wrapper,
   fieldProps,
+  extraButton,
 }: Props) {
   const {isLoaded} = useLoadScript(GOOGLE_MAPS_LOAD_OPTIONS);
 
@@ -286,6 +291,7 @@ function LegacyBillingDetailsForm({
       onSubmitError={onSubmitError}
       initialData={transformedInitialData}
       footerStyle={footerStyle}
+      extraButton={extraButton}
     >
       <FieldWrapper>
         {isDetailed && (

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -46,11 +46,13 @@ function BillingDetailsPanel({
   isNewBillingUI,
   analyticsEvent,
   shouldExpandInitially,
+  maxPanelWidth,
 }: {
   organization: Organization;
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
   isNewBillingUI?: boolean;
+  maxPanelWidth?: string;
   shouldExpandInitially?: boolean;
   title?: string;
 }) {
@@ -171,6 +173,7 @@ function BillingDetailsPanel({
       border="primary"
       radius="md"
       data-test-id="billing-details-panel"
+      maxWidth={maxPanelWidth}
     >
       <Flex direction="column" gap="lg" width="100%">
         <Heading as="h2" size="lg">

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -29,6 +29,7 @@ interface CreditCardPanelProps {
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
   isNewBillingUI?: boolean;
+  maxPanelWidth?: string;
   shouldExpandInitially?: boolean;
 }
 
@@ -52,6 +53,7 @@ function CreditCardPanel({
   ftcLocation,
   analyticsEvent,
   shouldExpandInitially,
+  maxPanelWidth,
 }: CreditCardPanelProps) {
   const [cardLastFourDigits, setCardLastFourDigits] = useState<string | null>(null);
   const [cardZipCode, setCardZipCode] = useState<string | null>(null);
@@ -163,6 +165,7 @@ function CreditCardPanel({
       border="primary"
       radius="md"
       data-test-id="credit-card-panel"
+      maxWidth={maxPanelWidth}
     >
       <Flex direction="column" gap="lg" width="100%">
         <Heading as="h2" size="lg">

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -65,11 +65,13 @@ function BillingInformation({organization, subscription, location}: Props) {
           isNewBillingUI={isNewBillingUI}
           ftcLocation={FTCConsentLocation.BILLING_DETAILS}
           budgetTerm={subscription.planDetails.budgetTerm}
+          maxPanelWidth="600px"
         />
         <BillingDetailsPanel
           organization={organization}
           subscription={subscription}
           isNewBillingUI={isNewBillingUI}
+          maxPanelWidth="600px"
         />
       </SubscriptionPageContainer>
     );
@@ -90,12 +92,14 @@ function BillingInformation({organization, subscription, location}: Props) {
               ftcLocation={FTCConsentLocation.BILLING_DETAILS}
               budgetTerm={subscription.planDetails.budgetTerm}
               shouldExpandInitially
+              maxPanelWidth="600px"
             />
             <BillingDetailsPanel
               organization={organization}
               subscription={subscription}
               isNewBillingUI={isNewBillingUI}
               shouldExpandInitially
+              maxPanelWidth="600px"
             />
           </Flex>
         ) : (

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import type {Location} from 'history';
 
 import {Flex} from 'sentry/components/core/layout';
@@ -20,8 +21,6 @@ import RecurringCredits from 'getsentry/views/subscriptionPage/recurringCredits'
 
 import SubscriptionHeader from './subscriptionHeader';
 
-const MAX_PANEL_WIDTH = '1000px';
-
 type Props = {
   location: Location;
   organization: Organization;
@@ -34,6 +33,8 @@ type Props = {
 function BillingInformation({organization, subscription, location}: Props) {
   const isNewBillingUI = hasNewBillingUI(organization);
   const hasBillingPerms = organization.access?.includes('org:billing');
+  const theme = useTheme();
+  const maxPanelWidth = theme.breakpoints.lg;
 
   if (subscription?.isSelfServePartner) {
     return <Redirect to={`/settings/${organization.slug}/billing/overview/`} />;
@@ -67,13 +68,13 @@ function BillingInformation({organization, subscription, location}: Props) {
           isNewBillingUI={isNewBillingUI}
           ftcLocation={FTCConsentLocation.BILLING_DETAILS}
           budgetTerm={subscription.planDetails.budgetTerm}
-          maxPanelWidth={MAX_PANEL_WIDTH}
+          maxPanelWidth={maxPanelWidth}
         />
         <BillingDetailsPanel
           organization={organization}
           subscription={subscription}
           isNewBillingUI={isNewBillingUI}
-          maxPanelWidth={MAX_PANEL_WIDTH}
+          maxPanelWidth={maxPanelWidth}
         />
       </SubscriptionPageContainer>
     );
@@ -94,14 +95,14 @@ function BillingInformation({organization, subscription, location}: Props) {
               ftcLocation={FTCConsentLocation.BILLING_DETAILS}
               budgetTerm={subscription.planDetails.budgetTerm}
               shouldExpandInitially
-              maxPanelWidth={MAX_PANEL_WIDTH}
+              maxPanelWidth={maxPanelWidth}
             />
             <BillingDetailsPanel
               organization={organization}
               subscription={subscription}
               isNewBillingUI={isNewBillingUI}
               shouldExpandInitially
-              maxPanelWidth={MAX_PANEL_WIDTH}
+              maxPanelWidth={maxPanelWidth}
             />
           </Flex>
         ) : (

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -20,6 +20,8 @@ import RecurringCredits from 'getsentry/views/subscriptionPage/recurringCredits'
 
 import SubscriptionHeader from './subscriptionHeader';
 
+const MAX_PANEL_WIDTH = '1000px';
+
 type Props = {
   location: Location;
   organization: Organization;
@@ -65,13 +67,13 @@ function BillingInformation({organization, subscription, location}: Props) {
           isNewBillingUI={isNewBillingUI}
           ftcLocation={FTCConsentLocation.BILLING_DETAILS}
           budgetTerm={subscription.planDetails.budgetTerm}
-          maxPanelWidth="600px"
+          maxPanelWidth={MAX_PANEL_WIDTH}
         />
         <BillingDetailsPanel
           organization={organization}
           subscription={subscription}
           isNewBillingUI={isNewBillingUI}
-          maxPanelWidth="600px"
+          maxPanelWidth={MAX_PANEL_WIDTH}
         />
       </SubscriptionPageContainer>
     );
@@ -92,14 +94,14 @@ function BillingInformation({organization, subscription, location}: Props) {
               ftcLocation={FTCConsentLocation.BILLING_DETAILS}
               budgetTerm={subscription.planDetails.budgetTerm}
               shouldExpandInitially
-              maxPanelWidth="600px"
+              maxPanelWidth={MAX_PANEL_WIDTH}
             />
             <BillingDetailsPanel
               organization={organization}
               subscription={subscription}
               isNewBillingUI={isNewBillingUI}
               shouldExpandInitially
-              maxPanelWidth="600px"
+              maxPanelWidth={MAX_PANEL_WIDTH}
             />
           </Flex>
         ) : (


### PR DESCRIPTION

<img width="2562" height="1353" alt="Screenshot 2025-11-05 at 9 06 06 AM" src="https://github.com/user-attachments/assets/79c0487d-c983-4ae0-9dfb-d2ffb10d36b1" />

These panels should not take up the whole screen size for larger screens.