### PR TITLE
ref(replay): clean up dead summaries code and pass replay start/end to seer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -357,8 +357,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:replay-ai-summaries-mobile", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable replay AI summaries for web replays
     manager.add("organizations:replay-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable replay summary log parsing via Seer RPC
-    manager.add("organizations:replay-ai-summaries-rpc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable version 2 of release serializer
     manager.add("organizations:releases-serializer-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable version 2 of reprocessing (completely distinct from v1)

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Any
 
 import sentry_sdk
@@ -17,16 +18,10 @@ from sentry.models.project import Project
 from sentry.replays.lib.seer_api import seer_summarization_connection_pool
 from sentry.replays.lib.storage import storage
 from sentry.replays.post_process import process_raw_response
-from sentry.replays.query import get_replay_range, query_replay_instance
-from sentry.replays.usecases.reader import fetch_segments_metadata, iter_segment_data
-from sentry.replays.usecases.summarize import (
-    fetch_error_details,
-    fetch_trace_connected_errors,
-    get_summary_logs,
-)
+from sentry.replays.query import query_replay_instance
 from sentry.seer.seer_setup import has_seer_access
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
-from sentry.utils import json, metrics
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -159,16 +154,15 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
                 {"sample_rate": self.sample_rate_post} if self.sample_rate_post else None
             ),
         ):
-
             if not self.has_replay_summary_access(project, request):
                 return self.respond(
                     {"detail": "Replay summaries are not available for this organization."},
                     status=403,
                 )
 
+            # We use the frontend's segment count to keep summaries consistent with the video displayed in the UI.
             num_segments = request.data.get("num_segments", 0)
             temperature = request.data.get("temperature", None)
-            start, end = default_start_end_dates()
 
             # Limit data with the frontend's segment count, to keep summaries consistent with the video displayed in the UI.
             # While the replay is live, the FE and BE may have different counts.
@@ -184,114 +178,33 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
                 )
                 num_segments = MAX_SEGMENTS_TO_SUMMARIZE
 
-            if features.has(
-                "organizations:replay-ai-summaries-rpc", project.organization, actor=request.user
-            ):
-                snuba_response = query_replay_instance(
-                    project_id=project.id,
-                    replay_id=replay_id,
-                    start=start,
-                    end=end,
-                    organization=project.organization,
-                    request_user_id=request.user.id,
-                )
-                if not snuba_response:
-                    return self.respond(
-                        {"detail": "Replay not found."},
-                        status=404,
-                    )
-
-                return self.make_seer_request(
-                    SEER_START_TASK_ENDPOINT_PATH,
-                    {
-                        "logs": [],
-                        "use_rpc": True,
-                        "num_segments": num_segments,
-                        "replay_id": replay_id,
-                        "organization_id": project.organization.id,
-                        "project_id": project.id,
-                        "temperature": temperature,
-                    },
-                )
-
-            # Fetch the replay's error and trace IDs from the replay_id.
+            # Query for replay existence and start/end times, to prevent spawning a Seer task and DB entry for non-existent replays.
+            start, end = default_start_end_dates()  # Query last 90d.
             snuba_response = query_replay_instance(
                 project_id=project.id,
                 replay_id=replay_id,
                 start=start,
                 end=end,
                 organization=project.organization,
-                request_user_id=request.user.id,
             )
-            processed_response = process_raw_response(
-                snuba_response,
-                fields=[],  # Defaults to all fields.
-            )
-
-            if not processed_response:
+            if not snuba_response:
                 return self.respond(
                     {"detail": "Replay not found."},
                     status=404,
                 )
 
-            error_ids = processed_response[0].get("error_ids", [])
-            trace_ids = processed_response[0].get("trace_ids", [])
+            # We expect the start and end times to be present, and error + respond 500 if they're not.
+            replay = process_raw_response(snuba_response, fields=[])[0]
+            replay_start = datetime.fromisoformat(replay.get("started_at") or "")
+            replay_end = datetime.fromisoformat(replay.get("finished_at") or "")
 
