### PR TITLE
fix(traces): Show quota exceeded alert in more cases

### DIFF
--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -71,6 +71,12 @@ describe('LogsPage', () => {
       method: 'GET',
       body: [],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/stats_v2/`,
+      method: 'GET',
+      body: {},
+    });
   });
 
   it('should call APIs as expected', async () => {

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -42,6 +42,9 @@ import {
 import {StyledPageFilterBar} from 'sentry/views/explore/logs/styles';
 import type {PickableDays} from 'sentry/views/explore/utils';
 
+// eslint-disable-next-line no-restricted-imports,boundaries/element-types
+import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAlert';
+
 type OnboardingProps = {
   organization: Organization;
   project: Project;
@@ -401,6 +404,7 @@ export function LogsTabOnboarding({
           </StyledPageFilterBar>
         </ExploreFilterSection>
         <OnboardingContainer>
+          <QuotaExceededAlert referrer="logs-explore" traceItemDataset="logs" />
           <Onboarding project={project} organization={organization} />
         </OnboardingContainer>
       </Layout.Main>

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -160,6 +160,12 @@ describe('LogsTabContent', () => {
       method: 'GET',
       body: [],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/stats_v2/`,
+      method: 'GET',
+      body: {},
+    });
   });
 
   it('should call APIs as expected', async () => {

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -362,9 +362,7 @@ export function LogsTabContent({
               error={tableData.error}
             />
           </OverChartButtonGroup>
-          {!tableData.isPending && tableData.isEmpty && (
-            <QuotaExceededAlert referrer="logs-explore" traceItemDataset="logs" />
-          )}
+          <QuotaExceededAlert referrer="logs-explore" traceItemDataset="logs" />
           <LogsDownSamplingAlert
             timeseriesResult={timeseriesResult}
             tableResult={infiniteLogsQueryResult}

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -109,6 +109,7 @@ export function SpansTabOnboarding({
         <DatePageFilter {...datePageFilterProps} />
       </PageFilterBar>
       <OnboardingContentSection>
+        <QuotaExceededAlert referrer="spans-explore" traceItemDataset="spans" />
         <Onboarding project={project} organization={organization} />
       </OnboardingContentSection>
     </Layout.Body>
@@ -438,22 +439,6 @@ function SpanTabContentSection({
     interval,
   });
 
-  const resultsLength =
-    {
-      aggregate: aggregatesTableResult.result.data?.length,
-      samples: spansTableResult.result.data?.length,
-      traces: tracesTableResult.result.data?.data?.length,
-    }[queryType] ?? 0;
-
-  const hasResults = !!resultsLength;
-
-  const resultsLoading =
-    queryType === 'aggregate'
-      ? aggregatesTableResult.result.isPending
-      : queryType === 'samples'
-        ? spansTableResult.result.isPending
-        : tracesTableResult.result.isPending;
-
   const error = defined(timeseriesResult.error)
     ? null // if the timeseries errors, we prefer to show that error in the chart
     : queryType === 'samples'
@@ -495,9 +480,7 @@ function SpanTabContentSection({
         </ActionButtonsGroup>
       </OverChartButtonGroup>
       {defined(id) && <DroppedFieldsAlert />}
-      {!resultsLoading && !hasResults && (
-        <QuotaExceededAlert referrer="spans-explore" traceItemDataset="spans" />
-      )}
+      <QuotaExceededAlert referrer="spans-explore" traceItemDataset="spans" />
       <ExtrapolationEnabledAlert />
       {defined(error) && (
         <Alert.Container>

--- a/static/gsApp/hooks/performance/usePerformanceUsageStats.tsx
+++ b/static/gsApp/hooks/performance/usePerformanceUsageStats.tsx
@@ -13,7 +13,7 @@ type PerformanceStatsGroup = {
 };
 
 type PartialUsageStats = {
-  groups: PerformanceStatsGroup[];
+  groups?: PerformanceStatsGroup[];
 };
 
 export function usePerformanceUsageStats({
@@ -49,7 +49,7 @@ export function usePerformanceUsageStats({
 
   return {
     ...results,
-    data: results.data?.groups.find(group =>
+    data: results.data?.groups?.find(group =>
       [
         'transaction_usage_exceeded',
         'span_usage_exceeded',


### PR DESCRIPTION
Quota exceeded alert should always show when it's needed to make it clear no more data is being ingested due to quota reasons.

Closes EXP-585