### PR TITLE
feat(uptime): Add duration + uptime % to detector details

### DIFF
--- a/static/app/views/detectors/components/details/uptime/index.spec.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.spec.tsx
@@ -1,6 +1,7 @@
 import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {UptimeSummaryFixture} from 'sentry-fixture/uptimeSummary';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -72,5 +73,43 @@ describe('UptimeDetectorDetails', () => {
     });
 
     expect(await screen.findByText('Recent Check-Ins')).toBeInTheDocument();
+  });
+
+  it('renders Duration section with data', async () => {
+    const detector = UptimeDetectorFixture({id: '3'});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/uptime-summary/',
+      body: {
+        '3': UptimeSummaryFixture({avgDurationUs: 150_000}),
+      },
+    });
+
+    render(<UptimeDetectorDetails detector={detector} project={project} />, {
+      organization,
+    });
+
+    expect(await screen.findByText('Duration')).toBeInTheDocument();
+    expect(await screen.findByText('150ms')).toBeInTheDocument();
+  });
+
+  it('renders Uptime section with percentage', async () => {
+    const detector = UptimeDetectorFixture({id: '3'});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/uptime-summary/',
+      body: {
+        '3': UptimeSummaryFixture({
+          totalChecks: 100,
+          downtimeChecks: 5,
+          failedChecks: 0,
+          missedWindowChecks: 0,
+        }),
+      },
+    });
+
+    render(<UptimeDetectorDetails detector={detector} project={project} />, {
+      organization,
+    });
+
+    expect(await screen.findByText('95%')).toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -1,8 +1,11 @@
 import {useCallback, useState} from 'react';
 
 import {CodeBlock} from 'sentry/components/core/code';
+import {Grid} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {KeyValueTableRow} from 'sentry/components/keyValueTable';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import Placeholder from 'sentry/components/placeholder';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t, tn} from 'sentry/locale';
@@ -20,6 +23,9 @@ import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
+import {UptimeDuration} from 'sentry/views/insights/uptime/components/duration';
+import {UptimePercent} from 'sentry/views/insights/uptime/components/percent';
+import {useUptimeMonitorSummaries} from 'sentry/views/insights/uptime/utils/useUptimeMonitorSummary';
 
 type UptimeDetectorDetailsProps = {
   detector: UptimeDetector;
@@ -28,6 +34,12 @@ type UptimeDetectorDetailsProps = {
 
 export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetailsProps) {
   const dataSource = detector.dataSources[0];
+
+  const {data: uptimeSummaries} = useUptimeMonitorSummaries({
+    detectorIds: [detector.id],
+  });
+  const summary =
+    uptimeSummaries === undefined ? undefined : (uptimeSummaries?.[detector.id] ?? null);
 
   // Only display the missed window legend when there are visible missed window
   // check-ins in the timeline
@@ -81,6 +93,36 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
           <Section title={t('Legend')}>
             <DetailsTimelineLegend showMissedLegend={showMissedLegend} />
           </Section>
+          <Grid columns="max-content max-content" gap="3xl">
+            <Section title={t('Duration')}>
+              {summary === undefined ? (
+                <Text size="xl">
+                  <Placeholder width="60px" height="1lh" />
+                </Text>
+              ) : summary === null ? (
+                '-'
+              ) : (
+                <UptimeDuration size="xl" summary={summary} />
+              )}
+            </Section>
+            <Section title={t('Uptime')}>
+              {summary === undefined ? (
+                <Text size="xl">
+                  <Placeholder width="60px" height="1lh" />
+                </Text>
+              ) : summary === null ? (
+                '-'
+              ) : (
+                <UptimePercent
+                  size="xl"
+                  summary={summary}
+                  note={t(
+                    'The total calculated uptime of this monitors over the last 90 days.'
+                  )}
+                />
+              )}
+            </Section>
+          </Grid>
           <DetectorDetailsAssignee owner={detector.owner} />
           <DetectorExtraDetails>
             <KeyValueTableRow

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -240,6 +240,12 @@ describe('DetectorDetails', () => {
         body: [],
       });
 
+      // Mock uptime summary endpoint
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/uptime-summary/',
+        body: {},
+      });
+
       // Mock uptime checks endpoint
       MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${project.slug}/uptime/${uptimeDetector.id}/checks/`,
@@ -301,7 +307,7 @@ describe('DetectorDetails', () => {
       expect(await screen.findByText('Recent Check-Ins')).toBeInTheDocument();
 
       // Verify check-in data is displayed
-      expect(screen.getAllByText('Uptime')).toHaveLength(2); // timeline legend + check-in row
+      expect(screen.getAllByText('Uptime')).toHaveLength(3); // section heading + timeline legend + check-in row
       expect(screen.getByText('200')).toBeInTheDocument();
       expect(screen.getByText('US East')).toBeInTheDocument();
       expect(screen.getAllByText('Failure')).toHaveLength(2); // timeline legend + check-in row


### PR DESCRIPTION
Fixes: [NEW-572: Duration and uptime % summary should be available](https://linear.app/getsentry/issue/NEW-572/duration-and-uptime-percent-summary-should-be-available)