### PR TITLE
feat: Prettify Unity `active_scene_name` context

### DIFF
--- a/static/app/components/events/contexts/platformContext/unity.spec.tsx
+++ b/static/app/components/events/contexts/platformContext/unity.spec.tsx
@@ -7,6 +7,7 @@ import {getUnityContextData} from 'sentry/components/events/contexts/platformCon
 
 const MOCK_UNITY_CONTEXT = {
   type: 'unity' as const,
+  active_scene_name: '2_NativeSupport',
   copy_texture_support: 'Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture',
   editor_version: '2022.1.23f1',
   install_mode: 'Store',
@@ -28,6 +29,11 @@ const MOCK_REDACTION = {
 describe('UnityContext', () => {
   it('returns values and according to the parameters', () => {
     expect(getUnityContextData({data: MOCK_UNITY_CONTEXT})).toEqual([
+      {
+        key: 'active_scene_name',
+        subject: 'Active Scene Name',
+        value: '2_NativeSupport',
+      },
       {
         key: 'copy_texture_support',
         subject: 'Copy Texture Support',

--- a/static/app/components/events/contexts/platformContext/unity.tsx
+++ b/static/app/components/events/contexts/platformContext/unity.tsx
@@ -6,6 +6,12 @@ import type {KeyValueListData} from 'sentry/types/group';
 export function getUnityContextData({data}: {data: UnityContext}): KeyValueListData {
   return getContextKeys({data}).map(ctxKey => {
     switch (ctxKey) {
+      case UnityContextKey.ACTIVE_SCENE_NAME:
+        return {
+          key: ctxKey,
+          subject: t('Active Scene Name'),
+          value: data.active_scene_name,
+        };
       case UnityContextKey.COPY_TEXTURE_SUPPORT:
         return {
           key: ctxKey,

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -520,6 +520,7 @@ interface OtelContext extends Partial<Record<OtelContextKey, unknown>>, BaseCont
 }
 
 export enum UnityContextKey {
+  ACTIVE_SCENE_NAME = 'active_scene_name',
   COPY_TEXTURE_SUPPORT = 'copy_texture_support',
   EDITOR_VERSION = 'editor_version',
   INSTALL_MODE = 'install_mode',
@@ -528,6 +529,7 @@ export enum UnityContextKey {
 }
 
 export interface UnityContext {
+  [UnityContextKey.ACTIVE_SCENE_NAME]: string;
   [UnityContextKey.COPY_TEXTURE_SUPPORT]: string;
   [UnityContextKey.EDITOR_VERSION]: string;
   [UnityContextKey.INSTALL_MODE]: string;


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2073

The Unity SDK automatically adds the currently active scene's name to the Unity context. This should be as pretty as the rest so we can go from

<img width="427" height="205" alt="Screenshot 2025-11-10 at 16 41 14" src="https://github.com/user-attachments/assets/a6d8308b-c742-4887-8936-573691389a27" />

to this

<img width="427" height="201" alt="Screenshot 2025-11-10 at 16 41 01" src="https://github.com/user-attachments/assets/e582f5ce-0e28-4165-a594-e501f2f77610" />
