### PR TITLE
perf(widget-builder): Prevent unnecessary re-render of `DashboardDetail` when opening the Widget Builder

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -227,7 +227,7 @@ class DashboardDetail extends Component<Props, State> {
     if (
       prevProps.organization !== this.props.organization ||
       prevProps.location !== this.props.location ||
-      prevProps.router !== this.props.router ||
+      prevProps.navigate !== this.props.navigate ||
       prevProps.dashboard !== this.props.dashboard
     ) {
       this.setState({

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -226,7 +226,8 @@ class DashboardDetail extends Component<Props, State> {
 
     if (
       prevProps.organization !== this.props.organization ||
-      prevProps.location !== this.props.location ||
+      prevProps.location.query.unselectedSeries !==
+        this.props.location.query.unselectedSeries ||
       prevProps.navigate !== this.props.navigate ||
       prevProps.dashboard !== this.props.dashboard
     ) {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -226,6 +226,10 @@ class DashboardDetail extends Component<Props, State> {
 
     if (
       prevProps.organization !== this.props.organization ||
+      // The only part of `location` used by `WidgetLegendSelectionState` is
+      // `unselectedSeries`. Don't bother comparing anything else. Once this
+      // component is a functional component, we'll move the selection state
+      // into a hook, and make sure it doesn't re-render too much.
       prevProps.location.query.unselectedSeries !==
         this.props.location.query.unselectedSeries ||
       prevProps.navigate !== this.props.navigate ||


### PR DESCRIPTION
`DashboardDetail` is the whole dashboard, so it's expensive to re-render. Right now, when the Widget Builder opens it re-renders twice. One of them is legitimate, because the Widget Builder is now open. One of them is because `widgetBuilderSelectionState` was re-calculated, which is not needed.

We only need to recalculate the selection state if the URL selection changed. If it did not, skip it, and skip the render. This saves like a 300ms render in some cases.

**Before:**
<img width="310" height="190" alt="Screenshot 2025-11-07 at 3 37 09 PM" src="https://github.com/user-attachments/assets/490819f5-21a5-4621-91c8-c349377486e1" />

**After:**
<img width="313" height="218" alt="Screenshot 2025-11-07 at 3 39 51 PM" src="https://github.com/user-attachments/assets/2b6f455a-7586-494d-af76-20fee4b85170" />
