### PR TITLE
ci: Fix Github job to run python3 -m tools.api_urls_to_typescript

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -253,9 +253,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - # get a non-default github token so that any changes are verified by CI
-        if: env.SECRET_ACCESS == 'true'
-        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+      - uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         id: token
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
@@ -265,7 +263,6 @@ jobs:
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
-        id: setup
         with:
           mode: backend-ci
 
@@ -274,8 +271,7 @@ jobs:
           python3 -m tools.api_urls_to_typescript
 
       - name: Apply any file changes
-        # note: this runs "always" or else it's skipped when pre-commit fails
-        if: env.SECRET_ACCESS == 'true' && startsWith(github.ref, 'refs/pull') && always()
+        if: github.ref != 'refs/heads/master' && always()
         uses: getsentry/action-github-commit@31f6706ca1a7b9ad6d22c1b07bf3a92eabb05632 # v2.0.0
         with:
           github-token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Before the job wasnt running properly because `env.SECRET_ACCESS` was some copy+pasta that doesnt work in this workflow. Instead the fix is to stop the job on failure, and have fewer conditions on each step
