### PR TITLE
ref(crons): Update monitor incident title and subtitle

### DIFF
--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -160,6 +160,8 @@ def send_incident_occurrence(
             owner_actor = None
             monitor_env.monitor.update(owner_user_id=None, owner_team_id=None)
 
+    failure_reason = get_failure_reason(previous_checkins)
+
     occurrence = IssueOccurrence(
         id=uuid.uuid4().hex,
         resource_id=None,
@@ -167,12 +169,12 @@ def send_incident_occurrence(
         event_id=uuid.uuid4().hex,
         fingerprint=[incident.grouphash],
         type=MonitorIncidentType,
-        issue_title=f"Monitor failure: {monitor_env.monitor.name}",
-        subtitle="Your monitor has reached its failure threshold.",
+        issue_title=f"Cron failure: {monitor_env.monitor.name}",
+        subtitle=f"Your monitor is failing: {failure_reason}.",
         evidence_display=[
             IssueEvidence(
                 name="Failure reason",
-                value=str(get_failure_reason(previous_checkins)),
+                value=str(failure_reason),
                 important=True,
             ),
             IssueEvidence(

--- a/tests/sentry/monitors/logic/test_incident_occurrence.py
+++ b/tests/sentry/monitors/logic/test_incident_occurrence.py
@@ -106,8 +106,8 @@ class IncidentOccurrenceTestCase(TestCase):
             **{
                 "project_id": self.project.id,
                 "fingerprint": [self.incident.grouphash],
-                "issue_title": f"Monitor failure: {self.monitor.name}",
-                "subtitle": "Your monitor has reached its failure threshold.",
+                "issue_title": f"Cron failure: {self.monitor.name}",
+                "subtitle": "Your monitor is failing: 1 timeout and 1 error check-ins detected.",
                 "resource_id": None,
                 "evidence_data": {},
                 "evidence_display": [
@@ -191,8 +191,8 @@ class IncidentOccurrenceTestCase(TestCase):
             **{
                 "project_id": self.project.id,
                 "fingerprint": [self.incident.grouphash],
-                "issue_title": f"Monitor failure: {self.monitor.name}",
-                "subtitle": "Your monitor has reached its failure threshold.",
+                "issue_title": f"Cron failure: {self.monitor.name}",
+                "subtitle": "Your monitor is failing: 1 timeout and 1 error check-ins detected.",
                 "resource_id": None,
                 "evidence_data": {"detector_id": detector.id},
                 "evidence_display": [


### PR DESCRIPTION
Changes monitor incident issue title from "Monitor failure" to "Cron failure" and updates the subtitle to include the specific failure reason instead of the generic "Your monitor has reached its failure threshold" message.

Fixes [NEW-552: Add Cron monitor failure reason to the event's message](https://linear.app/getsentry/issue/NEW-552/add-cron-monitor-failure-reason-to-the-events-message)