### PR TITLE
ref(workflow_engine): Route detector deletion through validators

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -9,6 +9,8 @@ from rest_framework import serializers
 from sentry import audit_log
 from sentry.api.fields.actor import ActorField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.constants import ObjectStatus
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
 from sentry.utils.audit import create_audit_entry
@@ -143,6 +145,18 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
 
         DetectorLifeCycleHooks.on_after_update(instance)
         return instance
+
+    def delete(self) -> None:
+        """
+        Delete the detector by scheduling it for deletion.
+
+        Subclasses can override this to perform detector-specific cleanup before
+        deletion (e.g., removing billing seats, cleaning up external resources).
+        They should call super().delete() to perform the actual deletion.
+        """
+        assert self.instance is not None
+        RegionScheduledDeletion.schedule(self.instance, days=0, actor=self.context["request"].user)
+        self.instance.update(status=ObjectStatus.PENDING_DELETION)
 
     def _create_data_source(self, validated_data_source, detector: Detector):
         data_source_creator = validated_data_source["_creator"]


### PR DESCRIPTION
Adds delete() method to BaseDetectorTypeValidator to consolidate all
CRUD operations (create, update, delete) within validators. This allows
detector-specific logic to be cleanly overridden in subclass validators
and replaces the need for lifecycle hooks.

- Validators already handle create() and update() with access to old state
  via self.instance
- Validators can raise ValidationError for user-facing errors (e.g., billing
  seat failures)
- Overriding delete() allows immediate actions when a user perceives their
  detector as deleted (e.g., freeing billing seats, stopping checks)
- Additional async cleanup still happens via data source-specific deletion
  tasks that the detector cascades into

The default implementation schedules the detector for deletion and updates
its status. Subclasses can override to perform detector-specific cleanup
before calling super().delete().

Part of [NEW-610: Provide way for detectors `after_update` hooks to have knowledge of what changed](https://linear.app/getsentry/issue/NEW-610/provide-way-for-detectors-after-update-hooks-to-have-knowledge-of-what)