### PR TITLE
fix(ui): moment deprecated date formatting in `useFlagSeries()`

### DIFF
--- a/static/app/components/featureFlags/hooks/useFlagSeries.tsx
+++ b/static/app/components/featureFlags/hooks/useFlagSeries.tsx
@@ -48,8 +48,9 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
           }
         );
 
-        const eventIsBefore = moment(event?.dateCreated).isBefore(moment(time));
-        const formattedDate = moment(time).from(event?.dateCreated, true);
+        const timeObject = moment(data.xAxis);
+        const eventIsBefore = moment(event?.dateCreated).isBefore(timeObject);
+        const formattedDate = timeObject.from(event?.dateCreated, true);
         const suffix = eventIsBefore
           ? t(' (%s after this event)', formattedDate)
           : t(' (%s before this event)', formattedDate);


### PR DESCRIPTION
This fixes the following console.warn that we are getting in prod:

```
 Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments:
```

We were calling `moment()` with a formatted date string, instead, we can use unix timestamp.
