### PR TITLE
ref(tracemetrics): Reduce analytic events firing

### DIFF
--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -740,7 +740,7 @@ export function useMetricsPanelAnalytics({
       return;
     }
 
-    if (metricSamplesTableResult.result.isFetching) {
+    if (metricSamplesTableResult.result.isFetching || !dataScanned) {
       return;
     }
 

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -30,6 +30,14 @@ export function ExploreSecondaryNav() {
     perPage: MAX_STARRED_QUERIES_DISPLAYED,
   });
 
+  const userPlatforms = useMemo(
+    () =>
+      Array.from(
+        new Set(projects.map(project => (project.platform as PlatformKey) || 'unknown'))
+      ).sort(),
+    [projects]
+  );
+
   const hasMetricsSupportedPlatform = projects.some(project => {
     const platform = project.platform || 'unknown';
     return Array.from(limitedMetricsSupportPrefixes).some(prefix =>
@@ -37,14 +45,10 @@ export function ExploreSecondaryNav() {
     );
   });
 
-  const userPlatforms = useMemo(
-    () => [
-      ...new Set(projects.map(project => (project.platform as PlatformKey) || 'unknown')),
-    ],
-    [projects]
-  );
-
   useEffect(() => {
+    if (userPlatforms.length === 0) {
+      return;
+    }
     trackAnalytics('metrics.nav.rendered', {
       organization,
       metrics_tab_visible: hasMetricsSupportedPlatform,


### PR DESCRIPTION
### Summary
Need to update them to only fire once per dep updates, and not on empty content.

