### PR TITLE
fix(aci): Allow null integration_id in action validator

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -20,7 +20,7 @@ class BaseActionValidator(CamelSnakeSerializer):
     data: Any = serializers.JSONField()
     config: Any = serializers.JSONField()
     type = serializers.ChoiceField(choices=[(t.value, t.name) for t in Action.Type])
-    integration_id = serializers.IntegerField(required=False)
+    integration_id = serializers.IntegerField(required=False, allow_null=True)
     status = serializers.CharField(required=False)
 
     def _get_action_handler(self) -> builtins.type[ActionHandler]:


### PR DESCRIPTION
There is already logic in the validator which handles `None`, so there's no reason not to allow it.

Making this change because we include it in the workflow endpoint payload from the frontend, which returns the error:

```
{"actionFilters":{"integrationid":["This field may not be null."]}}
```