### PR TITLE
ref(grouping): Use new exception subcomponent ordering in new config

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -67,6 +67,8 @@ FALL_2025_GROUPING_CONFIG = "newstyle:2025-11-21"
 register_grouping_config(
     id=FALL_2025_GROUPING_CONFIG,
     base="newstyle:2023-01-11",
-    initial_context={},
+    initial_context={
+        "use_legacy_exception_subcomponent_order": False,
+    },
     enhancements_base="all-platforms:2025-11-21",
 )

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.298054+00:00'
+created: '2025-11-03T21:52:52.602999+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "738e7d2503464bc264b4f791286f5122"
+    hash: "fa86c1473c78dd5f6008506ed614f1d9"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "actix_web::pipeline"
           stacktrace*
             frame* (marked in-app by the client)
               function*
@@ -269,15 +271,15 @@ contributing variants:
                 "lib.rs"
               function*
                 "log::__private_api_log"
-          type*
-            "actix_web::pipeline"
   system*
-    hash: "19a96e0438d28e48355653def82f887a"
+    hash: "0fd89da61ff62bc3b09751ac8ce133f9"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "actix_web::pipeline"
           stacktrace*
             frame*
               function*
@@ -597,5 +599,3 @@ contributing variants:
                 "hub.rs"
               function*
                 "sentry::hub::Hub::with_active::{{closure}}"
-          type*
-            "actix_web::pipeline"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.326178+00:00'
+created: '2025-11-03T21:52:52.625601+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,17 +24,17 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "2552498cfe69a6ddf1dcdde5440ce9c3"
+    hash: "b4626f44de843f1f586ff2648425c4f0"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "ApplicationNotResponding"
           stacktrace*
             frame*
               module*
                 "androidx.recyclerview.widget.RecyclerView"
               function*
                 "onLayout"
-          type*
-            "ApplicationNotResponding"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.346447+00:00'
+created: '2025-11-03T21:52:52.643005+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "228c649a3aa0901622c0a0e66ab0522c"
+    hash: "85f90327d3b9ef257838f2664b9915e6"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "System.Exception"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -41,15 +43,15 @@ contributing variants:
                 "SentryTest2.Controllers.ValuesController"
               function*
                 "Get"
-          type*
-            "System.Exception"
   system*
-    hash: "4ccd0f1953483581ba360c7518f90332"
+    hash: "97dff72812f7f33f6fd01179d7963d07"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "System.Exception"
           stacktrace*
             frame*
               module*
@@ -206,5 +208,3 @@ contributing variants:
                 "SentryTest2.Controllers.ValuesController"
               function*
                 "Get"
-          type*
-            "System.Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.441801+00:00'
+created: '2025-11-03T21:52:52.725415+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,19 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "4ef1fb44d656c3be2a146971f2a222dc"
+    hash: "3bb283edd206ca9069e3da4ce9c11869"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "<redacted>"
+          ns_error*
+            domain*
+              "<redacted>"
+            code*
+              2
           stacktrace*
             frame* (marked in-app by the client)
               function*
@@ -40,6 +47,13 @@ contributing variants:
             frame* (marked in-app by the client)
               function*
                 "stripped_application_code"
+  system*
+    hash: "ab329c350a2abfdf4798139a4aee0d8b"
+    contributing component: exception
+    hint: None
+    root_component:
+      system*
+        exception*
           type*
             "<redacted>"
           ns_error*
@@ -47,13 +61,6 @@ contributing variants:
               "<redacted>"
             code*
               2
-  system*
-    hash: "47481871aa8d5ab5729cf2db78ce3032"
-    contributing component: exception
-    hint: None
-    root_component:
-      system*
-        exception*
           stacktrace*
             frame*
               function*
@@ -70,10 +77,3 @@ contributing variants:
             frame*
               function*
                 "stripped_application_code"
-          type*
-            "<redacted>"
-          ns_error*
-            domain*
-              "<redacted>"
-            code*
-              2

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.515973+00:00'
+created: '2025-11-03T21:52:52.791272+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "6b059b9febc815ac18ac4d2082e38a9b"
+    hash: "452f63c005af7ac8bd3ce1f988b04471"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "ConnectionError"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -66,15 +68,15 @@ contributing variants:
                 "call_script"
               context_line*
                 "return script(keys, args, client)"
-          type*
-            "ConnectionError"
   system*
-    hash: "013d3477a774fe20c468dc8accd516f1"
+    hash: "b23d305fce7a3c4343f5c57a2937bfad"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "ConnectionError"
           stacktrace*
             frame*
               module*
@@ -153,5 +155,3 @@ contributing variants:
                 "read_response"
               context_line*
                 "(e.args,))"
-          type*
-            "ConnectionError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.551797+00:00'
+created: '2025-11-03T21:52:52.808787+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "161ce02ecc5d6685a72e8e520ab726b3"
+    hash: "9c580bff7b008113595f9f1e0ef1962f"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "FailedToFetchError"
           stacktrace*
             frame* (marked in-app by stack trace rule (function:playFetch +app))
               filename*
@@ -38,15 +40,15 @@ contributing variants:
                 "playFetch"
               context_line*
                 "raise FailedToFetchError('Charlie didn't bring the ball back!');"
-          type*
-            "FailedToFetchError"
   system*
-    hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+    hash: "27e4433059022647e4d83d344cbf738c"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "FailedToFetchError"
           stacktrace*
             frame*
               filename*
@@ -62,5 +64,3 @@ contributing variants:
                 "playFetch"
               context_line*
                 "raise FailedToFetchError('Charlie didn't bring the ball back!');"
-          type*
-            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.570879+00:00'
+created: '2025-11-03T21:52:52.826596+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+    hash: "9b3e1c08a50257c5ad760f1f3205a48b"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "FailedToFetchError"
           stacktrace*
             frame*
               filename*
@@ -38,5 +40,3 @@ contributing variants:
                 "handleRequest"
               context_line*
                 "return handler(request);"
-          type*
-            "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.826231+00:00'
+created: '2025-11-03T21:52:53.061731+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,15 +24,15 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "9509e122c6175606d52862fa4f64853c"
+    hash: "ebcb7aa3baed0b2447fed7b265db777c"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "ValueError"
           stacktrace*
             frame* (marked in-app by the client)
               filename*
                 "baz.py"
-          type*
-            "ValueError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:55.845055+00:00'
+created: '2025-11-03T21:52:53.078735+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,23 +24,23 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "669cb6664e0f5fed38665da04e464f7e"
+    hash: "8c527d091797ca91a535be7b461e5059"
     contributing component: chained_exception
     hint: None
     root_component:
       app*
         chained_exception*
           exception*
+            type*
+              "ValueError"
             stacktrace*
               frame* (marked in-app by the client)
                 filename*
                   "baz.py"
-            type*
-              "ValueError"
           exception*
+            type*
+              "ValueError"
             stacktrace*
               frame* (marked in-app by the client)
                 filename*
                   "baz.py"
-            type*
-              "ValueError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:56.130746+00:00'
+created: '2025-11-03T21:52:53.334773+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,13 +24,15 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "d505dfb9059ac63c11955233323a9100"
+    hash: "1ddf9a146f61f3c8667d7312727caff2"
     contributing component: chained_exception
     hint: None
     root_component:
       app*
         chained_exception*
           exception*
+            type*
+              "DoStuffException"
             stacktrace*
               frame* (marked in-app by the client)
                 module*
@@ -42,30 +44,30 @@ contributing variants:
                   "dostuff"
                 function*
                   "do_different_stuff"
-            type*
-              "DoStuffException"
           exception*
+            type*
+              "DoOtherStuffException"
             stacktrace*
               frame* (marked in-app by the client)
                 module*
                   "dostuff"
                 function*
                   "do_other_stuff"
-            type*
-              "DoOtherStuffException"
           exception*
             type*
               "System.AggregateException"
             value*
               "One or more errors occurred."
   system*
-    hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
+    hash: "f9f80cec48a38448579e3c41b9c525f5"
     contributing component: chained_exception
     hint: None
     root_component:
       system*
         chained_exception*
           exception*
+            type*
+              "DoStuffException"
             stacktrace*
               frame*
                 module*
@@ -77,14 +79,12 @@ contributing variants:
                   "dostuff"
                 function*
                   "do_different_stuff"
-            type*
-              "DoStuffException"
           exception*
+            type*
+              "DoOtherStuffException"
             stacktrace*
               frame*
                 module*
                   "dostuff"
                 function*
                   "do_other_stuff"
-            type*
-              "DoOtherStuffException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:56.187302+00:00'
+created: '2025-11-03T21:52:53.382494+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "26552f86ca2368e708afa1df6effc1c5"
+    hash: "9b140b41d4ae2bd9588ccff62cb8358f"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "TypeError"
           stacktrace*
             frame*
               module*
@@ -41,5 +43,3 @@ contributing variants:
                 "app/views/settings/components/forms/form"
               context_line*
                 "this.model.submitError(error);"
-          type*
-            "TypeError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:56.346438+00:00'
+created: '2025-11-03T21:52:53.445325+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "87497299851e09febfecf4e84e0d45ba"
+    hash: "c670c5a80a2775994bd2d63b408abd6c"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "EXC_BAD_ACCESS"
           stacktrace*
             frame*
               function*
@@ -37,5 +39,3 @@ contributing variants:
             frame*
               function*
                 "objc_release"
-          type*
-            "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.086583+00:00'
+created: '2025-11-03T21:52:54.053559+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,27 +24,29 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "4b8bbc500bd2cabfcadc1f1be867e0bb"
+    hash: "98ba9d44b8e7924ce21654996f92c2eb"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "*pq.Error"
           stacktrace*
             frame* (marked in-app by the client)
               module*
                 "main"
               function*
                 "background.func2"
-          type*
-            "*pq.Error"
   system*
-    hash: "348fc4026c9fa11ffba8fbfa80a134c9"
+    hash: "6bbf86806a0ec54202e633626ae09bd4"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "*pq.Error"
           stacktrace*
             frame*
               module*
@@ -56,5 +58,3 @@ contributing variants:
                 "main"
               function*
                 "background.func2"
-          type*
-            "*pq.Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.532598+00:00'
+created: '2025-11-03T21:52:54.447884+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,13 +29,15 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "19163f3ca34f5995c69d85351ce3d697"
+    hash: "b0dbf92202bf38adc8710e8ccd55d3df"
     contributing component: exception
     hint: None
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
     root_component:
       app*
         exception*
+          type*
+            "SoftTimeLimitExceeded"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -121,17 +123,17 @@ contributing variants:
                 "_prefetch"
               context_line*
                 "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
-          type*
-            "SoftTimeLimitExceeded"
     values: ["{{ default }}","soft-timelimit-exceeded"]
   system*
-    hash: "847950eb44d280e6758d136c763d6ddc"
+    hash: "e440cd285687bab8b861ff96fe713929"
     contributing component: exception
     hint: None
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
     root_component:
       system*
         exception*
+          type*
+            "SoftTimeLimitExceeded"
           stacktrace*
             frame*
               module*
@@ -252,6 +254,4 @@ contributing variants:
                 "soft_timeout_sighandler"
               context_line*
                 "raise SoftTimeLimitExceeded()"
-          type*
-            "SoftTimeLimitExceeded"
     values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.675575+00:00'
+created: '2025-11-03T21:52:54.547826+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,13 +24,15 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
+    hash: "db7a5bf0e72c22eb770a3be8940782c6"
     contributing component: chained_exception
     hint: None
     root_component:
       system*
         chained_exception*
           exception*
+            type*
+              "BindException"
             stacktrace*
               frame*
                 module*
@@ -142,9 +144,9 @@ contributing variants:
                   "sun.nio.ch.Net"
                 function*
                   "bind0"
-            type*
-              "BindException"
           exception*
+            type*
+              "LifecycleException"
             stacktrace*
               frame*
                 module*
@@ -216,9 +218,9 @@ contributing variants:
                   "org.apache.catalina.connector.Connector"
                 function*
                   "startInternal"
+          exception*
             type*
               "LifecycleException"
-          exception*
             stacktrace*
               frame*
                 module*
@@ -285,5 +287,3 @@ contributing variants:
                   "org.apache.catalina.util.LifecycleBase"
                 function*
                   "start"
-            type*
-              "LifecycleException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.702564+00:00'
+created: '2025-11-03T21:52:54.571709+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "ef2555bf7958ada8eefafbfdaed1c409"
+    hash: "6c27831782d10c44d7d0a01ef3f9c71e"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "ArithmeticException"
           stacktrace*
             frame*
               module*
@@ -276,5 +278,3 @@ contributing variants:
                 "jdk.internal.reflect.NativeMethodAccessorImpl"
               function*
                 "invoke0"
-          type*
-            "ArithmeticException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.771786+00:00'
+created: '2025-11-03T21:52:54.622913+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "c0f3f7d6deb17aec9d07259ac684fad0"
+    hash: "e734632ed44ebbaaeee1d0f589397a1a"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "ReferenceError"
           stacktrace*
             frame*
               filename*
@@ -91,5 +93,3 @@ contributing variants:
                 "react-dom.development.js"
               function* (trimmed javascript function)
                 "callCallback"
-          type*
-            "ReferenceError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.871730+00:00'
+created: '2025-11-03T21:52:54.684476+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "6ab78545e13144405fb21dadb9045b91"
+    hash: "96955d6eb6b1c842b7c64ac8eb3ffe8d"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               module*
@@ -45,5 +47,3 @@ contributing variants:
             frame*
               function* (trimmed javascript function)
                 "run"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.897553+00:00'
