### PR TITLE
ref(data_export): return the created job

### DIFF
--- a/src/sentry/profiles/data_export.py
+++ b/src/sentry/profiles/data_export.py
@@ -38,7 +38,7 @@ def export_profiles_data(
         logger.exception("Could not find organization", extra={"organization.id": organization_id})
         return None
 
-    create_transfer_job(
+    job = create_transfer_job(
         gcp_project_id=gcp_project_id,
         transfer_job_name=None,
         source_bucket=source_bucket,
@@ -51,3 +51,4 @@ def export_profiles_data(
         do_create_transfer_job=request_create_transfer_job,
     )
     logger.info("Successfully scheduled recording export job.")
+    return job

--- a/src/sentry/profiles/data_export.py
+++ b/src/sentry/profiles/data_export.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import timedelta
 
+from google.cloud.storage_transfer_v1 import TransferJob
+
 from sentry.models.organization import Organization
 from sentry.replays.data_export import create_transfer_job, request_create_transfer_job
 
@@ -18,7 +20,7 @@ def export_profiles_data(
     blob_export_job_duration: timedelta = EXPORT_JOB_DURATION_DEFAULT,
     source_bucket: str = EXPORT_JOB_SOURCE_BUCKET,
     pubsub_topic_name: str | None = None,
-) -> None:
+) -> TransferJob:
     logger.info(
         "Starting profiles export...",
         extra={

--- a/src/sentry/profiles/data_export.py
+++ b/src/sentry/profiles/data_export.py
@@ -38,7 +38,7 @@ def export_profiles_data(
         logger.info("Found organization", extra={"organization.slug": organization.slug})
     except Organization.DoesNotExist:
         logger.exception("Could not find organization", extra={"organization.id": organization_id})
-        return None
+        raise
 
     job = create_transfer_job(
         gcp_project_id=gcp_project_id,

--- a/src/sentry/replays/data_export.py
+++ b/src/sentry/replays/data_export.py
@@ -127,10 +127,9 @@ def export_clickhouse_rows(
 #  \______/  \______/  \______/
 
 
-def request_create_transfer_job(request: CreateTransferJobRequest) -> None:
+def request_create_transfer_job(request: CreateTransferJobRequest) -> TransferJob:
     client = storage_transfer_v1.StorageTransferServiceClient()
-    client.create_transfer_job(request)
-    return None
+    return client.create_transfer_job(request)
 
 
 def create_transfer_job[T](

--- a/src/sentry/replays/data_export.py
+++ b/src/sentry/replays/data_export.py
@@ -165,7 +165,7 @@ def create_transfer_job[T](
     :param job_duration: The amount of time the job should take to complete. Longer runs put less
         pressure on our buckets.
     :param destination_prefix:
-    :param notification_topic: Specifying a topic will enable automatic run retries on failure.
+    :param notification_topic: topic to which we'll notify the success or failure of the transfer.
     :param do_create_transfer_job: Injected function which creates the transfer-job.
     :param get_current_datetime: Injected function which computes the current datetime.
     """
@@ -197,7 +197,11 @@ def create_transfer_job[T](
     if notification_topic:
         transfer_job.notification_config = NotificationConfig(
             pubsub_topic=notification_topic,
-            event_types=[NotificationConfig.EventType.TRANSFER_OPERATION_FAILED],
+            event_types=[
+                NotificationConfig.EventType.TRANSFER_OPERATION_FAILED,
+                NotificationConfig.EventType.TRANSFER_OPERATION_SUCCESS,
+                NotificationConfig.EventType.TRANSFER_OPERATION_ABORTED,
+            ],
             payload_format=NotificationConfig.PayloadFormat.JSON,
         )
 

--- a/tests/sentry/replays/unit/test_data_export.py
+++ b/tests/sentry/replays/unit/test_data_export.py
@@ -69,7 +69,11 @@ def test_export_blob_data() -> None:
             ),
             notification_config=NotificationConfig(
                 pubsub_topic=pubsub_topic,
-                event_types=[NotificationConfig.EventType.TRANSFER_OPERATION_FAILED],
+                event_types=[
+                    NotificationConfig.EventType.TRANSFER_OPERATION_FAILED,
+                    NotificationConfig.EventType.TRANSFER_OPERATION_SUCCESS,
+                    NotificationConfig.EventType.TRANSFER_OPERATION_ABORTED,
+                ],
                 payload_format=NotificationConfig.PayloadFormat.JSON,
             ),
         )


### PR DESCRIPTION
* `export_profiles_data` now returns the `TransferJob` created instance so that we can access its attributes (job name, etc.)
* `SUCCESS` and `ABORT` states are also notified to the *pubsub* topic