### PR TITLE
fix(tracemetrics): Allow metric info in saved queries

### DIFF
--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -61,6 +61,27 @@ class AggregateFieldSerializer(serializers.Serializer):
         )
 
 
+class MetricSerializer(serializers.Serializer):
+    name = serializers.CharField(
+        required=True,
+        help_text="The name of the metric.",
+    )
+    type = serializers.ChoiceField(
+        choices=[
+            "counter",
+            "gauge",
+            "distribution",
+        ],
+        required=True,
+        help_text="The type of the metric.",
+    )
+    unit = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="The unit of the metric (e.g., 'millisecond'). See MetricUnit in relay",
+    )
+
+
 @extend_schema_serializer(exclude_fields=["groupby"])
 class QuerySerializer(serializers.Serializer):
     fields = ListField(
@@ -104,6 +125,11 @@ class QuerySerializer(serializers.Serializer):
             "aggregate",
         ],
         help_text="The mode of the query.",
+    )
+    metric = MetricSerializer(
+        required=False,
+        allow_null=True,
+        help_text="The metric configuration (only used for metrics dataset).",
     )
 
 
@@ -173,6 +199,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
             "mode",
             "aggregateField",
             "aggregateOrderby",
+            "metric",
         ]
 
         for key in query_keys:
@@ -182,6 +209,10 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
         if "query" in data:
             query["query"] = []
             for q in data["query"]:
+                if "metric" in q and data["dataset"] != "metrics":
+                    raise serializers.ValidationError(
+                        "Metric field is only allowed for metrics dataset"
+                    )
                 inner_query = {}
                 for key in inner_query_keys:
                     if key in q:

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -213,6 +213,10 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
                     raise serializers.ValidationError(
                         "Metric field is only allowed for metrics dataset"
                     )
+                if data["dataset"] == "metrics" and "metric" not in q:
+                    raise serializers.ValidationError(
+                        "Metric field is required for metrics dataset"
+                    )
                 inner_query = {}
                 for key in inner_query_keys:
                     if key in q:

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1112,3 +1112,141 @@ class ExploreSavedQueriesTest(APITestCase):
 
         assert response_without_flag.status_code == 200, response_without_flag.content
         assert len(response_without_flag.data) == 5
+
+    def test_post_metrics_dataset_with_metric_field(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Metrics query with metric field",
+                    "projects": self.project_ids,
+                    "dataset": "metrics",
+                    "query": [
+                        {
+                            "fields": ["count()"],
+                            "mode": "aggregate",
+                            "metric": {
+                                "name": "sentry.alert_endpoint.executed",
+                                "type": "counter",
+                            },
+                        }
+                    ],
+                    "range": "24h",
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["dataset"] == "metrics"
+        assert data["query"] == [
+            {
+                "fields": ["count()"],
+                "mode": "aggregate",
+                "metric": {
+                    "name": "sentry.alert_endpoint.executed",
+                    "type": "counter",
+                },
+            }
+        ]
+
+    def test_post_metrics_dataset_with_metric_field_and_unit(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Metrics query with unit",
+                    "projects": self.project_ids,
+                    "dataset": "metrics",
+                    "query": [
+                        {
+                            "fields": ["avg()"],
+                            "mode": "aggregate",
+                            "metric": {
+                                "name": "sentry.response_time",
+                                "type": "gauge",
+                                "unit": "millisecond",
+                            },
+                        }
+                    ],
+                    "range": "1h",
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["dataset"] == "metrics"
+        assert data["query"] == [
+            {
+                "fields": ["avg()"],
+                "mode": "aggregate",
+                "metric": {
+                    "name": "sentry.response_time",
+                    "type": "gauge",
+                    "unit": "millisecond",
+                },
+            }
+        ]
+
+    def test_get_metrics_dataset_with_metric_field(self) -> None:
+        query = {
+            "range": "24h",
+            "query": [
+                {
+                    "fields": ["count()"],
+                    "mode": "aggregate",
+                    "metric": {
+                        "name": "sentry.alert_endpoint.executed",
+                        "type": "counter",
+                    },
+                }
+            ],
+        }
+
+        model = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Test metrics query",
+            query=query,
+            dataset=ExploreSavedQueryDataset.METRICS,
+        )
+        model.set_projects(self.project_ids)
+
+        with self.feature(self.features):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200, response.content
+
+        test_query = None
+        for item in response.data:
+            if item["name"] == "Test metrics query":
+                test_query = item
+                break
+
+        assert test_query is not None
+        assert test_query["dataset"] == "metrics"
+        assert test_query["query"][0]["metric"] == {
+            "name": "sentry.alert_endpoint.executed",
+            "type": "counter",
+        }
+
+    def test_post_non_metrics_dataset_rejects_metric_field(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Spans query with invalid metric",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                            "metric": {
+                                "name": "sentry.alert_endpoint.executed",
+                                "type": "counter",
+                            },
+                        }
+                    ],
+                    "range": "24h",
+                },
+            )
+        assert response.status_code == 400, response.content
+        assert "Metric field is only allowed for metrics dataset" in str(response.content)

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1249,4 +1249,24 @@ class ExploreSavedQueriesTest(APITestCase):
                 },
             )
         assert response.status_code == 400, response.content
-        assert "Metric field is only allowed for metrics dataset" in str(response.content)
+        assert "Metric field is only allowed for metrics dataset" in str(response.data)
+
+    def test_post_metrics_dataset_requires_metric_field(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Metrics query without metric field",
+                    "projects": self.project_ids,
+                    "dataset": "metrics",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                },
+            )
+        assert response.status_code == 400, response.content
+        assert "Metric field is required for metrics dataset" in str(response.data)


### PR DESCRIPTION
### Summary
This allows 'metric' for the metrics dataset for saved queries. We can make this required later.
