### PR TITLE
feat(crons): Add billing seat management for detector validators

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sentry.models.project import Project
+    from sentry.workflow_engine.models import Detector
 
 MONITOR_CONFIG = {
     "type": "object",
@@ -810,6 +811,15 @@ class MonitorEnvBrokenDetection(Model):
     class Meta:
         app_label = "monitors"
         db_table = "sentry_monitorenvbrokendetection"
+
+
+def get_cron_monitor(detector: Detector) -> Monitor:
+    """
+    Given a detector get the matching cron monitor.
+    """
+    data_source = detector.data_sources.first()
+    assert data_source
+    return Monitor.objects.get(id=int(data_source.source_id))
 
 
 @data_source_type_registry.register(DATA_SOURCE_CRON_MONITOR)

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -6,22 +6,25 @@ from django.conf import settings
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.utils import timezone
+from rest_framework.exceptions import ErrorDetail
 
 from sentry.analytics.events.cron_monitor_created import CronMonitorCreated, FirstCronMonitorCreated
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.models.rule import Rule, RuleSource
-from sentry.monitors.models import Monitor, MonitorStatus, ScheduleType
+from sentry.monitors.models import Monitor, MonitorStatus, ScheduleType, get_cron_monitor
+from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.monitors.validators import (
     MonitorDataSourceValidator,
     MonitorIncidentDetectorValidator,
     MonitorValidator,
 )
+from sentry.quotas.base import SeatAssignmentResult
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.types.actor import Actor
 from sentry.utils.outcomes import Outcome
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
-from sentry.workflow_engine.models import DataConditionGroup
+from sentry.workflow_engine.models import DataConditionGroup, DataSource, DataSourceDetector
 
 
 class MonitorValidatorCreateTest(MonitorTestCase):
@@ -166,7 +169,6 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         }
         validator = MonitorValidator(data=data, context=self.context)
         assert not validator.is_valid()
