### PR TITLE
feat(aci): fallback to issue stream detector for events

### DIFF
--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -117,10 +117,10 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
     if issue_occurrence is None or evt.group.issue_type.detector_settings is None:
         # if there are no detector settings, default to the error detector
         detector = Detector.get_error_detector_for_project(evt.project_id)
-    elif issue_occurrence:
-        detector = Detector.objects.filter(
-            id=issue_occurrence.evidence_data.get("detector_id", None)
-        ).first()
+    elif issue_occurrence and (detector_id := issue_occurrence.evidence_data.get("detector_id")):
+        detector = Detector.objects.filter(id=detector_id).first()
+    if detector:
+        return detector
 
     if detector:
         return detector

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -119,10 +119,8 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
         detector = Detector.get_error_detector_for_project(evt.project_id)
     elif issue_occurrence and (detector_id := issue_occurrence.evidence_data.get("detector_id")):
         detector = Detector.objects.filter(id=detector_id).first()
-    if detector:
-        return detector
 
-    if detector:
+    if detector is not None:
         return detector
 
     try:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -281,8 +281,8 @@ def get_detectors_by_groupevents_bulk(
             result.update(mapping)
 
             # events with missing detectors can be picked up by the issue stream detector
-            for project_id, events in detector_id_to_events.items():
-                if project_id not in found_detector_ids:
+            for detector_id, events in detector_id_to_events.items():
+                if detector_id not in found_detector_ids:
                     issue_stream_events.extend(events)
 
             missing_detector_ids.update(set(detector_id_to_events.keys()) - found_detector_ids)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -31,7 +31,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
     get_data_conditions_for_group,
     process_data_condition_group,
 )
-from sentry.workflow_engine.processors.detector import get_detector_by_event
+from sentry.workflow_engine.processors.detector import get_detectors_by_event
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context, scopedstats
@@ -410,7 +410,7 @@ def get_environment_by_event(event_data: WorkflowEventData) -> Environment | Non
 
 @scopedstats.timer()
 def _get_associated_workflows(
-    detector: Detector, environment: Environment | None, event_data: WorkflowEventData
+    detectors: list[Detector], environment: Environment | None, event_data: WorkflowEventData
 ) -> set[Workflow]:
     """
     This is a wrapper method to get the workflows associated with a detector and environment.
@@ -424,7 +424,7 @@ def _get_associated_workflows(
     workflows = set(
         Workflow.objects.filter(
             environment_filter,
-            detectorworkflow__detector_id=detector.id,
+            detectorworkflow__detector_id__in=[detector.id for detector in detectors],
             enabled=True,
         )
         .select_related("environment")
@@ -451,7 +451,7 @@ def _get_associated_workflows(
                 "event_data": asdict(event_data),
                 "event_environment_id": environment.id if environment else None,
                 "workflows": [workflow.id for workflow in workflows],
-                "detector_type": detector.type,
+                "detector_types": [detector.type for detector in detectors],
             },
         )
 
@@ -479,8 +479,12 @@ def process_workflows(
     )
 
     try:
-        if detector is None and isinstance(event_data.event, GroupEvent):
-            detector = get_detector_by_event(event_data)
+        if isinstance(event_data.event, GroupEvent):
+            event_detectors = get_detectors_by_event(event_data)
+            if detector:
+                event_detectors.event_type_detector = detector
+            else:
+                detector = event_detectors.get_preferred_detector()
 
         if detector is None:
             raise ValueError("Unable to determine the detector for the event")
@@ -515,7 +519,9 @@ def process_workflows(
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
 
-    workflows = _get_associated_workflows(detector, environment, event_data)
+    workflows = _get_associated_workflows(
+        event_detectors.get_all_detectors(), environment, event_data
+    )
     if not workflows:
         # If there aren't any workflows, there's nothing to evaluate
         return set()

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -478,6 +478,8 @@ def process_workflows(
         fire_actions,
     )
 
+    detectors = [detector] if detector else []
+
     try:
         if isinstance(event_data.event, GroupEvent):
             event_detectors = get_detectors_by_event(event_data)
@@ -485,6 +487,8 @@ def process_workflows(
                 event_detectors.event_type_detector = detector
             else:
                 detector = event_detectors.get_preferred_detector()
+
+            detectors = event_detectors.get_all_detectors()
 
         if detector is None:
             raise ValueError("Unable to determine the detector for the event")
@@ -519,9 +523,7 @@ def process_workflows(
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
 
-    workflows = _get_associated_workflows(
-        event_detectors.get_all_detectors(), environment, event_data
-    )
+    workflows = _get_associated_workflows(detectors, environment, event_data)
     if not workflows:
         # If there aren't any workflows, there's nothing to evaluate
         return set()

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -916,6 +916,18 @@ class TestGetDetectorsByEvent(TestCase):
         )
         assert result.get_preferred_detector() == self.issue_stream_detector
 
+    def test_no_detector(self) -> None:
+        self.detector.delete()
+        self.issue_stream_detector.delete()
+
+        group_event = GroupEvent.from_event(self.event, self.group)
+        group_event.occurrence = None
+
+        event_data = WorkflowEventData(event=group_event, group=self.group)
+
+        with pytest.raises(Detector.DoesNotExist):
+            get_detectors_by_event(event_data)
+
 
 class TestGetDetectorsByGroupEventsBulk(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -41,6 +41,7 @@ class BaseWorkflowIntegrationTest(BaseWorkflowTest):
             name_prefix="e2e-test",
             detector_type="metric_issue",
         )
+        self.issue_stream_detector = self.create_detector(project=self.project, type="issue_stream")
 
         detector_conditions = self.create_data_condition_group()
         self.create_data_condition(
@@ -207,6 +208,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             name_prefix="e2e-test",
             detector_type="error",
         )
+        self.issue_stream_detector = self.create_detector(project=self.project, type="issue_stream")
         self.workflow_triggers.conditions.all().delete()
         self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
 


### PR DESCRIPTION
When attempting to find a detector for an event, fallback to the issue stream detector if:
1. The event is not an error event, or
2. The event has an occurrence but doesn't have a `detector_id` in the `evidence_data`

We will pick up at most 2 detectors for each event and at least 1 (the issue stream detector). We may or may not be able to pick up the associated issue type detector because it might not exist yet. We pick up all the workflows associated with both detectors, and use the preferred detector to record WorkflowFireHistory if the detectors share workflows. Otherwise, use the correct detector for the correct workflow.

I also updated the logic within delayed processing to apply the fallback logic to bulk fetching detectors for events. We would prefer to find the appropriate issue type detector but fall back to the issue stream detector.