### PR TITLE
fix(eco): Cap the maximum timeout for Sentry App webhook sends to 5s

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -173,7 +173,7 @@ def _webhook_issue_data(
     name="sentry.sentry_apps.tasks.sentry_apps.send_alert_webhook_v2",
     namespace=sentryapp_tasks,
     retry=Retry(times=3, delay=60 * 5),
-    processing_deadline_duration=30,
+    processing_deadline_duration=5,
     silo_mode=SiloMode.REGION,
 )
 @retry_decorator
@@ -698,7 +698,7 @@ def get_webhook_data(
     namespace=sentryapp_tasks,
     retry=Retry(times=3, delay=60 * 5),
     compression_type=CompressionType.ZSTD,
-    processing_deadline_duration=30,
+    processing_deadline_duration=5,
     silo_mode=SiloMode.REGION,
 )
 @retry_decorator


### PR DESCRIPTION
Caps sentry app webhook sending to a maximum of 5s, reducing backlogging of our sentry app webhook tasks when extraneous latency bumps occur.
