### PR TITLE
feat(aci): add detector descriptions to details page

### DIFF
--- a/static/app/views/detectors/components/details/common/description.tsx
+++ b/static/app/views/detectors/components/details/common/description.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t} from 'sentry/locale';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {MarkedText} from 'sentry/utils/marked/markedText';
+
+export function DetectorDetailsDescription({
+  description,
+}: {
+  description: Detector['description'];
+}) {
+  if (!description) {
+    return null;
+  }
+  return (
+    <Section title={t('Description')}>
+      <StyledMarkedText text={description} />
+    </Section>
+  );
+}
+
+const StyledMarkedText = styled(MarkedText)`
+  word-wrap: break-word;
+
+  p {
+    margin: 0;
+  }
+`;

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useCallback, useState} from 'react';
-import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
@@ -23,7 +22,6 @@ import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
 import toArray from 'sentry/utils/array/toArray';
-import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -32,6 +30,7 @@ import {
 } from 'sentry/views/alerts/rules/crons/utils';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DetectorDetailsDescription} from 'sentry/views/detectors/components/details/common/description';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
@@ -230,11 +229,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
                 showUnknownLegend={showUnknownLegend}
               />
             </Section>
-            {detector.description && (
-              <Section title={t('Describe')}>
-                <StyledMarkedText text={detector.description} />
-              </Section>
-            )}
+            <DetectorDetailsDescription description={detector.description} />
             <DetectorExtraDetails>
               <KeyValueTableRow
                 keyName={t('Monitor slug')}
@@ -326,11 +321,3 @@ function useDocsPanel(monitorSlug: string, project: Project) {
       resizable: true,
     });
 }
-
-const StyledMarkedText = styled(MarkedText)`
-  word-wrap: break-word;
-
-  p {
-    margin: 0;
-  }
-`;

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
@@ -22,6 +23,7 @@ import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
 import toArray from 'sentry/utils/array/toArray';
+import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -228,6 +230,11 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
                 showUnknownLegend={showUnknownLegend}
               />
             </Section>
+            {detector.description && (
+              <Section title={t('Describe')}>
+                <StyledMarkedText text={detector.description} />
+              </Section>
+            )}
             <DetectorExtraDetails>
               <KeyValueTableRow
                 keyName={t('Monitor slug')}
@@ -319,3 +326,11 @@ function useDocsPanel(monitorSlug: string, project: Project) {
       resizable: true,
     });
 }
