### PR TITLE
perf: Reduce unnecessary updates of `usePageFilters`

### DIFF
--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -107,6 +107,16 @@ const storeConfig: PageFiltersStoreDefinition = {
    * Initializes the page filters store data
    */
   onInitializeUrlState(newSelection, persist = true) {
+    // Do a deep comparison. Shallow comparison would compare the `projects`
+    // array by identity rather than the projects inside, and falsely report
+    // that they're different. In this case, we care about the specific values,
+    // and that comparison is still much cheaper than the unnecessary re-render
+    // that updating the store would cause. This method is called pretty rarely,
+    // and it might be possible to call it even less.
+    if (valueIsEqual(this.state.selection, newSelection, true)) {
+      return;
+    }
+
     this.state = {
       ...this.state,
       isReady: true,


### PR DESCRIPTION
`usePageFilters` relies on `useSyncExternalStore`. Right now, that store updates at some unfortunate times (e.g., when opening the Widget Builder modal) and causes very expensive re-renders.

In this PR, I'm adding another `valueIsEqual` check to avoid an expensive re-render caused by an extra initialization. I considered removing the extra initialization, but the code is in `PageFiltersContainer`, and is more complicated and error-prone.

For Widget Builder, this saves almost 300ms while opening the modal in some cases!

**Before:**
<img width="581" height="114" alt="Screenshot 2025-11-05 at 4 15 29 PM" src="https://github.com/user-attachments/assets/e014bb3c-d880-4d5f-bf3a-82144d31f047" />

There's no after, since that render is skipped.
