### PR TITLE
feat(data-forwarding): Implement a frontend interface for forwarding

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1234,6 +1234,11 @@ function buildRoutes(): RouteObject[] {
       name: t('Stats'),
       children: statsChildren,
     },
+    {
+      path: 'data-forwarding/',
+      name: t('Data Forwarding'),
+      component: make(() => import('sentry/views/settings/organizationDataForwarding')),
+    },
   ];
   const orgSettingsRoutes: SentryRouteObject = {
     component: make(

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -178,6 +178,17 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           show: ({organization}) => !!organization && !organization.hideAiFeatures,
           id: 'seer',
         },
+        {
+          path: `${organizationSettingsPathPrefix}/data-forwarding/`,
+          title: t('Data Forwarding'),
+          description: t('Manage data forwarding across your organization'),
+          id: 'data-forwarding',
+          badge: () => <FeatureBadge type="beta" />,
+          recordAnalytics: true,
+          show: ({organization}) =>
+            !!organization &&
+            organization.features.includes('data-forwarding-revamp-access'),
+        },
       ],
     },
     {

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -127,6 +127,17 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           id: 'audit-log',
         },
         {
+          path: `${organizationSettingsPathPrefix}/data-forwarding/`,
+          title: t('Data Forwarding'),
+          description: t('Manage data forwarding across your organization'),
+          id: 'data-forwarding',
+          badge: () => <FeatureBadge type="beta" />,
+          recordAnalytics: true,
+          show: ({organization}) =>
+            !!organization &&
+            organization.features.includes('data-forwarding-revamp-access'),
+        },
+        {
           path: `${organizationSettingsPathPrefix}/relay/`,
           title: t('Relay'),
           description: t('Manage relays connected to the organization'),
@@ -177,17 +188,6 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           ),
           show: ({organization}) => !!organization && !organization.hideAiFeatures,
           id: 'seer',
-        },
-        {
-          path: `${organizationSettingsPathPrefix}/data-forwarding/`,
-          title: t('Data Forwarding'),
-          description: t('Manage data forwarding across your organization'),
-          id: 'data-forwarding',
-          badge: () => <FeatureBadge type="beta" />,
-          recordAnalytics: true,
-          show: ({organization}) =>
-            !!organization &&
-            organization.features.includes('data-forwarding-revamp-access'),
         },
       ],
     },

