### PR TITLE
feat(performance): Updates web vitals issue detection task to respect user threshold and enabled settings

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -101,7 +101,7 @@ DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "transaction_duration_regression_detection_enabled": True,
     "function_duration_regression_detection_enabled": True,
     "db_query_injection_detection_enabled": False,
-    "web_vitals_detection_enabled": False,
+    "web_vitals_detection_enabled": True,
 }
 
 DEFAULT_PROJECT_PERFORMANCE_GENERAL_SETTINGS = {

--- a/src/sentry/tasks/web_vitals_issue_detection.py
+++ b/src/sentry/tasks/web_vitals_issue_detection.py
@@ -4,6 +4,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from sentry import features, options
+from sentry.issue_detection.performance_detection import get_merged_settings
 from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
@@ -24,7 +25,7 @@ logger = logging.getLogger("sentry.tasks.web_vitals_issue_detection")
 TRANSACTIONS_PER_PROJECT_LIMIT = 5
 DEFAULT_START_TIME_DELTA = {"days": 7}  # Low scores within this time range create web vital issues
 SCORE_THRESHOLD = 0.9  # Scores below this threshold will create web vital issues
-SAMPLES_COUNT_THRESHOLD = 10  # TODO: Use project config threshold setting. Web Vitals require at least this amount of samples to create an issue
+DEFAULT_SAMPLES_COUNT_THRESHOLD = 10
 VITALS: list[WebVitalIssueDetectionType] = ["lcp", "fcp", "cls", "ttfb", "inp"]
 
 
@@ -58,6 +59,11 @@ def run_web_vitals_issue_detection() -> None:
 
     for project in projects:
         if not check_seer_setup_for_project(project):
+            continue
+
+        # Check if web vitals detection is enabled in the project's performance issue settings
+        performance_settings = get_merged_settings(project.id)
+        if not performance_settings.get("web_vitals_detection_enabled", False):
             continue
 
         detect_web_vitals_issues_for_project.delay(project.id)
@@ -113,6 +119,12 @@ def get_highest_opportunity_page_vitals_for_project(
 
     end_time = datetime.now(UTC)
     start_time = end_time - timedelta(**start_time_delta)
+
+    # Get the samples count threshold from performance issue settings
+    performance_settings = get_merged_settings(project.id)
+    samples_count_threshold = performance_settings.get(
+        "web_vitals_count", DEFAULT_SAMPLES_COUNT_THRESHOLD
+    )
 
     snuba_params = SnubaParams(
         start=start_time,
@@ -171,7 +183,7 @@ def get_highest_opportunity_page_vitals_for_project(
             p75_value = row.get(f"p75(measurements.{vital})")
             samples_count = row.get(f"count_scores(measurements.score.{vital})")
             score_under_threshold = score is not None and score < SCORE_THRESHOLD
-            enough_samples = samples_count is not None and samples_count >= SAMPLES_COUNT_THRESHOLD
+            enough_samples = samples_count is not None and samples_count >= samples_count_threshold
             if (
                 score is not None
                 and score_under_threshold

--- a/tests/sentry/issues/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/issues/endpoints/test_project_performance_issue_settings.py
@@ -36,7 +36,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
         assert response.data["file_io_on_main_thread_detection_enabled"]
         assert response.data["consecutive_db_queries_detection_enabled"]
         assert response.data["large_render_blocking_asset_detection_enabled"]
-        assert not response.data["web_vitals_detection_enabled"]  # Disabled by default
+        assert response.data["web_vitals_detection_enabled"]
 
         get_value.return_value = {
             "slow_db_queries_detection_enabled": False,

--- a/tests/sentry/tasks/test_web_vitals_issue_detection.py
+++ b/tests/sentry/tasks/test_web_vitals_issue_detection.py
@@ -444,3 +444,29 @@ class WebVitalsIssueDetectionDataTest(TestCase, SnubaTestCase, SpanTestCase):
                 call_args_list[0].kwargs["event_data"]["contexts"]["trace"]["trace_id"]
                 == p75_span["trace_id"]
             )
+
+    @patch("sentry.tasks.web_vitals_issue_detection.detect_web_vitals_issues_for_project.delay")
+    @patch("sentry.tasks.web_vitals_issue_detection.get_merged_settings")
+    def test_run_detection_does_not_run_for_project_when_user_has_disabled(
+        self, mock_get_merged_settings, mock_detect_web_vitals_issues_for_project
+    ):
+        mock_get_merged_settings.return_value = {
+            "web_vitals_detection_enabled": False,
+        }
+        project = self.create_project()
+
+        with (
+            self.mock_seer_ack(),
+            self.mock_code_mapping(),
+            self.options(
+                {
+                    "issue-detection.web-vitals-detection.enabled": True,
+                    "issue-detection.web-vitals-detection.projects-allowlist": [project.id],
+                }
+            ),
+            self.feature("organizations:gen-ai-features"),
+            TaskRunner(),
+        ):
+            run_web_vitals_issue_detection()
+
+            assert not mock_detect_web_vitals_issues_for_project.called


### PR DESCRIPTION
Updates the web vitals issue detection task to use project settings to control enabled and minimum sample count threshold.

**Also sets web vitals issue detection to be enabled by default** (Detection is still guarded by allowlists an several other options and eligibility checks. We just want the project setting to be on by default for GA)