### PR TITLE
fix(aci): fix error state for nonexistent monitor details

### DIFF
--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -175,6 +175,7 @@ function AutomationDetailLoadingStates({automationId}: {automationId: string}) {
     data: automation,
     isPending,
     isError,
+    error,
     refetch,
   } = useAutomationQuery(automationId);
 
@@ -183,7 +184,12 @@ function AutomationDetailLoadingStates({automationId}: {automationId: string}) {
   }
 
   if (isError) {
-    return <LoadingError onRetry={refetch} />;
+    return (
+      <LoadingError
+        message={error.status === 404 ? t('The alert could not be found.') : undefined}
+        onRetry={refetch}
+      />
+    );
   }
 
   return <AutomationDetailContent automation={automation} />;

--- a/static/app/views/detectors/detail.tsx
+++ b/static/app/views/detectors/detail.tsx
@@ -14,8 +14,10 @@ import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 function DetectorDetailsLoadingStates({
   detectorId,
   project,
+  isFetchingProjects,
 }: {
   detectorId: string;
+  isFetchingProjects: boolean;
   project: Project | undefined;
 }) {
   const {
@@ -26,7 +28,7 @@ function DetectorDetailsLoadingStates({
     refetch,
   } = useDetectorQuery(detectorId);
 
-  if (isPending || !project) {
+  if (isPending || isFetchingProjects) {
     return <LoadingIndicator />;
   }
 
@@ -67,7 +69,11 @@ export default function DetectorDetails() {
       id="DetectorDetails-Body"
       isLoading={isLoading}
     >
-      <DetectorDetailsLoadingStates detectorId={params.detectorId} project={project} />
+      <DetectorDetailsLoadingStates
+        detectorId={params.detectorId}
+        project={project}
+        isFetchingProjects={isFetchingProjects}
+      />
     </VisuallyCompleteWithData>
   );
 }


### PR DESCRIPTION
`!project` check was causing an infinite loading spinner on the monitor details page for nonexistent monitors

also improved the error message for automation details page when the resource does not exist