### PR TITLE
ref(onboarding): Split flask onboarding docs

### DIFF
--- a/static/app/gettingStartedDocs/python/flask/index.tsx
+++ b/static/app/gettingStartedDocs/python/flask/index.tsx
@@ -1,0 +1,31 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  feedbackOnboardingJsLoader,
+  replayOnboardingJsLoader,
+} from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/python/python/agentMonitoring';
+import {crashReport} from 'sentry/gettingStartedDocs/python/python/crashReport';
+import {featureFlag} from 'sentry/gettingStartedDocs/python/python/featureFlag';
+import {logs} from 'sentry/gettingStartedDocs/python/python/logs';
+import {mcp} from 'sentry/gettingStartedDocs/python/python/mcp';
+import {profiling} from 'sentry/gettingStartedDocs/python/python/profiling';
+
+import {onboarding} from './onboarding';
+import {performance} from './performance';
+
+const docs: Docs = {
+  onboarding,
+  replayOnboardingJsLoader,
+  profilingOnboarding: profiling({basePackage: 'sentry-sdk[flask]'}),
+  performanceOnboarding: performance,
+  crashReportOnboarding: crashReport,
+  featureFlagOnboarding: featureFlag,
+  feedbackOnboardingJsLoader,
+  agentMonitoringOnboarding: agentMonitoring,
+  mcpOnboarding: mcp,
+  logsOnboarding: logs({
+    packageName: 'sentry-sdk[flask]',
+  }),
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/python/flask/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python/flask/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from './flask';
+import docs from '.';
 
 describe('flask onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python/flask/onboarding.tsx
+++ b/static/app/gettingStartedDocs/python/flask/onboarding.tsx
@@ -1,29 +1,15 @@
 import {ExternalLink} from 'sentry/components/core/link';
 import {
   StepType,
-  type Docs,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  feedbackOnboardingJsLoader,
-  replayOnboardingJsLoader,
-} from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
-import {agentMonitoring} from 'sentry/gettingStartedDocs/python/python/agentMonitoring';
-import {crashReport} from 'sentry/gettingStartedDocs/python/python/crashReport';
-import {featureFlag} from 'sentry/gettingStartedDocs/python/python/featureFlag';
-import {logs, verify} from 'sentry/gettingStartedDocs/python/python/logs';
-import {mcp} from 'sentry/gettingStartedDocs/python/python/mcp';
-import {
-  alternativeProfiling,
-  profiling,
-} from 'sentry/gettingStartedDocs/python/python/profiling';
+import {verify} from 'sentry/gettingStartedDocs/python/python/logs';
+import {alternativeProfiling} from 'sentry/gettingStartedDocs/python/python/profiling';
 import {getPythonInstallCodeBlock} from 'sentry/gettingStartedDocs/python/python/utils';
 import {t, tct} from 'sentry/locale';
 
-type Params = DocsParams;
-
-const getSdkSetupSnippet = (params: Params) => `import sentry_sdk
+const getSdkSetupSnippet = (params: DocsParams) => `import sentry_sdk
 from flask import Flask
 
 sentry_sdk.init(
@@ -65,7 +51,7 @@ sentry_sdk.init(
 )
 `;
 
-const onboarding: OnboardingConfig = {
+export const onboarding: OnboardingConfig = {
   introduction: () =>
     tct('The Flask integration adds support for the [link:Flask Framework].', {
       link: <ExternalLink href="https://flask.palletsprojects.com" />,
@@ -84,7 +70,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  configure: (params: Params) => [
+  configure: (params: DocsParams) => [
     {
       type: StepType.CONFIGURE,
       content: [
@@ -115,7 +101,7 @@ app = Flask(__name__)
       ],
     },
   ],
-  verify: (params: Params) => [
+  verify: (params: DocsParams) => [
     {
       type: StepType.VERIFY,
       content: [
@@ -156,7 +142,7 @@ def hello_world():
       ],
     },
   ],
-  nextSteps: (params: Params) => {
+  nextSteps: (params: DocsParams) => {
     const steps = [] as any[];
     if (params.isLogsSelected) {
       steps.push({
@@ -171,91 +157,3 @@ def hello_world():
     return steps;
   },
 };
-
-const performanceOnboarding: OnboardingConfig = {
-  introduction: () =>
-    t(
-      "Adding Performance to your Flask project is simple. Make sure you've got these basics down."
-    ),
-  install: onboarding.install,
-  configure: params => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'To configure the Sentry SDK, initialize it in your [code:settings.py] file:',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-import sentry-sdk
-
-sentry_sdk.init(
-    dsn: "${params.dsn.public}",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
-)`,
-        },
-        {
-          type: 'text',
-          text: tct(
-            'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
-            {
-              linkTracingOptions: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/options/#tracing-options" />
-              ),
-              linkTracesSampler: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/sampling/" />
-              ),
-              linkSampleTransactions: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/sampling/" />
-              ),
-            }
-          ),
-        },
-      ],
-    },
-  ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
-              ),
-            }
-          ),
-        },
-      ],
-    },
-  ],
-  nextSteps: () => [],
-};
-
-const docs: Docs = {
-  onboarding,
-  replayOnboardingJsLoader,
-  profilingOnboarding: profiling({basePackage: 'sentry-sdk[flask]'}),
-  performanceOnboarding,
-  crashReportOnboarding: crashReport,
-  featureFlagOnboarding: featureFlag,
-  feedbackOnboardingJsLoader,
-  agentMonitoringOnboarding: agentMonitoring,
-  mcpOnboarding: mcp,
-  logsOnboarding: logs({
-    packageName: 'sentry-sdk[flask]',
-  }),
-};
-
-export default docs;

--- a/static/app/gettingStartedDocs/python/flask/performance.tsx
+++ b/static/app/gettingStartedDocs/python/flask/performance.tsx
@@ -1,0 +1,79 @@
+import {ExternalLink} from 'sentry/components/core/link';
+import {
+  StepType,
+  type OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+
+import {onboarding} from './onboarding';
+
+export const performance: OnboardingConfig = {
+  introduction: () =>
+    t(
+      "Adding Performance to your Flask project is simple. Make sure you've got these basics down."
+    ),
+  install: onboarding.install,
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'To configure the Sentry SDK, initialize it in your [code:settings.py] file:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+import sentry-sdk
+
+sentry_sdk.init(
+    dsn: "${params.dsn.public}",
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,
+)`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Learn more about tracing [linkTracingOptions:options], how to use the [linkTracesSampler:traces_sampler] function, or how to [linkSampleTransactions:sample transactions].',
+            {
+              linkTracingOptions: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/options/#tracing-options" />
+              ),
+              linkTracesSampler: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/sampling/" />
+              ),
+              linkSampleTransactions: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/configuration/sampling/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Python application.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/automatic-instrumentation/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+  nextSteps: () => [],
+};

--- a/static/app/gettingStartedDocs/python/flask/performance.tsx
+++ b/static/app/gettingStartedDocs/python/flask/performance.tsx
@@ -28,10 +28,10 @@ export const performance: OnboardingConfig = {
           type: 'code',
           language: 'python',
           code: `
-import sentry-sdk
+import sentry_sdk
 
 sentry_sdk.init(
-    dsn: "${params.dsn.public}",
+    dsn="${params.dsn.public}",
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
     traces_sample_rate=1.0,


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms