### PR TITLE
fix(eco): Refactors prevent webhook forwarder to check the full set of headers, use enums

### DIFF
--- a/src/sentry/integrations/github/webhook_types.py
+++ b/src/sentry/integrations/github/webhook_types.py
@@ -5,6 +5,10 @@ GITHUB_WEBHOOK_TYPE_HEADER = "HTTP_X_GITHUB_EVENT"
 
 class GithubWebhookType(StrEnum):
     INSTALLATION = "installation"
+    INSTALLATION_REPOSITORIES = "installation_repositories"
     ISSUE = "issues"
+    ISSUE_COMMENT = "issue_comment"
     PULL_REQUEST = "pull_request"
+    PULL_REQUEST_REVIEW_COMMENT = "pull_request_review_comment"
+    PULL_REQUEST_REVIEW = "pull_request_review"
     PUSH = "push"

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -100,16 +100,9 @@ class GithubRequestParser(BaseRequestParser):
             if codecov_regions:
                 self.try_forward_to_codecov(event=event)
 
-        logger.info(
-            "overwatch.debug.forward_if_applicable.begin",
-            extra={
-                "headers_keys": list(self.request.headers.keys()),
-                "integration_id": integration.id,
-            },
-        )
         # The overwatch forwarder implements its own region-based checks
         OverwatchGithubWebhookForwarder(integration=integration).forward_if_applicable(
-            event=event, headers=self.request.headers
+            event=event, headers=self.request.META
         )
 
         return self.get_response_from_webhookpayload(

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -100,11 +100,13 @@ class GithubRequestParser(BaseRequestParser):
             if codecov_regions:
                 self.try_forward_to_codecov(event=event)
 
+        response = self.get_response_from_webhookpayload(
+            regions=regions, identifier=integration.id, integration_id=integration.id
+        )
+
         # The overwatch forwarder implements its own region-based checks
         OverwatchGithubWebhookForwarder(integration=integration).forward_if_applicable(
             event=event, headers=self.request.META
         )
 
-        return self.get_response_from_webhookpayload(
-            regions=regions, identifier=integration.id, integration_id=integration.id
-        )
+        return response

--- a/src/sentry/overwatch_webhooks/webhook_forwarder.py
+++ b/src/sentry/overwatch_webhooks/webhook_forwarder.py
@@ -109,12 +109,8 @@ class OverwatchGithubWebhookForwarder:
         region_name = None
         try:
             enabled_regions = options.get("overwatch.enabled-regions")
-            logger.info(
-                "overwatch.debug.enabled_regions", extra={"enabled_regions": enabled_regions}
-            )
             if not enabled_regions:
                 # feature isn't enabled, no work to do
-                logger.info("overwatch.debug.excluded.feature_not_enabled", extra={})
                 return
 
             orgs_by_region = self._get_org_summaries_by_region_for_integration(
@@ -178,10 +174,6 @@ class OverwatchGithubWebhookForwarder:
                     region=region_name,
                     app_id=app_id,
                 )
-                logger.info(
-                    "overwatch.debug.webhook_detail.created",
-                    extra={"region_name": region_name, "app_id": app_id},
-                )
 
                 publisher = OverwatchWebhookPublisher(
                     integration_provider=self.integration.provider,
@@ -193,9 +185,6 @@ class OverwatchGithubWebhookForwarder:
                     "overwatch.forward-webhooks.success",
                     sample_rate=1.0,
                     tags={"forward_region": region_name},
-                )
-                logger.info(
-                    "overwatch.debug.metrics_incr.success", extra={"region_name": region_name}
                 )
         except Exception:
             metrics.incr(

--- a/src/sentry/overwatch_webhooks/webhook_forwarder.py
+++ b/src/sentry/overwatch_webhooks/webhook_forwarder.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from sentry import options
 from sentry.constants import ObjectStatus
+from sentry.integrations.github.webhook_types import GITHUB_WEBHOOK_TYPE_HEADER, GithubWebhookType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.organizationmapping import OrganizationMapping
@@ -16,12 +17,12 @@ from sentry.utils import metrics
 
 # TODO: Double check that this includes all of the events you care about.
 GITHUB_EVENTS_TO_FORWARD_OVERWATCH = {
-    "installation",
-    "installation_repositories",
-    "issue_comment",
-    "pull_request",
-    "pull_request_review_comment",
-    "pull_request_review",
+    GithubWebhookType.INSTALLATION,
+    GithubWebhookType.INSTALLATION_REPOSITORIES,
+    GithubWebhookType.ISSUE_COMMENT,
+    GithubWebhookType.PULL_REQUEST,
+    GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT,
+    GithubWebhookType.PULL_REQUEST_REVIEW,
 }
 
 
@@ -45,7 +46,7 @@ class OverwatchGithubWebhookForwarder:
         self.integration = integration
 
     def should_forward_to_overwatch(self, headers: Mapping[str, str]) -> bool:
-        return headers.get("HTTP_X_GITHUB_EVENT") in GITHUB_EVENTS_TO_FORWARD_OVERWATCH
+        return headers.get(GITHUB_WEBHOOK_TYPE_HEADER) in GITHUB_EVENTS_TO_FORWARD_OVERWATCH
 
     def _get_org_summaries_by_region_for_integration(
         self, integration: Integration


### PR DESCRIPTION
This PR does a few different things:

1. Updates forwarder code to use common enums for Github header checks.
2. Passes the `request.META` property for the headers dictionary as opposed to `request.headers`
    - Django's `META` [property](https://docs.djangoproject.com/en/5.2/ref/request-response/#django.http.HttpRequest.META) contains all available headers for the request, while `headers` [property](https://docs.djangoproject.com/en/5.2/ref/request-response/#django.http.HttpRequest.headers) contains only HTTP prefixed ones.
3. Cleans up some of our spammier logging
