### PR TITLE
fix(aci): Better naming for metric monitors on issue details page

### DIFF
--- a/static/app/utils/issueTypeConfig/metricConfig.tsx
+++ b/static/app/utils/issueTypeConfig/metricConfig.tsx
@@ -101,8 +101,8 @@ const metricConfig: IssueCategoryConfigMapping = {
     },
     detector: {
       enabled: true,
-      title: t('Metric Alert Detector'),
-      ctaText: t('View detector details'),
+      title: t('Metric Monitor'),
+      ctaText: t('View monitor details'),
     },
     header: {
       filterBar: {enabled: true, fixedEnvironment: true},

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
@@ -58,15 +58,15 @@ describe('DetectorSection', () => {
       </IssueDetailsContext>
     );
 
-    expect(screen.getByText('Metric Alert Detector')).toBeInTheDocument();
-    const link = screen.getByRole('button', {name: 'View detector details'});
+    expect(screen.getByText('Metric Monitor')).toBeInTheDocument();
+    const link = screen.getByRole('button', {name: 'View monitor details'});
     expect(link).toHaveAttribute(
       'href',
       `/organizations/${organization.slug}/issues/alerts/rules/details/${detectorId}/`
     );
     expect(
       screen.getByText(
-        'This issue was created by a metric alert detector. View the detector details to learn more.'
+        'This issue was created by a metric monitor. View the monitor details to learn more.'
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -66,7 +66,7 @@ export function getDetectorDetails({
       detectorId,
       detectorPath: makeMonitorDetailsPathname(organization.slug, detectorId),
       description: t(
-        'This issue was created by a metric alert detector. View the detector details to learn more.'
+        'This issue was created by a metric monitor. View the monitor details to learn more.'
       ),
     };
   }

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -55,7 +55,7 @@ export function getDetectorDetails({
         }),
         // TODO(issues): We can probably enrich this description with details from the alert itself.
         description: t(
-          'This issue was created by a metric alert detector. View the detector details to learn more.'
+          'This issue was created by a metric monitor. View the monitor details to learn more.'
         ),
       };
     }


### PR DESCRIPTION
These were referring to "metric alert issues" and "metric alert detectors". Updates to "metric monitor"