### PR TITLE
feat(ACI): Send historical data to seer on update

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -273,7 +273,8 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                 raise serializers.ValidationError(
                     "Invalid extrapolation mode for this detector type."
                 )
-        # Handle anomaly detection
+
+        # Handle a dynamic detector's snuba query changing
         if instance.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC:
             if snuba_query.query != data_source.get(
                 "query"
@@ -326,7 +327,6 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
         ):
             # Detector has been changed to become a dynamic detector
             send_new_detector_data(instance)
-            # update_detector_data(instance, updated_data_source_data)
 
         instance.save()
 

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 from rest_framework import serializers
 
@@ -280,7 +280,8 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                 "query"
             ) or snuba_query.aggregate != data_source.get("aggregate"):
                 try:
-                    update_detector_data(instance, data_source)
+                    validated_data_source = cast(dict[str, Any], data_source)
+                    update_detector_data(instance, validated_data_source)
                 except Exception:
                     # don't update the snuba query if we failed to send data to Seer
                     raise serializers.ValidationError(

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -332,13 +332,13 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                 enable_disable_subscriptions(query_subscriptions, enabled)
 
         # Handle data sources
-        updated_data_source_data: SnubaQueryDataSourceType | None = None
+        data_source: SnubaQueryDataSourceType | None = None
 
         if "data_sources" in validated_data:
-            updated_data_source_data = validated_data.pop("data_sources")[0]
+            data_source = validated_data.pop("data_sources")[0]
 
-        if updated_data_source_data is not None:
-            self.update_data_source(instance, updated_data_source_data)
+        if data_source is not None:
+            self.update_data_source(instance, data_source)
 
         instance.save()
 

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -43,7 +43,7 @@ seer_anomaly_detection_connection_pool = connection_from_url(
 
 def _fetch_related_models(
     detector: Detector, method: str
-) -> tuple[DataSource, DataCondition, SnubaQuery] | None:
+) -> tuple[DataSource, DataCondition, SnubaQuery]:
     # XXX: it is technically possible (though not used today) that a detector could have multiple data sources
     data_source_detector = DataSourceDetector.objects.filter(detector_id=detector.id).first()
     if not data_source_detector:
@@ -84,6 +84,7 @@ def update_detector_data(
     updated_fields: dict[str, Any],
 ) -> None:
     data_source, data_condition, snuba_query = _fetch_related_models(detector, "update")
+
     # use setattr to avoid saving the models until the Seer call has successfully finished,
     # otherwise they would be in a bad state
     updated_data_condition_data = updated_fields.get("condition_group", {}).get("conditions")
@@ -127,6 +128,7 @@ def send_new_detector_data(detector: Detector) -> None:
     Send historical data for a new Detector to Seer.
     """
     data_source, data_condition, snuba_query = _fetch_related_models(detector, "create")
+
     try:
         handle_send_historical_data_to_seer(
             detector, data_source, data_condition, snuba_query, detector.project, SeerMethod.CREATE

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -68,7 +68,6 @@ def _fetch_related_models(
             condition_result__in=[
                 DetectorPriorityLevel.HIGH,
                 DetectorPriorityLevel.MEDIUM,
-                DetectorPriorityLevel.LOW,
             ],
         )
     except (DataCondition.DoesNotExist, DataCondition.MultipleObjectsReturned):

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -122,8 +122,14 @@ def update_detector_data(
             SeerMethod.UPDATE,
             event_types,
         )
-    except (TimeoutError, MaxRetryError, ParseError, ValidationError):
-        raise ValidationError("Couldn't send data to Seer, unable to update detector")
+    except TimeoutError:
+        raise ValidationError("Timed out sending data to Seer, unable to update detector")
+    except MaxRetryError:
+        raise ValidationError("Hit max retries sending data to Seer, unable to update detector")
+    except ParseError:
+        raise ValidationError("Couldn't parse response from Seer, unable to update detector")
+    except ValidationError:
+        raise ValidationError("Hit validation error, unable to update detector")
     metrics.incr("anomaly_detection_monitor.updated")
 
 

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -40,7 +40,9 @@ seer_anomaly_detection_connection_pool = connection_from_url(
 )
 
 
-def update_detector_data(detector: Detector, data_source: SnubaQueryDataSourceType) -> None:
+def update_detector_data(
+    detector: Detector, updated_data_source_data: SnubaQueryDataSourceType
+) -> None:
     try:
         data_source = DataSourceDetector.objects.get(detector_id=detector.id).data_source
     except DataSourceDetector.DoesNotExist:
@@ -67,24 +69,21 @@ def update_detector_data(detector: Detector, data_source: SnubaQueryDataSourceTy
         raise DetectorException(
             f"Could not create detector, data condition {dcg_id} not found or too many found."
         )
-    # use setattr to avoid saving the detector until the Seer call has successfully finished,
-    # otherwise the detector would be in a bad state
-    for k, v in data_source.items():
-        setattr(data_source, k, v)
+    # use setattr to avoid saving the snuba query until the Seer call has successfully finished,
+    # otherwise it would be in a bad state
+    event_types = snuba_query.event_types
+    if updated_data_source_data:
+        event_types = updated_data_source_data.get("eventTypes")
 
-    for k, v in data_source.items():
-        if k == "dataset":
-            v = v.value
-        elif k == "time_window":
-            time_window = data_source.get("time_window")
-            v = (
-                int(time_window.total_seconds())
-                if time_window is not None
-                else snuba_query.time_window
-            )
-        elif k == "event_types":
-            continue
-        setattr(snuba_query, k, v)
+        for k, v in updated_data_source_data.items():
+            if k == "dataset":
+                v = v.value
+            elif k == "time_window":
+                time_window = updated_data_source_data.get("time_window")
+                v = time_window if time_window is not None else snuba_query.time_window
+            elif k == "event_types":
+                continue
+            setattr(snuba_query, k, v)
 
     try:
         handle_send_historical_data_to_seer(
@@ -94,7 +93,7 @@ def update_detector_data(detector: Detector, data_source: SnubaQueryDataSourceTy
             snuba_query,
             detector.project,
             SeerMethod.UPDATE,
-            data_source.event_types,
+            event_types,
         )
     except (TimeoutError, MaxRetryError, ParseError, ValidationError):
         raise ValidationError("Couldn't send data to Seer, unable to update detector")

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -667,9 +667,6 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         assert condition.comparison == 100
         assert condition.condition_result == DetectorPriorityLevel.HIGH
 
-        assert mock_seer_request.call_count == 1
-        mock_seer_request.return_mock()
-
         mock_audit.assert_called()
         mock_audit.reset_mock()
 

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -626,6 +626,12 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
                         "comparison": 100,
                         "conditionResult": DetectorPriorityLevel.HIGH,
                     },
+                    {
+                        "type": Condition.LESS_OR_EQUAL,
+                        "comparison": 100,
+                        "conditionResult": DetectorPriorityLevel.OK,
+                        "conditionGroupId": self.data_condition_group.id,
+                    },
                 ],
             },
             "name": new_name,  # change the name
@@ -843,7 +849,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         assert condition_group.organization_id == self.project.organization_id
 
         conditions = list(DataCondition.objects.filter(condition_group=condition_group))
-        assert len(conditions) == 1
+        assert len(conditions) == 2
         condition = conditions[0]
         assert condition.type == Condition.GREATER
         assert condition.comparison == 100

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -195,7 +195,7 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
             },
         }
 
-    def create_static_detector(self) -> None:
+    def create_static_detector(self) -> Detector:
         validator = MetricIssueDetectorValidator(
             data=self.valid_data,
             context=self.context,
@@ -225,7 +225,7 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
 
         return static_detector
 
-    def create_dynamic_detector(self) -> None:
+    def create_dynamic_detector(self) -> Detector:
         validator = MetricIssueDetectorValidator(
             data=self.valid_anomaly_detection_data,
             context=self.context,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -719,7 +719,7 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         self.detector.save()
 
         # Update with valid new config
-        updated_config = {"detection_type": "dynamic", "comparison_delta": 3600}
+        updated_config = {"detection_type": "percent", "comparison_delta": 3600}
         data = {
             "config": updated_config,
         }
@@ -737,7 +737,7 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         assert self.detector.config == updated_config
         # API returns camelCase
         assert response.data["config"] == {
-            "detectionType": "dynamic",
+            "detectionType": "percent",
             "comparisonDelta": 3600,
         }
 


### PR DESCRIPTION
When a static or percent based detector is changed to become a dynamic detector we need to send Seer historical data for that detector so it can detect anomalies. Also when a dynamic detector's snuba query query or aggregate changes we need to update the data Seer has so it's detecting anomalies on the correct data. This PR also handles not updating the existing data if the call to Seer fails for any reason.