### PR TITLE
fix(types): Remove invalid select_related on ManyToMany field

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -531,9 +531,7 @@ def is_url_auto_monitored_for_project(project: Project, url: str) -> bool:
                 UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
                 UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value,
             ),
-        )
-        .select_related("data_sources")
-        .values_list("data_sources__source_id", flat=True)
+        ).values_list("data_sources__source_id", flat=True)
     )
 
     return UptimeSubscription.objects.filter(


### PR DESCRIPTION
## Summary
Remove select_related("data_sources") since data_sources is a ManyToMany field. Django doesn't support select_related on M2M relationships.

## Changes
- Remove `.select_related("data_sources")` call
- Query still works correctly with values_list across the M2M relationship

## Test plan
- Existing tests pass
- Mypy type checking passes