### PR TITLE
ref(orgredirect): Move orgredirect endpoint to open-source Sentry

### DIFF
--- a/src/sentry/analytics/events/org_redirect.py
+++ b/src/sentry/analytics/events/org_redirect.py
@@ -1,0 +1,18 @@
+from sentry import analytics
+
+
+@analytics.eventclass("org_redirect")
+class OrgRedirectEvent(analytics.Event):
+    """Tracking analytics for organization redirects"""
+
+    user_id: int
+    organization_id: int | None = None
+    path: str
+
+
+# Only register if not already registered (allows getsentry to register its own version)
+try:
+    analytics.register(OrgRedirectEvent)
+except AssertionError:
+    # Already registered (likely by getsentry)
+    pass

--- a/src/sentry/web/frontend/org_redirect.py
+++ b/src/sentry/web/frontend/org_redirect.py
@@ -1,0 +1,51 @@
+import re
+
+import sentry_sdk
+from django.http import HttpResponseRedirect
+
+from sentry import analytics, features
+from sentry.analytics.events.org_redirect import OrgRedirectEvent
+from sentry.organizations.absolute_url import customer_domain_path, generate_organization_url
+from sentry.organizations.services.organization import RpcOrganization
+from sentry.web.frontend.base import BaseView, control_silo_view
+
+
+@control_silo_view
+class OrgRedirect(BaseView):
+    auth_required = True
+
+    def get_url(self, request, organization: RpcOrganization):
+        # path in sentry comes after /orgredirect/
+        path = request.get_full_path().replace("/orgredirect/", "/")
+        # make it work for __orgslug__ and :orgslug
+        path = re.sub("__orgslug__", organization.slug, path, flags=re.IGNORECASE)
+        path = re.sub(":orgslug", organization.slug, path, flags=re.IGNORECASE)
+        if request.subdomain == organization.slug or features.has("system:multi-region"):
+            path = customer_domain_path(path)
+            return f"{generate_organization_url(organization.slug)}{path}"
+        return path
+
+    def handle(self, request):
+        if self.active_organization:
+            try:
+                analytics.record(
+                    OrgRedirectEvent(
+                        user_id=request.user.id,
+                        organization_id=self.active_organization.organization.id,
+                        path=request.get_full_path(),
+                    )
+                )
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+            redirect_url = self.get_url(request, self.active_organization.organization)
+            return HttpResponseRedirect(redirect_url)
+        try:
+            analytics.record(
+                OrgRedirectEvent(
+                    user_id=request.user.id,
+                    path=request.get_full_path(),
+                )
+            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+        return self.redirect_to_org(request)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -42,6 +42,7 @@ from sentry.web.frontend.js_sdk_loader import JavaScriptSdkLoader
 from sentry.web.frontend.mailgun_inbound_webhook import MailgunInboundWebhookView
 from sentry.web.frontend.oauth_authorize import OAuthAuthorizeView
 from sentry.web.frontend.oauth_token import OAuthTokenView
+from sentry.web.frontend.org_redirect import OrgRedirect
 from sentry.web.frontend.organization_auth_settings import OrganizationAuthSettingsView
 from sentry.web.frontend.organization_avatar import OrganizationAvatarPhotoView
 from sentry.web.frontend.out import OutView
@@ -297,6 +298,11 @@ urlpatterns += [
                 ),
             ]
         ),
