### PR TITLE
fix(tracemetrics): Update FE to send metric to saved queries

### DIFF
--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -7,6 +7,7 @@ import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {ExploreQueryChangedReason} from 'sentry/views/explore/hooks/useSaveQuery';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export type RawGroupBy = {
@@ -35,12 +36,14 @@ type ReadableQuery = {
   mode: Mode;
   orderby: string;
   query: string;
-
   // a query can have either
   // - `aggregateField` which contains a list of group bys and visualizes merged together
   // - `groupby` and `visualize` which contains the group bys and visualizes separately
   aggregateField?: Array<RawGroupBy | RawVisualize>;
+
   groupby?: string[];
+  // Only used for metrics dataset.
+  metric?: TraceMetric;
   visualize?: RawVisualize[];
 };
 
@@ -55,7 +58,10 @@ export class SavedQueryQuery {
   groupby: string[];
   visualize: RawVisualize[];
 
+  metric?: TraceMetric; // Only used for metrics dataset.
+
   constructor(query: ReadableQuery) {
+    this.metric = query.metric;
     this.fields = query.fields;
     this.mode = query.mode;
     this.orderby = query.orderby;

--- a/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
+++ b/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
@@ -69,6 +69,7 @@ export function useSaveMetricsMultiQuery() {
               ...groupBys,
               ...(yAxes.length > 0 ? [{yAxes, chartType}] : []),
             ],
+            metric: metricQuery.metric,
             fields: metricQuery.queryParams.fields,
             orderby: metricQuery.queryParams.sortBys[0]
               ? encodeSort(metricQuery.queryParams.sortBys[0])

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -155,6 +155,7 @@ export function getMetricsUrlFromSavedQueryUrl({
 
     return {
       ...defaultQuery,
+      metric: queryItem.metric ?? defaultQuery.metric,
       queryParams: defaultQuery.queryParams.replace({
         mode: queryItem.mode,
         query: queryItem.query,


### PR DESCRIPTION
### Summary
This sends the metric in the SavedQueryQuery as well, which we need to pick a specific metric

