### PR TITLE
ref(aci): decouple detector from workflowfirehistory in API

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -10,13 +10,7 @@ from sentry.api.serializers import Serializer, serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse
 from sentry.models.group import Group
 from sentry.utils.cursors import Cursor, CursorResult
-from sentry.workflow_engine.models import (
-    Detector,
-    DetectorGroup,
-    DetectorWorkflow,
-    Workflow,
-    WorkflowFireHistory,
-)
+from sentry.workflow_engine.models import Detector, DetectorGroup, Workflow, WorkflowFireHistory
 
 
 @dataclass(frozen=True)
@@ -125,11 +119,13 @@ def fetch_workflow_groups_paginated(
     # subquery that retrieves row with the largest date in a group
     group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[:1]
 
-    # Subquery to get the detector_id from DetectorGroup, ensuring the detector is connected to the workflow
+    # Subquery to get the detector_id from DetectorGroup.
+    # The detector does not currently need to be connected to the workflow.
     detector_subquery = DetectorGroup.objects.filter(
         group=OuterRef("group"),
-        detector_id__in=DetectorWorkflow.objects.filter(workflow=workflow).values("detector_id"),
-    ).values("detector_id")[:1]
+    ).values(
+        "detector_id"
+    )[:1]
 
     qs = (
         filtered_history.select_related("group")

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -10,7 +10,13 @@ from sentry.api.serializers import Serializer, serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse
 from sentry.models.group import Group
 from sentry.utils.cursors import Cursor, CursorResult
-from sentry.workflow_engine.models import Detector, Workflow, WorkflowFireHistory
+from sentry.workflow_engine.models import (
+    Detector,
+    DetectorGroup,
+    DetectorWorkflow,
+    Workflow,
+    WorkflowFireHistory,
+)
 
 
 @dataclass(frozen=True)
@@ -118,13 +124,20 @@ def fetch_workflow_groups_paginated(
 
     # subquery that retrieves row with the largest date in a group
     group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[:1]
+
+    # Subquery to get the detector_id from DetectorGroup, ensuring the detector is connected to the workflow
+    detector_subquery = DetectorGroup.objects.filter(
+        group=OuterRef("group"),
+        detector_id__in=DetectorWorkflow.objects.filter(workflow=workflow).values("detector_id"),
+    ).values("detector_id")[:1]
+
     qs = (
-        filtered_history.select_related("group", "detector")
+        filtered_history.select_related("group")
         .values("group")
         .annotate(count=Count("group"))
         .annotate(event_id=Subquery(group_max_dates.values("event_id")))
         .annotate(last_triggered=Max("date_added"))
-        .annotate(detector_id=Subquery(group_max_dates.values("detector_id")))
+        .annotate(detector_id=Subquery(detector_subquery))
     )
 
     # Count distinct groups for pagination

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_group_history_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_group_history_serializer.py
@@ -32,6 +32,14 @@ class WorkflowGroupsPaginatedTest(TestCase):
             project_id=self.project.id,
             type=MetricIssue.slug,
         )
+        self.create_detector_workflow(
+            detector=self.detector_1,
+            workflow=self.workflow,
+        )
+        DetectorGroup.objects.create(
+            detector=self.detector_1,
+            group=self.group,
+        )
         for i in range(3):
             self.history.append(
                 WorkflowFireHistory(
@@ -46,6 +54,14 @@ class WorkflowGroupsPaginatedTest(TestCase):
             project_id=self.project.id,
             type=MetricIssue.slug,
         )
+        self.create_detector_workflow(
+            detector=self.detector_2,
+            workflow=self.workflow,
+        )
+        DetectorGroup.objects.create(
+            detector=self.detector_2,
+            group=self.group_2,
+        )
         self.history.append(
             WorkflowFireHistory(
                 detector=self.detector_2,
@@ -58,6 +74,14 @@ class WorkflowGroupsPaginatedTest(TestCase):
         self.detector_3 = self.create_detector(
             project_id=self.project.id,
             type=MetricIssue.slug,
+        )
+        self.create_detector_workflow(
+            detector=self.detector_3,
+            workflow=self.workflow,
+        )
+        DetectorGroup.objects.create(
+            detector=self.detector_3,
+            group=self.group_3,
         )
         for i in range(2):
             self.history.append(

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_group_history_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_group_history_serializer.py
@@ -11,7 +11,7 @@ from sentry.workflow_engine.endpoints.serializers.workflow_group_history_seriali
     WorkflowGroupHistory,
     fetch_workflow_groups_paginated,
 )
-from sentry.workflow_engine.models import Workflow, WorkflowFireHistory
+from sentry.workflow_engine.models import DetectorGroup, Workflow, WorkflowFireHistory
 
 pytestmark = [requires_snuba]
 

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_group_history_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_group_history_serializer.py
@@ -32,10 +32,6 @@ class WorkflowGroupsPaginatedTest(TestCase):
             project_id=self.project.id,
             type=MetricIssue.slug,
         )
-        self.create_detector_workflow(
-            detector=self.detector_1,
-            workflow=self.workflow,
-        )
         DetectorGroup.objects.create(
             detector=self.detector_1,
             group=self.group,
@@ -54,10 +50,6 @@ class WorkflowGroupsPaginatedTest(TestCase):
             project_id=self.project.id,
             type=MetricIssue.slug,
         )
-        self.create_detector_workflow(
-            detector=self.detector_2,
-            workflow=self.workflow,
-        )
         DetectorGroup.objects.create(
             detector=self.detector_2,
             group=self.group_2,
@@ -74,10 +66,6 @@ class WorkflowGroupsPaginatedTest(TestCase):
         self.detector_3 = self.create_detector(
             project_id=self.project.id,
             type=MetricIssue.slug,
-        )
-        self.create_detector_workflow(
-            detector=self.detector_3,
-            workflow=self.workflow,
         )
         DetectorGroup.objects.create(
             detector=self.detector_3,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -37,10 +37,6 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
             detector=self.detector,
             group=self.group,
         )
-        self.create_detector_workflow(
-            detector=self.detector,
-            workflow=self.workflow,
-        )
         for i in range(3):
             self.history.append(
                 WorkflowFireHistory(
@@ -57,10 +53,6 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         DetectorGroup.objects.create(
             detector=self.detector_2,
             group=self.group_2,
-        )
-        self.create_detector_workflow(
-            detector=self.detector_2,
-            workflow=self.workflow,
         )
         self.history.append(
             WorkflowFireHistory(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -1,6 +1,8 @@
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.incidents.grouptype import MetricIssue
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
@@ -8,6 +10,7 @@ from sentry.workflow_engine.endpoints.serializers.workflow_group_history_seriali
     WorkflowGroupHistory,
     WorkflowGroupHistorySerializer,
 )
+from sentry.workflow_engine.models import DetectorGroup
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
 
 pytestmark = [requires_snuba]
@@ -26,6 +29,18 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
 
         self.history: list[WorkflowFireHistory] = []
         self.workflow = self.create_workflow(organization=self.organization)
+        self.detector = self.create_detector(
+            project_id=self.project.id,
+            type=ErrorGroupType.slug,
+        )
+        DetectorGroup.objects.create(
+            detector=self.detector,
+            group=self.group,
+        )
+        self.create_detector_workflow(
+            detector=self.detector,
+            workflow=self.workflow,
+        )
         for i in range(3):
             self.history.append(
                 WorkflowFireHistory(
@@ -35,6 +50,18 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
                 )
             )
         self.group_2 = self.create_group()
+        self.detector_2 = self.create_detector(
+            project_id=self.project.id,
+            type=MetricIssue.slug,
+        )
+        DetectorGroup.objects.create(
+            detector=self.detector_2,
+            group=self.group_2,
+        )
+        self.create_detector_workflow(
+            detector=self.detector_2,
+            workflow=self.workflow,
+        )
         self.history.append(
             WorkflowFireHistory(
                 workflow=self.workflow,
@@ -63,14 +90,18 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group, 3, self.base_triggered_date, self.history[0].event_id, detector=None
+                    self.group,
+                    3,
+                    self.base_triggered_date,
+                    self.history[0].event_id,
+                    detector=self.detector,
                 ),
                 WorkflowGroupHistory(
                     self.group_2,
                     1,
                     self.base_triggered_date,
                     self.history[-1].event_id,
-                    detector=None,
+                    detector=self.detector_2,
                 ),
             ],
             self.user,
@@ -88,7 +119,11 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group, 3, self.base_triggered_date, self.history[0].event_id, detector=None
+                    self.group,
+                    3,
+                    self.base_triggered_date,
+                    self.history[0].event_id,
+                    detector=self.detector,
                 )
             ],
             self.user,
@@ -111,7 +146,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
                     1,
                     self.base_triggered_date,
                     self.history[-1].event_id,
-                    detector=None,
+                    detector=self.detector_2,
                 )
             ],
             self.user,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -30,7 +30,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         self.history: list[WorkflowFireHistory] = []
         self.workflow = self.create_workflow(organization=self.organization)
         self.detector = self.create_detector(
-            project_id=self.project.id,
+            project=self.project,
             type=ErrorGroupType.slug,
         )
         DetectorGroup.objects.create(
@@ -47,7 +47,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
             )
         self.group_2 = self.create_group()
         self.detector_2 = self.create_detector(
-            project_id=self.project.id,
+            project=self.project,
             type=MetricIssue.slug,
         )
         DetectorGroup.objects.create(


### PR DESCRIPTION
Since we now have `DetectorGroup` rows being written, we could refactor the `WorkflowGroupHistory` API to use `DetectorGroup`, rather than use a column on `WorkflowFireHistory` (which shouldn't need to know which detector triggered the workflow to be fired).

Don't use `DetectorWorkflow` to check for active detector - workflow connections because a detector might have been disconnected from the workflow since the workflow was triggered for that issue.