+    ),
+    re_path(
+        r"^orgredirect/",
+        OrgRedirect.as_view(),
+        name="sentry-org-redirect",
     ),
     re_path(
         r"^login-redirect/$",

--- a/tests/sentry/web/frontend/test_org_redirect.py
+++ b/tests/sentry/web/frontend/test_org_redirect.py
@@ -1,0 +1,240 @@
+from unittest.mock import MagicMock, patch
+
+from django.urls import reverse
+
+from sentry.analytics.events.org_redirect import OrgRedirectEvent
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class TestOrgRedirect(TestCase):
+    def test_unauthenticated(self) -> None:
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__orgSlug__/integrations/?param=test"
+        )
+        response = self.client.get(url, format="json", follow=True)
+        assert response.status_code == 200
+        assert response.redirect_chain == [("/auth/login/", 302)]
+
+    def test_no_last_active_org(self) -> None:
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__orgSlug__/integrations/?param=test"
+        )
+        response = self.client.get(url, format="json", follow=True)
+        assert response.status_code == 200
+        # Redirects to organization creation
+        assert ("/organizations/new/", 302) in response.redirect_chain
+
+    @with_feature("system:multi-region")
+    def test_path_redirect(self) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__orgSlug__/integrations/?param=test"
+        )
+        response = self.client.get(url, format="json", follow=True)
+        assert response.status_code == 200
+        assert response.redirect_chain == [
+            (org.absolute_url(f"/settings/{org.slug}/integrations/?param=test"), 302)
+        ]
+
+    @with_feature("system:multi-region")
+    def test_path_redirect_case_insensitive(self) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__OrGslUg__/integrations/?param=test"
+        )
+        response = self.client.get(url, format="json", follow=True)
+        assert response.status_code == 200
+        assert response.redirect_chain == [
+            (org.absolute_url(f"/settings/{org.slug}/integrations/?param=test"), 302)
+        ]
+
+    @with_feature("system:multi-region")
+    def test_colon_path_redirect(self) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/:orgslug/integrations/?param=test"
+        )
+        response = self.client.get(url, format="json", follow=True)
+        assert response.status_code == 200
+        assert response.redirect_chain == [
+            (org.absolute_url(f"/settings/{org.slug}/integrations/?param=test"), 302)
+        ]
+
+    @patch("sentry.analytics.record")
+    def test_analytics_org(self, mock_record: MagicMock) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/:orgslug/integrations/?param=test"
+        )
+        self.client.get(url, format="json")
+        assert_last_analytics_event(
+            mock_record,
+            OrgRedirectEvent(
+                user_id=self.user.id,
+                organization_id=org.id,
+                path=url,
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    def test_analytics_no_org(self, mock_record: MagicMock) -> None:
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/:orgslug/integrations/?param=test"
+        )
+        self.client.get(url, format="json")
+        assert_last_analytics_event(
+            mock_record,
+            OrgRedirectEvent(
+                user_id=self.user.id,
+                path=url,
+            ),
+        )
+
+
+@control_silo_test
+class TestOrgRedirectCustomerDomain(TestCase):
+    def get_response(self, url, SERVER_NAME=None):
+        if SERVER_NAME is None:
+            SERVER_NAME = "albertos-apples.testserver"
+        return self.client.get(url, format="json", follow=True, SERVER_NAME=SERVER_NAME)
+
+    def test_unauthenticated(self) -> None:
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__orgSlug__/integrations/?param=test"
+        )
+        response = self.get_response(url)
+        assert response.status_code == 200
+        assert response.redirect_chain == [("/auth/login/", 302)]
+
+    def test_no_last_active_org(self) -> None:
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__orgSlug__/integrations/?param=test"
+        )
+        response = self.get_response(url)
+        assert response.status_code == 200
+        # Should redirect to org creation
+        assert ("http://testserver/organizations/new/", 302) in response.redirect_chain
+
+    def test_path_redirect(self) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__orgSlug__/integrations/?param=test"
+        )
+        response = self.get_response(url, SERVER_NAME=f"{org.slug}.testserver")
+        assert response.status_code == 200
+        assert response.redirect_chain == [
+            (
+                f"http://{org.slug}.testserver/settings/integrations/?param=test",
+                302,
+            ),
+        ]
+
+    def test_path_redirect_with_customer_domain_feature(self) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/__orgSlug__/integrations/?param=test"
+        )
+        with self.feature({"system:multi-region": True}):
+            response = self.client.get(url, format="json", follow=True)
+            assert response.status_code == 200
+            assert response.redirect_chain == [
+                (
+                    f"http://{org.slug}.testserver/settings/integrations/?param=test",
+                    302,
+                ),
+            ]
+
+    @patch("sentry.analytics.record")
+    def test_analytics_org(self, mock_record: MagicMock) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/:orgslug/integrations/?param=test"
+        )
+        response = self.get_response(url, SERVER_NAME=f"{org.slug}.testserver")
+        assert response.status_code == 200
+        assert response.redirect_chain == [
+            (
+                f"http://{org.slug}.testserver/settings/integrations/?param=test",
+                302,
+            ),
+        ]
+        assert_last_analytics_event(
+            mock_record,
+            OrgRedirectEvent(
+                user_id=self.user.id,
+                organization_id=org.id,
+                path=url,
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    def test_analytics_no_org(self, mock_record: MagicMock) -> None:
+        self.login_as(self.user)
+        url = (
+            reverse(
+                "sentry-org-redirect",
+            )
+            + "settings/:orgslug/integrations/?param=test"
+        )
+        response = self.get_response(url)
+        assert response.status_code == 200
+        # Should redirect to org creation
+        assert ("http://testserver/organizations/new/", 302) in response.redirect_chain
+
+        assert_last_analytics_event(
+            mock_record,
+            OrgRedirectEvent(
+                user_id=self.user.id,
+                path=url,
+            ),
+        )


### PR DESCRIPTION
The orgredirect endpoint contains no billing-related functionality and
can be moved from getsentry to the open-source Sentry repository.

This commit adds the endpoint to Sentry with a compatibility layer that
allows both repos to coexist during deployment. The analytics event
registration is wrapped in a try/except to handle cases where getsentry
has already registered the event, preventing conflicts.

Key differences from getsentry implementation:
- Uses `redirect_to_org()` instead of `marketing_landing()` when no
  active organization is found
- Test expectations adjusted to not expect hash fragments in URLs
  (standard HTTP behavior)

After this is deployed, the endpoint can be safely removed from getsentry.

Fixes [RTC-480: Self hosted login opens wrong url](https://linear.app/getsentry/issue/RTC-480/self-hosted-login-opens-wrong-url)