### PR TITLE
chore(aci milestone 3): add more info to dual processing logs

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -169,6 +169,7 @@ class SubscriptionProcessor:
                     "num_results": len(results),
                     "value": aggregation_value,
                     "detector_id": detector.id,
+                    "subscription_update": subscription_update,
                 },
             )
         return results


### PR DESCRIPTION
`value` is stuck at the last critical aggregation value for non dual written detectors. Find out why,