+created: '2025-11-03T21:52:54.701427+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "c63e8727af1a8fe75872b6a762797113"
+    hash: "811a408067f03b8eff2437a8e7515966"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               filename*
@@ -67,5 +69,3 @@ contributing variants:
                 "test.html"
               function* (trimmed javascript function)
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.921909+00:00'
+created: '2025-11-03T21:52:54.718897+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "c63e8727af1a8fe75872b6a762797113"
+    hash: "811a408067f03b8eff2437a8e7515966"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               filename*
@@ -67,5 +69,3 @@ contributing variants:
                 "test.html"
               function*
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.947185+00:00'
+created: '2025-11-03T21:52:54.735160+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "c63e8727af1a8fe75872b6a762797113"
+    hash: "811a408067f03b8eff2437a8e7515966"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               filename*
@@ -67,5 +69,3 @@ contributing variants:
                 "test.html"
               function*
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.973255+00:00'
+created: '2025-11-03T21:52:54.752364+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "b2602ad455472dede8e4c340d8a7eaba"
+    hash: "c21dd7692399d460904836c279bbeb36"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               module*
@@ -67,5 +69,3 @@ contributing variants:
                 "test"
               function* (trimmed javascript function)
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:57.996023+00:00'
+created: '2025-11-03T21:52:54.768563+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "b2602ad455472dede8e4c340d8a7eaba"
+    hash: "c21dd7692399d460904836c279bbeb36"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               module*
@@ -67,5 +69,3 @@ contributing variants:
                 "test"
               function*
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.019935+00:00'
+created: '2025-11-03T21:52:54.787298+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "b2602ad455472dede8e4c340d8a7eaba"
+    hash: "c21dd7692399d460904836c279bbeb36"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               module*
@@ -67,5 +69,3 @@ contributing variants:
                 "test"
               function*
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.044141+00:00'
+created: '2025-11-03T21:52:54.804262+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "b2602ad455472dede8e4c340d8a7eaba"
+    hash: "c21dd7692399d460904836c279bbeb36"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               module*
@@ -67,5 +69,3 @@ contributing variants:
                 "test"
               function*
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.066681+00:00'
+created: '2025-11-03T21:52:54.822189+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "c63e8727af1a8fe75872b6a762797113"
+    hash: "811a408067f03b8eff2437a8e7515966"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               filename*
@@ -67,5 +69,3 @@ contributing variants:
                 "test.html"
               function*
                 "aha"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.093232+00:00'
+created: '2025-11-03T21:52:54.839892+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "4a3cf3893b6485428dd02da116c8370e"
+    hash: "b5165008246a0897e1e7d18eb1df4d33"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "NotFoundError"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -51,15 +53,15 @@ contributing variants:
                 "app/api"
               context_line*
                 "const preservedError = new Error();"
-          type*
-            "NotFoundError"
   system*
-    hash: "d5456487ea8dccfe96c1968b19870978"
+    hash: "f9e1efa045242909883a37dc74e4fc97"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "NotFoundError"
           stacktrace*
             frame*
               module*
@@ -151,5 +153,3 @@ contributing variants:
                 "app/api"
               context_line*
                 "const preservedError = new Error();"
-          type*
-            "NotFoundError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.119405+00:00'
+created: '2025-11-03T21:52:54.859092+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "4a3cf3893b6485428dd02da116c8370e"
+    hash: "b5165008246a0897e1e7d18eb1df4d33"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "NotFoundError"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -51,15 +53,15 @@ contributing variants:
                 "app/api"
               context_line*
                 "const preservedError = new Error();"
-          type*
-            "NotFoundError"
   system*
-    hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
+    hash: "ff35b5385c8228096073758c6f50075b"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "NotFoundError"
           stacktrace*
             frame*
               module*
@@ -131,5 +133,3 @@ contributing variants:
                 "app/api"
               context_line*
                 "const preservedError = new Error();"
-          type*
-            "NotFoundError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.191345+00:00'
+created: '2025-11-03T21:52:54.899397+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "4665d486184740231357ab63f4543a8d"
+    hash: "04604148d9d04bfb7b3b3c19810a995c"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "Exception"
           stacktrace*
             frame* (marked in-app by the client)
               filename*
@@ -50,15 +52,15 @@ contributing variants:
                 "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
               context_line*
                 "throw new Exception('LARAVEL TEST');"
-          type*
-            "Exception"
   system*
-    hash: "107ed03036d901157372f260bc3df446"
+    hash: "f3b018db683f7190f410fec0fbc1a9b3"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Exception"
           stacktrace*
             frame*
               filename*
@@ -408,5 +410,3 @@ contributing variants:
                 "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
               context_line*
                 "throw new Exception('LARAVEL TEST');"
-          type*
-            "Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.162618+00:00'
+created: '2025-11-03T21:52:54.878461+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,27 +24,29 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "a728cdf5d62c8e017c35c3fe04051b6e"
+    hash: "bf617e996d4427cda2f75c965c4266e2"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "Exception"
           stacktrace*
             frame* (marked in-app by the client)
               filename*
                 "server.php"
               context_line*
                 "require_once __DIR__.'/public/index.php';"
-          type*
-            "Exception"
   system*
-    hash: "63c67781779781d9b0a442a5b2bdb976"
+    hash: "dc13fee96d9e544e8aee8f1b4e6cbf22"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Exception"
           stacktrace*
             frame*
               filename*
@@ -65,5 +67,3 @@ contributing variants:
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
               context_line*
                 "? $pipe->{$this->method}(...$parameters)"
-          type*
-            "Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.320113+00:00'
+created: '2025-11-03T21:52:54.990338+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "70b7b816193e06eb5d6649989fbaf605"
+    hash: "ca6e8f30e1e7b088514deb26ec59b379"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "SIGABRT"
           stacktrace*
             frame*
               function*
@@ -51,5 +53,3 @@ contributing variants:
             frame*
               function*
                 "abort"
-          type*
-            "SIGABRT"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.410687+00:00'
+created: '2025-11-03T21:52:55.057325+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "dcfcd48a02c100bbe4023cbc783054f0"
+    hash: "e1b3abdef8ab7e7c723645e9f52a44c6"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "NS_ERROR_NOT_INITIALIZED"
           stacktrace*
             frame*
               module*
@@ -123,5 +125,3 @@ contributing variants:
             frame*
               module*
                 "sentry/dist/vendor"
-          type*
-            "NS_ERROR_NOT_INITIALIZED"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.764869+00:00'
+created: '2025-11-03T21:52:55.242379+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "a20509269752c9a1bea6078851e4d39c"
+    hash: "6a84e724a0d67c6b036ecc24fcfb4be5"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -67,15 +69,15 @@ contributing variants:
                 "backend.ts"
               function* (trimmed javascript function)
                 "eventFromException"
-          type*
-            "Error"
   system*
-    hash: "252dc79eb5653bf822e2684d90734cb8"
+    hash: "97adcd276fbfdd9ae8271c04255e522f"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Error"
           stacktrace*
             frame*
               module*
@@ -137,5 +139,3 @@ contributing variants:
                 "backend.ts"
               function* (trimmed javascript function)
                 "eventFromException"
-          type*
-            "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.806334+00:00'
+created: '2025-11-03T21:52:55.274422+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,42 +24,42 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "c52ebcc2d9d0780a23c7d99831678830"
+    hash: "beb01c07d991f36b9da1e90fc7169ad8"
     contributing component: chained_exception
     hint: None
     root_component:
       app*
         chained_exception*
           exception*
+            type*
+              "ValueError"
             stacktrace*
               frame* (marked in-app by the client)
                 filename*
                   "baz.py"
-            type*
-              "ValueError"
           exception*
             type*
               "ValueError"
             value*
               "hello world"
   system*
-    hash: "669cb6664e0f5fed38665da04e464f7e"
+    hash: "8c527d091797ca91a535be7b461e5059"
     contributing component: chained_exception
     hint: None
     root_component:
       system*
         chained_exception*
           exception*
+            type*
+              "ValueError"
             stacktrace*
               frame*
                 filename*
                   "baz.py"
-            type*
-              "ValueError"
           exception*
+            type*
+              "ValueError"
             stacktrace*
               frame*
                 filename*
                   "baz.py"
-            type*
-              "ValueError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.829867+00:00'
+created: '2025-11-03T21:52:55.291097+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "121caa876de75ec51bf72ed4c852cd75"
+    hash: "4ec09a051686463f01ce05bffbcf3f89"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "MultiValueDictKeyError"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -45,15 +47,15 @@ contributing variants:
                 "handle"
               context_line*
                 "email = request.POST['user']"
-          type*
-            "MultiValueDictKeyError"
   system*
-    hash: "a5af2577d4caca8f983657c5d1919e14"
+    hash: "b19423b06ce0a7e46ae8b00e12804378"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "MultiValueDictKeyError"
           stacktrace*
             frame*
               module*
@@ -76,5 +78,3 @@ contributing variants:
                 "__getitem__"
               context_line*
                 "raise MultiValueDictKeyError(repr(key))"
-          type*
-            "MultiValueDictKeyError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.852902+00:00'
+created: '2025-11-03T21:52:55.308321+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "90888e813b09fa25061af2883c0fb9bd"
+    hash: "5c0a281b9f8602e5d639d2f722fe5a9a"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "MultiValueDictKeyError"
           stacktrace*
             frame*
               module*
@@ -52,5 +54,3 @@ contributing variants:
                 "_wrapper"
               context_line*
                 "return bound_func(*args, **kwargs)"
-          type*
-            "MultiValueDictKeyError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.873836+00:00'
+created: '2025-11-03T21:52:55.333808+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "d59239f5aad3304d60beb1fde3369b78"
+    hash: "721f24ff0b900f7945b4da03890d2a83"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "HTTPError"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -45,15 +47,15 @@ contributing variants:
                 "send_notification"
               context_line*
                 "resp.raise_for_status()"
-          type*
-            "HTTPError"
   system*
-    hash: "133db3f366b1327dab4e661f66dfb961"
+    hash: "d2490be282c0ada7e13288fd90fb0cb3"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "HTTPError"
           stacktrace*
             frame*
               module*
@@ -76,5 +78,3 @@ contributing variants:
                 "raise_for_status"
               context_line*
                 "raise HTTPError(http_error_msg, response=self)"
-          type*
-            "HTTPError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:58.962370+00:00'
+created: '2025-11-03T21:52:55.410066+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "73470e545e51eea9cff8a6c006f68f57"
+    hash: "33e3ac91fc256d3dfb789693be30a883"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "TypeError"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -41,15 +43,15 @@ contributing variants:
                 "App"
               context_line*
                 "<Button"
-          type*
-            "TypeError"
   system*
-    hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
+    hash: "618e6a3beb1ecd7d01616b554f6c873a"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "TypeError"
           stacktrace*
             frame*
               module*
@@ -159,5 +161,3 @@ contributing variants:
                 "App"
               context_line*
                 "<Button"
-          type*
-            "TypeError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.141787+00:00'
+created: '2025-11-03T21:52:55.538168+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
+    hash: "193a67f0b7f8b5a69f29dc6a259d47c3"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "log_demo"
           stacktrace*
             frame*
               function*
@@ -49,5 +51,3 @@ contributing variants:
             frame*
               function*
                 "log::__private_api_log"
-          type*
-            "log_demo"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.227417+00:00'
+created: '2025-11-03T21:52:55.601703+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,15 +24,15 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "eb87c1031dba55b67df86fb9fff59dc6"
+    hash: "ef42635ff82b83bc711ed7c65b7cb189"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "log_demo"
           stacktrace*
             frame*
               function*
                 "log_demo::main"
-          type*
-            "log_demo"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.250260+00:00'
+created: '2025-11-03T21:52:55.618297+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,25 +24,27 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "eb87c1031dba55b67df86fb9fff59dc6"
+    hash: "ef42635ff82b83bc711ed7c65b7cb189"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "log_demo"
           stacktrace*
             frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
               function*
                 "log_demo::main"
-          type*
-            "log_demo"
   system*
-    hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
+    hash: "193a67f0b7f8b5a69f29dc6a259d47c3"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "log_demo"
           stacktrace*
             frame*
               function*
@@ -62,5 +64,3 @@ contributing variants:
             frame*
               function*
                 "log::__private_api_log"
-          type*
-            "log_demo"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.271742+00:00'
+created: '2025-11-03T21:52:55.635516+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,25 +24,27 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "eb87c1031dba55b67df86fb9fff59dc6"
+    hash: "ef42635ff82b83bc711ed7c65b7cb189"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "log_demo"
           stacktrace*
             frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
               function*
                 "log_demo::main"
-          type*
-            "log_demo"
   system*
-    hash: "0817e4e604fbe88c4534eff166df1db9"
+    hash: "68021c81b00bc4f2f983b11f10efbfda"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "log_demo"
           stacktrace*
             frame*
               function*
@@ -56,5 +58,3 @@ contributing variants:
             frame*
               function*
                 "log_demo::main"
-          type*
-            "log_demo"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.394743+00:00'
+created: '2025-11-03T21:52:55.718050+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,27 +24,29 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "a12d579fed7636c2a5d2fae110c95ce5"
+    hash: "63f25f224c4a56add964d1570880704c"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "NullReferenceException"
           stacktrace*
             frame* (marked in-app by the client)
               filename*
                 "samplescript.cs"
               function*
                 "SampleScript.ThrowNull ()"
-          type*
-            "NullReferenceException"
   system*
-    hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
+    hash: "7909deacdb3f511a715efb7f2670d4dc"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "NullReferenceException"
           stacktrace*
             frame*
               filename*
@@ -86,5 +88,3 @@ contributing variants:
                 "samplescript.cs"
               function*
                 "SampleScript.ThrowNull ()"
-          type*
-            "NullReferenceException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.419187+00:00'
+created: '2025-11-03T21:52:55.736291+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "ecb890e5cd60dec2b626d500cc866de4"
+    hash: "2301317599ab22875b83ce2dafdab6ce"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "EXC_BAD_ACCESS"
           stacktrace*
             frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
@@ -106,15 +108,15 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
               function*
                 "USentryPlaygroundUtils::Terminate"
-          type*
-            "EXC_BAD_ACCESS"
   system*
