### PR TITLE
:bug: fix(github): Use `issues.assignees` for inbound assignment sync

### DIFF
--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -3012,7 +3012,27 @@ ISSUES_ASSIGNED_EVENT_EXAMPLE = r"""{
       "type": "User",
       "site_admin": false
     },
-    "assignees": [],
+    "assignees": [
+      {
+        "login": "octocat",
+        "id": 1,
+        "avatar_url": "https://avatars.githubusercontent.com/u/1?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      }
+    ],
     "milestone": null,
     "comments": 0,
     "created_at": "2015-05-05T23:40:28Z",

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -547,14 +547,43 @@ class IssuesEventWebhook(GitHubWebhook):
         """
         Handle issue assignment and unassignment events.
 
+        When switching assignees, GitHub sends two webhooks (assigned and unassigned) in
+        non-deterministic order. To avoid race conditions, we sync based on the current
+        state in issue.assignees rather than the delta in the assignee field.
+
         Args:
             integration: The GitHub integration
             event: The webhook event payload
             external_issue_key: The formatted issue key
             action: The action type ('assigned' or 'unassigned')
         """
-        assignee = event.get("assignee", {})
-        assignee_gh_name = assignee.get("login")
+        # Use issue.assignees (current state) instead of assignee (delta) to avoid race conditions
+        issue = event.get("issue", {})
+        assignees = issue.get("assignees", [])
+
+        # If there are no assignees, deassign
+        if not assignees:
+            sync_group_assignee_inbound_by_external_actor(
+                integration=integration,
+                external_user_name="",  # Not used for deassignment
+                external_issue_key=external_issue_key,
+                assign=False,
+            )
+            logger.info(
+                "github.webhook.assignment.synced",
+                extra={
+                    "integration_id": integration.id,
+                    "external_issue_key": external_issue_key,
+                    "assignee_name": None,
+                    "action": "deassigned",
+                },
+            )
+            return
+
+        # GitHub supports multiple assignees, but Sentry currently only supports one
+        # Take the first assignee from the current state
+        first_assignee = assignees[0]
+        assignee_gh_name = first_assignee.get("login")
 
         if not assignee_gh_name:
             logger.warning(
@@ -574,7 +603,7 @@ class IssuesEventWebhook(GitHubWebhook):
             integration=integration,
             external_user_name=assignee_name,
             external_issue_key=external_issue_key,
-            assign=(action == IssueEvenntWebhookActionType.ASSIGNED.value),
+            assign=True,
         )
 
         logger.info(
@@ -584,6 +613,7 @@ class IssuesEventWebhook(GitHubWebhook):
                 "external_issue_key": external_issue_key,
                 "assignee_name": assignee_name,
                 "action": action,
+                "total_assignees": len(assignees),
             },
         )
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -1038,8 +1038,8 @@ class IssuesEventWebhookTest(APITestCase):
             data=ISSUES_ASSIGNED_EVENT_EXAMPLE,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="issues",
-            HTTP_X_HUB_SIGNATURE="sha1=e19d80f5a6e09e20d126e923464778bb4b601a7e",
-            HTTP_X_HUB_SIGNATURE_256="sha256=e91927e8d8e0db9cb1f5ead889bba2deb24aa2f8925a8eae85ba732424604489",
+            HTTP_X_HUB_SIGNATURE="sha1=75deab06ede0068fe16b5f1f6ee1a9509738e006",
+            HTTP_X_HUB_SIGNATURE_256="sha256=1703af48011c6709662f776163fce1e86772eff189f94e1ebff5ad66a81b711e",
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 
@@ -1081,9 +1081,11 @@ class IssuesEventWebhookTest(APITestCase):
 
         rpc_integration = integration_service.get_integration(integration_id=self.integration.id)
 
+        # With the fix, we now use issue.assignees (current state) instead of assignee (delta)
+        # ISSUES_UNASSIGNED_EVENT_EXAMPLE has assignees=[], so we deassign
         mock_sync.assert_called_once_with(
             integration=rpc_integration,
-            external_user_name="@octocat",
+            external_user_name="",
             external_issue_key="baxterthehacker/public-repo#2",
             assign=False,
         )
@@ -1123,8 +1125,8 @@ class IssuesEventWebhookTest(APITestCase):
             data=ISSUES_ASSIGNED_EVENT_EXAMPLE,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="issues",
-            HTTP_X_HUB_SIGNATURE="sha1=e19d80f5a6e09e20d126e923464778bb4b601a7e",
-            HTTP_X_HUB_SIGNATURE_256="sha256=e91927e8d8e0db9cb1f5ead889bba2deb24aa2f8925a8eae85ba732424604489",
+            HTTP_X_HUB_SIGNATURE="sha1=75deab06ede0068fe16b5f1f6ee1a9509738e006",
+            HTTP_X_HUB_SIGNATURE_256="sha256=1703af48011c6709662f776163fce1e86772eff189f94e1ebff5ad66a81b711e",
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 


### PR DESCRIPTION
## Problem

When switching assignees on a GitHub issue externally (e.g., changing from @billybobthebot to @iamrajjoshi), Sentry would sometimes end up with the wrong assignee or no assignee at all.

## Root cause: 
GitHub sends two webhooks when switching assignees:
  - `issues.unassigned` (for the person being removed)
  - `issues.assigned` (for the person being added)

These webhooks arrive in non-deterministic order, creating a race condition. The old implementation used the assignee field at the root of the webhook payload, which represents the delta (the person being added/removed), not the current state.

##  Race condition scenarios:

 **Scenario 1: assigned arrives first, then unassigned**
1. assigned webhook (assignee=user2) → syncs to user2 ✓
2. unassigned webhook (assignee=user1) → syncs to user1 ✗

**Scenario 2: unassigned arrives first, then assigned**
1. unassigned webhook (assignee=user1) → syncs to user1 ✗
2. assigned webhook (assignee=user2) → syncs to user2 ✓

In both cases, there's a window where the wrong assignee gets synced, and depending on timing, the final state could be incorrect.

##  Solution

Use `issue.assignees` (current state after the action) instead of assignee (the delta) when syncing assignments. This ensures both webhooks converge to the same final state regardless of arrival order.

##  After fix:
  - Both assigned and unassigned webhooks now look at issue.assignees[]
  - If issue.assignees is empty → deassign
  - If issue.assignees has users → assign to the first user (Sentry only supports single assignee)
  - Both webhooks now produce the same result regardless of order

**Note**

GitHub supports multiple assignees per issue, but Sentry currently only supports a single assignee per issue, so we take the first user Github returns. It is generally the oldest user to be assigned (based on what I have seen)

https://github.com/user-attachments/assets/498b1a17-8026-4ec7-a69d-df3d89fbd7f5




### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
