### PR TITLE
feat(ow-deletions): Add Overwatch notification on organization deletion

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3125,6 +3125,7 @@ CODECOV_API_BASE_URL = "https://api.codecov.io"
 OVERWATCH_REGION_URLS: dict[str, str] = cast(
     dict[str, str], env("OVERWATCH_REGION_URLS", {}, type=env_types.Dict)
 )
+OVERWATCH_REGION_URL: str | None = os.getenv("OVERWATCH_REGION_URL")
 OVERWATCH_WEBHOOK_SECRET: str | None = os.getenv("OVERWATCH_WEBHOOK_SECRET")
 
 # Devserver configuration overrides.

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from django.db import router, transaction
 
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.deletions.tasks.overwatch import notify_overwatch_organization_deleted
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.organizations.services.organization_actions.impl import (
     update_organization_with_outbox_message,
@@ -71,7 +72,6 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
         return relations
 
     def delete_instance(self, instance: Organization) -> None:
-        from sentry.deletions.tasks.overwatch import notify_overwatch_organization_deleted
 
         org_id = instance.id
         org_slug = instance.slug

--- a/src/sentry/deletions/tasks/overwatch.py
+++ b/src/sentry/deletions/tasks/overwatch.py
@@ -62,8 +62,8 @@ def notify_overwatch_organization_deleted(
         )
         return
 
-    # Get the Overwatch URL for this region
-    base_url = settings.OVERWATCH_REGION_URLS.get(region_name)
+    # Get the Overwatch URL
+    base_url = settings.OVERWATCH_REGION_URL
     if not base_url:
         logger.warning(
             "overwatch.organization_deleted.missing_region_url",

--- a/src/sentry/deletions/tasks/overwatch.py
+++ b/src/sentry/deletions/tasks/overwatch.py
@@ -35,8 +35,19 @@ def notify_overwatch_organization_deleted(
         )
         return
 
-    local_region = get_local_region()
-    region_name = local_region.name
+    try:
+        local_region = get_local_region()
+        region_name = local_region.name
+    except Exception as e:
+        logger.exception(
+            "overwatch.organization_deleted.region_error",
+            extra={
+                "organization_id": organization_id,
+                "organization_slug": organization_slug,
+                "error": str(e),
+            },
+        )
+        return
 
     # Check if this region is enabled for Overwatch notifications
     enabled_regions = options.get("overwatch.enabled-regions")

--- a/src/sentry/deletions/tasks/overwatch.py
+++ b/src/sentry/deletions/tasks/overwatch.py
@@ -88,7 +88,6 @@ def notify_overwatch_organization_deleted(
     }
     payload = json.dumps(payload_data).encode("utf-8")
 
-    # Generate HMAC signature
     signature = hmac.new(
         settings.OVERWATCH_WEBHOOK_SECRET.encode("utf-8"),
         payload,

--- a/src/sentry/deletions/tasks/overwatch.py
+++ b/src/sentry/deletions/tasks/overwatch.py
@@ -1,0 +1,131 @@
+import hashlib
+import hmac
+import logging
+from typing import Any
+
+import requests
+from django.conf import settings
+
+from sentry import options
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import deletion_tasks
+from sentry.types.region import get_local_region
+from sentry.utils import json, metrics
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.deletions.overwatch_notify_organization_deleted",
+    namespace=deletion_tasks,
+    max_retries=3,
+    default_retry_delay=60,
+)
+def notify_overwatch_organization_deleted(
+    organization_id: int, organization_slug: str, **kwargs: Any
+) -> None:
+    """
+    Notify Overwatch for the current region that an organization has been deleted.
+    Sends organization_id and slug to the /webhooks/sentry endpoint for the local region.
+    """
+    if not settings.OVERWATCH_WEBHOOK_SECRET:
+        logger.warning(
+            "overwatch.organization_deleted.no_secret",
+            extra={"organization_id": organization_id, "organization_slug": organization_slug},
+        )
+        return
+
+    local_region = get_local_region()
+    region_name = local_region.name
+
+    # Check if this region is enabled for Overwatch notifications
+    enabled_regions = options.get("overwatch.enabled-regions")
+    if not enabled_regions or region_name not in enabled_regions:
+        logger.debug(
+            "overwatch.organization_deleted.region_not_enabled",
+            extra={
+                "organization_id": organization_id,
+                "organization_slug": organization_slug,
+                "region_name": region_name,
+            },
+        )
+        return
+
+    # Get the Overwatch URL for this region
+    base_url = settings.OVERWATCH_REGION_URLS.get(region_name)
+    if not base_url:
+        logger.warning(
+            "overwatch.organization_deleted.missing_region_url",
+            extra={
+                "organization_id": organization_id,
+                "organization_slug": organization_slug,
+                "region_name": region_name,
+            },
+        )
+        metrics.incr(
+            "overwatch.organization_deleted.sent",
+            amount=1,
+            tags={"status": "failure", "region": region_name},
+        )
+        return
+
+    payload_data = {
+        "event_type": "organization_delete",
+        "organization_id": organization_id,
+        "organization_slug": organization_slug,
+        "region": region_name,
+    }
+    payload = json.dumps(payload_data).encode("utf-8")
+
+    # Generate HMAC signature
+    signature = hmac.new(
+        settings.OVERWATCH_WEBHOOK_SECRET.encode("utf-8"),
+        payload,
+        hashlib.sha256,
+    ).hexdigest()
+
+    headers = {
+        "content-type": "application/json;charset=utf-8",
+        "x-sentry-overwatch-signature": signature,
+    }
+
+    try:
+        endpoint = f"{base_url}/webhooks/sentry"
+        response = requests.post(
+            endpoint,
+            data=payload,
+            headers=headers,
+            timeout=10,
+        )
+        response.raise_for_status()
+
+        logger.info(
+            "overwatch.organization_deleted.success",
+            extra={
+                "organization_id": organization_id,
+                "organization_slug": organization_slug,
+                "region_name": region_name,
+                "status_code": response.status_code,
+            },
+        )
+        metrics.incr(
+            "overwatch.organization_deleted.sent",
+            amount=1,
+            tags={"status": "success", "region": region_name},
+        )
+
+    except requests.RequestException as e:
+        logger.exception(
+            "overwatch.organization_deleted.failed",
+            extra={
+                "organization_id": organization_id,
+                "organization_slug": organization_slug,
+                "region_name": region_name,
+                "error": str(e),
+            },
+        )
+        metrics.incr(
+            "overwatch.organization_deleted.sent",
+            amount=1,
+            tags={"status": "failure", "region": region_name},
+        )

--- a/tests/sentry/deletions/tasks/test_overwatch.py
+++ b/tests/sentry/deletions/tasks/test_overwatch.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import responses
@@ -22,12 +23,14 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="test-secret",
-        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+        OVERWATCH_REGION_URL="https://overwatch-us.example.com",
     )
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
     @patch("sentry.deletions.tasks.overwatch.logger")
     @patch("sentry.deletions.tasks.overwatch.metrics")
-    def test_region_not_enabled(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+    def test_region_not_enabled(
+        self, mock_metrics: Any, mock_logger: Any, mock_get_local_region: Any
+    ) -> None:
         """Test that nothing happens when local region is not in enabled list"""
         mock_get_local_region.return_value = self.mock_region
 
@@ -48,7 +51,9 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
     @patch("sentry.deletions.tasks.overwatch.logger")
     @patch("sentry.deletions.tasks.overwatch.metrics")
-    def test_no_webhook_secret(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+    def test_no_webhook_secret(
+        self, mock_metrics: Any, mock_logger: Any, mock_get_local_region: Any
+    ) -> None:
         """Test that a warning is logged when secret is not configured"""
         mock_get_local_region.return_value = self.mock_region
 
@@ -66,14 +71,14 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="test-secret",
-        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+        OVERWATCH_REGION_URL="https://overwatch-us.example.com",
     )
     @responses.activate
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
     @patch("sentry.deletions.tasks.overwatch.logger")
     @patch("sentry.deletions.tasks.overwatch.metrics")
     def test_successful_notification(
-        self, mock_metrics, mock_logger, mock_get_local_region
+        self, mock_metrics: Any, mock_logger: Any, mock_get_local_region: Any
     ) -> None:
         """Test successful notification to the local region"""
         mock_get_local_region.return_value = self.mock_region
@@ -129,13 +134,15 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="test-secret",
-        OVERWATCH_REGION_URLS={},  # No URL configured for us region
+        OVERWATCH_REGION_URL=None,  # No URL configured
     )
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
     @patch("sentry.deletions.tasks.overwatch.logger")
     @patch("sentry.deletions.tasks.overwatch.metrics")
-    def test_missing_region_url(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
-        """Test handling when local region doesn't have a URL configured"""
+    def test_missing_region_url(
+        self, mock_metrics: Any, mock_logger: Any, mock_get_local_region: Any
+    ) -> None:
+        """Test handling when OVERWATCH_REGION_URL is not configured"""
         mock_get_local_region.return_value = self.mock_region
 
         with self.options({"overwatch.enabled-regions": ["us"]}):
@@ -159,13 +166,15 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="test-secret",
-        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+        OVERWATCH_REGION_URL="https://overwatch-us.example.com",
     )
     @responses.activate
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
     @patch("sentry.deletions.tasks.overwatch.logger")
     @patch("sentry.deletions.tasks.overwatch.metrics")
-    def test_request_failure(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+    def test_request_failure(
+        self, mock_metrics: Any, mock_logger: Any, mock_get_local_region: Any
+    ) -> None:
         """Test handling of HTTP request failures"""
         mock_get_local_region.return_value = self.mock_region
 
@@ -194,11 +203,11 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="test-secret",
-        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+        OVERWATCH_REGION_URL="https://overwatch-us.example.com",
     )
     @responses.activate
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
-    def test_request_timeout(self, mock_get_local_region) -> None:
+    def test_request_timeout(self, mock_get_local_region: Any) -> None:
         """Test that requests have a timeout configured"""
         import requests
 
@@ -218,11 +227,11 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="secret-with-special-chars-!@#$%",
-        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+        OVERWATCH_REGION_URL="https://overwatch-us.example.com",
     )
     @responses.activate
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
-    def test_signature_with_special_characters(self, mock_get_local_region) -> None:
+    def test_signature_with_special_characters(self, mock_get_local_region: Any) -> None:
         """Test that signature is correctly generated with special characters in secret"""
         mock_get_local_region.return_value = self.mock_region
 
