### PR TITLE
fix(deletions): Update GroupHashMetadata in batches

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -240,6 +240,51 @@ def delete_project_group_hashes(project_id: int) -> None:
     delete_group_hashes(project_id, issue_platform_group_ids)
 
 
+def update_group_hash_metadata_in_batches(hash_ids: Sequence[int]) -> int:
+    """
+    Update seer_matched_grouphash to None for GroupHashMetadata rows
+    that reference the given hash_ids, in batches to avoid timeouts.
+
+    This function performs the update in smaller batches to reduce lock
+    contention and prevent statement timeouts when many rows need updating.
+
+    Returns the total number of rows updated.
+    """
+    # First, get all the IDs that need updating
+    metadata_ids = list(
+        GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).values_list(
+            "id", flat=True
+        )
+    )
+
+    if not metadata_ids:
+        return 0
+
+    batch_size = options.get(
+        "deletions.group-hashes-metadata.update-seer-matched-grouphash-ids-batch-size", 1000
+    )
+    total_updated = 0
+    for i in range(0, len(metadata_ids), batch_size):
+        batch = metadata_ids[i : i + batch_size]
+        updated = GroupHashMetadata.objects.filter(id__in=batch).update(seer_matched_grouphash=None)
+        total_updated += updated
+
+    metrics.incr(
+        "deletions.group_hash_metadata.rows_updated",
+        amount=total_updated,
+        sample_rate=1.0,
+    )
+    logger.info(
+        "update_group_hash_metadata_in_batches.complete",
+        extra={
+            "hash_ids_count": len(hash_ids),
+            "total_updated": total_updated,
+        },
+    )
+
+    return total_updated
+
+
 def delete_group_hashes(
     project_id: int,
     group_ids: Sequence[int],
@@ -276,9 +321,7 @@ def delete_group_hashes(
             # If we update the columns first, the deletion of the grouphash metadata rows will have less work to do,
             # thus, improving the performance of the deletion.
             if options.get("deletions.group-hashes-metadata.update-seer-matched-grouphash-ids"):
-                GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).update(
-                    seer_matched_grouphash=None
-                )
+                update_group_hash_metadata_in_batches(hash_ids)
             GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
             GroupHash.objects.filter(id__in=hash_ids).delete()
 

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -260,9 +260,8 @@ def update_group_hash_metadata_in_batches(hash_ids: Sequence[int]) -> int:
     if not metadata_ids:
         return 0
 
-    batch_size = options.get(
-        "deletions.group-hashes-metadata.update-seer-matched-grouphash-ids-batch-size", 1000
-    )
+    option_batch_size = options.get("deletions.group-hash-metadata.batch-size", 1000)
+    batch_size = max(1, option_batch_size)
     total_updated = 0
     for i in range(0, len(metadata_ids), batch_size):
         batch = metadata_ids[i : i + batch_size]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -343,7 +343,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "deletions.group-hashes-metadata.update-seer-matched-grouphash-ids-batch-size",
+    "deletions.group-hash-metadata.batch-size",
     default=1000,
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -343,6 +343,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "deletions.group-hashes-metadata.update-seer-matched-grouphash-ids-batch-size",
+    default=1000,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "deletions.group-hashes-metadata.update-seer-matched-grouphash-ids",
     default=False,
     type=Bool,


### PR DESCRIPTION
This is a follow-up to #102612.

Fixes [SENTRY-5C13](https://sentry.sentry.io/issues/7001709353/).

For posterity 
```
OperationalError
canceling statement due to user request

SQL: UPDATE "sentry_grouphashmetadata" SET "seer_matched_grouphash_id" = NULL WHERE "sentry_grouphashmetadata"."seer_matched_grouphash_id" IN (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
```
[Link](https://github.com/getsentry/sentry/blob/cdfbaa2cebe0f119104586cbe11da667072d5637/src/sentry/deletions/defaults/group.py#L267-L272) to code:
```python
if options.get("deletions.group-hashes-metadata.update-seer-matched-grouphash-ids"):
    # This is the line where the error comes from
    GroupHashMetadata.objects.filter(
        seer_matched_grouphash_id__in=hash_ids
    ).update(seer_matched_grouphash=None)
GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
GroupHash.objects.filter(id__in=hash_ids).delete()
```