### PR TITLE
fix(types): Fix detector_id annotation collision in workflow serializer

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -120,12 +120,11 @@ def fetch_workflow_groups_paginated(
     # subquery that retrieves row with the largest date in a group
     group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[:1]
     qs = (
-        filtered_history.select_related("group", "detector")
-        .values("group")
+        filtered_history.values("group")
         .annotate(count=Count("group"))
         .annotate(event_id=Subquery(group_max_dates.values("event_id")))
         .annotate(last_triggered=Max("date_added"))
-        .annotate(detector_id=Subquery(group_max_dates.values("detector_id")))
+        .annotate(detector_id=Subquery(group_max_dates.values("detector_id")))  # type: ignore[no-redef]
     )
 
     return cast(


### PR DESCRIPTION
## Summary
Remove unnecessary select_related("detector") and add type: ignore for detector_id annotation which collides with the existing model field name but is needed for the grouped query result.

## Changes
- Remove `.select_related("detector")` which is not needed after `.values()`
- Add `# type: ignore[no-redef]` for unavoidable annotation name collision

## Test plan
- Existing tests pass
- Mypy type checking passes