### PR TITLE
fix(types): Add cast for HybridCloudForeignKey in test fixture

### DIFF
--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -92,7 +92,11 @@ def reset_watermarks() -> None:
 
 @pytest.fixture
 def saved_search_owner_id_field() -> HybridCloudForeignKey[int, int]:
-    return SavedSearch._meta.get_field("owner_id")
+    from typing import cast
+
+    field = SavedSearch._meta.get_field("owner_id")
+    assert isinstance(field, HybridCloudForeignKey)
+    return cast(HybridCloudForeignKey[int, int], field)
 
 
 @django_db_all


### PR DESCRIPTION
## Summary
Add isinstance check and cast to narrow the generic type parameters for HybridCloudForeignKey fixture return type.

## Changes
- Add isinstance check for HybridCloudForeignKey
- Use cast() to narrow generic type parameters to [int, int]
- Ensures type safety in test fixture

## Test plan
- Existing tests pass
- Mypy type checking passes