### PR TITLE
ref(tracemetrics): Add metric tab platform-based visibility

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -396,6 +396,12 @@ export const withMetricsOnboarding: Set<PlatformKey> = new Set([]);
 // List of platforms that do not have metrics support. We make use of this list in the product to not provide any Metrics
 export const withoutMetricsSupport: Set<PlatformKey> = new Set([]);
 
+export const limitedMetricsSupportPrefixes: Set<string> = new Set([
+  'javascript',
+  'node',
+  'python',
+]);
+
 export const profiling: PlatformKey[] = [
   'android',
   'apple',
@@ -421,6 +427,7 @@ export const profiling: PlatformKey[] = [
   'javascript-sveltekit',
   'javascript-tanstackstart-react',
   'javascript-vue',
+
   'node',
   'node-awslambda',
   'node-azurefunctions',

--- a/static/app/utils/analytics/metricsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/metricsAnalyticsEvent.tsx
@@ -7,6 +7,11 @@ export type MetricsAnalyticsEventParameters = {
     platform: PlatformKey | 'unknown';
     supports_onboarding_checklist: boolean;
   };
+  'metrics.nav.rendered': {
+    metrics_tab_visible: boolean;
+    organization: Organization;
+    platforms: Array<PlatformKey | 'unknown'>;
+  };
   'metrics.onboarding': {
     organization: Organization;
     platform: PlatformKey | 'unknown';
@@ -33,6 +38,7 @@ type MetricsAnalyticsEventKey = keyof MetricsAnalyticsEventParameters;
 
 export const metricsAnalyticsEventMap: Record<MetricsAnalyticsEventKey, string | null> = {
   'metrics.explorer.setup_button_clicked': 'Metrics Setup Button Clicked',
+  'metrics.nav.rendered': 'Metrics Nav Rendered',
   'metrics.onboarding': 'Metrics Explore Empty State (Onboarding)',
   'metrics.onboarding_platform_docs_viewed':
     'Metrics Explore Empty State (Onboarding) - Platform Docs Viewed',

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -1,10 +1,14 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {limitedMetricsSupportPrefixes} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
+import type {PlatformKey} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {useGetSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
@@ -17,6 +21,7 @@ const MAX_STARRED_QUERIES_DISPLAYED = 20;
 export function ExploreSecondaryNav() {
   const organization = useOrganization();
   const location = useLocation();
+  const {projects} = useProjects();
 
   const baseUrl = `/organizations/${organization.slug}/explore`;
 
@@ -24,6 +29,28 @@ export function ExploreSecondaryNav() {
     starred: true,
     perPage: MAX_STARRED_QUERIES_DISPLAYED,
   });
+
+  const hasMetricsSupportedPlatform = projects.some(project => {
+    const platform = project.platform || 'unknown';
+    return Array.from(limitedMetricsSupportPrefixes).some(prefix =>
+      platform.startsWith(prefix)
+    );
+  });
+
+  const userPlatforms = useMemo(
+    () => [
+      ...new Set(projects.map(project => (project.platform as PlatformKey) || 'unknown')),
+    ],
+    [projects]
+  );
+
+  useEffect(() => {
+    trackAnalytics('metrics.nav.rendered', {
+      organization,
+      metrics_tab_visible: hasMetricsSupportedPlatform,
+      platforms: userPlatforms,
+    });
+  }, [organization, hasMetricsSupportedPlatform, userPlatforms]);
 
   return (
     <Fragment>
@@ -51,15 +78,17 @@ export function ExploreSecondaryNav() {
               {t('Logs')}
             </SecondaryNav.Item>
           </Feature>
-          <Feature features="tracemetrics-enabled">
-            <SecondaryNav.Item
-              to={`${baseUrl}/metrics/`}
-              analyticsItemName="explore_metrics"
-              trailingItems={<FeatureBadge type="alpha" />}
-            >
-              {t('Metrics')}
-            </SecondaryNav.Item>
-          </Feature>
+          {hasMetricsSupportedPlatform && (
+            <Feature features="tracemetrics-enabled">
+              <SecondaryNav.Item
+                to={`${baseUrl}/metrics/`}
+                analyticsItemName="explore_metrics"
+                trailingItems={<FeatureBadge type="alpha" />}
+              >
+                {t('Metrics')}
+              </SecondaryNav.Item>
+            </Feature>
+          )}
           <Feature
             features="discover-basic"
             hookName="feature-disabled:discover2-sidebar-item"


### PR DESCRIPTION
### Summary
Only users that have python or js platform projects at all will see the metric tab in the first place.

Refs LOGS-492


