### PR TITLE
fix(widget-builder): Prevent re-render of expensive components from `PageFiltersContainer` initialization

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -5,9 +5,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
-import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {ReleasesProvider} from 'sentry/utils/releases/releasesProvider';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -17,39 +15,25 @@ import ReleasesSelectControl from 'sentry/views/dashboards/releasesSelectControl
 function WidgetBuilderFilterBar({releases}: {releases: string[]}) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
+
   return (
-    <PageFiltersContainer
-      skipLoadLastUsed
-      skipInitializeUrlParams
-      disablePersistence
-      defaultSelection={{
-        datetime: {
-          start: null,
-          end: null,
-          utc: false,
-          period: DEFAULT_STATS_PERIOD,
-        },
-      }}
+    <Tooltip
+      title={t('Changes to these filters can only be made at the dashboard level')}
+      skipWrapper
     >
-      <Tooltip
-        title={t('Changes to these filters can only be made at the dashboard level')}
-        skipWrapper
-      >
-        <StyledPageFilterBar>
-          <ProjectPageFilter disabled onChange={() => {}} />
-          <EnvironmentPageFilter disabled onChange={() => {}} />
-          <DatePageFilter disabled onChange={() => {}} />
-          <ReleasesProvider organization={organization} selection={selection}>
-            <ReleasesSelectControl
-              isDisabled
-              id="releases-select-control"
-              handleChangeFilter={() => {}}
-              selectedReleases={releases}
-            />
-          </ReleasesProvider>
-        </StyledPageFilterBar>
-      </Tooltip>
-    </PageFiltersContainer>
+      <StyledPageFilterBar>
+        <ProjectPageFilter disabled />
+        <EnvironmentPageFilter disabled />
+        <DatePageFilter disabled />
+        <ReleasesProvider organization={organization} selection={selection}>
+          <ReleasesSelectControl
+            isDisabled
+            id="releases-select-control"
+            selectedReleases={releases}
+          />
+        </ReleasesProvider>
+      </StyledPageFilterBar>
+    </Tooltip>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -4,6 +4,7 @@ import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -99,15 +100,17 @@ describe('NewWidgetBuilder', () => {
 
   it('renders', async () => {
     render(
-      <WidgetBuilderV2
-        isOpen
-        onClose={onCloseMock}
-        dashboard={DashboardFixture([])}
-        dashboardFilters={{}}
-        onSave={onSaveMock}
-        openWidgetTemplates={false}
-        setOpenWidgetTemplates={jest.fn()}
-      />,
+      <PageFiltersContainer skipLoadLastUsed skipInitializeUrlParams disablePersistence>
+        <WidgetBuilderV2
+          isOpen
+          onClose={onCloseMock}
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{}}
+          onSave={onSaveMock}
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </PageFiltersContainer>,
       {
         router,
         organization,


### PR DESCRIPTION
This is a successor to https://github.com/getsentry/sentry/pull/102818! The Widget Builder preview renders a `<PageFilterContainer>` around the preview but that's not necessary. In fact, it's harmful, because rendering that component causes a re-initialization of `PageFilterStore`, which causes all components that subscribe to `usePageFilters` to re-render

**Before:**

<img width="581" height="114" alt="Screenshot 2025-11-05 at 4 15 29 PM" src="https://github.com/user-attachments/assets/a3f283f9-e49d-4d56-b2ba-3ee0bfc7881b" />

Remove this component prevents the re-render, which can save on the order of 300ms from the render time.