-    hash: "57493ac3e558feffb778cf170a7fd986"
+    hash: "65c0ee687814f8d166cc29c9443ffc8a"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "EXC_BAD_ACCESS"
           stacktrace*
             frame*
               function*
@@ -203,5 +205,3 @@ contributing variants:
             frame*
               function*
                 "FGenericPlatformMisc::RaiseException"
-          type*
-            "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.492751+00:00'
+created: '2025-11-03T21:52:55.792998+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "e7a1be23aff9a117598bb893ed4bedb4"
+    hash: "dca3cb1a150c80ca2103ca14a870736e"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "Ensure failed"
           stacktrace*
             frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
@@ -100,15 +102,15 @@ contributing variants:
             frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
                 "UObject::execCallMathFunction"
-          type*
-            "Ensure failed"
   system*
-    hash: "1bba3ace796a07d167af26959c6039c9"
+    hash: "d8dceed7558e86d6622149fd98607a02"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Ensure failed"
           stacktrace*
             frame*
               function*
@@ -191,5 +193,3 @@ contributing variants:
             frame*
               function*
                 "TMulticastDelegateBase<T>::Broadcast<T>"
-          type*
-            "Ensure failed"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:59.516870+00:00'
+created: '2025-11-03T21:52:55.813388+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,12 +24,14 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
+    hash: "8961a4ec639f0697b27b860bbaf365bb"
     contributing component: exception
     hint: None
     root_component:
       app*
         exception*
