### PR TITLE
ref(tracemetrics): Hide copy about updating projects

### DIFF
--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -186,13 +186,7 @@ function Onboarding({organization, project}: OnboardingProps) {
     // This currently covers all non-supported platforms as `doesNotSupportMetrics` is empty.
     return (
       <OnboardingPanel project={project} isUnsupportedPlatform>
-        <div>
-          {tct(
-            "We're working to bring Metrics support to [platform]. Stay updated by joining the discussion!",
-
-            {platform: <strong>{currentPlatform?.name || project.slug}</strong>}
-          )}
-        </div>
+        <div>{t('Stay updated by joining the discussion!')}</div>
         <br />
         <div>
           <LinkButton


### PR DESCRIPTION
This is confusing for the time being since some projects are already underway.


