### PR TITLE
fix(explorer): allow extra fields in client models

### DIFF
--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -15,6 +15,9 @@ class ToolCall(BaseModel):
     function: str
     args: str
 
+    class Config:
+        extra = "allow"
+
 
 class Message(BaseModel):
     """A message in the conversation."""
@@ -22,6 +25,9 @@ class Message(BaseModel):
     role: Literal["user", "assistant", "tool_use"]
     content: str | None = None
     tool_calls: list[ToolCall] | None = None
+
+    class Config:
+        extra = "allow"
 
 
 class MemoryBlock(BaseModel):
@@ -32,6 +38,9 @@ class MemoryBlock(BaseModel):
     timestamp: str
     loading: bool = False
 
+    class Config:
+        extra = "allow"
+
 
 class SeerRunState(BaseModel):
     """State of a Seer Explorer session."""
@@ -40,3 +49,6 @@ class SeerRunState(BaseModel):
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error"]
     updated_at: str
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
Allows all data from Seer to reach the frontend even if we don't explicitly define the field in the explorer client's models.