### PR TITLE
feat(aci): Reorganize metric monitor form

### DIFF
--- a/static/app/views/detectors/components/forms/metric/resolveSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/resolveSection.tsx
@@ -4,8 +4,6 @@ import {Text} from 'sentry/components/core/text/text';
 import type {RadioOption} from 'sentry/components/forms/controls/radioGroup';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import RadioField from 'sentry/components/forms/fields/radioField';
-import {Container} from 'sentry/components/workflowEngine/ui/container';
-import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {getResolutionDescription} from 'sentry/views/detectors/utils/getDetectorResolutionDescription';
@@ -131,43 +129,39 @@ export function ResolveSection() {
   ];
 
   return (
-    <Container>
-      <Section title={t('Resolve')}>
-        <div>
-          <FormRow>
-            <StyledRadioField
-              name={METRIC_DETECTOR_FORM_FIELDS.resolutionStrategy}
-              aria-label={t('Resolution method')}
-              choices={resolutionStrategyChoices}
-              defaultValue="automatic"
-              preserveOnUnmount
-            />
-          </FormRow>
-          {resolutionStrategy === 'custom' && (
-            <DescriptionContainer onClick={e => e.preventDefault()}>
-              <Text>
-                {conditionType === DataConditionType.GREATER
-                  ? t('Less than')
-                  : t('More than')}
-              </Text>
-              <ThresholdField
-                hideLabel
-                aria-label={t('Resolution threshold')}
-                name={METRIC_DETECTOR_FORM_FIELDS.resolutionValue}
-                inline={false}
-                flexibleControlStateSize
-                placeholder="0"
-                suffix={thresholdSuffix}
-                validate={validateResolutionThreshold}
-                required
-                preserveOnUnmount
-                size="xs"
-              />
-            </DescriptionContainer>
-          )}
-        </div>
-      </Section>
-    </Container>
+    <div>
+      <FormRow>
+        <StyledRadioField
+          name={METRIC_DETECTOR_FORM_FIELDS.resolutionStrategy}
+          aria-label={t('Resolution method')}
+          choices={resolutionStrategyChoices}
+          defaultValue="automatic"
+          preserveOnUnmount
+        />
+      </FormRow>
+      {resolutionStrategy === 'custom' && (
+        <DescriptionContainer onClick={e => e.preventDefault()}>
+          <Text>
+            {conditionType === DataConditionType.GREATER
+              ? t('Less than')
+              : t('More than')}
+          </Text>
+          <ThresholdField
+            hideLabel
+            aria-label={t('Resolution threshold')}
+            name={METRIC_DETECTOR_FORM_FIELDS.resolutionValue}
+            inline={false}
+            flexibleControlStateSize
+            placeholder="0"
+            suffix={thresholdSuffix}
+            validate={validateResolutionThreshold}
+            required
+            preserveOnUnmount
+            size="xs"
+          />
+        </DescriptionContainer>
+      )}
+    </div>
   );
 }
 

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -24,7 +24,6 @@ import {
   METRIC_DETECTOR_FORM_FIELDS,
   useMetricDetectorFormField,
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
-import {DetectorQueryFilterBuilder} from 'sentry/views/detectors/components/forms/metric/queryFilterBuilder';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
@@ -304,13 +303,8 @@ export function Visualize() {
   const lockSpanOptions =
     dataset === DetectorDataset.SPANS && aggregate === AggregationKey.COUNT;
 
-  const hasVisibleParameters =
-    Boolean(aggregateMetadata?.parameters?.length) &&
-    dataset !== DetectorDataset.SPANS &&
-    dataset !== DetectorDataset.LOGS;
-
   return (
-    <AggregateContainer hasParameters={hasVisibleParameters}>
+    <Flex direction="column" gap="md">
       <Flex gap="md" align="end">
         <FieldContainer>
           <div>
@@ -389,50 +383,21 @@ export function Visualize() {
           );
         })}
       </Flex>
-
-      {/* Only show filter inline when no additional parameters */}
-      {!hasVisibleParameters && (
-        <Flex flex={1} gap="md">
-          <DetectorQueryFilterBuilder />
-        </Flex>
-      )}
-
-      {/* Show filter on separate row when parameters are visible */}
-      {hasVisibleParameters && (
-        <Flex flex={1} gap="md">
-          <DetectorQueryFilterBuilder />
-        </Flex>
-      )}
-    </AggregateContainer>
+    </Flex>
   );
 }
-
-const AggregateContainer = styled('div')<{hasParameters: boolean}>`
-  display: grid;
-  grid-template-columns: ${p => (p.hasParameters ? '1fr' : '1fr 2fr')};
-  grid-template-rows: ${p => (p.hasParameters ? 'auto auto' : 'auto')};
-  align-items: start;
-  gap: ${space(2)};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(2)} ${space(2)};
-  background-color: ${p => p.theme.backgroundSecondary};
-
-  @media (max-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto;
-  }
-`;
 
 const FieldContainer = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(0.5)};
   flex: 1;
+  max-width: 425px;
 `;
 
 const StyledAggregateSelect = styled(CompactSelect)`
   width: 100%;
+  max-width: 425px;
   & > button {
     width: 100%;
     font-weight: normal;
@@ -441,6 +406,7 @@ const StyledAggregateSelect = styled(CompactSelect)`
 
 const StyledVisualizeSelect = styled(CompactSelect)`
   width: 100%;
+  max-width: 425px;
   & > button {
     width: 100%;
     font-weight: normal;


### PR DESCRIPTION
Moves fields around to where they are in the new designs. Does not yet handle collapse and prebuilt query dropdown.
https://www.figma.com/design/99EtM4v3UYfGCN0QJU1QfI/Alerts-are-Issues?node-id=8891-22221&t=RkxNCgkkWjuvz6sP-4

before

<img width="1486" height="774" alt="image" src="https://github.com/user-attachments/assets/813b6764-9594-4e4b-a050-2538a28bd291" />


after

<img width="1346" height="812" alt="image" src="https://github.com/user-attachments/assets/93ebb0c7-ef1b-434f-aa0f-13e5f539df30" />