-            result = get_replay_range(
-                organization_id=project.organization.id, project_id=project.id, replay_id=replay_id
-            )
-
-            if result is not None:
-                start, end = result
-
-            # Fetch same-trace errors.
-            trace_connected_errors = fetch_trace_connected_errors(
-                project=project,
-                trace_ids=trace_ids,
-                start=start,
-                end=end,
-                limit=100,
-            )
-            trace_connected_error_ids = {x["id"] for x in trace_connected_errors}
-
-            # Fetch directly linked errors, if they weren't returned by the trace query.
-            direct_errors = fetch_error_details(
-                project_id=project.id,
-                error_ids=[x for x in error_ids if x not in trace_connected_error_ids],
-            )
-
-            error_events = direct_errors + trace_connected_errors
-
-            metrics.distribution(
-                "replays.endpoints.project_replay_summary.direct_errors",
-                value=len(direct_errors),
-            )
-            metrics.distribution(
-                "replays.endpoints.project_replay_summary.trace_connected_errors",
-                value=len(trace_connected_errors),
-            )
-            metrics.distribution(
-                "replays.endpoints.project_replay_summary.num_trace_ids",
-                value=len(trace_ids),
-            )
-
-            # Download segment data.
-            # XXX: For now this is capped to 100 and blocking. DD shows no replays with >25 segments, but we should still stress test and figure out how to deal with large replays.
-            segment_md = fetch_segments_metadata(project.id, replay_id, 0, num_segments)
-            segment_data = iter_segment_data(segment_md)
-
-            # Combine replay and error data and parse into logs.
-            logs = get_summary_logs(segment_data, error_events, project.id)
-
-            # Post to Seer to start a summary task.
-            # XXX: Request isn't streaming. Limitation of Seer authentication. Would be much faster if we
-            # could stream the request data since the GCS download will (likely) dominate latency.
             return self.make_seer_request(
                 SEER_START_TASK_ENDPOINT_PATH,
                 {
-                    "logs": logs,
-                    "num_segments": num_segments,
                     "replay_id": replay_id,
+                    "replay_start": replay_start.isoformat(),
+                    "replay_end": replay_end.isoformat(),
+                    "num_segments": num_segments,
                     "organization_id": project.organization.id,
                     "project_id": project.id,
                     "temperature": temperature,

--- a/tests/sentry/replays/endpoints/test_project_replay_summary.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summary.py
@@ -1,25 +1,18 @@
 import uuid
-import zlib
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import requests
 from django.conf import settings
 from django.urls import reverse
 
-from sentry.feedback.lib.utils import FeedbackCreationSource
-from sentry.feedback.usecases.ingest.create_feedback import create_feedback_issue
 from sentry.replays.endpoints.project_replay_summary import (
     SEER_POLL_STATE_ENDPOINT_PATH,
     SEER_START_TASK_ENDPOINT_PATH,
 )
-from sentry.replays.lib.storage import FilestoreBlob, RecordingSegmentStorageMeta
 from sentry.replays.testutils import mock_replay
-from sentry.replays.usecases.summarize import EventDict
 from sentry.testutils.cases import SnubaTestCase, TransactionTestCase
-from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 
 
@@ -33,8 +26,6 @@ class MockSeerResponse:
         return self.json_data
 
 
-# have to use TransactionTestCase because we're using threadpools
-@requires_snuba
 class ProjectReplaySummaryTestCase(
     TransactionTestCase,
     SnubaTestCase,
@@ -64,27 +55,18 @@ class ProjectReplaySummaryTestCase(
         super().tearDown()
 
     def store_replay(self, dt: datetime | None = None, **kwargs: Any) -> None:
-        replay = mock_replay(dt or datetime.now(UTC), self.project.id, self.replay_id, **kwargs)
+        replay = mock_replay(
+            dt or datetime.now(UTC) - timedelta(minutes=1),  # Avoid clock skew query issues.
+            self.project.id,
+            self.replay_id,
+            **kwargs,
+        )
         response = requests.post(
             settings.SENTRY_SNUBA + "/tests/entities/replays/insert", json=[replay]
         )
         assert response.status_code == 200
 
-    def save_recording_segment(
-        self, segment_id: int, data: bytes, compressed: bool = True, is_archived: bool = False
-    ) -> None:
-        metadata = RecordingSegmentStorageMeta(
-            project_id=self.project.id,
-            replay_id=self.replay_id,
-            segment_id=segment_id,
-            retention_days=30,
-            file_id=None,
-        )
-        FilestoreBlob().set(metadata, zlib.compress(data) if compressed else data)
-
     def test_feature_flag_disabled(self) -> None:
-        self.save_recording_segment(0, json.dumps([]).encode())
-
         features = [
             (False, True),
             (True, False),
@@ -130,30 +112,14 @@ class ProjectReplaySummaryTestCase(
 
     @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
     def test_post_simple(self, mock_make_seer_api_request: Mock) -> None:
-        mock_response = MockSeerResponse(200, json_data={"hello": "world"})
-        mock_make_seer_api_request.return_value = mock_response
+        mock_make_seer_api_request.return_value = MockSeerResponse(
+            200, json_data={"hello": "world"}
+        )
 
-        data = [
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "hello"},
-                },
-            },
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "world"},
-                },
-            },
-        ]
-        self.save_recording_segment(0, json.dumps(data).encode())
-        self.save_recording_segment(1, json.dumps([]).encode())
-        self.store_replay()
+        start = datetime.now(UTC) - timedelta(days=3)
+        end = datetime.now(UTC) - timedelta(days=2, hours=23)
+        self.store_replay(dt=start, segment_id=0)
+        self.store_replay(dt=end, segment_id=1)
 
         with self.feature(self.features):
             response = self.client.post(
@@ -167,460 +133,30 @@ class ProjectReplaySummaryTestCase(
         call_args = mock_make_seer_api_request.call_args
         assert call_args[1]["path"] == SEER_START_TASK_ENDPOINT_PATH
         request_body = json.loads(call_args[1]["body"].decode())
-        assert request_body == {
-            "logs": ["Logged: 'hello' at 0.0", "Logged: 'world' at 0.0"],
-            "num_segments": 2,
-            "replay_id": self.replay_id,
-            "organization_id": self.organization.id,
-            "project_id": self.project.id,
-            "temperature": None,
-        }
 
-    def test_post_out_of_date_range(self) -> None:
-        data = [
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "hello"},
-                },
-            },
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "world"},
-                },
-            },
-        ]
-        self.save_recording_segment(0, json.dumps(data).encode())
-        self.save_recording_segment(1, json.dumps([]).encode())
-        self.store_replay(dt=before_now(days=80))
+        assert request_body["replay_id"] == self.replay_id
+        assert abs(datetime.fromisoformat(request_body["replay_start"]) - start) <= timedelta(
+            seconds=1
+        )
+        assert abs(datetime.fromisoformat(request_body["replay_end"]) - end) <= timedelta(seconds=1)
+        assert request_body["num_segments"] == 2
+        assert request_body["organization_id"] == self.organization.id
+        assert request_body["project_id"] == self.project.id
+        assert request_body["temperature"] is None
 
