### PR TITLE
ref(aci): remove passing in detector to action.trigger attempt 2

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.endpoints.utils.test_fire_action import test_fire_ac
 from sentry.workflow_engine.migration_helpers.rule_action import (
     translate_rule_data_actions_to_notification_actions,
 )
-from sentry.workflow_engine.models import Detector, Workflow
+from sentry.workflow_engine.models import Workflow
 from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
@@ -161,14 +161,6 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             organization=rule.project.organization,
         )
 
-        detector = Detector(
-            id=TEST_NOTIFICATION_ID,
-            project=rule.project,
-            name=rule.label,
-            enabled=True,
-            type=ErrorGroupType.slug,
-        )
-
         event_data = WorkflowEventData(
             event=test_event,
             group=test_event.group,
@@ -190,7 +182,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                 action_exceptions.append(f"An unexpected error occurred. Error ID: '{error_id}'")
                 continue
 
-            action_exceptions.extend(test_fire_action(action, event_data, detector))
+            action_exceptions.extend(test_fire_action(action, event_data))
 
         status = None
         data = None

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -23,7 +23,7 @@ from sentry.workflow_engine.endpoints.organization_workflow_index import (
 )
 from sentry.workflow_engine.endpoints.utils.test_fire_action import test_fire_action
 from sentry.workflow_engine.endpoints.validators.base.action import BaseActionValidator
-from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
@@ -121,14 +121,6 @@ def test_fire_actions(actions: list[dict[str, Any]], project: Project):
         group=test_event.group,
     )
 
