### PR TITLE
fix(ui): truncate previousPeriod dates depending on granularity

### DIFF
--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -10,7 +10,7 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 
 import type {PageFiltersState} from './types';
 
-type StatsPeriodType = 'h' | 'd' | 's' | 'm' | 'w';
+export type StatsPeriodType = 'h' | 'd' | 's' | 'm' | 'w';
 
 type SingleParamValue = string | undefined | null;
 type ParamValue = string[] | SingleParamValue;

--- a/static/app/views/insights/pages/platform/nextjs/utils.test.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/utils.test.tsx
@@ -1,0 +1,95 @@
+import {truncatePeriod} from './utils';
+
+describe('truncatePeriod', () => {
+  const testDate = new Date('2025-10-15T08:44:23.123Z'); // Wednesday
+
+  it('should return null when start or end is null', () => {
+    expect(truncatePeriod({start: null, end: testDate}, 'd')).toBe(null);
+    expect(truncatePeriod({start: testDate, end: null}, 'd')).toBe(null);
+    expect(truncatePeriod({start: null, end: null}, 'd')).toBe(null);
+  });
+
+  describe('seconds truncation', () => {
+    it('should truncate milliseconds but keep seconds', () => {
+      const result = truncatePeriod({start: testDate, end: testDate}, 's');
+
+      expect(result).not.toBe(null);
+      expect(result!.start).toBe('2025-10-15T08:44:23.000Z');
+      expect(result!.end).toBe('2025-10-15T08:44:23.000Z');
+    });
+  });
+
+  describe('minutes truncation', () => {
+    it('should truncate seconds and milliseconds but keep minutes', () => {
+      const result = truncatePeriod({start: testDate, end: testDate}, 'm');
+
+      expect(result).not.toBe(null);
+      expect(result!.start).toBe('2025-10-15T08:44:00.000Z');
+      expect(result!.end).toBe('2025-10-15T08:44:00.000Z');
+    });
+  });
+
+  describe('hours truncation', () => {
+    it('should truncate seconds and milliseconds but keep hours and minutes', () => {
+      const result = truncatePeriod({start: testDate, end: testDate}, 'h');
+
+      expect(result).not.toBe(null);
+      expect(result!.start).toBe('2025-10-15T08:44:00.000Z');
+      expect(result!.end).toBe('2025-10-15T08:44:00.000Z');
+    });
+  });
+
+  describe('days truncation', () => {
+    it('should truncate minutes, seconds, and milliseconds but keep hours', () => {
+      const result = truncatePeriod({start: testDate, end: testDate}, 'd');
+
+      expect(result).not.toBe(null);
+      expect(result!.start).toBe('2025-10-15T08:00:00.000Z');
+      expect(result!.end).toBe('2025-10-15T08:00:00.000Z');
+    });
+  });
+
+  describe('weeks truncation', () => {
+    it('should truncate minutes, seconds, and milliseconds but keep date and hours', () => {
+      const result = truncatePeriod({start: testDate, end: testDate}, 'w');
+
+      expect(result).not.toBe(null);
+      expect(result!.start).toBe('2025-10-15T08:00:00.000Z');
+      expect(result!.end).toBe('2025-10-15T08:00:00.000Z');
+    });
+
+    it('should handle different dates with week truncation', () => {
+      const sunday = new Date('2025-10-12T08:44:23.123Z'); // Sunday
+      const result = truncatePeriod({start: sunday, end: sunday}, 'w');
+
+      expect(result).not.toBe(null);
+      expect(result!.start).toBe('2025-10-12T08:00:00.000Z');
+      expect(result!.end).toBe('2025-10-12T08:00:00.000Z');
+    });
+  });
+
+  describe('different start and end dates', () => {
+    it('should truncate both start and end dates independently', () => {
+      const startDate = new Date('2025-10-15T08:44:23.123Z'); // Wednesday
+      const endDate = new Date('2025-10-16T14:30:45.567Z'); // Thursday
+
+      const result = truncatePeriod({start: startDate, end: endDate}, 'd');
+
+      expect(result).not.toBe(null);
+      expect(result!.start).toBe('2025-10-15T08:00:00.000Z');
+      expect(result!.end).toBe('2025-10-16T14:00:00.000Z');
+    });
+
+    it('should handle week truncation with different dates', () => {
+      const startDate = new Date('2025-10-15T08:44:23.123Z'); // Wednesday
+      const endDate = new Date('2025-10-19T14:30:45.567Z'); // Sunday
+
+      const result = truncatePeriod({start: startDate, end: endDate}, 'w');
+
+      expect(result).not.toBe(null);
+      // Both should truncate minutes, seconds, milliseconds but keep date and hours
+      expect(result!.start).toBe('2025-10-15T08:00:00.000Z'); // Wednesday with time truncated
+      expect(result!.end).toBe('2025-10-19T14:00:00.000Z'); // Sunday with time truncated
+    });
+  });
+});

--- a/static/app/views/insights/pages/platform/nextjs/utils.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/utils.tsx
@@ -14,11 +14,7 @@ type AbsoluteDateTimeObject = {
   start: DateString;
 };
 
