### PR TITLE
feat(autofix): Track instructions_provided on Code It Up clicks

### DIFF
--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -486,7 +486,10 @@ function AutofixSolutionDisplay({
     });
   };
 
-  const hasInstructions = instructions.trim().length > 0;
+  // Check if instructions were provided (either typed in input or already added to solution)
+  const hasInstructions =
+    instructions.trim().length > 0 ||
+    solutionItems.some(item => item.timeline_item_type === 'human_instruction');
 
   useEffect(() => {
     setSolutionItems(

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -486,10 +486,12 @@ function AutofixSolutionDisplay({
     });
   };
 
-  // Check if instructions were provided (either typed in input or already added to solution)
+  // Check if instructions were provided (either typed in input or already added to solution and active)
   const hasInstructions =
     instructions.trim().length > 0 ||
-    solutionItems.some(item => item.timeline_item_type === 'human_instruction');
+    solutionItems.some(
+      item => item.timeline_item_type === 'human_instruction' && item.is_active !== false
+    );
 
   useEffect(() => {
     setSolutionItems(

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -486,6 +486,11 @@ function AutofixSolutionDisplay({
     });
   };
 
+  // Check if instructions were provided (either typed or already added to solution)
+  const hasInstructions =
+    instructions.trim().length > 0 ||
+    solutionItems.some(item => item.timeline_item_type === 'human_instruction');
+
   useEffect(() => {
     setSolutionItems(
       solution.map(item => ({
@@ -650,6 +655,9 @@ function AutofixSolutionDisplay({
               onClick={handleCodeItUp}
               analyticsEventName="Autofix: Code It Up"
               analyticsEventKey="autofix.solution.code"
+              analyticsParams={{
+                instruction_provided: hasInstructions,
+              }}
               title={t('Implement this solution in code with Seer')}
             >
               {t('Code It Up')}

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -486,10 +486,7 @@ function AutofixSolutionDisplay({
     });
   };
 
-  // Check if instructions were provided (either typed or already added to solution)
-  const hasInstructions =
-    instructions.trim().length > 0 ||
-    solutionItems.some(item => item.timeline_item_type === 'human_instruction');
+  const hasInstructions = instructions.trim().length > 0;
 
   useEffect(() => {
     setSolutionItems(


### PR DESCRIPTION
Add analytics to capture whether a user provided instructions when clicking "Code it up". 

Fixes AIML-1530