### PR TITLE
bug(size-analysis): Fix issue where multiple commit comparisons might be present from accidental local uploads, leading to hard crash

### DIFF
--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from enum import IntEnum
 
 from django.db import models
@@ -13,6 +14,8 @@ from sentry.db.models.fields.bounded import (
 )
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 from sentry.models.commitcomparison import CommitComparison
+
+logger = logging.getLogger(__name__)
 
 
 @region_silo_model
@@ -167,13 +170,27 @@ class PreprodArtifact(DefaultFieldsModel):
         if not self.commit_comparison:
             return PreprodArtifact.objects.none()
 
-        try:
-            base_commit_comparison = CommitComparison.objects.get(
-                head_sha=self.commit_comparison.base_sha,
-                organization_id=self.project.organization_id,
-            )
-        except CommitComparison.DoesNotExist:
+        base_commit_comparisons_qs = CommitComparison.objects.filter(
+            head_sha=self.commit_comparison.base_sha,
+            organization_id=self.project.organization_id,
+        ).order_by("date_added")
+        base_commit_comparisons = list(base_commit_comparisons_qs)
+
+        if len(base_commit_comparisons) == 0:
             return PreprodArtifact.objects.none()
+        elif len(base_commit_comparisons) == 1:
+            base_commit_comparison = base_commit_comparisons[0]
+        else:
+            logger.warning(
+                "preprod.models.get_base_artifact_for_commit.multiple_base_commit_comparisons",
+                extra={
+                    "head_sha": self.commit_comparison.head_sha,
+                    "organization_id": self.project.organization_id,
+                    "base_commit_comparisons": base_commit_comparisons,
+                },
+            )
+            # Take first (oldest) commit comparison
+            base_commit_comparison = base_commit_comparisons[0]
 
         return PreprodArtifact.objects.filter(
             commit_comparison=base_commit_comparison,

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from enum import IntEnum
 
+import sentry_sdk
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
@@ -187,6 +188,13 @@ class PreprodArtifact(DefaultFieldsModel):
                     "head_sha": self.commit_comparison.head_sha,
                     "organization_id": self.project.organization_id,
                     "base_commit_comparisons": base_commit_comparisons,
+                },
+            )
+            sentry_sdk.capture_message(
+                "Multiple base commitcomparisons found",
+                level="error",
+                extras={
+                    "sha": self.commit_comparison.head_sha,
                 },
             )
             # Take first (oldest) commit comparison

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -187,7 +187,7 @@ class PreprodArtifact(DefaultFieldsModel):
                 extra={
                     "head_sha": self.commit_comparison.head_sha,
                     "organization_id": self.project.organization_id,
-                    "base_commit_comparisons": base_commit_comparisons,
+                    "base_commit_comparison_ids": [c.id for c in base_commit_comparisons],
                 },
             )
             sentry_sdk.capture_message(


### PR DESCRIPTION
Handles some edge cases we've seen where a user might accidentally upload a build locally, resulting in two `CommitComparison` objects being found for the base_sha when we try to find a `PreprodArtifact`'s base build. We currently don't gracefully handle this as it admittedly is a bit unexpected.

Instead of hard failing, this will now log a warning and take the oldest matching CommitComparison, which should give the first build uploaded and likely the build we want, i.e. the build uploaded from CI. Adds a test to confirm this ordering too.