-export function getPreviousPeriod({
-  period,
-  start,
-  end,
-}: DateTimeObject): AbsoluteDateTimeObject | null {
+export function getPreviousPeriod({period, start, end}: DateTimeObject) {
   if (start && end) {
     return doGetPreviousPeriod({start, end});
   }
@@ -59,7 +55,7 @@ const doGetPreviousPeriod = ({start, end}: AbsoluteDateTimeObject) => {
 export const truncatePeriod = (
   {start, end}: {end: Date | null; start: Date | null},
   periodType: StatsPeriodType
-): AbsoluteDateTimeObject | null => {
+) => {
   const truncateDate = (date: Date): string => {
     // Create a new date to avoid mutating the original
     const newDate = new Date(date);

--- a/static/app/views/insights/pages/platform/nextjs/utils.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/utils.tsx
@@ -1,6 +1,11 @@
 import type {DateTimeObject} from 'sentry/components/charts/utils';
+import {
+  parseStatsPeriod,
+  type StatsPeriodType,
+} from 'sentry/components/organizations/pageFilters/parse';
 import type {DateString} from 'sentry/types/core';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
+import {unreachable} from 'sentry/utils/unreachable';
 
 const MAX_PERIOD_HOURS = 14 * 24;
 
@@ -23,16 +28,16 @@ export function getPreviousPeriod({
     const currentStart = new Date(
       currentEnd.getTime() - parsePeriodToHours(period) * 60 * 60 * 1000
     );
-    return doGetPreviousPeriod({start: currentStart, end: currentEnd});
+    const previous = doGetPreviousPeriod({start: currentStart, end: currentEnd});
+    const periodLength = parseStatsPeriod(period)?.periodLength;
+
+    return previous && periodLength ? truncatePeriod(previous, periodLength) : null;
   }
 
   return null;
 }
 
-const doGetPreviousPeriod = ({
-  start,
-  end,
-}: AbsoluteDateTimeObject): AbsoluteDateTimeObject | null => {
+const doGetPreviousPeriod = ({start, end}: AbsoluteDateTimeObject) => {
   if (!start || !end) {
     return null;
   }
@@ -42,11 +47,48 @@ const doGetPreviousPeriod = ({
     return null;
   }
 
-  const newEnd = new Date(start).toISOString();
-  const newStart = new Date(new Date(start).getTime() - duration).toISOString();
+  const newEnd = new Date(start);
+  const newStart = new Date(new Date(start).getTime() - duration);
 
   return {
     start: newStart,
     end: newEnd,
+  };
+};
+
+export const truncatePeriod = (
+  {start, end}: {end: Date | null; start: Date | null},
+  periodType: StatsPeriodType
+): AbsoluteDateTimeObject | null => {
+  const truncateDate = (date: Date): string => {
+    // Create a new date to avoid mutating the original
+    const newDate = new Date(date);
+
+    switch (periodType) {
+      case 's': // seconds - no truncation needed, already at seconds precision
+        newDate.setUTCMilliseconds(0);
+        break;
+      case 'm': // minutes and hours - truncate seconds and milliseconds
+      case 'h':
+        newDate.setUTCSeconds(0, 0);
+        break;
+      case 'd': // above hours - truncate minutes, seconds, and milliseconds
+      case 'w':
+        newDate.setUTCMinutes(0, 0, 0);
+        break;
+      default:
+        unreachable(periodType);
+    }
+
+    return newDate.toISOString();
+  };
+
+  if (!start || !end) {
+    return null;
+  }
+
+  return {
+    start: truncateDate(start),
+    end: truncateDate(end),
   };
 };

--- a/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
@@ -91,8 +91,8 @@ function usePerformanceScoreData({query}: {query?: string}): ProjectScoreQuery {
         projects: pageFilterChartParams.project,
         environments: pageFilterChartParams.environment,
         datetime: {
-          start: previousPeriodParams?.start!,
-          end: previousPeriodParams?.end!,
+          start: previousPeriodParams?.start ?? null,
+          end: previousPeriodParams?.end ?? null,
           period: null,
           utc: !!pageFilterChartParams.utc,
         },


### PR DESCRIPTION
I noticed that navigating to frontend overview re-loads one widget, the `WebVitals` widget, every time, while others have caching:

https://github.com/user-attachments/assets/7955dce5-dd74-4db1-b82c-81578f7c53a2

The reason behind this is that `WebVitals` makes two requests, one for the current range (7d in the video) and one for the “previous” range. However, since the backend doesn’t do previous ranges, we calculate the days for this on the FE and send the `{ start, end }` days for this (thank you @obostjancic for getting me in the right direction here)

However, the calculation is sending very granular dates, up to milliseconds exact. This in turn means every time we get a new date string, we get a new QueryKey, thus missing out on caching.

This PR introduces a fix where those dates get truncated depending on the selected dateRange:

- for seconds (e.g. `30s`), we only cut milliseconds, as we still want this to be quite granular
- for minutes and hours, we remove seconds and milliseconds. that effectively gives you 1 minute caching if you have e.g. `10h`
- for days and weeks, we also remove minutes. If your dateRange is `7d`, we will send the same dates to the backend as long as the hour matches, so no new requests within one hour.

I think that’s a good compromise that still keeps enough granularity but also allows caching. Removing more than minutes doesn’t make much sense because it means for e.g. `7d`, we’d only get data from “up until yesterday”, which seems too imprecise, and it’s fine to make another request when the hour changes.

Note: If you select a custom dateRange (absolute date) in the UI, no truncation is necessary because it’s already exact down to minutes, because you can select minutes in the UI (and minutes are also stored in the url).

after:

https://github.com/user-attachments/assets/f5fb18ca-f7ef-4e85-9a5d-d365584231d8