--- a/static/app/views/settings/organizationDataForwarding/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/forms.tsx
@@ -1,0 +1,179 @@
+import type {JsonFormObject} from 'sentry/components/forms/types';
+import IdBadge from 'sentry/components/idBadge';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import {DataForwarderProviderSlug} from 'sentry/views/settings/organizationDataForwarding/types';
+
+export function getDataForwarderFormGroups({
+  provider,
+  projects,
+}: {
+  projects: Project[];
+  provider: DataForwarderProviderSlug;
+}): JsonFormObject[] {
+  let providerFormGroups: JsonFormObject[] = [];
+  switch (provider) {
+    case DataForwarderProviderSlug.SQS:
+      providerFormGroups = [SQS_GLOBAL_CONFIGURATION_FORM];
+      break;
+    case DataForwarderProviderSlug.SEGMENT:
+      providerFormGroups = [SEGMENT_GLOBAL_CONFIGURATION_FORM];
+      break;
+    case DataForwarderProviderSlug.SPLUNK:
+      providerFormGroups = [SPLUNK_GLOBAL_CONFIGURATION_FORM];
+      break;
+    default:
+      return [];
+  }
+  return [ENABLEMENT_FORM, ...providerFormGroups, getProjectConfigurationForm(projects)];
+}
+
+const ENABLEMENT_FORM: JsonFormObject = {
+  title: t('Enablement'),
+  fields: [
+    {
+      name: 'is_enabled',
+      label: 'Enable data forwarding',
+      type: 'boolean',
+      defaultValue: false,
+      help: 'Will be disabled until the initial setup is complete.',
+      disabled: true,
+    },
+  ],
+};
+
+function getProjectConfigurationForm(projects: Project[]): JsonFormObject {
+  const projectOptions = projects.map(project => ({
+    value: project.id,
+    label: project.slug,
+    leadingItems: <IdBadge project={project} avatarSize={16} disableLink hideName />,
+  }));
+  return {
+    title: t('Project Configuration'),
+    fields: [
+      {
+        name: 'enroll_new_projects',
+        label: 'Auto-enroll new projects',
+        type: 'boolean',
+        help: 'Should new projects automatically forward their data?',
+      },
+      {
+        name: 'project_ids',
+        label: 'Forwarding projects',
+        type: 'select',
+        multiple: true,
+        defaultValue: [],
+        help: 'Select the projects which should forward their data.',
+        options: projectOptions,
+      },
+    ],
+  };
+}
+
+const SQS_GLOBAL_CONFIGURATION_FORM: JsonFormObject = {
+  title: t('Global Configuration'),
+  fields: [
+    {
+      name: 'queue_url',
+      label: 'Queue URL',
+      type: 'text',
+      required: true,
+      help: 'The URL of the SQS queue to forward events to.',
+      placeholder: 'e.g. https://sqs.us-east-1.amazonaws.com/12345678/myqueue',
+    },
+    {
+      name: 'region',
+      label: 'Region',
+      type: 'text',
+      required: true,
+      help: 'The region of the SQS queue to forward events to.',
+      placeholder: 'e.g. us-east-1',
+    },
+    {
+      name: 'access_key',
+      label: 'Access Key',
+      type: 'text',
+      required: true,
+      help: 'Currently only long-term IAM access keys are supported.',
+      placeholder: 'e.g. AKIAIOSFODNN7EXAMPLE',
+    },
+    {
+      name: 'secret_key',
+      label: 'Secret Key',
+      type: 'text',
+      required: true,
+      help: 'Only visible once when the access key is created..',
+      placeholder: 'e.g. wJalrXUtnFEMI1K7MDENGSbPxRfiCYEXAMPLEKEY',
+    },
+    {
+      name: 'message_group_id',
+      label: 'Message Group ID',
+      type: 'text',
+      required: false,
+      help: 'Required for FIFO queues, exclude for standard queues',
+      placeholder: 'e.g. my-message-group-id',
+    },
+    {
+      name: 's3_bucket',
+      label: 'S3 Bucket',
+      type: 'text',
+      required: false,
+      help: 'Specify a bucket to store events in S3. The SQS message will contain a reference to the payload location in S3. If no S3 bucket is provided, events over the SQS limit of 256KB will not be forwarded.',
+      placeholder: 'e.g. my-s3-bucket',
+    },
+  ],
+};
+
+const SEGMENT_GLOBAL_CONFIGURATION_FORM: JsonFormObject = {
+  title: t('Global Configuration'),
+  fields: [
+    {
+      name: 'segment_write_key',
+      label: 'Write Key',
+      type: 'text',
+      required: true,
+      help: 'Add an HTTP API Source to your Segment workspace to generate a write key.',
+      placeholder: 'e.g. itA5bLOPNxccvZ9ON1NYg9EXAMPLEKEY',
+    },
+  ],
+};
+
+const SPLUNK_GLOBAL_CONFIGURATION_FORM: JsonFormObject = {
+  title: t('Global Configuration'),
+  fields: [
+    {
+      name: 'instance_url',
+      label: 'Instance URL',
+      type: 'text',
+      required: true,
+      help: 'The HTTP Event Collector endpoint for your Splunk instance. Ensure indexer acknowledgement is disabled.',
+      placeholder: 'e.g. https://input-foo.cloud.splunk.com:8088',
+    },
+    {
+      name: 'token',
+      label: 'Token',
+      type: 'text',
+      required: true,
+      help: 'The token generated for your HTTP Event Collector.',
+      placeholder: 'e.g. 1234567890abcdef1234567890abcdef',
+    },
+    {
+      name: 'index',
+      label: 'Index',
+      type: 'text',
+      required: true,
+      defaultValue: 'main',
+      placeholder: 'e.g. main',
+      help: 'The index to use for the events.',
+    },
+    {
+      name: 'source',
+      label: 'Source',
+      type: 'text',
+      required: true,
+      defaultValue: 'sentry',
+      placeholder: 'e.g. sentry',
+      help: 'The source to use for the events.',
+    },
+  ],
+};

--- a/static/app/views/settings/organizationDataForwarding/hooks.tsx
+++ b/static/app/views/settings/organizationDataForwarding/hooks.tsx
@@ -1,0 +1,13 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useHasDataForwardingAccess() {
+  const organization = useOrganization();
+  const featureSet = new Set(organization.features);
+
+  return (
+    // Can access the new UI/UX and endpoints
+    featureSet.has('data-forwarding-revamp-access') &&
+    // Can access the feature itself (subscription-based)
+    featureSet.has('data-forwarding')
+  );
+}

--- a/static/app/views/settings/organizationDataForwarding/hooks.tsx
+++ b/static/app/views/settings/organizationDataForwarding/hooks.tsx
@@ -75,6 +75,7 @@ export function useMutateDataForwarder({
         })
       );
       queryClient.invalidateQueries({queryKey: [endpoint]});
