### PR TITLE
feat(ai-generations): Query configuration

### DIFF
--- a/static/app/views/insights/aiGenerations/views/components/generationsChart.tsx
+++ b/static/app/views/insights/aiGenerations/views/components/generationsChart.tsx
@@ -1,10 +1,10 @@
 import {Fragment, useMemo} from 'react';
-import {parseAsStringEnum, useQueryState} from 'nuqs';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 
 import {IconClock} from 'sentry/icons/iconClock';
 import {IconGraph} from 'sentry/icons/iconGraph';
+import {t} from 'sentry/locale';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
@@ -14,16 +14,18 @@ import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/p
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
+  useSetQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {useCombinedQuery} from 'sentry/views/insights/agents/hooks/useCombinedQuery';
-import {getAIGenerationsFilter} from 'sentry/views/insights/agents/utils/query';
+import {AI_GENERATIONS_PAGE_FILTER} from 'sentry/views/insights/aiGenerations/views/utils/constants';
 import {Referrer} from 'sentry/views/insights/aiGenerations/views/utils/referrer';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
-
-enum ChartType {
-  BAR = 'bar',
-  LINE = 'line',
-  AREA = 'area',
-}
+import type {SpanFields} from 'sentry/views/insights/types';
 
 const CHART_TYPE_OPTIONS = [
   {
@@ -49,21 +51,74 @@ const plottableConstructors: Record<
   [ChartType.AREA]: Area,
 };
 
+const chartTypeIconMap: Record<ChartType, 'line' | 'bar' | 'area'> = {
+  [ChartType.BAR]: 'bar',
+  [ChartType.LINE]: 'line',
+  [ChartType.AREA]: 'area',
+};
+
+function prettifyAggregation(aggregation: string): string {
+  if (aggregation === 'count(span.duration)') {
+    return 'count(generations)';
+  }
+  return aggregation;
+}
+
 export function GenerationsChart() {
-  const [interval, setInterval, intervalOptions] = useChartInterval();
+  const visualizes = useQueryParamsVisualizes();
+  const setVisualizes = useSetQueryParamsVisualizes();
 
-  const [chartType, setChartType] = useQueryState(
-    'chartType',
-    parseAsStringEnum(Object.values(ChartType)).withDefault(ChartType.BAR)
+  function handleChartTypeChange(index: number, chartType: ChartType) {
+    const newVisualizes = visualizes.map((visualize, i) => {
+      if (i === index) {
+        visualize = visualize.replace({chartType});
+      }
+      return visualize.serialize();
+    });
+    setVisualizes(newVisualizes);
+  }
+
+  return (
+    <Fragment>
+      {visualizes.map((visualize, index) => {
+        return (
+          <ChartWidget
+            key={index}
+            visualize={visualize}
+            onChartTypeChange={chartType => handleChartTypeChange(index, chartType)}
+          />
+        );
+      })}
+    </Fragment>
   );
+}
 
-  const query = useCombinedQuery(getAIGenerationsFilter());
+export function ChartWidget({
+  visualize,
+  onChartTypeChange,
+}: {
+  onChartTypeChange: (chartType: ChartType) => void;
+  visualize: Visualize;
+}) {
+  const groupBys = useQueryParamsGroupBys().filter(Boolean);
+  const [interval, setInterval, intervalOptions] = useChartInterval();
+  const chartType = visualize.chartType;
 
+  const query = useCombinedQuery(AI_GENERATIONS_PAGE_FILTER);
   const {data, isLoading, error} = useFetchSpanTimeSeries(
     {
       query,
-      yAxis: ['count(span.duration)'],
+      yAxis: [visualize.yAxis] as any,
+      groupBy: groupBys as SpanFields[],
       interval,
+      sort:
+        groupBys.length > 0 && groupBys[0]
+          ? {
+              field: groupBys[0],
+              kind: 'desc' as const,
+            }
+          : undefined,
+      topEvents: groupBys.length > 0 ? 5 : undefined,
     },
     Referrer.GENERATIONS_CHART
   );
@@ -83,20 +138,20 @@ export function GenerationsChart() {
 
   return (
     <Widget
-      Title={<Widget.WidgetTitle title="count(generations)" />}
+      Title={<Widget.WidgetTitle title={prettifyAggregation(visualize.yAxis)} />}
       Actions={
         <Fragment>
           <CompactSelect
             triggerProps={{
-              icon: <IconGraph type={chartType} />,
+              icon: <IconGraph type={chartTypeIconMap[chartType]} />,
               borderless: true,
               showChevron: false,
               size: 'xs',
             }}
             value={chartType}
-            menuTitle="Type"
+            menuTitle={t('Type')}
             options={CHART_TYPE_OPTIONS}
-            onChange={option => setChartType(option.value)}
+            onChange={option => onChartTypeChange(option.value)}
           />
           <CompactSelect
             value={interval}
@@ -107,7 +162,7 @@ export function GenerationsChart() {
               showChevron: false,
               size: 'xs',
             }}
-            menuTitle="Interval"
+            menuTitle={t('Interval')}
             options={intervalOptions}
           />
         </Fragment>

--- a/static/app/views/insights/aiGenerations/views/components/generationsChart.tsx
+++ b/static/app/views/insights/aiGenerations/views/components/generationsChart.tsx
@@ -93,7 +93,7 @@ export function GenerationsChart() {
   );
 }
 
-export function ChartWidget({
+function ChartWidget({
   visualize,
   onChartTypeChange,
 }: {

--- a/static/app/views/insights/aiGenerations/views/components/generationsToolbar.tsx
+++ b/static/app/views/insights/aiGenerations/views/components/generationsToolbar.tsx
@@ -1,0 +1,452 @@
+import {useCallback, useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect';
+import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
+import {AggregationKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
+import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
+import {
+  ToolbarFooter,
+  ToolbarSection,
+} from 'sentry/views/explore/components/toolbar/styles';
+import {
+  ToolbarGroupByAddGroupBy,
+  ToolbarGroupByDropdown,
+  ToolbarGroupByHeader,
+} from 'sentry/views/explore/components/toolbar/toolbarGroupBy';
+import {
+  ToolbarVisualizeAddChart,
+  ToolbarVisualizeDropdown,
+  ToolbarVisualizeHeader,
+} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
+import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
+import {
+  useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
+  useSetQueryParamsGroupBys,
+  useSetQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {
+  isVisualizeFunction,
+  MAX_VISUALIZES,
+  VisualizeFunction,
+  type Visualize,
+} from 'sentry/views/explore/queryParams/visualize';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {GENERATIONS_COUNT_FIELD} from 'sentry/views/insights/aiGenerations/views/utils/constants';
+
+export const GENERATIONS_AGGREGATES: Array<SelectOption<AggregationKey>> = [
+  {
+    label: t('count'),
+    value: AggregationKey.COUNT,
+  },
+  {
+    label: t('count unique'),
+    value: AggregationKey.COUNT_UNIQUE,
+  },
+  {
+    label: t('sum'),
+    value: AggregationKey.SUM,
+  },
+  {
+    label: t('avg'),
+    value: AggregationKey.AVG,
+  },
+  {
+    label: t('p50'),
+    value: AggregationKey.P50,
+  },
+  {
+    label: t('p75'),
+    value: AggregationKey.P75,
+  },
+  {
+    label: t('p90'),
+    value: AggregationKey.P90,
+  },
+  {
+    label: t('p95'),
+    value: AggregationKey.P95,
+  },
+  {
+    label: t('p99'),
+    value: AggregationKey.P99,
+  },
+  {
+    label: t('max'),
+    value: AggregationKey.MAX,
+  },
+  {
+    label: t('min'),
+    value: AggregationKey.MIN,
+  },
+];
+
+interface GenerationsToolbarProps {
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+}
+
+export function GenerationsToolbar({numberTags, stringTags}: GenerationsToolbarProps) {
+  return (
+    <Container>
+      <ToolbarVisualize numberTags={numberTags} stringTags={stringTags} />
+      <ToolbarGroupBy numberTags={numberTags} stringTags={stringTags} />
+    </Container>
+  );
+}
+
+function ToolbarVisualize({numberTags, stringTags}: GenerationsToolbarProps) {
+  const sortedNumberKeys: string[] = useMemo(() => {
+    const keys = Object.keys(numberTags);
+    keys.sort();
+    return keys;
+  }, [numberTags]);
+
+  const sortedStringKeys: string[] = useMemo(() => {
+    const keys = Object.keys(stringTags);
+    keys.sort();
+    return keys;
+  }, [stringTags]);
+
+  const visualizes = useQueryParamsVisualizes();
+  const setVisualizes = useSetQueryParamsVisualizes();
+
+  const addChart = useCallback(() => {
+    const newVisualizes = [
+      ...visualizes,
+      new VisualizeFunction(`count(${GENERATIONS_COUNT_FIELD})`),
+    ].map(visualize => visualize.serialize());
+    setVisualizes(newVisualizes);
+  }, [setVisualizes, visualizes]);
+
+  const replaceOverlay = useCallback(
+    (group: number, newVisualize: Visualize) => {
+      const newVisualizes = visualizes.map((visualize, i) => {
+        if (i === group) {
+          return newVisualize.serialize();
+        }
+        return visualize.serialize();
+      });
+      setVisualizes(newVisualizes);
+    },
+    [setVisualizes, visualizes]
+  );
+
+  const onDelete = useCallback(
+    (group: number) => {
+      const newVisualizes = visualizes.toSpliced(group, 1).map(visualize => {
+        return visualize.serialize();
+      });
+      setVisualizes(newVisualizes);
+    },
+    [setVisualizes, visualizes]
+  );
+
+  const canDelete =
+    visualizes.filter(visualize => isVisualizeFunction(visualize)).length > 1;
+
+  return (
+    <ToolbarSection data-test-id="section-visualizes">
+      <ToolbarVisualizeHeader />
+      {visualizes.map((visualize, group) => {
+        if (isVisualizeFunction(visualize)) {
+          return (
+            <VisualizeDropdown
+              key={group}
+              canDelete={canDelete}
+              onDelete={() => onDelete(group)}
+              onReplace={newVisualize => replaceOverlay(group, newVisualize)}
+              visualize={visualize}
+              sortedNumberKeys={sortedNumberKeys}
+              sortedStringKeys={sortedStringKeys}
+            />
+          );
+        }
+        return null;
+      })}
+      <ToolbarFooter>
+        <ToolbarVisualizeAddChart
+          add={addChart}
+          disabled={visualizes.length >= MAX_VISUALIZES}
+        />
+      </ToolbarFooter>
+    </ToolbarSection>
+  );
+}
+
+interface VisualizeDropdownProps {
+  canDelete: boolean;
+  onDelete: () => void;
+  onReplace: (visualize: Visualize) => void;
+  sortedNumberKeys: string[];
+  sortedStringKeys: string[];
+  visualize: VisualizeFunction;
+}
+
+function VisualizeDropdown({
+  canDelete,
+  onDelete,
+  onReplace,
+  visualize,
+  sortedNumberKeys,
+  sortedStringKeys,
+}: VisualizeDropdownProps) {
+  const aggregateOptions: Array<SelectOption<AggregationKey>> = useMemo(() => {
+    return GENERATIONS_AGGREGATES.map(aggregate => {
+      const defaultArgument = getDefaultArgument(
+        aggregate.value,
+        sortedNumberKeys[0] || null
+      );
+      return {...aggregate, disabled: !defined(defaultArgument)};
+    });
+  }, [sortedNumberKeys]);
+
+  const aggregateFunction = visualize.parsedFunction?.name ?? '';
+  const aggregateParam = visualize.parsedFunction?.arguments?.[0] ?? '';
+
+  const fieldOptions = useMemo(() => {
+    if (aggregateFunction === AggregationKey.COUNT) {
+      return [{label: t('generations'), value: GENERATIONS_COUNT_FIELD}];
+    }
+
+    return aggregateFunction === AggregationKey.COUNT_UNIQUE
+      ? [
+          ...sortedNumberKeys.map(key => {
+            const label = prettifyTagKey(key);
+            return {
+              label,
+              value: key,
+              textValue: key,
+              trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+              showDetailsInOverlay: true,
+              details: (
+                <AttributeDetails
+                  column={key}
+                  kind={FieldKind.MEASUREMENT}
+                  label={label}
+                  traceItemType={TraceItemDataset.SPANS}
+                />
+              ),
+            };
+          }),
+          ...sortedStringKeys.map(key => {
+            const label = prettifyTagKey(key);
+            return {
+              label,
+              value: key,
+              textValue: key,
+              trailingItems: <TypeBadge kind={FieldKind.TAG} />,
+              showDetailsInOverlay: true,
+              details: (
+                <AttributeDetails
+                  column={key}
+                  kind={FieldKind.TAG}
+                  label={label}
+                  traceItemType={TraceItemDataset.SPANS}
+                />
+              ),
+            };
+          }),
+        ].toSorted((a, b) => {
+          const aLabel = prettifyTagKey(a.value);
+          const bLabel = prettifyTagKey(b.value);
+          return aLabel.localeCompare(bLabel);
+        })
+      : sortedNumberKeys.map(key => {
+          const label = prettifyTagKey(key);
+          return {
+            label,
+            value: key,
+            textValue: key,
+            trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+            showDetailsInOverlay: true,
+            details: (
+              <AttributeDetails
+                column={key}
+                kind={FieldKind.MEASUREMENT}
+                label={label}
+                traceItemType={TraceItemDataset.SPANS}
+              />
+            ),
+          };
+        });
+  }, [aggregateFunction, sortedStringKeys, sortedNumberKeys]);
+
+  const onChangeAggregate = useCallback(
+    (option: SelectOption<SelectKey>) => {
+      if (typeof option.value === 'string') {
+        const yAxis = updateVisualizeAggregate({
+          newAggregate: option.value,
+          oldAggregate: aggregateFunction,
+          oldArgument: aggregateParam,
+          firstNumberKey: sortedNumberKeys[0] || null,
+        });
+        onReplace(visualize.replace({yAxis}));
+      }
+    },
+    [onReplace, visualize, aggregateFunction, aggregateParam, sortedNumberKeys]
+  );
+
+  const onChangeArgument = useCallback(
+    (_index: number, option: SelectOption<SelectKey>) => {
+      if (typeof option.value === 'string') {
+        const yAxis = `${aggregateFunction}(${option.value})`;
+        onReplace(visualize.replace({yAxis}));
+      }
+    },
+    [onReplace, aggregateFunction, visualize]
+  );
+
+  return (
+    <ToolbarVisualizeDropdown
+      aggregateOptions={aggregateOptions}
+      fieldOptions={fieldOptions}
+      canDelete={canDelete}
+      onChangeAggregate={onChangeAggregate}
+      onChangeArgument={onChangeArgument}
+      onDelete={onDelete}
+      parsedFunction={visualize.parsedFunction}
+    />
+  );
+}
+
+function ToolbarGroupBy({numberTags, stringTags}: GenerationsToolbarProps) {
+  const groupBys = useQueryParamsGroupBys();
+  const setGroupBys = useSetQueryParamsGroupBys();
+
+  const options = useMemo(
+    () =>
+      [
+        {
+          label: '\u2014',
+          value: '',
+          textValue: '\u2014',
+        },
+        ...Object.keys(numberTags ?? {}).map(key => {
+          const label = prettifyTagKey(key);
+          return {
+            label,
+            value: key,
+            textValue: key,
+            trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+            showDetailsInOverlay: true,
+            details: (
+              <AttributeDetails
+                column={key}
+                kind={FieldKind.MEASUREMENT}
+                label={label}
+                traceItemType={TraceItemDataset.SPANS}
+              />
+            ),
+          };
+        }),
+        ...Object.keys(stringTags ?? {}).map(key => {
+          const label = prettifyTagKey(key);
+          return {
+            label,
+            value: key,
+            textValue: key,
+            trailingItems: <TypeBadge kind={FieldKind.TAG} />,
+            showDetailsInOverlay: true,
+            details: (
+              <AttributeDetails
+                column={key}
+                kind={FieldKind.TAG}
+                label={label}
+                traceItemType={TraceItemDataset.SPANS}
+              />
+            ),
+          };
+        }),
+      ].toSorted((a, b) => {
+        const aLabel = prettifyTagKey(a.value);
+        const bLabel = prettifyTagKey(b.value);
+        return aLabel.localeCompare(bLabel);
+      }),
+    [numberTags, stringTags]
+  );
+
+  const setGroupBysWithOp = useCallback(
+    (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
+      // automatically switch to aggregates mode when a group by is inserted/updated
+      if (op === 'insert' || op === 'update') {
+        setGroupBys(columns, Mode.AGGREGATE);
+      } else {
+        setGroupBys(columns);
+      }
+    },
+    [setGroupBys]
+  );
+
+  return (
+    <DragNDropContext columns={groupBys.slice()} setColumns={setGroupBysWithOp}>
+      {({editableColumns, insertColumn, updateColumnAtIndex, deleteColumnAtIndex}) => (
+        <ToolbarSection data-test-id="section-group-by">
+          <ToolbarGroupByHeader />
+          {editableColumns.map((column, i) => (
+            <ToolbarGroupByDropdown
+              key={column.id}
+              canDelete={editableColumns.length > 1}
+              column={column}
+              onColumnChange={c => updateColumnAtIndex(i, c)}
+              onColumnDelete={() => deleteColumnAtIndex(i)}
+              options={options}
+            />
+          ))}
+          <ToolbarFooter>
+            <ToolbarGroupByAddGroupBy add={() => insertColumn('')} disabled={false} />
+          </ToolbarFooter>
+        </ToolbarSection>
+      )}
+    </DragNDropContext>
+  );
+}
+
+function updateVisualizeAggregate({
+  newAggregate,
+  oldAggregate,
+  oldArgument,
+  firstNumberKey,
+}: {
+  firstNumberKey: string | null;
+  newAggregate: string;
+  oldAggregate: string;
+  oldArgument: string;
+}): string {
+  if (newAggregate === AggregationKey.COUNT) {
+    return `${AggregationKey.COUNT}(${GENERATIONS_COUNT_FIELD})`;
+  }
+
+  if (newAggregate === AggregationKey.COUNT_UNIQUE) {
+    return `${AggregationKey.COUNT_UNIQUE}(${GENERATIONS_COUNT_FIELD})`;
+  }
+
+  if (
+    oldAggregate === AggregationKey.COUNT ||
+    oldAggregate === AggregationKey.COUNT_UNIQUE
+  ) {
+    return `${newAggregate}(${getDefaultArgument(newAggregate, firstNumberKey) || ''})`;
+  }
+
+  return `${newAggregate}(${oldArgument})`;
+}
+
+function getDefaultArgument(
+  aggregate: string,
+  firstNumberKey: string | null
+): string | null {
+  if (aggregate === AggregationKey.COUNT || aggregate === AggregationKey.COUNT_UNIQUE) {
+    return GENERATIONS_COUNT_FIELD;
+  }
+
+  return firstNumberKey;
+}
+
+const Container = styled('div')`
+  min-width: 300px;
+`;

--- a/static/app/views/insights/aiGenerations/views/components/generationsToolbar.tsx
+++ b/static/app/views/insights/aiGenerations/views/components/generationsToolbar.tsx
@@ -39,7 +39,7 @@ import {
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {GENERATIONS_COUNT_FIELD} from 'sentry/views/insights/aiGenerations/views/utils/constants';
 
-export const GENERATIONS_AGGREGATES: Array<SelectOption<AggregationKey>> = [
+const GENERATIONS_AGGREGATES: Array<SelectOption<AggregationKey>> = [
   {
     label: t('count'),
     value: AggregationKey.COUNT,

--- a/static/app/views/insights/aiGenerations/views/overview.tsx
+++ b/static/app/views/insights/aiGenerations/views/overview.tsx
@@ -195,7 +195,7 @@ function PageWithProviders() {
 export default PageWithProviders;
 
 // TODO: This needs streamlining over the explore pages
-export const SidebarCollapseButton = withChonk(
+const SidebarCollapseButton = withChonk(
   styled(Button)<{sidebarOpen: boolean}>`
     ${p =>
       p.sidebarOpen &&

--- a/static/app/views/insights/aiGenerations/views/overview.tsx
+++ b/static/app/views/insights/aiGenerations/views/overview.tsx
@@ -1,9 +1,11 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 import {parseAsString, useQueryState} from 'nuqs';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
-import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {
@@ -11,24 +13,28 @@ import {
   useEAPSpanSearchQueryBuilderProps,
 } from 'sentry/components/performance/spanSearchQueryBuilder';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
+import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
+import {withChonk} from 'sentry/utils/theme/withChonk';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import {useTableCursor} from 'sentry/views/insights/agents/hooks/useTableCursor';
 import {Onboarding} from 'sentry/views/insights/agents/views/onboarding';
 import {GenerationsChart} from 'sentry/views/insights/aiGenerations/views/components/generationsChart';
 import {GenerationsTable} from 'sentry/views/insights/aiGenerations/views/components/generationsTable';
+import {GenerationsToolbar} from 'sentry/views/insights/aiGenerations/views/components/generationsToolbar';
 import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
-import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
-import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {ModuleName} from 'sentry/views/insights/types';
 
 function useShowOnboarding() {
@@ -44,6 +50,7 @@ function useShowOnboarding() {
 
 function AIGenerationsPage() {
   const organization = useOrganization();
+  const [sidebarOpen, setSidebarOpen] = useState(true);
   const showOnboarding = useShowOnboarding();
   const datePageFilterProps = limitMaxPickableDays(organization);
   const [searchQuery, setSearchQuery] = useQueryState(
@@ -98,37 +105,76 @@ function AIGenerationsPage() {
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
       <ModuleFeature moduleName={ModuleName.AI_GENERATIONS}>
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector />
-                    <InsightsEnvironmentSelector />
-                    <DatePageFilter {...datePageFilterProps} />
-                  </PageFilterBar>
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <EAPSpanSearchQueryBuilder {...eapSpanSearchQueryBuilderProps} />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
+        <Flex
+          gap="md"
+          wrap="wrap"
+          padding={{
+            xs: 'xl xl xl xl',
+            md: 'xl 2xl xl 2xl',
+          }}
+          borderBottom="muted"
+        >
+          <PageFilterBar condensed>
+            <InsightsProjectSelector />
+            <InsightsEnvironmentSelector />
+            <DatePageFilter {...datePageFilterProps} />
+          </PageFilterBar>
+          {!showOnboarding && (
+            <Flex flex={2} minWidth="50%">
+              <EAPSpanSearchQueryBuilder {...eapSpanSearchQueryBuilderProps} />
+            </Flex>
+          )}
+        </Flex>
 
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Stack direction="column" gap="xl">
-                    <GenerationsChart />
-                    <GenerationsTable />
-                  </Stack>
-                )}
-              </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
+        {showOnboarding ? (
+          <Onboarding />
+        ) : (
+          <Flex direction={{xs: 'column', md: 'row'}} height="100%">
+            {sidebarOpen && (
+              <Container
+                as="aside"
+                padding={{xs: 'md xl', md: 'xl 2xl md 3xl'}}
+                width={{xs: 'full', md: '343px'}}
+                background="primary"
+                borderRight={{md: 'muted'}}
+              >
+                <GenerationsToolbar numberTags={numberTags} stringTags={stringTags} />
+              </Container>
+            )}
+
+            <Container
+              flex={1}
+              padding={{
+                xs: 'lg xl 2xl xl',
+                md: sidebarOpen ? 'md 2xl xl lg' : 'md 2xl xl 2xl',
+              }}
+              borderTop="muted"
+              background="secondary"
+            >
+              <Stack direction="column" gap="md" align="start">
+                <SidebarCollapseButton
+                  sidebarOpen={sidebarOpen}
+                  onClick={() => setSidebarOpen(!sidebarOpen)}
+                  aria-label={sidebarOpen ? t('Collapse sidebar') : t('Expand sidebar')}
+                  size="xs"
+                  icon={
+                    <IconChevron
+                      isDouble
+                      direction={sidebarOpen ? 'left' : 'right'}
+                      size="xs"
+                    />
+                  }
+                >
+                  {sidebarOpen ? null : t('Advanced')}
+                </SidebarCollapseButton>
+                <Stack direction="column" gap="xl" align="start">
+                  <GenerationsChart />
+                  <GenerationsTable />
+                </Stack>
+              </Stack>
+            </Container>
+          </Flex>
+        )}
       </ModuleFeature>
     </SearchQueryBuilderProvider>
   );
@@ -138,10 +184,50 @@ function PageWithProviders() {
   return (
     <ModulePageProviders moduleName={ModuleName.AI_GENERATIONS}>
       <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
-        <AIGenerationsPage />
+        <SpansQueryParamsProvider>
+          <AIGenerationsPage />
+        </SpansQueryParamsProvider>
       </TraceItemAttributeProvider>
     </ModulePageProviders>
   );
 }
 
 export default PageWithProviders;
+
+// TODO: This needs streamlining over the explore pages
+export const SidebarCollapseButton = withChonk(
+  styled(Button)<{sidebarOpen: boolean}>`
+    ${p =>
+      p.sidebarOpen &&
+      css`
+        display: none;
+        border-left-color: ${p.theme.background};
+        border-top-left-radius: 0px;
+        border-bottom-left-radius: 0px;
+        margin-left: -13px;
+      `}
+
+    @media (min-width: ${p => p.theme.breakpoints.md}) {
+      display: block;
+    }
+  `,
+  chonkStyled(Button)<{sidebarOpen: boolean}>`
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    display: inline-flex;
+  }
+
+  ${p =>
+    p.sidebarOpen &&
+    css`
+      display: none;
+      margin-left: -13px;
+
+      &::after {
+        border-left-color: ${p.theme.background};
+        border-top-left-radius: 0px;
+        border-bottom-left-radius: 0px;
+      }
+    `}
+`
+);

--- a/static/app/views/insights/aiGenerations/views/utils/constants.tsx
+++ b/static/app/views/insights/aiGenerations/views/utils/constants.tsx
@@ -1,0 +1,5 @@
+import {getAIGenerationsFilter} from 'sentry/views/insights/agents/utils/query';
+
+export const GENERATIONS_COUNT_FIELD = 'span.duration';
+// Only show generation spans that result in a response to the user's message
+export const AI_GENERATIONS_PAGE_FILTER = `${getAIGenerationsFilter()}  AND !span.op:gen_ai.embeddings AND (has:gen_ai.response.text OR has:gen_ai.response.object)`;


### PR DESCRIPTION
Add drawer for configuring the displayed charts on the AI generations page.
<img width="1292" height="986" alt="Screenshot 2025-11-05 at 16 26 15" src="https://github.com/user-attachments/assets/5d3c901d-84de-4dd9-b7d3-605a7ed0e980" />
