### PR TITLE
ref(onboarding): Split dotnet onboarding docs

### DIFF
--- a/static/app/gettingStartedDocs/dotnet/awslambda.tsx
+++ b/static/app/gettingStartedDocs/dotnet/awslambda.tsx
@@ -10,7 +10,7 @@ import {
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
+import {feedback} from 'sentry/gettingStartedDocs/dotnet/dotnet/feedback';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -195,7 +195,7 @@ const crashReportOnboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/dotnet/dotnet/crashReport.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/crashReport.tsx
@@ -1,0 +1,30 @@
+import type {
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportGenericInstallSteps,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+
+export const crashReport: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: DocsParams) => getCrashReportGenericInstallSteps(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/dotnet/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};

--- a/static/app/gettingStartedDocs/dotnet/dotnet/feedback.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/feedback.tsx
@@ -52,5 +52,3 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
   verify: () => [],
   nextSteps: () => [],
 };
-
-export const csharpFeedbackOnboarding = feedback;

--- a/static/app/gettingStartedDocs/dotnet/dotnet/feedback.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/feedback.tsx
@@ -1,0 +1,56 @@
+import altCrashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/altCrashReportCallout';
+import {
+  StepType,
+  type OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportApiIntroduction,
+  getCrashReportInstallDescription,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+
+export const feedback: OnboardingConfig = {
+  introduction: () => getCrashReportApiIntroduction(),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportInstallDescription(),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'C#',
+              language: 'csharp',
+              code: `using Sentry;
+
+var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
+
+SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User");`,
+            },
+            {
+              label: 'F#',
+              language: 'fsharp',
+              code: `open Sentry
+
+let eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.")
+
+SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User")`,
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          content: altCrashReportCallout(),
+        },
+      ],
+    },
+  ],
+  configure: () => [],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
+export const csharpFeedbackOnboarding = feedback;

