### PR TITLE
fix(types): Add None check for identity_id in VstsApiClient

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -167,6 +167,8 @@ class VstsApiClient(IntegrationProxyClient, RepositoryClient):
     def identity(self):
         if self._identity:
             return self._identity
+        if self.identity_id is None:
+            raise ValueError("identity_id is required")
         self._identity = Identity.objects.get(id=self.identity_id)
         return self._identity
 


### PR DESCRIPTION
## Summary
Validate that identity_id is not None before querying Identity model, since identity_id is typed as int | None.

## Changes
- Add None check with ValueError for missing identity_id
- Ensures type safety when accessing Identity objects

## Test plan
- Existing tests pass
- Mypy type checking passes