### PR TITLE
feat(aci): Hide issue stream detectors from the UI

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -77,7 +77,8 @@ export type DetectorType =
   | 'error'
   | 'metric_issue'
   | 'monitor_check_in_failure'
-  | 'uptime_domain_failure';
+  | 'uptime_domain_failure'
+  | 'issue_stream';
 
 interface BaseMetricDetectorConfig {
   thresholdPeriod: number;

--- a/static/app/views/detectors/components/forms/index.tsx
+++ b/static/app/views/detectors/components/forms/index.tsx
@@ -25,7 +25,7 @@ function PlaceholderForm() {
     <Layout.Page>
       <Layout.Body>
         <Layout.Main width="full">
-          <LoadingError message={t('This monitor type is not yet implemented')} />
+          <LoadingError message={t('This monitor type can not be created')} />
         </Layout.Main>
       </Layout.Body>
     </Layout.Page>
@@ -42,6 +42,8 @@ export function NewDetectorForm({detectorType}: {detectorType: DetectorType}) {
       return <NewErrorDetectorForm />;
     case 'monitor_check_in_failure':
       return <NewCronDetectorForm />;
+    case 'issue_stream':
+      return <PlaceholderForm />;
     default:
       unreachable(detectorType);
       return <PlaceholderForm />;

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -159,7 +159,7 @@ describe('DetectorsList', () => {
       const mockDetectorsRequestErrorType = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
         body: [ErrorDetectorFixture({name: 'Error Detector'})],
-        match: [MockApiClient.matchQuery({query: 'type:error'})],
+        match: [MockApiClient.matchQuery({query: '!type:issue_stream type:error'})],
       });
 
       render(<DetectorsList />, {organization});
@@ -191,7 +191,11 @@ describe('DetectorsList', () => {
             owner: ActorFixture({id: testUser.id, name: testUser.email, type: 'user'}),
           }),
         ],
-        match: [MockApiClient.matchQuery({query: 'assignee:test@example.com'})],
+        match: [
+          MockApiClient.matchQuery({
+            query: '!type:issue_stream assignee:test@example.com',
+          }),
+        ],
       });
 
       render(<DetectorsList />, {organization});
@@ -484,7 +488,11 @@ describe('DetectorsList', () => {
         headers: {
           'X-Hits': '50',
         },
-        match: [MockApiClient.matchQuery({query: 'assignee:test@example.com'})],
+        match: [
+          MockApiClient.matchQuery({
+            query: '!type:issue_stream assignee:test@example.com',
+          }),
+        ],
       });
 
       // Click through menus to select assignee

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -36,7 +36,10 @@ interface DetectorHeadingInfo {
   title: string;
 }
 
-const DETECTOR_TYPE_HEADING_MAPPING: Record<DetectorType, DetectorHeadingInfo> = {
+const DETECTOR_TYPE_HEADING_MAPPING: Record<
+  Exclude<DetectorType, 'issue_stream'>,
+  DetectorHeadingInfo
+> = {
   error: {
     title: t('Error Monitors'),
     description: t(

--- a/static/app/views/detectors/monitorViewContext.tsx
+++ b/static/app/views/detectors/monitorViewContext.tsx
@@ -22,7 +22,7 @@ export interface MonitorViewContextValue {
    */
   additionalColumns?: MonitorListAdditionalColumn[];
   assigneeFilter?: string;
-  detectorFilter?: DetectorType;
+  detectorFilter?: Exclude<DetectorType, 'issue_stream'>;
   emptyState?: React.ReactNode;
   renderVisualization?: (params: RenderVisualizationParams) => React.ReactNode;
   showTimeRangeSelector?: boolean;

--- a/static/app/views/detectors/utils/detectorTypeConfig.tsx
+++ b/static/app/views/detectors/utils/detectorTypeConfig.tsx
@@ -23,6 +23,10 @@ const DETECTOR_TYPE_CONFIG: Record<DetectorType, DetectorTypeConfig> = {
     userCreateable: true,
     label: t('Uptime'),
   },
+  issue_stream: {
+    userCreateable: false,
+    label: t('Issue Stream'),
+  },
 };
 
 export function isValidDetectorType(detectorType: DetectorType) {

--- a/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.spec.tsx
@@ -115,7 +115,7 @@ describe('useMetricDetectorLimit', () => {
       '/organizations/org-slug/detectors/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: 'type:metric',
+          query: '!type:issue_stream type:metric',
           per_page: 1,
         }),
       })


### PR DESCRIPTION
Automatically applies `!type:issue_stream` when using `useDetetectorsQuery()` so that users won't see this detector type in the list views or when connecting monitors.