+    def test_post_replay_not_found(self) -> None:
         with self.feature(self.features):
             response = self.client.post(
-                self.url
-                + f"?start={before_now(days=3).isoformat().replace('+00:00', 'Z')}&end={before_now(days=0).isoformat().replace('+00:00', 'Z')}",
-                data={"num_segments": 2},
-                content_type="application/json",
+                self.url, data={"num_segments": 2}, content_type="application/json"
             )
-
-        assert response.status_code == 404
-
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_post_with_both_direct_and_trace_connected_errors(
-        self, mock_make_seer_api_request: Mock
-    ) -> None:
-        """Test handling of breadcrumbs with both direct and trace connected errors. Error logs should not be duplicated."""
-        mock_response = MockSeerResponse(200, json_data={"hello": "world"})
-        mock_make_seer_api_request.return_value = mock_response
-
-        now = datetime.now(UTC)
-        trace_id = uuid.uuid4().hex
-        span_id = "1" + uuid.uuid4().hex[:15]
-
-        # Create a direct error event that is not trace connected.
-        direct_event_id = uuid.uuid4().hex
-        direct_error_timestamp = now.timestamp() - 2
-        self.store_event(
-            data={
-                "event_id": direct_event_id,
-                "timestamp": direct_error_timestamp,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "ZeroDivisionError",
-                            "value": "division by zero",
-                        }
-                    ]
-                },
-                "contexts": {
-                    "replay": {"replay_id": self.replay_id},
-                    "trace": {
-                        "type": "trace",
-                        "trace_id": uuid.uuid4().hex,
-                        "span_id": span_id,
-                    },
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        # Create a trace connected error event
-        connected_event_id = uuid.uuid4().hex
-        connected_error_timestamp = now.timestamp() - 1
-        project_2 = self.create_project()
-        self.store_event(
-            data={
-                "event_id": connected_event_id,
-                "timestamp": connected_error_timestamp,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "ConnectionError",
-                            "value": "Failed to connect to database",
-                        }
-                    ]
-                },
-                "contexts": {
-                    "trace": {
-                        "type": "trace",
-                        "trace_id": trace_id,
-                        "span_id": span_id,
-                    }
-                },
-            },
-            project_id=project_2.id,
-        )
-
-        # Store the replay with both error IDs and trace IDs
-        self.store_replay(
-            error_ids=[direct_event_id],
-            trace_ids=[trace_id],
-        )
-
-        data = [
-            {
-                "type": 5,
-                "timestamp": float(now.timestamp()),
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "hello"},
-                },
-            }
-        ]
-        self.save_recording_segment(0, json.dumps(data).encode())
-
-        with self.feature(self.features):
-            response = self.client.post(
-                self.url, data={"num_segments": 1}, content_type="application/json"
-            )
-            assert response.status_code == 200
-            assert response.json() == {"hello": "world"}
-
-        mock_make_seer_api_request.assert_called_once()
-        request_body = json.loads(mock_make_seer_api_request.call_args[1]["body"].decode())
-        logs = request_body["logs"]
-        assert len(logs) == 3
-        assert any("ZeroDivisionError" in log for log in logs)
-        assert any("division by zero" in log for log in logs)
-        assert any("ConnectionError" in log for log in logs)
-        assert any("Failed to connect to database" in log for log in logs)
-
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_post_with_feedback_breadcrumb(self, mock_make_seer_api_request: Mock) -> None:
-        """Test handling of a feedback breadcrumb when the feedback
-        is in nodestore, but hasn't reached Snuba yet.
-        If the feedback is in Snuba (guaranteed for SDK v8.0.0+),
-        it should be de-duped like in the duplicate_feedback test below."""
-        mock_response = MockSeerResponse(
-            200,
-            json_data={"hello": "world"},
-        )
-        mock_make_seer_api_request.return_value = mock_response
-
-        now = datetime.now(UTC)
-        feedback_event_id = uuid.uuid4().hex
-
-        self.store_event(
-            data={
-                "type": "feedback",
-                "event_id": feedback_event_id,
-                "timestamp": now.timestamp(),
-                "contexts": {
-                    "feedback": {
-                        "contact_email": "josh.ferge@sentry.io",
-                        "name": "Josh Ferge",
-                        "message": "Great website!",
-                        "replay_id": self.replay_id,
-                        "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
-                    },
-                },
-            },
-            project_id=self.project.id,
-        )
-        self.store_replay()
-
-        data = [
-            {
-                "type": 5,
-                "timestamp": float(now.timestamp()),
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {
-                        "category": "sentry.feedback",
-                        "data": {"feedbackId": feedback_event_id},
-                    },
-                },
-            },
-        ]
-        self.save_recording_segment(0, json.dumps(data).encode())
-
-        with self.feature(self.features):
-            response = self.client.post(
-                self.url, data={"num_segments": 1}, content_type="application/json"
-            )
-
-        assert response.status_code == 200
-        assert response.json() == {"hello": "world"}
-
-        mock_make_seer_api_request.assert_called_once()
-        request_body = json.loads(mock_make_seer_api_request.call_args[1]["body"].decode())
-        logs = request_body["logs"]
-        assert "User submitted feedback: 'Great website!'" in logs[0]
-
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_post_with_trace_errors_both_datasets(
-        self, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        """Test that trace connected error snuba query works correctly with both datasets."""
-        mock_response = MockSeerResponse(200, {"hello": "world"})
-        mock_make_seer_api_request.return_value = mock_response
-
-        now = datetime.now(UTC)
-        project_1 = self.create_project()
-        project_2 = self.create_project()
-
-        # Create regular error event - errors dataset
-        event_id_1 = uuid.uuid4().hex
-        trace_id_1 = uuid.uuid4().hex
-        timestamp_1 = (now - timedelta(minutes=2)).timestamp()
-        self.store_event(
-            data={
-                "event_id": event_id_1,
-                "timestamp": timestamp_1,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "ValueError",
-                            "value": "Invalid input",
-                        }
-                    ]
-                },
-                "contexts": {
-                    "trace": {
-                        "type": "trace",
-                        "trace_id": trace_id_1,
-                        "span_id": "1" + uuid.uuid4().hex[:15],
-                    }
-                },
-            },
-            project_id=project_1.id,
-        )
-
-        # Create feedback event - issuePlatform dataset
-        event_id_2 = uuid.uuid4().hex
-        trace_id_2 = uuid.uuid4().hex
-        timestamp_2 = (now - timedelta(minutes=5)).timestamp()
-
-        feedback_data = {
-            "type": "feedback",
-            "event_id": event_id_2,
-            "timestamp": timestamp_2,
-            "contexts": {
-                "feedback": {
-                    "contact_email": "test@example.com",
-                    "name": "Test User",
-                    "message": "Great website",
-                    "replay_id": self.replay_id,
-                    "url": "https://example.com",
-                },
-                "trace": {
-                    "type": "trace",
-                    "trace_id": trace_id_2,
-                    "span_id": "2" + uuid.uuid4().hex[:15],
-                },
-            },
-        }
-
-        create_feedback_issue(
-            feedback_data, project_2, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
-
-        # Store the replay with all trace IDs
-        self.store_replay(trace_ids=[trace_id_1, trace_id_2])
-
-        data = [
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "hello"},
-                },
-            },
-        ]
-        self.save_recording_segment(0, json.dumps(data).encode())
-
-        with self.feature(self.features):
-            response = self.client.post(
-                self.url, data={"num_segments": 1}, content_type="application/json"
-            )
-
-        assert response.status_code == 200
-        assert response.get("Content-Type") == "application/json"
-        assert response.json() == {"hello": "world"}
-
-        mock_make_seer_api_request.assert_called_once()
-        call_args = mock_make_seer_api_request.call_args
-        request_body = json.loads(call_args[1]["body"].decode())
-        logs = request_body["logs"]
-        assert len(logs) == 3
-
-        # Verify that feedback event is included
-        assert "Great website" in logs[1]
-        assert "User submitted feedback" in logs[1]
-
-        # Verify that regular error event is included
-        assert "ValueError" in logs[2]
-        assert "Invalid input" in logs[2]
-        assert "User experienced an error" in logs[2]
-
-    @patch("sentry.replays.usecases.summarize.fetch_feedback_details")
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_post_with_trace_errors_duplicate_feedback(
-        self, mock_make_seer_api_request: MagicMock, mock_fetch_feedback_details: MagicMock
-    ) -> None:
-        """Test that duplicate feedback events are filtered.
-        Duplicates may happen when the replay has a feedback breadcrumb,
-        and the feedback is also returned from the Snuba query for trace-connected errors."""
-        mock_response = MockSeerResponse(200, {"hello": "world"})
-        mock_make_seer_api_request.return_value = mock_response
-
-        now = datetime.now(UTC)
-        feedback_event_id = uuid.uuid4().hex
-        feedback_event_id_2 = uuid.uuid4().hex
-        trace_id = uuid.uuid4().hex
-        trace_id_2 = uuid.uuid4().hex
-
-        # Create feedback event - issuePlatform dataset
-        feedback_data: dict[str, Any] = {
-            "type": "feedback",
-            "event_id": feedback_event_id,
-            "timestamp": (now - timedelta(minutes=3)).timestamp(),
-            "contexts": {
-                "feedback": {
-                    "contact_email": "test@example.com",
-                    "name": "Test User",
-                    "message": "Great website",
-                    "replay_id": self.replay_id,
-                    "url": "https://example.com",
-                },
-                "trace": {
-                    "type": "trace",
-                    "trace_id": trace_id,
-                    "span_id": "1" + uuid.uuid4().hex[:15],
-                },
-            },
-        }
-
-        # Create another feedback event - issuePlatform dataset
-        feedback_data_2: dict[str, Any] = {
-            "type": "feedback",
-            "event_id": feedback_event_id_2,
-            "timestamp": (now - timedelta(minutes=2)).timestamp(),
-            "contexts": {
-                "feedback": {
-                    "contact_email": "test2@example.com",
-                    "name": "Test User 2",
-                    "message": "Broken website",
-                    "replay_id": self.replay_id,
-                    "url": "https://example.com",
-                },
-                "trace": {
-                    "type": "trace",
-                    "trace_id": trace_id_2,
-                    "span_id": "1" + uuid.uuid4().hex[:15],
-                },
-            },
-        }
-
-        create_feedback_issue(
-            feedback_data, self.project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
-        create_feedback_issue(
-            feedback_data_2, self.project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
-
-        self.store_replay(trace_ids=[trace_id, trace_id_2])
-
-        # mock SDK feedback event with same event_id as the first feedback event
-        data = [
-            {
-                "type": 5,
-                "timestamp": float((now - timedelta(minutes=3)).timestamp()),
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {
-                        "category": "sentry.feedback",
-                        "data": {"feedbackId": feedback_event_id},
-                    },
-                },
-            },
-        ]
-        self.save_recording_segment(0, json.dumps(data).encode())
-
-        # Mock fetch_feedback_details to return a dup of the first feedback event.
-        # In prod this is from nodestore. We had difficulties writing to nodestore in tests.
-        mock_fetch_feedback_details.return_value = EventDict(
-            id=feedback_event_id,
-            title="User Feedback",
-            message=feedback_data["contexts"]["feedback"]["message"],
-            timestamp=float(feedback_data["timestamp"]),
-            category="feedback",
-        )
-
-        with self.feature(self.features):
-            response = self.client.post(
-                self.url, data={"num_segments": 1}, content_type="application/json"
-            )
-
-        assert response.status_code == 200
-        assert response.get("Content-Type") == "application/json"
-        assert response.json() == {"hello": "world"}
-
-        mock_make_seer_api_request.assert_called_once()
-        call_args = mock_make_seer_api_request.call_args
-        request_body = json.loads(call_args[1]["body"].decode())
-        logs = request_body["logs"]
-
-        # Verify that only the unique feedback logs are included
-        assert len(logs) == 2
-        assert "User submitted feedback" in logs[0]
-        assert "Great website" in logs[0]
-        assert "User submitted feedback" in logs[1]
-        assert "Broken website" in logs[1]
+            assert response.status_code == 404
 
     @patch("sentry.replays.endpoints.project_replay_summary.MAX_SEGMENTS_TO_SUMMARIZE", 1)
     @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
     def test_post_max_segments_exceeded(self, mock_make_seer_api_request: Mock) -> None:
-        mock_response = MockSeerResponse(200, json_data={"hello": "world"})
-        mock_make_seer_api_request.return_value = mock_response
-
-        data1 = [
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "hello"},
-                },
-            }
-        ]
-        data2 = [
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "world"},
-                },
-            },
-        ]
-        self.save_recording_segment(0, json.dumps(data1).encode())
-        self.save_recording_segment(1, json.dumps(data2).encode())
+        mock_make_seer_api_request.return_value = MockSeerResponse(
+            200, json_data={"hello": "world"}
+        )
         self.store_replay()
 
         with self.feature(self.features):
