### PR TITLE
feat(aci): set up process_workflows to handle multiple detectors

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -181,16 +181,13 @@ def filter_recently_fired_workflow_actions(
         workflow_ids.add(workflow_id)
 
     # Map workflow_id to preferred detector
-    detector_workflows = (
-        DetectorWorkflow.objects.filter(workflow_id__in=workflow_ids)
-        .select_related("detector")
-        .order_by("workflow_id", "id")
-    )
+    detector_workflows = DetectorWorkflow.objects.filter(
+        workflow_id__in=workflow_ids, detector__in=detectors
+    ).select_related("detector")
 
     workflow_id_to_detectors: dict[int, list[Detector]] = defaultdict(list)
     for dw in detector_workflows:
-        if dw.detector in detectors:
-            workflow_id_to_detectors[dw.workflow_id].append(dw.detector)
+        workflow_id_to_detectors[dw.workflow_id].append(dw.detector)
 
     workflow_id_to_preferred_detector: dict[int, Detector] = {
         workflow_id: get_preferred_detector(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -722,7 +722,7 @@ def fire_actions_for_groups(
 
                 dcgs_for_group = groups_to_fire.get(group.id, set())
                 filtered_actions = filter_recently_fired_workflow_actions(
-                    dcgs_for_group, workflow_event_data
+                    [detector], dcgs_for_group, workflow_event_data
                 )
 
                 metrics.incr(
@@ -732,7 +732,6 @@ def fire_actions_for_groups(
                 )
 
                 workflow_fire_histories = create_workflow_fire_histories(
-                    detector,
                     filtered_actions,
                     workflow_event_data,
                     should_trigger_actions(group_event.group.type),
@@ -758,7 +757,7 @@ def fire_actions_for_groups(
                 )
                 total_actions += len(filtered_actions)
 
-                fire_actions(filtered_actions, detector, workflow_event_data)
+                fire_actions(filtered_actions, workflow_event_data)
 
     logger.debug(
         "workflow_engine.delayed_workflow.triggered_actions_summary",

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -56,10 +56,13 @@ def get_preferred_detector(detectors: list[Detector], type: str) -> Detector:
     )
     event_type_detector = next((detector for detector in detectors if detector.type == type), None)
 
-    if event_type_detector is None:
+    if event_type_detector is not None:
+        return event_type_detector
+
+    if issue_stream_detector is not None:
         return issue_stream_detector
 
-    return event_type_detector
+    raise ValueError(f"No detector found for type: {type}")
 
 
 def _ensure_detector(project: Project, type: str) -> Detector:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -44,6 +44,24 @@ class UnableToAcquireLockApiError(SentryAPIException):
     message = "Unable to acquire lock for issue alert migration."
 
 
+def get_preferred_detector(detectors: list[Detector], type: str) -> Detector:
+    if len(detectors) == 1:
+        return detectors[0]
+
+    elif len(detectors) != 2:
+        raise ValueError(f"Expected 1 or 2 detectors, got {len(detectors)}")
+
+    issue_stream_detector = next(
+        (detector for detector in detectors if detector.type == IssueStreamGroupType.slug), None
+    )
+    event_type_detector = next((detector for detector in detectors if detector.type == type), None)
+
+    if event_type_detector is None:
+        return issue_stream_detector
+
+    return event_type_detector
+
+
 def _ensure_detector(project: Project, type: str) -> Detector:
     """
     Ensure that a detector of a given type exists for a project.

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -411,7 +411,7 @@ def get_environment_by_event(event_data: WorkflowEventData) -> Environment | Non
 @scopedstats.timer()
 def _get_associated_workflows(
     detectors: list[Detector], environment: Environment | None, event_data: WorkflowEventData
-) -> list[Workflow]:
+) -> set[Workflow]:
     """
     This is a wrapper method to get the workflows associated with a detector and environment.
     Used in process_workflows to wrap the query + logging into a single method

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import Any, cast
 
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.services.eventstore.models import GroupEvent
@@ -36,8 +37,9 @@ def create_workflow_fire_histories(
     """
     # Extract workflow_id and detector_id from the annotated actions
     # Each action has been annotated with workflow_id and detector_id in filter_recently_fired_workflow_actions
-    workflow_id_to_detector_id = dict(
-        actions_to_fire.values_list("workflow_id", "detector_id").distinct()
+    # these are added at runtime, cast to avoid type errors
+    workflow_id_to_detector_id: dict[int, int] = dict(
+        cast(Any, actions_to_fire).values_list("workflow_id", "detector_id").distinct()
     )
 
     event_id = (

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -23,7 +23,7 @@ logger = log_context.get_logger(__name__)
 
 
 def build_trigger_action_task_params(
-    action: Action, detector: Detector, event_data: WorkflowEventData
+    action: Action, event_data: WorkflowEventData
 ) -> dict[str, object]:
     """
     Build parameters for trigger_action task invocation.
@@ -45,7 +45,7 @@ def build_trigger_action_task_params(
 
     return {
         "action_id": action.id,
-        "detector_id": detector.id,
+        "detector_id": getattr(action, "detector_id", None),
         "workflow_id": getattr(action, "workflow_id", None),
         "event_id": event_id,
         "activity_id": activity_id,

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -51,7 +51,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.event_data
+            [self.detector], set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action}
         assert {getattr(action, "workflow_id") for action in triggered_actions} == {
@@ -84,7 +84,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_3.update(date_updated=timezone.now() - timedelta(days=2))
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.event_data
+            [self.detector], set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action, action_3}
 
@@ -102,7 +102,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         self.create_workflow_data_condition_group(workflow, action_group)
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.event_data
+            [self.detector], set(DataConditionGroup.objects.all()), self.event_data
         )
         # dedupes action if both workflows will fire it
         assert set(triggered_actions) == {self.action}
@@ -126,7 +126,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status.update(date_updated=timezone.now() - timedelta(hours=1))
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.event_data
+            [self.detector], set(DataConditionGroup.objects.all()), self.event_data
         )
         # fires one action for the workflow that can fire it
         assert set(triggered_actions) == {self.action}

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -163,7 +163,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        mock_filter.assert_called_with({workflow_filters}, self.event_data)
+        mock_filter.assert_called_with([self.error_detector], {workflow_filters}, self.event_data)
 
     def test_same_environment_only(self) -> None:
         env = self.create_environment(project=self.project)

--- a/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
@@ -1,3 +1,5 @@
+from django.db.models import Value
+
 from sentry.workflow_engine.models import Action, WorkflowFireHistory
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import WorkflowEventData
@@ -21,9 +23,11 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
 
     def test_create_workflow_fire_histories(self) -> None:
+        # annotate action with detector_id
         create_workflow_fire_histories(
-            self.detector,
-            Action.objects.filter(id=self.action.id),
+            Action.objects.filter(id=self.action.id).annotate(
+                detector_id=Value(self.detector.id), workflow_id=Value(self.workflow.id)
+            ),
             self.event_data,
             is_single_processing=True,
             is_delayed=False,


### PR DESCRIPTION
With the issue stream detector, events coming into `process_workflows` could pick up 2 detectors. We should handle these detectors accordingly.

A workflow being processed may be connected to up to 2 detectors. We should pick the preferred detector (issue type is possible, otherwise fall back to issue stream detector) to create the `WorkflowFireHistory` with and to fire the action, but use all detectors to figure out what workflows to process.

We can annotate the action with the preferred detector id in order to generate the correct payload to queue the `trigger_action` task with. The annotations can also be used to figure out the mapping between workflow id and preferred detector id to create `WorkflowFireHistories`.