@@ -247,12 +256,14 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="test-secret",
-        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+        OVERWATCH_REGION_URL="https://overwatch-us.example.com",
     )
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
     @patch("sentry.deletions.tasks.overwatch.logger")
     @patch("sentry.deletions.tasks.overwatch.metrics")
-    def test_get_local_region_error(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+    def test_get_local_region_error(
+        self, mock_metrics: Any, mock_logger: Any, mock_get_local_region: Any
+    ) -> None:
         """Test handling when get_local_region raises an exception"""
         mock_get_local_region.side_effect = Exception("Region not configured")
 
@@ -271,13 +282,15 @@ class NotifyOverwatchOrganizationDeletedTest(TestCase):
 
     @override_settings(
         OVERWATCH_WEBHOOK_SECRET="test-secret",
-        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+        OVERWATCH_REGION_URL="https://overwatch-us.example.com",
     )
     @responses.activate
     @patch("sentry.deletions.tasks.overwatch.get_local_region")
     @patch("sentry.deletions.tasks.overwatch.logger")
     @patch("sentry.deletions.tasks.overwatch.metrics")
-    def test_different_region_name(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+    def test_different_region_name(
+        self, mock_metrics: Any, mock_logger: Any, mock_get_local_region: Any
+    ) -> None:
         """Test that the correct region name from get_local_region is used"""
         eu_region = MagicMock()
         eu_region.name = "eu"

--- a/tests/sentry/deletions/tasks/test_overwatch.py
+++ b/tests/sentry/deletions/tasks/test_overwatch.py
@@ -1,0 +1,299 @@
+import hashlib
+import hmac
+from unittest.mock import MagicMock, patch
+
+import responses
+from django.test import override_settings
+
+from sentry.deletions.tasks.overwatch import notify_overwatch_organization_deleted
+from sentry.testutils.cases import TestCase
+from sentry.utils import json
+
+
+class NotifyOverwatchOrganizationDeletedTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization_id = 12345
+        self.organization_slug = "test-org"
+
+        # Mock region
+        self.mock_region = MagicMock()
+        self.mock_region.name = "us"
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+    )
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    @patch("sentry.deletions.tasks.overwatch.logger")
+    @patch("sentry.deletions.tasks.overwatch.metrics")
+    def test_region_not_enabled(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+        """Test that nothing happens when local region is not in enabled list"""
+        mock_get_local_region.return_value = self.mock_region
+
+        with self.options({"overwatch.enabled-regions": []}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        mock_logger.debug.assert_called_once_with(
+            "overwatch.organization_deleted.region_not_enabled",
+            extra={
+                "organization_id": self.organization_id,
+                "organization_slug": self.organization_slug,
+                "region_name": "us",
+            },
+        )
+        mock_metrics.incr.assert_not_called()
+
+    @override_settings(OVERWATCH_WEBHOOK_SECRET=None)
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    @patch("sentry.deletions.tasks.overwatch.logger")
+    @patch("sentry.deletions.tasks.overwatch.metrics")
+    def test_no_webhook_secret(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+        """Test that a warning is logged when secret is not configured"""
+        mock_get_local_region.return_value = self.mock_region
+
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        mock_logger.warning.assert_called_once_with(
+            "overwatch.organization_deleted.no_secret",
+            extra={
+                "organization_id": self.organization_id,
+                "organization_slug": self.organization_slug,
+            },
+        )
+        mock_metrics.incr.assert_not_called()
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+    )
+    @responses.activate
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    @patch("sentry.deletions.tasks.overwatch.logger")
+    @patch("sentry.deletions.tasks.overwatch.metrics")
+    def test_successful_notification(
+        self, mock_metrics, mock_logger, mock_get_local_region
+    ) -> None:
+        """Test successful notification to the local region"""
+        mock_get_local_region.return_value = self.mock_region
+
+        responses.add(
+            responses.POST,
+            "https://overwatch-us.example.com/webhooks/sentry",
+            status=200,
+        )
+
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        # Verify the request was made
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+
+        # Verify the payload
+        payload = json.loads(request.body)
+        assert payload == {
+            "event_type": "organization_delete",
+            "organization_id": self.organization_id,
+            "organization_slug": self.organization_slug,
+            "region": "us",
+        }
+
+        # Verify the signature header
+        expected_signature = hmac.new(
+            b"test-secret",
+            request.body,
+            hashlib.sha256,
+        ).hexdigest()
+        assert request.headers["x-sentry-overwatch-signature"] == expected_signature
+        assert request.headers["content-type"] == "application/json;charset=utf-8"
+
+        # Verify logging
+        mock_logger.info.assert_called_once_with(
+            "overwatch.organization_deleted.success",
+            extra={
+                "organization_id": self.organization_id,
+                "organization_slug": self.organization_slug,
+                "region_name": "us",
+                "status_code": 200,
+            },
+        )
+
+        # Verify metrics
+        mock_metrics.incr.assert_called_once_with(
+            "overwatch.organization_deleted.sent",
+            amount=1,
+            tags={"status": "success", "region": "us"},
+        )
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+        OVERWATCH_REGION_URLS={},  # No URL configured for us region
+    )
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    @patch("sentry.deletions.tasks.overwatch.logger")
+    @patch("sentry.deletions.tasks.overwatch.metrics")
+    def test_missing_region_url(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+        """Test handling when local region doesn't have a URL configured"""
+        mock_get_local_region.return_value = self.mock_region
+
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        mock_logger.warning.assert_called_once_with(
+            "overwatch.organization_deleted.missing_region_url",
+            extra={
+                "organization_id": self.organization_id,
+                "organization_slug": self.organization_slug,
+                "region_name": "us",
+            },
+        )
+
+        # Verify failure metric
+        mock_metrics.incr.assert_called_once_with(
+            "overwatch.organization_deleted.sent",
+            amount=1,
+            tags={"status": "failure", "region": "us"},
+        )
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+    )
+    @responses.activate
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    @patch("sentry.deletions.tasks.overwatch.logger")
+    @patch("sentry.deletions.tasks.overwatch.metrics")
+    def test_request_failure(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+        """Test handling of HTTP request failures"""
+        mock_get_local_region.return_value = self.mock_region
+
+        responses.add(
+            responses.POST,
+            "https://overwatch-us.example.com/webhooks/sentry",
+            status=500,
+        )
+
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        # Verify error logging
+        mock_logger.exception.assert_called_once()
+        call_args = mock_logger.exception.call_args
+        assert call_args[0][0] == "overwatch.organization_deleted.failed"
+        assert call_args[1]["extra"]["organization_id"] == self.organization_id
+        assert call_args[1]["extra"]["region_name"] == "us"
+
+        # Verify failure metric
+        mock_metrics.incr.assert_called_once_with(
+            "overwatch.organization_deleted.sent",
+            amount=1,
+            tags={"status": "failure", "region": "us"},
+        )
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+    )
+    @responses.activate
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    def test_request_timeout(self, mock_get_local_region) -> None:
+        """Test that requests have a timeout configured"""
+        import requests
+
+        mock_get_local_region.return_value = self.mock_region
+
+        responses.add(
+            responses.POST,
+            "https://overwatch-us.example.com/webhooks/sentry",
+            body=requests.exceptions.Timeout(),
+        )
+
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            # Should not raise, timeout is caught
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        assert len(responses.calls) == 1
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="secret-with-special-chars-!@#$%",
+        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+    )
+    @responses.activate
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    def test_signature_with_special_characters(self, mock_get_local_region) -> None:
+        """Test that signature is correctly generated with special characters in secret"""
+        mock_get_local_region.return_value = self.mock_region
+
+        responses.add(
+            responses.POST,
+            "https://overwatch-us.example.com/webhooks/sentry",
+            status=200,
+        )
+
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        request = responses.calls[0].request
+        payload = request.body
+
+        expected_signature = hmac.new(
+            b"secret-with-special-chars-!@#$%",
+            payload,
+            hashlib.sha256,
+        ).hexdigest()
+        assert request.headers["x-sentry-overwatch-signature"] == expected_signature
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+    )
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    @patch("sentry.deletions.tasks.overwatch.logger")
+    @patch("sentry.deletions.tasks.overwatch.metrics")
+    def test_get_local_region_error(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+        """Test handling when get_local_region raises an exception"""
+        mock_get_local_region.side_effect = Exception("Region not configured")
+
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        # Verify error logging
+        mock_logger.exception.assert_called_once()
+        call_args = mock_logger.exception.call_args
+        assert call_args[0][0] == "overwatch.organization_deleted.region_error"
+        assert call_args[1]["extra"]["organization_id"] == self.organization_id
+        assert call_args[1]["extra"]["error"] == "Region not configured"
+
+        # No metrics should be recorded
+        mock_metrics.incr.assert_not_called()
+
+    @override_settings(
+        OVERWATCH_WEBHOOK_SECRET="test-secret",
+        OVERWATCH_REGION_URLS={"us": "https://overwatch-us.example.com"},
+    )
+    @responses.activate
+    @patch("sentry.deletions.tasks.overwatch.get_local_region")
+    @patch("sentry.deletions.tasks.overwatch.logger")
+    @patch("sentry.deletions.tasks.overwatch.metrics")
+    def test_different_region_name(self, mock_metrics, mock_logger, mock_get_local_region) -> None:
+        """Test that the correct region name from get_local_region is used"""
+        eu_region = MagicMock()
+        eu_region.name = "eu"
+        mock_get_local_region.return_value = eu_region
+
+        # us is enabled but we're in eu region (not enabled)
+        with self.options({"overwatch.enabled-regions": ["us"]}):
+            notify_overwatch_organization_deleted(self.organization_id, self.organization_slug)
+
+        # Should log that eu region is not enabled
+        mock_logger.debug.assert_called_once_with(
+            "overwatch.organization_deleted.region_not_enabled",
+            extra={
+                "organization_id": self.organization_id,
+                "organization_slug": self.organization_slug,
+                "region_name": "eu",
+            },
+        )
+        mock_metrics.incr.assert_not_called()

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -401,7 +402,7 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
     @responses.activate
     @patch("sentry.deletions.tasks.overwatch.notify_overwatch_organization_deleted")
     def test_overwatch_notification_on_deletion(
-        self, mock_notify_overwatch_organization_deleted
+        self, mock_notify_overwatch_organization_deleted: Any
     ) -> None:
         """Test that Overwatch is notified when an organization is deleted"""
         org = self.create_organization(name="test")


### PR DESCRIPTION
## Summary

Implements webhook notifications to Overwatch when organizations are deleted in Sentry. This builds on top of the Overwatch webhook forwarding infrastructure from #99389, enabling Overwatch to clean up organization-specific data when an organization is removed from Sentry.

### Core Implementation

- **Celery Task** (`src/sentry/deletions/tasks/overwatch.py`): New async task that sends organization deletion notifications to configured Overwatch regions
- **Deletion Hook** (`src/sentry/deletions/defaults/organization.py`): Modified `OrganizationDeletionTask.delete_instance()` to trigger webhook notifications via `transaction.on_commit()`









