### PR TITLE
ref(feedback): Update Seer consent flow for user feedback AI summaries & categories

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
@@ -49,13 +49,19 @@ export default function FeedbackCategories() {
   const navigate = useNavigate();
   const organization = useOrganization();
 
+  const skipConsentFlow = organization.features.includes('gen-ai-consent-flow-removal');
+
   const hasWildcardOperators = organization.features.includes(
     'search-query-builder-wildcard-operators'
   );
 
   useEffect(() => {
     // Analytics for the rendered state. Should match the conditions below.
-    if (isPending || isOrgSeerSetupPending || !setupAcknowledgement.orgHasAcknowledged) {
+    if (
+      isPending ||
+      isOrgSeerSetupPending ||
+      (!skipConsentFlow && !setupAcknowledgement.orgHasAcknowledged)
+    ) {
       return;
     }
     if (isError) {
@@ -81,6 +87,7 @@ export default function FeedbackCategories() {
     isError,
     tooFewFeedbacks,
     categories,
+    skipConsentFlow,
     setupAcknowledgement.orgHasAcknowledged,
     isPending,
     isOrgSeerSetupPending,
@@ -103,7 +110,7 @@ export default function FeedbackCategories() {
     tooFewFeedbacks ||
     !categories ||
     categories.length === 0 ||
-    !setupAcknowledgement.orgHasAcknowledged
+    (!skipConsentFlow && !setupAcknowledgement.orgHasAcknowledged)
   ) {
     return null;
   }

--- a/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
@@ -19,12 +19,14 @@ export default function FeedbackSummary() {
     useOrganizationSeerSetup();
   const organization = useOrganization();
 
+  const skipConsentFlow = organization.features.includes('gen-ai-consent-flow-removal');
+
   useEffect(() => {
     // Analytics for the rendered state. Should match the conditions below.
     if (isPending || isOrgSeerSetupPending) {
       return;
     }
-    if (!setupAcknowledgement.orgHasAcknowledged) {
+    if (!skipConsentFlow && !setupAcknowledgement.orgHasAcknowledged) {
       trackAnalytics('feedback.summary.seer-cta-rendered', {
         organization,
       });
@@ -46,6 +48,7 @@ export default function FeedbackSummary() {
     isError,
     tooFewFeedbacks,
     setupAcknowledgement.orgHasAcknowledged,
+    skipConsentFlow,
     isPending,
     isOrgSeerSetupPending,
   ]);
@@ -54,7 +57,7 @@ export default function FeedbackSummary() {
     return <LoadingPlaceholder />;
   }
 
-  if (!setupAcknowledgement.orgHasAcknowledged) {
+  if (!skipConsentFlow && !setupAcknowledgement.orgHasAcknowledged) {
     return (
       <SummaryContent>
         {tct(

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -1,14 +1,17 @@
 import styled from '@emotion/styled';
 
+import {ExternalLink} from '@sentry/scraps/link/link';
+
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {Disclosure} from 'sentry/components/core/disclosure';
 import {Flex} from 'sentry/components/core/layout';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import FeedbackCategories from 'sentry/components/feedback/summaryCategories/feedbackCategories';
 import FeedbackSummary from 'sentry/components/feedback/summaryCategories/feedbackSummary';
 import {IconThumb} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
@@ -75,7 +78,19 @@ export default function FeedbackSummaryCategories() {
           }
         >
           <Flex gap="xs" align="center">
-            {t('Summary')} <FeatureBadge type="new" />
+            <Tooltip
+              title={tct(
+                `Powered by generative AI. Learn more about our [link:AI privacy principles].`,
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/ai-privacy-and-security/" />
+                  ),
+                }
+              )}
+            >
+              {t('Summary')}
+            </Tooltip>
+            <FeatureBadge type="new" />
           </Flex>
         </Disclosure.Title>
         <Disclosure.Content>


### PR DESCRIPTION
relates to REPLAY-783

Remove the Seer org acknowledgement check based on the gen-ai-consent-flow-removal feature flag. Add an informative tooltip.

<img width="656" height="200" alt="Screenshot 2025-11-06 at 2 21 06 PM" src="https://github.com/user-attachments/assets/3f66c1e1-4fc6-4c82-914d-e0d81e253cb0" />
