### PR TITLE
feat(dashboards): Use a single value selector for boolean filters

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -247,7 +247,7 @@ export function getPredefinedValues({
   ];
 }
 
-function tokenSupportsMultipleValues(
+export function tokenSupportsMultipleValues(
   token: TokenResult<Token.FILTER>,
   keys: TagCollection,
   fieldDefinition: FieldDefinition | null

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -33,6 +33,7 @@ export const DATASET_CHOICES = new Map<WidgetType, string>([
 
 const UNSUPPORTED_FIELD_KINDS = [FieldKind.FUNCTION];
 const UNSUPPORTED_FIELD_VALUE_TYPES = [FieldValueType.DATE];
+const IGNORE_DEFAULT_VALUES = [FieldValueType.STRING, FieldValueType.BOOLEAN];
 
 export function getDatasetLabel(dataset: WidgetType) {
   return DATASET_CHOICES.get(dataset) ?? '';
@@ -129,7 +130,7 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
             const fieldDefinition = fieldDefinitionMap.get(selectedFilterKey.key) ?? null;
             const valueType = fieldDefinition?.valueType;
 
-            if (valueType && valueType !== FieldValueType.STRING) {
+            if (valueType && !IGNORE_DEFAULT_VALUES.includes(valueType)) {
               defaultFilterValue = getInitialFilterText(
                 selectedFilterKey.key,
                 fieldDefinition,


### PR DESCRIPTION
Boolean filters previously used the multi select. If a list of booleans (e.g. [true,false]) is used in a widget query, an error is thrown by the backend because booleans are expected to be single values. To avoid this error completely, this PR uses a single value compact select for booleans (and any other filter token that doesn't support multi select).