### PR TITLE
feat(dashboards): render query module as dashboard

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -1,134 +1,15 @@
-import {t} from 'sentry/locale';
-import {
-  DisplayType,
-  WidgetType,
-  type DashboardDetails,
-} from 'sentry/views/dashboards/types';
+import {type DashboardDetails} from 'sentry/views/dashboards/types';
+import {QUERIES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries';
+import {SESSION_HEALTH_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/sessionHealth';
 
 export enum PrebuiltDashboardId {
   FRONTEND_SESSION_HEALTH = 1,
+  BACKEND_QUERIES = 2,
 }
 
-export const PREBUILT_DASHBOARDS: Record<
-  PrebuiltDashboardId,
-  Omit<DashboardDetails, 'id'>
-> = {
-  [PrebuiltDashboardId.FRONTEND_SESSION_HEALTH]: {
-    dateCreated: '',
-    filters: {},
-    projects: [],
-    title: 'Frontend Session Health',
-    widgets: [
-      {
-        id: 'unhealthy-sessions',
-        title: t('Unhealthy Sessions'),
-        displayType: DisplayType.LINE,
-        widgetType: WidgetType.RELEASE,
-        interval: '',
-        queries: [
-          {
-            name: '',
-            conditions: '',
-            fields: ['unhealthy_rate(session)'],
-            aggregates: ['unhealthy_rate(session)'],
-            columns: [],
-            orderby: '',
-          },
-        ],
-        layout: {x: 0, y: 0, w: 3, h: 3, minH: 2},
-      },
-      {
-        id: 'user-health',
-        title: t('User Health'),
-        displayType: DisplayType.AREA,
-        widgetType: WidgetType.RELEASE,
-        interval: '',
-        queries: [
-          {
-            name: '',
-            conditions: '',
-            fields: [
-              'abnormal_rate(user)',
-              'crash_rate(user)',
-              'errored_rate(user)',
-              'unhandled_rate(user)',
-            ],
-            aggregates: [
-              'abnormal_rate(user)',
-              'crash_rate(user)',
-              'errored_rate(user)',
-              'unhandled_rate(user)',
-            ],
-            columns: [],
-            orderby: '',
-          },
-        ],
-        layout: {x: 3, y: 0, w: 3, h: 3, minH: 2},
-      },
-      {
-        id: 'session-health',
-        title: t('Session Health'),
-        displayType: DisplayType.AREA,
-        widgetType: WidgetType.RELEASE,
-        interval: '',
-        queries: [
-          {
-            name: '',
-            conditions: '',
-            fields: [
-              'abnormal_rate(session)',
-              'crash_rate(session)',
-              'errored_rate(session)',
-              'unhandled_rate(session)',
-            ],
-            aggregates: [
-              'abnormal_rate(session)',
-              'crash_rate(session)',
-              'errored_rate(session)',
-              'unhandled_rate(session)',
-            ],
-            columns: [],
-            orderby: '',
-          },
-        ],
-        layout: {x: 0, y: 3, w: 2, h: 3, minH: 2},
-      },
-      {
-        id: 'session-counts',
-        title: t('Session Counts'),
-        displayType: DisplayType.LINE,
-        widgetType: WidgetType.RELEASE,
-        interval: '',
-        queries: [
-          {
-            name: '',
-            conditions: '',
-            fields: ['session.status', 'sum(session)'],
-            aggregates: ['sum(session)'],
-            columns: ['session.status'],
-            orderby: '',
-          },
-        ],
-        layout: {x: 2, y: 3, w: 2, h: 3, minH: 2},
-      },
-      {
-        id: 'user-counts',
-        title: t('User Counts'),
-        displayType: DisplayType.LINE,
-        widgetType: WidgetType.RELEASE,
-        interval: '4h',
-        queries: [
-          {
-            name: '',
-            conditions: '',
-            fields: ['session.status', 'count_unique(user)'],
-            aggregates: ['count_unique(user)'],
-            columns: ['session.status'],
-            orderby: '',
-          },
-        ],
-        layout: {x: 4, y: 3, w: 2, h: 3, minH: 2},
-      },
-    ],
-  },
+export type PrebuiltDashboard = Omit<DashboardDetails, 'id'>;
+
+export const PREBUILT_DASHBOARDS: Record<PrebuiltDashboardId, PrebuiltDashboard> = {
+  [PrebuiltDashboardId.FRONTEND_SESSION_HEALTH]: SESSION_HEALTH_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.BACKEND_QUERIES]: QUERIES_PREBUILT_CONFIG,
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries.ts
@@ -1,0 +1,135 @@
+import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {EXCLUDED_DB_OPS} from 'sentry/views/insights/database/settings';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
+
+const BASE_FILTERS = {
+  [SpanFields.SPAN_CATEGORY]: ModuleName.DB,
+  [`!${SpanFields.SPAN_OP}`]: `[${EXCLUDED_DB_OPS.join(',')}]`,
+  has: SpanFields.NORMALIZED_DESCRIPTION,
+};
+
+const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString();
+
+export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
+  dateCreated: '',
+  projects: [],
+  title: 'Backend Queries',
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'span.system',
+          name: 'span.system',
+          kind: FieldKind.TAG,
+        },
+        value: 'span.system:postgresql',
+      },
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'span.action',
+          name: 'span.action',
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'span.domain',
+          name: 'span.domain',
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
+  widgets: [
+    {
+      id: 'throughput',
+      title: t('Queries Per Minute'),
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '',
+      queries: [
+        {
+          name: '',
+          conditions: FILTER_STRING,
+          fields: ['epm()'],
+          aggregates: ['epm()'],
+          columns: [],
+          orderby: 'epm()',
+        },
+      ],
+      layout: {
+        y: 0,
+        w: 3,
+        h: 2,
+        x: 0,
+        minH: 2,
+      },
+    },
+    {
+      id: 'duration',
+      title: t('Average Duration'),
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '',
+      queries: [
+        {
+          name: '',
+          conditions: FILTER_STRING,
+          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          columns: [],
+          orderby: `avg(${SpanFields.SPAN_SELF_TIME})`,
+        },
+      ],
+      layout: {
+        y: 0,
+        w: 3,
+        h: 2,
+        x: 3,
+        minH: 2,
+      },
+    },
+    {
+      id: 'queries-table',
+      title: t('Queries List'),
+      displayType: DisplayType.TABLE,
+      widgetType: WidgetType.SPANS,
+      interval: '',
+      queries: [
+        {
+          name: '',
+          conditions: FILTER_STRING,
+          fields: [
+            SpanFields.NORMALIZED_DESCRIPTION,
+            'epm()',
+            `avg(${SpanFields.SPAN_SELF_TIME})`,
+            `sum(${SpanFields.SPAN_SELF_TIME})`,
+          ],
+          aggregates: [
+            'epm()',
+            `avg(${SpanFields.SPAN_SELF_TIME})`,
+            `sum(${SpanFields.SPAN_SELF_TIME})`,
+          ],
+          columns: [SpanFields.NORMALIZED_DESCRIPTION],
+          orderby: `sum(${SpanFields.SPAN_SELF_TIME})`,
+        },
+      ],
+      layout: {
+        y: 2,
+        w: 6,
+        h: 6,
+        x: 0,
+        minH: 2,
+      },
+    },
+  ],
+};

