### PR TITLE
feat(dashboards): Include predefined values in the global filter selector

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -181,7 +181,7 @@ function getSuggestionDescription(group: SearchGroup | SearchItem) {
   return undefined;
 }
 
-function getPredefinedValues({
+export function getPredefinedValues({
   fieldDefinition,
   key,
   filterValue,

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -4,6 +4,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderState';
 import {getFilterValueType} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {cleanFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils';
+import {getInitialFilterText} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {
   TermOperator,
@@ -52,6 +53,19 @@ export function parseFilterValue(
     return [];
   }
   return parsedResult.filter(token => token.type === Token.FILTER);
+}
+
+export function getFilterToken(
+  globalFilter: GlobalFilter,
+  fieldDefinition: FieldDefinition | null
+) {
+  const {tag, value} = globalFilter;
+  let filterValue = value;
+  if (value === '') {
+    filterValue = getInitialFilterText(tag.key, fieldDefinition, false);
+  }
+  const filterTokens = parseFilterValue(filterValue, globalFilter);
+  return filterTokens[0] ?? null;
 }
 
 export function isValidNumericFilterValue(


### PR DESCRIPTION
Some tags have predefined values. This PR adds a check for predefined values and adds them to the global filter selector options if there are any. If predefined values exist, they should be used and tag values should not be fetched.

Fixes [DAIN-1008](https://linear.app/getsentry/issue/DAIN-1008/assigned-assigned-or-suggested-etc-dont-work-as-global-filters)