### PR TITLE
fix(uptime): Do not mention consecutive failures in issue details

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
@@ -131,9 +131,7 @@ describe('DetectorSection', () => {
       `/organizations/${organization.slug}/issues/alerts/rules/uptime/${project.slug}/${detectorId}/details/`
     );
     expect(
-      screen.getByText(
-        'This issue was created by an uptime monitoring alert rule after detecting 3 consecutive failed checks.'
-      )
+      screen.getByText('This issue was created by an uptime monitoring alert rule.')
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -98,9 +98,7 @@ export function getDetectorDetails({
         organization,
       }),
       // TODO(issues): Update this to mention detectors when that language is user-facing
-      description: t(
-        'This issue was created by an uptime monitoring alert rule after detecting 3 consecutive failed checks.'
-      ),
+      description: t('This issue was created by an uptime monitoring alert rule.'),
     };
   }
   return {};


### PR DESCRIPTION
Fixes [NEW-586: Fix issue details uptime issue hardcoded "3 failed / 3 recover checkin](https://linear.app/getsentry/issue/NEW-586/fix-issue-details-uptime-issue-hardcoded-3-failed-3-recover-checkin)