### PR TITLE
feat(replay): Fix resize split pane breaks network tabs

### DIFF
--- a/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
+++ b/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
@@ -63,8 +63,6 @@ const CloseButtonWrapper = styled('div')`
 `;
 
 const StyledSplitDivider = styled(SplitDivider)`
-  padding: ${space(0.75)};
-
   :hover,
   &[data-is-held='true'] {
     z-index: ${p => p.theme.zIndex.initial};

--- a/static/app/views/replays/detail/network/details/tabs.tsx
+++ b/static/app/views/replays/detail/network/details/tabs.tsx
@@ -36,8 +36,6 @@ function NetworkDetailsTabs() {
 }
 
 const TabsContainer = styled('div')`
-  padding-top: ${space(0.5)};
-  padding-inline: ${space(1.5)};
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 


### PR DESCRIPTION
This fixes a bug with the details split pane where the resize cursor gets stuck as enabled and you cant click the network detail tabs. I've removed the padding which seems to be the main cause.

Before
<img width="759" height="69" alt="image" src="https://github.com/user-attachments/assets/e6fed3c3-0d75-4a55-89bc-66a4779c3109" />


After
<img width="683" height="53" alt="image" src="https://github.com/user-attachments/assets/26c00b6c-ce04-4a7c-afc6-4d79b6ce0e2e" />
