### PR TITLE
test(widgets): Migrate widget builder test away from mock router

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1,6 +1,4 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -22,6 +20,10 @@ import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
 jest.mock('sentry/utils/useNavigate');
+
+const DASHBOARD_WIDGET_BUILDER_PATHNAME =
+  '/organizations/org-slug/dashboards/new/widget/new/';
+const DASHBOARD_WIDGET_BUILDER_ROUTE = '/organizations/:orgId/dashboards/new/widget/new/';
 
 describe('Visualize', () => {
   let organization!: ReturnType<typeof OrganizationFixture>;
@@ -84,18 +86,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: ['p90(transaction.duration)', 'max(spans.db)'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -120,18 +121,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: ['max(spans.db)'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -152,18 +152,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: ['max(spans.db)'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -184,18 +183,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: ['count()'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -218,18 +216,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: ['max(spans.db)'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -251,18 +248,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: ['count()'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -292,18 +288,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['transaction.duration'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -322,18 +317,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['count()'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -358,18 +352,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['count()'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -390,18 +383,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['count()'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -420,18 +412,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               yAxis: ['transaction.duration'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -450,18 +441,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['max(spans.db)'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -480,18 +470,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['count_if(transaction.duration,equals,testValue)'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -517,18 +506,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['count_if(transaction.duration,equals,testValue)'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -557,18 +545,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['transaction.duration'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -587,18 +574,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               field: ['transaction'],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -622,18 +608,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.ISSUE,
               field: ['issue.id'],
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -649,18 +634,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
               yAxis: ['p90(transaction.duration)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -680,18 +664,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.BIG_NUMBER,
               field: ['count()'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -708,18 +691,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.BIG_NUMBER,
               field: ['count()'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -737,18 +719,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
               field: ['p50(transaction.duration)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -791,17 +772,16 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.BIG_NUMBER,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -825,14 +805,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.TRANSACTIONS, displayType: DisplayType.LINE},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -847,18 +826,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.BIG_NUMBER,
               field: ['count_unique(user)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -880,19 +858,18 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.BIG_NUMBER,
               field: ['count_unique(1)', 'count_unique(2)', 'count_unique(3)'],
               selectedAggregate: '2',
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -917,14 +894,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.RELEASE, field: ['crash_free_rate(session)']},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -945,14 +921,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.TRANSACTIONS, field: ['transaction.duration']},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -971,17 +946,16 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               field: ['count_if(transaction.duration,equals,300)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1004,17 +978,16 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.RELEASE,
               field: ['crash_free_rate(session)', 'environment'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1031,14 +1004,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.TRANSACTIONS, field: ['apdex(3000)']},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1058,14 +1030,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.TRANSACTIONS, field: ['apdex(9999)']},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1082,17 +1053,16 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               field: ['equation|count()+1', 'count()'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1108,18 +1078,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               field: ['transaction.duration', 'transaction.id'],
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1135,14 +1104,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.TRANSACTIONS, field: ['count()']},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1165,14 +1133,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.RELEASE, field: ['crash_free_rate(session)']},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1192,14 +1159,13 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {dataset: WidgetType.RELEASE, field: ['crash_free_rate(session)']},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1226,17 +1192,16 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               field: ['p50(transaction.duration)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1297,18 +1262,17 @@ describe('Visualize', () => {
         </WidgetBuilderProvider>,
         {
           organization,
-
-          router: RouterFixture({
-            location: LocationFixture({
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 dataset: WidgetType.SPANS,
                 displayType: DisplayType.LINE,
                 yAxis: ['p90(span.duration)'],
               },
-            }),
-          }),
-
-          deprecatedRouterMocks: true,
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
         }
       );
 
@@ -1330,18 +1294,17 @@ describe('Visualize', () => {
         </WidgetBuilderProvider>,
         {
           organization,
-
-          router: RouterFixture({
-            location: LocationFixture({
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 dataset: WidgetType.SPANS,
                 displayType: DisplayType.LINE,
                 yAxis: ['count(span.duration)'],
               },
-            }),
-          }),
-
-          deprecatedRouterMocks: true,
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
         }
       );
 
@@ -1371,18 +1334,17 @@ describe('Visualize', () => {
         </WidgetBuilderProvider>,
         {
           organization,
-
-          router: RouterFixture({
-            location: LocationFixture({
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 dataset: WidgetType.SPANS,
                 displayType: DisplayType.TABLE,
                 field: ['p90(span.duration)'],
               },
-            }),
-          }),
-
-          deprecatedRouterMocks: true,
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
         }
       );
 
@@ -1402,18 +1364,17 @@ describe('Visualize', () => {
         </WidgetBuilderProvider>,
         {
           organization,
-
-          router: RouterFixture({
-            location: LocationFixture({
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 dataset: WidgetType.SPANS,
                 displayType: DisplayType.TABLE,
                 field: ['span.duration'],
               },
-            }),
-          }),
-
-          deprecatedRouterMocks: true,
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
         }
       );
 
@@ -1450,18 +1411,17 @@ describe('Visualize', () => {
         </WidgetBuilderProvider>,
         {
           organization,
-
-          router: RouterFixture({
-            location: LocationFixture({
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 dataset: WidgetType.SPANS,
                 displayType: DisplayType.TABLE,
                 field: ['count(span.duration)'],
               },
-            }),
-          }),
-
-          deprecatedRouterMocks: true,
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
         }
       );
 
@@ -1481,17 +1441,17 @@ describe('Visualize', () => {
         </WidgetBuilderProvider>,
         {
           organization: organizationWithFlag,
-          router: RouterFixture({
-            location: LocationFixture({
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 dataset: WidgetType.SPANS,
                 displayType: DisplayType.TABLE,
                 yAxis: ['count(span.duration)'],
               },
-            }),
-          }),
-
-          deprecatedRouterMocks: true,
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
         }
       );
 
@@ -1536,17 +1496,17 @@ describe('Visualize', () => {
         </WidgetBuilderProvider>,
         {
           organization: organizationWithFlag,
-          router: RouterFixture({
-            location: LocationFixture({
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
               query: {
                 dataset: WidgetType.SPANS,
                 displayType: DisplayType.TABLE,
                 yAxis: ['count(span.duration)'],
               },
-            }),
-          }),
-
-          deprecatedRouterMocks: true,
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
         }
       );
 
@@ -1589,18 +1549,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.SPANS,
               displayType: DisplayType.LINE,
               yAxis: ['count(span.duration)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
     expect(
@@ -1616,18 +1575,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.SPANS,
               displayType: DisplayType.LINE,
               yAxis: ['avg(span.self_time)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1659,18 +1617,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.SPANS,
               displayType: DisplayType.LINE,
               yAxis: ['epm()'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
     expect(
@@ -1688,18 +1645,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.SPANS,
               displayType: DisplayType.LINE,
               yAxis: ['failure_rate()'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
     expect(
@@ -1717,18 +1673,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.SPANS,
               displayType: DisplayType.LINE,
               yAxis: ['avg(span.self_time)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1758,18 +1713,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.SPANS,
               displayType: DisplayType.LINE,
               yAxis: ['avg(span.self_time)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1800,18 +1754,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.SPANS,
               displayType: DisplayType.LINE,
               yAxis: ['count(span.duration)'],
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1873,16 +1826,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization: organizationWithDeprecation,
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
               yAxis: ['p95(transaction.duration)'],
             },
-          }),
-        }),
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 
@@ -1907,16 +1861,17 @@ describe('Visualize', () => {
       </WidgetBuilderProvider>,
       {
         organization: organizationWithoutDeprecation,
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
               yAxis: ['p95(transaction.duration)'],
             },
-          }),
-        }),
-        deprecatedRouterMocks: true,
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
       }
     );
 


### PR DESCRIPTION
Switches to the full featured memory based test router instead of the entirely mocked router.
