### PR TITLE
feat(timeseries): Add support for trace metrics in `useFetchEventsTimeSeries`

### DIFF
--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -64,6 +64,52 @@ describe('useFetchEventsTimeSeries', () => {
     );
   });
 
+  it('fetches trace metrics from `/events-timeseries`', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: [],
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useFetchEventsTimeSeries(
+        DiscoverDatasets.TRACEMETRICS,
+        {
+          yAxis: 'per_second(value)',
+          metric: {
+            name: 'attachment_count',
+            type: 'counter',
+          },
+        },
+        REFERRER
+      )
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          excludeOther: 0,
+          partial: 1,
+          referrer: 'test-query',
+          dataset: 'tracemetrics',
+          statsPeriod: '10d',
+          yAxis: 'per_second(value)',
+          metricName: 'attachment_count',
+          metricType: 'counter',
+          environment: ['prod'],
+          project: [42],
+          interval: '30m',
+          sampling: 'NORMAL',
+        },
+      })
+    );
+  });
+
   it('can be disabled', async () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-timeseries/`,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -141,6 +141,7 @@ export const useSortedTimeSeries = <
       sampling: samplingMode,
       extrapolate: !disableAggregateExtrapolation,
       enabled: isTimeSeriesEndpointComparisonEnabled,
+      metric: traceMetric,
     },
     `${referrer}-time-series`
   );


### PR DESCRIPTION
`useFetchEventsTimeSeries` can now accept a `metric` option, and append the information to the request.

The types are pretty loose for now (i.e., you can omit `metric` on trace metrics requests, technically, or add `metric` to spans requests) but the overloads for this function make the situation even worse. IMO this is fine for now, this is not a likely mistake. If anyone has ideas on how to implement this cleanly, I'm all ears!