### PR TITLE
fix(org-stats): selecting/unselecting my projects doesn't trigger stats_v2 requests

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -75,7 +75,15 @@ describe('OrganizationStats', () => {
    * Base + Error Handling
    */
   it('renders the base view', async () => {
-    render(<OrganizationStats />, {organization});
+    render(<OrganizationStats />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/stats/',
+          query: {project: [ALL_ACCESS_PROJECTS.toString()]},
+        },
+      },
+    });
 
     expect(await screen.findByTestId('usage-stats-chart')).toBeInTheDocument();
 
@@ -245,6 +253,12 @@ describe('OrganizationStats', () => {
     OrganizationStore.onUpdate(newOrg, {replace: true});
     render(<OrganizationStats />, {
       organization: newOrg,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/stats/',
+          query: {project: [ALL_ACCESS_PROJECTS.toString()]},
+        },
+      },
     });
 
     expect(await screen.findByText('All Projects')).toBeInTheDocument();

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -19,7 +19,6 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {DATA_CATEGORY_INFO, DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
@@ -167,10 +166,7 @@ export class OrganizationStatsInner extends Component<OrganizationStatsProps> {
 
   // Project selection from GlobalSelectionHeader
   get projectIds(): number[] {
-    const selection_projects = this.props.selection.projects.length
-      ? this.props.selection.projects
-      : [ALL_ACCESS_PROJECTS];
-    return selection_projects;
+    return this.props.selection.projects;
   }
 
   get isSingleProject(): boolean {


### PR DESCRIPTION
contributes to https://linear.app/getsentry/issue/TET-1370/check-filters-on-stats-and-usage-page-for-project-dropdown