+          type*
+            "Ensure failed"
           stacktrace*
             frame* (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
               function*
@@ -122,15 +124,15 @@ contributing variants:
                 "sentryplaygroundutils.cpp"
               function*
                 "USentryPlaygroundUtils::Terminate"
-          type*
-            "Ensure failed"
   system*
-    hash: "65244b22630821cacd0be603ebcef671"
+    hash: "4fa979767cc67d57c9bc771f6e48ed45"
     contributing component: exception
     hint: None
     root_component:
       system*
         exception*
+          type*
+            "Ensure failed"
           stacktrace*
             frame*
               function*
@@ -270,5 +272,3 @@ contributing variants:
             frame*
               function*
                 "sentry_unwind_stack_from_ucontext"
-          type*
-            "Ensure failed"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:25.505722+00:00'
+created: '2025-11-03T21:49:30.370714+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2606,7 +2606,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "738e7d2503464bc264b4f791286f5122",
+    "hash": "fa86c1473c78dd5f6008506ed614f1d9",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -5213,7 +5213,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "19a96e0438d28e48355653def82f887a",
+    "hash": "0fd89da61ff62bc3b09751ac8ce133f9",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:39.291195+00:00'
+created: '2025-11-03T21:49:30.398767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7871,7 +7871,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "2552498cfe69a6ddf1dcdde5440ce9c3",
+    "hash": "b4626f44de843f1f586ff2648425c4f0",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:25.556848+00:00'
+created: '2025-11-03T21:49:30.420424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1094,7 +1094,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "228c649a3aa0901622c0a0e66ab0522c",
+    "hash": "85f90327d3b9ef257838f2664b9915e6",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -2234,7 +2234,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "4ccd0f1953483581ba360c7518f90332",
+    "hash": "97dff72812f7f33f6fd01179d7963d07",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:25.655967+00:00'
+created: '2025-11-03T21:49:30.512071+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1072,7 +1072,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "4ef1fb44d656c3be2a146971f2a222dc",
+    "hash": "3bb283edd206ca9069e3da4ce9c11869",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -2145,7 +2145,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "47481871aa8d5ab5729cf2db78ce3032",
+    "hash": "ab329c350a2abfdf4798139a4aee0d8b",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:25.742767+00:00'
+created: '2025-11-03T21:49:30.584349+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -553,7 +553,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "6b059b9febc815ac18ac4d2082e38a9b",
+    "hash": "452f63c005af7ac8bd3ce1f988b04471",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -1152,7 +1152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "013d3477a774fe20c468dc8accd516f1",
+    "hash": "b23d305fce7a3c4343f5c57a2937bfad",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:25.761440+00:00'
+created: '2025-11-03T21:49:30.609148+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -237,7 +237,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "161ce02ecc5d6685a72e8e520ab726b3",
+    "hash": "9c580bff7b008113595f9f1e0ef1962f",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -475,7 +475,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "c5e4b4a9ad1803c4d4ca7feee5e430ae",
+    "hash": "27e4433059022647e4d83d344cbf738c",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:39.495417+00:00'
+created: '2025-11-03T21:49:30.627068+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -391,7 +391,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "fe92cff6711f8a0a30cabb8b9245b1d6",
+    "hash": "9b3e1c08a50257c5ad760f1f3205a48b",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:26.047407+00:00'
+created: '2025-11-03T21:49:30.895525+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -100,7 +100,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "9509e122c6175606d52862fa4f64853c",
+    "hash": "ebcb7aa3baed0b2447fed7b265db777c",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:26.068185+00:00'
+created: '2025-11-03T21:49:30.914947+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -173,7 +173,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "chained exception stacktraces — in-app frames",
-    "hash": "669cb6664e0f5fed38665da04e464f7e",
+    "hash": "8c527d091797ca91a535be7b461e5059",
     "hint": null,
     "key": "app_chained_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:26.412659+00:00'
+created: '2025-11-03T21:49:31.182678+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -276,7 +276,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "chained exception stacktraces — in-app frames",
-    "hash": "d505dfb9059ac63c11955233323a9100",
+    "hash": "1ddf9a146f61f3c8667d7312727caff2",
     "hint": null,
     "key": "app_chained_exception_stacktrace",
     "type": "component"
@@ -520,7 +520,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "chained exception stacktraces — all frames",
-    "hash": "4f9cc6a81f4eb34f9e917374f281b9dc",
+    "hash": "f9f80cec48a38448579e3c41b9c525f5",
     "hint": null,
     "key": "system_chained_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:40.020621+00:00'
+created: '2025-11-03T21:49:31.230538+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -311,7 +311,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "26552f86ca2368e708afa1df6effc1c5",
+    "hash": "9b140b41d4ae2bd9588ccff62cb8358f",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:40.157261+00:00'
+created: '2025-11-03T21:49:31.373855+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -507,7 +507,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "87497299851e09febfecf4e84e0d45ba",
+    "hash": "c670c5a80a2775994bd2d63b408abd6c",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:27.519940+00:00'
+created: '2025-11-03T21:49:32.084657+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -139,7 +139,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "4b8bbc500bd2cabfcadc1f1be867e0bb",
+    "hash": "98ba9d44b8e7924ce21654996f92c2eb",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "348fc4026c9fa11ffba8fbfa80a134c9",
+    "hash": "6bbf86806a0ec54202e633626ae09bd4",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:28.054948+00:00'
+created: '2025-11-03T21:49:32.445066+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -822,7 +822,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames and custom fingerprint",
-    "hash": "19163f3ca34f5995c69d85351ce3d697",
+    "hash": "b0dbf92202bf38adc8710e8ccd55d3df",
     "hint": null,
     "key": "app_exception_stacktrace_hybrid_fingerprint",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\"",
@@ -1650,7 +1650,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames and custom fingerprint",
-    "hash": "847950eb44d280e6758d136c763d6ddc",
+    "hash": "e440cd285687bab8b861ff96fe713929",
     "hint": null,
     "key": "system_exception_stacktrace_hybrid_fingerprint",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\"",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.186883+00:00'
+created: '2025-11-03T21:49:32.537725+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -3976,7 +3976,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "chained exception stacktraces — all frames",
-    "hash": "1959b227a7cf6acf7f3fd401b5d9f09b",
+    "hash": "db7a5bf0e72c22eb770a3be8940782c6",
     "hint": null,
     "key": "system_chained_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.207982+00:00'
+created: '2025-11-03T21:49:32.558490+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -4034,7 +4034,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "ef2555bf7958ada8eefafbfdaed1c409",
+    "hash": "6c27831782d10c44d7d0a01ef3f9c71e",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.255238+00:00'
+created: '2025-11-03T21:49:32.606443+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -931,7 +931,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "c0f3f7d6deb17aec9d07259ac684fad0",
+    "hash": "e734632ed44ebbaaeee1d0f589397a1a",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.317732+00:00'
+created: '2025-11-03T21:49:32.667768+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -407,7 +407,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "6ab78545e13144405fb21dadb9045b91",
+    "hash": "96955d6eb6b1c842b7c64ac8eb3ffe8d",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.334711+00:00'
+created: '2025-11-03T21:49:32.685756+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -791,7 +791,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hash": "811a408067f03b8eff2437a8e7515966",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.351161+00:00'
+created: '2025-11-03T21:49:32.703766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -799,7 +799,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hash": "811a408067f03b8eff2437a8e7515966",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.367789+00:00'
+created: '2025-11-03T21:49:32.722112+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -729,7 +729,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hash": "811a408067f03b8eff2437a8e7515966",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.383664+00:00'
+created: '2025-11-03T21:49:32.739050+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -827,7 +827,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hash": "c21dd7692399d460904836c279bbeb36",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.400163+00:00'
+created: '2025-11-03T21:49:32.756333+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -835,7 +835,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hash": "c21dd7692399d460904836c279bbeb36",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.416138+00:00'
+created: '2025-11-03T21:49:32.773218+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -765,7 +765,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hash": "c21dd7692399d460904836c279bbeb36",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.432523+00:00'
+created: '2025-11-03T21:49:32.789805+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -889,7 +889,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hash": "c21dd7692399d460904836c279bbeb36",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.448581+00:00'
+created: '2025-11-03T21:49:32.810581+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -857,7 +857,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hash": "811a408067f03b8eff2437a8e7515966",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:28.639599+00:00'
+created: '2025-11-03T21:49:32.832040+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -861,7 +861,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "4a3cf3893b6485428dd02da116c8370e",
+    "hash": "b5165008246a0897e1e7d18eb1df4d33",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -1723,7 +1723,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "d5456487ea8dccfe96c1968b19870978",
+    "hash": "f9e1efa045242909883a37dc74e4fc97",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:28.664293+00:00'
+created: '2025-11-03T21:49:32.851479+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -718,7 +718,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "4a3cf3893b6485428dd02da116c8370e",
+    "hash": "b5165008246a0897e1e7d18eb1df4d33",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -1437,7 +1437,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "0b81da6ea3d7cc82b1d4825b7aac0b8d",
+    "hash": "ff35b5385c8228096073758c6f50075b",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:28.712370+00:00'
+created: '2025-11-03T21:49:32.893474+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2167,7 +2167,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "4665d486184740231357ab63f4543a8d",
+    "hash": "04604148d9d04bfb7b3b3c19810a995c",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -4335,7 +4335,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "107ed03036d901157372f260bc3df446",
+    "hash": "f3b018db683f7190f410fec0fbc1a9b3",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:28.685156+00:00'
+created: '2025-11-03T21:49:32.869767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -193,7 +193,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "a728cdf5d62c8e017c35c3fe04051b6e",
+    "hash": "bf617e996d4427cda2f75c965c4266e2",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -387,7 +387,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "63c67781779781d9b0a442a5b2bdb976",
+    "hash": "dc13fee96d9e544e8aee8f1b4e6cbf22",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.616085+00:00'
+created: '2025-11-03T21:49:32.988337+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1651,7 +1651,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "70b7b816193e06eb5d6649989fbaf605",
+    "hash": "ca6e8f30e1e7b088514deb26ec59b379",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.681034+00:00'
+created: '2025-11-03T21:49:33.063973+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2071,7 +2071,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "dcfcd48a02c100bbe4023cbc783054f0",
+    "hash": "e1b3abdef8ab7e7c723645e9f52a44c6",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.201205+00:00'
+created: '2025-11-03T21:49:33.253504+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -491,7 +491,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "a20509269752c9a1bea6078851e4d39c",
+    "hash": "6a84e724a0d67c6b036ecc24fcfb4be5",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -983,7 +983,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "252dc79eb5653bf822e2684d90734cb8",
+    "hash": "97adcd276fbfdd9ae8271c04255e522f",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.241227+00:00'
+created: '2025-11-03T21:49:33.287153+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -173,7 +173,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "chained exception stacktraces — in-app frames",
-    "hash": "c52ebcc2d9d0780a23c7d99831678830",
+    "hash": "beb01c07d991f36b9da1e90fc7169ad8",
     "hint": null,
     "key": "app_chained_exception_stacktrace",
     "type": "component"
@@ -347,7 +347,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "chained exception stacktraces — all frames",
-    "hash": "669cb6664e0f5fed38665da04e464f7e",
+    "hash": "8c527d091797ca91a535be7b461e5059",
     "hint": null,
     "key": "system_chained_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.263258+00:00'
+created: '2025-11-03T21:49:33.304811+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -509,7 +509,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "121caa876de75ec51bf72ed4c852cd75",
+    "hash": "4ec09a051686463f01ce05bffbcf3f89",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -1019,7 +1019,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "a5af2577d4caca8f983657c5d1919e14",
+    "hash": "b19423b06ce0a7e46ae8b00e12804378",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:41.927602+00:00'
+created: '2025-11-03T21:49:33.323152+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1019,7 +1019,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "90888e813b09fa25061af2883c0fb9bd",
+    "hash": "5c0a281b9f8602e5d639d2f722fe5a9a",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.305631+00:00'
+created: '2025-11-03T21:49:33.340168+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -201,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "d59239f5aad3304d60beb1fde3369b78",
+    "hash": "721f24ff0b900f7945b4da03890d2a83",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -448,7 +448,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "133db3f366b1327dab4e661f66dfb961",
+    "hash": "d2490be282c0ada7e13288fd90fb0cb3",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.395668+00:00'
+created: '2025-11-03T21:49:33.407626+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1024,7 +1024,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "73470e545e51eea9cff8a6c006f68f57",
+    "hash": "33e3ac91fc256d3dfb789693be30a883",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -2049,7 +2049,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "ecd413627f0d90a5a25cb28d1ba9c39f",
+    "hash": "618e6a3beb1ecd7d01616b554f6c873a",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:42.117808+00:00'
+created: '2025-11-03T21:49:33.523468+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -573,7 +573,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
+    "hash": "193a67f0b7f8b5a69f29dc6a259d47c3",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-30T17:09:42.187408+00:00'
+created: '2025-11-03T21:49:33.593847+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -573,7 +573,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "eb87c1031dba55b67df86fb9fff59dc6",
+    "hash": "ef42635ff82b83bc711ed7c65b7cb189",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.660605+00:00'
+created: '2025-11-03T21:49:33.611035+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -286,7 +286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "eb87c1031dba55b67df86fb9fff59dc6",
+    "hash": "ef42635ff82b83bc711ed7c65b7cb189",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -573,7 +573,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
+    "hash": "193a67f0b7f8b5a69f29dc6a259d47c3",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.680025+00:00'
+created: '2025-11-03T21:49:33.627562+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -286,7 +286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "eb87c1031dba55b67df86fb9fff59dc6",
+    "hash": "ef42635ff82b83bc711ed7c65b7cb189",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -573,7 +573,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "0817e4e604fbe88c4534eff166df1db9",
+    "hash": "68021c81b00bc4f2f983b11f10efbfda",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.779326+00:00'
+created: '2025-11-03T21:49:33.707448+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -333,7 +333,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "a12d579fed7636c2a5d2fae110c95ce5",
+    "hash": "63f25f224c4a56add964d1570880704c",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -667,7 +667,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "c0dbeebf0430b3310ad1f7ceb48553a6",
+    "hash": "7909deacdb3f511a715efb7f2670d4dc",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.802311+00:00'
+created: '2025-11-03T21:49:33.726515+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1061,7 +1061,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "ecb890e5cd60dec2b626d500cc866de4",
+    "hash": "2301317599ab22875b83ce2dafdab6ce",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -2123,7 +2123,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "57493ac3e558feffb778cf170a7fd986",
+    "hash": "65c0ee687814f8d166cc29c9443ffc8a",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.875182+00:00'
+created: '2025-11-03T21:49:33.788451+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2851,7 +2851,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "e7a1be23aff9a117598bb893ed4bedb4",
+    "hash": "dca3cb1a150c80ca2103ca14a870736e",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -5703,7 +5703,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "1bba3ace796a07d167af26959c6039c9",
+    "hash": "d8dceed7558e86d6622149fd98607a02",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:19:29.899552+00:00'
+created: '2025-11-03T21:49:33.808465+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1637,7 +1637,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — in-app frames",
-    "hash": "4717aeb08ff642726ef6ea8f1ce55cdf",
+    "hash": "8961a4ec639f0697b27b860bbaf365bb",
     "hint": null,
     "key": "app_exception_stacktrace",
     "type": "component"
@@ -3275,7 +3275,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "contributes": true,
     "description": "exception stacktrace — all frames",
-    "hash": "65244b22630821cacd0be603ebcef671",
+    "hash": "4fa979767cc67d57c9bc771f6e48ed45",
     "hint": null,
     "key": "system_exception_stacktrace",
     "type": "component"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/actix.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:50.857047+00:00'
+created: '2025-11-03T21:48:46.282076+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "738e7d2503464bc264b4f791286f5122"
+  hash: "fa86c1473c78dd5f6008506ed614f1d9"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "actix_web::pipeline"
+        value (ignored because stacktrace takes precedence)
+          "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
         stacktrace*
           frame (marked in-app by the client but ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -392,18 +396,18 @@ app:
               "hub.rs"
             function*
               "sentry::hub::Hub::with_active::{{closure}}"
-        type*
-          "actix_web::pipeline"
-        value (ignored because stacktrace takes precedence)
-          "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
 --------------------------------------------------------------------------
 system:
-  hash: "19a96e0438d28e48355653def82f887a"
+  hash: "0fd89da61ff62bc3b09751ac8ce133f9"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "actix_web::pipeline"
+        value (ignored because stacktrace takes precedence)
+          "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -786,7 +790,3 @@ system:
               "hub.rs"
             function*
               "sentry::hub::Hub::with_active::{{closure}}"
-        type*
-          "actix_web::pipeline"
-        value (ignored because stacktrace takes precedence)
-          "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:50.883099+00:00'
+created: '2025-11-03T21:48:46.305498+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "ApplicationNotResponding"
+        value* (stripped event-specific values)
+          "Application Not Responding for at least <int> ms."
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -767,10 +771,6 @@ app:
               "sourcefile"
             function*
               "getChildAt"
-        type*
-          "ApplicationNotResponding"
-        value* (stripped event-specific values)
-          "Application Not Responding for at least <int> ms."
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -789,12 +789,16 @@ app:
               "getThreadStackTrace"
 --------------------------------------------------------------------------
 system:
-  hash: "2552498cfe69a6ddf1dcdde5440ce9c3"
+  hash: "b4626f44de843f1f586ff2648425c4f0"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "ApplicationNotResponding"
+        value (ignored because stacktrace takes precedence)
+          "Application Not Responding for at least <int> ms."
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
@@ -1552,10 +1556,6 @@ system:
               "sourcefile"
             function*
               "getChildAt"
-        type*
-          "ApplicationNotResponding"
-        value (ignored because stacktrace takes precedence)
-          "Application Not Responding for at least <int> ms."
       threads (ignored because system exception takes precedence)
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/aspnetcore.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:50.909818+00:00'
+created: '2025-11-03T21:48:46.324148+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "228c649a3aa0901622c0a0e66ab0522c"
+  hash: "85f90327d3b9ef257838f2664b9915e6"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "System.Exception"
+        value (ignored because stacktrace takes precedence)
+          "sync exception"
         stacktrace*
           frame (marked out of app by the client)
             module*
@@ -168,10 +172,6 @@ app:
               "valuescontroller.cs"
             function*
               "Get"
-        type*
-          "System.Exception"
-        value (ignored because stacktrace takes precedence)
-          "sync exception"
 --------------------------------------------------------------------------
 default:
   hash: null
@@ -183,12 +183,16 @@ default:
         "An unhandled exception has occurred while executing the request."
 --------------------------------------------------------------------------
 system:
-  hash: "4ccd0f1953483581ba360c7518f90332"
+  hash: "97dff72812f7f33f6fd01179d7963d07"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "System.Exception"
+        value (ignored because stacktrace takes precedence)
+          "sync exception"
         stacktrace*
           frame*
             module*
@@ -347,7 +351,3 @@ system:
               "valuescontroller.cs"
             function*
               "Get"
-        type*
-          "System.Exception"
-        value (ignored because stacktrace takes precedence)
-          "sync exception"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:50.951385+00:00'
+created: '2025-11-03T21:48:46.357569+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "SIGSEGV"
+        value*
+          "Segfault"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
           frame (marked out of app by the client)
@@ -25,10 +29,6 @@ app:
           frame (marked out of app by the client)
             function*
               "kill"
-        type (ignored because exception is synthetic)
-          "SIGSEGV"
-        value*
-          "Segfault"
 --------------------------------------------------------------------------
 system:
   hash: "d9c9b0f9ba46e32fddd7cd1512fad235"
@@ -37,6 +37,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "SIGSEGV"
+        value (ignored because stacktrace takes precedence)
+          "Segfault"
         stacktrace*
           frame
           frame
@@ -52,7 +56,3 @@ system:
           frame*
             function*
               "kill"
-        type (ignored because exception is synthetic)
-          "SIGSEGV"
-        value (ignored because stacktrace takes precedence)
-          "Segfault"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:50.987914+00:00'
+created: '2025-11-03T21:48:46.390553+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "ChunkLoadError"
+        value*
+          "ChunkLoadError: something something..."
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -18,10 +22,6 @@ app:
               "bar.tsx"
             function*
               "main"
-        type*
-          "ChunkLoadError"
-        value*
-          "ChunkLoadError: something something..."
 --------------------------------------------------------------------------
 built_in_fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
@@ -35,6 +35,10 @@ system:
   root_component:
     system (ignored because built-in fingerprint takes precedence)
       exception*
+        type*
+          "ChunkLoadError"
+        value (ignored because stacktrace takes precedence)
+          "ChunkLoadError: something something..."
         stacktrace*
           frame*
             module*
@@ -43,7 +47,3 @@ system:
               "bar.tsx"
             function*
               "main"
-        type*
-          "ChunkLoadError"
-        value (ignored because stacktrace takes precedence)
-          "ChunkLoadError: something something..."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:50.969579+00:00'
+created: '2025-11-03T21:48:46.373701+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "ChunkLoadError"
+        value*
+          "ChunkLoadError: something else..."
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -18,10 +22,6 @@ app:
               "foo.tsx"
             function*
               "main"
-        type*
-          "ChunkLoadError"
-        value*
-          "ChunkLoadError: something else..."
 --------------------------------------------------------------------------
 built_in_fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
@@ -35,6 +35,10 @@ system:
   root_component:
     system (ignored because built-in fingerprint takes precedence)
       exception*
+        type*
+          "ChunkLoadError"
+        value (ignored because stacktrace takes precedence)
+          "ChunkLoadError: something else..."
         stacktrace*
           frame*
             module*
@@ -43,7 +47,3 @@ system:
               "foo.tsx"
             function*
               "main"
-        type*
-          "ChunkLoadError"
-        value (ignored because stacktrace takes precedence)
-          "ChunkLoadError: something else..."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/callee_guaranteed.pysnap
@@ -1,15 +1,22 @@
 ---
-created: '2025-10-29T21:18:51.007416+00:00'
+created: '2025-11-03T21:48:46.409409+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "4ef1fb44d656c3be2a146971f2a222dc"
+  hash: "3bb283edd206ca9069e3da4ce9c11869"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "<redacted>"
+        ns_error*
+          domain*
+            "<redacted>"
+          code*
+            2
         stacktrace*
           frame (marked out of app by the client)
             function*
@@ -122,6 +129,14 @@ app:
           frame (marked in-app by the client but ignored due to recursion)
             function*
               "stripped_application_code"
+--------------------------------------------------------------------------
+system:
+  hash: "ab329c350a2abfdf4798139a4aee0d8b"
+  contributing component: exception
+  hint: None
+  root_component:
+    system*
+      exception*
         type*
           "<redacted>"
         ns_error*
@@ -129,14 +144,6 @@ app:
             "<redacted>"
           code*
             2
---------------------------------------------------------------------------
-system:
-  hash: "47481871aa8d5ab5729cf2db78ce3032"
-  contributing component: exception
-  hint: None
-  root_component:
-    system*
-      exception*
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -249,10 +256,3 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-        type*
-          "<redacted>"
-        ns_error*
-          domain*
-            "<redacted>"
-          code*
-            2

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/connection_error.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:51.107350+00:00'
+created: '2025-11-03T21:48:46.474973+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "6b059b9febc815ac18ac4d2082e38a9b"
+  hash: "452f63c005af7ac8bd3ce1f988b04471"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "ConnectionError"
+        value (ignored because stacktrace takes precedence)
+          "Error while reading from socket: ('Connection closed by server.',)"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -110,10 +114,6 @@ app:
               "read_response"
             context_line*
               "(e.args,))"
-        type*
-          "ConnectionError"
-        value (ignored because stacktrace takes precedence)
-          "Error while reading from socket: ('Connection closed by server.',)"
 --------------------------------------------------------------------------
 default:
   hash: null
@@ -125,12 +125,16 @@ default:
         "%s.process_error"
 --------------------------------------------------------------------------
 system:
-  hash: "013d3477a774fe20c468dc8accd516f1"
+  hash: "b23d305fce7a3c4343f5c57a2937bfad"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "ConnectionError"
+        value (ignored because stacktrace takes precedence)
+          "Error while reading from socket: ('Connection closed by server.',)"
         stacktrace*
           frame*
             module*
@@ -231,7 +235,3 @@ system:
               "read_response"
             context_line*
               "(e.args,))"
-        type*
-          "ConnectionError"
-        value (ignored because stacktrace takes precedence)
-          "Error while reading from socket: ('Connection closed by server.',)"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/contributing_system_and_app_frames.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:51.127940+00:00'
+created: '2025-11-03T21:48:46.491792+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "161ce02ecc5d6685a72e8e520ab726b3"
+  hash: "9c580bff7b008113595f9f1e0ef1962f"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace*
           frame (marked out of app by stack trace rule (function:runApp -app))
             filename*
@@ -39,18 +43,18 @@ app:
               "playFetch"
             context_line*
               "raise FailedToFetchError('Charlie didn't bring the ball back!');"
-        type*
-          "FailedToFetchError"
-        value (ignored because stacktrace takes precedence)
-          "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
+  hash: "27e4433059022647e4d83d344cbf738c"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -group))
             filename*
@@ -80,7 +84,3 @@ system:
               "playFetch"
             context_line*
               "raise FailedToFetchError('Charlie didn't bring the ball back!');"
-        type*
-          "FailedToFetchError"
-        value (ignored because stacktrace takes precedence)
-          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:51.148957+00:00'
+created: '2025-11-03T21:48:46.509651+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "FailedToFetchError"
+        value*
+          "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by stack trace rule (function:runApp -app))
             filename*
@@ -32,18 +36,18 @@ app:
               "recordMetrics"
             context_line*
               "return withMetrics(handler, metricName, tags);"
-        type*
-          "FailedToFetchError"
-        value*
-          "FailedToFetchError: Charlie didn't bring the ball back!"
 --------------------------------------------------------------------------
 system:
-  hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
+  hash: "9b3e1c08a50257c5ad760f1f3205a48b"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "FailedToFetchError"
+        value (ignored because stacktrace takes precedence)
+          "FailedToFetchError: Charlie didn't bring the ball back!"
         stacktrace*
           frame (ignored by stack trace rule (function:runApp -group))
             filename*
