### PR TITLE
feat(autofix): Change logic to check for existing runs

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1590,8 +1590,8 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     event = job["event"]
     group = event.group
 
-    # Only run on issues with no existing scan
-    if group.seer_fixability_score is not None:
+    # Only run if automation hasn't been triggered yet
+    if group.seer_autofix_last_triggered is not None:
         return
 
     # check currently supported issue categories for Seer
@@ -1646,6 +1646,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     if is_seer_scanner_rate_limited(project, group.organization):
         return
 
+    group.update(seer_autofix_last_triggered=timezone.now())
     start_seer_automation.delay(group.id)
 
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1590,7 +1590,12 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     event = job["event"]
     group = event.group
 
-    # Only run if automation hasn't been triggered yet
+    # Only run on issues with no existing scan
+    # TODO: Remove this check when we fully rely on seer_autofix_last_triggered after V0
+    if group.seer_fixability_score is not None:
+        return
+
+    # Check if automation already triggered
     if group.seer_autofix_last_triggered is not None:
         return
 


### PR DESCRIPTION
## PR Details
+ For the V0 launch of triage signals we are changing the threshold and condition for starting an autofix run. 
+ More details explanation here: https://www.notion.so/sentry/Triage-Signals-V0-Technical-Implementation-Details-2a18b10e4b5d8086a7ceddaf4194849a?source=copy_link#2a18b10e4b5d80d2ab2ce33d12db52e0
+ As mentioned in the doc above, we can't use seer_fixability_score alone as a check now.
+ I can keep this change behind a **feature flag** too but I think it's generally safe to rollout. I'm totally okay to use the feature flag too though. 
