### PR TITLE
fix(dynamic-sampling): add option for switching bw spans and transactions (v2)

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1152,10 +1152,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         #       so we need to refactor this into an async task we can run and observe
         org_id = organization.id
         measure = SamplingMeasure.TRANSACTIONS
-        if options.get("dynamic-sampling.check_span_feature_flag") and features.has(
-            "organizations:dynamic-sampling-spans", organization
-        ):
-            measure = SamplingMeasure.SPANS
+        if options.get("dynamic-sampling.check_span_feature_flag"):
+            span_org_ids = options.get("dynamic-sampling.measure.spans") or []
+            if org_id in span_org_ids:
+                measure = SamplingMeasure.SPANS
 
         projects_with_tx_count_and_rates = []
         for chunk in query_project_counts_by_org(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2181,6 +2181,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_MODIFIABLE_RATE,
 )
 
+# List of organization IDs that should be using spans for rebalancing in dynamic sampling.
+register(
+    "dynamic-sampling.measure.spans",
+    default=[],
+    type=Sequence,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # === Hybrid cloud subsystem options ===
 # UI rollout
 register(

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
@@ -287,9 +287,11 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
 class TestPartitionByMeasure(TestCase):
     def test_partition_by_measure_with_spans_feature(self) -> None:
         org = self.create_organization("test-org1")
-        with (
-            self.options({"dynamic-sampling.check_span_feature_flag": True}),
-            self.feature({"organizations:dynamic-sampling-spans": True}),
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": True,
+                "dynamic-sampling.measure.spans": [org.id],
+            }
         ):
             result = partition_by_measure([org.id])
             assert SamplingMeasure.SPANS in result
@@ -299,9 +301,11 @@ class TestPartitionByMeasure(TestCase):
 
     def test_partition_by_measure_without_spans_feature(self) -> None:
         org = self.create_organization("test-org1")
-        with (
-            self.options({"dynamic-sampling.check_span_feature_flag": True}),
-            self.feature({"organizations:dynamic-sampling-spans": False}),
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": True,
+                "dynamic-sampling.measure.spans": [],
+            }
         ):
             result = partition_by_measure([org.id])
             assert SamplingMeasure.SPANS in result
@@ -311,11 +315,48 @@ class TestPartitionByMeasure(TestCase):
 
     def test_partition_by_measure_with_span_feature_flag_disabled(self) -> None:
         org = self.create_organization("test-org1")
-        with (
-            self.options({"dynamic-sampling.check_span_feature_flag": False}),
-            self.feature({"organizations:dynamic-sampling-spans": True}),
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": False,
+                "dynamic-sampling.measure.spans": [org.id],
+            }
         ):
             result = partition_by_measure([org.id])
             assert SamplingMeasure.TRANSACTIONS in result
             assert SamplingMeasure.SPANS not in result
             assert result[SamplingMeasure.TRANSACTIONS] == [org.id]
+
+    def test_partition_by_measure_returns_sorted_output_multiple_orgs(self) -> None:
+        orgs = [self.create_organization(f"test-org{i}") for i in range(10)]
+        org_ids = [org.id for org in reversed(orgs)]
+
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": True,
+                "dynamic-sampling.measure.spans": [orgs[2].id, orgs[7].id, orgs[5].id],
+            }
+        ):
+            result = partition_by_measure(org_ids)
+
+            assert result[SamplingMeasure.SPANS] == sorted([orgs[2].id, orgs[7].id, orgs[5].id])
+            expected_transaction_orgs = sorted(
+                [org.id for org in orgs if org.id not in [orgs[2].id, orgs[7].id, orgs[5].id]]
+            )
+            assert result[SamplingMeasure.TRANSACTIONS] == expected_transaction_orgs
+
+    def test_partition_by_measure_returns_sorted_when_feature_disabled(self) -> None:
+        org1 = self.create_organization("test-org1")
+        org2 = self.create_organization("test-org2")
+        org3 = self.create_organization("test-org3")
+
+        org_ids = [org3.id, org1.id, org2.id]
+
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": False,
+            }
+        ):
+            result = partition_by_measure(org_ids)
+
+            assert result[SamplingMeasure.TRANSACTIONS] == sorted(org_ids)
+            assert SamplingMeasure.SPANS not in result


### PR DESCRIPTION
- Use an option with a list of orgs instead of feature flags because it's faster
- Should be in-memory and therefore significantly faster than feature flags 
- We can do this because we do not expect large quantities of orgs to be added to this
- Previous batch-checking solution had high performance penalty despite multiple optimizations

Reapplies https://github.com/getsentry/sentry/pull/102576 - the metrics didn't look good in the beginning, so I reverted, but afterwards everything seemed to work fine, so I think we can apply it after all

Contributes to TET-1147