+      queryClient.invalidateQueries({queryKey: listQueryKey});
     },
     onError: error => {
       const displayError =

--- a/static/app/views/settings/organizationDataForwarding/hooks.tsx
+++ b/static/app/views/settings/organizationDataForwarding/hooks.tsx
@@ -1,4 +1,16 @@
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t, tct} from 'sentry/locale';
+import {
+  useApiQuery,
+  useMutation,
+  useQueryClient,
+  type ApiQueryKey,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {DataForwarder} from 'sentry/views/settings/organizationDataForwarding/types';
 
 export function useHasDataForwardingAccess() {
   const organization = useOrganization();
@@ -10,4 +22,69 @@ export function useHasDataForwardingAccess() {
     // Can access the feature itself (subscription-based)
     featureSet.has('data-forwarding')
   );
+}
+
+const makeDataForwarderQueryKey = (params: {orgSlug: string}): ApiQueryKey => [
+  `/organizations/${params.orgSlug}/data-forwarders/`,
+];
+
+export function useDataForwarders({
+  params,
+  options,
+}: {
+  options: Partial<UseApiQueryOptions<DataForwarder[]>>;
+  params: {orgSlug: string};
+}) {
+  return useApiQuery<DataForwarder[]>(makeDataForwarderQueryKey(params), {
+    staleTime: 30000,
+    ...options,
+  });
+}
+
+export function useMutateDataForwarder({
+  params,
+}: {
+  params: {dataForwarderId: string; orgSlug: string};
+}) {
+  const api = useApi({persistInFlight: false});
+  const queryClient = useQueryClient();
+  return useMutation<DataForwarder, RequestError, DataForwarder>({
+    mutationFn: data =>
+      api.requestPromise(
+        `/organizations/${params.orgSlug}/data-forwarders/${params.dataForwarderId}/`,
+        {method: 'PUT', data}
+      ),
+    onSuccess: (dataForwarder: DataForwarder) => {
+      addSuccessMessage(
+        tct('[provider] data forwarder updated', {provider: dataForwarder.provider})
+      );
+      queryClient.invalidateQueries({queryKey: makeDataForwarderQueryKey(params)});
+    },
+    onError: _error => {
+      addErrorMessage(t('Failed to update data forwarder'));
+    },
+  });
+}
+
+export function useDeleteDataForwarder({
+  params,
+}: {
+  params: {dataForwarderId: string; orgSlug: string};
+}) {
+  const api = useApi({persistInFlight: false});
+  const queryClient = useQueryClient();
+  return useMutation<void, RequestError, {dataForwarderId: string; orgSlug: string}>({
+    mutationFn: ({dataForwarderId, orgSlug}) =>
+      api.requestPromise(
+        `/organizations/${orgSlug}/data-forwarders/${dataForwarderId}/`,
+        {method: 'DELETE'}
+      ),
+    onSuccess: () => {
+      addSuccessMessage(t('Data forwarder deleted'));
+      queryClient.invalidateQueries({queryKey: makeDataForwarderQueryKey(params)});
+    },
+    onError: _error => {
+      addErrorMessage(t('Failed to delete data forwarder'));
+    },
+  });
 }

--- a/static/app/views/settings/organizationDataForwarding/hooks.tsx
+++ b/static/app/views/settings/organizationDataForwarding/hooks.tsx
@@ -9,29 +9,16 @@ import {
 } from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
-import useOrganization from 'sentry/utils/useOrganization';
 import {
   ProviderLabels,
   type DataForwarder,
 } from 'sentry/views/settings/organizationDataForwarding/types';
 
-export function useHasDataForwardingAccess() {
-  const organization = useOrganization();
-  const featureSet = new Set(organization.features);
-
-  return (
-    // Can access the new UI/UX and endpoints
-    featureSet.has('data-forwarding-revamp-access') &&
-    // Can access the feature itself (subscription-based)
-    featureSet.has('data-forwarding')
-  );
-}
-
 const makeDataForwarderQueryKey = (params: {orgSlug: string}): ApiQueryKey => [
   `/organizations/${params.orgSlug}/forwarding/`,
 ];
 
-export function useDataForwarders({
+function useDataForwarders({
   params,
   options,
 }: {
@@ -40,11 +27,13 @@ export function useDataForwarders({
 }) {
   return useApiQuery<DataForwarder[]>(makeDataForwarderQueryKey(params), {
     staleTime: 30000,
-
     ...options,
   });
 }
 
+/**
+ * Simplified hook to get the primary data forwarder for an organization.
+ */
 export function useDataForwarder({
   orgSlug,
 }: {

--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -71,12 +71,15 @@ export default function OrganizationDataForwarding() {
         return;
       }
       const initialData: Record<string, any> = {
+        is_enabled: dataForwarder.isEnabled,
         enroll_new_projects: dataForwarder.enrollNewProjects,
         project_ids: dataForwarder.enrolledProjects.map(project => project.id),
         ...dataForwarder.config,
       };
       setCombinedFormState(prev => ({...prev, [dataForwarder.provider]: initialData}));
-      formModel.setInitialData(initialData ?? {...combinedFormState[provider]});
+      formModel.setInitialData(
+        dataForwarder ? initialData : {...combinedFormState[provider]}
+      );
       formModel.setFormOptions({onFieldChange: updateCombinedFormState});
       formModel.validateFormCompletion();
     },
@@ -147,7 +150,7 @@ export default function OrganizationDataForwarding() {
         >
           <JsonForm
             forms={getDataForwarderFormGroups({
-              provider,
+              provider: dataForwarder ? dataForwarder.provider : provider,
               projects,
               dataForwarder,
               organization,

--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -1,23 +1,76 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge/featureBadge';
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import FormModel from 'sentry/components/forms/model';
 import {Hovercard} from 'sentry/components/hovercard';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {getDataForwarderFormGroups} from 'sentry/views/settings/organizationDataForwarding/forms';
 import {useHasDataForwardingAccess} from 'sentry/views/settings/organizationDataForwarding/hooks';
+import {
+  DataForwarderProviderSlug,
+  ProviderLabels,
+} from 'sentry/views/settings/organizationDataForwarding/types';
 
 export default function OrganizationDataForwarding() {
+  const formModel = useMemo(() => new FormModel(), []);
+  const organization = useOrganization();
+  const {projects} = useProjects({orgId: organization.slug});
+  const [provider, setProvider] = useState<DataForwarderProviderSlug>(
+    DataForwarderProviderSlug.SEGMENT
+  );
+
+  const [combinedFormState, setCombinedFormState] = useState<
+    Record<DataForwarderProviderSlug, Record<string, any>>
+  >({
+    [DataForwarderProviderSlug.SEGMENT]: {},
+    [DataForwarderProviderSlug.SQS]: {},
+    [DataForwarderProviderSlug.SPLUNK]: {},
+  });
+
+  const updateCombinedFormState = useCallback(
+    (id: string, finalValue: any) => {
+      setCombinedFormState(prev => ({
+        ...prev,
+        [provider]: {
+          ...prev[provider],
+          [id]: finalValue,
+        },
+      }));
+    },
+    [provider]
+  );
+
+  useEffect(
+    () => {
+      formModel.setInitialData({...combinedFormState[provider]});
+      formModel.setFormOptions({
+        onFieldChange: updateCombinedFormState,
+      });
+      formModel.validateFormCompletion();
+    },
+    // We don't want to re-run every time the combined state changes, only the provider
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [provider, formModel, updateCombinedFormState]
+  );
+
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Data Forwarding')} />
-      <Container>
-        <Flex align="center" justify="between" gap="xl">
+      <Flex direction="column" gap="lg">
+        <Flex align="center" justify="between" gap="2xl">
           <Flex direction="column" gap="sm">
             <Flex align="center" gap="lg">
               <Heading as="h1">{t('Data Forwarding')}</Heading>
@@ -36,7 +89,24 @@ export default function OrganizationDataForwarding() {
           </Flex>
           <DataForwardingSetupButton />
         </Flex>
-      </Container>
+        <Tabs value={provider} onChange={setProvider}>
+          <TabList variant="floating">
+            {Object.entries(ProviderLabels).map(([key, label]) => (
+              <TabList.Item key={key}>
+                <Flex align="center" gap="sm">
+                  <PluginIcon
+                    pluginId={key === DataForwarderProviderSlug.SQS ? 'amazon-sqs' : key}
+                  />
+                  <b>{label}</b>
+                </Flex>
+              </TabList.Item>
+            ))}
+          </TabList>
+        </Tabs>
+        <Form model={formModel}>
+          <JsonForm forms={getDataForwarderFormGroups({provider, projects})} />
+        </Form>
+      </Flex>
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -1,0 +1,63 @@
+import {Fragment} from 'react';
+
+import {FeatureBadge} from '@sentry/scraps/badge/featureBadge';
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import {Hovercard} from 'sentry/components/hovercard';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import {useHasDataForwardingAccess} from 'sentry/views/settings/organizationDataForwarding/hooks';
+
+export default function OrganizationDataForwarding() {
+  return (
+    <Fragment>
+      <SentryDocumentTitle title={t('Data Forwarding')} />
+      <Container>
+        <Flex align="center" justify="between" gap="xl">
+          <Flex direction="column" gap="sm">
+            <Flex align="center" gap="lg">
+              <Heading as="h1">{t('Data Forwarding')}</Heading>
+              <FeatureBadge type="beta" />
+            </Flex>
+            <Text variant="muted">
+              {tct(
+                'Pipe your Sentry error events into other business intelligence tools. Learn more about this feature in our [link:docs].',
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/organization/integrations/data-forwarding/" />
+                  ),
+                }
+              )}
+            </Text>
+          </Flex>
+          <DataForwardingSetupButton />
+        </Flex>
+      </Container>
+    </Fragment>
+  );
+}
+
+function DataForwardingSetupButton() {
+  const hasAccess = useHasDataForwardingAccess();
+  return hasAccess ? (
+    <Button priority="primary">{t('Start Setup')}</Button>
+  ) : (
+    <Hovercard
+      body={
+        <FeatureDisabled
+          features={['data-forwarding-revamp-access', 'data-forwarding']}
+          featureName={t('Data Forwarding')}
+          hideHelpToggle
+        />
+      }
+    >
+      <Button priority="primary" disabled>
+        {t('Start Setup')}
+      </Button>
+    </Hovercard>
+  );
+}

--- a/static/app/views/settings/organizationDataForwarding/types.ts
+++ b/static/app/views/settings/organizationDataForwarding/types.ts
@@ -12,7 +12,7 @@ export const ProviderLabels: Record<DataForwarderProviderSlug, string> = {
   [DataForwarderProviderSlug.SPLUNK]: 'Splunk',
 };
 
-export interface DataForwarderProject {
+interface DataForwarderProject {
   dataForwarderId: string;
   effectiveConfig: Record<string, any>;
   id: string;

--- a/static/app/views/settings/organizationDataForwarding/types.ts
+++ b/static/app/views/settings/organizationDataForwarding/types.ts
@@ -1,0 +1,11 @@
+export enum DataForwarderProviderSlug {
+  SEGMENT = 'segment',
+  SQS = 'sqs',
+  SPLUNK = 'splunk',
+}
+
+export const ProviderLabels: Record<DataForwarderProviderSlug, string> = {
+  [DataForwarderProviderSlug.SEGMENT]: 'Segment',
+  [DataForwarderProviderSlug.SQS]: 'Amazon SQS',
+  [DataForwarderProviderSlug.SPLUNK]: 'Splunk',
+};

--- a/static/app/views/settings/organizationDataForwarding/types.ts
+++ b/static/app/views/settings/organizationDataForwarding/types.ts
@@ -1,3 +1,5 @@
+import type {AvatarProject} from 'sentry/types/project';
+
 export enum DataForwarderProviderSlug {
   SEGMENT = 'segment',
   SQS = 'sqs',
@@ -9,3 +11,22 @@ export const ProviderLabels: Record<DataForwarderProviderSlug, string> = {
   [DataForwarderProviderSlug.SQS]: 'Amazon SQS',
   [DataForwarderProviderSlug.SPLUNK]: 'Splunk',
 };
+
+export interface DataForwarderProject {
+  dataForwarderId: string;
+  effectiveConfig: Record<string, any>;
+  id: string;
+  overrides: Record<string, any>;
+  project: Required<AvatarProject>;
+}
+
+export interface DataForwarder {
+  config: Record<string, any>;
+  enrollNewProjects: boolean;
+  enrolledProjects: Array<Required<AvatarProject>>;
+  id: string;
+  isEnabled: boolean;
+  organizationId: string;
+  projectConfigs: DataForwarderProject[];
+  provider: DataForwarderProviderSlug;
+}


### PR DESCRIPTION
This PR introduces a frontend interface to interact with the data forwarding API but there are a few limitations:
- It doesn't really feel responsive yet,  the setup is uneventful when complete and must be saved at the bottom of the page each time
- Deleting the forwarder doesn't reset the form to empty yet
- The error messaging is just dropping JSON in an alert
- The update and create options are all in the same page, so it's hard to tell if you're modifying or creating a new forwarder
- There is no interface for updating the project level configurations yet -- that might be better on a separate page.

But at minimum we can interact with an API and this is all behind a feature flag.

https://github.com/user-attachments/assets/b11d88fb-88f7-4e56-b2a4-4eeab3c39cfd

