### PR TITLE
feat(events): Deduplicate snuba query conditions

### DIFF
--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Iterable
 
 import sentry_sdk
 from django.db.models import Q, QuerySet
@@ -29,7 +29,7 @@ def _get_all_related_redirects_query(
 
 
 def get_all_merged_group_ids(
-    group_ids: Sequence[str | int], threshold=SIZE_THRESHOLD_FOR_CLICKHOUSE
+    group_ids: Iterable[str | int], threshold=SIZE_THRESHOLD_FOR_CLICKHOUSE
 ) -> set[str | int]:
     with sentry_sdk.start_span(op="get_all_merged_group_ids") as span:
         group_id_set = set(group_ids)
@@ -47,7 +47,6 @@ def get_all_merged_group_ids(
                 # each iteration, it's fine if we're a bit over. That's negligible compared
                 # to the scale-of-thousands Clickhouse threshold.
                 threshold_breaker_set = group_id_set.copy()
-                break
 
         out = group_id_set if threshold_breaker_set is None else threshold_breaker_set
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -313,7 +313,7 @@ class PrepareQueryParamsTest(TestCase):
         g1 = self.create_group(id=1)
         g2 = self.create_group(id=2)
         g3 = self.create_group(id=3)
-        self.create_group(id=4)
+        g4 = self.create_group(id=4)
 
         GroupRedirect.objects.create(
             organization_id=g1.project.organization_id,
@@ -329,10 +329,36 @@ class PrepareQueryParamsTest(TestCase):
         options.set("snuba.preprocess-group-redirects", True)
 
         params = SnubaQueryParams(dataset=Dataset.Events, filter_keys={"group_id": {g1.id}})
-        assert params.filter_keys["group_id"] == {g1.id, g2.id, g3.id}
+        assert params.conditions[0] == ["group_id", "IN", {g1.id, g2.id, g3.id}]
 
         params = SnubaQueryParams(dataset=Dataset.Events, conditions=[["group_id", "=", g1.id]])
         assert params.conditions[0] == ["group_id", "IN", {g1.id, g2.id, g3.id}]
+
+        params = SnubaQueryParams(
+            dataset=Dataset.Events,
+            filter_keys={"group_id": {g4.id}},
+            conditions=[["group_id", "IN", [g1.id, g4.id]]],
+        )
+        assert params.conditions[0] == ["group_id", "IN", {g4.id}]
+
+        params = SnubaQueryParams(
+            dataset=Dataset.Events,
+            conditions=[["group_id", "IN", [g1.id, g4.id]], ["group_id", "IN", [g1.id]]],
+        )
+        assert params.conditions[0] == ["group_id", "IN", {g1.id, g2.id, g3.id}]
+
+        params = SnubaQueryParams(
+            dataset=Dataset.Events,
+            conditions=[["group_id", "IN", [g1.id, g4.id]], ["group_id", "NOT IN", [g1.id]]],
+        )
+        assert params.conditions[0] == ["group_id", "IN", {g4.id}]
+
+        params = SnubaQueryParams(
+            dataset=Dataset.Events,
+            conditions=[["foo", "=", "bar"]],
+        )
+        assert params.conditions[0] == ["foo", "=", "bar"]
+        assert len(params.conditions) == 1
 
 
 class QuantizeTimeTest(unittest.TestCase):


### PR DESCRIPTION
# Summary

To help prepare for the shift to EAP (an immutable data store), we need to stop updating Event rows in search backend on group merge. To do so, we track these "redirects" in a separate table and preprocess search queries to include all of those redirected group IDs.

This has run into a process where we're developing queries that are too big for Clickhouse. Part of that appears to be that we're constructing Snuba queries with multiple `group_id` conditions.

This PR folds those multiple conditions into one — e.g. `group_id IN (1,2,3) AND group_id IN (1,2,4)` would just become `group_id IN (1,2)`.

# Test Plan

Expanded the test case around preprocessing to look for this intersection logic; `pytest` shows it passing.