### PR TITLE
fix(preprod): handle integration permission errors

### DIFF
--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import uuid
 from unittest.mock import Mock, patch
 
+import responses
+
 from sentry.integrations.source_code_management.status_check import StatusCheckStatus
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.repository import Repository
 from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
+from sentry.shared_integrations.exceptions import ApiForbiddenError, IntegrationConfigurationError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -445,3 +448,111 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert "com.example.uploading" in summary
         assert "com.example.failed" in summary
         assert "Upload timeout" in summary
+
+    @responses.activate
+    def test_create_preprod_status_check_task_github_permission_error(self):
+        """Test task handles GitHub permission errors without retrying."""
+        preprod_artifact = self._create_preprod_artifact(
+            state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=preprod_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,
+            max_download_size=1024 * 1024,
+            min_install_size=2 * 1024 * 1024,
+            max_install_size=2 * 1024 * 1024,
+        )
+
+        integration = self.create_integration(
+            organization=self.organization,
+            external_id="123",
+            provider="github",
+            metadata={"access_token": "test_token", "expires_at": "2099-01-01T00:00:00Z"},
+        )
+
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="owner/repo",
+            provider="integrations:github",
+            integration_id=integration.id,
+        )
+
+        responses.add(
+            responses.POST,
+            "https://api.github.com/repos/owner/repo/check-runs",
+            status=403,
+            json={
+                "message": "Resource not accessible by integration",
+                "documentation_url": "https://docs.github.com/rest/checks/runs#create-a-check-run",
+            },
+        )
+
+        with self.tasks():
+            try:
+                create_preprod_status_check_task(preprod_artifact.id)
+                assert False, "Expected IntegrationConfigurationError to be raised"
+            except IntegrationConfigurationError as e:
+                assert "GitHub App lacks permissions" in str(e)
+                assert "required permissions" in str(e)
+
+        # Verify no retries due to ignore policy
+        assert len(responses.calls) == 1
+        assert (
+            responses.calls[0].request.url == "https://api.github.com/repos/owner/repo/check-runs"
+        )
+
+    @responses.activate
+    def test_create_preprod_status_check_task_github_non_permission_403(self):
+        """Test task re-raises non-permission 403 errors (for potential retry)."""
+        preprod_artifact = self._create_preprod_artifact(
+            state=PreprodArtifact.ArtifactState.PROCESSED
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=preprod_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,
+            max_download_size=1024 * 1024,
+            min_install_size=2 * 1024 * 1024,
+            max_install_size=2 * 1024 * 1024,
+        )
+
+        integration = self.create_integration(
+            organization=self.organization,
+            external_id="456",
+            provider="github",
+            metadata={"access_token": "test_token", "expires_at": "2099-01-01T00:00:00Z"},
+        )
+
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="owner/repo",
+            provider="integrations:github",
+            integration_id=integration.id,
+        )
+
+        # 403 error that's NOT permission-related (should be re-raised, not converted)
+        responses.add(
+            responses.POST,
+            "https://api.github.com/repos/owner/repo/check-runs",
+            status=403,
+            json={
+                "message": "Repository is temporarily unavailable",
+            },
+        )
+
+        with self.tasks():
+            try:
+                create_preprod_status_check_task(preprod_artifact.id)
+                assert False, "Expected ApiForbiddenError to be raised"
+            except ApiForbiddenError as e:
+                assert "temporarily unavailable" in str(e)
+
+        assert len(responses.calls) == 1
+        assert (
+            responses.calls[0].request.url == "https://api.github.com/repos/owner/repo/check-runs"
+        )


### PR DESCRIPTION
This is a common issue for orgs when they first integrate and we want extra visibility around when it happens. I see other parts of our integrations codebase treats this as a `IntegrationConfigurationError`, so doing the same here.

I also noticed that these were being retried up to our limit which doesn't make sense since it is not a recoverable error. I added `IntegrationConfigurationError` to our error ignore list.

Resolves EME-611