### PR TITLE
feat(explorer): add artifacts to client

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_runs.py
@@ -13,7 +13,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.models.organization import Organization
-from sentry.seer.explorer.client import get_seer_runs
+from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.models import SeerPermissionError
 
 logger = logging.getLogger(__name__)
@@ -48,9 +48,8 @@ class OrganizationSeerExplorerRunsEndpoint(OrganizationEndpoint):
 
         def _make_seer_runs_request(offset: int, limit: int) -> dict[str, Any]:
             try:
-                runs = get_seer_runs(
-                    organization=organization,
-                    user=request.user,
+                client = SeerExplorerClient(organization, request.user)
+                runs = client.get_runs(
                     category_key=category_key,
                     category_value=category_value,
                     offset=offset,

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -227,6 +227,7 @@ class SeerExplorerClient:
             except ValidationError as e:
                 # Log but don't fail - keep artifact as None
                 state.artifact = None
+                state.raw_artifact = None
                 logger.warning(
                     "Failed to parse artifact",
                     extra={

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -1,42 +1,43 @@
 """
-Seer Explorer Client - Simple interface for running AI debugging agents.
+Seer Explorer Client - Type-safe interface for running AI debugging agents.
 
-This module provides a minimal interface for Sentry developers to build agentic features
-with full Sentry context, all without directly touching Seer code.
+This module provides a class-based interface for Sentry developers to build agentic features
+with full Sentry context and optional structured artifact generation.
 
 Example usage:
-    from sentry.seer.explorer.client import start_seer_run, continue_seer_run, get_seer_run
+    from sentry.seer.explorer.client import SeerExplorerClient
+    from pydantic import BaseModel
 
-    # Start a new conversation (client automatically collects user/org context)
-    run_id = start_seer_run(
-        organization=organization,
-        prompt="Analyze trace XYZ and find performance issues",
-        user=request.user,
-    )
+    # Simple usage
+    client = SeerExplorerClient(organization, user)
+    run_id = client.start_run("Analyze trace XYZ and find performance issues")
+    state = client.get_run(run_id)
 
-    # Continue the conversation
-    continue_seer_run(
-        run_id=run_id,
-        organization=organization,
-        prompt="What about memory leaks?",
-    )
+    # With artifacts
+    class BugAnalysis(BaseModel):
+        issue_count: int
+        severity: str
+        recommendations: list[str]
 
-    # Get current status (non-blocking)
-    state = get_seer_run(run_id=run_id, organization=organization)
-    print(state.status, state.blocks)
+    client = SeerExplorerClient(organization, user, artifact_schema=BugAnalysis)
+    run_id = client.start_run("Analyze recent 500 errors")
+    state = client.get_run(run_id, blocking=True)
 
-    # Or wait for completion (blocking with polling)
-    state = get_seer_run(run_id=run_id, organization=organization, blocking=True)
+    # Artifact is automatically reconstructed as BugAnalysis instance
+    if state.artifact:
+        print(f"Found {state.artifact.issue_count} issues")
 """
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import Any, Generic, TypeVar
 
 import orjson
 import requests
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from pydantic import BaseModel, ValidationError
 
 from sentry.models.organization import Organization
 from sentry.seer.explorer.client_models import ExplorerRun, SeerRunState
@@ -50,237 +51,267 @@ from sentry.seer.models import SeerPermissionError
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.users.models.user import User
 
+logger = logging.getLogger(__name__)
 
-def start_seer_run(
-    organization: Organization,
-    prompt: str,
-    user: User | AnonymousUser | None = None,
-    on_page_context: str | None = None,
-    category_key: str | None = None,
-    category_value: str | None = None,
-) -> int:
+T = TypeVar("T", bound=BaseModel)
+
+
+class SeerExplorerClient(Generic[T]):
     """
-    Start a new Seer Explorer session.
+    Type-safe client for Seer Explorer with automatic artifact reconstruction.
 
-    The client automatically collects user/org context (teams, projects, etc.)
-    and sends it to Seer for the agent to use.
+    This class provides a clean interface for interacting with the Seer Explorer API.
+    When an artifact_schema is provided, the client automatically:
+    1. Serializes the Pydantic model to JSON Schema for the API
+    2. Reconstructs returned artifacts as typed Pydantic instances
 
     Args:
         organization: Sentry organization
-        prompt: The initial task/query for the agent
-        user: User (from request.user, can be User or AnonymousUser or None)
-        on_page_context: Optional context from the user's screen
-        category_key: Optional category key for filtering/grouping runs (e.g., "bug-fixer", "researcher"). Should identify the purpose/use case of the run.
-        category_value: Optional category value for filtering/grouping runs (e.g., "issue-123", "a5b32"). Should identify individual runs within the category.
+        user: User for permission checks (can be User, AnonymousUser, or None)
+        artifact_schema: Optional Pydantic model class for structured artifact generation
 
-    Returns:
-        int: The run ID that can be used to fetch results or continue the conversation
+    Example:
+        class IssueAnalysis(BaseModel):
+            issue_count: int
+            severity: str
 
-    Raises:
-        SeerPermissionError: If the user/org doesn't have access to Seer Explorer
-        requests.HTTPError: If the Seer API request fails
+        client = SeerExplorerClient(org, user, artifact_schema=IssueAnalysis)
+        run_id = client.start_run("Analyze errors")
+        state = client.get_run(run_id)
+        # state.artifact is already an IssueAnalysis instance!
     """
-    # Check access
-    has_access, error = has_seer_explorer_access_with_detail(organization, user)
-    if not has_access:
-        raise SeerPermissionError(error or "Access denied")
 
-    path = "/v1/automation/explorer/chat"
+    def __init__(
+        self,
+        organization: Organization,
+        user: User | AnonymousUser | None = None,
+        artifact_schema: type[T] | None = None,
+    ):
+        self.organization = organization
+        self.user = user
+        self.artifact_schema = artifact_schema
 
-    payload: dict[str, Any] = {
-        "organization_id": organization.id,
-        "query": prompt,
-        "run_id": None,
-        "insert_index": None,
-        "on_page_context": on_page_context,
-        "user_org_context": collect_user_org_context(user, organization),
-    }
+        # Validate access on init
+        has_access, error = has_seer_explorer_access_with_detail(organization, user)
+        if not has_access:
+            raise SeerPermissionError(error or "Access denied")
 
-    if category_key or category_value:
-        if not category_key or not category_value:
-            raise ValueError("category_key and category_value must be provided together")
-        payload["category_key"] = category_key
-        payload["category_value"] = category_value
+    def start_run(
+        self,
+        prompt: str,
+        on_page_context: str | None = None,
+        category_key: str | None = None,
+        category_value: str | None = None,
+    ) -> int:
+        """
+        Start a new Seer Explorer session.
 
-    body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
+        The client automatically collects user/org context (teams, projects, etc.)
+        and sends it to Seer for the agent to use. If artifact_schema was provided
+        in the constructor, it will be automatically included.
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
-    )
+        Args:
+            prompt: The initial task/query for the agent
+            on_page_context: Optional context from the user's screen
+            category_key: Optional category key for filtering/grouping runs
+            category_value: Optional category value for filtering/grouping runs
 
-    response.raise_for_status()
-    result = response.json()
-    return result["run_id"]
+        Returns:
+            int: The run ID that can be used to fetch results or continue the conversation
 
+        Raises:
+            requests.HTTPError: If the Seer API request fails
+        """
+        path = "/v1/automation/explorer/chat"
 
-def continue_seer_run(
-    run_id: int,
-    organization: Organization,
-    prompt: str,
-    user: User | AnonymousUser | None = None,
-    insert_index: int | None = None,
-    on_page_context: str | None = None,
-) -> int:
-    """
-    Continue an existing Seer Explorer session.
+        payload: dict[str, Any] = {
+            "organization_id": self.organization.id,
+            "query": prompt,
+            "run_id": None,
+            "insert_index": None,
+            "on_page_context": on_page_context,
+            "user_org_context": collect_user_org_context(self.user, self.organization),
+        }
 
-    This allows you to add follow-up queries to an ongoing conversation.
-    User context is NOT collected again (it was already captured at start).
+        # Add artifact schema if provided
+        if self.artifact_schema:
+            payload["artifact_schema"] = self.artifact_schema.schema()
 
-    Args:
-        run_id: The run ID from start_seer_run()
-        organization: Sentry organization
-        prompt: The follow-up task/query for the agent
-        user: User (for permission check)
-        insert_index: Optional index to insert the message at
-        on_page_context: Optional context from the user's screen
+        if category_key or category_value:
+            if not category_key or not category_value:
+                raise ValueError("category_key and category_value must be provided together")
+            payload["category_key"] = category_key
+            payload["category_value"] = category_value
 
-    Returns:
-        int: The run ID (same as input)
+        body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-    Raises:
-        SeerPermissionError: If the user/org doesn't have access to Seer Explorer
-        requests.HTTPError: If the Seer API request fails
-    """
-    # Check access
-    has_access, error = has_seer_explorer_access_with_detail(organization, user)
-    if not has_access:
-        raise SeerPermissionError(error or "Access denied")
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}{path}",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(body),
+            },
+        )
 
-    path = "/v1/automation/explorer/chat"
+        response.raise_for_status()
+        result = response.json()
+        return result["run_id"]
 
-    payload: dict[str, Any] = {
-        "organization_id": organization.id,
-        "query": prompt,
-        "run_id": run_id,
-        "insert_index": insert_index,
-        "on_page_context": on_page_context,
-    }
+    def continue_run(
+        self,
+        run_id: int,
+        prompt: str,
+        insert_index: int | None = None,
+        on_page_context: str | None = None,
+    ) -> int:
+        """
+        Continue an existing Seer Explorer session.
 
-    body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
+        This allows you to add follow-up queries to an ongoing conversation.
+        User context is NOT collected again (it was already captured at start).
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
-    )
+        Args:
+            run_id: The run ID from start_run()
+            prompt: The follow-up task/query for the agent
+            insert_index: Optional index to insert the message at
+            on_page_context: Optional context from the user's screen
 
-    response.raise_for_status()
-    result = response.json()
-    return result["run_id"]
+        Returns:
+            int: The run ID (same as input)
 
+        Raises:
+            requests.HTTPError: If the Seer API request fails
+        """
+        path = "/v1/automation/explorer/chat"
 
-def get_seer_run(
-    run_id: int,
-    organization: Organization,
-    user: User | AnonymousUser | None = None,
-    blocking: bool = False,
-    poll_interval: float = 2.0,
-    poll_timeout: float = 600.0,
-) -> SeerRunState:
-    """
-    Get the status/result of a Seer Explorer session.
+        payload: dict[str, Any] = {
+            "organization_id": self.organization.id,
+            "query": prompt,
+            "run_id": run_id,
+            "insert_index": insert_index,
+            "on_page_context": on_page_context,
+        }
 
-    Args:
-        run_id: The run ID returned from start_seer_run()
-        organization: Sentry organization
-        user: User (for permission check)
-        blocking: If True, blocks until the run completes (with polling)
-              If False, returns current state immediately
-        poll_interval: Seconds between polls when blocking=True
-        poll_timeout: Maximum seconds to wait when blocking=True
+        body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-    Returns:
-        SeerRunState: State object with blocks, status, etc.
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}{path}",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(body),
+            },
+        )
 
-    Raises:
-        SeerPermissionError: If the user/org doesn't have access to Seer Explorer
-        requests.HTTPError: If the Seer API request fails
-        TimeoutError: If polling exceeds poll_timeout when blocking=True
-    """
-    # Check access
-    has_access, error = has_seer_explorer_access_with_detail(organization, user)
-    if not has_access:
-        raise SeerPermissionError(error or "Access denied")
+        response.raise_for_status()
+        result = response.json()
+        return result["run_id"]
 
-    if blocking:
-        return poll_until_done(run_id, organization, poll_interval, poll_timeout)
+    def get_run(
+        self,
+        run_id: int,
+        blocking: bool = False,
+        poll_interval: float = 2.0,
+        poll_timeout: float = 600.0,
+    ) -> SeerRunState:
+        """
+        Get the status/result of a Seer Explorer session.
 
-    return fetch_run_status(run_id, organization)
+        If artifact_schema was provided in the constructor and an artifact was generated,
+        it will be automatically reconstructed as a typed Pydantic instance.
 
+        Args:
+            run_id: The run ID returned from start_run()
+            blocking: If True, blocks until the run completes (with polling)
+            poll_interval: Seconds between polls when blocking=True
+            poll_timeout: Maximum seconds to wait when blocking=True
 
-def get_seer_runs(
-    organization: Organization,
-    user: User | AnonymousUser | None = None,
-    category_key: str | None = None,
-    category_value: str | None = None,
-    offset: int | None = None,
-    limit: int | None = None,
-) -> list[ExplorerRun]:
-    """
-    Get a list of Seer Explorer runs for the given organization with optional filters.
+        Returns:
+            SeerRunState: State object with blocks, status, and optionally reconstructed artifact
 
-    This function supports flexible filtering by user_id, category_key, or category_value.
-    At least one filter should be provided to avoid returning all runs for the org.
+        Raises:
+            requests.HTTPError: If the Seer API request fails
+            TimeoutError: If polling exceeds poll_timeout when blocking=True
+        """
+        if blocking:
+            state = poll_until_done(run_id, self.organization, poll_interval, poll_timeout)
+        else:
+            state = fetch_run_status(run_id, self.organization)
 
-    Args:
-        organization: Sentry organization
-        user: Optional user to filter runs by (if provided, only returns runs for this user)
-        category_key: Optional category key to filter by (e.g., "bug-fixer", "researcher")
-        category_value: Optional category value to filter by (e.g., "issue-123", "a5b32")
-        offset: Optional offset for pagination
-        limit: Optional limit for pagination
+        # Automatically reconstruct artifact if schema was provided
+        if state.artifact and self.artifact_schema:
+            try:
+                state.artifact = self.artifact_schema.parse_obj(state.artifact)
+            except ValidationError as e:
+                # Log but don't fail - keep raw dict
+                logger.warning(
+                    "Failed to reconstruct artifact",
+                    extra={
+                        "run_id": run_id,
+                        "error": str(e),
+                        "artifact_schema": self.artifact_schema.__name__,
+                    },
+                )
 
-    Returns:
-        list[ExplorerRun]: List of runs matching the filters, sorted by most recent first
+        return state
 
-    Raises:
-        SeerPermissionError: If the user/org doesn't have access to Seer Explorer
-        requests.HTTPError: If the Seer API request fails
-    """
-    has_access, error = has_seer_explorer_access_with_detail(organization, user)
-    if not has_access:
-        raise SeerPermissionError(error or "Access denied")
+    def get_runs(
+        self,
+        category_key: str | None = None,
+        category_value: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> list[ExplorerRun]:
+        """
+        Get a list of Seer Explorer runs for the organization with optional filters.
 
-    path = "/v1/automation/explorer/runs"
+        This function supports flexible filtering by user_id (from client), category_key,
+        or category_value. At least one filter should be provided to avoid returning all runs.
 
-    payload: dict[str, Any] = {
-        "organization_id": organization.id,
-    }
+        Args:
+            category_key: Optional category key to filter by (e.g., "bug-fixer")
+            category_value: Optional category value to filter by (e.g., "issue-123")
+            offset: Optional offset for pagination
+            limit: Optional limit for pagination
 
-    # Add optional filters
-    if user and hasattr(user, "id"):
-        payload["user_id"] = user.id
-    if category_key is not None:
-        payload["category_key"] = category_key
-    if category_value is not None:
-        payload["category_value"] = category_value
-    if offset is not None:
-        payload["offset"] = offset
-    if limit is not None:
-        payload["limit"] = limit
+        Returns:
+            list[ExplorerRun]: List of runs matching the filters, sorted by most recent first
 
-    body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
+        Raises:
+            requests.HTTPError: If the Seer API request fails
+        """
+        path = "/v1/automation/explorer/runs"
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
-    )
+        payload: dict[str, Any] = {
+            "organization_id": self.organization.id,
+        }
 
-    response.raise_for_status()
-    result = response.json()
+        # Add optional filters
+        if self.user and hasattr(self.user, "id"):
+            payload["user_id"] = self.user.id
+        if category_key is not None:
+            payload["category_key"] = category_key
+        if category_value is not None:
+            payload["category_value"] = category_value
+        if offset is not None:
+            payload["offset"] = offset
+        if limit is not None:
+            payload["limit"] = limit
 
-    runs = [ExplorerRun(**run) for run in result.get("data", [])]
-    return runs
+        body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
+
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}{path}",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(body),
+            },
+        )
+
+        response.raise_for_status()
+        result = response.json()
+
+        runs = [ExplorerRun(**run) for run in result.get("data", [])]
+        return runs

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -239,14 +239,14 @@ class SeerExplorerClient(Generic[T]):
         else:
             state = fetch_run_status(run_id, self.organization)
 
