### PR TITLE
nit(aci): fix borders on select all alert

### DIFF
--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -219,6 +219,9 @@ export function AutomationsTableActions({
 
 const FullWidthAlert = styled(Alert)`
   grid-column: 1 / -1;
+  border-radius: 0;
+  border: none;
+  border-bottom: 1px solid ${p => p.theme.yellow300};
 `;
 
 const ActionsBarWrapper = styled('div')`

--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -190,7 +190,7 @@ export function AutomationsTableActions({
         </ActionsBarWrapper>
       </SimpleTable.Header>
       {pageSelected && !allResultsVisible && (
-        <FullWidthAlert type="warning" showIcon={false}>
+        <FullWidthAlert type="warning" system showIcon={false}>
           <Flex justify="center" wrap="wrap" gap="md">
             {allInQuerySelected ? (
               tct('Selected all [count] alerts that match this search query.', {
@@ -219,9 +219,6 @@ export function AutomationsTableActions({
 
 const FullWidthAlert = styled(Alert)`
   grid-column: 1 / -1;
-  border-radius: 0;
-  border: none;
-  border-bottom: 1px solid ${p => p.theme.yellow300};
 `;
 
 const ActionsBarWrapper = styled('div')`

--- a/static/app/views/detectors/components/detectorListTable/actions.tsx
+++ b/static/app/views/detectors/components/detectorListTable/actions.tsx
@@ -243,6 +243,9 @@ export function DetectorsTableActions({
 
 const FullWidthAlert = styled(Alert)`
   grid-column: 1 / -1;
+  border-radius: 0;
+  border: none;
+  border-bottom: 1px solid ${p => p.theme.yellow300};
 `;
 
 const ActionsBarWrapper = styled('div')`

--- a/static/app/views/detectors/components/detectorListTable/actions.tsx
+++ b/static/app/views/detectors/components/detectorListTable/actions.tsx
@@ -214,7 +214,7 @@ export function DetectorsTableActions({
         </ActionsBarWrapper>
       </SimpleTable.Header>
       {pageSelected && !allResultsVisible && (
-        <FullWidthAlert type="warning" showIcon={false}>
+        <FullWidthAlert type="warning" system showIcon={false}>
           <Flex justify="center" wrap="wrap" gap="md">
             {allInQuerySelected ? (
               tct('Selected all [count] monitors that match this search query.', {
@@ -243,9 +243,6 @@ export function DetectorsTableActions({
 
 const FullWidthAlert = styled(Alert)`
   grid-column: 1 / -1;
-  border-radius: 0;
-  border: none;
-  border-bottom: 1px solid ${p => p.theme.yellow300};
 `;
 
 const ActionsBarWrapper = styled('div')`


### PR DESCRIPTION
before

<img width="1434" height="904" alt="image" src="https://github.com/user-attachments/assets/725d0d5c-6f51-470c-a7c0-8b3621fbc02c" />


after - looks the same as the issue stream

<img width="1362" height="116" alt="Screenshot 2025-11-07 at 11 40 57 AM" src="https://github.com/user-attachments/assets/40153550-636d-4aa2-bbe6-8b375d4157a7" />
