### PR TITLE
ref(onboarding): Split python gcpfunctions onboarding docs

### DIFF
--- a/static/app/gettingStartedDocs/python/gcpfunctions/index.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions/index.tsx
@@ -1,0 +1,19 @@
+import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/python/python/agentMonitoring';
+import {crashReport} from 'sentry/gettingStartedDocs/python/python/crashReport';
+import {logs} from 'sentry/gettingStartedDocs/python/python/logs';
+import {mcp} from 'sentry/gettingStartedDocs/python/python/mcp';
+import {profiling} from 'sentry/gettingStartedDocs/python/python/profiling';
+
+import {onboarding} from './onboarding';
+
+const docs: Docs = {
+  onboarding,
+  crashReportOnboarding: crashReport,
+  profilingOnboarding: profiling(),
+  agentMonitoringOnboarding: agentMonitoring,
+  mcpOnboarding: mcp,
+  logsOnboarding: logs(),
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/python/gcpfunctions/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './gcpfunctions';
+import docs from '.';
 
 describe('gcpfunctions onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python/gcpfunctions/onboarding.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions/onboarding.tsx
@@ -1,24 +1,15 @@
 import {ExternalLink} from 'sentry/components/core/link';
 import {
   StepType,
-  type Docs,
   type DocsParams,
   type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {agentMonitoring} from 'sentry/gettingStartedDocs/python/python/agentMonitoring';
-import {crashReport} from 'sentry/gettingStartedDocs/python/python/crashReport';
-import {logs, verify} from 'sentry/gettingStartedDocs/python/python/logs';
-import {mcp} from 'sentry/gettingStartedDocs/python/python/mcp';
-import {
-  alternativeProfiling,
-  profiling,
-} from 'sentry/gettingStartedDocs/python/python/profiling';
+import {verify} from 'sentry/gettingStartedDocs/python/python/logs';
+import {alternativeProfiling} from 'sentry/gettingStartedDocs/python/python/profiling';
 import {getPythonInstallCodeBlock} from 'sentry/gettingStartedDocs/python/python/utils';
 import {t, tct} from 'sentry/locale';
 
-type Params = DocsParams;
-
-const getSdkSetupSnippet = (params: Params) => `
+const getSdkSetupSnippet = (params: DocsParams) => `
 import sentry_sdk
 from sentry_sdk.integrations.gcp import GcpIntegration
 
@@ -64,7 +55,7 @@ sentry_sdk.init(
 def http_function_entrypoint(request):
     ...`;
 
-const getTimeoutWarningSnippet = (params: Params) => `
+const getTimeoutWarningSnippet = (params: DocsParams) => `
 sentry_sdk.init(
     dsn="${params.dsn.public}",
     integrations=[
@@ -72,7 +63,7 @@ sentry_sdk.init(
     ],
 )`;
 
-const onboarding: OnboardingConfig = {
+export const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
@@ -87,7 +78,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  configure: (params: Params) => [
+  configure: (params: DocsParams) => [
     {
       type: StepType.CONFIGURE,
       content: [
@@ -160,7 +151,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: (params: Params) => [
+  verify: (params: DocsParams) => [
     {
       type: StepType.VERIFY,
       content: [
@@ -174,7 +165,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  nextSteps: (params: Params) => {
+  nextSteps: (params: DocsParams) => {
     const steps = [];
     if (params.isLogsSelected) {
       steps.push({
@@ -189,14 +180,3 @@ const onboarding: OnboardingConfig = {
     return steps;
   },
 };
-
-const docs: Docs = {
-  onboarding,
-  crashReportOnboarding: crashReport,
-  profilingOnboarding: profiling(),
-  agentMonitoringOnboarding: agentMonitoring,
-  mcpOnboarding: mcp,
-  logsOnboarding: logs(),
-};
-
-export default docs;


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-864/introduce-folders-for-onboarding-platforms