### PR TITLE
fix(tracing): Disable context menu for empty trace ids

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -351,11 +351,6 @@ describe('Performance GridEditable Table', () => {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
-      headers: {
-        Link:
-          '<http://localhost/api/0/organizations/org-slug/events/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
-          '<http://localhost/api/0/organizations/org-slug/events/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
-      },
       body: {
         meta: {
           fields: {

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -226,6 +226,11 @@ export default function EventsTable({
         return rendered;
       }
 
+      // Disable context menu for empty trace values
+      if (field === 'trace' && !dataRow.trace) {
+        return rendered;
+      }
+
       const cellActionHandler = handleCellAction(column);
 
       if (field === 'id' || field === 'trace') {


### PR DESCRIPTION
In the issue details page, we have an events table that has a Trace column. When there is a value, you can click on the cell to open a context menu where you can do things like "Open trace". There is a bug when the trace is empty and displays (no value) and you click on it, you're able to access this context menu. It should be disabled when trace is empty.

Partially closes JAVASCRIPT-2SH3