### PR TITLE
ref(onboarding): Split django onboarding docs

### DIFF
--- a/static/app/gettingStartedDocs/python/django/index.tsx
+++ b/static/app/gettingStartedDocs/python/django/index.tsx
@@ -10,13 +10,14 @@ import {logs} from 'sentry/gettingStartedDocs/python/python/logs';
 import {mcp} from 'sentry/gettingStartedDocs/python/python/mcp';
 import {profiling} from 'sentry/gettingStartedDocs/python/python/profiling';
 
-import {onboarding, performanceOnboarding} from './onboarding';
+import {onboarding} from './onboarding';
+import {performance} from './performance';
 
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling({basePackage: 'sentry-sdk[django]'}),
-  performanceOnboarding,
+  performanceOnboarding: performance,
   crashReportOnboarding: crashReport,
   featureFlagOnboarding: featureFlag,
   feedbackOnboardingJsLoader,

--- a/static/app/gettingStartedDocs/python/django/index.tsx
+++ b/static/app/gettingStartedDocs/python/django/index.tsx
@@ -1,0 +1,30 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  feedbackOnboardingJsLoader,
+  replayOnboardingJsLoader,
+} from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/python/python/agentMonitoring';
+import {crashReport} from 'sentry/gettingStartedDocs/python/python/crashReport';
+import {featureFlag} from 'sentry/gettingStartedDocs/python/python/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/python/python/logs';
+import {mcp} from 'sentry/gettingStartedDocs/python/python/mcp';
+import {profiling} from 'sentry/gettingStartedDocs/python/python/profiling';
+
+import {onboarding, performanceOnboarding} from './onboarding';
+
+const docs: Docs = {
+  onboarding,
+  replayOnboardingJsLoader,
+  profilingOnboarding: profiling({basePackage: 'sentry-sdk[django]'}),
+  performanceOnboarding,
+  crashReportOnboarding: crashReport,
+  featureFlagOnboarding: featureFlag,
+  feedbackOnboardingJsLoader,
+  agentMonitoringOnboarding: agentMonitoring,
+  mcpOnboarding: mcp,
+  logsOnboarding: logs({
+    packageName: 'sentry-sdk[django]',
+  }),
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/python/django/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python/django/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './django';
+import docs from '.';
 
 describe('django onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python/django/onboarding.tsx
+++ b/static/app/gettingStartedDocs/python/django/onboarding.tsx
@@ -1,29 +1,15 @@
 import {ExternalLink} from 'sentry/components/core/link';
 import {
   StepType,
-  type Docs,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  feedbackOnboardingJsLoader,
-  replayOnboardingJsLoader,
-} from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
-import {agentMonitoring} from 'sentry/gettingStartedDocs/python/python/agentMonitoring';
-import {crashReport} from 'sentry/gettingStartedDocs/python/python/crashReport';
-import {featureFlag} from 'sentry/gettingStartedDocs/python/python/featureFlag';
-import {logs, verify} from 'sentry/gettingStartedDocs/python/python/logs';
-import {mcp} from 'sentry/gettingStartedDocs/python/python/mcp';
-import {
-  alternativeProfiling,
-  profiling,
-} from 'sentry/gettingStartedDocs/python/python/profiling';
+import {verify} from 'sentry/gettingStartedDocs/python/python/logs';
+import {alternativeProfiling} from 'sentry/gettingStartedDocs/python/python/profiling';
 import {getPythonInstallCodeBlock} from 'sentry/gettingStartedDocs/python/python/utils';
 import {t, tct} from 'sentry/locale';
 
-type Params = DocsParams;
-
-const getSdkSetupSnippet = (params: Params) => `
+const getSdkSetupSnippet = (params: DocsParams) => `
 import sentry_sdk
 
 sentry_sdk.init(
@@ -65,7 +51,7 @@ sentry_sdk.init(
 )
 `;
 
-const onboarding: OnboardingConfig = {
+export const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
@@ -80,7 +66,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  configure: (params: Params) => [
+  configure: (params: DocsParams) => [
     {
       type: StepType.CONFIGURE,
       content: [
@@ -104,7 +90,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: (params: Params) => [
+  verify: (params: DocsParams) => [
     {
       type: StepType.VERIFY,
       content: [
@@ -152,7 +138,7 @@ urlpatterns = [
       ],
     },
   ],
-  nextSteps: (params: Params) => {
+  nextSteps: (params: DocsParams) => {
     const steps = [] as any[];
     if (params.isLogsSelected) {
       steps.push({
@@ -168,7 +154,7 @@ urlpatterns = [
   },
 };
 
-const performanceOnboarding: OnboardingConfig = {
+export const performanceOnboarding: OnboardingConfig = {
   introduction: () =>
     t(
       "Adding Performance to your Django project is simple. Make sure you've got these basics down."
@@ -239,20 +225,3 @@ sentry_sdk.init(
   ],
   nextSteps: () => [],
 };
-
-const docs: Docs = {
-  onboarding,
-  replayOnboardingJsLoader,
-  profilingOnboarding: profiling({basePackage: 'sentry-sdk[django]'}),
-  performanceOnboarding,
-  crashReportOnboarding: crashReport,
-  featureFlagOnboarding: featureFlag,
-  feedbackOnboardingJsLoader,
-  agentMonitoringOnboarding: agentMonitoring,
-  mcpOnboarding: mcp,
-  logsOnboarding: logs({
-    packageName: 'sentry-sdk[django]',
-  }),
-};
-
-export default docs;

--- a/static/app/gettingStartedDocs/python/django/performance.tsx
+++ b/static/app/gettingStartedDocs/python/django/performance.tsx
@@ -1,0 +1,80 @@
+import {ExternalLink} from 'sentry/components/core/link';
+import {
+  StepType,
+  type OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+
+import {onboarding} from './onboarding';
+
+export const performance: OnboardingConfig = {
+  introduction: () =>
+    t(
+      "Adding Performance to your Django project is simple. Make sure you've got these basics down."
+    ),
+  install: onboarding.install,
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'To configure the Sentry SDK, initialize it in your [code:settings.py] file:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import sentry_sdk
+
+sentry_sdk.init(
+  dsn: "${params.dsn.public}",
+
+  // Set traces_sample_rate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  traces_sample_rate=1.0,
+)`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to do [linkSampleTransactions:sampling].',
+            {
+              linkTracingOptions: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/options/#tracing-options" />
+              ),
+              linkTracesSampler: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/sampling/" />
+              ),
+              linkSampleTransactions: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/sampling/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  nextSteps: () => [],
+};

--- a/static/app/gettingStartedDocs/python/django/performance.tsx
+++ b/static/app/gettingStartedDocs/python/django/performance.tsx
@@ -31,11 +31,11 @@ export const performance: OnboardingConfig = {
 import sentry_sdk
 
 sentry_sdk.init(
-  dsn="${params.dsn.public}",
+    dsn="${params.dsn.public}",
 
-  # Set traces_sample_rate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
-  traces_sample_rate=1.0,
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,
 )`,
         },
         {

--- a/static/app/gettingStartedDocs/python/django/performance.tsx
+++ b/static/app/gettingStartedDocs/python/django/performance.tsx
@@ -31,10 +31,10 @@ export const performance: OnboardingConfig = {
 import sentry_sdk
 
 sentry_sdk.init(
-  dsn: "${params.dsn.public}",
+  dsn="${params.dsn.public}",
 
-  // Set traces_sample_rate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
+  # Set traces_sample_rate to 1.0 to capture 100%
+  # of transactions for performance monitoring.
   traces_sample_rate=1.0,
 )`,
         },


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms