### PR TITLE
fix(types): Validate groupId in installation external issue actions

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issue_actions.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issue_actions.py
@@ -57,6 +57,8 @@ class SentryAppInstallationExternalIssueActionsEndpoint(SentryAppInstallationBas
             return Response(external_issue_action_serializer.errors, status=400)
 
         group_id = data.get("groupId")
+        if not group_id:
+            return Response({"groupId": ["This field is required"]}, status=400)
         del data["groupId"]
 
         try:


### PR DESCRIPTION
## Summary
Add validation to ensure groupId is provided in request data, returning 400 error if missing before querying the Group model.

## Changes
- Add None check for group_id after extracting from request data
- Return 400 error with proper field validation message
- Type-safe query to Group model

## Test plan
- Existing tests pass
- Mypy type checking passes