### PR TITLE
ref(tests): remove XMLHttpRequest in mock API

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -275,8 +275,7 @@ class Client implements ApiNamespace.Client {
             abort: () => {},
             then: () => {},
             error: () => {},
-          },
-          new XMLHttpRequest()
+          }
         );
 
         this.handleRequestError(


### PR DESCRIPTION
this isn't needed as all tests pass without it, but it breaks the msw poc because the service worker intercepts that "request" too
