### PR TITLE
ref(aci): remove detector usage in WorkflowFireHistory and action firing

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -975,7 +975,6 @@ def process_workflow_engine(job: PostProcessJob) -> None:
     try:
         process_workflows_event.apply_async(
             kwargs=dict(
-                project_id=job["event"].project_id,
                 event_id=job["event"].event_id,
                 occurrence_id=job["event"].occurrence_id,
                 group_id=job["event"].group_id,

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -28,7 +28,6 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowActionGroupStatus,
 )
-from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
 from sentry.workflow_engine.types import WorkflowEventData
@@ -149,13 +148,11 @@ def get_unique_active_actions(
 
 
 @scopedstats.timer()
-def fire_actions(
-    actions: BaseQuerySet[Action], detector: Detector, event_data: WorkflowEventData
-) -> None:
+def fire_actions(actions: BaseQuerySet[Action], event_data: WorkflowEventData) -> None:
     deduped_actions = get_unique_active_actions(actions)
 
     for action in deduped_actions:
-        task_params = build_trigger_action_task_params(action, detector, event_data)
+        task_params = build_trigger_action_task_params(action, event_data)
         trigger_action.apply_async(kwargs=task_params, headers={"sentry-propagate-traces": False})
 
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -545,7 +545,6 @@ def process_workflows(
 
     should_trigger_actions = should_fire_workflow_actions(organization, event_data.group.type)
     create_workflow_fire_histories(
-        detector,
         actions,
         event_data,
         should_trigger_actions,
@@ -553,5 +552,6 @@ def process_workflows(
         start_timestamp=event_start_time,
     )
 
-    fire_actions(actions, detector, event_data)
+    fire_actions(actions, event_data)
+
     return WorkflowEvaluation(tainted=False, data=workflow_evaluation_data)

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -10,7 +10,6 @@ from sentry.workflow_engine.models import (
     Action,
     DataCondition,
     DataConditionGroup,
-    Detector,
     WorkflowDataConditionGroup,
     WorkflowFireHistory,
 )
@@ -24,7 +23,6 @@ EnqueuedAction = tuple[DataConditionGroup, list[DataCondition]]
 
 @scopedstats.timer()
 def create_workflow_fire_histories(
-    detector: Detector,
     actions_to_fire: BaseQuerySet[Action],
     event_data: WorkflowEventData,
     is_single_processing: bool,
@@ -66,7 +64,6 @@ def create_workflow_fire_histories(
 
     fire_histories = [
         WorkflowFireHistory(
-            detector_id=detector.id,
             workflow_id=workflow_id,
             group=event_data.group,
             event_id=event_id,

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -75,7 +75,7 @@ def trigger_action(
     group_state: GroupState,
     has_reappeared: bool,
     has_escalated: bool,
-    detector_id: int | None = None,
+    detector_id: int | None = None,  # TODO: remove
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.workflow_engine.processors.detector import get_detector_from_event_data

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -77,10 +77,7 @@ def trigger_action(
     detector_id: int | None = None,  # TODO: remove
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-    from sentry.workflow_engine.processors.detector import (
-        get_detector_by_group,
-        get_detector_from_event_data,
-    )
+    from sentry.workflow_engine.processors.detector import get_detector_from_event_data
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):
@@ -102,12 +99,10 @@ def trigger_action(
             has_reappeared=has_reappeared,
             has_escalated=has_escalated,
         )
-        detector = get_detector_from_event_data(event_data)
     elif activity_id is not None:
         event_data = build_workflow_event_data_from_activity(
             activity_id=activity_id, group_id=group_id
         )
-        detector = get_detector_by_group(event_data.group)
     else:
         # This should never happen, and if it does, need to investigate
         logger.error(
@@ -115,6 +110,8 @@ def trigger_action(
             extra={"event_id": event_id, "activity_id": activity_id},
         )
         raise ValueError("Exactly one of event_id or activity_id must be provided")
+
+    detector = get_detector_from_event_data(event_data)
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -12,7 +12,6 @@ from sentry.taskworker.retry import Retry
 from sentry.utils import metrics
 from sentry.utils.exceptions import timeout_grouping_context
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.tasks.utils import (
     build_workflow_event_data_from_activity,
     build_workflow_event_data_from_event,
@@ -78,7 +77,10 @@ def trigger_action(
     detector_id: int | None = None,  # TODO: remove
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-    from sentry.workflow_engine.processors.detector import get_detector_from_event_data
+    from sentry.workflow_engine.processors.detector import (
+        get_detector_by_group,
+        get_detector_from_event_data,
+    )
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):
@@ -100,10 +102,12 @@ def trigger_action(
             has_reappeared=has_reappeared,
             has_escalated=has_escalated,
         )
+        detector = get_detector_from_event_data(event_data)
     elif activity_id is not None:
         event_data = build_workflow_event_data_from_activity(
             activity_id=activity_id, group_id=group_id
         )
+        detector = get_detector_by_group(event_data.group)
     else:
         # This should never happen, and if it does, need to investigate
         logger.error(
@@ -111,8 +115,6 @@ def trigger_action(
             extra={"event_id": event_id, "activity_id": activity_id},
         )
         raise ValueError("Exactly one of event_id or activity_id must be provided")
-
-    detector = get_detector_by_event(event_data)
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -11,7 +11,8 @@ from sentry.taskworker import namespaces
 from sentry.taskworker.retry import Retry
 from sentry.utils import metrics
 from sentry.utils.exceptions import timeout_grouping_context
-from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.tasks.utils import (
     build_workflow_event_data_from_activity,
     build_workflow_event_data_from_event,
@@ -23,7 +24,7 @@ logger = log_context.get_logger(__name__)
 
 
 def build_trigger_action_task_params(
-    action: Action, detector: Detector, event_data: WorkflowEventData
+    action: Action, event_data: WorkflowEventData
 ) -> dict[str, object]:
     """
     Build parameters for trigger_action task invocation.
@@ -45,7 +46,6 @@ def build_trigger_action_task_params(
 
     return {
         "action_id": action.id,
-        "detector_id": detector.id,
         "workflow_id": getattr(action, "workflow_id", None),
         "event_id": event_id,
         "activity_id": activity_id,
@@ -90,11 +90,6 @@ def trigger_action(
 
     action = Action.objects.annotate(workflow_id=Value(workflow_id)).get(id=action_id)
 
-    # TODO: remove detector usage from this task
-    detector: Detector | None = None
-    if detector_id is not None:
-        detector = Detector.objects.get(id=detector_id)
-
     if event_id is not None:
         event_data = build_workflow_event_data_from_event(
             event_id=event_id,
@@ -117,8 +112,7 @@ def trigger_action(
         )
         raise ValueError("Exactly one of event_id or activity_id must be provided")
 
-    if not detector:
-        detector = get_detector_from_event_data(event_data)
+    detector = get_detector_by_event(event_data)
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -103,7 +103,7 @@ def process_workflows_event(
     has_reappeared: bool,
     has_escalated: bool,
     start_timestamp_seconds: float | None = None,
-    project_id: int | None = None,
+    project_id: int | None = None,  # TODO: remove
     **kwargs: dict[str, Any],
 ) -> None:
     from sentry.workflow_engine.processors.workflow import process_workflows

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -927,14 +927,12 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
         # First call should be for workflow1/group1
         first_call_kwargs = mock_trigger.call_args_list[0].kwargs["kwargs"]
-        assert first_call_kwargs["detector_id"] == self.detector.id
         assert first_call_kwargs["event_id"] == self.event1.event_id
         assert first_call_kwargs["group_id"] == self.group1.id
         assert first_call_kwargs["workflow_id"] == self.workflow1.id
 
         # Second call should be for workflow2/group2
         second_call_kwargs = mock_trigger.call_args_list[1].kwargs["kwargs"]
-        assert second_call_kwargs["detector_id"] == self.detector.id
         assert second_call_kwargs["event_id"] == self.event2.event_id
         assert second_call_kwargs["group_id"] == self.group2.id
         assert second_call_kwargs["workflow_id"] == self.workflow2.id

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -749,7 +749,12 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         self.batch_client = DelayedWorkflowClient()
 
     @patch("sentry.utils.metrics.incr")
-    def test_metrics_issue_dual_processing_metrics(self, mock_incr: MagicMock) -> None:
+    @patch("sentry.workflow_engine.tasks.utils.IssueOccurrence.fetch")
+    def test_metrics_issue_dual_processing_metrics(
+        self, mock_fetch: MagicMock, mock_incr: MagicMock
+    ) -> None:
+        mock_fetch.return_value = self.group_event.occurrence
+
         with self.tasks():
             process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         mock_incr.assert_any_call(

--- a/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
@@ -41,7 +41,6 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
         initial_count = WorkflowFireHistory.objects.count()
 
         result = create_workflow_fire_histories(
-            self.detector,
             Action.objects.filter(id=self.action.id),
             self.event_data,
             is_single_processing=False,
@@ -52,7 +51,6 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
         assert WorkflowFireHistory.objects.count() == initial_count
 
         assert not WorkflowFireHistory.objects.filter(
-            detector=self.detector,
             workflow=self.workflow,
             group=self.group,
             event_id=self.group_event.event_id,

--- a/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
@@ -22,7 +22,6 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
 
     def test_create_workflow_fire_histories(self) -> None:
         create_workflow_fire_histories(
-            self.detector,
             Action.objects.filter(id=self.action.id),
             self.event_data,
             is_single_processing=True,
@@ -30,7 +29,7 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
         )
         assert (
             WorkflowFireHistory.objects.filter(
-                detector=self.detector,
+                detector=None,
                 workflow=self.workflow,
                 group=self.group,
                 event_id=self.group_event.event_id,


### PR DESCRIPTION
Title

Should merge https://github.com/getsentry/sentry/pull/102918 first. Also removes need for `get_detectors_by_groupevents_bulk`!