### PR TITLE
fix(types): Use project_id field in UserOption.unset_value

### DIFF
--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -59,7 +59,8 @@ class UserOptionManager(OptionManager["UserOption"]):
         """
         This isn't implemented for user-organization scoped options yet, because it hasn't been needed.
         """
-        self.filter(user=user, project=project, key=key).delete()
+        project_id: int | None = project.id if isinstance(project, Model) else project
+        self.filter(user=user, project_id=project_id, key=key).delete()
 
         if not hasattr(self, "_metadata"):
             return


### PR DESCRIPTION
## Summary
Change filter to use project_id instead of project since the model has a project_id field, not a project ForeignKey field.

## Changes
- Update `UserOption.unset_value()` to use `project_id` in filter query
- Add proper type conversion for project parameter

## Test plan
- Existing tests pass
- Mypy type checking passes