-    detector = Detector(
-        id=TEST_NOTIFICATION_ID,
-        project=project,
-        name="Test Detector",
-        enabled=True,
-        type="error",
-    )
-
     for action_data in actions:
         # Create a temporary Action object (not saved to database)
         action = Action(
@@ -143,7 +135,7 @@ def test_fire_actions(actions: list[dict[str, Any]], project: Project):
         setattr(action, "workflow_id", workflow_id)
 
         # Test fire the action and collect any exceptions
-        exceptions = test_fire_action(action, workflow_event_data, detector)
+        exceptions = test_fire_action(action, workflow_event_data)
         if exceptions:
             action_exceptions.extend(exceptions)
 

--- a/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
@@ -3,15 +3,13 @@ import logging
 import sentry_sdk
 
 from sentry.shared_integrations.exceptions import IntegrationFormError
-from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
 
 
-def test_fire_action(
-    action: Action, event_data: WorkflowEventData, detector: Detector
-) -> list[str]:
+def test_fire_action(action: Action, event_data: WorkflowEventData) -> list[str]:
     """
     This function will fire an action and return a list of exceptions that occurred.
     """
@@ -19,7 +17,6 @@ def test_fire_action(
     try:
         action.trigger(
             event_data=event_data,
-            detector=detector,
         )
     except Exception as exc:
         if isinstance(exc, IntegrationFormError):

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -124,9 +124,9 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         return action_handler_registry.get(action_type)
 
     def trigger(self, event_data: WorkflowEventData) -> None:
-        from sentry.workflow_engine.processors.detector import get_detector_by_group
+        from sentry.workflow_engine.processors.detector import get_detector_from_event_data
 
-        detector = get_detector_by_group(event_data.group)
+        detector = get_detector_from_event_data(event_data)
 
         with metrics.timer(
             "workflow_engine.action.trigger.execution_time",

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -124,9 +124,10 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         return action_handler_registry.get(action_type)
 
     def trigger(self, event_data: WorkflowEventData) -> None:
-        from sentry.workflow_engine.processors.detector import get_detector_by_event
+        from sentry.workflow_engine.processors.detector import get_detector_by_group
 
-        detector = get_detector_by_event(event_data)
+        detector = get_detector_by_group(event_data.group)
+
         with metrics.timer(
             "workflow_engine.action.trigger.execution_time",
             tags={"action_type": self.type, "detector_type": detector.type},

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 import logging
 from enum import StrEnum
-from typing import TYPE_CHECKING, ClassVar, TypedDict
+from typing import ClassVar, TypedDict
 
 from django.db import models
 from django.db.models import Q
@@ -22,10 +22,6 @@ from sentry.utils import metrics
 from sentry.workflow_engine.models.json_config import JSONConfigBase
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
-
-if TYPE_CHECKING:
-    from sentry.workflow_engine.models import Detector
-
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +123,10 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         action_type = Action.Type(self.type)
         return action_handler_registry.get(action_type)
 
-    def trigger(self, event_data: WorkflowEventData, detector: Detector) -> None:
+    def trigger(self, event_data: WorkflowEventData) -> None:
+        from sentry.workflow_engine.processors.detector import get_detector_by_event
+
+        detector = get_detector_by_event(event_data)
         with metrics.timer(
             "workflow_engine.action.trigger.execution_time",
             tags={"action_type": self.type, "detector_type": detector.type},

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -163,6 +163,8 @@ def get_detector_from_event_data(event_data: WorkflowEventData) -> Detector:
             return get_detector_by_event(event_data)
         elif isinstance(event_data.event, Activity):
             return get_detector_by_group(event_data.group)
+        else:
+            raise TypeError(f"Cannot determine the detector from {type(event_data.event)}.")
     except Detector.DoesNotExist:
         logger.exception(
             "Detector not found for event data",
@@ -176,9 +178,7 @@ def get_detector_from_event_data(event_data: WorkflowEventData) -> Detector:
                 "group_id": event_data.group.id,
             },
         )
-        raise Detector.DoesNotExist("Detector not found for event data")
-
-    raise TypeError(f"Cannot determine the detector from {type(event_data.event)}.")
+        raise
 
 
 class _SplitEvents(NamedTuple):

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -142,7 +142,9 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
 
 def get_detector_by_group(group: Group) -> Detector:
     try:
-        return DetectorGroup.objects.get(group=group).detector
+        detector = DetectorGroup.objects.get(group=group).detector
+        if detector is not None:
+            return detector
     except DetectorGroup.DoesNotExist:
         logger.exception(
             "DetectorGroup not found for group",
@@ -152,7 +154,7 @@ def get_detector_by_group(group: Group) -> Detector:
 
     try:
         return Detector.objects.get(project_id=group.project_id, type=group.issue_type.slug)
-    except Detector.DoesNotExist:
+    except (Detector.DoesNotExist, Detector.MultipleObjectsReturned):
         # return issue stream detector
         return Detector.objects.get(project_id=group.project_id, type=IssueStreamGroupType.slug)
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -165,7 +165,7 @@ def get_detector_from_event_data(event_data: WorkflowEventData) -> Detector:
             return get_detector_by_group(event_data.group)
     except Detector.DoesNotExist:
         logger.exception(
-            "Detector not found for event",
+            "Detector not found for event data",
             extra={
                 "type": type(event_data.event),
                 "id": (
@@ -176,6 +176,7 @@ def get_detector_from_event_data(event_data: WorkflowEventData) -> Detector:
                 "group_id": event_data.group.id,
             },
         )
+        raise Detector.DoesNotExist("Detector not found for event data")
 
     raise TypeError(f"Cannot determine the detector from {type(event_data.event)}.")
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -141,6 +141,10 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
 
 
 def get_detector_by_group(group: Group) -> Detector:
+    """
+    Returns Detector associated with this group, either based on DetectorGroup,
+    (project, type), or if those fail, returns the Issue Stream detector.
+    """
     try:
         detector = DetectorGroup.objects.get(group=group).detector
         if detector is not None:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -139,6 +139,23 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
     return detector
 
 
+def get_detector_by_group(group: Group) -> Detector:
+    try:
+        return DetectorGroup.objects.get(group=group).detector
+    except DetectorGroup.DoesNotExist:
+        logger.exception(
+            "DetectorGroup not found for group",
+            extra={"group_id": group.id},
+        )
+        pass
+
+    try:
+        return Detector.objects.get(project_id=group.project_id, type=group.issue_type.slug)
+    except Detector.DoesNotExist:
+        # return issue stream detector
+        return Detector.objects.get(project_id=group.project_id, type=IssueStreamGroupType.slug)
+
+
 class _SplitEvents(NamedTuple):
     events_with_occurrences: list[tuple[GroupEvent, int]]
     error_events: list[GroupEvent]

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -158,12 +158,26 @@ def get_detector_by_group(group: Group) -> Detector:
 
 
 def get_detector_from_event_data(event_data: WorkflowEventData) -> Detector:
-    if isinstance(event_data.event, GroupEvent):
-        return get_detector_by_event(event_data)
-    elif isinstance(event_data.event, Activity):
-        return get_detector_by_group(event_data.group)
-    else:
-        raise TypeError(f"Cannot determine the detector from {type(event_data.event)}.")
+    try:
+        if isinstance(event_data.event, GroupEvent):
+            return get_detector_by_event(event_data)
+        elif isinstance(event_data.event, Activity):
+            return get_detector_by_group(event_data.group)
+    except Detector.DoesNotExist:
+        logger.exception(
+            "Detector not found for event",
+            extra={
+                "type": type(event_data.event),
+                "id": (
+                    event_data.event.event_id
+                    if isinstance(event_data.event, GroupEvent)
+                    else event_data.event.id
+                ),
+                "group_id": event_data.group.id,
+            },
+        )
+
+    raise TypeError(f"Cannot determine the detector from {type(event_data.event)}.")
 
 
 class _SplitEvents(NamedTuple):

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -78,7 +78,7 @@ def trigger_action(
     detector_id: int | None = None,
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-    from sentry.workflow_engine.processors.detector import get_detector_by_event
+    from sentry.workflow_engine.processors.detector import get_detector_by_group
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):
@@ -119,7 +119,8 @@ def trigger_action(
         raise ValueError("Exactly one of event_id or activity_id must be provided")
 
     if detector is None:
-        detector = get_detector_by_event(event_data)
+        # Detector is used in action firing for activities for metric alert resolution.
+        detector = get_detector_by_group(event_data.group)
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -76,13 +76,9 @@ def trigger_action(
     has_reappeared: bool,
     has_escalated: bool,
     detector_id: int | None = None,
-    project_id: int | None = None,
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
     from sentry.workflow_engine.processors.detector import get_detector_by_event
-
-    if project_id is None and detector_id is None:
-        raise ValueError("Either project_id or detector_id must be provided")
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):
@@ -98,12 +94,9 @@ def trigger_action(
     detector: Detector | None = None
     if detector_id is not None:
         detector = Detector.objects.get(id=detector_id)
-        project_id = detector.project_id
 
     if event_id is not None:
-        assert project_id is not None
         event_data = build_workflow_event_data_from_event(
-            project_id=project_id,
             event_id=event_id,
             group_id=group_id,
             workflow_id=workflow_id,

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -79,6 +79,10 @@ def trigger_action(
     project_id: int | None = None,
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+    from sentry.workflow_engine.processors.detector import get_detector_by_event
+
+    if project_id is None and detector_id is None:
+        raise ValueError("Either project_id or detector_id must be provided")
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):
@@ -89,18 +93,15 @@ def trigger_action(
         raise ValueError("Exactly one of event_id or activity_id must be provided")
 
     action = Action.objects.annotate(workflow_id=Value(workflow_id)).get(id=action_id)
-    detector = Detector.objects.get(id=detector_id)
 
-    metrics.incr(
-        "workflow_engine.tasks.trigger_action_task_started",
-        tags={"action_type": action.type, "detector_type": detector.type},
-        sample_rate=1.0,
-    )
-
-    if project_id is None:
+    # TODO: remove detector usage from this task after we start passing in project_id
+    detector: Detector | None = None
+    if detector_id is not None:
+        detector = Detector.objects.get(id=detector_id)
         project_id = detector.project_id
 
     if event_id is not None:
+        assert project_id is not None
         event_data = build_workflow_event_data_from_event(
             project_id=project_id,
             event_id=event_id,
@@ -123,6 +124,15 @@ def trigger_action(
             extra={"event_id": event_id, "activity_id": activity_id},
         )
         raise ValueError("Exactly one of event_id or activity_id must be provided")
+
+    if detector is None:
+        detector = get_detector_by_event(event_data)
+
+    metrics.incr(
+        "workflow_engine.tasks.trigger_action_task_started",
+        tags={"action_type": action.type, "detector_type": detector.type},
+        sample_rate=1.0,
+    )
 
     should_trigger_actions = should_fire_workflow_actions(
         detector.project.organization, event_data.group.type

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -78,7 +78,10 @@ def trigger_action(
     detector_id: int | None = None,
 ) -> None:
     from sentry.notifications.notification_action.utils import should_fire_workflow_actions
-    from sentry.workflow_engine.processors.detector import get_detector_by_group
+    from sentry.workflow_engine.processors.detector import (
+        get_detector_by_event,
+        get_detector_by_group,
+    )
 
     # XOR check to ensure exactly one of event_id or activity_id is provided
     if (event_id is not None) == (activity_id is not None):
@@ -105,11 +108,14 @@ def trigger_action(
             has_reappeared=has_reappeared,
             has_escalated=has_escalated,
         )
-
+        if not detector:
+            detector = get_detector_by_event(event_data)
     elif activity_id is not None:
         event_data = build_workflow_event_data_from_activity(
             activity_id=activity_id, group_id=group_id
         )
+        if not detector:
+            detector = get_detector_by_group(event_data.group)
     else:
         # This should never happen, and if it does, need to investigate
         logger.error(
@@ -117,10 +123,6 @@ def trigger_action(
             extra={"event_id": event_id, "activity_id": activity_id},
         )
         raise ValueError("Exactly one of event_id or activity_id must be provided")
-
-    if detector is None:
-        # Detector is used in action firing for activities for metric alert resolution.
-        detector = get_detector_by_group(event_data.group)
 
     metrics.incr(
         "workflow_engine.tasks.trigger_action_task_started",

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -90,7 +90,7 @@ def trigger_action(
 
     action = Action.objects.annotate(workflow_id=Value(workflow_id)).get(id=action_id)
 
-    # TODO: remove detector usage from this task after we start passing in project_id
+    # TODO: remove detector usage from this task
     detector: Detector | None = None
     if detector_id is not None:
         detector = Detector.objects.get(id=detector_id)

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -64,7 +64,6 @@ class EventNotFoundError(Exception):
 
 @scopedstats.timer()
 def build_workflow_event_data_from_event(
-    project_id: int,
     event_id: str,
     group_id: int,
     workflow_id: int | None = None,
@@ -78,14 +77,14 @@ def build_workflow_event_data_from_event(
     This method handles all the database fetching and object construction logic.
     Raises EventNotFoundError if the event is not found.
     """
-
+    group = Group.objects.get_from_cache(id=group_id)
+    project_id = group.project_id
     event = fetch_event(event_id, project_id)
     if event is None:
         raise EventNotFoundError(event_id, project_id)
 
     occurrence = IssueOccurrence.fetch(occurrence_id, project_id) if occurrence_id else None
 
-    group = Group.objects.get_from_cache(id=group_id)
     group_event = GroupEvent.from_event(event, group)
     group_event.occurrence = occurrence
 

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -96,7 +96,6 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
     on_silent=DataConditionGroup.DoesNotExist,
 )
 def process_workflows_event(
-    project_id: int,
     event_id: str,
     group_id: int,
     occurrence_id: str | None,
@@ -104,6 +103,7 @@ def process_workflows_event(
     has_reappeared: bool,
     has_escalated: bool,
     start_timestamp_seconds: float | None = None,
+    project_id: int | None = None,
     **kwargs: dict[str, Any],
 ) -> None:
     from sentry.workflow_engine.processors.workflow import process_workflows
@@ -114,7 +114,6 @@ def process_workflows_event(
     with recorder.record():
         try:
             event_data = build_workflow_event_data_from_event(
-                project_id=project_id,
                 event_id=event_id,
                 group_id=group_id,
                 occurrence_id=occurrence_id,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -99,7 +99,10 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         assert mock_send_trigger.call_count == 1
         pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
         assert pagerduty_data is not None
-        assert pagerduty_data["payload"]["summary"].startswith(f"[{self.detector.name}]:")
+        # test notification has its own type, so it will pick up the issue stream detector
+        assert pagerduty_data["payload"]["summary"].startswith(
+            f"[{self.issue_stream_detector.name}]:"
+        )
 
     @mock.patch.object(NotifyEventAction, "after")
     @mock.patch(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -99,10 +99,7 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         assert mock_send_trigger.call_count == 1
         pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
         assert pagerduty_data is not None
-        # test notification has its own type, so it will pick up the issue stream detector
-        assert pagerduty_data["payload"]["summary"].startswith(
-            f"[{self.issue_stream_detector.name}]:"
-        )
+        assert pagerduty_data["payload"]["summary"].startswith(f"[{self.detector.name}]:")
 
     @mock.patch.object(NotifyEventAction, "after")
     @mock.patch(

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -70,7 +70,7 @@ class TestAction(TestCase):
             # Verify the registry was queried with the correct action type
             mock_get.assert_called_once_with(Action.Type.SLACK)
 
-    @patch("sentry.workflow_engine.processors.detector.get_detector_by_event")
+    @patch("sentry.workflow_engine.processors.detector.get_detector_by_group")
     def test_trigger_calls_handler_execute(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_get_detector.return_value = Mock(spec=Detector, type="error")
@@ -82,7 +82,7 @@ class TestAction(TestCase):
                 self.mock_event, self.action, mock_get_detector.return_value
             )
 
-    @patch("sentry.workflow_engine.processors.detector.get_detector_by_event")
+    @patch("sentry.workflow_engine.processors.detector.get_detector_by_group")
     def test_trigger_with_failing_handler(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_handler.execute.side_effect = Exception("Handler failed")
@@ -93,7 +93,7 @@ class TestAction(TestCase):
                 self.action.trigger(self.mock_event)
 
     @patch("sentry.utils.metrics.incr")
-    @patch("sentry.workflow_engine.processors.detector.get_detector_by_event")
+    @patch("sentry.workflow_engine.processors.detector.get_detector_by_group")
     def test_trigger_metrics(self, mock_get_detector: MagicMock, mock_incr: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_get_detector.return_value = Mock(spec=Detector, type="error")

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -78,7 +78,9 @@ class TestAction(TestCase):
         with patch.object(self.action, "get_handler", return_value=mock_handler):
             self.action.trigger(self.mock_event)
 
-            mock_handler.execute.assert_called_once_with(self.mock_event, self.action)
+            mock_handler.execute.assert_called_once_with(
+                self.mock_event, self.action, mock_get_detector.return_value
+            )
 
     @patch("sentry.workflow_engine.processors.detector.get_detector_by_event")
     def test_trigger_with_failing_handler(self, mock_get_detector: MagicMock) -> None:

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -70,7 +70,7 @@ class TestAction(TestCase):
             # Verify the registry was queried with the correct action type
             mock_get.assert_called_once_with(Action.Type.SLACK)
 
-    @patch("sentry.workflow_engine.processors.detector.get_detector_by_group")
+    @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
     def test_trigger_calls_handler_execute(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_get_detector.return_value = Mock(spec=Detector, type="error")
@@ -82,7 +82,7 @@ class TestAction(TestCase):
                 self.mock_event, self.action, mock_get_detector.return_value
             )
 
-    @patch("sentry.workflow_engine.processors.detector.get_detector_by_group")
+    @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
     def test_trigger_with_failing_handler(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_handler.execute.side_effect = Exception("Handler failed")
@@ -93,7 +93,7 @@ class TestAction(TestCase):
                 self.action.trigger(self.mock_event)
 
     @patch("sentry.utils.metrics.incr")
-    @patch("sentry.workflow_engine.processors.detector.get_detector_by_group")
+    @patch("sentry.workflow_engine.processors.detector.get_detector_from_event_data")
     def test_trigger_metrics(self, mock_get_detector: MagicMock, mock_incr: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_get_detector.return_value = Mock(spec=Detector, type="error")

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -6,7 +6,7 @@ from jsonschema import ValidationError
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
 from sentry.utils.registry import NoRegistrationExistsError
-from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 
 
@@ -16,7 +16,6 @@ class TestAction(TestCase):
         self.group = self.create_group()
 
         self.mock_event = WorkflowEventData(event=mock_group_event, group=self.group)
-        self.mock_detector = Mock(name="detector")
         self.action = Action(type=Action.Type.SLACK)
         self.config_schema = {
             "$id": "https://example.com/user-profile.schema.json",
@@ -71,35 +70,39 @@ class TestAction(TestCase):
             # Verify the registry was queried with the correct action type
             mock_get.assert_called_once_with(Action.Type.SLACK)
 
-    def test_trigger_calls_handler_execute(self) -> None:
+    @patch("sentry.workflow_engine.processors.detector.get_detector_by_event")
+    def test_trigger_calls_handler_execute(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
+        mock_get_detector.return_value = Mock(spec=Detector, type="error")
 
         with patch.object(self.action, "get_handler", return_value=mock_handler):
-            self.action.trigger(self.mock_event, self.mock_detector)
+            self.action.trigger(self.mock_event)
 
-            mock_handler.execute.assert_called_once_with(
-                self.mock_event, self.action, self.mock_detector
-            )
+            mock_handler.execute.assert_called_once_with(self.mock_event, self.action)
 
-    def test_trigger_with_failing_handler(self) -> None:
+    @patch("sentry.workflow_engine.processors.detector.get_detector_by_event")
+    def test_trigger_with_failing_handler(self, mock_get_detector: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
         mock_handler.execute.side_effect = Exception("Handler failed")
+        mock_get_detector.return_value = Mock(spec=Detector, type="error")
 
         with patch.object(self.action, "get_handler", return_value=mock_handler):
             with pytest.raises(Exception, match="Handler failed"):
-                self.action.trigger(self.mock_event, self.mock_detector)
+                self.action.trigger(self.mock_event)
 
     @patch("sentry.utils.metrics.incr")
-    def test_trigger_metrics(self, mock_incr: MagicMock) -> None:
+    @patch("sentry.workflow_engine.processors.detector.get_detector_by_event")
+    def test_trigger_metrics(self, mock_get_detector: MagicMock, mock_incr: MagicMock) -> None:
         mock_handler = Mock(spec=ActionHandler)
+        mock_get_detector.return_value = Mock(spec=Detector, type="error")
 
         with patch.object(self.action, "get_handler", return_value=mock_handler):
-            self.action.trigger(self.mock_event, self.mock_detector)
+            self.action.trigger(self.mock_event)
 
             mock_handler.execute.assert_called_once()
             mock_incr.assert_called_once_with(
                 "workflow_engine.action.trigger",
-                tags={"action_type": self.action.type, "detector_type": self.mock_detector.type},
+                tags={"action_type": self.action.type, "detector_type": "error"},
                 sample_rate=1.0,
             )
 


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/103000

But adds in fetching the detector correctly for Activities. Detector is specifically needed to send activity notifications correctly for metric issue resolution