### PR TITLE
fix(types): Extract debug_file_id for type narrowing

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -346,10 +346,11 @@ class DebugFilesEndpoint(ProjectEndpoint):
         :qparam string id: The id of the DIF to delete.
         :auth: required
         """
-        if request.GET.get("id") and _has_delete_permission(request.access, project):
+        debug_file_id = request.GET.get("id")
+        if debug_file_id and _has_delete_permission(request.access, project):
             with atomic_transaction(using=router.db_for_write(File)):
                 debug_file = (
-                    ProjectDebugFile.objects.filter(id=request.GET.get("id"), project_id=project.id)
+                    ProjectDebugFile.objects.filter(id=debug_file_id, project_id=project.id)
                     .select_related("file")
                     .first()
                 )


### PR DESCRIPTION
## Summary
Extract debug_file_id to a variable before the conditional check to enable proper type narrowing for mypy.

## Changes
- Extract `debug_file_id = request.GET.get("id")` to variable
- Use variable in conditional and query
- Enables mypy to understand debug_file_id is not None in the conditional branch

## Test plan
- Existing tests pass
- Mypy type checking passes