### PR TITLE
fix(widget-viewer): View span samples should open in explore

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1418,6 +1418,12 @@ describe('Modals -> WidgetViewerModal', () => {
         url: '/organizations/org-slug/events-stats/',
         body: {},
       });
+      initialData = initializeOrg({
+        organization: {
+          features: ['discover-cell-actions-v2'],
+        },
+        projects: [ProjectFixture()],
+      });
     });
 
     it('renders the Open in Explore button', async () => {
@@ -1469,6 +1475,51 @@ describe('Modals -> WidgetViewerModal', () => {
             // The orderby should appear in the field array
             field: ['span.description', 'p90(span.duration)', 'count(span.duration)'],
           }),
+        })
+      );
+    });
+
+    it('links to the spans page when "View span samples" is clicked in the context menu', async () => {
+      const mockSpanWidget = WidgetFixture({
+        widgetType: WidgetType.SPANS,
+        title: 'Span Transactions Widget',
+        displayType: DisplayType.TABLE,
+        queries: [
+          {
+            fields: ['transaction', 'count()'],
+            aggregates: ['count()'],
+            columns: ['transaction'],
+            name: '',
+            conditions: '',
+            orderby: '',
+          },
+        ],
+      });
+
+      await renderModal({
+        initialData,
+        widget: mockSpanWidget,
+        tableData: [
+          {
+            title: 'Span Transactions Widget',
+            data: [{transaction: 'test-transaction', count: 10, id: 'test-id'}],
+          },
+        ],
+      });
+
+      const transactionCell = await screen.findByText('test-transaction');
+      expect(transactionCell).toBeInTheDocument();
+
+      await userEvent.click(transactionCell);
+
+      const menuOption = await screen.findByText('View span samples');
+      expect(menuOption).toBeInTheDocument();
+
+      await userEvent.click(menuOption);
+
+      expect(initialData.router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathname: expect.stringContaining('/organizations/org-slug/explore/traces/'),
         })
       );
     });

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -479,6 +479,7 @@ function WidgetViewerModal(props: Props) {
       eventView,
       theme,
       projects,
+      selectedQueryIndex,
     });
   }
 
@@ -508,6 +509,7 @@ function WidgetViewerModal(props: Props) {
       eventView,
       theme,
       projects,
+      selectedQueryIndex,
     });
   };
 
@@ -987,6 +989,7 @@ interface ViewerTableV2Props {
   navigate: ReactRouter3Navigate;
   organization: Organization;
   projects: Project[];
+  selectedQueryIndex: number;
   setChartUnmodified: React.Dispatch<React.SetStateAction<boolean>>;
   tableWidget: Widget;
   theme: Theme;
@@ -1013,6 +1016,7 @@ function ViewerTableV2({
   projects,
   dashboardFilters,
   modalSelection,
+  selectedQueryIndex,
 }: ViewerTableV2Props) {
   const page = decodeInteger(location.query[WidgetViewerQueryField.PAGE]) ?? 0;
   const links = parseLinkHeader(pageLinks ?? null);
@@ -1043,7 +1047,7 @@ function ViewerTableV2({
   const datasetConfig = getDatasetConfig(widget.widgetType);
   const aliases = decodeColumnAliases(
     tableColumns,
-    tableWidget.queries[0]?.fieldAliases ?? [],
+    tableWidget.queries[selectedQueryIndex]?.fieldAliases ?? [],
     tableWidget.widgetType === WidgetType.ISSUE
       ? datasetConfig?.getFieldHeaderMap?.()
       : {}
@@ -1161,7 +1165,8 @@ function ViewerTableV2({
               modalSelection,
               widget,
               organization,
-              dashboardFilters
+              dashboardFilters,
+              selectedQueryIndex
             );
             navigate(getExploreUrl(dataRow));
           }

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -88,7 +88,10 @@ import {
   performanceScoreTooltip,
 } from 'sentry/views/dashboards/utils';
 import {checkUserHasEditAccess} from 'sentry/views/dashboards/utils/checkUserHasEditAccess';
-import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {
+  getWidgetExploreUrl,
+  getWidgetTableRowExploreUrlFunction,
+} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {
   SESSION_DURATION_ALERT,
   WidgetDescription,
@@ -466,6 +469,8 @@ function WidgetViewerModal(props: Props) {
       fields,
       widget,
       tableWidget,
+      dashboardFilters,
+      modalSelection,
       setChartUnmodified,
       widths,
       location,
@@ -493,6 +498,8 @@ function WidgetViewerModal(props: Props) {
       fields,
       widget,
       tableWidget,
+      dashboardFilters,
+      modalSelection,
       setChartUnmodified,
       widths,
       location,
@@ -971,10 +978,12 @@ function renderTotalResults(totalResults?: string, widgetType?: WidgetType) {
 }
 
 interface ViewerTableV2Props {
+  dashboardFilters: DashboardFilters | undefined;
   eventView: EventView;
   fields: string[];
   loading: boolean;
   location: Location;
+  modalSelection: PageFilters;
   navigate: ReactRouter3Navigate;
   organization: Organization;
   projects: Project[];
@@ -1002,6 +1011,8 @@ function ViewerTableV2({
   eventView,
   theme,
   projects,
+  dashboardFilters,
+  modalSelection,
 }: ViewerTableV2Props) {
   const page = decodeInteger(location.query[WidgetViewerQueryField.PAGE]) ?? 0;
   const links = parseLinkHeader(pageLinks ?? null);
@@ -1144,6 +1155,17 @@ function ViewerTableV2({
           } satisfies RenderFunctionBaggage;
         }}
         allowedCellActions={cellActions}
+        onTriggerCellAction={(action, _value, dataRow) => {
+          if (action === Actions.OPEN_ROW_IN_EXPLORE) {
+            const getExploreUrl = getWidgetTableRowExploreUrlFunction(
+              modalSelection,
+              widget,
+              organization,
+              dashboardFilters
+            );
+            navigate(getExploreUrl(dataRow));
+          }
+        }}
       />
       {!(
         tableWidget.queries[0]!.orderby.match(/^-?release$/) &&

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -455,17 +455,18 @@ export function getWidgetTableRowExploreUrlFunction(
   selection: PageFilters,
   widget: Widget,
   organization: Organization,
-  dashboardFilters?: DashboardFilters
+  dashboardFilters?: DashboardFilters,
+  selectedQueryIndex = 0
 ) {
   return (dataRow: TabularRow) => {
     let fields: string[] = [];
-    if (widget.queries[0]?.fields) {
-      fields = widget.queries[0].fields.filter(
+    if (widget.queries[selectedQueryIndex]?.fields) {
+      fields = widget.queries[selectedQueryIndex].fields.filter(
         (field: string) => !isAggregateFieldOrEquation(field)
       );
     }
 
-    const query = new MutableSearch(widget.queries[0]?.conditions ?? '');
+    const query = new MutableSearch(widget.queries[selectedQueryIndex]?.conditions ?? '');
     fields.map(field => {
       const value = dataRow[field];
       if (!defined(value)) {


### PR DESCRIPTION
This View span samples button from the widget viewer should have opened up in explore. We missed passing in a handler that handles this action type. Tbh the button should not have been allowed to render if we didn't have it hooked up, so that might need to be an update, but for a later time.