### PR TITLE
fix(aci): Always create metric monitor resolution threshold

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -222,8 +222,8 @@ export function createConditions(
   // Use custom value if provided, otherwise use MEDIUM threshold if available, else HIGH threshold
   const resolutionConditionType =
     data.conditionType === DataConditionType.GREATER
-      ? DataConditionType.LESS
-      : DataConditionType.GREATER;
+      ? DataConditionType.LESS_OR_EQUAL
+      : DataConditionType.GREATER_OR_EQUAL;
 
   const resolutionComparison =
     data.resolutionStrategy === 'custom' &&

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -218,23 +218,27 @@ export function createConditions(
     });
   }
 
-  // Optionally add explicit resolution (OK) condition when manual strategy is chosen
-  if (
+  // Always add an explicit resolution (OK) condition
+  // Use custom value if provided, otherwise use MEDIUM threshold if available, else HIGH threshold
+  const resolutionConditionType =
+    data.conditionType === DataConditionType.GREATER
+      ? DataConditionType.LESS
+      : DataConditionType.GREATER;
+
+  const resolutionComparison =
     data.resolutionStrategy === 'custom' &&
     defined(data.resolutionValue) &&
     data.resolutionValue !== ''
-  ) {
-    const resolutionConditionType =
-      data.conditionType === DataConditionType.GREATER
-        ? DataConditionType.LESS
-        : DataConditionType.GREATER;
+      ? parseFloat(data.resolutionValue) || 0
+      : defined(data.mediumThreshold) && data.mediumThreshold !== ''
+        ? parseFloat(data.mediumThreshold) || 0
+        : parseFloat(data.highThreshold) || 0;
 
-    conditions.push({
-      type: resolutionConditionType,
-      comparison: parseFloat(data.resolutionValue) || 0,
-      conditionResult: DetectorPriorityLevel.OK,
-    });
-  }
+  conditions.push({
+    type: resolutionConditionType,
+    comparison: resolutionComparison,
+    conditionResult: DetectorPriorityLevel.OK,
+  });
 
   return conditions;
 }

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -324,7 +324,10 @@ describe('DetectorEdit', () => {
                 },
               ],
               conditionGroup: {
-                conditions: [{comparison: 8, conditionResult: 75, type: 'gt'}],
+                conditions: [
+                  {comparison: 8, conditionResult: 75, type: 'gt'},
+                  {comparison: 8, conditionResult: 0, type: 'lt'},
+                ],
                 logicType: 'any',
               },
               config: {detectionType: 'static', thresholdPeriod: 1},

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -326,7 +326,7 @@ describe('DetectorEdit', () => {
               conditionGroup: {
                 conditions: [
                   {comparison: 8, conditionResult: 75, type: 'gt'},
-                  {comparison: 8, conditionResult: 0, type: 'lt'},
+                  {comparison: 8, conditionResult: 0, type: 'lte'},
                 ],
                 logicType: 'any',
               },

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -190,7 +190,7 @@ describe('DetectorEdit', () => {
                   {
                     comparison: 100,
                     conditionResult: 0,
-                    type: 'lt',
+                    type: 'lte',
                   },
                 ],
                 logicType: 'any',
@@ -277,7 +277,7 @@ describe('DetectorEdit', () => {
                   {
                     comparison: 100,
                     conditionResult: 0,
-                    type: 'lt',
+                    type: 'lte',
                   },
                 ],
                 logicType: 'any',
@@ -348,7 +348,7 @@ describe('DetectorEdit', () => {
               conditionGroup: {
                 conditions: [
                   {comparison: 100, conditionResult: 75, type: 'gt'},
-                  {comparison: 100, conditionResult: 0, type: 'lt'},
+                  {comparison: 100, conditionResult: 0, type: 'lte'},
                 ],
                 logicType: 'any',
               },
@@ -426,7 +426,7 @@ describe('DetectorEdit', () => {
                 {
                   comparison: 80,
                   conditionResult: 0,
-                  type: 'lt',
+                  type: 'lte',
                 },
               ],
             },
@@ -490,7 +490,7 @@ describe('DetectorEdit', () => {
                 {
                   comparison: 50,
                   conditionResult: 0,
-                  type: 'lt',
+                  type: 'lte',
                 },
               ],
             },

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -59,7 +59,7 @@ function DataConditionGroupFixture(
       // OK (resolution) condition - uses same comparison value with swapped operator
       DataConditionFixture({
         id: '2',
-        type: DataConditionType.LESS,
+        type: DataConditionType.LESS_OR_EQUAL,
         conditionResult: DetectorPriorityLevel.OK,
       }),
     ],

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -53,7 +53,16 @@ function DataConditionGroupFixture(
   params: Partial<MetricConditionGroup> = {}
 ): MetricConditionGroup {
   return {
-    conditions: [DataConditionFixture()],
+    conditions: [
+      // HIGH priority condition
+      DataConditionFixture(),
+      // OK (resolution) condition - uses same comparison value with swapped operator
+      DataConditionFixture({
+        id: '2',
+        type: DataConditionType.LESS,
+        conditionResult: DetectorPriorityLevel.OK,
+      }),
+    ],
     id: '1',
     logicType: DataConditionGroupLogicType.ANY,
     ...params,


### PR DESCRIPTION
Always adds a resolution threshold, apparently they do not resolve otherwise. The default resolution threshold is the same as the medium threshold if available otherwise high.
