### PR TITLE
test(dashboards): Migrate a few widget builder tests off deprecatedRouterMocks

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -1,6 +1,4 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -16,6 +14,7 @@ jest.mock('sentry/views/explore/contexts/spanTagsContext');
 
 describe('QueryFilterBuilder', () => {
   let organization: Organization;
+
   beforeEach(() => {
     organization = OrganizationFixture({
       features: [],
@@ -41,18 +40,16 @@ describe('QueryFilterBuilder', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               query: [],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.TABLE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
     expect(
@@ -68,14 +65,12 @@ describe('QueryFilterBuilder', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {query: [], dataset: WidgetType.SPANS, displayType: DisplayType.TABLE},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
     expect(
@@ -93,18 +88,16 @@ describe('QueryFilterBuilder', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               query: [],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 
@@ -121,18 +114,16 @@ describe('QueryFilterBuilder', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               query: [],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 
@@ -157,14 +148,12 @@ describe('QueryFilterBuilder', () => {
       </WidgetBuilderProvider>,
       {
         organization,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {query: [], dataset: WidgetType.SPANS, displayType: DisplayType.LINE},
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 
@@ -185,18 +174,16 @@ describe('QueryFilterBuilder', () => {
       </WidgetBuilderProvider>,
       {
         organization: organizationWithFeature,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               query: [],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 
@@ -207,10 +194,6 @@ describe('QueryFilterBuilder', () => {
   });
 
   it('enables search bar when transaction widget type but no discover-saved-queries-deprecation feature flag', async () => {
-    const organizationWithoutFeature = OrganizationFixture({
-      features: [],
-    });
-
     render(
       <WidgetBuilderProvider>
         <WidgetBuilderQueryFilterBuilder
@@ -219,19 +202,17 @@ describe('QueryFilterBuilder', () => {
         />
       </WidgetBuilderProvider>,
       {
-        organization: organizationWithoutFeature,
-
-        router: RouterFixture({
-          location: LocationFixture({
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               query: [],
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -1,6 +1,3 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -25,15 +22,14 @@ describe('Thresholds', () => {
         <Thresholds dataType="duration" dataUnit="millisecond" />
       </WidgetBuilderProvider>,
       {
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               thresholds: '{"max_values":{"max1":100},"unit":"millisecond"}',
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 
@@ -53,10 +49,7 @@ describe('Thresholds', () => {
     render(
       <WidgetBuilderProvider>
         <Thresholds dataType="duration" dataUnit="millisecond" />
-      </WidgetBuilderProvider>,
-      {
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     await userEvent.type(screen.getByLabelText('First Maximum'), '100');
@@ -79,15 +72,14 @@ describe('Thresholds', () => {
         <Thresholds dataType="duration" dataUnit="millisecond" />
       </WidgetBuilderProvider>,
       {
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               thresholds: '{"max_values":{"max1":100,"max2":200},"unit":"millisecond"}',
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 
@@ -114,15 +106,14 @@ describe('Thresholds', () => {
         />
       </WidgetBuilderProvider>,
       {
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               thresholds: '{"max_values":{"max1":-200,"max2":100},"unit":"millisecond"}',
             },
-          }),
-        }),
-
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 
@@ -134,10 +125,7 @@ describe('Thresholds', () => {
     render(
       <WidgetBuilderProvider>
         <Thresholds dataType="duration" dataUnit="millisecond" />
-      </WidgetBuilderProvider>,
-      {
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     await userEvent.type(screen.getByLabelText('First Maximum'), '0.5');
@@ -174,14 +162,14 @@ describe('Thresholds', () => {
         <Thresholds dataType="duration" dataUnit="millisecond" />
       </WidgetBuilderProvider>,
       {
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
             query: {
               thresholds: '{"max_values":{"max1":100},"unit":"millisecond"}',
             },
-          }),
-        }),
-        deprecatedRouterMocks: true,
+          },
+        },
       }
     );
 

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -1,6 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -14,13 +11,6 @@ jest.mock('sentry/utils/useNavigate', () => ({
 const mockUseNavigate = jest.mocked(useNavigate);
 
 describe('TypeSelector', () => {
-  let router!: ReturnType<typeof RouterFixture>;
-  let organization!: ReturnType<typeof OrganizationFixture>;
-  beforeEach(() => {
-    router = RouterFixture();
-    organization = OrganizationFixture();
-  });
-
   it('changes the visualization type', async () => {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);
@@ -28,12 +18,7 @@ describe('TypeSelector', () => {
     render(
       <WidgetBuilderProvider>
         <TypeSelector />
-      </WidgetBuilderProvider>,
-      {
-        router,
-        organization,
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     // click dropdown
@@ -43,7 +28,6 @@ describe('TypeSelector', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
-        ...router.location,
         query: expect.objectContaining({displayType: 'bar'}),
       }),
       expect.anything()
@@ -54,12 +38,7 @@ describe('TypeSelector', () => {
     render(
       <WidgetBuilderProvider>
         <TypeSelector error={{displayType: 'Please select a type'}} />
-      </WidgetBuilderProvider>,
-      {
-        router,
-        organization,
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     expect(await screen.findByText('Please select a type')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -1,6 +1,4 @@
 import debounce from 'lodash/debounce';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -29,10 +27,6 @@ jest.mock('sentry/views/dashboards/widgetLibrary/data', () => ({
 }));
 
 const mockUseNavigate = jest.mocked(useNavigate);
-
-const router = RouterFixture({
-  location: LocationFixture({query: {}}),
-});
 
 jest.mock('sentry/actionCreators/indicator');
 
@@ -70,10 +64,7 @@ describe('WidgetTemplatesList', () => {
           setIsPreviewDraggable={jest.fn()}
           setCustomizeFromLibrary={jest.fn()}
         />
-      </WidgetBuilderProvider>,
-      {
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     expect(await screen.findByText('Duration Distribution')).toBeInTheDocument();
@@ -91,10 +82,7 @@ describe('WidgetTemplatesList', () => {
           setIsPreviewDraggable={jest.fn()}
           setCustomizeFromLibrary={jest.fn()}
         />
-      </WidgetBuilderProvider>,
-      {
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     const widgetTemplate = await screen.findByText('Duration Distribution');
@@ -120,11 +108,7 @@ describe('WidgetTemplatesList', () => {
           setIsPreviewDraggable={jest.fn()}
           setCustomizeFromLibrary={jest.fn()}
         />
-      </WidgetBuilderProvider>,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     const widgetTemplate = screen.getByText('Duration Distribution');
@@ -134,7 +118,6 @@ describe('WidgetTemplatesList', () => {
 
     expect(mockNavigate).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        ...router.location,
         query: expect.objectContaining({
           description: 'some description',
           title: 'Duration Distribution',
@@ -157,10 +140,7 @@ describe('WidgetTemplatesList', () => {
           setIsPreviewDraggable={jest.fn()}
           setCustomizeFromLibrary={jest.fn()}
         />
-      </WidgetBuilderProvider>,
-      {
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     const widgetTemplate = await screen.findByText('Duration Distribution');


### PR DESCRIPTION
Moves tests to the full featured memory router
