### PR TITLE
feat(explorer): add categories search to client

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -96,9 +96,10 @@ def start_seer_run(
         "user_org_context": collect_user_org_context(user, organization),
     }
 
-    if category_key is not None:
+    if category_key or category_value:
+        if not category_key or not category_value:
+            raise ValueError("category_key and category_value must be provided together")
         payload["category_key"] = category_key
-    if category_value is not None:
         payload["category_value"] = category_value
 
     body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -39,7 +39,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.models.organization import Organization
-from sentry.seer.explorer.client_models import SeerRunState
+from sentry.seer.explorer.client_models import ExplorerRun, SeerRunState
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
     fetch_run_status,
@@ -56,6 +56,8 @@ def start_seer_run(
     prompt: str,
     user: User | AnonymousUser | None = None,
     on_page_context: str | None = None,
+    category_key: str | None = None,
+    category_value: str | None = None,
 ) -> int:
     """
     Start a new Seer Explorer session.
@@ -68,6 +70,8 @@ def start_seer_run(
         prompt: The initial task/query for the agent
         user: User (from request.user, can be User or AnonymousUser or None)
         on_page_context: Optional context from the user's screen
+        category_key: Optional category key for filtering/grouping runs (e.g., "bug-fixer", "researcher"). Should identify the purpose/use case of the run.
+        category_value: Optional category value for filtering/grouping runs (e.g., "issue-123", "a5b32"). Should identify individual runs within the category.
 
     Returns:
         int: The run ID that can be used to fetch results or continue the conversation
@@ -91,6 +95,11 @@ def start_seer_run(
         "on_page_context": on_page_context,
         "user_org_context": collect_user_org_context(user, organization),
     }
+
+    if category_key is not None:
+        payload["category_key"] = category_key
+    if category_value is not None:
+        payload["category_value"] = category_value
 
     body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
@@ -207,10 +216,70 @@ def get_seer_run(
     return fetch_run_status(run_id, organization)
 
 
-# TODO: Add these once Seer API supports them:
-# - find_seer_runs() - search for past runs
-# - Tool configuration (currently explorer has fixed tools)
-# - Structured output artifacts
-# - Sentry data context (issue_id, trace_id, etc.)
-# - Custom agent names, categories, and category values
-# - Custom tools
+def get_seer_runs(
+    organization: Organization,
+    user: User | AnonymousUser | None = None,
+    category_key: str | None = None,
+    category_value: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+) -> list[ExplorerRun]:
+    """
+    Get a list of Seer Explorer runs for the given organization with optional filters.
+
+    This function supports flexible filtering by user_id, category_key, or category_value.
+    At least one filter should be provided to avoid returning all runs for the org.
+
+    Args:
+        organization: Sentry organization
+        user: Optional user to filter runs by (if provided, only returns runs for this user)
+        category_key: Optional category key to filter by (e.g., "bug-fixer", "researcher")
+        category_value: Optional category value to filter by (e.g., "issue-123", "a5b32")
+        offset: Optional offset for pagination
+        limit: Optional limit for pagination
+
+    Returns:
+        list[ExplorerRun]: List of runs matching the filters, sorted by most recent first
+
+    Raises:
+        SeerPermissionError: If the user/org doesn't have access to Seer Explorer
+        requests.HTTPError: If the Seer API request fails
+    """
+    has_access, error = has_seer_explorer_access_with_detail(organization, user)
+    if not has_access:
+        raise SeerPermissionError(error or "Access denied")
+
+    path = "/v1/automation/explorer/runs"
+
+    payload: dict[str, Any] = {
+        "organization_id": organization.id,
+    }
+
+    # Add optional filters
+    if user and hasattr(user, "id"):
+        payload["user_id"] = user.id
+    if category_key is not None:
+        payload["category_key"] = category_key
+    if category_value is not None:
+        payload["category_value"] = category_value
+    if offset is not None:
+        payload["offset"] = offset
+    if limit is not None:
+        payload["limit"] = limit
+
+    body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
+
+    response = requests.post(
+        f"{settings.SEER_AUTOFIX_URL}{path}",
+        data=body,
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            **sign_with_seer_secret(body),
+        },
+    )
+
+    response.raise_for_status()
+    result = response.json()
+
+    runs = [ExplorerRun(**run) for run in result.get("data", [])]
+    return runs

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -4,6 +4,7 @@ Pydantic models for Seer Explorer client.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel
@@ -49,6 +50,20 @@ class SeerRunState(BaseModel):
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error"]
     updated_at: str
+
+    class Config:
+        extra = "allow"
+
+
+class ExplorerRun(BaseModel):
+    """A single Explorer run record with metadata."""
+
+    run_id: int
+    title: str
+    last_triggered_at: datetime
+    created_at: datetime
+    category_key: str | None = None
+    category_value: str | None = None
 
     class Config:
         extra = "allow"

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -116,6 +116,36 @@ class TestStartSeerRun(TestCase):
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
 
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    def test_start_seer_run_category_key_only_raises_error(self, mock_access):
+        """Test that ValueError is raised when only category_key is provided"""
+        mock_access.return_value = (True, None)
+
+        with pytest.raises(
+            ValueError, match="category_key and category_value must be provided together"
+        ):
+            start_seer_run(
+                organization=self.organization,
+                prompt="Test query",
+                user=self.user,
+                category_key="bug-fixer",
+            )
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    def test_start_seer_run_category_value_only_raises_error(self, mock_access):
+        """Test that ValueError is raised when only category_value is provided"""
+        mock_access.return_value = (True, None)
+
+        with pytest.raises(
+            ValueError, match="category_key and category_value must be provided together"
+        ):
+            start_seer_run(
+                organization=self.organization,
+                prompt="Test query",
+                user=self.user,
+                category_value="issue-123",
+            )
+
 
 class TestContinueSeerRun(TestCase):
     def setUp(self):

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from sentry.seer.explorer.client import continue_seer_run, get_seer_run, start_seer_run
+from sentry.seer.explorer.client import (
+    continue_seer_run,
+    get_seer_run,
+    get_seer_runs,
+    start_seer_run,
+)
 from sentry.seer.explorer.client_models import SeerRunState
 from sentry.testutils.cases import TestCase
 
@@ -84,6 +89,32 @@ class TestStartSeerRun(TestCase):
                 user=self.user,
             )
         assert "Feature flag not enabled" in str(exc_info.value)
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_start_seer_run_with_categories(self, mock_collect_context, mock_post, mock_access):
+        """Test starting a run with category fields"""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 999}
+        mock_post.return_value = mock_response
+
+        run_id = start_seer_run(
+            organization=self.organization,
+            prompt="Fix bug",
+            user=self.user,
+            category_key="bug-fixer",
+            category_value="issue-123",
+        )
+
+        assert run_id == 999
+        import orjson
+
+        body = orjson.loads(mock_post.call_args[1]["data"])
+        assert body["category_key"] == "bug-fixer"
+        assert body["category_value"] == "issue-123"
 
 
 class TestContinueSeerRun(TestCase):
@@ -204,3 +235,44 @@ class TestGetSeerRun(TestCase):
 
         with pytest.raises(requests.HTTPError):
             get_seer_run(run_id=123, organization=self.organization)
+
+
+class TestGetSeerRuns(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.requests.post")
+    def test_get_seer_runs_basic(self, mock_post, mock_access):
+        """Test getting runs with filters"""
+        mock_access.return_value = (True, None)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "run_id": 1,
+                    "title": "Test",
+                    "last_triggered_at": "2024-01-01T00:00:00",
+                    "created_at": "2024-01-01T00:00:00",
+                    "category_key": "bug-fixer",
+                    "category_value": "issue-123",
+                }
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        runs = get_seer_runs(
+            organization=self.organization,
+            category_key="bug-fixer",
+            category_value="issue-123",
+        )
+
+        assert len(runs) == 1
+        assert runs[0].category_key == "bug-fixer"
+        import orjson
+
+        body = orjson.loads(mock_post.call_args[1]["data"])
+        assert body["category_key"] == "bug-fixer"
+        assert body["category_value"] == "issue-123"


### PR DESCRIPTION
Allows users of the client to set a category key and value. For default UI runs, these are null. 
Also enables searching runs by user and category in the client.
And migrates the explorer_runs endpoint to re-use the client function.

Requires https://github.com/getsentry/seer/pull/3913