### PR TITLE
chore(preprod): add size analysis docs to insights (eme-513)

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -5,6 +5,7 @@ import {AnimatePresence, motion} from 'framer-motion';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text/heading';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose, IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -18,6 +19,16 @@ interface AppSizeInsightsSidebarProps {
   onClose: () => void;
   processedInsights: ProcessedInsight[];
   platform?: Platform;
+}
+
+function getInsightsDocsUrl(platform?: Platform): string {
+  if (platform === 'macos' || platform === 'ios') {
+    return 'https://docs.sentry.io/platforms/apple/guides/ios/size-analysis/insights/';
+  }
+  if (platform === 'android') {
+    return 'https://docs.sentry.io/platforms/android/size-analysis/insights/';
+  }
+  return 'https://docs.sentry.io/product/size-analysis/#build-details';
 }
 
 export function AppSizeInsightsSidebar({
@@ -88,9 +99,17 @@ export function AppSizeInsightsSidebar({
       >
         <Flex height="100%" direction="column">
           <Header padding="xl" align="center" justify="between">
-            <Heading as="h2" size="xl">
-              {t('Insights')}
-            </Heading>
+            <Flex align="center" gap="sm">
+              <Heading as="h2" size="xl">
+                {t('Insights')}
+              </Heading>
+              <PageHeadingQuestionTooltip
+                docsUrl={getInsightsDocsUrl(platform)}
+                title={t(
+                  'Insights help you identify opportunities to reduce your app size.'
+                )}
+              />
+            </Flex>
             <Button
               size="sm"
               icon={<IconClose />}


### PR DESCRIPTION
<img width="341" height="90" alt="image" src="https://github.com/user-attachments/assets/3ca3a318-e121-44c4-82c2-5b2dad6fe089" />

going to see about linking every insight to corresponding insight in docs, but we'd have to maintain a name mapping from this repo to the docs

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
