### PR TITLE
chore(size-analysis): Add org slug to logs used in preprod sentry dashboard

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -164,6 +164,7 @@ def assemble_preprod_artifact(
             "preprod_artifact_id": artifact_id,
             "project_id": project_id,
             "organization_id": org_id,
+            "organization_slug": organization.slug,
             "checksum": checksum,
         },
     )

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -141,6 +141,7 @@ def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
             "status": status.value,
             "check_id": check_id,
             "organization_id": preprod_artifact.project.organization_id,
+            "organization_slug": preprod_artifact.project.organization.slug,
         },
     )
 


### PR DESCRIPTION
Will allow us to use org slugs in our dashboard for size analysis for easier identifying usage.