### PR TITLE
fix(api) Fix deleting relocated organizations

### DIFF
--- a/src/sentry/organizations/services/organization_actions/impl.py
+++ b/src/sentry/organizations/services/organization_actions/impl.py
@@ -42,7 +42,8 @@ def mark_organization_as_pending_deletion_with_outbox_message(
 ) -> Organization | None:
     with outbox_context(transaction.atomic(router.db_for_write(Organization))):
         update_count = Organization.objects.filter(
-            id=org_id, status=OrganizationStatus.ACTIVE
+            id=org_id,
+            status__in=[OrganizationStatus.ACTIVE, OrganizationStatus.RELOCATION_PENDING_APPROVAL],
         ).update(status=OrganizationStatus.PENDING_DELETION)
 
         if not update_count:


### PR DESCRIPTION
If an organization is relocated but not approved, we should be able to delete those organizations via the API to clean up state.