-        from rest_framework.exceptions import ErrorDetail
 
         assert validator.errors["nonFieldErrors"] == [
             ErrorDetail(
@@ -973,14 +975,6 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert monitor.owner_user_id is None
         assert monitor.owner_team_id is None
 
-    @patch("sentry.quotas.backend.assign_seat")
-    def test_create_source_creates_monitor(self, mock_assign_seat):
-        mock_assign_seat.return_value = Outcome.ACCEPTED
-        validator = self._create_validator()
-        assert validator.is_valid(), validator.errors
-        monitor = validator.validated_create_source(validator.validated_data)
-        self._assert_monitor_attributes(monitor, "Test Monitor", "test-monitor", "0 * * * *")
-
     def test_validate_with_owner(self):
         team = self.create_team(organization=self.organization)
         data = self._get_valid_data(owner=f"team:{team.id}")
@@ -1020,14 +1014,6 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert not validator.is_valid()
         assert "slug" in validator.errors
         assert 'The slug "test-monitor" is already in use.' in str(validator.errors["slug"])
-
-    @patch("sentry.quotas.backend.assign_seat")
-    def test_quota_rejection_disables_monitor(self, mock_assign_seat):
-        mock_assign_seat.return_value = Outcome.RATE_LIMITED
-        validator = self._create_validator()
-        assert validator.is_valid(), validator.errors
-        monitor = validator.validated_create_source(validator.validated_data)
-        assert monitor.status == ObjectStatus.DISABLED
 
     def test_update_monitor(self):
         monitor = Monitor.objects.create(
@@ -1123,3 +1109,203 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
         assert validator.is_valid(), validator.errors
         assert "_creator" in validator.validated_data["data_sources"][0]
         assert validator.validated_data["data_sources"][0]["data_source_type"] == "cron_monitor"
+
+    @patch("sentry.quotas.backend.assign_seat", return_value=Outcome.ACCEPTED)
+    def test_create_enabled_assigns_seat(self, mock_assign_seat):
+        """Test that creating an enabled detector assigns a billing seat."""
+
+        condition_group = DataConditionGroup.objects.create(
+            organization_id=self.organization.id,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        context = {**self.context, "condition_group": condition_group}
+        validator = MonitorIncidentDetectorValidator(
+            data=self.valid_data,
+            context=context,
+        )
+        assert validator.is_valid(), validator.errors
+        detector = validator.save()
+
+        detector.refresh_from_db()
+        assert detector.enabled is True
+
+        # Verify seat was assigned exactly once (not double-called)
+        monitor = get_cron_monitor(detector)
+        mock_assign_seat.assert_called_once_with(DataCategory.MONITOR, monitor)
+
+    @patch("sentry.quotas.backend.assign_seat", return_value=Outcome.RATE_LIMITED)
+    def test_create_enabled_no_seat_available(self, mock_assign_seat):
+        """
+        Test that creating a detector with no seats available creates it but
+        leaves it disabled.
+        """
+        condition_group = DataConditionGroup.objects.create(
+            organization_id=self.organization.id,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        context = {**self.context, "condition_group": condition_group}
+        validator = MonitorIncidentDetectorValidator(
+            data=self.valid_data,
+            context=context,
+        )
+        assert validator.is_valid(), validator.errors
+        detector = validator.save()
+
+        detector.refresh_from_db()
+        # Detector created but not enabled due to no seat assignment
+        assert detector.enabled is False
+        monitor = get_cron_monitor(detector)
+        assert monitor.status == ObjectStatus.DISABLED
+
+        # Verify seat assignment was attempted exactly once (not double-called)
+        mock_assign_seat.assert_called_once_with(DataCategory.MONITOR, monitor)
+
+    @patch("sentry.quotas.backend.assign_seat", return_value=Outcome.ACCEPTED)
+    def test_update_enable_assigns_seat(self, mock_assign_seat):
+        """
+        Test that enabling a previously disabled detector assigns a seat.
+        """
+        # Create a disabled detector
+        detector = self.create_detector(
+            project=self.project,
+            name="Test Detector",
+            type="monitor_check_in_failure",
+            enabled=False,
+        )
+        monitor = self._create_monitor(
+            name="Test Monitor",
+            slug="test-monitor",
+            status=ObjectStatus.DISABLED,
+        )
+        data_source = DataSource.objects.create(
+            type=DATA_SOURCE_CRON_MONITOR,
+            organization_id=self.organization.id,
+            source_id=str(monitor.id),
+        )
+        DataSourceDetector.objects.create(data_source=data_source, detector=detector)
+
+        validator = MonitorIncidentDetectorValidator(
+            instance=detector, data={"enabled": True}, context=self.context, partial=True
+        )
+        assert validator.is_valid(), validator.errors
+        validator.save()
+
+        detector.refresh_from_db()
+        monitor.refresh_from_db()
+        assert detector.enabled is True
+        assert monitor.status == ObjectStatus.ACTIVE
+
+        # Verify seat was assigned exactly once
+        mock_assign_seat.assert_called_once_with(DataCategory.MONITOR, monitor)
+
+    @patch(
+        "sentry.quotas.backend.check_assign_seat",
+        return_value=SeatAssignmentResult(assignable=False, reason="No seats available"),
+    )
+    def test_update_enable_no_seat_available(self, mock_check_seat):
+        """
+        Test that enabling fails with validation error when no seats are
+        available.
+        """
+        # Create a disabled detector
+        detector = self.create_detector(
+            project=self.project,
+            name="Test Detector",
+            type="monitor_check_in_failure",
+            enabled=False,
+        )
+        monitor = self._create_monitor(
+            name="Test Monitor",
+            slug="test-monitor",
+            status=ObjectStatus.DISABLED,
+        )
+        data_source = DataSource.objects.create(
+            type=DATA_SOURCE_CRON_MONITOR,
+            organization_id=self.organization.id,
+            source_id=str(monitor.id),
+        )
+        DataSourceDetector.objects.create(data_source=data_source, detector=detector)
+
+        validator = MonitorIncidentDetectorValidator(
+            instance=detector, data={"enabled": True}, context=self.context, partial=True
+        )
+
+        # Validation should fail due to no seats available
+        assert not validator.is_valid()
+        assert "enabled" in validator.errors
+        assert validator.errors["enabled"] == ["No seats available"]
+
+        # Detector and monitor should still be disabled
+        detector.refresh_from_db()
+        monitor.refresh_from_db()
+        assert detector.enabled is False
+        assert monitor.status == ObjectStatus.DISABLED
+
+        # Verify seat availability check was performed
+        mock_check_seat.assert_called_with(DataCategory.MONITOR, monitor)
+
+    @patch("sentry.quotas.backend.disable_seat")
+    def test_update_disable_disables_seat(self, mock_disable_seat):
+        """Test that disabling a previously enabled detector disables the seat."""
+        # Create an enabled detector
+        detector = self.create_detector(
+            project=self.project,
+            name="Test Detector",
+            type="monitor_check_in_failure",
+            enabled=True,
+        )
+        monitor = self._create_monitor(
+            name="Test Monitor",
+            slug="test-monitor",
+            status=ObjectStatus.ACTIVE,
+        )
+        data_source = DataSource.objects.create(
+            type=DATA_SOURCE_CRON_MONITOR,
+            organization_id=self.organization.id,
+            source_id=str(monitor.id),
+        )
+        DataSourceDetector.objects.create(data_source=data_source, detector=detector)
+
+        validator = MonitorIncidentDetectorValidator(
+            instance=detector, data={"enabled": False}, context=self.context, partial=True
+        )
+        assert validator.is_valid(), validator.errors
+        validator.save()
+
+        detector.refresh_from_db()
+        monitor.refresh_from_db()
+        assert detector.enabled is False
+        assert monitor.status == ObjectStatus.DISABLED
+
+        # Verify disable_seat was called exactly once
+        mock_disable_seat.assert_called_once_with(DataCategory.MONITOR, monitor)
+
+    @patch("sentry.quotas.backend.remove_seat")
+    def test_delete_removes_seat(self, mock_remove_seat: MagicMock) -> None:
+        """Test that deleting a detector removes its billing seat immediately."""
+        detector = self.create_detector(
+            project=self.project,
+            name="Test Detector",
+            type="monitor_check_in_failure",
+            enabled=True,
+        )
+        monitor = self._create_monitor(
+            name="Test Monitor",
+            slug="test-monitor",
+            status=ObjectStatus.ACTIVE,
+        )
+        data_source = DataSource.objects.create(
+            type=DATA_SOURCE_CRON_MONITOR,
+            organization_id=self.organization.id,
+            source_id=str(monitor.id),
+        )
+        DataSourceDetector.objects.create(data_source=data_source, detector=detector)
+
+        validator = MonitorIncidentDetectorValidator(
+            instance=detector, data={}, context=self.context
+        )
+
+        validator.delete()
+
+        # Verify remove_seat was called exactly once
+        mock_remove_seat.assert_called_once_with(DataCategory.MONITOR, monitor)


### PR DESCRIPTION
Implements billing seat management for cron monitor detectors via the MonitorIncidentDetectorValidator. This ensures that cron monitors created through the detector API properly handle seat assignment, validation, and removal.

Changes:
- Add validate_enabled() to check seat availability before enabling
- Modify create() to assign seats with graceful degradation when no seats are available (detector created but disabled)
- Modify update() to handle enable/disable transitions with seat operations and race condition handling
- Add delete() to remove seats immediately when detector is deleted
- Add comprehensive test coverage for all seat management scenarios

Uses generic seat APIs (assign_seat, check_assign_seat, disable_seat, remove_seat) with DataCategory.MONITOR following the same pattern as uptime monitors.

Fixes [NEW-619: Ensure CRUD / enable+disable Cron Detectors in new UI handles assigning / unassigning seats](https://linear.app/getsentry/issue/NEW-619/ensure-crud-enabledisable-cron-detectors-in-new-ui-handles-assigning)