### PR TITLE
ref(producer): Remove rollout option for ConfluentProducer

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -629,14 +629,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Rollout configuration for Arroyo ConfluentProducer
-# Controls the rollout of individual Kafka producers by name
-register(
-    "arroyo.producer.confluent-producer-rollout",
-    type=Dict,
-    default={},
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)

--- a/src/sentry/utils/confluent_producer.py
+++ b/src/sentry/utils/confluent_producer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from arroyo.backends.kafka import ConfluentProducer
 from confluent_kafka import Producer
 
 
@@ -17,4 +18,4 @@ def get_confluent_producer(
     Returns:
         confluent_kafka Producer
     """
-    return Producer(configuration)
+    return ConfluentProducer(configuration)

--- a/src/sentry/utils/confluent_producer.py
+++ b/src/sentry/utils/confluent_producer.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from arroyo.backends.kafka import ConfluentProducer
 from confluent_kafka import Producer
-
-from sentry import options
 
 
 def get_confluent_producer(
@@ -20,14 +17,4 @@ def get_confluent_producer(
     Returns:
         confluent_kafka Producer
     """
-    rollout_config = options.get("arroyo.producer.confluent-producer-rollout", {})
-    name = configuration.get("client.id")
-
-    # f"sentry.sentry_metrics.slicing_router.{current_sliceable}.{current_slice_id}"
-    if name is not None and isinstance(name, str):
-        if name.startswith("sentry.sentry_metrics.slicing_router"):
-            name = "sentry.sentry_metrics.slicing_router"
-
-    if rollout_config.get(name, False):
-        return ConfluentProducer(configuration)
     return Producer(configuration)

--- a/tests/sentry/sentry_metrics/consumers/test_slicing_router.py
+++ b/tests/sentry/sentry_metrics/consumers/test_slicing_router.py
@@ -20,7 +20,6 @@ from sentry.sentry_metrics.consumers.indexer.slicing_router import (
     _validate_slicing_config,
     _validate_slicing_consumer_config,
 )
-from sentry.testutils.helpers.options import override_options
 
 KAFKA_SNUBA_GENERIC_METRICS = "snuba-generic-metrics"
 
@@ -79,7 +78,6 @@ def setup_slicing() -> Generator[None]:
 
 
 @pytest.mark.parametrize("org_id", [1, 127, 128, 256, 257])
-@override_options({"arroyo.producer.confluent-producer-rollout": {}})
 def test_with_slicing(metrics_message, setup_slicing) -> None:
     """
     With partitioning settings, the SlicingRouter should route to the correct topic
@@ -96,7 +94,6 @@ def test_with_slicing(metrics_message, setup_slicing) -> None:
         assert False, "unexpected org_id"
 
 
-@override_options({"arroyo.producer.confluent-producer-rollout": {}})
 def test_with_no_org_in_routing_header(setup_slicing) -> None:
     """
     With partitioning settings, the SlicingRouter should route to the correct topic

--- a/tests/sentry/utils/test_confluent_producer.py
+++ b/tests/sentry/utils/test_confluent_producer.py
@@ -1,11 +1,9 @@
 from arroyo.backends.kafka import ConfluentProducer
 from confluent_kafka import Producer
 
-from sentry.testutils.helpers.options import override_options
 from sentry.utils.confluent_producer import get_confluent_producer
 
 
-@override_options({"arroyo.producer.confluent-producer-rollout": {"test_producer": True}})
 def test_get_confluent_producer() -> None:
     configuration = {
         "bootstrap.servers": "localhost:9092",
@@ -20,26 +18,3 @@ def test_get_confluent_producer() -> None:
 
     for attrs in Producer.__dict__.keys():
         assert hasattr(producer, attrs)
-
-
-@override_options({"arroyo.producer.confluent-producer-rollout": {"test_producer": False}})
-def test_get_confluent_producer_not_rolled_out() -> None:
-    configuration = {
-        "bootstrap.servers": "localhost:9092",
-        "client.id": "test_producer",
-    }
-
-    producer = get_confluent_producer(configuration)
-    assert isinstance(producer, Producer)
-    assert not isinstance(producer, ConfluentProducer)
-
-
-@override_options({"arroyo.producer.confluent-producer-rollout": {}})
-def test_get_confluent_producer_no_client_id() -> None:
-    configuration = {
-        "bootstrap.servers": "localhost:9092",
-    }
-
-    producer = get_confluent_producer(configuration)
-    assert isinstance(producer, Producer)
-    assert not isinstance(producer, ConfluentProducer)


### PR DESCRIPTION
Since ConfluentProducer are rolled out in s4s, de, and us without any errors, next step is rolling out to 100%.

Refs STREAM-549