### PR TITLE
chore(aci): Remove uses of workflow-engine-issue-alert-dual-write feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -519,7 +519,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable processing activity updates in workflow engine
     manager.add("organizations:workflow-engine-process-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for issue alert issues (see: alerts create issues)
-    manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable workflow processing for metric issues
     manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single processing through workflow engine for issue alerts

--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -4,7 +4,6 @@ import sentry_sdk
 from django.db import IntegrityError
 from django.db.models.signals import post_save
 
-from sentry import features
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.project import Project
 from sentry.workflow_engine.models import Detector
@@ -16,13 +15,10 @@ logger = logging.getLogger(__name__)
 def create_project_detectors(instance, created, **kwargs):
     if created:
         try:
-            if features.has(
-                "organizations:workflow-engine-issue-alert-dual-write", instance.organization
-            ):
-                Detector.objects.create(
-                    name=ERROR_DETECTOR_NAME, type=ErrorGroupType.slug, project=instance, config={}
-                )
-                logger.info("project.detector-created", extra={"project_id": instance.id})
+            Detector.objects.create(
+                name=ERROR_DETECTOR_NAME, type=ErrorGroupType.slug, project=instance, config={}
+            )
+            logger.info("project.detector-created", extra={"project_id": instance.id})
         except IntegrityError as e:
             sentry_sdk.capture_exception(e)
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -84,6 +84,7 @@ from sentry.issues.grouptype import (
     PerformanceFileIOMainThreadGroupType,
     PerformanceNPlusOneGroupType,
     PerformanceSlowDBQueryGroupType,
+    import_grouptype,
 )
 from sentry.issues.ingest import send_issue_occurrence_to_eventstream
 from sentry.mail import mail_adapter
@@ -217,6 +218,15 @@ class BaseTestCase(Fixtures):
         auth.register(DummyProvider)
         yield
         auth.unregister(DummyProvider)
+
+    @pytest.fixture(autouse=True)
+    def register_grouptypes(self):
+        """
+        Ensure all grouptypes are imported and registered before tests run.
+        This is necessary because creating projects now always creates detectors,
+        which require grouptypes to be registered.
+        """
+        import_grouptype()
 
     def tasks(self):
         return TaskRunner()

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -112,7 +112,7 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
         type=WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
         conditions=conditions,
         filters=filters,
-        match=data["action_match"],
+        match=data.get("action_match"),
     )
 
     try:
@@ -130,7 +130,7 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
             workflow=workflow,
             conditions=conditions,
             filters=filters,
-            filter_match=data["filter_match"],
+            filter_match=data.get("filter_match"),
         )
         WorkflowDataConditionGroup.objects.create(workflow=workflow, condition_group=if_dcg)
 
@@ -138,7 +138,7 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
         dcg=if_dcg,
         type=WorkflowDataConditionGroupType.ACTION_FILTER,
         conditions=conditions,
-        match=data["filter_match"],
+        match=data.get("filter_match"),
         filters=filters,
     )
 
@@ -146,7 +146,7 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
     create_workflow_actions(if_dcg=if_dcg, actions=data["actions"])  # action(s) must exist
 
     workflow.environment_id = rule.environment_id
-    if frequency := data["frequency"]:
+    if frequency := data.get("frequency"):
         workflow.config["frequency"] = frequency
 
     workflow.owner_user_id = rule.owner_user_id


### PR DESCRIPTION
At this point, we always dual write (unless we're only writing to workflow-engine, in which case this flag isn't relevant).
