### PR TITLE
fix(aci): Handle unknown detector types gracefully

### DIFF
--- a/static/app/views/detectors/utils/detectorTypeConfig.tsx
+++ b/static/app/views/detectors/utils/detectorTypeConfig.tsx
@@ -30,9 +30,9 @@ export function isValidDetectorType(detectorType: DetectorType) {
 }
 
 export function detectorTypeIsUserCreateable(detectorType: DetectorType) {
-  return DETECTOR_TYPE_CONFIG[detectorType].userCreateable ?? false;
+  return DETECTOR_TYPE_CONFIG[detectorType]?.userCreateable ?? false;
 }
 
 export function getDetectorTypeLabel(detectorType: DetectorType) {
-  return DETECTOR_TYPE_CONFIG[detectorType].label ?? 'Unknown';
+  return DETECTOR_TYPE_CONFIG[detectorType]?.label ?? 'Unknown';
 }


### PR DESCRIPTION
This way new detector types won't cause a hard crash