### PR TITLE
feat(tracemetrics): Add metric into aggregate arguments

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -311,7 +311,7 @@ class AggregateDefinition(FunctionDefinition):
     An optional function that takes in the resolved argument and returns the attribute key to aggregate on.
     If not provided, assumes the aggregate is on the first argument.
     """
-    attribute_resolver: Callable[[ResolvedArguments], AttributeKey] | None = None
+    attribute_resolver: Callable[[ResolvedArgument], AttributeKey] | None = None
 
     def resolve(
         self,
@@ -334,7 +334,72 @@ class AggregateDefinition(FunctionDefinition):
                 raise InvalidSearchQuery("Aggregates accept attribute keys only")
             resolved_attribute = resolved_arguments[0]
             if self.attribute_resolver is not None:
-                resolved_attribute = self.attribute_resolver(resolved_arguments)
+                resolved_attribute = self.attribute_resolver(resolved_attribute)
+
+        return ResolvedAggregate(
+            public_alias=alias,
+            internal_name=self.internal_function,
+            search_type=search_type,
+            internal_type=self.internal_type,
+            processor=self.processor,
+            extrapolation=(
+                self.extrapolation if not search_config.disable_aggregate_extrapolation else False
+            ),
+            argument=resolved_attribute,
+        )
+
+
+@dataclass(kw_only=True)
+class TraceMetricAggregateDefinition(FunctionDefinition):
+    internal_function: Function.ValueType
+    attribute_resolver: Callable[[ResolvedArgument], AttributeKey] | None = None
+
+    def __post_init__(self) -> None:
+        if len(self.arguments) != 4:
+            raise InvalidSearchQuery(
+                f"Trace metric aggregates expects exactly 4 arguments to be defined, got {len(self.arguments)}"
+            )
+
+        if not isinstance(self.arguments[0], AttributeArgumentDefinition):
+            raise InvalidSearchQuery(
+                "Trace metric aggregates expect argument 0 to be of type AttributeArgumentDefinition"
+            )
+
+        for i in range(1, 4):
+            if not isinstance(self.arguments[i], ValueArgumentDefinition):
+                raise InvalidSearchQuery(
+                    f"Trace metric aggregates expects argument {i} to be of type ValueArgumentDefinition"
+                )
+
+    def resolve(
+        self,
+        alias: str,
+        search_type: constants.SearchType,
+        resolved_arguments: ResolvedArguments,
+        snuba_params: SnubaParams,
+        query_result_cache: dict[str, EAPResponse],
+        search_config: SearchResolverConfig,
+    ) -> ResolvedAggregate:
+        if not isinstance(resolved_arguments[0], AttributeKey):
+            raise InvalidSearchQuery(
+                "Trace metric aggregates expect argument 0 to be of type AttributeArgumentDefinition"
+            )
+
+        resolved_attribute = resolved_arguments[0]
+        if self.attribute_resolver is not None:
+            resolved_attribute = self.attribute_resolver(resolved_attribute)
+
+        if all(resolved_argument != "" for resolved_argument in resolved_arguments[1:-1]):
+            # a metric was passed
+            # TODO: we need to put it into the top level query conditions
+            pass
+        elif all(resolved_argument == "" for resolved_argument in resolved_arguments[1:-1]):
+            # no metrics were specified, assume we query all metrics
+            pass
+        else:
+            raise InvalidSearchQuery(
+                f"Trace metric aggregates expect the full metric to be specified, got name:{resolved_arguments[1]} type:{resolved_arguments[2]} unit:{resolved_arguments[3]}"
+            )
 
         return ResolvedAggregate(
             public_alias=alias,
@@ -519,25 +584,18 @@ def attribute_key_to_tuple(attribute_key: AttributeKey) -> tuple[str, AttributeK
 
 def count_argument_resolver_optimized(
     always_present_attributes: list[AttributeKey],
-) -> Callable[[ResolvedArguments], AttributeKey]:
+) -> Callable[[ResolvedArgument], AttributeKey]:
     always_present_attributes_set = {
         attribute_key_to_tuple(attribute) for attribute in always_present_attributes
     }
 
-    def count_argument_resolver(resolved_arguments: ResolvedArguments) -> AttributeKey:
-        if len(resolved_arguments) != 1:
-            raise InvalidSearchQuery(
-                f"Aggregates expects exactly 1 argument, got {len(resolved_arguments)}"
-            )
-
-        if not isinstance(resolved_arguments[0], AttributeKey):
+    def count_argument_resolver(resolved_argument: ResolvedArgument) -> AttributeKey:
+        if not isinstance(resolved_argument, AttributeKey):
             raise InvalidSearchQuery("Aggregates accept attribute keys only")
 
-        resolved_attribute: AttributeKey = resolved_arguments[0]
-
-        if attribute_key_to_tuple(resolved_attribute) in always_present_attributes_set:
+        if attribute_key_to_tuple(resolved_argument) in always_present_attributes_set:
             return AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT)
 
-        return resolved_attribute
+        return resolved_argument
 
     return count_argument_resolver

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -389,11 +389,11 @@ class TraceMetricAggregateDefinition(FunctionDefinition):
         if self.attribute_resolver is not None:
             resolved_attribute = self.attribute_resolver(resolved_attribute)
 
-        if all(resolved_argument != "" for resolved_argument in resolved_arguments[1:-1]):
+        if all(resolved_argument != "" for resolved_argument in resolved_arguments[1:]):
             # a metric was passed
             # TODO: we need to put it into the top level query conditions
             pass
-        elif all(resolved_argument == "" for resolved_argument in resolved_arguments[1:-1]):
+        elif all(resolved_argument == "" for resolved_argument in resolved_arguments[1:]):
             # no metrics were specified, assume we query all metrics
             pass
         else:

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -350,7 +350,7 @@ class AggregateDefinition(FunctionDefinition):
 
 
 @dataclass(kw_only=True)
-class TraceMetricAggregateDefinition(FunctionDefinition):
+class TraceMetricAggregateDefinition(AggregateDefinition):
     internal_function: Function.ValueType
     attribute_resolver: Callable[[ResolvedArgument], AttributeKey] | None = None
 

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -987,7 +987,7 @@ class SearchResolver:
 
             # If there are missing arguments, and the argument definition has a default arg, use the default arg
             # this assumes the missing args are at the beginning or end of the arguments list
-            if missing_args > 0 and argument_definition.default_arg:
+            if missing_args > 0 and argument_definition.default_arg is not None:
                 if isinstance(argument_definition, ValueArgumentDefinition):
                     parsed_args.append(argument_definition.default_arg)
                 else:

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -2,6 +2,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Functi
 
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
+    AggregateDefinition,
     AttributeArgumentDefinition,
     TraceMetricAggregateDefinition,
     ValueArgumentDefinition,
@@ -23,7 +24,7 @@ TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES = [
     AttributeKey(name="sentry.value", type=AttributeKey.Type.TYPE_DOUBLE),
 ]
 
-TRACE_METRICS_AGGREGATE_DEFINITIONS = {
+TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
     "count": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_COUNT,
         infer_search_type_from_arguments=False,

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -2,10 +2,12 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Functi
 
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
-    AggregateDefinition,
     AttributeArgumentDefinition,
+    TraceMetricAggregateDefinition,
+    ValueArgumentDefinition,
     count_argument_resolver_optimized,
 )
+from sentry.search.eap.validator import literal_validator
 
 
 def count_processor(count_value: int | None) -> int:
@@ -22,7 +24,7 @@ TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES = [
 ]
 
 TRACE_METRICS_AGGREGATE_DEFINITIONS = {
-    "count": AggregateDefinition(
+    "count": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_COUNT,
         infer_search_type_from_arguments=False,
         processor=count_processor,
@@ -34,14 +36,27 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     "number",
                     "integer",
                 },
-                default_arg="value",
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
         attribute_resolver=count_argument_resolver_optimized(
             TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES
         ),
     ),
-    "count_unique": AggregateDefinition(
+    "count_unique": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_UNIQ,
         default_search_type="integer",
         infer_search_type_from_arguments=False,
@@ -58,10 +73,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "sum": AggregateDefinition(
+    "sum": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_SUM,
         default_search_type="number",
         arguments=[
@@ -74,10 +103,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "avg": AggregateDefinition(
+    "avg": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_AVG,
         default_search_type="number",
         arguments=[
@@ -91,10 +134,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "p50": AggregateDefinition(
+    "p50": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_P50,
         default_search_type="number",
         arguments=[
@@ -108,10 +165,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "p75": AggregateDefinition(
+    "p75": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_P75,
         default_search_type="number",
         arguments=[
@@ -125,10 +196,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg="non"),
         ],
     ),
-    "p90": AggregateDefinition(
+    "p90": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_P90,
         default_search_type="number",
         arguments=[
@@ -142,10 +227,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "p95": AggregateDefinition(
+    "p95": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_P95,
         default_search_type="number",
         arguments=[
@@ -159,10 +258,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "p99": AggregateDefinition(
+    "p99": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_P99,
         default_search_type="number",
         arguments=[
@@ -176,10 +289,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "max": AggregateDefinition(
+    "max": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_MAX,
         default_search_type="number",
         arguments=[
@@ -193,10 +320,24 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
-    "min": AggregateDefinition(
+    "min": TraceMetricAggregateDefinition(
         internal_function=Function.FUNCTION_MIN,
         default_search_type="number",
         arguments=[
@@ -210,7 +351,21 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
-            )
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
+            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
 }

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -210,7 +210,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg="non"),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "p90": TraceMetricAggregateDefinition(

--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -97,7 +97,6 @@ TRACE_METRICS_FORMULA_DEFINITIONS = {
                     "number",
                     "integer",
                 },
-                default_arg="value",
             ),
             ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
             ValueArgumentDefinition(
@@ -127,7 +126,6 @@ TRACE_METRICS_FORMULA_DEFINITIONS = {
                     "number",
                     "integer",
                 },
-                default_arg="value",
             ),
             ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
             ValueArgumentDefinition(

--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -17,6 +17,7 @@ from sentry.search.eap.columns import (
     ValueArgumentDefinition,
 )
 from sentry.search.eap.trace_metrics.config import TraceMetricsSearchResolverConfig
+from sentry.search.eap.validator import literal_validator
 
 
 def _rate_internal(
@@ -89,10 +90,20 @@ TRACE_METRICS_FORMULA_DEFINITIONS = {
                 },
                 default_arg="value",
             ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
             ValueArgumentDefinition(
                 argument_types={"string"},
-                default_arg="counter",
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
             ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
         formula_resolver=per_second,
         is_aggregate=True,
@@ -109,10 +120,20 @@ TRACE_METRICS_FORMULA_DEFINITIONS = {
                 },
                 default_arg="value",
             ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
             ValueArgumentDefinition(
                 argument_types={"string"},
-                default_arg="counter",
+                validator=literal_validator(
+                    [
+                        "",
+                        "counter",
+                        "gauge",
+                        "distribution",
+                    ]
+                ),
+                default_arg="",
             ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
         formula_resolver=per_minute,
         is_aggregate=True,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3492,6 +3492,7 @@ class TraceMetricsTestCase(BaseTestCase, TraceItemTestCase):
         metric_name: str,
         metric_value: float,
         metric_type: Literal["counter", "distribution", "gauge"],
+        metric_unit: str | None = None,
         organization: Organization | None = None,
         project: Project | None = None,
         timestamp: datetime | None = None,
@@ -3522,6 +3523,12 @@ class TraceMetricsTestCase(BaseTestCase, TraceItemTestCase):
             f"sentry._internal.cooccuring.name.{metric_name}": AnyValue(bool_value=True),
             f"sentry._internal.cooccuring.type.{metric_type}": AnyValue(bool_value=True),
         }
+
+        if metric_unit is not None:
+            attributes_proto["sentry.metric_unit"] = AnyValue(string_value=metric_unit)
+            attributes_proto[f"sentry._internal.cooccuring.unit.{metric_unit}"] = AnyValue(
+                bool_value=True
+            )
 
         if attributes:
             for k, v in attributes.items():

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -150,7 +150,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["sum(value)"] == 8
+        assert data[0]["sum(value,request_count,counter,none)"] == 8
         assert meta["fields"]["sum(value,request_count,counter,none)"] == "number"
         assert meta["dataset"] == "tracemetrics"
 

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -8,7 +8,7 @@ from tests.snuba.api.endpoints.test_organization_events import OrganizationEvent
 class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestBase):
     dataset = "tracemetrics"
 
-    def test_simple_deprecated(self) -> None:
+    def test_simple_with_explicit_filter(self) -> None:
         trace_metrics = [
             self.create_trace_metric("foo", 1, "counter"),
             self.create_trace_metric("bar", 2, "counter"),
@@ -33,7 +33,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             },
         ]
 
-    def test_simple_aggregation_deprecated(self) -> None:
+    def test_simple_aggregation_with_explicit_filter(self) -> None:
         trace_metrics = [
             self.create_trace_metric("foo", 1, "counter"),
             self.create_trace_metric("bar", 2, "counter"),
@@ -106,16 +106,16 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             },
         ]
 
-    def test_per_minute_formula(self) -> None:
-        # Store 6 trace metrics over a 10 minute period
-        for _ in range(6):
-            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0, "counter")])
+    def test_sum(self):
+        self.store_trace_metrics(
+            [self.create_trace_metric("test_metric", i + 1, "counter") for i in range(6)]
+        )
 
         response = self.do_request(
             {
                 "metricName": "test_metric",
                 "metricType": "counter",
-                "field": ["per_minute(test_metric)"],
+                "field": ["sum(value)"],
                 "project": self.project.id,
                 "dataset": self.dataset,
                 "statsPeriod": "10m",
@@ -125,20 +125,95 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["per_minute(test_metric)"] == 0.6
-        assert meta["fields"]["per_minute(test_metric)"] == "rate"
+        assert data[0]["sum(value)"] == 21
+        assert meta["fields"]["sum(value)"] == "number"
         assert meta["dataset"] == "tracemetrics"
 
-    def test_per_second_formula(self) -> None:
+    def test_sum_with_counter_metric_type(self):
+        counter_metrics = [
+            self.create_trace_metric("request_count", 5.0, "counter"),
+            self.create_trace_metric("request_count", 3.0, "counter"),
+        ]
+        self.store_trace_metrics(counter_metrics)
+
+        response = self.do_request(
+            {
+                "metricName": "request_count",
+                "metricType": "counter",
+                "field": ["sum(value,request_count,counter,none)"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["sum(value)"] == 8
+        assert meta["fields"]["sum(value,request_count,counter,none)"] == "number"
+        assert meta["dataset"] == "tracemetrics"
+
+    def test_sum_with_distribution_metric_type(self):
+        gauge_metrics = [
+            self.create_trace_metric("request_duration", 75.0, "distribution"),
+            self.create_trace_metric("request_duration", 80.0, "distribution"),
+        ]
+        self.store_trace_metrics(gauge_metrics)
+
+        response = self.do_request(
+            {
+                "metricName": "request_duration",
+                "metricType": "distribution",
+                "field": [
+                    "sum(value, request_duration, distribution, none)"
+                ],  # Trying space in the formula here to make sure it works.
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data[0] == {
+            "sum(value, request_duration, distribution, none)": 155,
+        }
+
+    def test_per_minute_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
-        for _ in range(6):
-            self.store_trace_metrics([self.create_trace_metric("test_metric", 1.0, "counter")])
+        self.store_trace_metrics(
+            [self.create_trace_metric("test_metric", 1.0, "counter") for _ in range(6)]
+        )
 
         response = self.do_request(
             {
                 "metricName": "test_metric",
                 "metricType": "counter",
-                "field": ["per_second(test_metric, counter)"],
+                "field": ["per_minute(value)"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["per_minute(value)"] == 0.6
+        assert meta["fields"]["per_minute(value)"] == "rate"
+        assert meta["dataset"] == "tracemetrics"
+
+    def test_per_second_formula(self) -> None:
+        # Store 6 trace metrics over a 10 minute period
+        self.store_trace_metrics(
+            [self.create_trace_metric("test_metric", 1.0, "counter") for _ in range(6)]
+        )
+
+        response = self.do_request(
+            {
+                "metricName": "test_metric",
+                "metricType": "counter",
+                "field": ["per_second(value)"],
                 "project": self.project.id,
                 "dataset": self.dataset,
                 "statsPeriod": "10m",
@@ -149,9 +224,9 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         meta = response.data["meta"]
         assert len(data) == 1
         assert (
-            data[0]["per_second(test_metric, counter)"] == 0.01
+            data[0]["per_second(value)"] == 0.01
         )  # Over ten minute period, 6 events / 600 seconds = 0.01 events per second
-        assert meta["fields"]["per_second(test_metric, counter)"] == "rate"
+        assert meta["fields"]["per_second(value)"] == "rate"
         assert meta["dataset"] == "tracemetrics"
 
     def test_per_second_formula_with_counter_metric_type(self) -> None:
@@ -165,7 +240,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             {
                 "metricName": "request_count",
                 "metricType": "counter",
-                "field": ["per_second(request_count,counter)"],
+                "field": ["per_second(value,request_count,counter,none)"],
                 "project": self.project.id,
                 "dataset": self.dataset,
                 "statsPeriod": "10m",
@@ -173,7 +248,9 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         )
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert data[0] == {"per_second(request_count,counter)": pytest.approx(8 / 600, abs=0.001)}
+        assert data[0] == {
+            "per_second(value,request_count,counter,none)": pytest.approx(8 / 600, abs=0.001)
+        }
 
     def test_per_second_formula_with_gauge_metric_type(self) -> None:
         gauge_metrics = [
@@ -187,7 +264,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
                 "metricName": "cpu_usage",
                 "metricType": "gauge",
                 "field": [
-                    "per_second(cpu_usage, gauge)"
+                    "per_second(value, cpu_usage, gauge, none)"
                 ],  # Trying space in the formula here to make sure it works.
                 "project": self.project.id,
                 "dataset": self.dataset,
@@ -196,7 +273,9 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         )
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert data[0] == {"per_second(cpu_usage, gauge)": pytest.approx(2 / 600, abs=0.001)}
+        assert data[0] == {
+            "per_second(value, cpu_usage, gauge, none)": pytest.approx(2 / 600, abs=0.001)
+        }
 
     def test_per_second_formula_with_gauge_metric_type_without_top_level_metric_type(self) -> None:
         gauge_metrics = [
@@ -208,7 +287,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         response = self.do_request(
             {
                 "field": [
-                    "per_second(cpu_usage, gauge)"
+                    "per_second(value, cpu_usage, gauge, none)"
                 ],  # Trying space in the formula here to make sure it works.
                 "query": "metric.name:cpu_usage",
                 "project": self.project.id,
@@ -218,4 +297,51 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         )
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert data[0] == {"per_second(cpu_usage, gauge)": pytest.approx(2 / 600, abs=0.001)}
+        assert data[0] == {
+            "per_second(value, cpu_usage, gauge, none)": pytest.approx(2 / 600, abs=0.001)
+        }
+
+    def test_list_metrics(self):
+        trace_metrics = [
+            *[self.create_trace_metric("foo", 1, "counter") for _ in range(1)],
+            *[self.create_trace_metric("bar", 1, "gauge") for _ in range(2)],
+            *[self.create_trace_metric("baz", 1, "distribution") for _ in range(3)],
+            *[self.create_trace_metric("qux", 1, "distribution", "millisecond") for _ in range(4)],
+        ]
+        self.store_trace_metrics(trace_metrics)
+
+        # this query does not filter on any metrics, so scan all metrics
+        response = self.do_request(
+            {
+                "field": ["metric.name", "metric.type", "metric.unit", "count(metric.name)"],
+                "orderby": "metric.name",
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "metric.name": "bar",
+                "metric.type": "gauge",
+                "metric.unit": None,
+                "count(metric.name)": 2,
+            },
+            {
+                "metric.name": "baz",
+                "metric.type": "distribution",
+                "metric.unit": None,
+                "count(metric.name)": 3,
+            },
+            {
+                "metric.name": "foo",
+                "metric.type": "counter",
+                "metric.unit": None,
+                "count(metric.name)": 1,
+            },
+            {
+                "metric.name": "qux",
+                "metric.type": "distribution",
+                "metric.unit": "millisecond",
+                "count(metric.name)": 4,
+            },
+        ]


### PR DESCRIPTION
The top level params doesn't play nicely with dashboards so we're putting the metric name into the aggregation function. This just introduces the new signatures so we can update the frontend but still relies on the top level params. Once the frontend is updated to send the metric in the aggregate function, we can update the backend to actually handle them.