### PR TITLE
chore(preprod): Alert to Sentry on PreprodArtifact expiration

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -643,7 +643,7 @@ def detect_expired_preprod_artifacts() -> None:
     if updated_artifact_ids:
         for artifact_id in updated_artifact_ids:
             sentry_sdk.capture_message(
-                f"PreprodArtifact expired: artifact_id={artifact_id}",
+                "PreprodArtifact expired",
                 level="error",
                 extras={
                     "artifact_id": artifact_id,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -642,6 +642,13 @@ def detect_expired_preprod_artifacts() -> None:
 
     if updated_artifact_ids:
         for artifact_id in updated_artifact_ids:
+            sentry_sdk.capture_message(
+                f"PreprodArtifact expired: artifact_id={artifact_id}",
+                level="error",
+                extras={
+                    "artifact_id": artifact_id,
+                },
+            )
             try:
                 create_preprod_status_check_task.apply_async(
                     kwargs={"preprod_artifact_id": artifact_id}

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from hashlib import sha1
+from unittest.mock import patch
 
+import sentry_sdk
 from django.core.files.base import ContentFile
 from django.utils import timezone
 
@@ -738,6 +740,42 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
             expired_size_comparison.error_message
             and "30 minutes" in expired_size_comparison.error_message
         )
+
+    def test_detect_expired_preprod_artifacts_captures_sentry_message(self):
+        """Test that Sentry messages are captured for each expired artifact"""
+        current_time = timezone.now()
+        old_time = current_time - timedelta(minutes=35)
+
+        expired_artifact_1 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADING,
+        )
+        PreprodArtifact.objects.filter(id=expired_artifact_1.id).update(date_updated=old_time)
+
+        expired_artifact_2 = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+        )
+        PreprodArtifact.objects.filter(id=expired_artifact_2.id).update(date_updated=old_time)
+
+        with patch.object(sentry_sdk, "capture_message") as mock_capture_message:
+            detect_expired_preprod_artifacts()
+
+            # Should have captured a message for each expired artifact
+            assert mock_capture_message.call_count == 2
+
+            # Verify the message text and parameters
+            call_args_list = mock_capture_message.call_args_list
+            captured_artifact_ids = [call[1]["extras"]["artifact_id"] for call in call_args_list]
+
+            assert expired_artifact_1.id in captured_artifact_ids
+            assert expired_artifact_2.id in captured_artifact_ids
+
+            # Verify all calls have the same message text, error level, and contain artifact_id
+            for call in call_args_list:
+                assert call[0][0] == "PreprodArtifact expired"
+                assert call[1]["level"] == "error"
+                assert "artifact_id" in call[1]["extras"]
 
     def test_detect_expired_preprod_artifacts_mixed_states(self):
         """Test that only artifacts in the right states are considered for expiration"""


### PR DESCRIPTION
Had a recent upload fail to process due to a hang. We never received an alert directly from the point of the hang (separate issue), but we do have a fallthrough to catch hanging artifacts. This wires up a [custom message](https://docs.sentry.io/platforms/python/usage/#capturing-messages) which will create an issue for each hung artifact we catch.

Resolves EME-600