### PR TITLE
fix(deletions): Fetch GroupHashMetadata in chunks

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -290,6 +290,50 @@ def update_group_hash_metadata_in_batches(hash_ids: Sequence[int]) -> None:
         metrics.incr("deletions.group_hash_metadata.rows_updated", amount=updated, sample_rate=1.0)
 
 
+def update_group_hash_metadata_in_batches_old(hash_ids: Sequence[int]) -> int:
+    """
+    Update seer_matched_grouphash to None for GroupHashMetadata rows
+    that reference the given hash_ids, in batches to avoid timeouts.
+
+    This function performs the update in smaller batches to reduce lock
+    contention and prevent statement timeouts when many rows need updating.
+
+    Returns the total number of rows updated.
+    """
+    # First, get all the IDs that need updating
+    metadata_ids = list(
+        GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).values_list(
+            "id", flat=True
+        )
+    )
+
+    if not metadata_ids:
+        return 0
+
+    option_batch_size = options.get("deletions.group-hash-metadata.batch-size", 1000)
+    batch_size = max(1, option_batch_size)
+    total_updated = 0
+    for i in range(0, len(metadata_ids), batch_size):
+        batch = metadata_ids[i : i + batch_size]
+        updated = GroupHashMetadata.objects.filter(id__in=batch).update(seer_matched_grouphash=None)
+        total_updated += updated
+
+    metrics.incr(
+        "deletions.group_hash_metadata.rows_updated",
+        amount=total_updated,
+        sample_rate=1.0,
+    )
+    logger.info(
+        "update_group_hash_metadata_in_batches.complete",
+        extra={
+            "hash_ids_count": len(hash_ids),
+            "total_updated": total_updated,
+        },
+    )
+
+    return total_updated
+
+
 def delete_group_hashes(
     project_id: int,
     group_ids: Sequence[int],
@@ -325,7 +369,10 @@ def delete_group_hashes(
             # 2. Delete the GroupHashMetadata rows entirely (they'll be deleted anyway)
             # If we update the columns first, the deletion of the grouphash metadata rows will have less work to do,
             # thus, improving the performance of the deletion.
-            update_group_hash_metadata_in_batches(hash_ids)
+            if options.get("deletions.group-hash-metadata.use-old-update-method"):
+                update_group_hash_metadata_in_batches_old(hash_ids)
+            else:
+                update_group_hash_metadata_in_batches(hash_ids)
             GroupHashMetadata.objects.filter(grouphash_id__in=hash_ids).delete()
             GroupHash.objects.filter(id__in=hash_ids).delete()
 

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -260,48 +260,34 @@ def delete_project_group_hashes(project_id: int) -> None:
     delete_group_hashes(project_id, issue_platform_group_ids)
 
 
-def update_group_hash_metadata_in_batches(hash_ids: Sequence[int]) -> int:
+def update_group_hash_metadata_in_batches(hash_ids: Sequence[int]) -> None:
     """
     Update seer_matched_grouphash to None for GroupHashMetadata rows
     that reference the given hash_ids, in batches to avoid timeouts.
 
     This function performs the update in smaller batches to reduce lock
     contention and prevent statement timeouts when many rows need updating.
-
-    Returns the total number of rows updated.
     """
-    # First, get all the IDs that need updating
-    metadata_ids = list(
-        GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=hash_ids).values_list(
-            "id", flat=True
-        )
-    )
-
-    if not metadata_ids:
-        return 0
-
     option_batch_size = options.get("deletions.group-hash-metadata.batch-size", 1000)
     batch_size = max(1, option_batch_size)
-    total_updated = 0
-    for i in range(0, len(metadata_ids), batch_size):
-        batch = metadata_ids[i : i + batch_size]
+    metadata_ids = []
+    for i in range(0, len(hash_ids), batch_size):
+        batch = hash_ids[i : i + batch_size]
+        # We want batches of metadata ids, not just the ids
+        metadata_ids.append(
+            list(
+                GroupHashMetadata.objects.filter(seer_matched_grouphash_id__in=batch).values_list(
+                    "id", flat=True
+                )
+            )
+        )
+
+    if not metadata_ids:
+        return
+
+    for batch in metadata_ids:
         updated = GroupHashMetadata.objects.filter(id__in=batch).update(seer_matched_grouphash=None)
-        total_updated += updated
-
-    metrics.incr(
-        "deletions.group_hash_metadata.rows_updated",
-        amount=total_updated,
-        sample_rate=1.0,
-    )
-    logger.info(
-        "update_group_hash_metadata_in_batches.complete",
-        extra={
-            "hash_ids_count": len(hash_ids),
-            "total_updated": total_updated,
-        },
-    )
-
-    return total_updated
+        metrics.incr("deletions.group_hash_metadata.rows_updated", amount=updated, sample_rate=1.0)
 
 
 def delete_group_hashes(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -348,6 +348,14 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "deletions.group-hash-metadata.use-old-update-method",
+    default=False,  # Default using new update method
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+    description="If any problems arise, set the option to True to use the old update method.",
+)
+
 
 register(
     "cleanup.abort_execution",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -353,7 +353,6 @@ register(
     default=False,  # Default using new update method
     type=Bool,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
-    description="If any problems arise, set the option to True to use the old update method.",
 )
 
 

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from snuba_sdk import Column, Condition, Entity, Function, Op, Query, Request
 
 from sentry import deletions, nodestore
+from sentry.deletions.defaults.group import update_group_hash_metadata_in_batches
 from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -336,6 +337,54 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             assert not GroupHashMetadata.objects.filter(id=metadata_a_id).exists()
             assert not GroupHash.objects.filter(id=grouphash_b.id).exists()
             assert not GroupHashMetadata.objects.filter(id=metadata_b_id).exists()
+
+    def test_update_group_hash_metadata_in_batches(self) -> None:
+        """
+        Test that update_group_hash_metadata_in_batches correctly processes all records
+        in batches without getting stuck in an infinite loop, and that it correctly
+        updates seer_matched_grouphash to None.
+        """
+        num_additional_grouphashes = 5
+        # Create events with group hashes
+        event_a = self.store_event(data={"fingerprint": ["a"]}, project_id=self.project.id)
+        grouphash_a = GroupHash.objects.get(group_id=event_a.group_id)
+
+        # Create multiple events with different group hashes that reference grouphash_a
+        # This simulates multiple events that were matched to grouphash_a by Seer
+        additional_grouphashes = []
+        for i in range(num_additional_grouphashes):
+            event = self.store_event(data={"fingerprint": [i]}, project_id=self.project.id)
+            grouphash = GroupHash.objects.get(hash=event.get_primary_hash())
+            if grouphash.metadata is not None:
+                # Update the metadata to reference grouphash_a
+                grouphash.metadata.seer_matched_grouphash = grouphash_a
+                grouphash.metadata.save()
+            else:
+                raise AssertionError("GroupHashMetadata is None for grouphash id=%s" % grouphash.id)
+            additional_grouphashes.append(grouphash)
+
+        # Verify setup: all metadata records should reference grouphash_a
+        assert (
+            GroupHashMetadata.objects.filter(seer_matched_grouphash_id=grouphash_a.id).count()
+            == num_additional_grouphashes
+        )
+
+        # Test with a small batch size to force multiple batches
+        with mock.patch("sentry.deletions.defaults.group.options.get") as mock_options:
+            # Set batch size to 2 to force multiple batches
+            mock_options.return_value = 2
+            # Call the function to update all metadata that references grouphash_a
+            update_group_hash_metadata_in_batches([grouphash_a.id])
+
+        # Verify that all metadata records that referenced grouphash_a now have None
+        assert (
+            GroupHashMetadata.objects.filter(seer_matched_grouphash_id=grouphash_a.id).count() == 0
+        )
+
+        # Verify that the metadata records still exist but with seer_matched_grouphash=None
+        for grouphash in additional_grouphashes:
+            grouphash.metadata.refresh_from_db()
+            assert grouphash.metadata.seer_matched_grouphash is None
 
 
 class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -383,8 +383,11 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 
         # Verify that the metadata records still exist but with seer_matched_grouphash=None
         for grouphash in additional_grouphashes:
-            grouphash.metadata.refresh_from_db()
-            assert grouphash.metadata.seer_matched_grouphash is None
+            if grouphash.metadata is not None:
+                grouphash.metadata.refresh_from_db()
+                assert grouphash.metadata.seer_matched_grouphash is None
+            else:
+                raise AssertionError("GroupHashMetadata is None for grouphash id=%s" % grouphash.id)
 
 
 class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):


### PR DESCRIPTION
Some hashes can match upwards of 1M rows, thus, the select statement needs chunking.

This is a follow-up to https://github.com/getsentry/sentry/pull/102864 and https://github.com/getsentry/sentry/pull/102612.

Fixes [SENTRY-5C2V](https://sentry.sentry.io/issues/?project=1&query=SENTRY-5C2V).