### PR TITLE
fix(eco): renames the provider tag for the 'installation_attmept' metric

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -199,7 +199,8 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             self.clear_session()
 
         metrics.incr(
-            "sentry.integrations.installation_finished", tags={"integration": self.provider.key}
+            "sentry.integrations.installation_finished",
+            tags={"integration_name": self.provider.key},
         )
 
         return response

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -131,7 +131,7 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
         super().initialize()
 
         metrics.incr(
-            "sentry.integrations.installation_attempt", tags={"integration": self.provider.key}
+            "sentry.integrations.installation_attempt", tags={"integration_name": self.provider.key}
         )
 
     def finish_pipeline(self) -> HttpResponseBase:


### PR DESCRIPTION
Updates the tags for `installation_attempt` and `installation_finished` metrics to allow us to better query between our different SLO and general metrics in datadog.