### PR TITLE
feat(seer-cursor): cursor integration callouts in settings + drawer

### DIFF
--- a/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
@@ -1,0 +1,345 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {CursorIntegrationCta} from 'sentry/components/events/autofix/cursorIntegrationCta';
+
+describe('CursorIntegrationCta', () => {
+  const project = ProjectFixture();
+  const organization = OrganizationFixture({
+    features: ['integrations-cursor'],
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    localStorage.clear();
+
+    // Default mock for seer preferences
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: null,
+      },
+    });
+
+    // Default mock for coding agent integrations
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [],
+      },
+    });
+  });
+
+  describe('Feature Flag', () => {
+    it('does not render without integrations-cursor feature flag', () => {
+      const orgWithoutFlag = OrganizationFixture({
+        features: [],
+      });
+
+      const {container} = render(<CursorIntegrationCta project={project} />, {
+        organization: orgWithoutFlag,
+      });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders with integrations-cursor feature flag', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('shows loading placeholder while fetching preferences', () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    });
+
+    it('shows loading placeholder while fetching integrations', () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    });
+  });
+
+  describe('Stage 1: Integration Not Installed', () => {
+    it('shows install stage when cursor integration is not installed', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Connect Cursor to automatically hand off/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Install Cursor Integration'})
+      ).toBeInTheDocument();
+    });
+
+    it('links to cursor integration settings', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      const installLink = await screen.findByRole('button', {
+        name: 'Install Cursor Integration',
+      });
+      expect(installLink).toHaveAttribute('href', '/settings/integrations/cursor/');
+    });
+
+    it('includes documentation link', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      await screen.findByText('Cursor Agent Integration');
+      const docsLink = screen.getByRole('link', {name: 'Read the docs'});
+      expect(docsLink).toHaveAttribute(
+        'href',
+        'https://docs.sentry.io/integrations/cursor/'
+      );
+    });
+  });
+
+  describe('Stage 2: Integration Installed but Not Configured', () => {
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+        body: {
+          integrations: [
+            {
+              id: '123',
+              provider: 'cursor',
+              name: 'Cursor',
+            },
+          ],
+        },
+      });
+    });
+
+    it('shows configure stage when integration installed but not configured', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
+      expect(
+        screen.getByText(/You have the Cursor integration installed/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Set Seer to hand off to Cursor'})
+      ).toBeInTheDocument();
+    });
+
+    it('configures handoff when setup button is clicked', async () => {
+      const updateMock = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
+        method: 'POST',
+        body: {
+          repositories: [],
+          automated_run_stopping_point: 'root_cause',
+          automation_handoff: {
+            handoff_point: 'root_cause',
+            target: 'cursor_background_agent',
+            integration_id: 123,
+          },
+        },
+      });
+
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      const setupButton = await screen.findByRole('button', {
+        name: 'Set Seer to hand off to Cursor',
+      });
+      await userEvent.click(setupButton);
+
+      await waitFor(() => {
+        expect(updateMock).toHaveBeenCalledWith(
+          `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
+          expect.objectContaining({
+            method: 'POST',
+            data: {
+              repositories: [],
+              automated_run_stopping_point: 'root_cause',
+              automation_handoff: {
+                handoff_point: 'root_cause',
+                target: 'cursor_background_agent',
+                integration_id: 123,
+              },
+            },
+          })
+        );
+      });
+    });
+
+    it('includes link to project seer settings', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      await screen.findByText('Cursor Agent Integration');
+      const settingsLink = screen.getByRole('link', {
+        name: 'Configure in Seer project settings',
+      });
+      expect(settingsLink).toHaveAttribute(
+        'href',
+        `/settings/projects/${project.slug}/seer/`
+      );
+    });
+  });
+
+  describe('Stage 3: Integration Configured', () => {
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+        body: {
+          integrations: [
+            {
+              id: '123',
+              provider: 'cursor',
+              name: 'Cursor',
+            },
+          ],
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
+        body: {
+          code_mapping_repos: [],
+          preference: {
+            repositories: [],
+            automated_run_stopping_point: 'root_cause',
+            automation_handoff: {
+              handoff_point: 'root_cause',
+              target: 'cursor_background_agent',
+              integration_id: 123,
+            },
+          },
+        },
+      });
+    });
+
+    it('shows configured stage when handoff is set up', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
+      expect(screen.getByText(/Cursor handoff is active/)).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Set Seer to hand off to Cursor'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show setup button in configured stage', async () => {
+      render(<CursorIntegrationCta project={project} />, {
+        organization,
+      });
+
+      await screen.findByText('Cursor Agent Integration');
+      expect(
+        screen.queryByRole('button', {name: 'Set Seer to hand off to Cursor'})
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Dismissible Functionality', () => {
+    const dismissKey = 'test-dismiss-key';
+
+    it('shows dismiss button when dismissible is true', async () => {
+      render(
+        <CursorIntegrationCta project={project} dismissible dismissKey={dismissKey} />,
+        {
+          organization,
+        }
+      );
+
+      expect(await screen.findByRole('button', {name: 'Dismiss'})).toBeInTheDocument();
+    });
+
+    it('does not show dismiss button when dismissible is false', async () => {
+      render(<CursorIntegrationCta project={project} dismissible={false} />, {
+        organization,
+      });
+
+      await screen.findByText('Cursor Agent Integration');
+      expect(screen.queryByRole('button', {name: 'Dismiss'})).not.toBeInTheDocument();
+    });
+
+    it('hides component when dismissed', async () => {
+      render(
+        <CursorIntegrationCta project={project} dismissible dismissKey={dismissKey} />,
+        {
+          organization,
+        }
+      );
+
+      const dismissButton = await screen.findByRole('button', {name: 'Dismiss'});
+      await userEvent.click(dismissButton);
+
+      expect(screen.queryByText('Cursor Agent Integration')).not.toBeInTheDocument();
+
+      // Verify localStorage was set
+      expect(localStorage.getItem(dismissKey)).toBe('true');
+      expect(localStorage.getItem(`${dismissKey}-stage`)).toBe('install');
+    });
+
+    it('respects existing dismissal from localStorage', () => {
+      localStorage.setItem(dismissKey, 'true');
+
+      const {container} = render(
+        <CursorIntegrationCta project={project} dismissible dismissKey={dismissKey} />,
+        {
+          organization,
+        }
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('resets dismissal when stage changes', async () => {
+      localStorage.setItem(dismissKey, 'true');
+      localStorage.setItem(`${dismissKey}-stage`, 'install');
+
+      // Now mock the integration being installed (stage changes to 'configure')
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+        body: {
+          integrations: [
+            {
+              id: '123',
+              provider: 'cursor',
+              name: 'Cursor',
+            },
+          ],
+        },
+      });
+
+      render(
+        <CursorIntegrationCta project={project} dismissible dismissKey={dismissKey} />,
+        {
+          organization,
+        }
+      );
+
+      // Component should be visible since stage changed
+      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
+      expect(localStorage.getItem(dismissKey)).toBeNull();
+    });
+  });
+});

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -18,7 +18,6 @@ import Placeholder from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
-import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -28,14 +27,12 @@ interface CursorIntegrationCtaProps {
   dismissKey?: string;
   dismissible?: boolean;
   organization?: Organization;
-  variant?: 'drawer' | 'settings';
 }
 
 export function CursorIntegrationCta({
   project,
   dismissible = false,
   dismissKey,
-  variant = 'drawer',
 }: CursorIntegrationCtaProps) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
@@ -137,21 +134,19 @@ export function CursorIntegrationCta({
     return null;
   }
 
-  const CardWrapper = variant === 'drawer' ? DrawerCard : SettingsCard;
-
   // Show loading state while fetching data
   if (isLoadingPreferences || isLoadingIntegrations || isUpdatingPreferences) {
     return (
-      <CardWrapper>
+      <Card>
         <Placeholder height="120px" />
-      </CardWrapper>
+      </Card>
     );
   }
 
   // Stage 1: Integration not installed
   if (!hasCursorIntegration) {
     return (
-      <CardWrapper>
+      <Card>
         {dismissible && (
           <DismissButton
             size="xs"
@@ -184,14 +179,14 @@ export function CursorIntegrationCta({
             </LinkButton>
           </div>
         </Flex>
-      </CardWrapper>
+      </Card>
     );
   }
 
   // Stage 2: Integration installed but handoff not configured
   if (!isConfigured) {
     return (
-      <CardWrapper>
+      <Card>
         {dismissible && (
           <DismissButton
             size="xs"
@@ -227,13 +222,13 @@ export function CursorIntegrationCta({
             </Button>
           </div>
         </Flex>
-      </CardWrapper>
+      </Card>
     );
   }
 
   // Stage 3: Configured or just configured
   return (
-    <CardWrapper>
+    <Card>
       {dismissible && (
         <DismissButton
           size="xs"
@@ -251,58 +246,33 @@ export function CursorIntegrationCta({
           </Flex>
         </Heading>
         <Text>
-          {variant === 'settings'
-            ? tct(
-                'Cursor handoff is active. During automation runs, Seer will automatically trigger Cursor Background Agents. [docsLink:Read the docs] to learn more.',
-                {
-                  docsLink: (
-                    <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
-                  ),
-                }
-              )
-            : tct(
-                'Cursor handoff is active. During automation runs, Seer will automatically trigger Cursor Background Agents. [seerProjectSettings:Configure in Seer project settings] or [docsLink:read the docs] to learn more.',
-                {
-                  seerProjectSettings: (
-                    <Link to={`/settings/projects/${project.slug}/seer/`} />
-                  ),
-                  docsLink: (
-                    <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
-                  ),
-                }
-              )}
+          {tct(
+            'Cursor handoff is active. During automation runs, Seer will automatically trigger Cursor Background Agents. [docsLink:Read the docs] to learn more.',
+            {
+              docsLink: (
+                <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
+              ),
+            }
+          )}
         </Text>
       </Flex>
-    </CardWrapper>
+    </Card>
   );
 }
 
-const DrawerCard = styled('div')`
+const Card = styled('div')`
   position: relative;
-  background: ${p => p.theme.backgroundElevated};
-  overflow: visible;
+  padding: ${p => p.theme.space.xl};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(2)} ${space(2)};
-  box-shadow: ${p => p.theme.dropShadowMedium};
-  transition: all 0.3s ease-in-out;
-  margin-top: ${space(2)};
-  margin-bottom: ${space(2)};
-`;
-
-const SettingsCard = styled('div')`
-  position: relative;
-  padding: ${space(2)};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-  margin-top: ${space(3)};
-  margin-bottom: ${space(3)};
+  margin-top: ${p => p.theme.space['2xl']};
+  margin-bottom: ${p => p.theme.space['2xl']};
 `;
 
 const DismissButton = styled(Button)`
   position: absolute;
-  top: ${space(1)};
-  right: ${space(1)};
+  top: ${p => p.theme.space.md};
+  right: ${p => p.theme.space.md};
   color: ${p => p.theme.subText};
 
   &:hover {

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -1,0 +1,307 @@
+import {useCallback, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+import {useQueryClient} from '@tanstack/react-query';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {Button} from 'sentry/components/core/button/button';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {ExternalLink, Link} from 'sentry/components/core/link';
+import {
+  makeProjectSeerPreferencesQueryKey,
+  useProjectSeerPreferences,
+} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
+import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
+import Placeholder from 'sentry/components/placeholder';
+import {IconClose} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface CursorIntegrationCtaProps {
+  project: Project;
+  dismissKey?: string;
+  dismissible?: boolean;
+  organization?: Organization;
+  variant?: 'drawer' | 'settings';
+}
+
+export function CursorIntegrationCta({
+  project,
+  dismissible = false,
+  dismissKey,
+  variant = 'drawer',
+}: CursorIntegrationCtaProps) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  const {preference, isFetching: isLoadingPreferences} =
+    useProjectSeerPreferences(project);
+  const {mutate: updateProjectSeerPreferences, isPending: isUpdatingPreferences} =
+    useUpdateProjectSeerPreferences(project);
+  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
+    useCodingAgentIntegrations();
+
+  const cursorIntegration = codingAgentIntegrations?.integrations.find(
+    integration => integration.provider === 'cursor'
+  );
+
+  const [isDismissed, setIsDismissed] = useState(() => {
+    if (!dismissible || !dismissKey) {
+      return false;
+    }
+    return localStorage.getItem(dismissKey) === 'true';
+  });
+
+  const hasCursorIntegration = Boolean(
+    organization?.features.includes('integrations-cursor') && cursorIntegration
+  );
+  const isConfigured = Boolean(preference?.automation_handoff);
+
+  // Determine the current stage
+  const stage = hasCursorIntegration
+    ? isConfigured
+      ? 'configured'
+      : 'configure'
+    : 'install';
+
+  // Reset dismissal if stage changes
+  useEffect(() => {
+    if (!dismissible || !dismissKey) {
+      return;
+    }
+    const dismissedStage = localStorage.getItem(`${dismissKey}-stage`);
+    if (dismissedStage && dismissedStage !== stage) {
+      setIsDismissed(false);
+      localStorage.removeItem(dismissKey);
+    }
+  }, [stage, dismissKey, dismissible]);
+
+  const handleDismiss = useCallback(() => {
+    if (!dismissKey) {
+      return;
+    }
+    localStorage.setItem(dismissKey, 'true');
+    localStorage.setItem(`${dismissKey}-stage`, stage);
+    setIsDismissed(true);
+  }, [dismissKey, stage]);
+
+  const handleSetupClick = useCallback(() => {
+    if (!cursorIntegration) {
+      throw new Error('Cursor integration not found');
+    }
+    updateProjectSeerPreferences(
+      {
+        repositories: preference?.repositories || [],
+        automated_run_stopping_point: 'root_cause',
+        automation_handoff: {
+          handoff_point: 'root_cause',
+          target: 'cursor_background_agent',
+          integration_id: parseInt(cursorIntegration.id, 10),
+        },
+      },
+      {
+        onSuccess: () => {
+          // Invalidate queries to update the dropdown in the settings page
+          queryClient.invalidateQueries({
+            queryKey: [
+              makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
+            ],
+          });
+        },
+      }
+    );
+  }, [
+    project.slug,
+    organization.slug,
+    updateProjectSeerPreferences,
+    preference?.repositories,
+    cursorIntegration,
+    queryClient,
+  ]);
+
+  if (!organization) {
+    return null;
+  }
+
+  if (isDismissed) {
+    return null;
+  }
+
+  const CardWrapper = variant === 'drawer' ? DrawerCard : SettingsCard;
+
+  // Show loading state while fetching data
+  if (isLoadingPreferences || isLoadingIntegrations || isUpdatingPreferences) {
+    return (
+      <CardWrapper>
+        <Placeholder height="120px" />
+      </CardWrapper>
+    );
+  }
+
+  // Stage 1: Integration not installed
+  if (!hasCursorIntegration) {
+    return (
+      <CardWrapper>
+        {dismissible && (
+          <DismissButton
+            size="xs"
+            priority="link"
+            icon={<IconClose />}
+            aria-label={t('Dismiss')}
+            onClick={handleDismiss}
+          />
+        )}
+
+        <Flex direction="column" gap="lg">
+          <Heading as="h3">
+            <Flex direction="row" gap="sm" align="center">
+              <PluginIcon pluginId="cursor" /> <span>Cursor Agent Integration</span>
+            </Flex>
+          </Heading>
+          <Text>
+            {tct(
+              'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Background Agents for seamless code fixes. [docsLink:Read the docs] to learn more.',
+              {
+                docsLink: (
+                  <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
+                ),
+              }
+            )}
+          </Text>
+          <div>
+            <LinkButton to="/settings/integrations/cursor/" priority="default" size="sm">
+              {t('Install Cursor Integration')}
+            </LinkButton>
+          </div>
+        </Flex>
+      </CardWrapper>
+    );
+  }
+
+  // Stage 2: Integration installed but handoff not configured
+  if (!isConfigured) {
+    return (
+      <CardWrapper>
+        {dismissible && (
+          <DismissButton
+            size="xs"
+            priority="link"
+            icon={<IconClose />}
+            aria-label={t('Dismiss')}
+            onClick={handleDismiss}
+          />
+        )}
+
+        <Flex direction="column" gap="lg">
+          <Heading as="h3">
+            <Flex direction="row" gap="sm" align="center">
+              <PluginIcon pluginId="cursor" /> <span>Cursor Agent Integration</span>
+            </Flex>
+          </Heading>
+          <Text>
+            {tct(
+              'You have the Cursor integration installed. Set up Seer to hand off and trigger Cursor Background Agents during automation. [seerProjectSettings:Configure in Seer project settings] or [docsLink:read the docs] to learn more.',
+              {
+                seerProjectSettings: (
+                  <Link to={`/settings/projects/${project.slug}/seer/`} />
+                ),
+                docsLink: (
+                  <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
+                ),
+              }
+            )}
+          </Text>
+          <div>
+            <Button onClick={handleSetupClick} priority="default" size="sm">
+              {t('Set Seer to hand off to Cursor')}
+            </Button>
+          </div>
+        </Flex>
+      </CardWrapper>
+    );
+  }
+
+  // Stage 3: Configured or just configured
+  return (
+    <CardWrapper>
+      {dismissible && (
+        <DismissButton
+          size="xs"
+          priority="link"
+          icon={<IconClose />}
+          aria-label={t('Dismiss')}
+          onClick={handleDismiss}
+        />
+      )}
+
+      <Flex direction="column" gap="lg">
+        <Heading as="h3">
+          <Flex direction="row" gap="sm" align="center">
+            <PluginIcon pluginId="cursor" /> <span>Cursor Agent Integration</span>
+          </Flex>
+        </Heading>
+        <Text>
+          {variant === 'settings'
+            ? tct(
+                'Cursor handoff is active. During automation runs, Seer will automatically trigger Cursor Background Agents. [docsLink:Read the docs] to learn more.',
+                {
+                  docsLink: (
+                    <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
+                  ),
+                }
+              )
+            : tct(
+                'Cursor handoff is active. During automation runs, Seer will automatically trigger Cursor Background Agents. [seerProjectSettings:Configure in Seer project settings] or [docsLink:read the docs] to learn more.',
+                {
+                  seerProjectSettings: (
+                    <Link to={`/settings/projects/${project.slug}/seer/`} />
+                  ),
+                  docsLink: (
+                    <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
+                  ),
+                }
+              )}
+        </Text>
+      </Flex>
+    </CardWrapper>
+  );
+}
+
+const DrawerCard = styled('div')`
+  position: relative;
+  background: ${p => p.theme.backgroundElevated};
+  overflow: visible;
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(2)} ${space(2)};
+  box-shadow: ${p => p.theme.dropShadowMedium};
+  transition: all 0.3s ease-in-out;
+  margin-top: ${space(2)};
+  margin-bottom: ${space(2)};
+`;
+
+const SettingsCard = styled('div')`
+  position: relative;
+  padding: ${space(2)};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  margin-top: ${space(3)};
+  margin-bottom: ${space(3)};
+`;
+
+const DismissButton = styled(Button)`
+  position: absolute;
+  top: ${space(1)};
+  right: ${space(1)};
+  color: ${p => p.theme.subText};
+
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
+`;

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -58,9 +58,9 @@ export function CursorIntegrationCta({
     return localStorage.getItem(dismissKey) === 'true';
   });
 
-  const hasCursorIntegration = Boolean(
-    organization?.features.includes('integrations-cursor') && cursorIntegration
-  );
+  const hasCursorIntegrationFeatureFlag =
+    organization?.features.includes('integrations-cursor');
+  const hasCursorIntegration = Boolean(cursorIntegration);
   const isConfigured = Boolean(preference?.automation_handoff);
 
   // Determine the current stage
@@ -130,6 +130,10 @@ export function CursorIntegrationCta({
   }
 
   if (isDismissed) {
+    return null;
+  }
+
+  if (!hasCursorIntegrationFeatureFlag) {
     return null;
   }
 

--- a/static/app/components/events/autofix/preferences/hooks/useProjectSeerPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useProjectSeerPreferences.ts
@@ -11,7 +11,7 @@ export interface SeerPreferencesResponse {
   preference?: ProjectSeerPreferences | null;
 }
 
-function makeProjectSeerPreferencesQueryKey(orgSlug: string, projectSlug: string) {
+export function makeProjectSeerPreferencesQueryKey(orgSlug: string, projectSlug: string) {
   return `/projects/${orgSlug}/${projectSlug}/seer/preferences/`;
 }
 

--- a/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
@@ -1,12 +1,14 @@
+import {makeProjectSeerPreferencesQueryKey} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import type {Project} from 'sentry/types/project';
-import {useMutation} from 'sentry/utils/queryClient';
+import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export function useUpdateProjectSeerPreferences(project: Project) {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (data: ProjectSeerPreferences) => {
@@ -22,6 +24,11 @@ export function useUpdateProjectSeerPreferences(project: Project) {
           data: payload,
         }
       );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [makeProjectSeerPreferencesQueryKey(organization.slug, project.slug)],
+      });
     },
   });
 }

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -103,6 +103,7 @@ describe('SeerDrawer', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    localStorage.clear();
 
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
@@ -137,10 +138,24 @@ describe('SeerDrawer', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/group-search-views/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/`,
       body: {
         autofixAutomationTuning: 'off',
       },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/autofix-repos/`,
+      body: [],
     });
   });
 
@@ -632,5 +647,162 @@ describe('SeerDrawer', () => {
     expect(
       screen.getByText(/It currently only supports GitHub repositories/)
     ).toBeInTheDocument();
+  });
+
+  it('shows cursor integration onboarding step if integration is installed but handoff not configured', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [{external_id: 'repo-123', name: 'org/repo', provider: 'github'}],
+          automated_run_stopping_point: 'root_cause',
+          // No automation_handoff
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+        seerScannerAutomation: true,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/autofix-repos/`,
+      body: [
+        {
+          name: 'org/repo',
+          provider: 'github',
+          owner: 'org',
+          external_id: 'repo-123',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/group-search-views/starred/`,
+      body: [
+        {
+          id: '1',
+          name: 'Fixability View',
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        },
+      ],
+    });
+
+    render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization: OrganizationFixture({
+        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+      }),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    expect(
+      await screen.findByText('Hand Off to Cursor Background Agents')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Set Seer to hand off to Cursor'})
+    ).toBeInTheDocument();
+  });
+
+  it('does not show cursor integration step if localStorage skip key is set', async () => {
+    // Set skip key BEFORE rendering
+    localStorage.setItem(`seer-onboarding-cursor-skipped:${mockProject.id}`, 'true');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [{external_id: 'repo-123', name: 'org/repo', provider: 'github'}],
+          automated_run_stopping_point: 'root_cause',
+          // No automation_handoff
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+        seerScannerAutomation: true,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/autofix-repos/`,
+      body: [
+        {
+          name: 'org/repo',
+          provider: 'github',
+          owner: 'org',
+          external_id: 'repo-123',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/group-search-views/starred/`,
+      body: [
+        {
+          id: '1',
+          name: 'Fixability View',
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        },
+      ],
+    });
+
+    render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization: OrganizationFixture({
+        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+      }),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    // Should not show the step since it was skipped
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -146,7 +146,10 @@ describe('SeerNotices', () => {
     });
     const project = getProjectWithAutomation('medium');
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
-      organization,
+      organization: {
+        ...organization,
+        features: ['integrations-cursor'],
+      },
     });
     await waitFor(() => {
       expect(
@@ -189,7 +192,10 @@ describe('SeerNotices', () => {
     });
     const project = getProjectWithAutomation('medium');
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
-      organization,
+      organization: {
+        ...organization,
+        features: ['integrations-cursor'],
+      },
     });
 
     // Should not show the cursor step since it was skipped
@@ -247,7 +253,10 @@ describe('SeerNotices', () => {
     });
     const project = getProjectWithAutomation('medium');
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
-      organization,
+      organization: {
+        ...organization,
+        features: ['integrations-cursor'],
+      },
     });
 
     // Should not show the cursor step since handoff is already configured

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -155,7 +155,7 @@ describe('SeerNotices', () => {
     });
   });
 
-  it('does not show cursor integration step if localStorage skip key is set', async () => {
+  it('does not show cursor integration step if localStorage skip key is set', () => {
     // Set localStorage skip key
     localStorage.setItem(`seer-onboarding-cursor-skipped:${ProjectFixture().id}`, 'true');
 
@@ -201,7 +201,7 @@ describe('SeerNotices', () => {
     localStorage.removeItem(`seer-onboarding-cursor-skipped:${ProjectFixture().id}`);
   });
 
-  it('does not show cursor integration step if handoff is already configured', async () => {
+  it('does not show cursor integration step if handoff is already configured', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/coding-agents/`,
       body: {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -49,6 +49,12 @@ describe('SeerNotices', () => {
       url: `/projects/${organization.slug}/${ProjectFixture().slug}/autofix-repos/`,
       body: [createRepository()],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [],
+      },
+    });
   });
 
   it('shows automation step if automation is allowed and tuning is off', async () => {
@@ -98,6 +104,158 @@ describe('SeerNotices', () => {
     });
   });
 
+  it('shows cursor integration step if integration is installed but handoff not configured', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [],
+          automated_run_stopping_point: 'root_cause',
+          // No automation_handoff - handoff is not configured
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [
+        GroupSearchViewFixture({
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        }),
+      ],
+    });
+    const project = getProjectWithAutomation('medium');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization,
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText('Hand Off to Cursor Background Agents')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('does not show cursor integration step if localStorage skip key is set', async () => {
+    // Set localStorage skip key
+    localStorage.setItem(`seer-onboarding-cursor-skipped:${ProjectFixture().id}`, 'true');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [
+        GroupSearchViewFixture({
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        }),
+      ],
+    });
+    const project = getProjectWithAutomation('medium');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization,
+    });
+
+    // Should not show the cursor step since it was skipped
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
+
+    // Clean up localStorage
+    localStorage.removeItem(`seer-onboarding-cursor-skipped:${ProjectFixture().id}`);
+  });
+
+  it('does not show cursor integration step if handoff is already configured', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [],
+          automated_run_stopping_point: 'root_cause',
+          automation_handoff: {
+            handoff_point: 'root_cause',
+            target: 'cursor_background_agent',
+            integration_id: 123,
+          },
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [
+        GroupSearchViewFixture({
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        }),
+      ],
+    });
+    const project = getProjectWithAutomation('medium');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization,
+    });
+
+    // Should not show the cursor step since handoff is already configured
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
+  });
+
   it('does not render guided steps if all onboarding steps are complete', () => {
     MockApiClient.addMockResponse({
       method: 'GET',
@@ -126,5 +284,8 @@ describe('SeerNotices', () => {
     expect(screen.queryByText('Pick Repositories to Work In')).not.toBeInTheDocument();
     expect(screen.queryByText('Unleash Automation')).not.toBeInTheDocument();
     expect(screen.queryByText('Get Some Quick Wins')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -116,10 +116,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const cursorIntegration = codingAgentIntegrations?.integrations.find(
     integration => integration.provider === 'cursor'
   );
-  // const hasCursorFeatureFlagEnabled = Boolean(
-  //   organization.features.includes('integrations-cursor')
-  // );
-  const hasCursorFeatureFlagEnabled = true;
+  const hasCursorFeatureFlagEnabled = Boolean(
+    organization.features.includes('integrations-cursor')
+  );
   const isCursorHandoffConfigured = Boolean(preference?.automation_handoff);
 
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
@@ -436,8 +435,10 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                   key="cursor-integration"
                   stepKey="cursor-integration"
                   title={
-                    <Flex align="center" gap="sm">
-                      <PluginIcon pluginId="cursor" />
+                    <Flex align="baseline" gap="sm" display="inline-flex">
+                      <CursorPluginIcon>
+                        <PluginIcon pluginId="cursor" />
+                      </CursorPluginIcon>
                       {t('Hand Off to Cursor Background Agents')}
                     </Flex>
                   }
@@ -613,6 +614,10 @@ const CardIllustration = styled('img')`
 
 const CursorCardIllustration = styled(CardIllustration)`
   max-width: 160px;
+`;
+
+const CursorPluginIcon = styled('div')`
+  transform: translateY(3px);
 `;
 
 const StepContentRow = styled('div')`

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -6,6 +6,7 @@ import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
+import {CursorIntegrationCta} from 'sentry/components/events/autofix/cursorIntegrationCta';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
@@ -324,6 +325,11 @@ function ProjectSeer({
         })}
       />
       <ProjectSeerGeneralForm project={project} />
+      <CursorIntegrationCta
+        project={project}
+        organization={organization}
+        variant="settings"
+      />
       <AutofixRepositories project={project} />
       <Center>
         <LinkButton

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -325,11 +325,7 @@ function ProjectSeer({
         })}
       />
       <ProjectSeerGeneralForm project={project} />
-      <CursorIntegrationCta
-        project={project}
-        organization={organization}
-        variant="settings"
-      />
+      <CursorIntegrationCta project={project} organization={organization} />
       <AutofixRepositories project={project} />
       <Center>
         <LinkButton


### PR DESCRIPTION
Makes the cursor agent integration more discoverable by adding callouts to the seer project settings page and another seer onboarding step.

The main difference between this step and other seer steps is that it will not keep the onboarding steps around if you skip it (because not everyone has the cursor integration, so we make it truly skippable and not naggy)

## Onboarding Step:
Without integration set up:
<img width="1800" height="518" alt="CleanShot 2025-11-11 at 00 03 40@2x" src="https://github.com/user-attachments/assets/e0459fd5-3f18-4f09-ab49-1288116a1b40" />
With integration set up but without handoff set:
<img width="2040" height="526" alt="CleanShot 2025-11-11 at 00 04 05@2x" src="https://github.com/user-attachments/assets/4f8dae18-a244-4e61-8cef-9dfb60ddb26c" />
With handoff setup or onboarding step skipped:
<img width="1066" height="236" alt="CleanShot 2025-11-11 at 03 22 09@2x" src="https://github.com/user-attachments/assets/db6be34c-acaf-469a-96fe-fccc6a68caf3" />

## Settings callout:
Without integration set up:
<img width="2844" height="418" alt="CleanShot 2025-11-10 at 23 58 26@2x" src="https://github.com/user-attachments/assets/d7a1e1aa-c9db-430f-92e7-960d8121d9fd" />
With integration set up but without handoff set:
<img width="2904" height="518" alt="CleanShot 2025-11-10 at 23 59 00@2x" src="https://github.com/user-attachments/assets/a0a88dbf-f030-44ff-b7df-bbb8f5bce5e5" />
With handoff setup:
<img width="2930" height="498" alt="CleanShot 2025-11-11 at 03 23 37@2x" src="https://github.com/user-attachments/assets/4046ef2d-25f5-48a7-a6d4-85406a269e3d" />
