### PR TITLE
fix(types): Validate issueId in installation external issues endpoint

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
@@ -35,9 +35,13 @@ class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
     def post(self, request: Request, installation) -> Response:
         data = request.data
 
+        issue_id = data.get("issueId")
+        if not issue_id:
+            raise SentryAppError(message="issueId is required", status_code=400)
+
         try:
             group = Group.objects.get(
-                id=data.get("issueId"),
+                id=issue_id,
                 project_id__in=Project.objects.filter(organization_id=installation.organization_id),
             )
         except Group.DoesNotExist:


### PR DESCRIPTION
## Summary
Add validation to ensure issueId is provided, returning 400 error if missing before querying the Group model.

## Changes
- Extract issue_id from request data
- Add None check with SentryAppError(400) if missing
- Type-safe query to Group model

## Test plan
- Existing tests pass
- Mypy type checking passes