### PR TITLE
feat(consumers): ensure that gen_ai spans get the `gen_ai.agent.name` from the ancestor span

### DIFF
--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -146,9 +146,19 @@ class TreeEnricher:
         """
         Iterates over the ancestors of a span in order towards the root using the "parent_span_id" attribute.
         """
-        current = span
-        while current := self._span_hierarchy.get(current.get("parent_span_id")):
-            yield current
+        current: SpanEvent | None = span
+        parent_span_id: str | None = None
+
+        while current is not None:
+            parent_span_id = current.get("parent_span_id")
+            if parent_span_id is not None:
+                current = self._span_hierarchy.get(parent_span_id)
+            else:
+                current = None
+            if current is not None:
+                yield current
+            else:
+                break
 
     def _exclusive_time(self, span: SpanEvent) -> float:
         """

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -122,17 +122,13 @@ class TreeEnricher:
                 if attributes.get(key) is None:
                     attributes[key] = value
 
-            GENAI_SPAN_OPS_AGENT_CHILDREN = [
-                "gen_ai.execute_tool",
-                "gen_ai.handoff",
-                "gen_ai.run",
-                "gen_ai.create_agent",
-            ]
-            op = get_span_op(span)
-
-            if op in GENAI_SPAN_OPS_AGENT_CHILDREN and "gen_ai.agent.name" not in attributes:
+            if get_span_op(span).startswith("gen_ai.") and "gen_ai.agent.name" not in attributes:
                 for ancestor in self._iter_ancestors(span):
-                    if (agent_name := attribute_value(ancestor, "gen_ai.agent.name")) is not None:
+                    if (
+                        get_span_op(ancestor) == "gen_ai.invoke_agent"
+                        and (agent_name := attribute_value(ancestor, "gen_ai.agent.name"))
+                        is not None
+                    ):
                         attributes["gen_ai.agent.name"] = {
                             "type": "string",
                             "value": agent_name,

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -123,17 +123,18 @@ class TreeEnricher:
                     attributes[key] = value
 
             if get_span_op(span).startswith("gen_ai.") and "gen_ai.agent.name" not in attributes:
-                for ancestor in self._iter_ancestors(span):
+                if (parent_span_id := span.get("parent_span_id")) is not None:
+                    parent_span = self._spans_by_id.get(parent_span_id)
                     if (
-                        get_span_op(ancestor) == "gen_ai.invoke_agent"
-                        and (agent_name := attribute_value(ancestor, "gen_ai.agent.name"))
+                        parent_span is not None
+                        and get_span_op(parent_span) == "gen_ai.invoke_agent"
+                        and (agent_name := attribute_value(parent_span, "gen_ai.agent.name"))
                         is not None
                     ):
                         attributes["gen_ai.agent.name"] = {
                             "type": "string",
                             "value": agent_name,
                         }
-                        break
 
         attributes["sentry.exclusive_time_ms"] = {
             "type": "double",

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -79,7 +79,7 @@ class TreeEnricher:
         self._spans_by_id: dict[str, SpanEvent] = {}
         for span in spans:
             if "span_id" in span:
-                self._span_hierarchy[span["span_id"]] = span
+                self._spans_by_id[span["span_id"]] = span
             if parent_span_id := span.get("parent_span_id"):
                 interval = _span_interval(span)
                 self._span_intervals.setdefault(parent_span_id, []).append(interval)

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -471,3 +471,183 @@ def _mock_performance_issue_span(is_segment, attributes, **fields) -> SpanEvent:
             **fields,
         },
     )
+
+
+def test_enrich_gen_ai_agent_name_from_immediate_parent() -> None:
+    """Test that gen_ai.agent.name is inherited from the immediate parent."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="gen_ai.create_agent",
+        attributes={
+            "gen_ai.agent.name": {"type": "string", "value": "MyAgent"},
+        },
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        span_op="gen_ai.execute_tool",
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+    compatible_spans = [make_compatible(span) for span in enriched_spans]
+
+    parent, child = compatible_spans
+    assert attribute_value(parent, "gen_ai.agent.name") == "MyAgent"
+    assert attribute_value(child, "gen_ai.agent.name") == "MyAgent"
+
+
+def test_enrich_gen_ai_agent_name_from_ancestor() -> None:
+    """Test that gen_ai.agent.name is inherited from a grandparent ancestor."""
+    grandparent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="gen_ai.create_agent",
+        attributes={
+            "gen_ai.agent.name": {"type": "string", "value": "GrandparentAgent"},
+        },
+    )
+
+    parent_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455604.0,
+        span_op="some.operation",
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="cccccccccccccccc",
+        parent_span_id="bbbbbbbbbbbbbbbb",
+        start_timestamp=1609455602.0,
+        end_timestamp=1609455603.0,
+        span_op="gen_ai.run",
+    )
+
+    spans = [grandparent_span, parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+    compatible_spans = [make_compatible(span) for span in enriched_spans]
+
+    grandparent, parent, child = compatible_spans
+    assert attribute_value(grandparent, "gen_ai.agent.name") == "GrandparentAgent"
+    assert attribute_value(parent, "gen_ai.agent.name") is None
+    assert attribute_value(child, "gen_ai.agent.name") == "GrandparentAgent"
+
+
+def test_enrich_gen_ai_agent_name_not_overwritten() -> None:
+    """Test that gen_ai.agent.name is not overwritten if already set on the child."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="gen_ai.create_agent",
+        attributes={
+            "gen_ai.agent.name": {"type": "string", "value": "ParentAgent"},
+        },
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        span_op="gen_ai.handoff",
+        attributes={
+            "gen_ai.agent.name": {"type": "string", "value": "ChildAgent"},
+        },
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+    compatible_spans = [make_compatible(span) for span in enriched_spans]
+
+    parent, child = compatible_spans
+    assert attribute_value(parent, "gen_ai.agent.name") == "ParentAgent"
+    assert attribute_value(child, "gen_ai.agent.name") == "ChildAgent"
+
+
+def test_enrich_gen_ai_agent_name_not_set_without_ancestor() -> None:
+    """Test that gen_ai.agent.name is not set if no ancestor has it."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="some.operation",
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        span_op="gen_ai.execute_tool",
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+    compatible_spans = [make_compatible(span) for span in enriched_spans]
+
+    parent, child = compatible_spans
+    assert attribute_value(parent, "gen_ai.agent.name") is None
+    assert attribute_value(child, "gen_ai.agent.name") is None
+
+
+def test_enrich_gen_ai_agent_name_not_from_sibling() -> None:
+    """Test that gen_ai.agent.name is not taken from a sibling span."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="some.operation",
+    )
+
+    sibling_with_agent = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        span_op="gen_ai.create_agent",
+        attributes={
+            "gen_ai.agent.name": {"type": "string", "value": "SiblingAgent"},
+        },
+    )
+
+    target_child = build_mock_span(
+        project_id=1,
+        span_id="cccccccccccccccc",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455602.5,
+        end_timestamp=1609455603.5,
+        span_op="gen_ai.execute_tool",
+    )
+
+    spans = [parent_span, sibling_with_agent, target_child]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+    compatible_spans = [make_compatible(span) for span in enriched_spans]
+
+    parent, sibling, target = compatible_spans
+    assert attribute_value(parent, "gen_ai.agent.name") is None
+    assert attribute_value(sibling, "gen_ai.agent.name") == "SiblingAgent"
+    assert attribute_value(target, "gen_ai.agent.name") is None


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-1293/make-sure-that-agent-name-is-set-on-all-of-its-gen-ai-children


Supersedes: https://github.com/getsentry/sentry-python/pull/5030

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
