### PR TITLE
feat(onboarding): add FastMCP onboarding guides

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -474,7 +474,7 @@ export const mcpOnboarding: OnboardingConfig = {
       content: [
         {
           type: 'text',
-          text: t('Configure Sentry for MCP low-level monitoring:'),
+          text: t('Configure Sentry for MCP low-level server monitoring:'),
         },
         {
           type: 'code',
@@ -544,7 +544,7 @@ async def call_tool(name: str, arguments) -> list[TextContent]:
       content: [
         {
           type: 'text',
-          text: t('Configure Sentry for MCP low-level monitoring:'),
+          text: t('Configure Sentry for MCP SDK FastMCP monitoring:'),
         },
         {
           type: 'code',
@@ -573,7 +573,52 @@ sentry_sdk.init(
           language: 'python',
           code: `
 from mcp.server.fastmcp import FastMCP
-# from fastmcp import FastMCP if you are using the standalone version
+
+mcp = FastMCP("mcp-server")
+
+@mcp.tool()
+async def calculate_sum(a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
+`,
+        },
+      ],
+    };
+
+    const mcpFastMcpStandaloneStep: OnboardingStep = {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t('Configure Sentry for FastMCP monitoring:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import sentry_sdk
+from sentry_sdk.integrations.mcp import MCPIntegration
+
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    traces_sample_rate=1.0,
+    # Add data like inputs and responses to/from MCP servers;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    integrations=[
+        MCPIntegration(),
+    ],
+)`,
+        },
+        {
+          type: 'text',
+          text: t('Set up your FastMCP server:'),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+from fastmcp import FastMCP
 
 mcp = FastMCP("mcp-server")
 
@@ -611,6 +656,9 @@ sentry_sdk.init(
     const selected = (params.platformOptions as any)?.integration ?? 'mcp_fastmcp';
     if (selected === 'mcp_fastmcp') {
       return [mcpFastMcpStep];
+    }
+    if (selected === 'fastmcp') {
+      return [mcpFastMcpStandaloneStep];
     }
     if (selected === 'manual') {
       return [manualStep];

--- a/static/app/views/insights/mcp/views/onboarding.tsx
+++ b/static/app/views/insights/mcp/views/onboarding.tsx
@@ -217,7 +217,8 @@ export function Onboarding() {
       label: t('Integration'),
       items: isPythonPlatform
         ? [
-            {label: 'FastMCP', value: 'mcp_fastmcp'},
+            {label: 'FastMCP (MCP SDK)', value: 'mcp_fastmcp'},
+            {label: 'FastMCP (Standalone)', value: 'fastmcp'},
             {label: 'Low-level', value: 'mcp_lowlevel'},
             {label: 'Manual', value: 'manual'},
           ]


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-1328/fastmcp-documentation-onboarding

<img width="304" height="238" alt="Screenshot 2025-11-05 at 15 41 33" src="https://github.com/user-attachments/assets/52c1e533-52d5-49ea-b92a-35be296ad570" />
<img width="737" height="268" alt="Screenshot 2025-11-05 at 15 41 53" src="https://github.com/user-attachments/assets/3f6fedc1-b691-4d80-bd36-61a921e221c9" />

