### PR TITLE
fix(types): Add assertion for organization_id in trace item attributes

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -539,6 +539,8 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
         ]
 
     def semver_package_autocomplete_function(self):
+        assert self.snuba_params.organization_id is not None
+
         packages = (
             Release.objects.filter(
                 organization_id=self.snuba_params.organization_id, package__startswith=self.query


### PR DESCRIPTION
## Summary
Add assertion that organization_id is not None in semver_package_autocomplete_function since it's required for the Release query.

## Changes
- Add assertion for organization_id before Release query
- Ensures type safety when querying by organization_id

## Test plan
- Existing tests pass
- Mypy type checking passes