### PR TITLE
feat(aci): Track DataCondition errors and propagate such results as tainted

### DIFF
--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -5,23 +5,20 @@ from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.group import DEFAULT_TYPE_ID
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.endpoints.validators.error_detector import ErrorDetectorValidator
-from sentry.workflow_engine.handlers.detector.base import DetectorHandler
-from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
-    DetectorGroupKey,
-    DetectorSettings,
+from sentry.workflow_engine.handlers.detector.base import (
+    DetectorHandler,
+    GroupedDetectorEvaluationResult,
 )
+from sentry.workflow_engine.models.data_source import DataPacket
+from sentry.workflow_engine.types import DetectorSettings
 
 T = TypeVar("T")
 
 
 class ErrorDetectorHandler(DetectorHandler):
-    def evaluate(
-        self, data_packet: DataPacket[T]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+    def evaluate_impl(self, data_packet: DataPacket[T]) -> GroupedDetectorEvaluationResult:
         # placeholder
-        return {}
+        return GroupedDetectorEvaluationResult(result={}, tainted=False)
 
 
 @dataclass(frozen=True)

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -4,8 +4,15 @@ __all__ = [
     "DetectorHandler",
     "DetectorOccurrence",
     "DetectorStateData",
+    "GroupedDetectorEvaluationResult",
     "StatefulDetectorHandler",
 ]
 
-from .base import DataPacketEvaluationType, DataPacketType, DetectorHandler, DetectorOccurrence
+from .base import (
+    DataPacketEvaluationType,
+    DataPacketType,
+    DetectorHandler,
+    DetectorOccurrence,
+    GroupedDetectorEvaluationResult,
+)
 from .stateful import DetectorStateData, StatefulDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from sentry.issues.grouptype import GroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.types.actor import Actor
+from sentry.utils import metrics
 from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
 from sentry.workflow_engine.types import (
@@ -77,6 +78,12 @@ class DetectorOccurrence:
         )
 
 
+@dataclass(frozen=True)
+class GroupedDetectorEvaluationResult:
+    result: dict[DetectorGroupKey, DetectorEvaluationResult]
+    tainted: bool
+
+
 # TODO - @saponifi3d - Change this class to be a pure ABC and remove the `__init__` method.
 # TODO - @saponifi3d - Once the change is made, we should introduce a `BaseDetector` class to evaluate simple cases
 class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]):
@@ -102,10 +109,27 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]
         else:
             self.condition_group = None
 
-    @abc.abstractmethod
     def evaluate(
         self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult] | None:
+    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+        tags = {
+            "detector_type": self.detector.type,
+            "result": "unknown",
+        }
+        try:
+            value = self.evaluate_impl(data_packet)
+            tags["result"] = "tainted" if value.tainted else "success"
+            metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
+            return value.result
+        except Exception:
+            tags["result"] = "failure"
+            metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
+            raise
+
+    @abc.abstractmethod
+    def evaluate_impl(
+        self, data_packet: DataPacket[DataPacketType]
+    ) -> GroupedDetectorEvaluationResult:
         """
         This method is used to evaluate the data packet's value against the conditions on the detector.
         """

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -394,7 +394,7 @@ class StatefulDetectorHandler(
                 group_data_values[group_key]
             )
 
-            if condition_results is not None and condition_results.logic_result.error is not None:
+            if condition_results is not None and condition_results.logic_result.is_tainted():
                 tainted = True
 
             if condition_results is None or condition_results.logic_result.triggered is False:

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -19,6 +19,7 @@ from sentry.workflow_engine.handlers.detector.base import (
     DetectorHandler,
     DetectorOccurrence,
     EventData,
+    GroupedDetectorEvaluationResult,
 )
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
 from sentry.workflow_engine.processors.data_condition_group import (
@@ -371,13 +372,15 @@ class StatefulDetectorHandler(
             ],
         }
 
