### PR TITLE
fix(aci): Mark Detector+Workflow PENDING_DELETION in migration helper

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -919,8 +919,9 @@ def dual_delete_migrated_alert_rule(alert_rule: AlertRule) -> None:
             RegionScheduledDeletion.schedule(instance=workflow, days=0)
 
     else:
-        detector.update(status=ObjectStatus.PENDING_DELETION)
-        RegionScheduledDeletion.schedule(instance=detector, days=0)
+        with transaction.atomic(router.db_for_write(Detector)):
+            detector.update(status=ObjectStatus.PENDING_DELETION)
+            RegionScheduledDeletion.schedule(instance=detector, days=0)
 
     return
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -5,6 +5,7 @@ from typing import Any
 from django.db import router, transaction
 from django.forms import ValidationError
 
+from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import (
@@ -912,10 +913,13 @@ def dual_delete_migrated_alert_rule(alert_rule: AlertRule) -> None:
     if alert_rule_workflow:
         workflow: Workflow = alert_rule_workflow.workflow
         with transaction.atomic(router.db_for_write(Detector)):
+            detector.update(status=ObjectStatus.PENDING_DELETION)
+            workflow.update(status=ObjectStatus.PENDING_DELETION)
             RegionScheduledDeletion.schedule(instance=detector, days=0)
             RegionScheduledDeletion.schedule(instance=workflow, days=0)
 
     else:
+        detector.update(status=ObjectStatus.PENDING_DELETION)
         RegionScheduledDeletion.schedule(instance=detector, days=0)
 
     return


### PR DESCRIPTION
We aren't _required_ to mark these as PENDING_DELETION, but it's good practice as it allows querying to treat them as immediately gone, and (the motivation for this change) allows consistency monitoring queries to exclude pending deletion rows from their checks. 

The status is supposed to be `DELETION_IN_PROGRESS` while we're actively deleting, but it seems that our replication doesn't always order transaction perfectly and it is bursty, so we can have windows of observable missing children without the status update been applied yet. Setting it before scheduling (as is the intended pattern) should make this irrelevant.