### PR TITLE
fix(eco): Fixes sample rate for installation metrics

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -131,7 +131,9 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
         super().initialize()
 
         metrics.incr(
-            "sentry.integrations.installation_attempt", tags={"integration_name": self.provider.key}
+            "sentry.integrations.installation_attempt",
+            tags={"integration_name": self.provider.key},
+            sample_rate=1.0,
         )
 
     def finish_pipeline(self) -> HttpResponseBase:
@@ -201,6 +203,7 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
         metrics.incr(
             "sentry.integrations.installation_finished",
             tags={"integration_name": self.provider.key},
+            sample_rate=1.0,
         )
 
         return response


### PR DESCRIPTION
Missed this in my last PR. Bumps the sample rate to make it 100%, like our SLO metrics