@@ -634,31 +170,13 @@ class ProjectReplaySummaryTestCase(
         call_args = mock_make_seer_api_request.call_args
         assert call_args[1]["path"] == SEER_START_TASK_ENDPOINT_PATH
         request_body = json.loads(call_args[1]["body"].decode())
-        assert request_body == {
-            "logs": ["Logged: 'hello' at 0.0"],  # only 1 log from the first segment.
-            "num_segments": 1,  # capped to 1.
-            "replay_id": self.replay_id,
-            "organization_id": self.organization.id,
-            "project_id": self.project.id,
-            "temperature": None,
-        }
+        assert request_body["num_segments"] == 1
 
     @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
     def test_post_with_temperature(self, mock_make_seer_api_request: Mock) -> None:
-        mock_response = MockSeerResponse(200, json_data={"hello": "world"})
-        mock_make_seer_api_request.return_value = mock_response
-
-        data = [
-            {
-                "type": 5,
-                "timestamp": 0.0,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {"category": "console", "message": "hello"},
-                },
-            },
-        ]
-        self.save_recording_segment(0, json.dumps(data).encode())
+        mock_make_seer_api_request.return_value = MockSeerResponse(
+            200, json_data={"hello": "world"}
+        )
         self.store_replay()
 
         with self.feature(self.features):
