### PR TITLE
feat(tracemetrics): Add tracemetrics specific aggregate functions

### DIFF
--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -18,6 +18,7 @@ def count_processor(count_value: int | None) -> int:
 TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES = [
     AttributeKey(name="sentry.metric_name", type=AttributeKey.Type.TYPE_STRING),
     AttributeKey(name="sentry.metric_type", type=AttributeKey.Type.TYPE_STRING),
+    AttributeKey(name="sentry.value", type=AttributeKey.Type.TYPE_DOUBLE),
 ]
 
 TRACE_METRICS_AGGREGATE_DEFINITIONS = {

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -1,5 +1,215 @@
-from sentry.search.eap.ourlogs.aggregates import LOG_AGGREGATE_DEFINITIONS
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Function
 
-# For now, trace metrics uses the same aggregates as logs
-# This can be extended in the future with trace metrics specific aggregates
-TRACE_METRICS_AGGREGATE_DEFINITIONS = LOG_AGGREGATE_DEFINITIONS
+from sentry.search.eap import constants
+from sentry.search.eap.columns import (
+    AggregateDefinition,
+    AttributeArgumentDefinition,
+    count_argument_resolver_optimized,
+)
+
+
+def count_processor(count_value: int | None) -> int:
+    if count_value is None:
+        return 0
+    else:
+        return count_value
+
+
+TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES = [
+    AttributeKey(name="sentry.metric_name", type=AttributeKey.Type.TYPE_STRING),
+    AttributeKey(name="sentry.metric_type", type=AttributeKey.Type.TYPE_STRING),
+]
+
+TRACE_METRICS_AGGREGATE_DEFINITIONS = {
+    "count": AggregateDefinition(
+        internal_function=Function.FUNCTION_COUNT,
+        infer_search_type_from_arguments=False,
+        processor=count_processor,
+        default_search_type="integer",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "string",
+                    "number",
+                    "integer",
+                },
+                default_arg="value",
+            )
+        ],
+        attribute_resolver=count_argument_resolver_optimized(
+            TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES
+        ),
+    ),
+    "count_unique": AggregateDefinition(
+        internal_function=Function.FUNCTION_UNIQ,
+        default_search_type="integer",
+        infer_search_type_from_arguments=False,
+        processor=count_processor,
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "string",
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "sum": AggregateDefinition(
+        internal_function=Function.FUNCTION_SUM,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "avg": AggregateDefinition(
+        internal_function=Function.FUNCTION_AVG,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "p50": AggregateDefinition(
+        internal_function=Function.FUNCTION_P50,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "p75": AggregateDefinition(
+        internal_function=Function.FUNCTION_P75,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "p90": AggregateDefinition(
+        internal_function=Function.FUNCTION_P90,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "p95": AggregateDefinition(
+        internal_function=Function.FUNCTION_P95,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "p99": AggregateDefinition(
+        internal_function=Function.FUNCTION_P99,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "max": AggregateDefinition(
+        internal_function=Function.FUNCTION_MAX,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+    "min": AggregateDefinition(
+        internal_function=Function.FUNCTION_MIN,
+        default_search_type="number",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            )
+        ],
+    ),
+}


### PR DESCRIPTION
Don't rely on the definitions from logs and have it's own. Also apply the count optimization for tracemetrics.