### PR TITLE
chore(comp workflows): fix alignment

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/chart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/chart.tsx
@@ -273,7 +273,8 @@ export function Chart({
         grid={{
           left: 2,
           right: 8,
-          containLabel: true,
+          bottom: 40,
+          containLabel: false,
         }}
         xAxis={{
           show: true,


### PR DESCRIPTION
- Fix the alignment of the x axis between charts that do and do not have labels rendered

Before
<img width="1111" height="388" alt="image" src="https://github.com/user-attachments/assets/4febfd60-5081-45f2-9526-17e0a1fa057a" />

After
<img width="1044" height="629" alt="image" src="https://github.com/user-attachments/assets/430df77d-e6c2-4583-a06a-9e1575c335b3" />
