### PR TITLE
fix(prevent): Handle empty org object

### DIFF
--- a/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIConfig.tsx
@@ -10,7 +10,7 @@ interface UsePreventAIGitHubConfigOptions {
 interface UsePreventAIGitHubConfigResult {
   default_org_config: PreventAIConfig;
   schema_version: string;
-  organization?: PreventAIConfig;
+  organization?: PreventAIConfig | Record<string, never>;
 }
 
 export function usePreventAIGitHubConfig({gitOrgName}: UsePreventAIGitHubConfigOptions) {

--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -97,7 +97,11 @@ function ManageReposPanel({
     );
   }
 
-  const orgConfig = githubConfigData.organization ?? githubConfigData.default_org_config;
+  // If organization is an empty object (Record<string, never>), use default_org_config
+  const orgConfig =
+    githubConfigData.organization && Object.keys(githubConfigData.organization).length > 0
+      ? (githubConfigData.organization as PreventAIConfig)
+      : githubConfigData.default_org_config;
 
   const {doesUseOrgDefaults, repoConfig} = isEditingOrgDefaults
     ? {doesUseOrgDefaults: true, repoConfig: orgConfig.org_defaults}


### PR DESCRIPTION
Handle when the `organization` object is just `{}`, which can be returned by the api