### PR TITLE
add slug to failed status check log

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -130,6 +130,7 @@ def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
             extra={
                 "artifact_id": preprod_artifact.id,
                 "organization_id": preprod_artifact.project.organization_id,
+                "organization_slug": preprod_artifact.project.organization.slug,
             },
         )
         return


### PR DESCRIPTION
add org slug to failed status check log

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