-    def evaluate(
+    def evaluate_impl(
         self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+    ) -> GroupedDetectorEvaluationResult:
         dedupe_value = self.extract_dedupe_value(data_packet)
         group_data_values = self._extract_value_from_packet(data_packet)
         state = self.state_manager.get_state_data(list(group_data_values.keys()))
         results: dict[DetectorGroupKey, DetectorEvaluationResult] = {}
+
+        tainted = False
 
         for group_key, data_value in group_data_values.items():
             state_data: DetectorStateData = state[group_key]
@@ -391,7 +394,10 @@ class StatefulDetectorHandler(
                 group_data_values[group_key]
             )
 
-            if condition_results is None or condition_results.logic_result is False:
+            if condition_results is not None and condition_results.logic_result.error is not None:
+                tainted = True
+
+            if condition_results is None or condition_results.logic_result.triggered is False:
                 # Invalid condition result, nothing we can do
                 # Or if we didn't match any conditions in the evaluation
                 continue
@@ -441,7 +447,7 @@ class StatefulDetectorHandler(
             )
 
         self.state_manager.commit_state_updates()
-        return results
+        return GroupedDetectorEvaluationResult(result=results, tainted=tainted)
 
     def _create_resolve_message(
         self,
@@ -624,7 +630,7 @@ class StatefulDetectorHandler(
                 },
             )
 
-        if condition_evaluation.logic_result:
+        if condition_evaluation.logic_result.triggered:
             validated_condition_results: list[DetectorPriorityLevel] = [
                 condition_result.result
                 for condition_result in condition_evaluation.condition_results

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -19,7 +19,7 @@ from sentry.models.owner_base import OwnerModel
 from sentry.workflow_engine.models.data_condition import DataCondition, is_slow_condition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
 from sentry.workflow_engine.processors.data_condition_group import TriggerResult
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 
 from .json_config import JSONConfigBase
 
@@ -117,7 +117,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
                 "DataConditionGroup does not exist",
                 extra={"id": self.when_condition_group_id},
             )
-            return TriggerResult.FALSE, []
+            return TriggerResult(False, ConditionError(msg="DataConditionGroup does not exist")), []
         group_evaluation, remaining_conditions = process_data_condition_group(
             group, workflow_event_data, when_data_conditions
         )

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -18,6 +18,7 @@ from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.models.owner_base import OwnerModel
 from sentry.workflow_engine.models.data_condition import DataCondition, is_slow_condition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.processors.data_condition_group import TriggerResult
 from sentry.workflow_engine.types import WorkflowEventData
 
 from .json_config import JSONConfigBase
@@ -93,7 +94,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
 
     def evaluate_trigger_conditions(
         self, event_data: WorkflowEventData, when_data_conditions: list[DataCondition] | None = None
-    ) -> tuple[bool, list[DataCondition]]:
+    ) -> tuple[TriggerResult, list[DataCondition]]:
         """
         Evaluate the conditions for the workflow trigger and return if the evaluation was successful.
         If there aren't any workflow trigger conditions, the workflow is considered triggered.
@@ -104,7 +105,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         )
 
         if self.when_condition_group_id is None:
-            return True, []
+            return TriggerResult.TRUE, []
 
         workflow_event_data = replace(event_data, workflow_env=self.environment)
         try:
@@ -116,7 +117,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
                 "DataConditionGroup does not exist",
                 extra={"id": self.when_condition_group_id},
             )
-            return False, []
+            return TriggerResult.FALSE, []
         group_evaluation, remaining_conditions = process_data_condition_group(
             group, workflow_event_data, when_data_conditions
         )

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -41,18 +41,20 @@ class TriggerResult:
 
     @staticmethod
     def any(items: Iterable["TriggerResult"]) -> "TriggerResult":
-        for _ in (item for item in items if item.triggered and item.error is None):
+        items_list = list(items)
+        for _ in (item for item in items_list if item.triggered and item.error is None):
             return TriggerResult(triggered=True, error=None)
         # If we didn't have any untained Trues, the result is tainted.
-        some_error = next((item.error for item in items if item.error is not None), None)
-        return TriggerResult(triggered=any(item.triggered for item in items), error=some_error)
+        some_error = next((item.error for item in items_list if item.error is not None), None)
+        return TriggerResult(triggered=any(item.triggered for item in items_list), error=some_error)
 
     @staticmethod
     def all(items: Iterable["TriggerResult"]) -> "TriggerResult":
-        some_error = next((item.error for item in items if item.error is not None), None)
+        items_list = list(items)
+        some_error = next((item.error for item in items_list if item.error is not None), None)
         # if anything was tainted, the result is tainted.
         return TriggerResult(
-            triggered=all(item.triggered for item in items),
+            triggered=all(item.triggered for item in items_list),
             error=some_error,
         )
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -53,6 +53,15 @@ class TriggerResult:
         """
         return self.error is not None
 