@@ -66,7 +70,3 @@ system:
               "recordMetrics"
             context_line*
               "return withMetrics(handler, metricName, tags);"
-        type*
-          "FailedToFetchError"
-        value (ignored because stacktrace takes precedence)
-          "FailedToFetchError: Charlie didn't bring the ball back!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:51.341330+00:00'
+created: '2025-11-03T21:48:46.684443+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because custom client fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -164,10 +168,6 @@ app:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
@@ -181,6 +181,10 @@ system:
   root_component:
     system (ignored because custom client fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame*
             module*
@@ -335,7 +339,3 @@ system:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:51.322314+00:00'
+created: '2025-11-03T21:48:46.665299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -164,10 +168,6 @@ app:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
@@ -181,6 +181,10 @@ system:
   root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame*
             module*
@@ -335,7 +339,3 @@ system:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:51.365591+00:00'
+created: '2025-11-03T21:48:46.702383+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -164,10 +168,6 @@ app:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
@@ -181,6 +181,10 @@ system:
   root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame*
             module*
@@ -335,7 +339,3 @@ system:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:51.420329+00:00'
+created: '2025-11-03T21:48:46.737254+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,13 +12,13 @@ app:
       exception*
         type*
           "iOS_Swift.SampleError"
+        value (ignored because ns-error info takes precedence)
+          "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
         ns_error*
           domain*
             "iOS_Swift.SampleError"
           code*
             0
-        value (ignored because ns-error info takes precedence)
-          "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
       threads (ignored because app exception takes precedence)
         stacktrace*
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_compute_hashes_2.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2025-10-29T21:18:51.438210+00:00'
+created: '2025-11-03T21:48:46.753085+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "9509e122c6175606d52862fa4f64853c"
+  hash: "ebcb7aa3baed0b2447fed7b265db777c"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
-        stacktrace*
-          frame* (marked in-app by the client)
-            filename*
-              "baz.py"
         type*
           "ValueError"
         value (ignored because stacktrace takes precedence)
           "hello world"
+        stacktrace*
+          frame* (marked in-app by the client)
+            filename*
+              "baz.py"
 --------------------------------------------------------------------------
 system:
   hash: null
@@ -26,11 +26,11 @@ system:
   root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
-        stacktrace*
-          frame*
-            filename*
-              "baz.py"
         type*
           "ValueError"
         value (ignored because stacktrace takes precedence)
           "hello world"
+        stacktrace*
+          frame*
+            filename*
+              "baz.py"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_compute_hashes_3.pysnap
@@ -1,33 +1,33 @@
 ---
-created: '2025-10-29T21:18:51.455125+00:00'
+created: '2025-11-03T21:48:46.770148+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "669cb6664e0f5fed38665da04e464f7e"
+  hash: "8c527d091797ca91a535be7b461e5059"
   contributing component: chained_exception
   hint: None
   root_component:
     app*
       chained_exception*
         exception*
-          stacktrace*
-            frame* (marked in-app by the client)
-              filename*
-                "baz.py"
           type*
             "ValueError"
           value (ignored because stacktrace takes precedence)
             "hello world"
+          stacktrace*
+            frame* (marked in-app by the client)
+              filename*
+                "baz.py"
         exception*
-          stacktrace*
-            frame* (marked in-app by the client)
-              filename*
-                "baz.py"
           type*
             "ValueError"
           value (ignored because stacktrace takes precedence)
             "hello world"
+          stacktrace*
+            frame* (marked in-app by the client)
+              filename*
+                "baz.py"
 --------------------------------------------------------------------------
 system:
   hash: null
@@ -37,20 +37,20 @@ system:
     system (ignored because app exception takes precedence)
       chained_exception (ignored because hash matches app variant)
         exception*
-          stacktrace*
-            frame*
-              filename*
-                "baz.py"
           type*
             "ValueError"
           value (ignored because stacktrace takes precedence)
             "hello world"
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"
         exception*
-          stacktrace*
-            frame*
-              filename*
-                "baz.py"
           type*
             "ValueError"
           value (ignored because stacktrace takes precedence)
             "hello world"
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,16 +1,20 @@
 ---
-created: '2025-10-29T21:18:51.802701+00:00'
+created: '2025-11-03T21:48:47.065781+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "d505dfb9059ac63c11955233323a9100"
+  hash: "1ddf9a146f61f3c8667d7312727caff2"
   contributing component: chained_exception
   hint: None
   root_component:
     app*
       chained_exception*
         exception*
+          type*
+            "DoStuffException"
+          value (ignored because stacktrace takes precedence)
+            "Can't do the stuff"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -22,11 +26,11 @@ app:
                 "dostuff"
               function*
                 "do_different_stuff"
-          type*
-            "DoStuffException"
-          value (ignored because stacktrace takes precedence)
-            "Can't do the stuff"
         exception*
+          type*
+            "DoOtherStuffException"
+          value (ignored because stacktrace takes precedence)
+            "Can't do the other stuff"
           stacktrace*
             frame* (marked in-app by the client)
               module*
@@ -38,10 +42,6 @@ app:
                 "dostuff"
               function*
                 "do_other_stuff"
-          type*
-            "DoOtherStuffException"
-          value (ignored because stacktrace takes precedence)
-            "Can't do the other stuff"
         exception*
           type*
             "System.AggregateException"
@@ -49,13 +49,17 @@ app:
             "One or more errors occurred."
 --------------------------------------------------------------------------
 system:
-  hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
+  hash: "f9f80cec48a38448579e3c41b9c525f5"
   contributing component: chained_exception
   hint: None
   root_component:
     system*
       chained_exception*
         exception*
+          type*
+            "DoStuffException"
+          value (ignored because stacktrace takes precedence)
+            "Can't do the stuff"
           stacktrace*
             frame*
               module*
@@ -67,11 +71,11 @@ system:
                 "dostuff"
               function*
                 "do_different_stuff"
-          type*
-            "DoStuffException"
-          value (ignored because stacktrace takes precedence)
-            "Can't do the stuff"
         exception*
+          type*
+            "DoOtherStuffException"
+          value (ignored because stacktrace takes precedence)
+            "Can't do the other stuff"
           stacktrace*
             frame*
               module*
@@ -83,7 +87,3 @@ system:
                 "dostuff"
               function*
                 "do_other_stuff"
-          type*
-            "DoOtherStuffException"
-          value (ignored because stacktrace takes precedence)
-            "Can't do the other stuff"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:51.878066+00:00'
+created: '2025-11-03T21:48:47.115869+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "TypeError"
+        value*
+          "Cannot read property 'submitError' of null"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -27,18 +31,18 @@ app:
               "onError"
             context_line*
               "this.model.submitError(error);"
-        type*
-          "TypeError"
-        value*
-          "Cannot read property 'submitError' of null"
 --------------------------------------------------------------------------
 system:
-  hash: "26552f86ca2368e708afa1df6effc1c5"
+  hash: "9b140b41d4ae2bd9588ccff62cb8358f"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "TypeError"
+        value (ignored because stacktrace takes precedence)
+          "Cannot read property 'submitError' of null"
         stacktrace*
           frame*
             module*
@@ -56,7 +60,3 @@ system:
               "onError"
             context_line*
               "this.model.submitError(error);"
-        type*
-          "TypeError"
-        value (ignored because stacktrace takes precedence)
-          "Cannot read property 'submitError' of null"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:51.967515+00:00'
+created: '2025-11-03T21:48:47.177593+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,8 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "EXC_BAD_ACCESS"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -29,16 +31,16 @@ app:
           frame (marked out of app by the client)
             function*
               "objc_release"
-        type*
-          "EXC_BAD_ACCESS"
 --------------------------------------------------------------------------
 system:
-  hash: "87497299851e09febfecf4e84e0d45ba"
+  hash: "c670c5a80a2775994bd2d63b408abd6c"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "EXC_BAD_ACCESS"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -58,5 +60,3 @@ system:
           frame*
             function*
               "objc_release"
-        type*
-          "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/go_pkg_mod.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:52.762922+00:00'
+created: '2025-11-03T21:48:47.789210+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "4b8bbc500bd2cabfcadc1f1be867e0bb"
+  hash: "98ba9d44b8e7924ce21654996f92c2eb"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "*pq.Error"
+        value (ignored because stacktrace takes precedence)
+          "pq: cannot cast jsonb null to type integer"
         stacktrace*
           frame (marked out of app by stack trace rule (path:**/go/pkg/mod/** -app))
             module*
@@ -25,18 +29,18 @@ app:
               "main.go"
             function*
               "background.func2"
-        type*
-          "*pq.Error"
-        value (ignored because stacktrace takes precedence)
-          "pq: cannot cast jsonb null to type integer"
 --------------------------------------------------------------------------
 system:
-  hash: "348fc4026c9fa11ffba8fbfa80a134c9"
+  hash: "6bbf86806a0ec54202e633626ae09bd4"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "*pq.Error"
+        value (ignored because stacktrace takes precedence)
+          "pq: cannot cast jsonb null to type integer"
         stacktrace*
           frame*
             module*
@@ -52,7 +56,3 @@ system:
               "main.go"
             function*
               "background.func2"
-        type*
-          "*pq.Error"
-        value (ignored because stacktrace takes precedence)
-          "pq: cannot cast jsonb null to type integer"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.783431+00:00'
+created: '2025-11-03T21:48:47.808412+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / 0x00000032"
+        value* (stripped event-specific values)
+          "Fatal Error: EXC_BAD_ACCESS / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -139,10 +143,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "ImageLoaderMachOCompressed::rebase"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / 0x00000032"
-        value* (stripped event-specific values)
-          "Fatal Error: EXC_BAD_ACCESS / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "3da34e8c72dbcd4a490ac36eb7130638"
@@ -151,6 +151,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / 0x00000032"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -280,7 +284,3 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoaderMachOCompressed::rebase"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / 0x00000032"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXC_BAD_ACCESS / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.802796+00:00'
+created: '2025-11-03T21:48:47.826549+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value*
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -83,10 +87,6 @@ app:
           frame (non app frame)
             function*
               "RtlpOptimizeWaitOnAddressWaitList"
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_WRITE"
-        value*
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
 --------------------------------------------------------------------------
 system:
   hash: "ca733a48a19d237df8577d09449095d9"
@@ -95,6 +95,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -168,7 +172,3 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpOptimizeWaitOnAddressWaitList"
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_WRITE"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.823722+00:00'
+created: '2025-11-03T21:48:47.845500+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value*
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -99,10 +103,6 @@ app:
           frame (non app frame)
             function*
               "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-        value*
-          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
 --------------------------------------------------------------------------
 system:
   hash: "2c1bbd635b64d5adccdb64a620044075"
@@ -111,6 +111,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -200,7 +204,3 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.844160+00:00'
+created: '2025-11-03T21:48:47.862685+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
@@ -91,10 +95,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "9c336f632f6764c0f082a6a66edbf22d"
@@ -103,6 +103,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
@@ -184,7 +188,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.864858+00:00'
+created: '2025-11-03T21:48:47.881809+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -140,10 +144,6 @@ app:
             function*
               "__abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "49b6f72b6635cb43190c57ee56b026b0"
@@ -152,6 +152,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame
           frame (ignored by stack trace rule (category:threadbase -group v-group))
@@ -282,7 +286,3 @@ system:
             function*
               "__abort"
           frame
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.889664+00:00'
+created: '2025-11-03T21:48:47.901646+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -155,10 +159,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "49b6f72b6635cb43190c57ee56b026b0"
@@ -167,6 +167,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -312,7 +316,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.912997+00:00'
+created: '2025-11-03T21:48:47.919501+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+        value*
+          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -59,10 +63,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__dynamic_cast"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-        value*
-          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
@@ -71,6 +71,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -120,7 +124,3 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "__dynamic_cast"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.934142+00:00'
+created: '2025-11-03T21:48:47.938214+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+        value*
+          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -54,10 +58,6 @@ app:
             function*
               "stripped_application_code"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-        value*
-          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
@@ -66,6 +66,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -110,7 +114,3 @@ system:
             function*
               "stripped_application_code"
           frame
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.956481+00:00'
+created: '2025-11-03T21:48:47.958605+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -188,10 +192,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
@@ -200,6 +200,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -378,7 +382,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:52.978960+00:00'
+created: '2025-11-03T21:48:47.979385+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -193,10 +197,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
@@ -205,6 +205,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -388,7 +392,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.001812+00:00'
+created: '2025-11-03T21:48:48.001630+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -191,10 +195,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "7e64037e487c78ce0439f750a2ef503f"
@@ -203,6 +203,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -384,7 +388,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.020180+00:00'
+created: '2025-11-03T21:48:48.019106+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value*
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -41,10 +45,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_testcancel"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-        value*
-          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
@@ -53,6 +53,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -84,7 +88,3 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "_pthread_testcancel"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.041211+00:00'
+created: '2025-11-03T21:48:48.038348+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -125,10 +129,6 @@ app:
               "crashpad_client_win.cc"
             function*
               "crashpad::`anonymous namespace'::HandleAbortSignal"
-        type (ignored because exception is synthetic)
-          "0x40000015 / 0x00000001"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "6148c73af04344a8597354711f5951ea"
@@ -137,6 +137,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -252,7 +256,3 @@ system:
               "crashpad_client_win.cc"
             function*
               "crashpad::`anonymous namespace'::HandleAbortSignal"
-        type (ignored because exception is synthetic)
-          "0x40000015 / 0x00000001"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.061261+00:00'
+created: '2025-11-03T21:48:48.057857+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -125,10 +129,6 @@ app:
               "crashpad_client_win.cc"
             function*
               "crashpad::`anonymous namespace'::HandleAbortSignal"
-        type (ignored because exception is synthetic)
-          "0x40000015 / 0x00000001"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "1056f62d72ff8b4d0c3842d696dbb10a"
@@ -137,6 +137,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -252,7 +256,3 @@ system:
               "crashpad_client_win.cc"
             function*
               "crashpad::`anonymous namespace'::HandleAbortSignal"
-        type (ignored because exception is synthetic)
-          "0x40000015 / 0x00000001"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.084590+00:00'
+created: '2025-11-03T21:48:48.077798+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -146,10 +150,6 @@ app:
               "crashpad_client_win.cc"
             function*
               "crashpad::`anonymous namespace'::HandleAbortSignal"
-        type (ignored because exception is synthetic)
-          "0x40000015 / 0x00000001"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "15526a7b64e9b5dc6d89e7ebec864260"
@@ -158,6 +158,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -294,7 +298,3 @@ system:
               "crashpad_client_win.cc"
             function*
               "crashpad::`anonymous namespace'::HandleAbortSignal"
-        type (ignored because exception is synthetic)
-          "0x40000015 / 0x00000001"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,16 +1,20 @@
 ---
-created: '2025-10-29T21:18:53.140706+00:00'
+created: '2025-11-03T21:48:48.127457+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "19163f3ca34f5995c69d85351ce3d697"
+  hash: "b0dbf92202bf38adc8710e8ccd55d3df"
   contributing component: exception
   hint: None
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   root_component:
     app*
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -165,20 +169,20 @@ app:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"
   values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: "847950eb44d280e6758d136c763d6ddc"
+  hash: "e440cd285687bab8b861ff96fe713929"
   contributing component: exception
   hint: None
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   root_component:
     system*
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame*
             module*
@@ -333,8 +337,4 @@ system:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"
   values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.159529+00:00'
+created: '2025-11-03T21:48:48.148183+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -164,10 +168,6 @@ app:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
@@ -181,6 +181,10 @@ system:
   root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*
+        type*
+          "SoftTimeLimitExceeded"
+        value (ignored because stacktrace takes precedence)
+          "SoftTimeLimitExceeded()"
         stacktrace*
           frame*
             module*
@@ -335,7 +339,3 @@ system:
               "soft_timeout_sighandler"
             context_line*
               "raise SoftTimeLimitExceeded()"
-        type*
-          "SoftTimeLimitExceeded"
-        value (ignored because stacktrace takes precedence)
-          "SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.214678+00:00'
+created: '2025-11-03T21:48:48.199099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
         stacktrace*
           frame (marked out of app by the client)
             function*
@@ -145,10 +149,6 @@ app:
               "currentuserprofile.swift"
             function*
               "value"
-        type (ignored because exception is synthetic)
-          "EXC_BREAKPOINT"
-        value (ignored because stacktrace takes precedence)
-          "autoplayOption"
 --------------------------------------------------------------------------
 system:
   hash: "1921b991270e24c19ea1ed6863892d71"
@@ -157,6 +157,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -292,7 +296,3 @@ system:
               "currentuserprofile.swift"
             function*
               "value"
-        type (ignored because exception is synthetic)
-          "EXC_BREAKPOINT"
-        value (ignored because stacktrace takes precedence)
-          "autoplayOption"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.235909+00:00'
+created: '2025-11-03T21:48:48.222242+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,6 +11,10 @@ app:
     app (ignored because system exception takes precedence)
       chained_exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         exception*
+          type*
+            "BindException"
+          value*
+            "Address already in use"
           stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by the client)
               module*
@@ -173,11 +177,11 @@ app:
                 "net.java"
               function*
                 "bind0"
-          type*
-            "BindException"
-          value*
-            "Address already in use"
         exception*
+          type*
+            "LifecycleException"
+          value*
+            "service.getName(): \"Tomcat\";  Protocol handler start failed"
           stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by the client)
               module*
@@ -284,11 +288,11 @@ app:
                 "connector.java"
               function*
                 "startInternal"
+        exception*
           type*
             "LifecycleException"
-          value*
-            "service.getName(): \"Tomcat\";  Protocol handler start failed"
-        exception*
+          value* (stripped event-specific values)
+            "Failed to start component [Connector[HTTP/<float><int>]]"
           stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by stack trace rule (category:framework -app))
               module*
@@ -388,10 +392,6 @@ app:
                 "lifecyclebase.java"
               function*
                 "start"
-          type*
-            "LifecycleException"
-          value* (stripped event-specific values)
-            "Failed to start component [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 default:
   hash: null
@@ -403,13 +403,17 @@ default:
         "Failed to start connector [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 system:
-  hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
+  hash: "db7a5bf0e72c22eb770a3be8940782c6"
   contributing component: chained_exception
   hint: None
   root_component:
     system*
       chained_exception*
         exception*
+          type*
+            "BindException"
+          value (ignored because stacktrace takes precedence)
+            "Address already in use"
           stacktrace*
             frame (ignored by stack trace rule (module:io.sentry.* -group))
               module*
@@ -572,11 +576,11 @@ system:
                 "net.java"
               function*
                 "bind0"
-          type*
-            "BindException"
-          value (ignored because stacktrace takes precedence)
-            "Address already in use"
         exception*
+          type*
+            "LifecycleException"
+          value (ignored because stacktrace takes precedence)
+            "service.getName(): \"Tomcat\";  Protocol handler start failed"
           stacktrace*
             frame (ignored by stack trace rule (module:io.sentry.* -group))
               module*
@@ -683,11 +687,11 @@ system:
                 "connector.java"
               function*
                 "startInternal"
+        exception*
           type*
             "LifecycleException"
           value (ignored because stacktrace takes precedence)
-            "service.getName(): \"Tomcat\";  Protocol handler start failed"
-        exception*
+            "Failed to start component [Connector[HTTP/<float><int>]]"
           stacktrace*
             frame (ignored by stack trace rule (module:io.sentry.* -group))
               module*
@@ -787,7 +791,3 @@ system:
                 "lifecyclebase.java"
               function*
                 "start"
-          type*
-            "LifecycleException"
-          value (ignored because stacktrace takes precedence)
-            "Failed to start component [Connector[HTTP/<float><int>]]"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.257556+00:00'
+created: '2025-11-03T21:48:48.245903+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "ArithmeticException"
+        value*
+          "/ by zero"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -396,10 +400,6 @@ app:
               "application.java"
             function*
               "home"
-        type*
-          "ArithmeticException"
-        value*
-          "/ by zero"
 --------------------------------------------------------------------------
 default:
   hash: null
@@ -411,12 +411,16 @@ default:
         "Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.ArithmeticException: / by zero] with root cause"
 --------------------------------------------------------------------------
 system:
-  hash: "ef2555bf7958ada8eefafbfdaed1c409"
+  hash: "6c27831782d10c44d7d0a01ef3f9c71e"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "ArithmeticException"
+        value (ignored because stacktrace takes precedence)
+          "/ by zero"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
@@ -803,7 +807,3 @@ system:
               "application.java"
             function*
               "home"
-        type*
-          "ArithmeticException"
-        value (ignored because stacktrace takes precedence)
-          "/ by zero"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.311339+00:00'
+created: '2025-11-03T21:48:48.305076+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "ReferenceError"
+        value*
+          "varant is not defined"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             filename*
@@ -71,18 +75,18 @@ app:
               "react-dom.development.js"
             function* (trimmed javascript function)
               "callCallback"
-        type*
-          "ReferenceError"
-        value*
-          "varant is not defined"
 --------------------------------------------------------------------------
 system:
-  hash: "c0f3f7d6deb17aec9d07259ac684fad0"
+  hash: "e734632ed44ebbaaeee1d0f589397a1a"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "ReferenceError"
+        value (ignored because stacktrace takes precedence)
+          "varant is not defined"
         stacktrace*
           frame*
             filename*
@@ -144,7 +148,3 @@ system:
               "react-dom.development.js"
             function* (trimmed javascript function)
               "callCallback"
-        type*
-          "ReferenceError"
-        value (ignored because stacktrace takes precedence)
-          "varant is not defined"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.364644+00:00'
+created: '2025-11-03T21:48:48.363869+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app*
       exception*
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (module:@babel/** -app))
             module*
@@ -26,10 +30,6 @@ app:
               "tslib/tslib.es6"
             function* (trimmed javascript function)
               "sent"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
   hash: null
@@ -38,6 +38,10 @@ system:
   root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (module:@babel/** -group))
             module*
@@ -54,7 +58,3 @@ system:
               "tslib/tslib.es6"
             function* (trimmed javascript function)
               "sent"
-        type*
-          "Error"
-        value*
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.382896+00:00'
+created: '2025-11-03T21:48:48.383875+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (path:**https://unpkg.com/** -app))
             module*
@@ -33,18 +37,18 @@ app:
               "d3@7.6.1"
             function* (trimmed javascript function)
               "run"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "6ab78545e13144405fb21dadb9045b91"
+  hash: "96955d6eb6b1c842b7c64ac8eb3ffe8d"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             module*
@@ -68,7 +72,3 @@ system:
               "d3@7.6.1"
             function* (trimmed javascript function)
               "run"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.419817+00:00'
+created: '2025-11-03T21:48:48.404305+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             filename*
@@ -57,18 +61,18 @@ app:
               "test.html"
             function* (trimmed javascript function)
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "c63e8727af1a8fe75872b6a762797113"
+  hash: "811a408067f03b8eff2437a8e7515966"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             filename*
@@ -116,7 +120,3 @@ system:
               "test.html"
             function* (trimmed javascript function)
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.436958+00:00'
+created: '2025-11-03T21:48:48.424139+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             filename*
@@ -61,18 +65,18 @@ app:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "c63e8727af1a8fe75872b6a762797113"
+  hash: "811a408067f03b8eff2437a8e7515966"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             filename*
@@ -124,7 +128,3 @@ system:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.455544+00:00'
+created: '2025-11-03T21:48:48.446469+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             filename*
@@ -54,18 +58,18 @@ app:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "c63e8727af1a8fe75872b6a762797113"
+  hash: "811a408067f03b8eff2437a8e7515966"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             filename*
@@ -110,7 +114,3 @@ system:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.473167+00:00'
+created: '2025-11-03T21:48:48.467935+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -75,18 +79,18 @@ app:
               "test.html"
             function* (trimmed javascript function)
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "b2602ad455472dede8e4c340d8a7eaba"
+  hash: "c21dd7692399d460904836c279bbeb36"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             module*
@@ -152,7 +156,3 @@ system:
               "test.html"
             function* (trimmed javascript function)
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.490818+00:00'
+created: '2025-11-03T21:48:48.487877+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -79,18 +83,18 @@ app:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "b2602ad455472dede8e4c340d8a7eaba"
+  hash: "c21dd7692399d460904836c279bbeb36"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             module*
@@ -160,7 +164,3 @@ system:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.508534+00:00'
+created: '2025-11-03T21:48:48.509450+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -72,18 +76,18 @@ app:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "b2602ad455472dede8e4c340d8a7eaba"
+  hash: "c21dd7692399d460904836c279bbeb36"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             module*
@@ -146,7 +150,3 @@ system:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.536914+00:00'
+created: '2025-11-03T21:48:48.529111+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -78,18 +82,18 @@ app:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "b2602ad455472dede8e4c340d8a7eaba"
+  hash: "c21dd7692399d460904836c279bbeb36"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             module*
@@ -158,7 +162,3 @@ system:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.558080+00:00'
+created: '2025-11-03T21:48:48.547734+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             filename*
@@ -62,18 +66,18 @@ app:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "c63e8727af1a8fe75872b6a762797113"
+  hash: "811a408067f03b8eff2437a8e7515966"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
         stacktrace*
           frame*
             filename*
@@ -126,7 +130,3 @@ system:
               "test.html"
             function*
               "aha"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:53.578976+00:00'
+created: '2025-11-03T21:48:48.570354+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "4a3cf3893b6485428dd02da116c8370e"
+  hash: "b5165008246a0897e1e7d18eb1df4d33"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "NotFoundError"
+        value (ignored because stacktrace takes precedence)
+          "GET /issues/<int>/events/latest/ <int>"
         stacktrace*
           frame (marked out of app by the client)
             module*
@@ -173,18 +177,18 @@ app:
               "fetchGroupEventAndMarkSeen"
             context_line*
               "const preservedError = new Error();"
-        type*
-          "NotFoundError"
-        value (ignored because stacktrace takes precedence)
-          "GET /issues/<int>/events/latest/ <int>"
 --------------------------------------------------------------------------
 system:
-  hash: "d5456487ea8dccfe96c1968b19870978"
+  hash: "f9e1efa045242909883a37dc74e4fc97"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "NotFoundError"
+        value (ignored because stacktrace takes precedence)
+          "GET /issues/<int>/events/latest/ <int>"
         stacktrace*
           frame*
             module*
@@ -348,7 +352,3 @@ system:
               "fetchGroupEventAndMarkSeen"
             context_line*
               "const preservedError = new Error();"
-        type*
-          "NotFoundError"
-        value (ignored because stacktrace takes precedence)
-          "GET /issues/<int>/events/latest/ <int>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:53.598991+00:00'
+created: '2025-11-03T21:48:48.590975+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "4a3cf3893b6485428dd02da116c8370e"
+  hash: "b5165008246a0897e1e7d18eb1df4d33"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "NotFoundError"
+        value (ignored because stacktrace takes precedence)
+          "GET /issues/<int>/events/latest/ <int>"
         stacktrace*
           frame (marked in-app by the client but ignored low quality javascript frame)
             filename (ignored because filename suggests native code)
@@ -142,18 +146,18 @@ app:
               "fetchGroupEventAndMarkSeen"
             context_line*
               "const preservedError = new Error();"
-        type*
-          "NotFoundError"
-        value (ignored because stacktrace takes precedence)
-          "GET /issues/<int>/events/latest/ <int>"
 --------------------------------------------------------------------------
 system:
-  hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
+  hash: "ff35b5385c8228096073758c6f50075b"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "NotFoundError"
+        value (ignored because stacktrace takes precedence)
+          "GET /issues/<int>/events/latest/ <int>"
         stacktrace*
           frame (ignored low quality javascript frame)
             filename (ignored because filename suggests native code)
@@ -286,7 +290,3 @@ system:
               "fetchGroupEventAndMarkSeen"
             context_line*
               "const preservedError = new Error();"
-        type*
-          "NotFoundError"
-        value (ignored because stacktrace takes precedence)
-          "GET /issues/<int>/events/latest/ <int>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/laravel.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:53.637894+00:00'
+created: '2025-11-03T21:48:48.634769+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "4665d486184740231357ab63f4543a8d"
+  hash: "04604148d9d04bfb7b3b3c19810a995c"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "Exception"
+        value (ignored because stacktrace takes precedence)
+          "LARAVEL TEST"
         stacktrace*
           frame* (marked in-app by the client)
             filename*
@@ -359,18 +363,18 @@ app:
               "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
             context_line*
               "throw new Exception('LARAVEL TEST');"
-        type*
-          "Exception"
-        value (ignored because stacktrace takes precedence)
-          "LARAVEL TEST"
 --------------------------------------------------------------------------
 system:
-  hash: "107ed03036d901157372f260bc3df446"
+  hash: "f3b018db683f7190f410fec0fbc1a9b3"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Exception"
+        value (ignored because stacktrace takes precedence)
+          "LARAVEL TEST"
         stacktrace*
           frame*
             filename*
@@ -720,7 +724,3 @@ system:
               "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
             context_line*
               "throw new Exception('LARAVEL TEST');"
-        type*
-          "Exception"
-        value (ignored because stacktrace takes precedence)
-          "LARAVEL TEST"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/laravel_anonymous.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:53.616591+00:00'
+created: '2025-11-03T21:48:48.611715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a728cdf5d62c8e017c35c3fe04051b6e"
+  hash: "bf617e996d4427cda2f75c965c4266e2"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "Exception"
+        value (ignored because stacktrace takes precedence)
+          "LARAVEL TEST"
         stacktrace*
           frame* (marked in-app by the client)
             filename*
@@ -30,18 +34,18 @@ app:
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context_line*
               "? $pipe->{$this->method}(...$parameters)"
-        type*
-          "Exception"
-        value (ignored because stacktrace takes precedence)
-          "LARAVEL TEST"
 --------------------------------------------------------------------------
 system:
-  hash: "63c67781779781d9b0a442a5b2bdb976"
+  hash: "dc13fee96d9e544e8aee8f1b4e6cbf22"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Exception"
+        value (ignored because stacktrace takes precedence)
+          "LARAVEL TEST"
         stacktrace*
           frame*
             filename*
@@ -62,7 +66,3 @@ system:
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
             context_line*
               "? $pipe->{$this->method}(...$parameters)"
-        type*
-          "Exception"
-        value (ignored because stacktrace takes precedence)
-          "LARAVEL TEST"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.694092+00:00'
+created: '2025-11-03T21:48:48.690924+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -154,10 +158,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "b8baf791d22ac902d5f59a7eedd844fd"
@@ -166,6 +166,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -310,7 +314,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.716859+00:00'
+created: '2025-11-03T21:48:48.715852+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value* (stripped event-specific values)
+          "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -182,10 +186,6 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value* (stripped event-specific values)
-          "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "36be6e0b6123ef6ecfbef62f5cb88406"
@@ -194,6 +194,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -366,7 +370,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type (ignored because exception is synthetic)
-          "0x00000000 / 0x00000000"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.738417+00:00'
+created: '2025-11-03T21:48:48.738331+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "SIGABRT"
+        value*
+          "<redacted>"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -95,18 +99,18 @@ app:
           frame (marked out of app by the client)
             function*
               "__pthread_kill"
-        type*
-          "SIGABRT"
-        value*
-          "<redacted>"
 --------------------------------------------------------------------------
 system:
-  hash: "70b7b816193e06eb5d6649989fbaf605"
+  hash: "ca6e8f30e1e7b088514deb26ec59b379"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -192,7 +196,3 @@ system:
           frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
-        type*
-          "SIGABRT"
-        value (ignored because stacktrace takes precedence)
-          "<redacted>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.819123+00:00'
+created: '2025-11-03T21:48:48.803467+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,8 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "NS_ERROR_NOT_INITIALIZED"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
@@ -209,16 +211,16 @@ app:
               "wrapTimeFunction/<"
             context_line (ignored because line is too long)
               "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"
-        type*
-          "NS_ERROR_NOT_INITIALIZED"
 --------------------------------------------------------------------------
 system:
-  hash: "dcfcd48a02c100bbe4023cbc783054f0"
+  hash: "e1b3abdef8ab7e7c723645e9f52a44c6"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "NS_ERROR_NOT_INITIALIZED"
         stacktrace*
           frame*
             module*
@@ -418,5 +420,3 @@ system:
               "wrapTimeFunction/<"
             context_line (ignored because line is too long)
               "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"
-        type*
-          "NS_ERROR_NOT_INITIALIZED"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.836647+00:00'
+created: '2025-11-03T21:48:48.819932+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value*
+          "Holy shit everything is on fire!"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -20,10 +24,6 @@ app:
           frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value*
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
@@ -32,6 +32,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame*
             function*
@@ -42,7 +46,3 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.856517+00:00'
+created: '2025-11-03T21:48:48.836639+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value*
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -30,10 +34,6 @@ app:
             function*
               "OpenAdapter10"
           frame (marked out of app by the client)
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_READ"
-        value*
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
 --------------------------------------------------------------------------
 system:
   hash: "2e0d26cae5986fcda5edf66612a78268"
@@ -42,6 +42,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
         stacktrace*
           frame*
             function*
@@ -62,7 +66,3 @@ system:
             function*
               "OpenAdapter10"
           frame
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_READ"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.875925+00:00'
+created: '2025-11-03T21:48:48.852802+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value*
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -25,10 +29,6 @@ app:
               "OpenAdapter10"
           frame (marked out of app by the client)
           frame (marked out of app by the client)
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_READ"
-        value*
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
 --------------------------------------------------------------------------
 system:
   hash: "c85e23e804b52ea4b9f290ba838e77a0"
@@ -37,6 +37,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
         stacktrace*
           frame*
             function*
@@ -52,7 +56,3 @@ system:
               "OpenAdapter10"
           frame
           frame (ignored due to recursion)
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_READ"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.895429+00:00'
+created: '2025-11-03T21:48:48.868670+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value*
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -31,10 +35,6 @@ app:
             function*
               "OpenAdapter12"
           frame (marked out of app by the client)
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_READ"
-        value*
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
 --------------------------------------------------------------------------
 system:
   hash: "784442a33bd16c15013bb8f69f68e7d6"
@@ -43,6 +43,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
         stacktrace*
           frame*
             function*
@@ -64,7 +68,3 @@ system:
             function*
               "OpenAdapter12"
           frame
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_READ"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.916535+00:00'
+created: '2025-11-03T21:48:48.884914+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value*
+          "Holy shit everything is on fire!"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -20,10 +24,6 @@ app:
           frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value*
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
   hash: "8f4c7709e4af98d3c47ce3519690e6d9"
@@ -32,6 +32,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame (ignored because only 1 frame is considered by stack trace rule (family:native max-frames=1))
             function*
@@ -42,7 +46,3 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.937749+00:00'
+created: '2025-11-03T21:48:48.902096+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+        value*
+          "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -29,10 +33,6 @@ app:
           frame (marked out of app by the client)
             function*
               "nanov2_allocate_from_block.cold.1"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
-        value*
-          "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
 --------------------------------------------------------------------------
 system:
   hash: "3ff01ce959249abecc6bc8a8f1432b0b"
@@ -41,6 +41,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
         stacktrace*
           frame*
             function*
@@ -60,7 +64,3 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "nanov2_allocate_from_block.cold.1"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.959867+00:00'
+created: '2025-11-03T21:48:48.919359+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app*
       exception*
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame* (marked in-app by the client)
             function*
@@ -53,10 +57,6 @@ app:
           frame (marked out of app by the client)
             function (ignored unknown function)
               "<redacted>"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
   hash: "bbcdb2e1d8df09ffe0fffd30fb361d4b"
@@ -65,6 +65,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame*
             function*
@@ -108,7 +112,3 @@ system:
           frame
             function (ignored unknown function)
               "<redacted>"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.979377+00:00'
+created: '2025-11-03T21:48:48.937055+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value*
+          "Holy shit everything is on fire!"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             function*
@@ -20,10 +24,6 @@ app:
           frame (marked out of app by the client)
             function*
               "<lambda>::operator()"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value*
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
@@ -32,6 +32,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame*
             function*
@@ -42,7 +46,3 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
-        type (ignored because exception is synthetic)
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:53.998737+00:00'
+created: '2025-11-03T21:48:48.953800+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value*
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             filename*
@@ -36,10 +40,6 @@ app:
               "main.cpp"
             function*
               "`anonymous namespace'::crash"
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_WRITE"
-        value*
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
 --------------------------------------------------------------------------
 system:
   hash: "46b84e4da51648cc9f9741abd2bdad51"
@@ -48,6 +48,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
@@ -74,7 +78,3 @@ system:
               "main.cpp"
             function*
               "`anonymous namespace'::crash"
-        type (ignored because exception is synthetic)
-          "EXCEPTION_ACCESS_VIOLATION_WRITE"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:54.017670+00:00'
+created: '2025-11-03T21:48:48.971415+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value*
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             filename*
@@ -31,10 +35,6 @@ app:
               "main.cpp"
             function*
               "(anonymous namespace)::something::nested::Foo<T>::crash"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-        value*
-          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
       threads (ignored because thread has no stacktrace)
 --------------------------------------------------------------------------
 system:
@@ -44,6 +44,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace*
           frame*
             filename*
@@ -65,7 +69,3 @@ system:
               "main.cpp"
             function*
               "(anonymous namespace)::something::nested::Foo<T>::crash"
-        type (ignored because exception is synthetic)
-          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/node_exception_weird.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.040454+00:00'
+created: '2025-11-03T21:48:48.988222+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a20509269752c9a1bea6078851e4d39c"
+  hash: "6a84e724a0d67c6b036ecc24fcfb4be5"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bla"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -97,18 +101,18 @@ app:
               "backend.ts"
             function* (trimmed javascript function)
               "eventFromException"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bla"
 --------------------------------------------------------------------------
 system:
-  hash: "252dc79eb5653bf822e2684d90734cb8"
+  hash: "97adcd276fbfdd9ae8271c04255e522f"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bla"
         stacktrace*
           frame*
             module*
@@ -196,7 +200,3 @@ system:
               "backend.ts"
             function* (trimmed javascript function)
               "eventFromException"
-        type*
-          "Error"
-        value (ignored because stacktrace takes precedence)
-          "bla"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:54.059682+00:00'
+created: '2025-11-03T21:48:49.004067+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app*
       exception*
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (function:processTicksAndRejections -app))
             module*
@@ -23,10 +27,6 @@ app:
               "axiosinterceptor.js"
             function*
               "runMicrotasks"
-        type*
-          "Error"
-        value*
-          "bad"
 --------------------------------------------------------------------------
 system:
   hash: null
@@ -35,6 +35,10 @@ system:
   root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
+        type*
+          "Error"
+        value*
+          "bad"
         stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (function:processTicksAndRejections -group))
             module*
@@ -48,7 +52,3 @@ system:
               "axiosinterceptor.js"
             function*
               "runMicrotasks"
-        type*
-          "Error"
-        value*
-          "bad"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_exception_base.pysnap
@@ -1,56 +1,56 @@
 ---
-created: '2025-10-29T21:18:54.077681+00:00'
+created: '2025-11-03T21:48:49.020838+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "c52ebcc2d9d0780a23c7d99831678830"
+  hash: "beb01c07d991f36b9da1e90fc7169ad8"
   contributing component: chained_exception
   hint: None
   root_component:
     app*
       chained_exception*
         exception*
-          stacktrace*
-            frame* (marked in-app by the client)
-              filename*
-                "baz.py"
           type*
             "ValueError"
           value (ignored because stacktrace takes precedence)
             "hello world"
-        exception*
-          stacktrace (ignored because it contains no in-app frames)
-            frame (marked out of app by the client)
+          stacktrace*
+            frame* (marked in-app by the client)
               filename*
                 "baz.py"
+        exception*
           type*
             "ValueError"
           value*
             "hello world"
+          stacktrace (ignored because it contains no in-app frames)
+            frame (marked out of app by the client)
+              filename*
+                "baz.py"
 --------------------------------------------------------------------------
 system:
-  hash: "669cb6664e0f5fed38665da04e464f7e"
+  hash: "8c527d091797ca91a535be7b461e5059"
   contributing component: chained_exception
   hint: None
   root_component:
     system*
       chained_exception*
         exception*
-          stacktrace*
-            frame*
-              filename*
-                "baz.py"
           type*
             "ValueError"
           value (ignored because stacktrace takes precedence)
             "hello world"
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"
         exception*
-          stacktrace*
-            frame*
-              filename*
-                "baz.py"
           type*
             "ValueError"
           value (ignored because stacktrace takes precedence)
             "hello world"
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.098460+00:00'
+created: '2025-11-03T21:48:49.037739+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "121caa876de75ec51bf72ed4c852cd75"
+  hash: "4ec09a051686463f01ce05bffbcf3f89"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "MultiValueDictKeyError"
+        value (ignored because stacktrace takes precedence)
+          "\"'user'\""
         stacktrace*
           frame (marked out of app by the client)
             module*
@@ -101,18 +105,18 @@ app:
               "__getitem__"
             context_line*
               "raise MultiValueDictKeyError(repr(key))"
-        type*
-          "MultiValueDictKeyError"
-        value (ignored because stacktrace takes precedence)
-          "\"'user'\""
 --------------------------------------------------------------------------
 system:
-  hash: "a5af2577d4caca8f983657c5d1919e14"
+  hash: "b19423b06ce0a7e46ae8b00e12804378"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "MultiValueDictKeyError"
+        value (ignored because stacktrace takes precedence)
+          "\"'user'\""
         stacktrace*
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -204,7 +208,3 @@ system:
               "__getitem__"
             context_line*
               "raise MultiValueDictKeyError(repr(key))"
-        type*
-          "MultiValueDictKeyError"
-        value (ignored because stacktrace takes precedence)
-          "\"'user'\""

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:54.117081+00:00'
+created: '2025-11-03T21:48:49.056215+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "MultiValueDictKeyError"
+        value*
+          "\"'user'\""
         stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by the client)
             module*
@@ -101,18 +105,18 @@ app:
               "__getitem__"
             context_line*
               "raise MultiValueDictKeyError(repr(key))"
-        type*
-          "MultiValueDictKeyError"
-        value*
-          "\"'user'\""
 --------------------------------------------------------------------------
 system:
-  hash: "90888e813b09fa25061af2883c0fb9bd"
+  hash: "5c0a281b9f8602e5d639d2f722fe5a9a"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "MultiValueDictKeyError"
+        value (ignored because stacktrace takes precedence)
+          "\"'user'\""
         stacktrace*
           frame*
             module*
@@ -204,7 +208,3 @@ system:
               "__getitem__"
             context_line*
               "raise MultiValueDictKeyError(repr(key))"
-        type*
-          "MultiValueDictKeyError"
-        value (ignored because stacktrace takes precedence)
-          "\"'user'\""

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_http_error.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.136732+00:00'
+created: '2025-11-03T21:48:49.074194+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "d59239f5aad3304d60beb1fde3369b78"
+  hash: "721f24ff0b900f7945b4da03890d2a83"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "HTTPError"
+        value (ignored because stacktrace takes precedence)
+          "<int> Client Error: Too Many Requests for url: <url>"
         stacktrace*
           frame* (marked in-app by the client)
             module*
@@ -38,10 +42,6 @@ app:
               "raise_for_status"
             context_line*
               "raise HTTPError(http_error_msg, response=self)"
-        type*
-          "HTTPError"
-        value (ignored because stacktrace takes precedence)
-          "<int> Client Error: Too Many Requests for url: <url>"
 --------------------------------------------------------------------------
 default:
   hash: null
@@ -53,12 +53,16 @@ default:
         "%s.process_error"
 --------------------------------------------------------------------------
 system:
-  hash: "133db3f366b1327dab4e661f66dfb961"
+  hash: "d2490be282c0ada7e13288fd90fb0cb3"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "HTTPError"
+        value (ignored because stacktrace takes precedence)
+          "<int> Client Error: Too Many Requests for url: <url>"
         stacktrace*
           frame*
             module*
@@ -87,7 +91,3 @@ system:
               "raise_for_status"
             context_line*
               "raise HTTPError(http_error_msg, response=self)"
-        type*
-          "HTTPError"
-        value (ignored because stacktrace takes precedence)
-          "<int> Client Error: Too Many Requests for url: <url>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/react_native.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.222766+00:00'
+created: '2025-11-03T21:48:49.141554+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "73470e545e51eea9cff8a6c006f68f57"
+  hash: "33e3ac91fc256d3dfb789693be30a883"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "TypeError"
+        value (ignored because stacktrace takes precedence)
+          "undefined is not a function (evaluating '({}).invalidFunction()')"
         stacktrace*
           frame (marked out of app by the client)
             module*
@@ -203,18 +207,18 @@ app:
               "Button"
             context_line*
               "<Button"
-        type*
-          "TypeError"
-        value (ignored because stacktrace takes precedence)
-          "undefined is not a function (evaluating '({}).invalidFunction()')"
 --------------------------------------------------------------------------
 system:
-  hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
+  hash: "618e6a3beb1ecd7d01616b554f6c873a"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "TypeError"
+        value (ignored because stacktrace takes precedence)
+          "undefined is not a function (evaluating '({}).invalidFunction()')"
         stacktrace*
           frame*
             module*
@@ -408,7 +412,3 @@ system:
               "Button"
             context_line*
               "<Button"
-        type*
-          "TypeError"
-        value (ignored because stacktrace takes precedence)
-          "undefined is not a function (evaluating '({}).invalidFunction()')"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:54.363143+00:00'
+created: '2025-11-03T21:48:49.253376+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "log_demo"
+        value*
+          "Holy shit everything is on fire!"
         stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2))
           frame (non app frame)
             function*
@@ -32,18 +36,18 @@ app:
           frame (non app frame)
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value*
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
+  hash: "193a67f0b7f8b5a69f29dc6a259d47c3"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame*
             function*
@@ -66,7 +70,3 @@ system:
           frame*
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:54.436054+00:00'
+created: '2025-11-03T21:48:49.335227+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "log_demo"
+        value*
+          "Holy shit everything is on fire!"
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
@@ -32,18 +36,18 @@ app:
           frame (non app frame)
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value*
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "eb87c1031dba55b67df86fb9fff59dc6"
+  hash: "ef42635ff82b83bc711ed7c65b7cb189"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
@@ -66,7 +70,3 @@ system:
           frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.455969+00:00'
+created: '2025-11-03T21:48:49.370019+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "eb87c1031dba55b67df86fb9fff59dc6"
+  hash: "ef42635ff82b83bc711ed7c65b7cb189"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame (non app frame)
             function*
@@ -32,18 +36,18 @@ app:
           frame (non app frame)
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
+  hash: "193a67f0b7f8b5a69f29dc6a259d47c3"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame*
             function*
@@ -66,7 +70,3 @@ system:
           frame*
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust2.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.476162+00:00'
+created: '2025-11-03T21:48:49.397964+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "eb87c1031dba55b67df86fb9fff59dc6"
+  hash: "ef42635ff82b83bc711ed7c65b7cb189"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame (non app frame)
             function*
@@ -32,18 +36,18 @@ app:
           frame (non app frame)
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "0817e4e604fbe88c4534eff166df1db9"
+  hash: "68021c81b00bc4f2f983b11f10efbfda"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
         stacktrace*
           frame*
             function*
@@ -66,7 +70,3 @@ system:
           frame (ignored by stack trace rule (family:native function:*::__* -group))
             function*
               "log::__private_api_log"
-        type*
-          "log_demo"
-        value (ignored because stacktrace takes precedence)
-          "Holy shit everything is on fire!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unity.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.580594+00:00'
+created: '2025-11-03T21:48:49.480629+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a12d579fed7636c2a5d2fae110c95ce5"
+  hash: "63f25f224c4a56add964d1570880704c"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"
         stacktrace*
           frame (marked out of app by the client)
             filename*
@@ -51,18 +55,18 @@ app:
               "samplescript.cs"
             function*
               "SampleScript.ThrowNull ()"
-        type*
-          "NullReferenceException"
-        value (ignored because stacktrace takes precedence)
-          "Object reference not set to an instance of an object"
 --------------------------------------------------------------------------
 system:
-  hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
+  hash: "7909deacdb3f511a715efb7f2670d4dc"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"
         stacktrace*
           frame*
             filename*
@@ -104,7 +108,3 @@ system:
               "samplescript.cs"
             function*
               "SampleScript.ThrowNull ()"
-        type*
-          "NullReferenceException"
-        value (ignored because stacktrace takes precedence)
-          "Object reference not set to an instance of an object"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.601872+00:00'
+created: '2025-11-03T21:48:49.499753+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "ecb890e5cd60dec2b626d500cc866de4"
+  hash: "2301317599ab22875b83ce2dafdab6ce"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "EXC_BAD_ACCESS"
+        value (ignored because stacktrace takes precedence)
+          "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
         stacktrace*
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -107,18 +111,18 @@ app:
           frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "FGenericPlatformMisc::RaiseException"
-        type*
-          "EXC_BAD_ACCESS"
-        value (ignored because stacktrace takes precedence)
-          "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
 --------------------------------------------------------------------------
 system:
-  hash: "57493ac3e558feffb778cf170a7fd986"
+  hash: "65c0ee687814f8d166cc29c9443ffc8a"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "EXC_BAD_ACCESS"
+        value (ignored because stacktrace takes precedence)
+          "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -216,7 +220,3 @@ system:
           frame*
             function*
               "FGenericPlatformMisc::RaiseException"
-        type*
-          "EXC_BAD_ACCESS"
-        value (ignored because stacktrace takes precedence)
-          "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:54.621684+00:00'
+created: '2025-11-03T21:48:49.519229+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app*
       exception*
+        type (ignored because exception is synthetic)
+          "SIGTRAP"
+        value (ignored because stacktrace takes precedence)
+          "Trap"
         stacktrace*
           frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
@@ -79,10 +83,6 @@ app:
           frame (marked out of app by stack trace rule (category:system -app))
             function*
               "tgkill"
-        type (ignored because exception is synthetic)
-          "SIGTRAP"
-        value (ignored because stacktrace takes precedence)
-          "Trap"
 --------------------------------------------------------------------------
 system:
   hash: "f203e9bc12df86bb01fbd92a45643f86"
@@ -91,6 +91,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "SIGTRAP"
+        value (ignored because stacktrace takes precedence)
+          "Trap"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -160,7 +164,3 @@ system:
           frame*
             function*
               "tgkill"
-        type (ignored because exception is synthetic)
-          "SIGTRAP"
-        value (ignored because stacktrace takes precedence)
-          "Trap"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-29T21:18:54.642464+00:00'
+created: '2025-11-03T21:48:49.542317+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,6 +10,10 @@ app:
   root_component:
     app*
       exception*
+        type (ignored because exception is synthetic)
+          "unknown 0x00004000 / 0x7ff89574837a"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: unknown <hex> / <hex>"
         stacktrace*
           frame (marked in-app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -150,10 +154,6 @@ app:
           frame (marked out of app by stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
             function*
               "RaiseException"
-        type (ignored because exception is synthetic)
-          "unknown 0x00004000 / 0x7ff89574837a"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: unknown <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
   hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
@@ -162,6 +162,10 @@ system:
   root_component:
     system*
       exception*
+        type (ignored because exception is synthetic)
+          "unknown 0x00004000 / 0x7ff89574837a"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: unknown <hex> / <hex>"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -302,7 +306,3 @@ system:
           frame*
             function*
               "RaiseException"
-        type (ignored because exception is synthetic)
-          "unknown 0x00004000 / 0x7ff89574837a"
-        value (ignored because stacktrace takes precedence)
-          "Fatal Error: unknown <hex> / <hex>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.665740+00:00'
+created: '2025-11-03T21:48:49.567206+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "e7a1be23aff9a117598bb893ed4bedb4"
+  hash: "dca3cb1a150c80ca2103ca14a870736e"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "Ensure failed"
+        value (ignored because stacktrace takes precedence)
+          "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -134,10 +138,6 @@ app:
           frame (marked out of app by stack trace rule (family:native function:?[[]Sentry* -app))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
-        type*
-          "Ensure failed"
-        value (ignored because stacktrace takes precedence)
-          "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
       threads (ignored because app/system exception takes precedence)
         stacktrace*
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -265,12 +265,16 @@ app:
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
 --------------------------------------------------------------------------
 system:
-  hash: "1bba3ace796a07d167af26959c6039c9"
+  hash: "d8dceed7558e86d6622149fd98607a02"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Ensure failed"
+        value (ignored because stacktrace takes precedence)
+          "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -395,10 +399,6 @@ system:
           frame (ignored by stack trace rule (family:native function:?[[]Sentry* -group))
             function*
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
-        type*
-          "Ensure failed"
-        value (ignored because stacktrace takes precedence)
-          "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
       threads (ignored because app/system exception takes precedence)
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,15 +1,19 @@
 ---
-created: '2025-10-29T21:18:54.688337+00:00'
+created: '2025-11-03T21:48:49.591389+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
+  hash: "8961a4ec639f0697b27b860bbaf365bb"
   contributing component: exception
   hint: None
   root_component:
     app*
       exception*
+        type*
+          "Ensure failed"
+        value (ignored because stacktrace takes precedence)
+          "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
           frame (marked in-app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -179,18 +183,18 @@ app:
           frame (marked out of app by stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
             function*
               "sentry_unwind_stack_from_ucontext"
-        type*
-          "Ensure failed"
-        value (ignored because stacktrace takes precedence)
-          "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
 --------------------------------------------------------------------------
 system:
-  hash: "65244b22630821cacd0be603ebcef671"
+  hash: "4fa979767cc67d57c9bc771f6e48ed45"
   contributing component: exception
   hint: None
   root_component:
     system*
       exception*
+        type*
+          "Ensure failed"
+        value (ignored because stacktrace takes precedence)
+          "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
@@ -360,7 +364,3 @@ system:
           frame*
             function*
               "sentry_unwind_stack_from_ucontext"
-        type*
-          "Ensure failed"
-        value (ignored because stacktrace takes precedence)
-          "Ensure condition failed: ensurePtr != nullptr [File:D:\\projects\\sentry-unreal\\sample\\Source\\SentryPlayground\\SentryPlaygroundUtils.cpp] [Line: <int>]"

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -402,7 +402,7 @@ class ComponentTest(TestCase):
         exception_component = variants["app"].root_component.values[0]
         assert isinstance(exception_component, ExceptionGroupingComponent)
         assert [subcomponent.id for subcomponent in exception_component.values] == [
-            "stacktrace",
             "type",
             "value",
+            "stacktrace",
         ]


### PR DESCRIPTION
This turns off the `use_legacy_exception_subcomponent_order` grouping config option in the new grouping config, so that exception components will no longer [need to be rearranged](https://github.com/getsentry/sentry/blob/ef53faab4c12016a4a8dc41e67f97f6783852a46/src/sentry/grouping/component.py#L410-L427) before they're displayed in grouping info.