### PR TITLE
ref(tsdb): Remove undocumented stat choice from project stats endpoint

### DIFF
--- a/src/sentry/core/endpoints/project_stats.py
+++ b/src/sentry/core/endpoints/project_stats.py
@@ -72,8 +72,6 @@ class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
                 )
             except Environment.DoesNotExist:
                 raise ResourceDoesNotExist
-        elif stat == "forwarded":
-            stat_model = TSDBModel.project_total_forwarded
         else:
             try:
                 stat_model = FILTER_STAT_KEYS_TO_VALUES[stat]


### PR DESCRIPTION
The `TSDBModel.project_total_forwarded` is one of few legacy TSDB models that are still using Redis as a backend and this is an effort to remove it as it has only redis-blaster implementation.

It should be safe to remove as the documented choices for the `stat` params are:

```
        :qparam string stat: the name of the stat to query (``"received"``,
                             ``"rejected"``, ``"blacklisted"``, ``generated``)
```

<!-- Describe your PR here. -->

In a separate PR I'll remove the model's definition and write path.
