### PR TITLE
chore(explorer): reduce spans per trace to 1000

### DIFF
--- a/src/sentry/seer/explorer/index_data.py
+++ b/src/sentry/seer/explorer/index_data.py
@@ -189,7 +189,7 @@ def get_trace_for_transaction(transaction_name: str, project_id: int) -> TraceDa
         ],
         orderby=["precise.start_ts"],
         offset=0,
-        limit=5000,
+        limit=1000,
         referrer=Referrer.SEER_RPC,
         config=config,
         sampling_mode="NORMAL",


### PR DESCRIPTION
Reduce the max spans we fetch per transaction from 5000 to 1000. This should reduce bytes scanned, and for 99% of traces this has no effect.