### PR TITLE
fix(prevent): Use external id for pr review config

### DIFF
--- a/static/app/views/prevent/preventAI/manageReposPage.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPage.tsx
@@ -34,8 +34,7 @@ function ManageReposPage({integratedOrgs}: {integratedOrgs: OrganizationIntegrat
     searchTerm: undefined,
   });
   const reposData = useMemo(
-    () =>
-      uniqBy(queryResult.data?.pages.flatMap(result => result[0]) ?? [], 'externalId'),
+    () => uniqBy(queryResult.data?.pages.flatMap(result => result[0]) ?? [], 'id'),
     [queryResult.data?.pages]
   );
 

--- a/static/app/views/prevent/preventAI/manageReposPage.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPage.tsx
@@ -34,7 +34,8 @@ function ManageReposPage({integratedOrgs}: {integratedOrgs: OrganizationIntegrat
     searchTerm: undefined,
   });
   const reposData = useMemo(
-    () => uniqBy(queryResult.data?.pages.flatMap(result => result[0]) ?? [], 'id'),
+    () =>
+      uniqBy(queryResult.data?.pages.flatMap(result => result[0]) ?? [], 'externalId'),
     [queryResult.data?.pages]
   );
 

--- a/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
@@ -132,7 +132,7 @@ describe('ManageReposPanel', () => {
 
   it('shows feature toggles with correct initial state when repo has overrides', async () => {
     const configWithOverride = PreventAIConfigFixture();
-    configWithOverride.repo_overrides['repo-1'] = {
+    configWithOverride.repo_overrides['ext-1'] = {
       vanilla: {
         enabled: true,
         triggers: {on_command_phrase: false, on_ready_for_review: true},
@@ -175,7 +175,7 @@ describe('ManageReposPanel', () => {
     };
 
     const configWithOverride = PreventAIConfigFixture();
-    configWithOverride.repo_overrides['repo-1'] = PreventAIConfigFixture().org_defaults;
+    configWithOverride.repo_overrides['ext-1'] = PreventAIConfigFixture().org_defaults;
 
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
@@ -201,7 +201,7 @@ describe('ManageReposPanel', () => {
 
   it('shows feature toggles when repo has overrides', async () => {
     const configWithOverride = PreventAIConfigFixture();
-    configWithOverride.repo_overrides['repo-1'] = {
+    configWithOverride.repo_overrides['ext-1'] = {
       bug_prediction: {
         enabled: true,
         triggers: {on_command_phrase: true, on_ready_for_review: false},
@@ -250,7 +250,7 @@ describe('ManageReposPanel', () => {
     repoOverride.vanilla.enabled = true;
     repoOverride.bug_prediction.enabled = true;
     repoOverride.bug_prediction.sensitivity = 'high';
-    configWithOverride.repo_overrides['repo-1'] = repoOverride;
+    configWithOverride.repo_overrides['ext-1'] = repoOverride;
 
     MockApiClient.addMockResponse({
       url: `/organizations/${mockOrganization.slug}/prevent/ai/github/config/org-1/`,
@@ -301,7 +301,7 @@ describe('ManageReposPanel', () => {
       enabled: false,
       gitOrgName: 'org-1',
       originalConfig: PreventAIConfigFixture(),
-      repoId: 'repo-1',
+      repoId: 'ext-1',
     });
   });
 
@@ -320,7 +320,7 @@ describe('ManageReposPanel', () => {
 
   it('toggle is checked when repo has custom overrides', async () => {
     const configWithOverride = PreventAIConfigFixture();
-    configWithOverride.repo_overrides['repo-1'] = {
+    configWithOverride.repo_overrides['ext-1'] = {
       bug_prediction: {
         enabled: false,
         triggers: {on_command_phrase: false, on_ready_for_review: false},
@@ -368,7 +368,7 @@ describe('ManageReposPanel', () => {
           },
         },
         repo_overrides: {
-          'repo-1': {
+          'ext-1': {
             bug_prediction: {
               enabled: false,
               triggers: {on_command_phrase: false, on_ready_for_review: false},
@@ -408,7 +408,7 @@ describe('ManageReposPanel', () => {
           },
         },
         repo_overrides: {
-          'repo-1': {
+          'ext-1': {
             bug_prediction: {
               enabled: false,
               triggers: {on_command_phrase: true, on_ready_for_review: false},
@@ -424,7 +424,7 @@ describe('ManageReposPanel', () => {
           },
         },
       };
-      expect(getRepoConfig(orgConfig, 'repo-1')).toEqual({
+      expect(getRepoConfig(orgConfig, 'ext-1')).toEqual({
         doesUseOrgDefaults: false,
         repoConfig: {
           bug_prediction: {
@@ -462,7 +462,7 @@ describe('ManageReposPanel', () => {
         },
         repo_overrides: {},
       };
-      expect(getRepoConfig(orgConfig, 'repo-2')).toEqual({
+      expect(getRepoConfig(orgConfig, 'ext-2')).toEqual({
         doesUseOrgDefaults: true,
         repoConfig: orgConfig.org_defaults,
       });

--- a/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PreventAIConfigFixture} from 'sentry-fixture/prevent';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -58,8 +59,8 @@ describe('ManageReposPanel', () => {
   };
 
   const mockAllRepos = [
-    {id: 'repo-1', name: 'org-1/repo-1'},
-    {id: 'repo-2', name: 'org-1/repo-2'},
+    RepositoryFixture({id: 'repo-1', name: 'org-1/repo-1'}),
+    RepositoryFixture({id: 'repo-2', name: 'org-1/repo-2'}),
   ];
 
   const defaultProps: ManageReposPanelProps = {

--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -28,7 +28,7 @@ export type ManageReposPanelProps = {
   isEditingOrgDefaults: boolean;
   onClose: () => void;
   org: OrganizationIntegration;
-  allRepos?: Array<{id: string; name: string}>;
+  allRepos?: Repository[];
   onFocusRepoSelector?: () => void;
   repo?: Repository | null;
 };
@@ -110,7 +110,7 @@ function ManageReposPanel({
     : getRepoConfig(orgConfig, githubRepoId ?? '');
 
   const repoNamesWithOverrides = allRepos
-    .filter(r => orgConfig.repo_overrides?.hasOwnProperty(r.id))
+    .filter(r => orgConfig.repo_overrides?.hasOwnProperty(r.externalId))
     .map(r => getRepoNameWithoutOrg(r.name));
 
   return (

--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -103,9 +103,11 @@ function ManageReposPanel({
       ? (githubConfigData.organization as PreventAIConfig)
       : githubConfigData.default_org_config;
 
+  const githubRepoId = repo?.externalId;
+
   const {doesUseOrgDefaults, repoConfig} = isEditingOrgDefaults
     ? {doesUseOrgDefaults: true, repoConfig: orgConfig.org_defaults}
-    : getRepoConfig(orgConfig, repo?.id ?? '');
+    : getRepoConfig(orgConfig, githubRepoId ?? '');
 
   const repoNamesWithOverrides = allRepos
     .filter(r => orgConfig.repo_overrides?.hasOwnProperty(r.id))
@@ -205,7 +207,7 @@ function ManageReposPanel({
                       feature: 'use_org_defaults',
                       gitOrgName: org.name,
                       originalConfig: orgConfig,
-                      repoId: repo?.id,
+                      repoId: githubRepoId,
                       enabled: !doesUseOrgDefaults,
                     });
                   }}
@@ -247,7 +249,7 @@ function ManageReposPanel({
                         enabled: newValue,
                         gitOrgName: org.name,
                         originalConfig: orgConfig,
-                        repoId: repo?.id,
+                        repoId: githubRepoId,
                       });
                     }}
                     aria-label="Enable PR Review"
@@ -280,7 +282,7 @@ function ManageReposPanel({
                               enabled: true,
                               gitOrgName: org.name,
                               originalConfig: orgConfig,
-                              repoId: repo?.id,
+                              repoId: githubRepoId,
                               sensitivity: option.value,
                             })
                           }
@@ -326,7 +328,7 @@ function ManageReposPanel({
                         enabled: newValue,
                         gitOrgName: org.name,
                         originalConfig: orgConfig,
-                        repoId: repo?.id,
+                        repoId: githubRepoId,
                       });
                     }}
                     aria-label="Enable Test Generation"
@@ -365,7 +367,7 @@ function ManageReposPanel({
                         enabled: newValue,
                         gitOrgName: org.name,
                         originalConfig: orgConfig,
-                        repoId: repo?.id,
+                        repoId: githubRepoId,
                       });
                     }}
                     aria-label="Enable Error Prediction"
@@ -398,7 +400,7 @@ function ManageReposPanel({
                               enabled: true,
                               gitOrgName: org.name,
                               originalConfig: orgConfig,
-                              repoId: repo?.id,
+                              repoId: githubRepoId,
                               sensitivity: option.value,
                             })
                           }
@@ -437,7 +439,7 @@ function ManageReposPanel({
                               enabled: true,
                               gitOrgName: org.name,
                               originalConfig: orgConfig,
-                              repoId: repo?.id,
+                              repoId: githubRepoId,
                             });
                           }}
                           aria-label="Auto Run on Opened Pull Requests"
@@ -470,7 +472,7 @@ function ManageReposPanel({
                               enabled: true,
                               gitOrgName: org.name,
                               originalConfig: orgConfig,
-                              repoId: repo?.id,
+                              repoId: githubRepoId,
                             });
                           }}
                           aria-label="Run When Mentioned"


### PR DESCRIPTION
I was incorrectly using the repo id representing the sentry repositories id column instead of external id which is the id within github. Fix it here