### PR TITLE
feat(aci): create issue stream detector upon project creation

### DIFF
--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -1,7 +1,6 @@
 import logging
 
 import sentry_sdk
-from django.db import IntegrityError
 from django.db.models.signals import post_save
 
 from sentry import features
@@ -18,7 +17,7 @@ def create_project_detectors(instance, created, **kwargs):
                 "organizations:workflow-engine-issue-alert-dual-write", instance.organization
             ):
                 ensure_default_detectors(instance)
-        except IntegrityError as e:
+        except Exception as e:
             sentry_sdk.capture_exception(e)
 
 

--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -18,7 +18,6 @@ def create_project_detectors(instance, created, **kwargs):
                 "organizations:workflow-engine-issue-alert-dual-write", instance.organization
             ):
                 ensure_default_detectors(instance)
-                logger.info("project.detector-created", extra={"project_id": instance.id})
         except IntegrityError as e:
             sentry_sdk.capture_exception(e)
 

--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -5,7 +5,10 @@ from django.db.models.signals import post_save
 
 from sentry import features
 from sentry.models.project import Project
-from sentry.workflow_engine.processors.detector import ensure_default_detectors
+from sentry.workflow_engine.processors.detector import (
+    UnableToAcquireLockApiError,
+    ensure_default_detectors,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +20,7 @@ def create_project_detectors(instance, created, **kwargs):
                 "organizations:workflow-engine-issue-alert-dual-write", instance.organization
             ):
                 ensure_default_detectors(instance)
-        except Exception as e:
+        except UnableToAcquireLockApiError as e:
             sentry_sdk.capture_exception(e)
 
 

--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -8,7 +8,8 @@ from sentry import features
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.project import Project
 from sentry.workflow_engine.models import Detector
-from sentry.workflow_engine.types import ERROR_DETECTOR_NAME
+from sentry.workflow_engine.types import ERROR_DETECTOR_NAME, ISSUE_STREAM_DETECTOR_NAME
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,12 @@ def create_project_detectors(instance, created, **kwargs):
             ):
                 Detector.objects.create(
                     name=ERROR_DETECTOR_NAME, type=ErrorGroupType.slug, project=instance, config={}
+                )
+                Detector.objects.create(
+                    name=ISSUE_STREAM_DETECTOR_NAME,
+                    type=IssueStreamGroupType.slug,
+                    project=instance,
+                    config={},
                 )
                 logger.info("project.detector-created", extra={"project_id": instance.id})
         except IntegrityError as e:

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -37,6 +37,7 @@ from sentry.types.actor import Actor
 from sentry.users.models.user import User
 from sentry.users.models.user_option import UserOption
 from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
 class ProjectTest(APITestCase, TestCase):
@@ -476,13 +477,14 @@ class ProjectTest(APITestCase, TestCase):
         assert alert_rule.team_id is None
         assert alert_rule.user_id is None
 
-    def test_project_detector(self) -> None:
+    def test_project_detectors(self) -> None:
         project = self.create_project()
-        assert not Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
+        assert not Detector.objects.filter(project=project).exists()
 
         with self.feature({"organizations:workflow-engine-issue-alert-dual-write": True}):
             project = self.create_project()
             assert Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
+            assert Detector.objects.filter(project=project, type=IssueStreamGroupType.slug).exists()
 
 
 class ProjectOptionsTests(TestCase):


### PR DESCRIPTION
Missed this spot in order to fully dual write issue stream detectors in the same places as the error detector.