### PR TITLE
feat(tracemetrics): Support filtering metrics as optional

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -531,11 +531,12 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     )
                 elif scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
-                    metric_name, metric_type = get_trace_metric_from_request(request, organization)
+                    metric_name, metric_type, metric_unit = get_trace_metric_from_request(request)
 
                     return TraceMetricsSearchResolverConfig(
                         metric_name=metric_name,
                         metric_type=metric_type,
+                        metric_unit=metric_unit,
                         use_aggregate_conditions=use_aggregate_conditions,
                         auto_fields=True,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -243,11 +243,12 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
 
                 if scoped_dataset == TraceMetrics:
                     # tracemetrics uses aggregate conditions
-                    metric_name, metric_type = get_trace_metric_from_request(request, organization)
+                    metric_name, metric_type, metric_unit = get_trace_metric_from_request(request)
 
                     return TraceMetricsSearchResolverConfig(
                         metric_name=metric_name,
                         metric_type=metric_type,
+                        metric_unit=metric_unit,
                         auto_fields=False,
                         use_aggregate_conditions=True,
                         disable_aggregate_extrapolation=request.GET.get(

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -224,10 +224,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
 
             if dataset == TraceMetrics:
                 # tracemetrics uses aggregate conditions
-                metric_name, metric_type = get_trace_metric_from_request(request, organization)
+                metric_name, metric_type, metric_unit = get_trace_metric_from_request(request)
                 return TraceMetricsSearchResolverConfig(
                     metric_name=metric_name,
                     metric_type=metric_type,
+                    metric_unit=metric_unit,
                     auto_fields=False,
                     use_aggregate_conditions=True,
                     disable_aggregate_extrapolation=request.GET.get(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -590,8 +590,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:tracemetrics-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics in trace view UI
     manager.add("organizations:tracemetrics-traceview-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable trace metrics top level params
-    manager.add("organizations:tracemetrics-top-level-params", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # Enable feature flag to send expanded sentry apps webhooks (issue.created for all group categories)
     manager.add("organizations:expanded-sentry-apps-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/search/eap/trace_metrics/config.py
+++ b/src/sentry/search/eap/trace_metrics/config.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import Literal, cast
 
-from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.request import Request
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
@@ -10,8 +9,6 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
-from sentry import features
-from sentry.models.organization import Organization
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import SearchResolverConfig
 
@@ -20,8 +17,9 @@ MetricType = Literal["counter", "gauge", "distribution"]
 
 @dataclass(frozen=True, kw_only=True)
 class TraceMetricsSearchResolverConfig(SearchResolverConfig):
-    metric_name: str
-    metric_type: MetricType
+    metric_name: str | None
+    metric_type: MetricType | None
+    metric_unit: str | None
 
     def extra_conditions(self, search_resolver: SearchResolver) -> TraceItemFilter | None:
         if not self.metric_name or not self.metric_type:
@@ -35,24 +33,38 @@ class TraceMetricsSearchResolverConfig(SearchResolverConfig):
         if not isinstance(metric_type.proto_definition, AttributeKey):
             raise ValueError("Unable to resolve metric.type")
 
-        metric_name_filter = TraceItemFilter(
-            comparison_filter=ComparisonFilter(
-                key=metric_name.proto_definition,
-                op=ComparisonFilter.OP_EQUALS,
-                value=AttributeValue(val_str=self.metric_name),
-            )
-        )
-        metric_type_filter = TraceItemFilter(
-            comparison_filter=ComparisonFilter(
-                key=metric_type.proto_definition,
-                op=ComparisonFilter.OP_EQUALS,
-                value=AttributeValue(val_str=self.metric_type),
-            )
-        )
+        filters = [
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=metric_name.proto_definition,
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str=self.metric_name),
+                )
+            ),
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=metric_type.proto_definition,
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str=self.metric_type),
+                )
+            ),
+        ]
 
-        return TraceItemFilter(
-            and_filter=AndFilter(filters=[metric_name_filter, metric_type_filter])
-        )
+        if self.metric_unit:
+            metric_unit, _ = search_resolver.resolve_column("metric.unit")
+            if not isinstance(metric_unit.proto_definition, AttributeKey):
+                raise ValueError("Unable to resolve metric.unit")
+            filters.append(
+                TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=metric_unit.proto_definition,
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=AttributeValue(val_str=self.metric_unit),
+                    )
+                )
+            )
+
+        return TraceItemFilter(and_filter=AndFilter(filters=filters))
 
 
 ALLOWED_METRIC_TYPES: list[MetricType] = ["counter", "gauge", "distribution"]
@@ -60,34 +72,16 @@ ALLOWED_METRIC_TYPES: list[MetricType] = ["counter", "gauge", "distribution"]
 
 def get_trace_metric_from_request(
     request: Request,
-    organization: Organization,
-) -> tuple[str, MetricType]:
+) -> tuple[str | None, MetricType | None, str | None]:
     metric_name = request.GET.get("metricName")
     metric_type = request.GET.get("metricType")
+    metric_unit = request.GET.get("metricUnit")
 
-    if not features.has(
-        "organizations:tracemetrics-top-level-params", organization=organization, actor=request.user
-    ):
-        if not metric_name:
-            metric_name = ""
-        if not metric_type:
-            metric_type = ""
-    else:
-        errors = {}
+    if not metric_name:
+        metric_name = None
+    if not metric_type:
+        metric_type = None
+    if not metric_unit:
+        metric_unit = None
 
-        if not metric_name:
-            errors["metricName"] = ErrorDetail("This field is required.", code="required")
-
-        if not metric_type:
-            errors["metricType"] = ErrorDetail("This field is required.", code="required")
-        elif metric_type not in ALLOWED_METRIC_TYPES:
-            errors["metricType"] = ErrorDetail(
-                string=f'"{metric_type}" is not a valid choice.', code="invalid_choice"
-            )
-
-        if errors:
-            raise ValidationError(errors)
-
-        assert metric_name
-
-    return metric_name, cast(MetricType, metric_type)
+    return metric_name, cast(MetricType | None, metric_type), metric_unit

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -1,44 +1,12 @@
 from unittest import mock
 
 import pytest
-from rest_framework.exceptions import ErrorDetail
 
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
 
 class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestBase):
     dataset = "tracemetrics"
-
-    def test_missing_metric_name_and_type(self):
-        with self.feature("organizations:tracemetrics-top-level-params"):
-            response = self.do_request(
-                {
-                    "field": ["sum(value)"],
-                    "dataset": self.dataset,
-                    "project": self.project.id,
-                }
-            )
-            assert response.status_code == 400, response.content
-            assert response.data == {
-                "metricName": ErrorDetail("This field is required.", code="required"),
-                "metricType": ErrorDetail("This field is required.", code="required"),
-            }
-
-    def test_invalid_metric_type(self):
-        with self.feature("organizations:tracemetrics-top-level-params"):
-            response = self.do_request(
-                {
-                    "metricName": "foo",
-                    "metricType": "bar",
-                    "field": ["sum(value)"],
-                    "dataset": self.dataset,
-                    "project": self.project.id,
-                }
-            )
-            assert response.status_code == 400, response.content
-            assert response.data == {
-                "metricType": ErrorDetail('"bar" is not a valid choice.', code="invalid_choice"),
-            }
 
     def test_simple_deprecated(self) -> None:
         trace_metrics = [


### PR DESCRIPTION
We should still allow queries on trace metrics without a top level metric and add metric unit as a parameter.