### PR TITLE
feat(uptime): Add "This Uptime Monitor was auto-detected by Sentry"

### DIFF
--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -29,7 +29,7 @@ import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
-import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
+import {getDetectorSystemCreatedNotice} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 import {scheduleAsText} from 'sentry/views/insights/crons/utils/scheduleAsText';
 
@@ -213,11 +213,7 @@ export function DetectorLink({detector, className, openInNewTab}: DetectorLinkPr
       className={className}
       name={detector.name}
       link={makeMonitorDetailsPathname(org.slug, detector.id)}
-      systemCreated={
-        detectorTypeIsUserCreateable(detector.type)
-          ? undefined
-          : t('This monitor is managed by Sentry')
-      }
+      systemCreated={getDetectorSystemCreatedNotice(detector)}
       disabled={!detector.enabled}
       openInNewTab={openInNewTab}
       details={

--- a/static/app/views/detectors/utils/detectorTypeConfig.tsx
+++ b/static/app/views/detectors/utils/detectorTypeConfig.tsx
@@ -1,27 +1,35 @@
 import {t} from 'sentry/locale';
-import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
+import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
+import {UptimeMonitorMode} from 'sentry/views/alerts/rules/uptime/types';
 
 type DetectorTypeConfig = {
   label: string;
   userCreateable: boolean;
+  systemCreatedNotice?: (detector: Detector) => undefined | string;
 };
 
 const DETECTOR_TYPE_CONFIG: Record<DetectorType, DetectorTypeConfig> = {
   error: {
-    userCreateable: false,
     label: t('Error'),
+    userCreateable: false,
+    systemCreatedNotice: () => t('This monitor is managed by Sentry'),
   },
   metric_issue: {
-    userCreateable: true,
     label: t('Metric'),
+    userCreateable: true,
   },
   monitor_check_in_failure: {
-    userCreateable: true,
     label: t('Cron'),
+    userCreateable: true,
   },
   uptime_domain_failure: {
-    userCreateable: true,
     label: t('Uptime'),
+    userCreateable: true,
+    systemCreatedNotice: uptimeDetector =>
+      uptimeDetector.type === 'uptime_domain_failure' &&
+      uptimeDetector.config.mode !== UptimeMonitorMode.MANUAL
+        ? t('This Uptime Monitor was auto-detected by Sentry')
+        : undefined,
   },
 };
 
@@ -31,6 +39,10 @@ export function isValidDetectorType(detectorType: DetectorType) {
 
 export function detectorTypeIsUserCreateable(detectorType: DetectorType) {
   return DETECTOR_TYPE_CONFIG[detectorType]?.userCreateable ?? false;
+}
+
+export function getDetectorSystemCreatedNotice(detector: Detector) {
+  return DETECTOR_TYPE_CONFIG[detector.type]?.systemCreatedNotice?.(detector);
 }
 
 export function getDetectorTypeLabel(detectorType: DetectorType) {


### PR DESCRIPTION
Fixes [NEW-587: Ensure uptime detectors in list that are autodetected have the little sentry icon next to them](https://linear.app/getsentry/issue/NEW-587/ensure-uptime-detectors-in-list-that-are-autodetected-have-the-little)