### PR TITLE
fix(types): Add authentication assertions for user endpoints

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -29,6 +29,7 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         """
         Retrieve a list of starred views for the current organization member.
         """
+        assert request.user.is_authenticated
 
         starred_views = GroupSearchViewStarred.objects.filter(
             organization=organization, user_id=request.user.id

--- a/src/sentry/users/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_enroll.py
@@ -201,6 +201,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         # error rather than silently switch to the superuser/staff user.
 
         # Using `request.user` here because superuser/staff should not be able to set a user's 2fa
+        assert request.user.is_authenticated
         if user.id != request.user.id:
             user = User.objects.get(id=request.user.id)
 


### PR DESCRIPTION
## Summary
Add `assert request.user.is_authenticated` to endpoints that require authentication, helping mypy understand that `request.user.id` is always available.

## Changes
- `user_authenticator_enroll.py`: Endpoint has `@sudo_required` decorator
- `organization_group_search_views_starred.py`: Endpoint has `MemberPermission`

## Test plan
- Existing tests pass
- Mypy type checking passes