### PR TITLE
fix(types): Add None check for projectId in installation external requests

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
@@ -21,12 +21,15 @@ class SentryAppInstallationExternalRequestsEndpoint(SentryAppInstallationBaseEnd
     }
 
     def get(self, request: Request, installation) -> Response:
-        try:
-            project = Project.objects.get(
-                id=request.GET.get("projectId"), organization_id=installation.organization_id
-            )
-        except Project.DoesNotExist:
-            project = None
+        project_id = request.GET.get("projectId")
+        project = None
+        if project_id:
+            try:
+                project = Project.objects.get(
+                    id=project_id, organization_id=installation.organization_id
+                )
+            except Project.DoesNotExist:
+                pass
 
         kwargs = {
             "install": installation,


### PR DESCRIPTION
## Summary
Validate projectId before querying to handle the case where it's not provided in the request.

## Changes
- Extract project_id from request.GET
- Add None check before querying Project model
- Set project to None if projectId is missing or project doesn't exist

## Test plan
- Existing tests pass
- Mypy type checking passes