@@ -674,14 +192,7 @@ class ProjectReplaySummaryTestCase(
         call_args = mock_make_seer_api_request.call_args
         assert call_args[1]["path"] == SEER_START_TASK_ENDPOINT_PATH
         request_body = json.loads(call_args[1]["body"].decode())
-        assert request_body == {
-            "logs": ["Logged: 'hello' at 0.0"],
-            "num_segments": 1,
-            "replay_id": self.replay_id,
-            "organization_id": self.organization.id,
-            "project_id": self.project.id,
-            "temperature": 0.73,
-        }
+        assert request_body["temperature"] == 0.73
 
     @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
     def test_seer_timeout(self, mock_make_seer_api_request: Mock) -> None:
@@ -689,7 +200,6 @@ class ProjectReplaySummaryTestCase(
             mock_make_seer_api_request.side_effect = requests.exceptions.Timeout(
                 "Request timed out"
             )
-            self.save_recording_segment(0, json.dumps([]).encode())
             self.store_replay()
 
             with self.feature(self.features):
@@ -709,7 +219,6 @@ class ProjectReplaySummaryTestCase(
             mock_make_seer_api_request.side_effect = requests.exceptions.ConnectionError(
                 "Connection error"
             )
-            self.save_recording_segment(0, json.dumps([]).encode())
             self.store_replay()
 
             with self.feature(self.features):
@@ -729,7 +238,6 @@ class ProjectReplaySummaryTestCase(
             mock_make_seer_api_request.side_effect = requests.exceptions.RequestException(
                 "Generic request error"
             )
-            self.save_recording_segment(0, json.dumps([]).encode())
             self.store_replay()
 
             with self.feature(self.features):
@@ -740,7 +248,6 @@ class ProjectReplaySummaryTestCase(
                         self.url, data={"num_segments": 1}, content_type="application/json"
                     )
                 )
-
             assert response.status_code == 500, method
 
     @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
@@ -752,7 +259,6 @@ class ProjectReplaySummaryTestCase(
                     json_data={"error": "Test error"},
                 )
                 mock_make_seer_api_request.return_value = mock_response
-                self.save_recording_segment(0, json.dumps([]).encode())
                 self.store_replay()
 
                 with self.feature(self.features):
@@ -763,5 +269,4 @@ class ProjectReplaySummaryTestCase(
                             self.url, data={"num_segments": 1}, content_type="application/json"
                         )
                     )
-
                 assert response.status_code == 500, method

--- a/tests/sentry/replays/usecases/test_summarize.py
+++ b/tests/sentry/replays/usecases/test_summarize.py
@@ -1323,9 +1323,11 @@ class RpcGetReplaySummaryLogsTestCase(
         assert len(logs) == 3
 
         # Verify that regular error event is included
-        assert "ValueError" in logs[1]
-        assert "Invalid input" in logs[1]
-        assert "User experienced an error" in logs[1]
+        assert "ValueError" in logs[0]
+        assert "Invalid input" in logs[0]
+        assert "User experienced an error" in logs[0]
+
+        assert "hello" in logs[1]
 
         # Verify that feedback event is included
         assert "Great website" in logs[2]


### PR DESCRIPTION
Part of [AIML-1332: tool to view replay by id](https://linear.app/getsentry/issue/AIML-1332/tool-to-view-replay-by-id)

The rpc flag is fully rolled out so the old endpoint code can be cleaned up (logs are always parsed in rpc_get_replay_summary_logs now). Seer code is already cleaned up.

Also extracts replay start/end times from the replay details response, and passes it to Seer and the downstream RPC. This is useful info for 
- seer explorer 
- the DB's TTL job (currently uses last updated)
- future prompt updates for the chapter time ranges

Depends on https://github.com/getsentry/sentry-options-automator/pull/5655