+
+const StyledMarkedText = styled(MarkedText)`
+  word-wrap: break-word;
+
+  p {
+    margin: 0;
+  }
+`;

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -14,11 +14,11 @@ import {
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
-import {MarkedText} from 'sentry/utils/marked/markedText';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
+import {DetectorDetailsDescription} from 'sentry/views/detectors/components/details/common/description';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {MetricDetectorDetailsDetect} from 'sentry/views/detectors/components/details/metric/detect';
 import {getResolutionDescription} from 'sentry/views/detectors/utils/getDetectorResolutionDescription';
@@ -144,11 +144,7 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
       <Section title={t('Resolve')}>
         <DetectorResolve detector={detector} />
       </Section>
-      {detector.description && (
-        <Section title={t('Describe')}>
-          <StyledMarkedText text={detector.description} />
-        </Section>
-      )}
+      <DetectorDetailsDescription description={detector.description} />
       <DetectorExtraDetails>
         <DetectorExtraDetails.DateCreated detector={detector} />
         <DetectorExtraDetails.CreatedBy detector={detector} />
@@ -177,12 +173,4 @@ const PriorityCondition = styled('div')`
   justify-self: flex-end;
   font-size: ${p => p.theme.fontSize.md};
   color: ${p => p.theme.textColor};
-`;
-
-const StyledMarkedText = styled(MarkedText)`
-  word-wrap: break-word;
-
-  p {
-    margin: 0;
-  }
 `;

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import {MarkedText} from 'sentry/utils/marked/markedText';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -143,6 +144,11 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
       <Section title={t('Resolve')}>
         <DetectorResolve detector={detector} />
       </Section>
+      {detector.description && (
+        <Section title={t('Describe')}>
+          <StyledMarkedText text={detector.description} />
+        </Section>
+      )}
       <DetectorExtraDetails>
         <DetectorExtraDetails.DateCreated detector={detector} />
         <DetectorExtraDetails.CreatedBy detector={detector} />
@@ -171,4 +177,12 @@ const PriorityCondition = styled('div')`
   justify-self: flex-end;
   font-size: ${p => p.theme.fontSize.md};
   color: ${p => p.theme.textColor};
+`;
+
+const StyledMarkedText = styled(MarkedText)`
+  word-wrap: break-word;
+
+  p {
+    margin: 0;
+  }
 `;

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {CodeBlock} from 'sentry/components/core/code';
 import {KeyValueTableRow} from 'sentry/components/keyValueTable';
@@ -10,7 +9,6 @@ import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
-import {MarkedText} from 'sentry/utils/marked/markedText';
 import {DetailsTimeline} from 'sentry/views/alerts/rules/uptime/detailsTimeline';
 import {DetailsTimelineLegend} from 'sentry/views/alerts/rules/uptime/detailsTimelineLegend';
 import {
@@ -20,6 +18,7 @@ import {
 import {UptimeChecksTable} from 'sentry/views/alerts/rules/uptime/uptimeChecksTable';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DetectorDetailsDescription} from 'sentry/views/detectors/components/details/common/description';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 
@@ -84,11 +83,7 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
             <DetailsTimelineLegend showMissedLegend={showMissedLegend} />
           </Section>
           <DetectorDetailsAssignee owner={detector.owner} />
-          {detector.description && (
-            <Section title={t('Describe')}>
-              <StyledMarkedText text={detector.description} />
-            </Section>
-          )}
+          <DetectorDetailsDescription description={detector.description} />
           <DetectorExtraDetails>
             <KeyValueTableRow
               keyName={t('Interval')}
@@ -108,11 +103,3 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
     </DetailLayout>
   );
 }
-
-const StyledMarkedText = styled(MarkedText)`
-  word-wrap: break-word;
-
-  p {
-    margin: 0;
-  }
-`;

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {CodeBlock} from 'sentry/components/core/code';
 import {KeyValueTableRow} from 'sentry/components/keyValueTable';
@@ -9,6 +10,7 @@ import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
+import {MarkedText} from 'sentry/utils/marked/markedText';
 import {DetailsTimeline} from 'sentry/views/alerts/rules/uptime/detailsTimeline';
 import {DetailsTimelineLegend} from 'sentry/views/alerts/rules/uptime/detailsTimelineLegend';
 import {
@@ -82,6 +84,11 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
             <DetailsTimelineLegend showMissedLegend={showMissedLegend} />
           </Section>
           <DetectorDetailsAssignee owner={detector.owner} />
+          {detector.description && (
+            <Section title={t('Describe')}>
+              <StyledMarkedText text={detector.description} />
+            </Section>
+          )}
           <DetectorExtraDetails>
             <KeyValueTableRow
               keyName={t('Interval')}
@@ -101,3 +108,11 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
     </DetailLayout>
   );
 }
+
+const StyledMarkedText = styled(MarkedText)`
+  word-wrap: break-word;
+
+  p {
+    margin: 0;
+  }
+`;

--- a/static/app/views/detectors/components/forms/common/describeSection.tsx
+++ b/static/app/views/detectors/components/forms/common/describeSection.tsx
@@ -7,7 +7,7 @@ export function DescribeSection() {
   return (
     <Container>
       <Section
-        title={t('Describe')}
+        title={t('Description')}
         description={t('Additional context about this monitor for other team members.')}
       >
         <TextareaField


### PR DESCRIPTION
<img width="1207" height="804" alt="Screenshot 2025-11-05 at 10 14 58 AM" src="https://github.com/user-attachments/assets/88b3a34d-fcbc-4f4c-9ca8-f5b19f60da7c" />
