### PR TITLE
feat(triage signals): Fixability based stopping point for autofix

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -485,8 +485,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     # Normalize URL transaction names during ingestion.
     manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
-    # Enbale Triage signals V0 for AI powered issue classifiaction in sentry
-    manager.add("organizations:triage-signals-v0", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables unlimited auto-triggered autofix runs
     manager.add("organizations:unlimited-auto-triggered-autofix-runs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables view hierarchy attachment scrubbing
@@ -659,6 +657,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enables experimental span v2 processing in Relay.
     manager.add("projects:span-v2-experimental-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enbale Triage signals V0 for AI powered issue classifiaction in sentry
+    manager.add("projects:triage-signals-v0", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("projects:profiling-ingest-unsampled-profiles", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -24,7 +24,11 @@ from sentry.seer.autofix.constants import (
     FixabilityScoreThresholds,
     SeerAutomationSource,
 )
-from sentry.seer.autofix.utils import get_autofix_state, is_seer_autotriggered_autofix_rate_limited
+from sentry.seer.autofix.utils import (
+    AutofixStoppingPoint,
+    get_autofix_state,
+    is_seer_autotriggered_autofix_rate_limited,
+)
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
@@ -48,13 +52,35 @@ auto_run_source_map = {
 }
 
 
+def _get_stopping_point_from_fixability(fixability_score: float) -> AutofixStoppingPoint | None:
+    """
+    Determine the autofix stopping point based on fixability score.
+
+    Low fixability (< 0.40): No autofix (returns None)
+    Medium fixability (0.40 - 0.66): Stop at SOLUTION (before coding)
+    High fixability (>= 0.66): Go to OPEN_PR (full automation)
+    """
+    if fixability_score < FixabilityScoreThresholds.MEDIUM.value:
+        return None
+    elif fixability_score < FixabilityScoreThresholds.HIGH.value:
+        return AutofixStoppingPoint.SOLUTION
+    else:
+        return AutofixStoppingPoint.OPEN_PR
+
+
 @instrumented_task(
     name="sentry.tasks.autofix.trigger_autofix_from_issue_summary",
     namespace=seer_tasks,
     processing_deadline_duration=65,
     retry=Retry(times=1),
 )
-def _trigger_autofix_task(group_id: int, event_id: str, user_id: int | None, auto_run_source: str):
+def _trigger_autofix_task(
+    group_id: int,
+    event_id: str,
+    user_id: int | None,
+    auto_run_source: str,
+    stopping_point: AutofixStoppingPoint | None = None,
+):
     """
     Asynchronous task to trigger Autofix.
     """
@@ -82,6 +108,7 @@ def _trigger_autofix_task(group_id: int, event_id: str, user_id: int | None, aut
             event_id=event_id,
             user=user,
             auto_run_source=auto_run_source,
+            stopping_point=stopping_point,
         )
 
 
@@ -252,11 +279,16 @@ def _run_automation(
     if is_rate_limited:
         return
 
+    stopping_point = None
+    if features.has("organizations:triage-signals-v0", group.organization):
+        stopping_point = _get_stopping_point_from_fixability(issue_summary.scores.fixability_score)
+
     _trigger_autofix_task.delay(
         group_id=group.id,
         event_id=event.event_id,
         user_id=user_id,
         auto_run_source=auto_run_source,
+        stopping_point=stopping_point,
     )
 
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -55,10 +55,6 @@ auto_run_source_map = {
 def _get_stopping_point_from_fixability(fixability_score: float) -> AutofixStoppingPoint | None:
     """
     Determine the autofix stopping point based on fixability score.
-
-    Low fixability (< 0.40): No autofix (returns None)
-    Medium fixability (0.40 - 0.66): Stop at SOLUTION (before coding)
-    High fixability (>= 0.66): Go to OPEN_PR (full automation)
     """
     if fixability_score < FixabilityScoreThresholds.MEDIUM.value:
         return None

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -276,7 +276,7 @@ def _run_automation(
         return
 
     stopping_point = None
-    if features.has("organizations:triage-signals-v0", group.organization):
+    if features.has("projects:triage-signals-v0", group.project):
         stopping_point = _get_stopping_point_from_fixability(issue_summary.scores.fixability_score)
 
     _trigger_autofix_task.delay(

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -61,7 +61,7 @@ def _get_stopping_point_from_fixability(fixability_score: float) -> AutofixStopp
     elif fixability_score < FixabilityScoreThresholds.HIGH.value:
         return AutofixStoppingPoint.SOLUTION
     else:
-        return AutofixStoppingPoint.OPEN_PR
+        return AutofixStoppingPoint.CODE_CHANGES
 
 
 @instrumented_task(

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -722,27 +722,50 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
     @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    @pytest.mark.parametrize(
-        "score,expected",
-        [(0.80, AutofixStoppingPoint.OPEN_PR), (0.50, AutofixStoppingPoint.SOLUTION)],
-    )
-    def test_with_feature_flag(
-        self, score, expected, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
+    def test_high_fixability_open_pr(
+        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
     ):
         from sentry.seer.autofix.issue_summary import _run_automation
 
+        self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
             group_id=str(self.group.id),
             headline="h",
             whats_wrong="w",
             trace="t",
             possible_cause="c",
-            scores=SummarizeIssueScores(fixability_score=score),
+            scores=SummarizeIssueScores(fixability_score=0.80),
         )
         _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
-        assert mock_trigger.call_args[1]["stopping_point"] == expected
+        mock_trigger.assert_called_once()
+        assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.OPEN_PR
 
-    @with_feature("organizations:gen-ai-features")
+    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
+    @patch(
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        return_value=False,
+    )
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
+    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
+    def test_medium_fixability_solution(
+        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
+    ):
+        from sentry.seer.autofix.issue_summary import _run_automation
+
+        self.project.update_option("sentry:autofix_automation_tuning", "always")
+        mock_gen.return_value = SummarizeIssueResponse(
+            group_id=str(self.group.id),
+            headline="h",
+            whats_wrong="w",
+            trace="t",
+            possible_cause="c",
+            scores=SummarizeIssueScores(fixability_score=0.50),
+        )
+        _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        mock_trigger.assert_called_once()
+        assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.SOLUTION
+
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch(
         "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
@@ -754,6 +777,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     def test_without_feature_flag(self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger):
         from sentry.seer.autofix.issue_summary import _run_automation
 
+        self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
             group_id=str(self.group.id),
             headline="h",
@@ -762,6 +786,11 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
             possible_cause="c",
             scores=SummarizeIssueScores(fixability_score=0.80),
         )
-        _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+
+        with self.feature(
+            {"organizations:gen-ai-features": True, "organizations:triage-signals-v0": False}
+        ):
+            _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] is None

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -699,15 +699,15 @@ class TestGetStoppingPointFromFixability:
             (0.39, None),
             (0.40, AutofixStoppingPoint.SOLUTION),
             (0.65, AutofixStoppingPoint.SOLUTION),
-            (0.66, AutofixStoppingPoint.OPEN_PR),
-            (1.0, AutofixStoppingPoint.OPEN_PR),
+            (0.66, AutofixStoppingPoint.CODE_CHANGES),
+            (1.0, AutofixStoppingPoint.CODE_CHANGES),
         ],
     )
     def test_stopping_point_mapping(self, score, expected):
         assert _get_stopping_point_from_fixability(score) == expected
 
 
-@with_feature({"organizations:gen-ai-features": True, "organizations:triage-signals-v0": True})
+@with_feature({"organizations:gen-ai-features": True, "projects:triage-signals-v0": True})
 class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -723,7 +723,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
     @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    def test_high_fixability_open_pr(
+    def test_high_fixability_code_changes(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
     ):
         self.project.update_option("sentry:autofix_automation_tuning", "always")
@@ -737,7 +737,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         )
         _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
         mock_trigger.assert_called_once()
-        assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.OPEN_PR
+        assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch(
@@ -783,7 +783,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         )
 
         with self.feature(
-            {"organizations:gen-ai-features": True, "organizations:triage-signals-v0": False}
+            {"organizations:gen-ai-features": True, "projects:triage-signals-v0": False}
         ):
             _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -12,7 +12,13 @@ from sentry.issues.grouptype import WebVitalsGroup
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.locks import locks
 from sentry.seer.autofix.constants import SeerAutomationSource
-from sentry.seer.autofix.issue_summary import _call_seer, _get_event, get_issue_summary
+from sentry.seer.autofix.issue_summary import (
+    _call_seer,
+    _get_event,
+    _get_stopping_point_from_fixability,
+    get_issue_summary,
+)
+from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SummarizeIssueResponse, SummarizeIssueScores
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -682,3 +688,155 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 
         assert status_code == 200
         mock_call_seer.assert_called_once_with(self.group, serialized_event, None)
+
+
+class TestGetStoppingPointFromFixability:
+    """Tests for _get_stopping_point_from_fixability function."""
+
+    @pytest.mark.parametrize(
+        "fixability_score,expected_stopping_point",
+        [
+            # Low fixability (< 0.40) -> None
+            (0.0, None),
+            (0.25, None),
+            (0.39, None),
+            # Medium fixability (0.40 - 0.66) -> SOLUTION
+            (0.40, AutofixStoppingPoint.SOLUTION),
+            (0.50, AutofixStoppingPoint.SOLUTION),
+            (0.65, AutofixStoppingPoint.SOLUTION),
+            # High fixability (>= 0.66) -> OPEN_PR
+            (0.66, AutofixStoppingPoint.OPEN_PR),
+            (0.75, AutofixStoppingPoint.OPEN_PR),
+            (0.90, AutofixStoppingPoint.OPEN_PR),
+            (1.0, AutofixStoppingPoint.OPEN_PR),
+        ],
+    )
+    def test_stopping_point_mapping(self, fixability_score, expected_stopping_point):
+        """Test fixability score maps to correct stopping point."""
+        assert _get_stopping_point_from_fixability(fixability_score) == expected_stopping_point
+
+
+@with_feature({"organizations:gen-ai-features": True, "organizations:triage-signals-v0": True})
+class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
+    """Tests for _run_automation with stopping point computation."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.login_as(user=self.user)
+        event_data = load_data("python")
+        self.event = self.store_event(data=event_data, project_id=self.project.id)
+
+    @pytest.mark.parametrize(
+        "fixability_score,expected_stopping_point",
+        [
+            (0.80, AutofixStoppingPoint.OPEN_PR),
+            (0.50, AutofixStoppingPoint.SOLUTION),
+        ],
+    )
+    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
+    @patch("sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited")
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
+    def test_stopping_point_passed_to_trigger_with_feature_flag(
+        self,
+        mock_generate_fixability_score,
+        mock_has_budget,
+        mock_get_autofix_state,
+        mock_is_rate_limited,
+        mock_trigger_autofix_task,
+        fixability_score,
+        expected_stopping_point,
+    ):
+        """Test that correct stopping point is passed when feature flag is enabled."""
+        from sentry.seer.autofix.issue_summary import _run_automation
+
+        mock_generate_fixability_score.return_value = SummarizeIssueResponse(
+            group_id=str(self.group.id),
+            headline="headline",
+            whats_wrong="what",
+            trace="trace",
+            possible_cause="cause",
+            scores=SummarizeIssueScores(fixability_score=fixability_score),
+        )
+        mock_has_budget.return_value = True
+        mock_get_autofix_state.return_value = None
+        mock_is_rate_limited.return_value = False
+
+        _run_automation(
+            group=self.group,
+            user=self.user,
+            event=self.event,
+            source=SeerAutomationSource.ALERT,
+        )
+
+        mock_trigger_autofix_task.assert_called_once()
+        assert mock_trigger_autofix_task.call_args[1]["stopping_point"] == expected_stopping_point
+
+    @with_feature("organizations:gen-ai-features")
+    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
+    @patch("sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited")
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
+    def test_stopping_point_none_without_feature_flag(
+        self,
+        mock_generate_fixability_score,
+        mock_has_budget,
+        mock_get_autofix_state,
+        mock_is_rate_limited,
+        mock_trigger_autofix_task,
+    ):
+        """Test that stopping point is None when feature flag is disabled."""
+        from sentry.seer.autofix.issue_summary import _run_automation
+
+        mock_generate_fixability_score.return_value = SummarizeIssueResponse(
+            group_id=str(self.group.id),
+            headline="headline",
+            whats_wrong="what",
+            trace="trace",
+            possible_cause="cause",
+            scores=SummarizeIssueScores(fixability_score=0.80),
+        )
+        mock_has_budget.return_value = True
+        mock_get_autofix_state.return_value = None
+        mock_is_rate_limited.return_value = False
+
+        _run_automation(
+            group=self.group,
+            user=self.user,
+            event=self.event,
+            source=SeerAutomationSource.ALERT,
+        )
+
+        mock_trigger_autofix_task.assert_called_once()
+        assert mock_trigger_autofix_task.call_args[1]["stopping_point"] is None
+
+    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
+    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
+    def test_no_trigger_with_low_fixability(
+        self,
+        mock_generate_fixability_score,
+        mock_trigger_autofix_task,
+    ):
+        """Test that autofix is not triggered for low fixability scores."""
+        from sentry.seer.autofix.issue_summary import _run_automation
+
+        mock_generate_fixability_score.return_value = SummarizeIssueResponse(
+            group_id=str(self.group.id),
+            headline="headline",
+            whats_wrong="what",
+            trace="trace",
+            possible_cause="cause",
+            scores=SummarizeIssueScores(fixability_score=0.30),
+        )
+
+        _run_automation(
+            group=self.group,
+            user=self.user,
+            event=self.event,
+            source=SeerAutomationSource.ALERT,
+        )
+
+        mock_trigger_autofix_task.assert_not_called()

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -16,6 +16,7 @@ from sentry.seer.autofix.issue_summary import (
     _call_seer,
     _get_event,
     _get_stopping_point_from_fixability,
+    _run_automation,
     get_issue_summary,
 )
 from sentry.seer.autofix.utils import AutofixStoppingPoint
@@ -725,8 +726,6 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     def test_high_fixability_open_pr(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
     ):
-        from sentry.seer.autofix.issue_summary import _run_automation
-
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
             group_id=str(self.group.id),
@@ -751,8 +750,6 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     def test_medium_fixability_solution(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
     ):
-        from sentry.seer.autofix.issue_summary import _run_automation
-
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
             group_id=str(self.group.id),
@@ -775,8 +772,6 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_without_feature_flag(self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger):
-        from sentry.seer.autofix.issue_summary import _run_automation
-
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
             group_id=str(self.group.id),


### PR DESCRIPTION
## PR Details
+ Changing the logic to set the default stopping point of Autofix based on fixability score. The UI stopping point will still override this until the Settings UI is changed. 
+ Using this feature flag to just try out in the Seer org: https://github.com/getsentry/sentry-options-automator/blob/main/options/default/flagpole.yaml#L3207
+ More details in triage signals implementation document: https://www.notion.so/sentry/Triage-Signals-V0-Technical-Implementation-Details-2a18b10e4b5d8086a7ceddaf4194849a?source=copy_link#2a48b10e4b5d8064a52ac6b519630fc0
