### PR TITLE
feat(performance): Adds backend configurable options for web vitals issue detection enabled and count threshold

### DIFF
--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -203,6 +203,7 @@ def get_merged_settings(project_id: int | None = None) -> dict[str | Any, Any]:
         "sql_injection_query_value_length_threshold": options.get(
             "performance.issues.sql_injection.query_value_length_threshold"
         ),
+        "web_vitals_count": options.get("performance.issues.web_vitals.count_threshold"),
     }
 
     default_project_settings = (

--- a/src/sentry/issues/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/issues/endpoints/project_performance_issue_settings.py
@@ -27,6 +27,7 @@ from sentry.issues.grouptype import (
     PerformanceUncompressedAssetsGroupType,
     ProfileFunctionRegressionType,
     QueryInjectionVulnerabilityGroupType,
+    WebVitalsGroup,
 )
 
 MAX_VALUE = 2147483647
@@ -76,6 +77,8 @@ class ConfigurableThresholds(Enum):
     HTTP_OVERHEAD_REQUEST_DELAY = "http_request_delay_threshold"
     DB_QUERY_INJECTION = "db_query_injection_detection_enabled"
     SQL_INJECTION_QUERY_VALUE_LENGTH = "sql_injection_query_value_length_threshold"
+    WEB_VITALS = "web_vitals_detection_enabled"
+    WEB_VITALS_COUNT = "web_vitals_count"
 
 
 project_settings_to_group_map: dict[str, type[GroupType]] = {
@@ -93,6 +96,7 @@ project_settings_to_group_map: dict[str, type[GroupType]] = {
     InternalProjectOptions.TRANSACTION_DURATION_REGRESSION.value: PerformanceP95EndpointRegressionGroupType,
     InternalProjectOptions.FUNCTION_DURATION_REGRESSION.value: ProfileFunctionRegressionType,
     ConfigurableThresholds.DB_QUERY_INJECTION.value: QueryInjectionVulnerabilityGroupType,
+    ConfigurableThresholds.WEB_VITALS.value: WebVitalsGroup,
 }
 """
 A mapping of the management settings to the group type that the detector spawns.
@@ -114,6 +118,7 @@ thresholds_to_manage_map: dict[str, str] = {
     ConfigurableThresholds.CONSECUTIVE_HTTP_SPANS_MIN_TIME_SAVED.value: ConfigurableThresholds.CONSECUTIVE_HTTP_SPANS.value,
     ConfigurableThresholds.HTTP_OVERHEAD_REQUEST_DELAY.value: ConfigurableThresholds.HTTP_OVERHEAD.value,
     ConfigurableThresholds.SQL_INJECTION_QUERY_VALUE_LENGTH.value: ConfigurableThresholds.DB_QUERY_INJECTION.value,
+    ConfigurableThresholds.WEB_VITALS_COUNT.value: ConfigurableThresholds.WEB_VITALS.value,
 }
 """
 A mapping of threshold setting to the parent setting that manages it's detection.
@@ -164,6 +169,7 @@ class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
     http_request_delay_threshold = serializers.IntegerField(
         required=False, min_value=200, max_value=TEN_SECONDS  # ms
     )
+    web_vitals_count = serializers.IntegerField(required=False, min_value=5, max_value=100)
     uncompressed_assets_detection_enabled = serializers.BooleanField(required=False)
     consecutive_http_spans_detection_enabled = serializers.BooleanField(required=False)
     large_http_payload_detection_enabled = serializers.BooleanField(required=False)
@@ -178,6 +184,7 @@ class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
     transaction_duration_regression_detection_enabled = serializers.BooleanField(required=False)
     function_duration_regression_detection_enabled = serializers.BooleanField(required=False)
     db_query_injection_detection_enabled = serializers.BooleanField(required=False)
+    web_vitals_detection_enabled = serializers.BooleanField(required=False)
     sql_injection_query_value_length_threshold = serializers.IntegerField(
         required=False, min_value=3, max_value=10
     )

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -685,7 +685,7 @@ class MetricIssuePOC(GroupType):
 
 
 @dataclass(frozen=True)
-class WebVitalsGroup(GroupType):
+class WebVitalsGroup(GroupType):  # TODO: Rename to WebVitalsGroupType
     type_id = 10001
     slug = "web_vitals"
     description = "Web Vitals"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1985,6 +1985,11 @@ register(
     default=3,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "performance.issues.web_vitals.count_threshold",
+    default=10,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Adjusting some time buffers in the trace endpoint
 register(

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -101,6 +101,7 @@ DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "transaction_duration_regression_detection_enabled": True,
     "function_duration_regression_detection_enabled": True,
     "db_query_injection_detection_enabled": False,
+    "web_vitals_detection_enabled": False,
 }
 
 DEFAULT_PROJECT_PERFORMANCE_GENERAL_SETTINGS = {

--- a/src/sentry/tasks/web_vitals_issue_detection.py
+++ b/src/sentry/tasks/web_vitals_issue_detection.py
@@ -21,9 +21,7 @@ logger = logging.getLogger("sentry.tasks.web_vitals_issue_detection")
 TRANSACTIONS_PER_PROJECT_LIMIT = 5
 DEFAULT_START_TIME_DELTA = {"days": 7}  # Low scores within this time range create web vital issues
 SCORE_THRESHOLD = 0.9  # Scores below this threshold will create web vital issues
-SAMPLES_COUNT_THRESHOLD = (
-    10  # Web Vitals require at least this amount of samples to create an issue
-)
+SAMPLES_COUNT_THRESHOLD = 10  # TODO: Use project config threshold setting. Web Vitals require at least this amount of samples to create an issue
 VITALS: list[WebVitalIssueDetectionType] = ["lcp", "fcp", "cls", "ttfb", "inp"]
 
 

--- a/tests/sentry/issues/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/issues/endpoints/test_project_performance_issue_settings.py
@@ -36,6 +36,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
         assert response.data["file_io_on_main_thread_detection_enabled"]
         assert response.data["consecutive_db_queries_detection_enabled"]
         assert response.data["large_render_blocking_asset_detection_enabled"]
+        assert not response.data["web_vitals_detection_enabled"]  # Disabled by default
 
         get_value.return_value = {
             "slow_db_queries_detection_enabled": False,
@@ -48,6 +49,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             "file_io_on_main_thread_detection_enabled": False,
             "consecutive_db_queries_detection_enabled": False,
             "large_render_blocking_asset_detection_enabled": False,
+            "web_vitals_detection_enabled": False,
         }
 
         response = self.get_success_response(
@@ -64,6 +66,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
         assert not response.data["file_io_on_main_thread_detection_enabled"]
         assert not response.data["consecutive_db_queries_detection_enabled"]
         assert not response.data["large_render_blocking_asset_detection_enabled"]
+        assert not response.data["web_vitals_detection_enabled"]
 
     @patch("sentry.models.ProjectOption.objects.get_value")
     @with_feature("organizations:performance-view")
@@ -82,6 +85,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
                 "performance.issues.consecutive_db.min_time_saved_threshold": 300,
                 "performance.issues.n_plus_one_api_calls.total_duration": 300,
                 "performance.issues.consecutive_http.min_time_saved_threshold": 2000,
+                "performance.issues.web_vitals.count_threshold": 10,
             }
         ):
             response = self.get_success_response(
@@ -101,6 +105,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             assert response.data["consecutive_db_min_time_saved_threshold"] == 300
             assert response.data["n_plus_one_api_calls_total_duration_threshold"] == 300
             assert response.data["consecutive_http_spans_min_time_saved_threshold"] == 2000
+            assert response.data["web_vitals_count"] == 10
 
             get_value.return_value = {
                 "n_plus_one_db_duration_threshold": 10000,
@@ -115,6 +120,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
                 "consecutive_db_min_time_saved_threshold": 5000,
                 "n_plus_one_api_calls_total_duration_threshold": 500,
                 "consecutive_http_spans_min_time_saved_threshold": 1000,
+                "web_vitals_count": 10,
             }
 
             response = self.get_success_response(
@@ -134,6 +140,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             assert response.data["consecutive_db_min_time_saved_threshold"] == 5000
             assert response.data["n_plus_one_api_calls_total_duration_threshold"] == 500
             assert response.data["consecutive_http_spans_min_time_saved_threshold"] == 1000
+            assert response.data["web_vitals_count"] == 10
 
     def test_get_returns_error_without_feature_enabled(self) -> None:
         self.get_error_response(


### PR DESCRIPTION
Adds options to configure enabling Web Vitals issue detection and minimum sample count threshold.
Detection is disabled by default and count threshold is `10` by default.

TODO: These settings are currently unused. `src/sentry/tasks/web_vitals_issue_detection.py` will be updated in an upcoming PR to respect these settings.