--- a/static/app/views/dashboards/utils/prebuiltConfigs/sessionHealth.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/sessionHealth.ts
@@ -1,0 +1,122 @@
+import {t} from 'sentry/locale';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+
+export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
+  dateCreated: '',
+  filters: {},
+  projects: [],
+  title: 'Frontend Session Health',
+  widgets: [
+    {
+      id: 'unhealthy-sessions',
+      title: t('Unhealthy Sessions'),
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.RELEASE,
+      interval: '',
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: ['unhealthy_rate(session)'],
+          aggregates: ['unhealthy_rate(session)'],
+          columns: [],
+          orderby: '',
+        },
+      ],
+      layout: {x: 0, y: 0, w: 3, h: 3, minH: 2},
+    },
+    {
+      id: 'user-health',
+      title: t('User Health'),
+      displayType: DisplayType.AREA,
+      widgetType: WidgetType.RELEASE,
+      interval: '',
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: [
+            'abnormal_rate(user)',
+            'crash_rate(user)',
+            'errored_rate(user)',
+            'unhandled_rate(user)',
+          ],
+          aggregates: [
+            'abnormal_rate(user)',
+            'crash_rate(user)',
+            'errored_rate(user)',
+            'unhandled_rate(user)',
+          ],
+          columns: [],
+          orderby: '',
+        },
+      ],
+      layout: {x: 3, y: 0, w: 3, h: 3, minH: 2},
+    },
+    {
+      id: 'session-health',
+      title: t('Session Health'),
+      displayType: DisplayType.AREA,
+      widgetType: WidgetType.RELEASE,
+      interval: '',
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: [
+            'abnormal_rate(session)',
+            'crash_rate(session)',
+            'errored_rate(session)',
+            'unhandled_rate(session)',
+          ],
+          aggregates: [
+            'abnormal_rate(session)',
+            'crash_rate(session)',
+            'errored_rate(session)',
+            'unhandled_rate(session)',
+          ],
+          columns: [],
+          orderby: '',
+        },
+      ],
+      layout: {x: 0, y: 3, w: 2, h: 3, minH: 2},
+    },
+    {
+      id: 'session-counts',
+      title: t('Session Counts'),
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.RELEASE,
+      interval: '',
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: ['session.status', 'sum(session)'],
+          aggregates: ['sum(session)'],
+          columns: ['session.status'],
+          orderby: '',
+        },
+      ],
+      layout: {x: 2, y: 3, w: 2, h: 3, minH: 2},
+    },
+    {
+      id: 'user-counts',
+      title: t('User Counts'),
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.RELEASE,
+      interval: '4h',
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: ['session.status', 'count_unique(user)'],
+          aggregates: ['count_unique(user)'],
+          columns: ['session.status'],
+          orderby: '',
+        },
+      ],
+      layout: {x: 4, y: 3, w: 2, h: 3, minH: 2},
+    },
+  ],
+};

