### PR TITLE
fix(logs): Auto refresh should work with high fidelity mode

### DIFF
--- a/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
+++ b/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
@@ -30,6 +30,7 @@ export type AutoRefreshState =
 
 interface LogsAutoRefreshContextValue {
   autoRefresh: AutoRefreshState;
+  hasInitialized: boolean;
   isTableFrozen: boolean | undefined;
   pausedAt: number | undefined;
   refreshInterval: number;
@@ -87,6 +88,7 @@ export function LogsAutoRefreshProvider({
         isTableFrozen,
         pausedAt,
         setPausedAt,
+        hasInitialized: hasInitialized.current,
         ..._testContext,
       }}
     >

--- a/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
@@ -14,7 +14,7 @@ import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParams
 
 describe('LogsAutoRefresh Integration Tests', () => {
   const {organization, project, routerConfig, setupPageFilters, setupEventsMock} =
-    initializeLogsTest();
+    initializeLogsTest({orgFeatures: ['ourlogs-high-fidelity']});
 
   const testDate = new Date('2024-01-15T10:00:00.000Z');
   const {baseFixtures} = createLogFixtures(organization, project, testDate);
@@ -48,7 +48,7 @@ describe('LogsAutoRefresh Integration Tests', () => {
         analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
         source="location"
       >
-        <LogsPageDataProvider>{children}</LogsPageDataProvider>
+        <LogsPageDataProvider allowHighFidelity>{children}</LogsPageDataProvider>
       </LogsQueryParamsProvider>,
       options
     ) as ReturnType<typeof render> & {router: any}; // Can't select the router type without exporting it.

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -21,7 +21,10 @@ import {
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
+import {
+  useLogsAutoRefresh,
+  useLogsAutoRefreshEnabled,
+} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
@@ -408,6 +411,13 @@ export function useInfiniteLogsQuery({
 } = {}) {
   const _referrer = referrer ?? 'api.explore.logs-table';
   const autoRefresh = useLogsAutoRefreshEnabled();
+  const {hasInitialized: autoRefreshHasInitialized} = useLogsAutoRefresh();
+
+  // High fidelity and auto refresh are disjoint features and cannot
+  // be used together. So if auto refresh was ever initialized, we must
+  // disable high fidelity mode.
+  highFidelity = autoRefreshHasInitialized ? false : highFidelity;
+
   const {queryKey: queryKeyWithInfinite, other} = useLogsQueryKeyWithInfinite({
     referrer: _referrer,
     autoRefresh,


### PR DESCRIPTION
High fidelity mode breaks autorefresh because it uses a different cursor. This means the 2 features cannot be used together. This change ensures that once auto refresh is turned on, high fidelity mode is turned off for the remainder of that session.

Closes JAVASCRIPT-34DA
Closes JAVASCRIPT-34G1