### PR TITLE
feat(deletions): Bulk deletes for Activity

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -63,6 +63,8 @@ _GROUP_RELATED_MODELS = DIRECT_GROUP_RELATED_MODELS + (
     models.EventAttachment,
     NotificationMessage,
 )
+if options.get("deletions.activity.delete-in-bulk"):
+    _GROUP_RELATED_MODELS += (models.Activity,)
 
 
 class EventsBaseDeletionTask(BaseDeletionTask[Group]):

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from sentry import models, options
+from sentry.db.models.base import Model
 from sentry.deletions.tasks.nodestore import delete_events_for_groups_from_nodestore_and_eventstore
 from sentry.issues.grouptype import GroupCategory, InvalidGroupTypeError
 from sentry.models.group import Group, GroupStatus
@@ -65,15 +66,14 @@ _GROUP_RELATED_MODELS = DIRECT_GROUP_RELATED_MODELS + (
 )
 
 
-def get_group_related_models() -> tuple[type[models.Model], ...]:
+def get_group_related_models() -> Sequence[type[Model]]:
     """
     Returns the tuple of models related to groups that should be deleted.
     Checks options at runtime to allow dynamic configuration.
     """
-    models_list = _GROUP_RELATED_MODELS
     if options.get("deletions.activity.delete-in-bulk"):
-        models_list = models_list + (models.Activity,)
-    return models_list
+        return _GROUP_RELATED_MODELS + (models.Activity,)
+    return _GROUP_RELATED_MODELS
 
 
 class EventsBaseDeletionTask(BaseDeletionTask[Group]):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -348,6 +348,12 @@ register(
     type=Bool,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "deletions.activity.delete-in-bulk",
+    default=False,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "cleanup.abort_execution",


### PR DESCRIPTION
This will ensure we iteratively delete chunks of Activity rather than failing during Group instance delete.

This error will show en masse once the cleanup script runs again. This will start happening since we enabled #102612 today.

Fixes [SENTRY-5BYJ](https://sentry.sentry.io/issues/6997944963/).