+    def with_error(self, error: ConditionError) -> "TriggerResult":
+        """
+        Returns a new TriggerResult with the same triggered value but the given error.
+        If the result is already tainted, the error is ignored.
+        """
+        if self.is_tainted():
+            return self
+        return TriggerResult(triggered=self.triggered, error=error)
+
     @staticmethod
     def any(items: Iterable["TriggerResult"]) -> "TriggerResult":
         """

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
-from typing import TypeVar
+from collections.abc import Iterable
+from typing import ClassVar, NoReturn, TypeVar
 
 import sentry_sdk
 
@@ -8,7 +9,7 @@ from sentry.utils.function_cache import cache_func_for_models
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import is_slow_condition
 from sentry.workflow_engine.processors.data_condition import split_conditions_by_speed
-from sentry.workflow_engine.types import DataConditionResult
+from sentry.workflow_engine.types import ConditionError, DataConditionResult
 from sentry.workflow_engine.utils import scopedstats
 
 logger = logging.getLogger(__name__)
@@ -16,16 +17,77 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+@dataclasses.dataclass(frozen=True)
+class TriggerResult:
+    """
+    Represents the result of a trigger evaluation with taint tracking.
+
+    The triggered field indicates whether the trigger condition was met.
+
+    The error field contains error information if the evaluation was tainted.
+    When error is not None, it indicates that the result may not be accurate due to
+    errors encountered during evaluation. Note that there may have been additional
+    errors beyond the one captured here - this field contains a representative error
+    from the evaluation, not necessarily all errors that occurred.
+    """
+
+    triggered: bool
+    error: ConditionError | None
+
+    # Constant untainted TriggerResult values (initialized after class definition).
+    # These represent clean success/failure with no errors.
+    TRUE: ClassVar["TriggerResult"]
+    FALSE: ClassVar["TriggerResult"]
+
+    @staticmethod
+    def any(items: Iterable["TriggerResult"]) -> "TriggerResult":
+        for _ in (item for item in items if item.triggered and item.error is None):
+            return TriggerResult(triggered=True, error=None)
+        # If we didn't have any untained Trues, the result is tainted.
+        some_error = next((item.error for item in items if item.error is not None), None)
+        return TriggerResult(triggered=any(item.triggered for item in items), error=some_error)
+
+    @staticmethod
+    def all(items: Iterable["TriggerResult"]) -> "TriggerResult":
+        some_error = next((item.error for item in items if item.error is not None), None)
+        # if anything was tainted, the result is tainted.
+        return TriggerResult(
+            triggered=all(item.triggered for item in items),
+            error=some_error,
+        )
+
+    def __or__(self, other: "TriggerResult") -> "TriggerResult":
+        return TriggerResult(
+            triggered=self.triggered or other.triggered,
+            error=self.error or other.error,
+        )
+
+    def __and__(self, other: "TriggerResult") -> "TriggerResult":
+        return TriggerResult(
+            triggered=self.triggered and other.triggered,
+            error=self.error or other.error,
+        )
+
+    def __bool__(self) -> NoReturn:
+        raise AssertionError("TriggerResult cannot be used as a boolean")
+
+
+# Constant untainted TriggerResult values for common cases.
+# These are singleton instances representing clean success/failure with no errors.
+TriggerResult.TRUE = TriggerResult(triggered=True, error=None)
+TriggerResult.FALSE = TriggerResult(triggered=False, error=None)
+
+
 @dataclasses.dataclass()
 class ProcessedDataCondition:
-    logic_result: bool
+    logic_result: TriggerResult
     condition: DataCondition
     result: DataConditionResult
 
 
 @dataclasses.dataclass()
 class ProcessedDataConditionGroup:
-    logic_result: bool
+    logic_result: TriggerResult
     condition_results: list[ProcessedDataCondition]
 
 
@@ -76,35 +138,35 @@ def evaluate_condition_group_results(
     condition_results: list[ProcessedDataCondition],
     logic_type: DataConditionGroup.Type,
 ) -> ProcessedDataConditionGroup:
-    logic_result = False
+    logic_result = TriggerResult.FALSE
     group_condition_results: list[ProcessedDataCondition] = []
 
     if logic_type == DataConditionGroup.Type.NONE:
         # if we get to this point, no conditions were met
         # because we would have short-circuited
-        logic_result = True
+        logic_result = TriggerResult.TRUE
 
     elif logic_type == DataConditionGroup.Type.ANY:
-        logic_result = any(
-            [condition_result.logic_result for condition_result in condition_results]
+        logic_result = TriggerResult.any(
+            condition_result.logic_result for condition_result in condition_results
         )
 
-        if logic_result:
+        if logic_result.triggered:
             group_condition_results = [
                 condition_result
                 for condition_result in condition_results
-                if condition_result.logic_result
+                if condition_result.logic_result.triggered
             ]
 
     elif logic_type == DataConditionGroup.Type.ALL:
         conditions_met = [condition_result.logic_result for condition_result in condition_results]
-        logic_result = all(conditions_met)
+        logic_result = TriggerResult.all(conditions_met)
 
-        if logic_result:
+        if logic_result.triggered:
             group_condition_results = [
                 condition_result
                 for condition_result in condition_results
-                if condition_result.logic_result
+                if condition_result.logic_result.triggered
             ]
 
     return ProcessedDataConditionGroup(
@@ -126,33 +188,44 @@ def evaluate_data_conditions(
 
     if len(conditions_to_evaluate) == 0:
         # if we don't have any conditions, always return True
-        return ProcessedDataConditionGroup(logic_result=True, condition_results=[])
+        return ProcessedDataConditionGroup(logic_result=TriggerResult.TRUE, condition_results=[])
 
     for condition, value in conditions_to_evaluate:
         evaluation_result = condition.evaluate_value(value)
-        is_condition_triggered = evaluation_result is not None
+        cleaned_result: DataConditionResult
+        if isinstance(evaluation_result, ConditionError):
+            cleaned_result = None
+        else:
+            cleaned_result = evaluation_result
+        trigger_result = TriggerResult(
+            triggered=cleaned_result is not None,
+            error=evaluation_result if isinstance(evaluation_result, ConditionError) else None,
+        )
 
-        if is_condition_triggered:
+        if trigger_result.triggered:
             # Check for short-circuiting evaluations
             if logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
                 condition_result = ProcessedDataCondition(
-                    logic_result=True,
+                    logic_result=trigger_result,
                     condition=condition,
-                    result=evaluation_result,
+                    result=cleaned_result,
                 )
 
                 return ProcessedDataConditionGroup(
-                    logic_result=is_condition_triggered,
+                    logic_result=trigger_result,
                     condition_results=[condition_result],
                 )
 
             if logic_type == DataConditionGroup.Type.NONE:
-                return ProcessedDataConditionGroup(logic_result=False, condition_results=[])
+                return ProcessedDataConditionGroup(
+                    logic_result=TriggerResult(triggered=False, error=trigger_result.error),
+                    condition_results=[],
+                )
 
         result = ProcessedDataCondition(
-            logic_result=is_condition_triggered,
+            logic_result=trigger_result,
             condition=condition,
-            result=evaluation_result,
+            result=cleaned_result,
         )
         condition_results.append(result)
 
@@ -177,7 +250,10 @@ def process_data_condition_group(
             "Invalid DataConditionGroup.logic_type found in process_data_condition_group",
             extra={"logic_type": group.logic_type},
         )
-        return ProcessedDataConditionGroup(logic_result=False, condition_results=[]), []
+        trigger_result = TriggerResult(
+            triggered=False, error=ConditionError(msg="Invalid DataConditionGroup.logic_type")
+        )
+        return ProcessedDataConditionGroup(logic_result=trigger_result, condition_results=[]), []
 
     # Check if conditions are already prefetched before using cache
     all_conditions: list[DataCondition]
@@ -197,7 +273,7 @@ def process_data_condition_group(
         # there are only slow conditions to evaluate, do not evaluate an empty list of conditions
         # which would evaluate to True
         condition_group_result = ProcessedDataConditionGroup(
-            logic_result=False,
+            logic_result=TriggerResult.FALSE,
             condition_results=condition_results,
         )
         return condition_group_result, split_conds.slow
@@ -208,8 +284,8 @@ def process_data_condition_group(
     logic_result = processed_condition_group.logic_result
 
     # Check to see if we should return any remaining conditions based on the results
-    is_short_circuit_all = not logic_result and logic_type == DataConditionGroup.Type.ALL
-    is_short_circuit_any = logic_result and logic_type in (
+    is_short_circuit_all = not logic_result.triggered and logic_type == DataConditionGroup.Type.ALL
+    is_short_circuit_any = logic_result.triggered and logic_type in (
         DataConditionGroup.Type.ANY,
         DataConditionGroup.Type.ANY_SHORT_CIRCUIT,
     )

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -533,7 +533,7 @@ def _group_result_for_dcg(
 
     return evaluate_data_conditions(
         conditions_to_evaluate, DataConditionGroup.Type(dcg.logic_type)
-    ).logic_result
+    ).logic_result.triggered
 
 
 @sentry_sdk.trace

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -322,9 +322,6 @@ def process_detectors[T](
         ):
             detector_results = handler.evaluate(data_packet)
 
-        if detector_results is None:
-            return results
-
         for result in detector_results.values():
             logger_extra = {
                 "detector": detector.id,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -224,7 +224,7 @@ def evaluate_workflow_triggers(
                     },
                 )
         else:
-            if evaluation:
+            if evaluation.triggered:
                 triggered_workflows.add(workflow)
                 if dual_processing_logs_enabled:
                     try:
@@ -357,7 +357,7 @@ def evaluate_workflows_action_filters(
                     },
                 )
         else:
-            if group_evaluation.logic_result:
+            if group_evaluation.logic_result.triggered:
                 if delayed_workflow_item := queue_items_by_workflow.get(workflow):
                     if delayed_workflow_item.delayed_when_group_id:
                         # If there are already delayed when conditions,

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -50,6 +50,15 @@ DataConditionResult = DetectorPriorityLevel | int | float | bool | None
 
 @dataclass(frozen=True)
 class ConditionError:
+    """
+    Represents the failed evaluation of a data condition.
+    Not intended to be detailed or comprehensive; code returning this
+    is assumed to have already reported the error.
+
+    A message is provided for clarity and to aid in debugging; a singleton placeholder
+    value would also work, but would be less clear.
+    """
+
     msg: str
 
 
@@ -165,6 +174,11 @@ class DataConditionHandler(Generic[T]):
 
     @staticmethod
     def evaluate_value(value: T, comparison: Any) -> DataConditionResult:
+        """
+        Evaluate the value of a data condition.
+        Any error that results in a failure to provide a correct result should
+        raise a DataConditionEvaluationException.
+        """
         raise NotImplementedError
 
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -49,6 +49,11 @@ DataConditionResult = DetectorPriorityLevel | int | float | bool | None
 
 
 @dataclass(frozen=True)
+class ConditionError:
+    msg: str
+
+
+@dataclass(frozen=True)
 class DetectorEvaluationResult:
     # TODO - Should group key live at this level?
     group_key: DetectorGroupKey

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -13,13 +13,16 @@ from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.workflow_engine.handlers.detector import DetectorHandler, DetectorOccurrence
+from sentry.workflow_engine.handlers.detector import (
+    DetectorHandler,
+    DetectorOccurrence,
+    GroupedDetectorEvaluationResult,
+)
 from sentry.workflow_engine.handlers.detector.base import EventData
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
-    DetectorGroupKey,
     DetectorPriorityLevel,
     DetectorSettings,
 )
@@ -40,9 +43,13 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
         self.registry_patcher.start()
 
         class MockDetectorHandler(DetectorHandler[dict[Never, Never], bool]):
-            def evaluate(
+            def evaluate_impl(
                 self, data_packet: DataPacket[dict[Never, Never]]
-            ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+            ) -> GroupedDetectorEvaluationResult:
+                return GroupedDetectorEvaluationResult(
+                    result={None: DetectorEvaluationResult(None, True, DetectorPriorityLevel.HIGH)},
+                    tainted=False,
+                )
                 return {None: DetectorEvaluationResult(None, True, DetectorPriorityLevel.HIGH)}
 
             def extract_value(self, data_packet: DataPacket[dict[Never, Never]]) -> bool:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -50,7 +50,6 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
                     result={None: DetectorEvaluationResult(None, True, DetectorPriorityLevel.HIGH)},
                     tainted=False,
                 )
-                return {None: DetectorEvaluationResult(None, True, DetectorPriorityLevel.HIGH)}
 
             def extract_value(self, data_packet: DataPacket[dict[Never, Never]]) -> bool:
                 return True

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -5,7 +5,7 @@ import pytest
 
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models.data_condition import Condition, DataConditionEvaluationException
-from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.types import ConditionError, DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest, DataConditionHandlerMixin
 
 
@@ -18,7 +18,7 @@ class GetConditionResultTest(TestCase):
     def test_str(self) -> None:
         dc = self.create_data_condition(condition_result="wrong")
         with mock.patch("sentry.workflow_engine.models.data_condition.logger") as mock_logger:
-            assert dc.get_condition_result() is None
+            assert dc.get_condition_result() == ConditionError(msg="Invalid condition result")
             assert mock_logger.error.call_args[0][0] == "Invalid condition result"
 
     def test_int(self) -> None:
@@ -94,7 +94,7 @@ class EvaluateValueTest(DataConditionHandlerMixin, BaseWorkflowTest):
         dc = self.create_data_condition(
             type=Condition.GREATER, comparison=1.0, condition_result="wrong"
         )
-        assert dc.evaluate_value(2) is None
+        assert dc.evaluate_value(2) == ConditionError(msg="Invalid condition result")
 
     def test_condition_evaluation__data_condition_exception(self) -> None:
         def evaluate_value(value: int, comparison: int) -> bool:

--- a/tests/sentry/workflow_engine/models/test_workflow.py
+++ b/tests/sentry/workflow_engine/models/test_workflow.py
@@ -32,21 +32,21 @@ class WorkflowTest(BaseWorkflowTest):
 
     def test_evaluate_trigger_conditions__condition_new_event__True(self) -> None:
         evaluation, _ = self.workflow.evaluate_trigger_conditions(self.event_data)
-        assert evaluation is True
+        assert evaluation.triggered is True
 
     def test_evaluate_trigger_conditions__condition_new_event__False(self) -> None:
         # Update event to have been seen before
         self.group_event.group.times_seen = 5
 
         evaluation, _ = self.workflow.evaluate_trigger_conditions(self.event_data)
-        assert evaluation is False
+        assert evaluation.triggered is False
 
     def test_evaluate_trigger_conditions__no_conditions(self) -> None:
         self.workflow.when_condition_group = None
         self.workflow.save()
 
         evaluation, _ = self.workflow.evaluate_trigger_conditions(self.event_data)
-        assert evaluation is True
+        assert evaluation.triggered is True
 
     def test_evaluate_trigger_conditions__slow_condition(self) -> None:
         # Update group to _all_, since the fast condition is met
@@ -60,7 +60,7 @@ class WorkflowTest(BaseWorkflowTest):
             self.event_data
         )
 
-        assert evaluation is True
+        assert evaluation.triggered is True
         assert remaining_conditions == [slow_condition]
 
     def test_full_clean__success(self) -> None:

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -546,3 +546,25 @@ class TestTriggerResult(unittest.TestCase):
         result = TriggerResult.all(items)
         assert result.triggered is False
         assert result.error is None
+
+    def test_any_with_generator_preserves_error(self):
+        error = ConditionError(msg="test error")
+        items = [
+            TriggerResult(triggered=False, error=None),
+            TriggerResult(triggered=False, error=error),
+            TriggerResult(triggered=False, error=None),
+        ]
+        result = TriggerResult.any(item for item in items)
+        assert result.triggered is False
+        assert result.error == error
+
+    def test_all_with_generator_preserves_error(self):
+        error = ConditionError(msg="test error")
+        items = [
+            TriggerResult(triggered=True, error=None),
+            TriggerResult(triggered=True, error=error),
+            TriggerResult(triggered=True, error=None),
+        ]
+        result = TriggerResult.all(item for item in items)
+        assert result.triggered is True
+        assert result.error == error

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -39,6 +39,7 @@ from sentry.workflow_engine.models.data_condition import (
 )
 from sentry.workflow_engine.processors.data_condition_group import (
     ProcessedDataConditionGroup,
+    TriggerResult,
     get_slow_conditions_for_groups,
 )
 from sentry.workflow_engine.processors.delayed_workflow import (
@@ -940,7 +941,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_fire_actions_for_groups__workflow_fire_history(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            ProcessedDataConditionGroup(logic_result=True, condition_results=[]),
+            ProcessedDataConditionGroup(logic_result=TriggerResult.TRUE, condition_results=[]),
             [],
         )
 

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -220,9 +220,14 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         with mock.patch("sentry.utils.metrics.incr") as mock_incr:
             process_detectors(data_packet, [detector])
 
-            mock_incr.assert_called_once_with(
+            mock_incr.assert_any_call(
                 "workflow_engine.process_detector",
                 tags={"detector_type": detector.type},
+            )
+            mock_incr.assert_any_call(
+                "workflow_engine_detector.evaluation",
+                tags={"detector_type": detector.type, "result": "success"},
+                sample_rate=1.0,
             )
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")


### PR DESCRIPTION
DataCondition failures are currently reported to Sentry/logs individually, then treated as a non-triggering.
Here we return a special error type, so that the caller knows the result isn't necessarily reliable, and in DataConditionGroup logic we aggregate these results in such a way that we know at the end if an untrustworthy result influenced the outcome.

These "tainted" results are reported for each Detector evaluation, so we can track how often our results were influenced by errors, giving us a better high level picture of user impact than we'd have purely by looking at individual reported error counts.

This pattern will be extended to cover over DataCondition evaluation cases.
