### PR TITLE
feat(ui): Add hasExternalChanges prop to HybridFilter

### DIFF
--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -53,6 +53,11 @@ export interface HybridFilterProps<Value extends SelectKey>
    */
   disableCommit?: boolean;
   /**
+   * Additional staged changes from external state that should trigger
+   * the Apply/Cancel buttons.
+   */
+  hasExternalChanges?: boolean;
+  /**
    * Message to show in the menu footer
    */
   menuFooterMessage?: ((hasStagedChanges: any) => React.ReactNode) | React.ReactNode;
@@ -96,6 +101,7 @@ export function HybridFilter<Value extends SelectKey>({
   checkboxWrapper,
   checkboxPosition,
   disableCommit,
+  hasExternalChanges = false,
   ...selectProps
 }: HybridFilterProps<Value>) {
   /**
@@ -115,11 +121,13 @@ export function HybridFilter<Value extends SelectKey>({
   }, [onStagedValueChange, stagedValue]);
 
   /**
-   * Whether there are staged, uncommitted changes. Used to determine whether we should
-   * show the "Cancel"/"Apply" buttons.
+   * Whether there are staged, uncommitted changes, or external changes. Used to determine
+   * whether we should show the "Cancel"/"Apply" buttons.
    */
   const hasStagedChanges =
-    stagedValue.length !== value.length || !stagedValue.every(val => value.includes(val));
+    stagedValue.length !== value.length ||
+    !stagedValue.every(val => value.includes(val)) ||
+    hasExternalChanges;
 
   const commit = useCallback(
     (val: Value[]) => {


### PR DESCRIPTION
**Motivation**

I'm currently working on a global filter component that sets values for filters using HybridFilter. However, I have an extra 'attribute' which is the operator of the filter which is not being set through the HybridFilter options, and instead within the custom body of the filter (i.e. its state is managed externally). I would like my external changes to also trigger the apply button, and once it is clicked, it triggers my custom onChange handler that saves options + operator.

**Changes**
- Adds hasExternalChanges to hybrid filter so components are able to externally trigger the apply button
