### PR TITLE
chore(comp workflows): Update tooltip copy

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/chart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/chart.tsx
@@ -177,24 +177,15 @@ export function Chart({
         throw new Error('selectedParam or baselineParam is not defined');
       }
 
-      const selectedPercentage = Number(selectedParam?.data);
-      const baselinePercentage = Number(baselineParam?.data);
-
-      const isDifferent = selectedPercentage.toFixed(1) !== baselinePercentage.toFixed(1);
-
-      const status = isDifferent
-        ? {adjective: 'different', message: 'This is suspicious.'}
-        : {adjective: 'similar', message: 'Nothing unusual here.'};
-
       const name = selectedParam?.name ?? baselineParam?.name ?? '';
       const truncatedName =
         name.length > TOOLTIP_MAX_VALUE_LENGTH
           ? `${name.slice(0, TOOLTIP_MAX_VALUE_LENGTH)}...`
           : name;
 
-      return `<div style="max-width: 200px; white-space: normal; word-wrap: break-word; line-height: 1.2;">${truncatedName} <span style="color: ${theme.textColor};">is <strong>${status.adjective}</strong> ${isDifferent ? 'between' : 'across'} selected and baseline data. ${status.message}</span></div>`;
+      return `<div style="max-width: 200px; white-space: normal; word-wrap: break-word; line-height: 1.2; color: black;">${truncatedName}</div>`;
     },
-    [theme.textColor]
+    []
   );
 
   const chartXAxisLabelFormatter = useCallback(

--- a/static/app/views/explore/components/attributeBreakdowns/content.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/content.tsx
@@ -70,7 +70,7 @@ function EmptyState() {
       </Flex>
       <Text>
         {t(
-          "Drag to select an area on the chart and click 'Find Attribute Breakdowns' to analyze differences between selected and unselected (baseline) data. Attributes that differ most in frequency appear first, making it easier to identify key differences:"
+          "Drag to select an area on the chart and click 'Compare Attribute Breakdowns' to analyze differences between selected and unselected (baseline) data. Attributes that differ most in frequency appear first, making it easier to identify key differences:"
         )}
       </Text>
       <IllustrationWrapper>

--- a/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
@@ -81,7 +81,7 @@ export function FloatingTrigger({
       <List>
         <ListItem onClick={handleZoomIn}>{t('Zoom in')}</ListItem>
         <ListItem onClick={handleFindAttributeBreakdowns}>
-          {t('Find Attribute Breakdowns')}
+          {t('Compare Attribute Breakdowns')}
         </ListItem>
       </List>
     </div>,


### PR DESCRIPTION
- Forgot to push up a commit in my last copy PR
- Change from `Find` to `Compare` on the selection tooltip
- Remove the extra explanation text on hover tooltip

<img width="270" height="110" alt="image" src="https://github.com/user-attachments/assets/df950ea4-8d06-49b7-b13a-f060365a0321" />

<img width="359" height="233" alt="image" src="https://github.com/user-attachments/assets/75d90e7c-a3ce-4a89-aa2a-406f512d5959" />
