### PR TITLE
feat(seer): passthrough endpoint to return active seer llm models

### DIFF
--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -17,6 +17,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,6 @@ class SeerModelsEndpoint(Endpoint):
         except requests.exceptions.Timeout:
             logger.warning("Timeout when fetching models from Seer")
             raise SeerTimeoutError()
-        except requests.exceptions.RequestException as e:
-            logger.exception("Error fetching models from Seer", extra={"error": str(e)})
+        except (requests.exceptions.RequestException, json.JSONDecodeError):
+            logger.exception("Error fetching models from Seer")
             raise SeerConnectionError()

--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+from typing import TypedDict
+
+import requests
+from django.conf import settings
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
+
+
+class SeerModelsResponse(TypedDict):
+    """Response containing list of actively used LLM model names from Seer."""
+
+    models: list[str]
+
+
+@extend_schema(tags=["Seer"])
+@region_silo_endpoint
+class SeerModelsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+    owner = ApiOwner.ML_AI
+    permission_classes = ()
+
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=100, window=60),
+            }
+        }
+    )
+
+    @extend_schema(
+        operation_id="List Seer AI Models",
+        responses={
+            200: inline_sentry_response_serializer("SeerModelsResponse", SeerModelsResponse),
+        },
+    )
+    def get(self, request: Request) -> Response:
+        """
+        Get list of actively used LLM model names from Seer.
+
+        Returns the list of AI models that are currently used in production in Seer.
+        This endpoint does not require authentication and can be used to discover which models Seer uses.
+        """
+        path = "/v1/models"
+
+        try:
+            response = requests.get(
+                f"{settings.SEER_AUTOFIX_URL}{path}",
+                headers={
+                    "content-type": "application/json;charset=utf-8",
+                    **sign_with_seer_secret(b""),
+                },
+                timeout=5,
+            )
+            response.raise_for_status()
+
+            data = response.json()
+            return Response(data, status=200)
+
+        except requests.exceptions.Timeout:
+            logger.warning("Timeout when fetching models from Seer")
+            return Response(
+                {"error": "Request to Seer timed out"},
+                status=504,
+            )
+        except requests.exceptions.RequestException as e:
+            logger.exception("Error fetching models from Seer", extra={"error": str(e)})
+            return Response(
+                {"error": "Failed to fetch models from Seer"},
+                status=502,
+            )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -819,6 +819,7 @@ from .endpoints.relay import (
     RelayRegisterResponseEndpoint,
 )
 from .endpoints.rule_snooze import MetricRuleSnoozeEndpoint, RuleSnoozeEndpoint
+from .endpoints.seer_models import SeerModelsEndpoint
 from .endpoints.setup_wizard import SetupWizard
 from .endpoints.system_health import SystemHealthEndpoint
 from .endpoints.system_options import SystemOptionsEndpoint
@@ -3629,6 +3630,11 @@ urlpatterns = [
         r"^prompts-activity/$",
         PromptsActivityEndpoint.as_view(),
         name="sentry-api-0-prompts-activity",
+    ),
+    re_path(
+        r"^seer/models/$",
+        SeerModelsEndpoint.as_view(),
+        name="sentry-api-0-seer-models",
     ),
     # List Authenticators
     re_path(

--- a/tests/sentry/api/endpoints/test_seer_models.py
+++ b/tests/sentry/api/endpoints/test_seer_models.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.conf import settings
+from rest_framework import status
+
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.testutils.cases import APITestCase
+
+
+class TestSeerModels(APITestCase):
+    endpoint = "sentry-api-0-seer-models"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/api/0/seer/models/"
+
+    @patch("sentry.api.endpoints.seer_models.requests.get")
+    def test_get_models_successful(self, mock_get: MagicMock) -> None:
+        """Test successful retrieval of models from Seer."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "models": ["gpt-4", "claude-3", "gemini-pro"],
+        }
+        mock_get.return_value = mock_response
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {"models": ["gpt-4", "claude-3", "gemini-pro"]}
+
+        expected_url = f"{settings.SEER_AUTOFIX_URL}/v1/models"
+        expected_headers = {
+            "content-type": "application/json;charset=utf-8",
+            **sign_with_seer_secret(b""),
+        }
+        mock_get.assert_called_once_with(
+            expected_url,
+            headers=expected_headers,
+            timeout=5,
+        )
+
+    @patch("sentry.api.endpoints.seer_models.requests.get")
+    def test_get_models_no_authentication_required(self, mock_get: MagicMock) -> None:
+        """Test that the endpoint works without authentication."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": ["gpt-4"]}
+        mock_get.return_value = mock_response
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("sentry.api.endpoints.seer_models.requests.get")
+    def test_get_models_timeout(self, mock_get: MagicMock) -> None:
+        """Test handling of timeout errors."""
+        mock_get.side_effect = requests.exceptions.Timeout("Request timed out")
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_504_GATEWAY_TIMEOUT
+        assert response.data == {"error": "Request to Seer timed out"}
+
+    @patch("sentry.api.endpoints.seer_models.requests.get")
+    def test_get_models_request_exception(self, mock_get: MagicMock) -> None:
+        """Test handling of request exceptions."""
+        mock_get.side_effect = requests.exceptions.RequestException("Connection error")
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        assert response.data == {"error": "Failed to fetch models from Seer"}
+
+    @patch("sentry.api.endpoints.seer_models.requests.get")
+    def test_get_models_http_error(self, mock_get: MagicMock) -> None:
+        """Test handling of HTTP errors from Seer."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("Server error")
+        mock_get.return_value = mock_response
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        assert response.data == {"error": "Failed to fetch models from Seer"}
+
+    @patch("sentry.api.endpoints.seer_models.requests.get")
+    def test_get_models_empty_response(self, mock_get: MagicMock) -> None:
+        """Test handling of empty models list."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": []}
+        mock_get.return_value = mock_response
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {"models": []}

--- a/tests/sentry/api/endpoints/test_seer_models.py
+++ b/tests/sentry/api/endpoints/test_seer_models.py
@@ -61,7 +61,7 @@ class TestSeerModels(APITestCase):
         response = self.client.get(self.url)
 
         assert response.status_code == status.HTTP_504_GATEWAY_TIMEOUT
-        assert response.data == {"error": "Request to Seer timed out"}
+        assert response.data == {"detail": "Request to Seer timed out"}
 
     @patch("sentry.api.endpoints.seer_models.requests.get")
     def test_get_models_request_exception(self, mock_get: MagicMock) -> None:
@@ -71,7 +71,7 @@ class TestSeerModels(APITestCase):
         response = self.client.get(self.url)
 
         assert response.status_code == status.HTTP_502_BAD_GATEWAY
-        assert response.data == {"error": "Failed to fetch models from Seer"}
+        assert response.data == {"detail": "Failed to fetch models from Seer"}
 
     @patch("sentry.api.endpoints.seer_models.requests.get")
     def test_get_models_http_error(self, mock_get: MagicMock) -> None:
@@ -84,7 +84,7 @@ class TestSeerModels(APITestCase):
         response = self.client.get(self.url)
 
         assert response.status_code == status.HTTP_502_BAD_GATEWAY
-        assert response.data == {"error": "Failed to fetch models from Seer"}
+        assert response.data == {"detail": "Failed to fetch models from Seer"}
 
     @patch("sentry.api.endpoints.seer_models.requests.get")
     def test_get_models_empty_response(self, mock_get: MagicMock) -> None:


### PR DESCRIPTION
A public endpoint to see currently active-in-prod llm models used by Seer.
