### PR TITLE
test(ui): Migrate Version component from deprecatedRouterMocks

### DIFF
--- a/static/app/components/version.spec.tsx
+++ b/static/app/components/version.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import Version from 'sentry/components/version';
@@ -7,50 +5,36 @@ import Version from 'sentry/components/version';
 const VERSION = 'foo.bar.Baz@1.0.0+20200101';
 
 describe('Version', () => {
-  const router = RouterFixture();
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   it('renders', () => {
-    render(<Version version={VERSION} />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<Version version={VERSION} />);
   });
 
   it('shows correct parsed version', () => {
     // component uses @sentry/release-parser package for parsing versions
-    render(<Version version={VERSION} />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<Version version={VERSION} />);
 
     expect(screen.getByText('1.0.0 (20200101)')).toBeInTheDocument();
   });
 
   it('links to release page', async () => {
-    render(<Version version={VERSION} projectId="1" />, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    const {router} = render(<Version version={VERSION} projectId="1" />);
 
     await userEvent.click(screen.getByText('1.0.0 (20200101)'));
-    expect(router.push).toHaveBeenCalledWith({
-      pathname: '/mock-pathname/',
-      query: {
-        rd: 'show',
-        rdRelease: 'foo.bar.Baz@1.0.0+20200101',
-        rdReleaseProjectId: '1',
-        rdSource: 'release-version-link',
-      },
+    expect(router.location.query).toEqual({
+      rd: 'show',
+      rdRelease: 'foo.bar.Baz@1.0.0+20200101',
+      rdReleaseProjectId: '1',
+      rdSource: 'release-version-link',
     });
   });
 
   it('shows raw version in tooltip', async () => {
     jest.useFakeTimers();
-    render(<Version version={VERSION} tooltipRawVersion />, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    render(<Version version={VERSION} tooltipRawVersion />);
     expect(screen.queryByText(VERSION)).not.toBeInTheDocument();
 
     // Activate tooltip


### PR DESCRIPTION
Switches to the full featured memory based test router instead of the entirely mocked router.
