### PR TITLE
fix(listbox): Unfocus key when mouse leaves

### DIFF
--- a/static/app/components/core/compactSelect/listBox/index.spec.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.spec.tsx
@@ -1,0 +1,149 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+
+describe('ListBox', () => {
+  it('hides details overlay when mouse leaves the list', async () => {
+    render(
+      <CompactSelect
+        options={[
+          {
+            value: 'opt_one',
+            label: 'Option One',
+            details: 'Details for option one',
+            showDetailsInOverlay: true,
+          },
+          {
+            value: 'opt_two',
+            label: 'Option Two',
+            details: 'Details for option two',
+            showDetailsInOverlay: true,
+          },
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    await userEvent.hover(screen.getByRole('option', {name: 'Option One'}));
+
+    const detailsOverlay = await screen.findByRole('tooltip');
+    expect(detailsOverlay).toBeInTheDocument();
+    expect(detailsOverlay).toHaveTextContent('Details for option one');
+
+    const listBox = screen.getByRole('listbox');
+    await userEvent.unhover(listBox);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows different details when hovering over different options', async () => {
+    render(
+      <CompactSelect
+        options={[
+          {
+            value: 'opt_one',
+            label: 'Option One',
+            details: 'Details for option one',
+            showDetailsInOverlay: true,
+          },
+          {
+            value: 'opt_two',
+            label: 'Option Two',
+            details: 'Details for option two',
+            showDetailsInOverlay: true,
+          },
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    await userEvent.hover(screen.getByRole('option', {name: 'Option One'}));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Details for option one'
+    );
+
+    await userEvent.hover(screen.getByRole('option', {name: 'Option Two'}));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Details for option two'
+    );
+
+    await userEvent.unhover(screen.getByRole('listbox'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show details overlay when showDetailsInOverlay is false', async () => {
+    render(
+      <CompactSelect
+        options={[
+          {
+            value: 'opt_one',
+            label: 'Option One',
+            details: 'Details for option one',
+            showDetailsInOverlay: false,
+          },
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    await userEvent.hover(screen.getByRole('option', {name: 'Option One'}));
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    const option = screen.getByRole('option', {name: 'Option One'});
+    expect(option).toHaveTextContent('Details for option one');
+  });
+
+  it('maintains keyboard navigation focus when hovering', async () => {
+    render(
+      <CompactSelect
+        options={[
+          {
+            value: 'opt_one',
+            label: 'Option One',
+            details: 'Details for option one',
+            showDetailsInOverlay: true,
+          },
+          {
+            value: 'opt_two',
+            label: 'Option Two',
+            details: 'Details for option two',
+            showDetailsInOverlay: true,
+          },
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
+    });
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Details for option one'
+    );
+
+    await userEvent.keyboard('{ArrowDown}');
+    await waitFor(() => {
+      expect(screen.getByRole('option', {name: 'Option Two'})).toHaveFocus();
+    });
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Details for option two'
+    );
+
+    await userEvent.unhover(screen.getByRole('listbox'));
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -144,6 +144,10 @@ export function ListBox({
     }
   };
 
+  const onMouseLeave = () => {
+    listState.selectionManager.setFocusedKey(null);
+  };
+
   const listItems = useMemo(
     () =>
       [...listState.collection].filter(node => {
@@ -163,6 +167,7 @@ export function ListBox({
       <ListWrap
         {...mergeProps(listBoxProps, props)}
         onKeyDown={onKeyDown}
+        onMouseLeave={onMouseLeave}
         ref={mergeRefs(listElementRef, ref)}
       >
         {overlayIsOpen &&

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -144,10 +144,6 @@ export function ListBox({
     }
   };
 
-  const onMouseLeave = () => {
-    listState.selectionManager.setFocusedKey(null);
-  };
-
   const listItems = useMemo(
     () =>
       [...listState.collection].filter(node => {
@@ -160,12 +156,19 @@ export function ListBox({
     [listState.collection, hiddenOptions]
   );
 
+  const mergedProps = mergeProps(listBoxProps, props);
+
+  const onMouseLeave = (e: React.MouseEvent<HTMLUListElement>) => {
+    mergedProps.onMouseLeave?.(e);
+    listState.selectionManager.setFocusedKey(null);
+  };
+
   return (
     <Fragment>
       {listItems.length !== 0 && <ListSeparator role="separator" />}
       {listItems.length !== 0 && label && <ListLabel {...labelProps}>{label}</ListLabel>}
       <ListWrap
-        {...mergeProps(listBoxProps, props)}
+        {...mergedProps}
         onKeyDown={onKeyDown}
         onMouseLeave={onMouseLeave}
         ref={mergeRefs(listElementRef, ref)}


### PR DESCRIPTION
It was raised that the option descriptions shouldn't stay on the screen when a user mouses away from the dropdown, so I added a reset to the list state to unfocus the key if the user mouses away. Let me know if this deviates away from any specific intentions about keeping the key focused!

Before:

https://github.com/user-attachments/assets/e9e1ea02-b234-4c66-b3c5-fc09a4dda58d

After:


https://github.com/user-attachments/assets/fce2e32e-7da1-4a80-b944-ba878741ae15