-        # Automatically reconstruct artifact if schema was provided
-        if state.artifact and self.artifact_schema:
+        # Automatically parse raw_artifact into typed artifact if schema was provided
+        if state.raw_artifact and self.artifact_schema:
             try:
-                state.artifact = self.artifact_schema.parse_obj(state.artifact)
+                state.artifact = self.artifact_schema.parse_obj(state.raw_artifact)
             except ValidationError as e:
-                # Log but don't fail - keep raw dict
+                # Log but don't fail - keep artifact as None
                 logger.warning(
-                    "Failed to reconstruct artifact",
+                    "Failed to parse artifact",
                     extra={
                         "run_id": run_id,
                         "error": str(e),

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -223,8 +223,10 @@ class SeerExplorerClient:
         if state.raw_artifact and self.artifact_schema:
             try:
                 state.artifact = self.artifact_schema.parse_obj(state.raw_artifact)
+                state.raw_artifact = None  # clear now that it's not needed
             except ValidationError as e:
                 # Log but don't fail - keep artifact as None
+                state.artifact = None
                 logger.warning(
                     "Failed to parse artifact",
                     extra={

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -227,13 +227,13 @@ class SeerExplorerClient:
             except ValidationError as e:
                 # Log but don't fail - keep artifact as None
                 state.artifact = None
-                state.raw_artifact = None
                 logger.warning(
                     "Failed to parse artifact",
                     extra={
                         "run_id": run_id,
                         "error": str(e),
                         "artifact_schema": self.artifact_schema.__name__,
+                        "raw_artifact": state.raw_artifact,
                     },
                 )
 

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -51,7 +51,7 @@ class SeerRunState(BaseModel):
     status: Literal["processing", "completed", "error"]
     updated_at: str
     raw_artifact: dict[str, Any] | None = None
-    artifact: Any | None = None
+    artifact: BaseModel | None = None
     artifact_reason: str | None = None
 
     class Config:

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -5,11 +5,9 @@ Pydantic models for Seer Explorer client.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Literal
 
 from pydantic import BaseModel
-
-T = TypeVar("T", bound=BaseModel)
 
 
 class ToolCall(BaseModel):
@@ -45,7 +43,7 @@ class MemoryBlock(BaseModel):
         extra = "allow"
 
 
-class SeerRunState(BaseModel, Generic[T]):
+class SeerRunState(BaseModel):
     """State of a Seer Explorer session."""
 
     run_id: int
@@ -53,7 +51,7 @@ class SeerRunState(BaseModel, Generic[T]):
     status: Literal["processing", "completed", "error"]
     updated_at: str
     raw_artifact: dict[str, Any] | None = None
-    artifact: T | None = None
+    artifact: Any | None = None
     artifact_reason: str | None = None
 
     class Config:

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -5,9 +5,11 @@ Pydantic models for Seer Explorer client.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
 
 
 class ToolCall(BaseModel):
@@ -43,14 +45,15 @@ class MemoryBlock(BaseModel):
         extra = "allow"
 
 
-class SeerRunState(BaseModel):
+class SeerRunState(BaseModel, Generic[T]):
     """State of a Seer Explorer session."""
 
     run_id: int
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error"]
     updated_at: str
-    artifact: dict[str, Any] | BaseModel | None = None
+    raw_artifact: dict[str, Any] | None = None
+    artifact: T | None = None
     artifact_reason: str | None = None
 
     class Config:

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -5,7 +5,7 @@ Pydantic models for Seer Explorer client.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -50,6 +50,8 @@ class SeerRunState(BaseModel):
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error"]
     updated_at: str
+    artifact: dict[str, Any] | BaseModel | None = None
+    artifact_reason: str | None = None
 
     class Config:
         extra = "allow"

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -1,40 +1,65 @@
 from unittest.mock import MagicMock, patch
 
+import orjson
 import pytest
 import requests
+from pydantic import BaseModel
 
-from sentry.seer.explorer.client import (
-    continue_seer_run,
-    get_seer_run,
-    get_seer_runs,
-    start_seer_run,
-)
+from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.explorer.client_models import SeerRunState
+from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import TestCase
 
 
-class TestStartSeerRun(TestCase):
+class TestSeerExplorerClient(TestCase):
     def setUp(self):
         super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    def test_client_init_checks_access(self, mock_access):
+        """Test that client initialization checks access and raises on denial"""
+        mock_access.return_value = (False, "Feature flag not enabled")
+
+        with pytest.raises(SeerPermissionError) as exc_info:
+            SeerExplorerClient(self.organization, self.user)
+        assert "Feature flag not enabled" in str(exc_info.value)
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    def test_client_init_succeeds_with_access(self, mock_access):
+        """Test that client initialization succeeds with proper access"""
+        mock_access.return_value = (True, None)
+
+        client = SeerExplorerClient(self.organization, self.user)
+        assert client.organization == self.organization
+        assert client.user == self.user
+        assert client.artifact_schema is None
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    def test_client_init_with_artifact_schema(self, mock_access):
+        """Test that client stores artifact schema"""
+        mock_access.return_value = (True, None)
+
+        class TestSchema(BaseModel):
+            count: int
+
+        client = SeerExplorerClient(self.organization, self.user, artifact_schema=TestSchema)
+        assert client.artifact_schema == TestSchema
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
-    def test_start_seer_run_new_session(self, mock_collect_context, mock_post, mock_access):
-        """Test starting a new Seer run collects user context"""
+    def test_start_run_basic(self, mock_collect_context, mock_post, mock_access):
+        """Test starting a new run collects user context"""
         mock_access.return_value = (True, None)
         mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 123}
         mock_post.return_value = mock_response
 
-        run_id = start_seer_run(
-            organization=self.organization,
-            prompt="Test query",
-            user=self.user,
-        )
+        client = SeerExplorerClient(self.organization, self.user)
+        run_id = client.start_run("Test query")
 
         assert run_id == 123
         mock_collect_context.assert_called_once_with(self.user, self.organization)
@@ -42,58 +67,35 @@ class TestStartSeerRun(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
-    def test_start_seer_run_with_optional_params(self, mock_post, mock_access):
-        """Test starting a run with optional on_page_context"""
+    def test_start_run_with_optional_params(self, mock_post, mock_access):
+        """Test starting a run with optional parameters"""
         mock_access.return_value = (True, None)
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 789}
         mock_post.return_value = mock_response
 
-        run_id = start_seer_run(
-            organization=self.organization,
-            prompt="Query",
-            user=self.user,
-            on_page_context="some context",
-        )
+        client = SeerExplorerClient(self.organization, self.user)
+        run_id = client.start_run("Query", on_page_context="some context")
 
         assert run_id == 789
-        # Verify the payload includes optional params
         call_args = mock_post.call_args
         assert call_args is not None
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
-    def test_start_seer_run_http_error(self, mock_post, mock_access):
+    def test_start_run_http_error(self, mock_post, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
         mock_post.return_value.raise_for_status.side_effect = requests.HTTPError("API Error")
 
+        client = SeerExplorerClient(self.organization, self.user)
         with pytest.raises(requests.HTTPError):
-            start_seer_run(
-                organization=self.organization,
-                prompt="Test query",
-                user=self.user,
-            )
-
-    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
-    def test_start_seer_run_permission_denied(self, mock_access):
-        """Test that SeerPermissionError is raised when access is denied"""
-        from sentry.seer.models import SeerPermissionError
-
-        mock_access.return_value = (False, "Feature flag not enabled")
-
-        with pytest.raises(SeerPermissionError) as exc_info:
-            start_seer_run(
-                organization=self.organization,
-                prompt="Test query",
-                user=self.user,
-            )
-        assert "Feature flag not enabled" in str(exc_info.value)
+            client.start_run("Test query")
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
-    def test_start_seer_run_with_categories(self, mock_collect_context, mock_post, mock_access):
+    def test_start_run_with_categories(self, mock_collect_context, mock_post, mock_access):
         """Test starting a run with category fields"""
         mock_access.return_value = (True, None)
         mock_collect_context.return_value = {"user_id": self.user.id}
@@ -101,92 +103,62 @@ class TestStartSeerRun(TestCase):
         mock_response.json.return_value = {"run_id": 999}
         mock_post.return_value = mock_response
 
-        run_id = start_seer_run(
-            organization=self.organization,
-            prompt="Fix bug",
-            user=self.user,
-            category_key="bug-fixer",
-            category_value="issue-123",
-        )
+        client = SeerExplorerClient(self.organization, self.user)
+        run_id = client.start_run("Fix bug", category_key="bug-fixer", category_value="issue-123")
 
         assert run_id == 999
-        import orjson
-
         body = orjson.loads(mock_post.call_args[1]["data"])
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
-    def test_start_seer_run_category_key_only_raises_error(self, mock_access):
+    def test_start_run_category_key_only_raises_error(self, mock_access):
         """Test that ValueError is raised when only category_key is provided"""
         mock_access.return_value = (True, None)
 
+        client = SeerExplorerClient(self.organization, self.user)
         with pytest.raises(
             ValueError, match="category_key and category_value must be provided together"
         ):
-            start_seer_run(
-                organization=self.organization,
-                prompt="Test query",
-                user=self.user,
-                category_key="bug-fixer",
-            )
+            client.start_run("Test query", category_key="bug-fixer")
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
-    def test_start_seer_run_category_value_only_raises_error(self, mock_access):
+    def test_start_run_category_value_only_raises_error(self, mock_access):
         """Test that ValueError is raised when only category_value is provided"""
         mock_access.return_value = (True, None)
 
+        client = SeerExplorerClient(self.organization, self.user)
         with pytest.raises(
             ValueError, match="category_key and category_value must be provided together"
         ):
-            start_seer_run(
-                organization=self.organization,
-                prompt="Test query",
-                user=self.user,
-                category_value="issue-123",
-            )
-
-
-class TestContinueSeerRun(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.user = self.create_user()
-        self.organization = self.create_organization(owner=self.user)
+            client.start_run("Test query", category_value="issue-123")
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
-    def test_continue_seer_run_basic(self, mock_post, mock_access):
-        """Test continuing an existing Seer run"""
+    def test_continue_run_basic(self, mock_post, mock_access):
+        """Test continuing an existing run"""
         mock_access.return_value = (True, None)
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 456}
         mock_post.return_value = mock_response
 
-        run_id = continue_seer_run(
-            run_id=456,
-            organization=self.organization,
-            prompt="Follow up query",
-        )
+        client = SeerExplorerClient(self.organization, self.user)
+        run_id = client.continue_run(456, "Follow up query")
 
         assert run_id == 456
         assert mock_post.called
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
-    def test_continue_seer_run_with_all_params(self, mock_post, mock_access):
+    def test_continue_run_with_all_params(self, mock_post, mock_access):
         """Test continuing a run with all optional parameters"""
         mock_access.return_value = (True, None)
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 789}
         mock_post.return_value = mock_response
 
-        run_id = continue_seer_run(
-            run_id=789,
-            organization=self.organization,
-            prompt="Follow up",
-            insert_index=2,
-            on_page_context="context",
-        )
+        client = SeerExplorerClient(self.organization, self.user)
+        run_id = client.continue_run(789, "Follow up", insert_index=2, on_page_context="context")
 
         assert run_id == 789
         call_args = mock_post.call_args
@@ -194,27 +166,18 @@ class TestContinueSeerRun(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
-    def test_continue_seer_run_http_error(self, mock_post, mock_access):
+    def test_continue_run_http_error(self, mock_post, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
         mock_post.return_value.raise_for_status.side_effect = requests.HTTPError("API Error")
 
+        client = SeerExplorerClient(self.organization, self.user)
         with pytest.raises(requests.HTTPError):
-            continue_seer_run(
-                run_id=123,
-                organization=self.organization,
-                prompt="Test query",
-            )
-
-
-class TestGetSeerRun(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.organization = self.create_organization()
+            client.continue_run(123, "Test query")
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    def test_get_seer_run_immediate(self, mock_fetch, mock_access):
+    def test_get_run_immediate(self, mock_fetch, mock_access):
         """Test getting run status without waiting"""
         mock_access.return_value = (True, None)
         mock_state = SeerRunState(
@@ -225,7 +188,8 @@ class TestGetSeerRun(TestCase):
         )
         mock_fetch.return_value = mock_state
 
-        result = get_seer_run(run_id=123, organization=self.organization)
+        client = SeerExplorerClient(self.organization, self.user)
+        result = client.get_run(123)
 
         assert result.run_id == 123
         assert result.status == "processing"
@@ -233,7 +197,7 @@ class TestGetSeerRun(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.poll_until_done")
-    def test_get_seer_run_with_blocking(self, mock_poll, mock_access):
+    def test_get_run_with_blocking(self, mock_poll, mock_access):
         """Test getting run status with polling"""
         mock_access.return_value = (True, None)
         mock_state = SeerRunState(
@@ -244,13 +208,8 @@ class TestGetSeerRun(TestCase):
         )
         mock_poll.return_value = mock_state
 
-        result = get_seer_run(
-            run_id=123,
-            organization=self.organization,
-            blocking=True,
-            poll_interval=1.0,
-            poll_timeout=30.0,
-        )
+        client = SeerExplorerClient(self.organization, self.user)
+        result = client.get_run(123, blocking=True, poll_interval=1.0, poll_timeout=30.0)
 
         assert result.run_id == 123
         assert result.status == "completed"
@@ -258,24 +217,18 @@ class TestGetSeerRun(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    def test_get_seer_run_http_error(self, mock_fetch, mock_access):
+    def test_get_run_http_error(self, mock_fetch, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
         mock_fetch.side_effect = requests.HTTPError("API Error")
 
+        client = SeerExplorerClient(self.organization, self.user)
         with pytest.raises(requests.HTTPError):
-            get_seer_run(run_id=123, organization=self.organization)
-
-
-class TestGetSeerRuns(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.user = self.create_user()
-        self.organization = self.create_organization(owner=self.user)
+            client.get_run(123)
 
     @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
     @patch("sentry.seer.explorer.client.requests.post")
-    def test_get_seer_runs_basic(self, mock_post, mock_access):
+    def test_get_runs_basic(self, mock_post, mock_access):
         """Test getting runs with filters"""
         mock_access.return_value = (True, None)
         mock_response = MagicMock()
@@ -293,16 +246,103 @@ class TestGetSeerRuns(TestCase):
         }
         mock_post.return_value = mock_response
 
-        runs = get_seer_runs(
-            organization=self.organization,
-            category_key="bug-fixer",
-            category_value="issue-123",
-        )
+        client = SeerExplorerClient(self.organization, self.user)
+        runs = client.get_runs(category_key="bug-fixer", category_value="issue-123")
 
         assert len(runs) == 1
         assert runs[0].category_key == "bug-fixer"
-        import orjson
-
         body = orjson.loads(mock_post.call_args[1]["data"])
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
+
+
+class TestSeerExplorerClientArtifacts(TestCase):
+    """Test artifact schema passing and reconstruction"""
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_start_run_with_artifact_schema(self, mock_collect_context, mock_post, mock_access):
+        """Test that artifact schema is serialized and sent to API"""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 123}
+        mock_post.return_value = mock_response
+
+        class IssueAnalysis(BaseModel):
+            issue_count: int
+            severity: str
+
+        client = SeerExplorerClient(self.organization, self.user, artifact_schema=IssueAnalysis)
+        run_id = client.start_run("Analyze errors")
+
+        assert run_id == 123
+
+        # Verify artifact_schema was included in payload
+        body = orjson.loads(mock_post.call_args[1]["data"])
+        assert "artifact_schema" in body
+        assert body["artifact_schema"]["type"] == "object"
+        assert "issue_count" in body["artifact_schema"]["properties"]
+        assert "severity" in body["artifact_schema"]["properties"]
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.fetch_run_status")
+    def test_get_run_reconstructs_artifact(self, mock_fetch, mock_access):
+        """Test that artifact is automatically reconstructed from dict"""
+        mock_access.return_value = (True, None)
+
+        class BugReport(BaseModel):
+            bug_count: int
+            severity: str
+
+        # Mock API returns dict artifact
+        mock_state = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            artifact={"bug_count": 5, "severity": "high"},  # Raw dict from API
+            artifact_reason="Successfully generated",
+        )
+        mock_fetch.return_value = mock_state
+
+        client = SeerExplorerClient(self.organization, self.user, artifact_schema=BugReport)
+        result = client.get_run(123)
+
+        # Verify artifact was reconstructed as Pydantic model
+        assert isinstance(result.artifact, BugReport)
+        assert result.artifact.bug_count == 5
+        assert result.artifact.severity == "high"
+        assert result.artifact_reason == "Successfully generated"
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.fetch_run_status")
+    def test_get_run_with_none_artifact(self, mock_fetch, mock_access):
+        """Test that None artifact is handled gracefully"""
+        mock_access.return_value = (True, None)
+
+        class MySchema(BaseModel):
+            field: str
+
+        mock_state = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            artifact=None,
+            artifact_reason="Generation failed",
+        )
+        mock_fetch.return_value = mock_state
+
+        client = SeerExplorerClient(self.organization, self.user, artifact_schema=MySchema)
+        result = client.get_run(123)
+
+        # Verify None artifact is preserved
+        assert result.artifact is None
+        assert result.artifact_reason == "Generation failed"

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -307,7 +307,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
             blocks=[],
             status="completed",
             updated_at="2024-01-01T00:00:00Z",
-            artifact={"bug_count": 5, "severity": "high"},  # Raw dict from API
+            raw_artifact={"bug_count": 5, "severity": "high"},  # Raw dict from API
             artifact_reason="Successfully generated",
         )
         mock_fetch.return_value = mock_state
@@ -335,7 +335,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
             blocks=[],
             status="completed",
             updated_at="2024-01-01T00:00:00Z",
-            artifact=None,
+            raw_artifact=None,
             artifact_reason="Generation failed",
         )
         mock_fetch.return_value = mock_state


### PR DESCRIPTION
Adds support for devs to pass in a pydantic model as an artifact schema to the client, and to read the generated artifact back. Also refactors the client into a class to make managing all this easier.

Requries https://github.com/getsentry/seer/pull/3945