### PR TITLE
fix(preprod): send date fields to update Github check-run times

### DIFF
--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -6,6 +6,7 @@ configure()
 
 import logging
 import sys
+from datetime import timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -500,6 +501,12 @@ def main() -> None:
                 preprod_artifact.get_state_display(),
                 head_build_config.name if head_build_config else "None",
             )
+
+            # Simulate processing time by backdating the creation timestamp
+            # This ensures completed_at != started_at in the status check
+            preprod_artifact.date_added = preprod_artifact.date_added - timedelta(minutes=5)
+            preprod_artifact.save(update_fields=["date_added"])
+            logger.info("  ✓ Backdated artifact creation by 5 minutes (simulating processing time)")
 
             # Create size metrics if requested
             if create_metrics:


### PR DESCRIPTION
We weren't sending the `started_at` and `completed_at` fields to Github so the time always said 0s.

Processing:
<img width="214" height="60" alt="Screenshot 2025-11-10 at 2 54 32 PM" src="https://github.com/user-attachments/assets/9abb4d64-41e5-4556-aa90-d70dd0de5060" />

Completed:
<img width="200" height="56" alt="Screenshot 2025-11-10 at 2 55 30 PM" src="https://github.com/user-attachments/assets/d6d8f018-fb53-4c09-95ee-f531b7ce2485" />

Resolves EME-586