### PR TITLE
ref(groupingInfo): Refactor grouping info to avoid storing redundant data

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -39,8 +39,8 @@ export default function GroupingInfo({
       projectSlug,
     });
 
-  const variants = groupInfo
-    ? Object.values(groupInfo).sort((a, b) => {
+  const variants = groupInfo?.variants
+    ? Object.values(groupInfo.variants).sort((a, b) => {
         // Sort contributing variants before non-contributing ones
         if (a.contributes && !b.contributes) {
           return -1;

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -30,7 +30,7 @@ export function GroupInfoSummary({
         .join(', ')
     : t('nothing');
 
-  const groupingConfig = showGroupingConfig && groupInfo?.grouping_config;
+  const groupingConfig = showGroupingConfig && groupInfo?.grouping_config?.id;
 
   if (isPending && !hasPerformanceGrouping) {
     return (

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -22,7 +22,7 @@ export function GroupInfoSummary({
     group,
     projectSlug,
   });
-  const groupedBy = groupInfo
+  const groupedBy = groupInfo?.variants
     ? Object.values(groupInfo.variants)
         .filter(variant => variant.contributes && variant.description !== null)
         .map(variant => variant.description!)

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -23,21 +23,14 @@ export function GroupInfoSummary({
     projectSlug,
   });
   const groupedBy = groupInfo
-    ? Object.values(groupInfo)
+    ? Object.values(groupInfo.variants)
         .filter(variant => variant.contributes && variant.description !== null)
         .map(variant => variant.description!)
         .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
         .join(', ')
     : t('nothing');
 
-  const groupingConfig =
-    showGroupingConfig && groupInfo
-      ? (
-          Object.values(groupInfo).find(
-            variant => 'config' in variant && variant.config?.id
-          ) as any
-        )?.config?.id
-      : null;
+  const groupingConfig = groupInfo?.grouping_config;
 
   if (isPending && !hasPerformanceGrouping) {
     return (

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -30,7 +30,7 @@ export function GroupInfoSummary({
         .join(', ')
     : t('nothing');
 
-  const groupingConfig = showGroupingConfig && groupInfo?.grouping_config?.id;
+  const groupingConfig = showGroupingConfig && groupInfo?.grouping_config;
 
   if (isPending && !hasPerformanceGrouping) {
     return (

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -30,7 +30,7 @@ export function GroupInfoSummary({
         .join(', ')
     : t('nothing');
 
-  const groupingConfig = groupInfo?.grouping_config;
+  const groupingConfig = showGroupingConfig && groupInfo?.grouping_config;
 
   if (isPending && !hasPerformanceGrouping) {
     return (

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -43,7 +43,7 @@ function generatePerformanceGroupInfo({
 }: {
   event: Event;
   group: Group | undefined;
-}): EventGroupingInfoResponseOld | null {
+}): EventGroupingInfoResponseOld | EventGroupingInfoResponse | null {
   if (!event.occurrence) {
     return null;
   }

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -31,6 +31,11 @@ function eventGroupingInfoResponseOldToNew(
       }
     : null;
 }
+function isOld(
+  data: EventGroupingInfoResponseOld | EventGroupingInfoResponse | null
+): boolean {
+  return data ? !('grouping_config' in data) : false;
+}
 
 function generatePerformanceGroupInfo({
   event,
@@ -83,16 +88,20 @@ export function useEventGroupingInfo({
 
   const hasPerformanceGrouping = event.occurrence && event.type === 'transaction';
 
-  const {data, isPending, isError, isSuccess} = useApiQuery<EventGroupingInfoResponseOld>(
-    [`/projects/${organization.slug}/${projectSlug}/events/${event.id}/grouping-info/`],
-    {enabled: !hasPerformanceGrouping, staleTime: Infinity}
-  );
+  const {data, isPending, isError, isSuccess} = useApiQuery<
+    EventGroupingInfoResponseOld | EventGroupingInfoResponse
+  >([`/projects/${organization.slug}/${projectSlug}/events/${event.id}/grouping-info/`], {
+    enabled: !hasPerformanceGrouping,
+    staleTime: Infinity,
+  });
 
   const groupInfo = hasPerformanceGrouping
     ? generatePerformanceGroupInfo({group, event})
     : (data ?? null);
 
-  const groupInfoNew = eventGroupingInfoResponseOldToNew(groupInfo);
+  const groupInfoNew = isOld(groupInfo)
+    ? eventGroupingInfoResponseOldToNew(groupInfo as EventGroupingInfoResponseOld)
+    : (groupInfo as EventGroupingInfoResponse);
 
   return {
     groupInfo: groupInfoNew,

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -14,6 +14,7 @@ type EventGroupingInfoResponse = {
   variants: Record<string, EventGroupVariant>;
 };
 
+// temporary function to convert the old response structure to the new one
 function eventGroupingInfoResponseOldToNew(
   old: EventGroupingInfoResponseOld | null
 ): EventGroupingInfoResponse | null {
@@ -31,6 +32,8 @@ function eventGroupingInfoResponseOldToNew(
       }
     : null;
 }
+
+// temporary function to check if the respinse is old type
 function isOld(
   data: EventGroupingInfoResponseOld | EventGroupingInfoResponse | null
 ): boolean {

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {
   EventGroupVariantType,
   type Event,
+  type EventGroupingConfig,
   type EventGroupVariant,
 } from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -10,7 +11,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 type EventGroupingInfoResponseOld = Record<string, EventGroupVariant>;
 type EventGroupingInfoResponse = {
-  grouping_config: string;
+  grouping_config: EventGroupingConfig | null;
   variants: Record<string, EventGroupVariant>;
 };
 
@@ -19,11 +20,8 @@ function eventGroupingInfoResponseOldToNew(
   old: EventGroupingInfoResponseOld | null
 ): EventGroupingInfoResponse | null {
   const grouping_config = old
-    ? (
-        Object.values(old).find(
-          variant => 'config' in variant && variant.config?.id
-        ) as any
-      )?.config?.id
+    ? (Object.values(old).find(variant => 'config' in variant && variant.config) as any)
+        ?.config
     : null;
   return old
     ? {
@@ -57,7 +55,7 @@ function generatePerformanceGroupInfo({
 
   return group
     ? {
-        grouping_config: 'performance',
+        grouping_config: null,
         variants: {
           [group.issueType]: {
             contributes: true,

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -2,7 +2,6 @@ import {t} from 'sentry/locale';
 import {
   EventGroupVariantType,
   type Event,
-  type EventGroupingConfig,
   type EventGroupVariant,
 } from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -11,7 +10,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 type EventGroupingInfoResponseOld = Record<string, EventGroupVariant>;
 type EventGroupingInfoResponse = {
-  grouping_config: EventGroupingConfig | null;
+  grouping_config: string | null;
   variants: Record<string, EventGroupVariant>;
 };
 
@@ -20,8 +19,11 @@ function eventGroupingInfoResponseOldToNew(
   old: EventGroupingInfoResponseOld | null
 ): EventGroupingInfoResponse | null {
   const grouping_config = old
-    ? (Object.values(old).find(variant => 'config' in variant && variant.config) as any)
-        ?.config
+    ? (
+        Object.values(old).find(
+          variant => 'config' in variant && variant.config?.id
+        ) as any
+      )?.config?.id
     : null;
   return old
     ? {


### PR DESCRIPTION
First PR in a series to refactor grouping info data structure (see l[inear issue](https://linear.app/getsentry/issue/RTC-1232/refactor-grouping-info-to-avoid-storing-redundant-data)).

Make front end accept and implement new grouping info data structure with `grouping_config` pulled out of individual grouping variants. Now the front end can accept either the correct new `EventGroupingInfoResponse` or the old `EventGroupingInfoResponseOld` which it will convert into the correct `EventGroupingInfoResponse` data type. 

Replacement for #101135
