### PR TITLE
chore(data-forwarding): Limit access with feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -122,6 +122,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy v2 (with Break the Glass feature)
     manager.add("organizations:data-secrecy-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables access to the global data forwarding features
+    # Note: organizations:data-forwarding is a permanent, plan-based flag that enables access to the actual feature.
+    #       This flag will only be used to access the new UI/UX and endpoints before release.
+    manager.add("organizations:data-forwarding-revamp-access", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables synthesis of device.class in ingest
     manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable device.class as a selectable column

--- a/src/sentry/integrations/api/endpoints/data_forwarding_details.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_details.py
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -286,6 +287,9 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
     def put(
         self, request: Request, organization: Organization, data_forwarder: DataForwarder
     ) -> Response:
+        if not features.has("organizations:data-forwarding-revamp-access", organization):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
         # org:write users can update the main data forwarder configuration
         if request.access.has_scope("org:write"):
             return self._update_data_forwarder_config(request, organization, data_forwarder)
@@ -323,5 +327,8 @@ class DataForwardingDetailsEndpoint(OrganizationEndpoint):
     def delete(
         self, request: Request, organization: Organization, data_forwarder: DataForwarder
     ) -> Response:
+        if not features.has("organizations:data-forwarding-revamp-access", organization):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
         data_forwarder.delete()
         return self.respond(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/integrations/api/endpoints/data_forwarding_index.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_index.py
@@ -2,6 +2,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -41,6 +42,12 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationDataForwardingDetailsPermission,)
 
+    def convert_args(self, request: Request, *args, **kwargs):
+        args, kwargs = super().convert_args(request, *args, **kwargs)
+        if not features.has("organizations:data-forwarding-revamp-access", kwargs["organization"]):
+            raise PermissionDenied
+        return args, kwargs
+
     @extend_schema(
         operation_id="Retrieve Data Forwarding Configurations for an Organization",
         parameters=[GlobalParams.ORG_ID_OR_SLUG],
@@ -51,9 +58,6 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
     def get(self, request: Request, organization) -> Response:
-        if not features.has("organizations:data-forwarding-revamp-access", organization):
-            return self.respond(status=status.HTTP_403_FORBIDDEN)
-
         queryset = DataForwarder.objects.filter(organization_id=organization.id)
 
         return self.paginate(
@@ -77,7 +81,7 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
     def post(self, request: Request, organization) -> Response:
-        if not features.has("organizations:data-forwarding-revamp-access", organization):
+        if not features.has("organizations:data-forwarding", organization):
             return self.respond(status=status.HTTP_403_FORBIDDEN)
 
         data = request.data

--- a/src/sentry/integrations/api/endpoints/data_forwarding_index.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_index.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -50,6 +51,9 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
     def get(self, request: Request, organization) -> Response:
+        if not features.has("organizations:data-forwarding-revamp-access", organization):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
         queryset = DataForwarder.objects.filter(organization_id=organization.id)
 
         return self.paginate(
@@ -73,6 +77,9 @@ class DataForwardingIndexEndpoint(OrganizationEndpoint):
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
     def post(self, request: Request, organization) -> Response:
+        if not features.has("organizations:data-forwarding-revamp-access", organization):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
         data = request.data
         data["organization_id"] = organization.id
 

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
@@ -1,3 +1,5 @@
+from django.urls import reverse
+
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.testutils.cases import APITestCase
@@ -12,9 +14,21 @@ class DataForwardingIndexEndpointTest(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
 
+    def get_response(self, *args, **kwargs):
+        """
+        Override get_response to always add the required feature flag.
+        """
+        with self.feature({"organizations:data-forwarding-revamp-access": True}):
+            return super().get_response(*args, **kwargs)
+
 
 @region_silo_test
 class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
+
+    def test_without_feature_flag_access(self) -> None:
+        response = self.client.get(reverse(self.endpoint, args=(self.organization.slug,)))
+        assert response.status_code == 403
+
     def test_get_single_data_forwarder(self) -> None:
         data_forwarder = self.create_data_forwarder(
             provider=DataForwarderProviderSlug.SEGMENT,
@@ -122,6 +136,10 @@ class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
 @region_silo_test
 class DataForwardingIndexPostTest(DataForwardingIndexEndpointTest):
     method = "POST"
+
+    def test_without_feature_flag_access(self) -> None:
+        response = self.client.post(reverse(self.endpoint, args=(self.organization.slug,)))
+        assert response.status_code == 403
 
     def test_create_segment_data_forwarder(self) -> None:
         payload = {

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
@@ -18,16 +18,37 @@ class DataForwardingIndexEndpointTest(APITestCase):
         """
         Override get_response to always add the required feature flag.
         """
-        with self.feature({"organizations:data-forwarding-revamp-access": True}):
+        with self.feature(
+            {
+                "organizations:data-forwarding-revamp-access": True,
+                "organizations:data-forwarding": True,
+            }
+        ):
             return super().get_response(*args, **kwargs)
 
 
 @region_silo_test
 class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
 
-    def test_without_feature_flag_access(self) -> None:
-        response = self.client.get(reverse(self.endpoint, args=(self.organization.slug,)))
-        assert response.status_code == 403
+    def test_without_revamp_feature_flag_access(self) -> None:
+        with self.feature(
+            {
+                "organizations:data-forwarding-revamp-access": False,
+                "organizations:data-forwarding": True,
+            }
+        ):
+            response = self.client.get(reverse(self.endpoint, args=(self.organization.slug,)))
+            assert response.status_code == 403
+
+    def test_without_data_forwarding_feature_flag_access(self) -> None:
+        with self.feature(
+            {
+                "organizations:data-forwarding-revamp-access": True,
+                "organizations:data-forwarding": False,
+            }
+        ):
+            response = self.client.get(reverse(self.endpoint, args=(self.organization.slug,)))
+            assert response.status_code == 200
 
     def test_get_single_data_forwarder(self) -> None:
         data_forwarder = self.create_data_forwarder(
@@ -137,9 +158,25 @@ class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
 class DataForwardingIndexPostTest(DataForwardingIndexEndpointTest):
     method = "POST"
 
-    def test_without_feature_flag_access(self) -> None:
-        response = self.client.post(reverse(self.endpoint, args=(self.organization.slug,)))
-        assert response.status_code == 403
+    def test_without_revamp_feature_flag_access(self) -> None:
+        with self.feature(
+            {
+                "organizations:data-forwarding-revamp-access": False,
+                "organizations:data-forwarding": True,
+            }
+        ):
+            response = self.client.post(reverse(self.endpoint, args=(self.organization.slug,)))
+            assert response.status_code == 403
+
+    def test_without_data_forwarding_feature_flag_access(self) -> None:
+        with self.feature(
+            {
+                "organizations:data-forwarding-revamp-access": True,
+                "organizations:data-forwarding": False,
+            }
+        ):
+            response = self.client.post(reverse(self.endpoint, args=(self.organization.slug,)))
+            assert response.status_code == 403
 
     def test_create_segment_data_forwarder(self) -> None:
         payload = {

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding_details.py
@@ -1,3 +1,5 @@
+from django.urls import reverse
+
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
@@ -13,10 +15,28 @@ class DataForwardingDetailsEndpointTest(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
 
+    def get_response(self, *args, **kwargs):
+        """
+        Override get_response to always add the required feature flag.
+        """
+        with self.feature({"organizations:data-forwarding-revamp-access": True}):
+            return super().get_response(*args, **kwargs)
+
 
 @region_silo_test
 class DataForwardingDetailsPutTest(DataForwardingDetailsEndpointTest):
     method = "PUT"
+
+    def test_without_feature_flag_access(self) -> None:
+        data_forwarder = self.create_data_forwarder(
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "old_key"},
+            is_enabled=True,
+        )
+        response = self.client.put(
+            reverse(self.endpoint, args=(self.organization.slug, data_forwarder.id))
+        )
+        assert response.status_code == 403
 
     def test_update_data_forwarder(self) -> None:
         data_forwarder = self.create_data_forwarder(
@@ -37,9 +57,10 @@ class DataForwardingDetailsPutTest(DataForwardingDetailsEndpointTest):
             "project_ids": [self.project.id],
         }
 
-        response = self.get_success_response(
-            self.organization.slug, data_forwarder.id, status_code=200, **payload
-        )
+        with self.feature({"organizations:data-forwarding-revamp-access": True}):
+            response = self.get_success_response(
+                self.organization.slug, data_forwarder.id, status_code=200, **payload
+            )
 
         assert response.data["config"] == {"write_key": "new_key"}
         assert not response.data["isEnabled"]
@@ -457,6 +478,17 @@ class DataForwardingDetailsPutTest(DataForwardingDetailsEndpointTest):
 @region_silo_test
 class DataForwardingDetailsDeleteTest(DataForwardingDetailsEndpointTest):
     method = "DELETE"
+
+    def test_without_feature_flag_access(self) -> None:
+        data_forwarder = self.create_data_forwarder(
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "old_key"},
+            is_enabled=True,
+        )
+        response = self.client.delete(
+            reverse(self.endpoint, args=(self.organization.slug, data_forwarder.id))
+        )
+        assert response.status_code == 403
 
     def test_delete_data_forwarder(self) -> None:
         data_forwarder = self.create_data_forwarder(


### PR DESCRIPTION
Adds a feature flag to limit the access to the new endpoints.

Also checking the existing flag for access to the create/update endpoints, but not for get/delete (so that users who downgrade can delete their configs if they wish)