### PR TITLE
feat(deletions): Ensure models with group reference get deleted

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -87,11 +87,10 @@ DIRECT_GROUP_RELATED_MODELS = (
 # 1. Has an event_id field - per-event data that must be migrated during event
 #    reprocessing pipeline, not as a group bulk operation (UserReport, EventAttachment)
 # 2. Should NOT be transferred during reprocessing - transient or notification data
-#    that doesn't represent core group state (NotificationMessage, PlatformExternalIssue)
+#    that doesn't represent core group state (NotificationMessage)
 ADDITIONAL_GROUP_RELATED_MODELS = (
     models.UserReport,
     models.EventAttachment,
-    models.PlatformExternalIssue,
     NotificationMessage,
 )
 _GROUP_RELATED_MODELS = DIRECT_GROUP_RELATED_MODELS + ADDITIONAL_GROUP_RELATED_MODELS

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -30,9 +30,15 @@ GROUP_CHUNK_SIZE = 100
 EVENT_CHUNK_SIZE = 10000
 GROUP_HASH_ITERATIONS = 10000
 
-# Group models that relate only to groups and not to events. We assume those to
-# be safe to delete/mutate within a single transaction for user-triggered
-# actions (delete/reprocess/merge/unmerge)
+# Group models that relate only to groups and not to events. These models are
+# transferred during reprocessing operations because they represent group-level
+# metadata that should follow the group when events are reprocessed.
+#
+# Add a model to this list if it meets ALL of these criteria:
+# 1. NO event_id field - represents group state, not individual event data
+# 2. Should be TRANSFERRED during reprocessing - the metadata is about the group itself
+#    (e.g., assignments, bookmarks, resolutions, history) and should move with it
+# 3. Safe to bulk update with group_id changes during merge/unmerge operations
 DIRECT_GROUP_RELATED_MODELS = (
     # prioritize GroupHash
     models.GroupHash,
@@ -59,11 +65,21 @@ DIRECT_GROUP_RELATED_MODELS = (
     RuleFireHistory,
 )
 
-_GROUP_RELATED_MODELS = DIRECT_GROUP_RELATED_MODELS + (
+# Additional group-related models that require special handling during reprocessing.
+# Unlike DIRECT_GROUP_RELATED_MODELS which are migrated in bulk, these models need
+# per-event processing or should not be transferred at all.
+#
+# Add a model to this list if it meets ANY of these criteria:
+# 1. Has an event_id field - per-event data that must be migrated during event
+#    reprocessing pipeline, not as a group bulk operation (UserReport, EventAttachment)
+# 2. Should NOT be transferred during reprocessing - transient or notification data
+#    that doesn't represent core group state (NotificationMessage)
+ADDITIONAL_GROUP_RELATED_MODELS = (
     models.UserReport,
     models.EventAttachment,
     NotificationMessage,
 )
+_GROUP_RELATED_MODELS = DIRECT_GROUP_RELATED_MODELS + ADDITIONAL_GROUP_RELATED_MODELS
 
 
 def get_group_related_models() -> Sequence[type[Model]]:

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -75,7 +75,6 @@ DIRECT_GROUP_RELATED_MODELS = (
     models.GroupOwner,
     models.GroupEmailThread,
     models.GroupSubscription,
-    models.GroupHistory,
     models.GroupReaction,
     RuleFireHistory,
 )
@@ -88,10 +87,11 @@ DIRECT_GROUP_RELATED_MODELS = (
 # 1. Has an event_id field - per-event data that must be migrated during event
 #    reprocessing pipeline, not as a group bulk operation (UserReport, EventAttachment)
 # 2. Should NOT be transferred during reprocessing - transient or notification data
-#    that doesn't represent core group state (NotificationMessage)
+#    that doesn't represent core group state (NotificationMessage, PlatformExternalIssue)
 ADDITIONAL_GROUP_RELATED_MODELS = (
     models.UserReport,
     models.EventAttachment,
+    models.PlatformExternalIssue,
     NotificationMessage,
 )
 _GROUP_RELATED_MODELS = DIRECT_GROUP_RELATED_MODELS + ADDITIONAL_GROUP_RELATED_MODELS

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -1,3 +1,17 @@
+"""
+Group deletion configuration.
+
+This module defines which models should be deleted when a group is deleted and how
+they should be handled during reprocessing operations.
+
+IMPORTANT: When adding a new model with a group_id foreign key, you MUST add it to
+one of the model lists below, or tests will fail. See:
+  - tests/sentry/deletions/test_validate_group_related_models.py
+
+For guidance on which list to use, see the comments on DIRECT_GROUP_RELATED_MODELS
+and ADDITIONAL_GROUP_RELATED_MODELS below.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -76,6 +76,7 @@ DIRECT_GROUP_RELATED_MODELS = (
     models.GroupEmailThread,
     models.GroupSubscription,
     models.GroupHistory,
+    models.GroupReaction,
     RuleFireHistory,
 )
 

--- a/tests/sentry/deletions/test_validate_group_related_models.py
+++ b/tests/sentry/deletions/test_validate_group_related_models.py
@@ -11,7 +11,6 @@ import django.apps
 from django.db import models as django_models
 
 from sentry.db.models import FlexibleForeignKey
-from sentry.deletions import get_manager
 from sentry.deletions.defaults.group import (
     ADDITIONAL_GROUP_RELATED_MODELS,
     DIRECT_GROUP_RELATED_MODELS,
@@ -26,8 +25,8 @@ class GroupRelatedModelsCompletenessTest(TestCase):
     """
 
     # Models that don't need to be in either list (with justification).
-    # Note: Models with custom deletion tasks registered in deletions/__init__.py
-    # are automatically detected and don't need to be listed here.
+    # Note: Having a custom deletion task does NOT automatically handle group deletion.
+    # Models with group_id foreign keys must be explicitly added to one of the lists.
     EXEMPTED_MODELS: Mapping[str, str] = {
         # Add models here if they shouldn't be in either list, with a comment explaining why
         # Example: "sentry.SomeModel": "Uses custom deletion logic in XYZ",
@@ -56,22 +55,12 @@ class GroupRelatedModelsCompletenessTest(TestCase):
 
         return models_with_group_fk
 
-    def has_custom_deletion_task(self, model: type[django_models.Model]) -> bool:
-        """
-        Check if a model has a custom deletion task registered in the deletion manager.
-        This indicates the model has its own deletion handling logic.
-        """
-        deletion_manager = get_manager()
-        # Check if model is registered in the deletion task manager
-        return model in deletion_manager.tasks
-
     def test_all_group_related_models_are_registered(self) -> None:
         """
         Ensure all models with group foreign keys are in one of:
         - DIRECT_GROUP_RELATED_MODELS
         - ADDITIONAL_GROUP_RELATED_MODELS
         - EXEMPTED_MODELS (with justification)
-        - Has a custom deletion task registered in deletions/__init__.py
         """
         models_with_group_fk = self.get_models_with_group_foreign_key()
 
@@ -80,17 +69,11 @@ class GroupRelatedModelsCompletenessTest(TestCase):
 
         # Find unregistered models
         unregistered = set()
-        auto_handled = set()
         for model in models_with_group_fk:
             model_label = f"{model._meta.app_label}.{model.__name__}"
 
             # Skip if model is registered or exempted
             if model in registered_models or model_label in self.EXEMPTED_MODELS:
-                continue
-
-            # Check if model has a custom deletion task
-            if self.has_custom_deletion_task(model):
-                auto_handled.add(model_label)
                 continue
 
             unregistered.add(model_label)
@@ -104,18 +87,12 @@ class GroupRelatedModelsCompletenessTest(TestCase):
             for model_label in sorted(unregistered):
                 error_msg.append(f"  - {model_label}")
 
-            if auto_handled:
-                error_msg.append("\n\nAuto-handled models (have custom deletion tasks):")
-                for model_label in sorted(auto_handled):
-                    error_msg.append(f"  ✓ {model_label}")
-
             error_msg.extend(
                 [
                     "\n\nTo fix this, add the model to one of these in src/sentry/deletions/defaults/group.py:",
                     "  1. DIRECT_GROUP_RELATED_MODELS - if it should be transferred during reprocessing",
                     "  2. ADDITIONAL_GROUP_RELATED_MODELS - if it has event_id or shouldn't transfer",
-                    "  3. Register a custom deletion task in src/sentry/deletions/__init__.py",
-                    "  4. EXEMPTED_MODELS in this test - if it has special handling (with justification)",
+                    "  3. EXEMPTED_MODELS in this test - if it has special handling (with justification)",
                     "\nSee comments in group.py for decision criteria.",
                 ]
             )
@@ -148,16 +125,3 @@ class GroupRelatedModelsCompletenessTest(TestCase):
                 f"Models appear in both DIRECT_GROUP_RELATED_MODELS and "
                 f"ADDITIONAL_GROUP_RELATED_MODELS: {', '.join(duplicate_names)}"
             )
-
-    def test_custom_deletion_task_detection(self) -> None:
-        """
-        Verify that the custom deletion task detection is working correctly.
-        This ensures models with custom deletion tasks don't need manual exemption.
-        """
-        from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
-
-        # PlatformExternalIssue should be auto-detected as having a custom deletion task
-        assert self.has_custom_deletion_task(PlatformExternalIssue), (
-            "PlatformExternalIssue should have a custom deletion task registered. "
-            "If this fails, the auto-detection logic may be broken."
-        )

--- a/tests/sentry/deletions/test_validate_group_related_models.py
+++ b/tests/sentry/deletions/test_validate_group_related_models.py
@@ -11,6 +11,7 @@ import django.apps
 from django.db import models as django_models
 
 from sentry.db.models import FlexibleForeignKey
+from sentry.deletions import get_manager
 from sentry.deletions.defaults.group import (
     ADDITIONAL_GROUP_RELATED_MODELS,
     DIRECT_GROUP_RELATED_MODELS,
@@ -55,12 +56,22 @@ class GroupRelatedModelsCompletenessTest(TestCase):
 
         return models_with_group_fk
 
+    def has_custom_deletion_task(self, model: type[django_models.Model]) -> bool:
+        """
+        Check if a model has a custom deletion task registered in the deletion manager.
+        This indicates the model has its own deletion handling logic.
+        """
+        deletion_manager = get_manager()
+        # Check if model is registered in the deletion task manager
+        return model in deletion_manager.tasks
+
     def test_all_group_related_models_are_registered(self) -> None:
         """
         Ensure all models with group foreign keys are in one of:
         - DIRECT_GROUP_RELATED_MODELS
         - ADDITIONAL_GROUP_RELATED_MODELS
         - EXEMPTED_MODELS (with justification)
+        - Has a custom deletion task registered in deletions/__init__.py
         """
         models_with_group_fk = self.get_models_with_group_foreign_key()
 
@@ -69,11 +80,17 @@ class GroupRelatedModelsCompletenessTest(TestCase):
 
         # Find unregistered models
         unregistered = set()
+        auto_handled = set()
         for model in models_with_group_fk:
             model_label = f"{model._meta.app_label}.{model.__name__}"
 
             # Skip if model is registered or exempted
             if model in registered_models or model_label in self.EXEMPTED_MODELS:
+                continue
+
+            # Check if model has a custom deletion task
+            if self.has_custom_deletion_task(model):
+                auto_handled.add(model_label)
                 continue
 
             unregistered.add(model_label)
@@ -87,12 +104,18 @@ class GroupRelatedModelsCompletenessTest(TestCase):
             for model_label in sorted(unregistered):
                 error_msg.append(f"  - {model_label}")
 
+            if auto_handled:
+                error_msg.append("\n\nAuto-handled models (have custom deletion tasks):")
+                for model_label in sorted(auto_handled):
+                    error_msg.append(f"  ✓ {model_label}")
+
             error_msg.extend(
                 [
                     "\n\nTo fix this, add the model to one of these in src/sentry/deletions/defaults/group.py:",
                     "  1. DIRECT_GROUP_RELATED_MODELS - if it should be transferred during reprocessing",
                     "  2. ADDITIONAL_GROUP_RELATED_MODELS - if it has event_id or shouldn't transfer",
-                    "  3. EXEMPTED_MODELS in this test - if it has custom deletion logic (with justification)",
+                    "  3. Register a custom deletion task in src/sentry/deletions/__init__.py",
+                    "  4. EXEMPTED_MODELS in this test - if it has special handling (with justification)",
                     "\nSee comments in group.py for decision criteria.",
                 ]
             )
@@ -125,3 +148,16 @@ class GroupRelatedModelsCompletenessTest(TestCase):
                 f"Models appear in both DIRECT_GROUP_RELATED_MODELS and "
                 f"ADDITIONAL_GROUP_RELATED_MODELS: {', '.join(duplicate_names)}"
             )
+
+    def test_custom_deletion_task_detection(self) -> None:
+        """
+        Verify that the custom deletion task detection is working correctly.
+        This ensures models with custom deletion tasks don't need manual exemption.
+        """
+        from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+
+        # PlatformExternalIssue should be auto-detected as having a custom deletion task
+        assert self.has_custom_deletion_task(PlatformExternalIssue), (
+            "PlatformExternalIssue should have a custom deletion task registered. "
+            "If this fails, the auto-detection logic may be broken."
+        )

--- a/tests/sentry/deletions/test_validate_group_related_models.py
+++ b/tests/sentry/deletions/test_validate_group_related_models.py
@@ -1,0 +1,132 @@
+"""
+Tests to ensure all models with group foreign keys are properly registered
+in group deletion configuration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import django.apps
+from django.db import models as django_models
+
+from sentry.db.models import FlexibleForeignKey
+from sentry.deletions.defaults.group import (
+    ADDITIONAL_GROUP_RELATED_MODELS,
+    DIRECT_GROUP_RELATED_MODELS,
+)
+from sentry.testutils.cases import TestCase
+
+
+class GroupRelatedModelsCompletenessTest(TestCase):
+    """
+    Validates that all models with group foreign keys are accounted for in the
+    deletion configuration to prevent orphaned records or cascade delete timeouts.
+    """
+
+    # Models that don't need to be in either list (with justification)
+    EXEMPTED_MODELS: Mapping[str, str] = {
+        # Add models here if they shouldn't be in either list, with a comment explaining why
+        # Example: "sentry.SomeModel": "Uses custom deletion logic in XYZ",
+        "sentry.Activity": "TBD",
+        "sentry.GroupReaction": "TBD",
+        "sentry.PlatformExternalIssue": "TBD",
+    }
+
+    def get_models_with_group_foreign_key(self) -> set[type[django_models.Model]]:
+        """
+        Discover all models in the sentry app that have a foreign key to Group.
+        """
+        from sentry.models.group import Group
+
+        models_with_group_fk = set()
+
+        for model_class in django.apps.apps.get_models():
+            # Only check sentry app models
+            if model_class._meta.app_label not in ("sentry", "notifications"):
+                continue
+
+            # Skip the Group model itself
+            if model_class.__name__ == "Group":
+                continue
+
+            # Check all fields for foreign keys to Group
+            for field in model_class._meta.get_fields():
+                if isinstance(field, (django_models.ForeignKey, FlexibleForeignKey)):
+                    # Check if it points to Group
+                    if hasattr(field, "related_model") and field.related_model == Group:
+                        models_with_group_fk.add(model_class)
+                        break
+
+        return models_with_group_fk
+
+    def test_all_group_related_models_are_registered(self) -> None:
+        """
+        Ensure all models with group foreign keys are in one of:
+        - DIRECT_GROUP_RELATED_MODELS
+        - ADDITIONAL_GROUP_RELATED_MODELS
+        - EXEMPTED_MODELS (with justification)
+        """
+        models_with_group_fk = self.get_models_with_group_foreign_key()
+
+        # Get all registered models
+        registered_models = set(DIRECT_GROUP_RELATED_MODELS) | set(ADDITIONAL_GROUP_RELATED_MODELS)
+
+        # Find unregistered models
+        unregistered = set()
+        for model in models_with_group_fk:
+            model_label = f"{model._meta.app_label}.{model.__name__}"
+
+            # Skip if model is registered or exempted
+            if model in registered_models or model_label in self.EXEMPTED_MODELS:
+                continue
+
+            unregistered.add(model_label)
+
+        if unregistered:
+            error_msg = [
+                "\n\nModels with group_id foreign keys are not registered in group deletion configuration!",
+                "\nThis can cause orphaned records or cascade delete timeouts.",
+                "\n\nUnregistered models:",
+            ]
+            for model_label in sorted(unregistered):
+                error_msg.append(f"  - {model_label}")
+
+            error_msg.extend(
+                [
+                    "\n\nTo fix this, add the model to one of these in src/sentry/deletions/defaults/group.py:",
+                    "  1. DIRECT_GROUP_RELATED_MODELS - if it should be transferred during reprocessing",
+                    "  2. ADDITIONAL_GROUP_RELATED_MODELS - if it has event_id or shouldn't transfer",
+                    "  3. EXEMPTED_MODELS in this test - if it has custom deletion logic (with justification)",
+                    "\nSee comments in group.py for decision criteria.",
+                ]
+            )
+
+            raise AssertionError("".join(error_msg))
+
+    def test_exempted_models_have_justification(self) -> None:
+        """
+        Ensure all exempted models have a comment explaining why.
+        """
+        for model_label, reason in self.EXEMPTED_MODELS.items():
+            assert reason and reason.strip(), (
+                f"Model {model_label} is exempted but has no justification. "
+                f"Add a comment explaining why it doesn't need registration."
+            )
+
+    def test_no_duplicate_models_in_lists(self) -> None:
+        """
+        Ensure no model appears in both DIRECT_GROUP_RELATED_MODELS and
+        ADDITIONAL_GROUP_RELATED_MODELS.
+        """
+        direct_set = set(DIRECT_GROUP_RELATED_MODELS)
+        additional_set = set(ADDITIONAL_GROUP_RELATED_MODELS)
+
+        duplicates = direct_set & additional_set
+
+        if duplicates:
+            duplicate_names = [f"{m._meta.app_label}.{m.__name__}" for m in duplicates]
+            raise AssertionError(
+                f"Models appear in both DIRECT_GROUP_RELATED_MODELS and "
+                f"ADDITIONAL_GROUP_RELATED_MODELS: {', '.join(duplicate_names)}"
+            )

--- a/tests/sentry/deletions/test_validate_group_related_models.py
+++ b/tests/sentry/deletions/test_validate_group_related_models.py
@@ -31,10 +31,10 @@ class GroupRelatedModelsCompletenessTest(TestCase):
         # Add models here if they shouldn't be in either list, with a comment explaining why
         # Example: "sentry.SomeModel": "Uses custom deletion logic in XYZ",
         "sentry.Activity": "To be added soon",
-        "sentry.PlatformExternalIssue": "Has custom deletion task registered in deletions/__init__.py (PlatformExternalIssueDeletionTask)",
-        # "workflow_engine.DetectorGroup": "Has on_delete=CASCADE on group field, automatically deleted by Django",
-        # "workflow_engine.WorkflowActionGroupStatus": "Has on_delete=CASCADE (default) on group field, automatically deleted by Django",
-        # "workflow_engine.WorkflowFireHistory": "Has on_delete=CASCADE (default) on group field, automatically deleted by Django",
+        "sentry.PlatformExternalIssue": "TBD",
+        "workflow_engine.DetectorGroup": "TBD",
+        "workflow_engine.WorkflowActionGroupStatus": "TBD",
+        "workflow_engine.WorkflowFireHistory": "TBD",
     }
 
     def get_models_with_group_foreign_key(self) -> set[type[django_models.Model]]:

--- a/tests/sentry/deletions/test_validate_group_related_models.py
+++ b/tests/sentry/deletions/test_validate_group_related_models.py
@@ -24,28 +24,23 @@ class GroupRelatedModelsCompletenessTest(TestCase):
     deletion configuration to prevent orphaned records or cascade delete timeouts.
     """
 
-    # Models that don't need to be in either list (with justification)
+    # Models that don't need to be in either list (with justification).
+    # Note: Models with custom deletion tasks registered in deletions/__init__.py
+    # are automatically detected and don't need to be listed here.
     EXEMPTED_MODELS: Mapping[str, str] = {
         # Add models here if they shouldn't be in either list, with a comment explaining why
         # Example: "sentry.SomeModel": "Uses custom deletion logic in XYZ",
-        "sentry.Activity": "TBD",
-        "sentry.GroupReaction": "TBD",
-        "sentry.PlatformExternalIssue": "TBD",
     }
 
     def get_models_with_group_foreign_key(self) -> set[type[django_models.Model]]:
         """
-        Discover all models in the sentry app that have a foreign key to Group.
+        Discover all models that have a foreign key to Group.
         """
         from sentry.models.group import Group
 
         models_with_group_fk = set()
 
         for model_class in django.apps.apps.get_models():
-            # Only check sentry app models
-            if model_class._meta.app_label not in ("sentry", "notifications"):
-                continue
-
             # Skip the Group model itself
             if model_class.__name__ == "Group":
                 continue

--- a/tests/sentry/deletions/test_validate_group_related_models.py
+++ b/tests/sentry/deletions/test_validate_group_related_models.py
@@ -30,6 +30,11 @@ class GroupRelatedModelsCompletenessTest(TestCase):
     EXEMPTED_MODELS: Mapping[str, str] = {
         # Add models here if they shouldn't be in either list, with a comment explaining why
         # Example: "sentry.SomeModel": "Uses custom deletion logic in XYZ",
+        "sentry.Activity": "To be added soon",
+        "sentry.PlatformExternalIssue": "Has custom deletion task registered in deletions/__init__.py (PlatformExternalIssueDeletionTask)",
+        # "workflow_engine.DetectorGroup": "Has on_delete=CASCADE on group field, automatically deleted by Django",
+        # "workflow_engine.WorkflowActionGroupStatus": "Has on_delete=CASCADE (default) on group field, automatically deleted by Django",
+        # "workflow_engine.WorkflowFireHistory": "Has on_delete=CASCADE (default) on group field, automatically deleted by Django",
     }
 
     def get_models_with_group_foreign_key(self) -> set[type[django_models.Model]]:


### PR DESCRIPTION
There are certain groups which should not be processed during reprocessing and the added comments are to clarify which variable to add a model to.

This also adds a test to prevent adding models without adding it to the deletion system.

The distinction was added in #21899.