--- a/static/app/gettingStartedDocs/dotnet/dotnet/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/index.tsx
@@ -1,0 +1,15 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+import {crashReport} from './crashReport';
+import {feedback} from './feedback';
+import {onboarding} from './onboarding';
+import {profiling} from './profiling';
+
+const docs: Docs = {
+  onboarding,
+  feedbackOnboardingCrashApi: feedback,
+  crashReportOnboarding: crashReport,
+  profilingOnboarding: profiling,
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/dotnet/dotnet/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './dotnet';
+import docs from '.';
 
 describe('dotnet onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet/dotnet/onboarding.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/onboarding.tsx
@@ -8,19 +8,7 @@ import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
-const getInstallSnippetPackageManager = (params: DocsParams) => `
-Install-Package Sentry -Version ${getPackageVersion(
-  params,
-  'sentry.dotnet',
-  params.isProfilingSelected ? '4.3.0' : '3.34.0'
-)}`;
-
-const getInstallSnippetCoreCli = (params: DocsParams) => `
-dotnet add package Sentry -v ${getPackageVersion(
-  params,
-  'sentry.dotnet',
-  params.isProfilingSelected ? '4.3.0' : '3.34.0'
-)}`;
+import {getInstallSnippetCoreCli, getInstallSnippetPackageManager} from './utils';
 
 const getInstallProfilingSnippetPackageManager = (params: DocsParams) => `
 Install-Package Sentry.Profiling -Version ${getPackageVersion(
@@ -309,5 +297,3 @@ export const onboarding: OnboardingConfig = {
     },
   ],
 };
-
-export {getInstallSnippetPackageManager, getInstallSnippetCoreCli};

--- a/static/app/gettingStartedDocs/dotnet/dotnet/onboarding.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/onboarding.tsx
@@ -1,47 +1,35 @@
 import {ExternalLink} from 'sentry/components/core/link';
-import altCrashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/altCrashReportCallout';
 import type {
-  Docs,
   DocsParams,
   OnboardingConfig,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  getCrashReportApiIntroduction,
-  getCrashReportGenericInstallSteps,
-  getCrashReportInstallDescription,
-  getCrashReportModalConfigDescription,
-  getCrashReportModalIntroduction,
-} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
-import {getDotnetProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/dotnet';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
-type Params = DocsParams;
-
-const getInstallSnippetPackageManager = (params: Params) => `
+const getInstallSnippetPackageManager = (params: DocsParams) => `
 Install-Package Sentry -Version ${getPackageVersion(
   params,
   'sentry.dotnet',
   params.isProfilingSelected ? '4.3.0' : '3.34.0'
 )}`;
 
-const getInstallSnippetCoreCli = (params: Params) => `
+const getInstallSnippetCoreCli = (params: DocsParams) => `
 dotnet add package Sentry -v ${getPackageVersion(
   params,
   'sentry.dotnet',
   params.isProfilingSelected ? '4.3.0' : '3.34.0'
 )}`;
 
-const getInstallProfilingSnippetPackageManager = (params: Params) => `
+const getInstallProfilingSnippetPackageManager = (params: DocsParams) => `
 Install-Package Sentry.Profiling -Version ${getPackageVersion(
   params,
   'sentry.dotnet.profiling',
   '4.3.0'
 )}`;
 
-const getInstallProfilingSnippetCoreCli = (params: Params) => `
+const getInstallProfilingSnippetCoreCli = (params: DocsParams) => `
 dotnet add package Sentry.Profiling -v ${getPackageVersion(
   params,
   'sentry.dotnet.profiling',
@@ -53,7 +41,7 @@ enum DotNetPlatform {
   IOS_MACCATALYST = 1,
 }
 
-const getConfigureSnippet = (params: Params, platform?: DotNetPlatform) => `
+const getConfigureSnippet = (params: DocsParams, platform?: DotNetPlatform) => `
 using Sentry;
 
 SentrySdk.Init(options =>
@@ -121,7 +109,7 @@ var span = transaction.StartChild("test-child-operation");
 span.Finish(); // Mark the span as finished
 transaction.Finish(); // Mark the transaction as finished and send it to Sentry`;
 
-const onboarding: OnboardingConfig = {
+export const onboarding: OnboardingConfig = {
   introduction: () =>
     tct(
       'Sentry for .NET is a collection of NuGet packages provided by Sentry; it supports .NET Framework 4.6.1 and .NET Core 2.0 and above. At its core, Sentry for .NET provides a raw client for sending events to Sentry. If you use a framework such as [strong:ASP.NET, WinForms, WPF, MAUI, Xamarin, Serilog], or similar, we recommend visiting our [link:Sentry .NET] documentation for installation instructions.',
@@ -233,7 +221,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: (params: Params) => [
+  verify: (params: DocsParams) => [
     {
       type: StepType.VERIFY,
       content: [
@@ -322,81 +310,4 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
-export const csharpFeedbackOnboarding: OnboardingConfig = {
-  introduction: () => getCrashReportApiIntroduction(),
-  install: () => [
-    {
-      type: StepType.INSTALL,
-      content: [
-        {
-          type: 'text',
-          text: getCrashReportInstallDescription(),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'C#',
-              language: 'csharp',
-              code: `using Sentry;
-
-var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
-
-SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User");`,
-            },
-            {
-              label: 'F#',
-              language: 'fsharp',
-              code: `open Sentry
-
-let eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.")
-
-SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User")`,
-            },
-          ],
-        },
-        {
-          type: 'custom',
-          content: altCrashReportCallout(),
-        },
-      ],
-    },
-  ],
-  configure: () => [],
-  verify: () => [],
-  nextSteps: () => [],
-};
-
-const crashReportOnboarding: OnboardingConfig = {
-  introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportGenericInstallSteps(params),
-  configure: () => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: getCrashReportModalConfigDescription({
-            link: 'https://docs.sentry.io/platforms/dotnet/user-feedback/configuration/#crash-report-modal',
-          }),
-        },
-      ],
-    },
-  ],
-  verify: () => [],
-  nextSteps: () => [],
-};
-
-const profilingOnboarding = getDotnetProfilingOnboarding({
-  getInstallSnippetPackageManager,
-  getInstallSnippetCoreCli,
-});
-
-const docs: Docs = {
-  onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
-  crashReportOnboarding,
-  profilingOnboarding,
-};
-
-export default docs;
+export {getInstallSnippetPackageManager, getInstallSnippetCoreCli};

--- a/static/app/gettingStartedDocs/dotnet/dotnet/profiling.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/profiling.tsx
@@ -1,0 +1,8 @@
+import {getDotnetProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/dotnet';
+
+import {getInstallSnippetCoreCli, getInstallSnippetPackageManager} from './onboarding';
+
+export const profiling = getDotnetProfilingOnboarding({
+  getInstallSnippetPackageManager,
+  getInstallSnippetCoreCli,
+});

--- a/static/app/gettingStartedDocs/dotnet/dotnet/profiling.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/profiling.tsx
@@ -1,6 +1,6 @@
 import {getDotnetProfilingOnboarding} from 'sentry/utils/gettingStartedDocs/dotnet';
 
-import {getInstallSnippetCoreCli, getInstallSnippetPackageManager} from './onboarding';
+import {getInstallSnippetCoreCli, getInstallSnippetPackageManager} from './utils';
 
 export const profiling = getDotnetProfilingOnboarding({
   getInstallSnippetPackageManager,

--- a/static/app/gettingStartedDocs/dotnet/dotnet/utils.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet/utils.tsx
@@ -1,0 +1,16 @@
+import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+
+export const getInstallSnippetPackageManager = (params: DocsParams) => `
+Install-Package Sentry -Version ${getPackageVersion(
+  params,
+  'sentry.dotnet',
+  params.isProfilingSelected ? '4.3.0' : '3.34.0'
+)}`;
+
+export const getInstallSnippetCoreCli = (params: DocsParams) => `
+dotnet add package Sentry -v ${getPackageVersion(
+  params,
+  'sentry.dotnet',
+  params.isProfilingSelected ? '4.3.0' : '3.34.0'
+)}`;

--- a/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
@@ -10,7 +10,7 @@ import {
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
+import {feedback} from 'sentry/gettingStartedDocs/dotnet/dotnet/feedback';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -230,7 +230,7 @@ const crashReportOnboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/dotnet/maui.tsx
+++ b/static/app/gettingStartedDocs/dotnet/maui.tsx
@@ -11,7 +11,7 @@ import {
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
+import {feedback} from 'sentry/gettingStartedDocs/dotnet/dotnet/feedback';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -255,7 +255,7 @@ const crashReportOnboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/dotnet/winforms.tsx
+++ b/static/app/gettingStartedDocs/dotnet/winforms.tsx
@@ -11,7 +11,7 @@ import {
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
+import {feedback} from 'sentry/gettingStartedDocs/dotnet/dotnet/feedback';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -241,7 +241,7 @@ const crashReportOnboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/dotnet/wpf.tsx
+++ b/static/app/gettingStartedDocs/dotnet/wpf.tsx
@@ -11,7 +11,7 @@ import {
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
+import {feedback} from 'sentry/gettingStartedDocs/dotnet/dotnet/feedback';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -241,7 +241,7 @@ const crashReportOnboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/dotnet/xamarin.tsx
+++ b/static/app/gettingStartedDocs/dotnet/xamarin.tsx
@@ -10,7 +10,7 @@ import {
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
-import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
+import {feedback} from 'sentry/gettingStartedDocs/dotnet/dotnet/feedback';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -306,7 +306,7 @@ const crashReportOnboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding,
 };
 


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms