### PR TITLE
fix(replay-table): Ensure `sort_by` is always applied in URL

### DIFF
--- a/static/app/components/replays/table/useReplayTableSort.tsx
+++ b/static/app/components/replays/table/useReplayTableSort.tsx
@@ -3,6 +3,7 @@ import {useCallback, useRef} from 'react';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {encodeSort} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {decodeSorts} from 'sentry/utils/queryString';
 import useUrlParams from 'sentry/utils/url/useUrlParams';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -21,8 +22,12 @@ export default function useReplayTableSort({
   const defaultSortRef = useRef(defaultSort);
   const organization = useOrganization();
 
-  const {getParamValue, setParamValue} = useUrlParams(queryParamKey, '-started_at');
+  const {getParamValue, setParamValue} = useUrlParams(queryParamKey);
+
   const sortQuery = getParamValue();
+  if (isEmptyObject(sortQuery)) {
+    setParamValue(encodeSort(defaultSort));
+  }
   const sortType = decodeSorts(sortQuery).at(0) ?? defaultSortRef.current;
 
   const handleSortClick = useCallback(


### PR DESCRIPTION
Modifies Replay Table to always add `sort_by` into the URL
Context: I need this for the Replay Carousal to propagate `sort` downwards:

![Screen Recording 2025-11-05 at 10 21 34 AM](https://github.com/user-attachments/assets/eb0cc23c-cda9-463c-8ae8-cbd16f147141)
