### PR TITLE
chore(np): Shim fe for backend pr

### DIFF
--- a/static/app/debug/notifications/components/debugNotificationsExample.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsExample.tsx
@@ -55,7 +55,7 @@ export function DebugNotificationsExample({
           Body
         </Text>
         {displayFormat === ExampleDataFormat.FORMATTED ? (
-          <Text>{registration.example.body}</Text>
+          <Text>{JSON.stringify(registration.example.body)}</Text>
         ) : (
           <CodeBlock language="javascript">
             {JSON.stringify(registration.example.body)}

--- a/static/app/debug/notifications/previews/discordPreview.tsx
+++ b/static/app/debug/notifications/previews/discordPreview.tsx
@@ -46,7 +46,7 @@ export function DiscordPreview({
             <DiscordWhiteText size="md" bold>
               {subject}
             </DiscordWhiteText>
-            <DiscordWhiteText size="sm">{body}</DiscordWhiteText>
+            <DiscordWhiteText size="sm">{JSON.stringify(body)}</DiscordWhiteText>
             {chart && (
               <DiscordChart
                 height="100px"

--- a/static/app/debug/notifications/previews/slackPreview.tsx
+++ b/static/app/debug/notifications/previews/slackPreview.tsx
@@ -54,7 +54,7 @@ export function SlackPreview({
             <SlackBlackText size="xl" bold>
               {subject}
             </SlackBlackText>
-            <SlackBodyText>{body}</SlackBodyText>
+            <SlackBodyText>{JSON.stringify(body)}</SlackBodyText>
             <Flex gap="xs">
               {actions.map(action => (
                 <SlackLinkButton key={action.label} href={action.link}>

--- a/static/app/debug/notifications/previews/teamsPreview.tsx
+++ b/static/app/debug/notifications/previews/teamsPreview.tsx
@@ -75,7 +75,7 @@ export function TeamsPreview({
               <TeamsBlackText size="xl" bold>
                 {subject}
               </TeamsBlackText>
-              <TeamsBlackText>{body}</TeamsBlackText>
+              <TeamsBlackText>{JSON.stringify(body)}</TeamsBlackText>
               <Flex gap="md">
                 {actions.map(action => (
                   <TeamsLinkButton key={action.label} href={action.link}>


### PR DESCRIPTION
Since we're changing the backend body to be objects, we need to have a temp stringify. Before the actual fe PR lands else, the page is going to throw mucho errors. It will look weird for a bit e.g
<img width="1629" height="881" alt="image" src="https://github.com/user-attachments/assets/b8f5f881-cbf3-427f-af9e-d771c6048849" />
