### PR TITLE
fix(aci): ignore groups that shouldn't be manually resolved

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -448,7 +448,7 @@ def handle_resolve_in_release(
             continue
 
         # Users should only be able to manually resolve error issues
-        if not get_group_type_by_type_id(group.type).enable_user_status_and_priority_changes:
+        if not group.issue_type.enable_user_status_and_priority_changes:
             continue
 
         with transaction.atomic(router.db_for_write(Group)):

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -354,6 +354,8 @@ def handle_resolve_in_release(
     acting_user: RpcUser | User | None,
     result: MutableMapping[str, Any],
 ) -> tuple[dict[str, Any], int | None]:
+    from sentry.grouping.grouptype import ErrorGroupType
+
     res_type = None
     release = None
     commit = None
@@ -445,6 +447,10 @@ def handle_resolve_in_release(
     for group in group_list:
         # If the group is already resolved, we don't need to do anything
         if group.status == GroupStatus.RESOLVED:
+            continue
+
+        # Users should only be able to manually resolve error issues
+        if group.type != ErrorGroupType.type_id:
             continue
 
         with transaction.atomic(router.db_for_write(Group)):

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -25,7 +25,7 @@ from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializer
 from sentry.db.models.query import create_or_update
 from sentry.hybridcloud.rpc import coerce_id_from
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
-from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
+from sentry.issues.grouptype import GroupCategory
 from sentry.issues.ignored import handle_archived_until_escalating, handle_ignored
 from sentry.issues.merge import MergedGroup, handle_merge
 from sentry.issues.priority import update_priority
@@ -206,10 +206,7 @@ def update_groups(
     status = result.get("status")
     res_type = None
     if "priority" in result:
-        if any(
-            not get_group_type_by_type_id(group.type).enable_user_status_and_priority_changes
-            for group in groups
-        ):
+        if any(not group.issue_type.enable_user_status_and_priority_changes for group in groups):
             return Response(
                 {"detail": "Cannot manually set priority of one or more issues."},
                 status=HTTPStatus.BAD_REQUEST,
@@ -222,6 +219,12 @@ def update_groups(
             project_lookup=project_lookup,
         )
     if status in ("resolved", "resolvedInNextRelease"):
+        if any(not group.issue_type.enable_user_status_and_priority_changes for group in groups):
+            return Response(
+                {"detail": "Cannot manually resolve one or more issues."},
+                status=HTTPStatus.BAD_REQUEST,
+            )
+
         try:
             result, res_type = handle_resolve_in_release(
                 status,
@@ -445,10 +448,6 @@ def handle_resolve_in_release(
     for group in group_list:
         # If the group is already resolved, we don't need to do anything
         if group.status == GroupStatus.RESOLVED:
-            continue
-
-        # Users should only be able to manually resolve error issues
-        if not group.issue_type.enable_user_status_and_priority_changes:
             continue
 
         with transaction.atomic(router.db_for_write(Group)):

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -207,11 +207,11 @@ def update_groups(
     res_type = None
     if "priority" in result:
         if any(
-            not get_group_type_by_type_id(group.type).enable_user_priority_changes
+            not get_group_type_by_type_id(group.type).enable_user_status_and_priority_changes
             for group in groups
         ):
             return Response(
-                {"detail": "Cannot manually set priority of a metric issue."},
+                {"detail": "Cannot manually set priority of one or more issues."},
                 status=HTTPStatus.BAD_REQUEST,
             )
 
@@ -448,7 +448,7 @@ def handle_resolve_in_release(
             continue
 
         # Users should only be able to manually resolve error issues
-        if not get_group_type_by_type_id(group.type).enable_user_priority_changes:
+        if not get_group_type_by_type_id(group.type).enable_user_status_and_priority_changes:
             continue
 
         with transaction.atomic(router.db_for_write(Group)):

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -354,8 +354,6 @@ def handle_resolve_in_release(
     acting_user: RpcUser | User | None,
     result: MutableMapping[str, Any],
 ) -> tuple[dict[str, Any], int | None]:
-    from sentry.grouping.grouptype import ErrorGroupType
-
     res_type = None
     release = None
     commit = None
@@ -450,7 +448,7 @@ def handle_resolve_in_release(
             continue
 
         # Users should only be able to manually resolve error issues
-        if group.type != ErrorGroupType.type_id:
+        if not get_group_type_by_type_id(group.type).enable_user_priority_changes:
             continue
 
         with transaction.atomic(router.db_for_write(Group)):

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -333,7 +333,7 @@ class MetricIssue(GroupType):
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = False
     enable_workflow_notifications = False
-    enable_user_priority_changes = False
+    enable_user_status_and_priority_changes = False
     detector_settings = DetectorSettings(
         handler=MetricIssueDetectorHandler,
         validator=MetricIssueDetectorValidator,

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -219,7 +219,7 @@ class GroupType:
     enable_workflow_notifications = True
 
     # Controls whether users are able to manually update the group's priority.
-    enable_user_priority_changes = True
+    enable_user_status_and_priority_changes = True
 
     # Controls whether Seer automation is always triggered for this group type.
     always_trigger_seer_automation = False

--- a/src/sentry/workflow_engine/typings/grouptype.py
+++ b/src/sentry/workflow_engine/typings/grouptype.py
@@ -17,4 +17,4 @@ class IssueStreamGroupType(GroupType):
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = False
     enable_workflow_notifications = False
-    enable_user_priority_changes = False
+    enable_user_status_and_priority_changes = False

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4230,7 +4230,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             qs_params={"id": [group.id]}, priority=PriorityLevel.MEDIUM.to_str()
         )
         assert response.status_code == 400
-        assert response.data["detail"] == "Cannot manually set priority of a metric issue."
+        assert response.data["detail"] == "Cannot manually set priority of one or more issues."
 
 
 class GroupDeleteTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -490,21 +490,16 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_exclude_metric_issue(self) -> None:
         self.login_as(user=self.user)
 
-        error_group = self.create_group()
-        metric_issue_group = self.create_group(type=MetricIssue.type_id)
+        self.create_group()
+        self.create_group(type=MetricIssue.type_id)
 
         response = self.client.put(
             f"{self.path}?status=unresolved&query=is:unresolved",
             data={"status": "resolved"},
             format="json",
         )
-        assert response.status_code == 200, response.data
-
-        error_group.refresh_from_db()
-        metric_issue_group.refresh_from_db()
-
-        assert error_group.status == GroupStatus.RESOLVED
-        assert metric_issue_group.status == GroupStatus.UNRESOLVED
+        assert response.status_code == 400, response.data
+        assert response.data["detail"] == "Cannot manually resolve one or more issues."
 
     @patch("sentry.integrations.example.integration.ExampleIntegration.sync_status_outbound")
     def test_resolve_with_integration(self, mock_sync_status_outbound: MagicMock) -> None:


### PR DESCRIPTION
Metric issues should not be manually resolved. We prevent this on the frontend, but not in API calls. Add logic to ignore these groups on the backend.

[Fixes SENTRY-5BXQ](https://sentry.sentry.io/issues/6995480460/)