### PR TITLE
feat(consumer): add --retry-handle-destroyed flag

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -469,6 +469,7 @@ def get_stream_processor(
     add_global_tags: bool = False,
     profile_consumer_join: bool = False,
     enable_autocommit: bool = False,
+    retry_handle_destroyed: bool = False,
 ) -> StreamProcessor:
     from sentry.utils import kafka_config
 
@@ -527,6 +528,7 @@ def get_stream_processor(
             auto_offset_reset=auto_offset_reset,
             strict_offset_reset=strict_offset_reset,
             enable_auto_commit=enable_autocommit,
+            retry_handle_destroyed=retry_handle_destroyed,
         )
 
         if max_poll_interval_ms is not None:

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -556,6 +556,12 @@ def taskbroker_send_tasks(
     default=False,
     help="Enable Kafka autocommit mode with 1s commit interval. Offsets are stored via store_offsets and rdkafka commits them automatically.",
 )
+@click.option(
+    "--retry-handle-destroyed",
+    is_flag=True,
+    default=False,
+    help="Enable retrying on `KafkaError._DESTROY` during commit.",
+)
 @configuration
 def basic_consumer(
     consumer_name: str,


### PR DESCRIPTION
This adds a flag to our consumers to retry on `broker handle destroyed` errors, which sometimes occur when the consumer group coordinator changes while comitting during consumer shutdown.
The config option was added to arroyo in https://github.com/getsentry/arroyo/commit/c3923c056f86af0e6dd52d74876c860d542037ad.