### PR TITLE
fix(conduit): Decode conduit private key

### DIFF
--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -47,7 +47,7 @@ def generate_conduit_token(
             raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY not configured")
     try:
         conduit_private_key_decoded = base64.b64decode(conduit_private_key).decode("utf-8")
-    except binascii.Error as e:
+    except (binascii.Error, UnicodeDecodeError) as e:
         raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64") from e
 
     now = int(time.time())

--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import time
 import uuid
 from typing import NamedTuple
@@ -43,6 +45,10 @@ def generate_conduit_token(
         conduit_private_key = settings.CONDUIT_GATEWAY_PRIVATE_KEY
         if conduit_private_key is None:
             raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY not configured")
+    try:
+        conduit_private_key = base64.b64decode(conduit_private_key)
+    except binascii.Error as e:
+        raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64") from e
 
     now = int(time.time())
     exp = now + TOKEN_TTL_SEC

--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -46,7 +46,7 @@ def generate_conduit_token(
         if conduit_private_key is None:
             raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY not configured")
     try:
-        conduit_private_key_bytes = base64.b64decode(conduit_private_key)
+        conduit_private_key_decoded = base64.b64decode(conduit_private_key).decode("utf-8")
     except binascii.Error as e:
         raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64") from e
 
@@ -61,7 +61,7 @@ def generate_conduit_token(
         "iss": issuer,
         "aud": audience,
     }
-    return jwt.encode(payload, conduit_private_key_bytes, algorithm="RS256")
+    return jwt.encode(payload, conduit_private_key_decoded, algorithm="RS256")
 
 
 def get_conduit_credentials(

--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -46,7 +46,7 @@ def generate_conduit_token(
         if conduit_private_key is None:
             raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY not configured")
     try:
-        conduit_private_key = base64.b64decode(conduit_private_key)
+        conduit_private_key_bytes = base64.b64decode(conduit_private_key)
     except binascii.Error as e:
         raise ValueError("CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64") from e
 
@@ -61,7 +61,7 @@ def generate_conduit_token(
         "iss": issuer,
         "aud": audience,
     }
-    return jwt.encode(payload, conduit_private_key, algorithm="RS256")
+    return jwt.encode(payload, conduit_private_key_bytes, algorithm="RS256")
 
 
 def get_conduit_credentials(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3188,7 +3188,7 @@ if ngrok_host and SILO_DEVSERVER:
     SENTRY_FEATURES["system:multi-region"] = True
 
 CONDUIT_GATEWAY_PRIVATE_KEY: str | None = os.getenv("CONDUIT_GATEWAY_PRIVATE_KEY")
-CONDUIT_GATEWAY_URL: str = os.getenv("CONDUIT_GATEWAY_URL", "https://conduit.sentry.io")
+CONDUIT_GATEWAY_URL: str = os.getenv("CONDUIT_GATEWAY_URL", "http://127.0.0.1:9096")
 CONDUIT_GATEWAY_JWT_ISSUER: str = os.getenv("CONDUIT_GATEWAY_JWT_ISSUER", "sentry.io")
 CONDUIT_GATEWAY_JWT_AUDIENCE: str = os.getenv("CONDUIT_GATEWAY_JWT_AUDIENCE", "conduit")
 

--- a/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
+++ b/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
@@ -1,3 +1,4 @@
+import base64
 from unittest.mock import MagicMock, patch
 
 from django.test.utils import override_settings
@@ -6,6 +7,8 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import region_silo_test
 from tests.sentry.utils.test_jwt import RS256_KEY
+
+RS256_KEY_B64 = base64.b64encode(RS256_KEY.encode()).decode()
 
 
 @region_silo_test
@@ -17,7 +20,7 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
         self.login_as(user=self.user)
 
     @override_settings(
-        CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY,
+        CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,
         CONDUIT_GATEWAY_JWT_ISSUER="sentry",
         CONDUIT_GATEWAY_JWT_AUDIENCE="conduit",
         CONDUIT_GATEWAY_URL="https://conduit.example.com",
@@ -61,7 +64,7 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
         assert response.data == {"error": "Conduit is not configured properly"}
 
     @override_settings(
-        CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY,
+        CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,
         CONDUIT_GATEWAY_JWT_ISSUER="sentry",
         CONDUIT_GATEWAY_JWT_AUDIENCE="conduit",
         CONDUIT_GATEWAY_URL="https://conduit.example.com",
@@ -85,7 +88,7 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
         assert response1.data["conduit"]["channel_id"] != response2.data["conduit"]["channel_id"]
 
     @override_settings(
-        CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY,
+        CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,
         CONDUIT_GATEWAY_JWT_ISSUER="sentry",
         CONDUIT_GATEWAY_JWT_AUDIENCE="conduit",
         CONDUIT_GATEWAY_URL="https://conduit.example.com",

--- a/tests/sentry/conduit/test_auth.py
+++ b/tests/sentry/conduit/test_auth.py
@@ -1,3 +1,4 @@
+import base64
 import time
 from unittest.mock import patch
 
@@ -6,6 +7,8 @@ import pytest
 
 from sentry.conduit.auth import generate_channel_id, generate_conduit_token, get_conduit_credentials
 from tests.sentry.utils.test_jwt import RS256_KEY, RS256_PUB_KEY
+
+RS256_KEY_B64 = base64.b64encode(RS256_KEY.encode()).decode()
 
 
 def test_generate_channel_id_is_valid_uuid():
@@ -33,7 +36,7 @@ def test_generate_conduit_token_is_valid_jwt():
         channel_id,
         issuer="sentry",
         audience="conduit",
-        conduit_private_key=RS256_KEY,
+        conduit_private_key=RS256_KEY_B64,
     )
 
     assert isinstance(token, str)
@@ -60,7 +63,7 @@ def test_generate_conduit_token_has_expiration():
         channel_id,
         issuer="sentry",
         audience="conduit",
-        conduit_private_key=RS256_KEY,
+        conduit_private_key=RS256_KEY_B64,
     )
     after_time = int(time.time())
 
@@ -86,7 +89,7 @@ def test_generate_conduit_token_uses_settings():
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
 
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY_B64
         mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "test-issuer"
         mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "test-audience"
 
@@ -111,6 +114,18 @@ def test_generate_conduit_token_raises_when_missing():
     """Should raise an error if the private key is not configured."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
+    with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64"):
+        generate_conduit_token(
+            org_id,
+            channel_id,
+            conduit_private_key=RS256_KEY,
+        )
+
+
+def test_generate_conduit_token_raises_when_invalid_base64():
+    """Should raise an error if the private key isn't valid base64."""
+    org_id = 123
+    channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
     with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY not configured"):
         generate_conduit_token(
             org_id,
@@ -122,7 +137,7 @@ def test_get_conduit_credentials_returns_all_credentials():
     """Should return a url, token, and channel_id."""
     gateway_url = "https://conduit.example.com"
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY_B64
         mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
         mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
         mock_settings.CONDUIT_GATEWAY_URL = gateway_url
@@ -142,7 +157,7 @@ def test_get_conduit_credentials_uses_custom_url():
     """Should use provided gateway_url instead of settings."""
     gateway_url = "https://custom.conduit.io"
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY_B64
         mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
         mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
 
@@ -161,7 +176,7 @@ def test_get_conduit_credentials_token_is_valid():
     """Generated token should be decodable with correct claims."""
     gateway_url = "https://conduit.example.com"
     with patch("sentry.conduit.auth.settings") as mock_settings:
-        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY_B64
         mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
         mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
         mock_settings.CONDUIT_GATEWAY_URL = gateway_url

--- a/tests/sentry/conduit/test_auth.py
+++ b/tests/sentry/conduit/test_auth.py
@@ -114,11 +114,10 @@ def test_generate_conduit_token_raises_when_missing():
     """Should raise an error if the private key is not configured."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
-    with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64"):
+    with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY not configured"):
         generate_conduit_token(
             org_id,
             channel_id,
-            conduit_private_key=RS256_KEY,
         )
 
 
@@ -126,10 +125,11 @@ def test_generate_conduit_token_raises_when_invalid_base64():
     """Should raise an error if the private key isn't valid base64."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
-    with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY not configured"):
+    with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64"):
         generate_conduit_token(
             org_id,
             channel_id,
+            conduit_private_key=RS256_KEY,
         )
 
 

--- a/tests/sentry/conduit/test_auth.py
+++ b/tests/sentry/conduit/test_auth.py
@@ -133,6 +133,19 @@ def test_generate_conduit_token_raises_when_invalid_base64():
         )
 
 
+def test_generate_conduit_token_raises_when_invalid_utf8():
+    """Should raise an error if the private key isn't valid UTF-8 after base64 decode."""
+    org_id = 123
+    channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
+    invalid_utf8_base64 = base64.b64encode(b"\xff\xfe\xfd").decode()
+    with pytest.raises(ValueError, match="CONDUIT_GATEWAY_PRIVATE_KEY is not valid base64"):
+        generate_conduit_token(
+            org_id,
+            channel_id,
+            conduit_private_key=invalid_utf8_base64,
+        )
+
+
 def test_get_conduit_credentials_returns_all_credentials():
     """Should return a url, token, and channel_id."""
     gateway_url = "https://conduit.example.com"


### PR DESCRIPTION
Secrets are base64 encoded so the logic needs to decode it before using it.