--- a/static/app/views/insights/database/utils/useHasDashboardsPlatformaizedQueries.ts
+++ b/static/app/views/insights/database/utils/useHasDashboardsPlatformaizedQueries.ts
@@ -1,0 +1,7 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useHasDashboardsPlatformizedQueries() {
+  const organization = useOrganization();
+
+  return organization.features.includes('insights-queries-dashboard-migration');
+}

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -32,6 +32,8 @@ import {
 } from 'sentry/views/insights/database/components/tables/queriesTable';
 import {useSystemSelectorOptions} from 'sentry/views/insights/database/components/useSystemSelectorOptions';
 import {BASE_FILTERS} from 'sentry/views/insights/database/settings';
+import useHasDashboardsPlatformizedQueries from 'sentry/views/insights/database/utils/useHasDashboardsPlatformaizedQueries';
+import {PlatformizedQueriesOverview} from 'sentry/views/insights/database/views/platformizedOverview';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 export function DatabaseLandingPage() {
@@ -194,6 +196,10 @@ function AlertBanner(props: Omit<AlertProps, 'type' | 'showIcon'>) {
 const LIMIT = 25;
 
 function PageWithProviders() {
+  const hasDashboardsPlatformizedQueries = useHasDashboardsPlatformizedQueries();
+  if (hasDashboardsPlatformizedQueries) {
+    return <PlatformizedQueriesOverview />;
+  }
   return (
     <ModulePageProviders moduleName="db" analyticEventName="insight.page_loads.db">
       <DatabaseLandingPage />

--- a/static/app/views/insights/database/views/platformizedOverview.tsx
+++ b/static/app/views/insights/database/views/platformizedOverview.tsx
@@ -1,0 +1,52 @@
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import useRouter from 'sentry/utils/useRouter';
+import DashboardDetail from 'sentry/views/dashboards/detail';
+import type {DashboardDetails} from 'sentry/views/dashboards/types';
+import {DashboardState} from 'sentry/views/dashboards/types';
+import {
+  PREBUILT_DASHBOARDS,
+  PrebuiltDashboardId,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+
+const DASHBOARD_CONFIG = PREBUILT_DASHBOARDS[PrebuiltDashboardId.BACKEND_QUERIES];
+
+const FILTERS = DASHBOARD_CONFIG.filters;
+const WIDGETS = DASHBOARD_CONFIG.widgets;
+
+const DASHBOARD: DashboardDetails = {
+  id: 'queries-overview',
+  title: t('Backend Queries'),
+  widgets: WIDGETS,
+  dateCreated: '',
+  filters: FILTERS,
+  projects: undefined,
+};
+
+export function PlatformizedQueriesOverview() {
+  const location = useLocation();
+  const router = useRouter();
+
+  return (
+    <ModulePageProviders moduleName="db">
+      <DashboardDetail
+        dashboard={DASHBOARD}
+        location={location}
+        params={{
+          dashboardId: undefined,
+          templateId: undefined,
+          widgetId: undefined,
+          widgetIndex: undefined,
+        }}
+        route={{}}
+        routeParams={{}}
+        router={router}
+        routes={[]}
+        dashboards={[]}
+        initialState={DashboardState.EMBEDDED}
+        useTimeseriesVisualization
+      />
+    </ModulePageProviders>
+  );
+}


### PR DESCRIPTION
1. Renders the queries module as a dashboard if the feature is ON, this does as much as we can with the current dashboard functionality.
<img width="1496" height="792" alt="image" src="https://github.com/user-attachments/assets/d7e8f6cb-3b54-48d6-b9ef-367fd22b9a29" />

2. Refactors the static dashboards config a bit so that each one is in it's own file, it should make the prebuilt dashboards file less bloated and more organized.