### PR TITLE
fix(types): Add assertions for project_id and organization_id validation

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -93,13 +93,17 @@ class PromptsActivityEndpoint(Endpoint):
         # if project_id or organization_id in required fields make sure they exist
         # if NOT in required fields, insert dummy value so dups aren't recorded
         if "project_id" in required_fields:
-            if not Project.objects.filter(id=fields["project_id"]).exists():
+            project_id = fields["project_id"]
+            assert project_id is not None
+            if not Project.objects.filter(id=project_id).exists():
                 return Response({"detail": "Project no longer exists"}, status=400)
         else:
             fields["project_id"] = 0
 
         if "organization_id" in required_fields:
-            if not Organization.objects.filter(id=fields["organization_id"]).exists():
+            organization_id = fields["organization_id"]
+            assert organization_id is not None
+            if not Organization.objects.filter(id=organization_id).exists():
                 return Response({"detail": "Organization no longer exists"}, status=400)
         else:
             fields["organization_id"] = 0


### PR DESCRIPTION
## Summary
Add explicit assertions after None check to help mypy understand that project_id and organization_id are not None when checking if they exist.

## Changes
- Extract project_id and organization_id to variables
- Add assertions after the None check on line 90
- Helps mypy narrow types for database queries

## Test plan
- Existing tests pass
- Mypy type checking passes