### PR TITLE
feat(triage signals): Drop Where should Seer stop? setting if feature flag is on

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -278,6 +278,7 @@ def _run_automation(
     stopping_point = None
     if features.has("projects:triage-signals-v0", group.project):
         stopping_point = _get_stopping_point_from_fixability(issue_summary.scores.fixability_score)
+        logger.info("Fixability-based stopping point: %s", stopping_point)
 
     _trigger_autofix_task.delay(
         group_id=group.id,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -278,7 +278,6 @@ def _run_automation(
     stopping_point = None
     if features.has("projects:triage-signals-v0", group.project):
         stopping_point = _get_stopping_point_from_fixability(issue_summary.scores.fixability_score)
-        logger.info("Fixability-based stopping point: %s", stopping_point)
 
     _trigger_autofix_task.delay(
         group_id=group.id,

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -241,14 +241,16 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           : (preference?.automated_run_stopping_point ?? 'root_cause'),
       };
 
+  const formKey = hasFixabilityBasedStoppingPoint
+    ? 'fixability-based'
+    : preference?.automation_handoff
+      ? 'cursor_handoff'
+      : (preference?.automated_run_stopping_point ?? 'root_cause');
+
   return (
     <Fragment>
       <Form
-        key={
-          preference?.automation_handoff
-            ? 'cursor_handoff'
-            : (preference?.automated_run_stopping_point ?? 'root_cause')
-        }
+        key={formKey}
         saveOnBlur
         apiMethod="PUT"
         apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}


### PR DESCRIPTION
## PR details
+ The backend (in src/sentry/seer/autofix/issue_summary.py) already computes stopping points based on fixability scores when the feature flag is enabled. This frontend change ensures users don't see or try to set a manual preference that would be ignored anyway.
+ Just added a log line in the backend code. 

### Behavior
+ Feature Flag ON (triage-signals-v0 enabled) (only enabled for Seer project):
  - "Where should Seer stop?" dropdown is hidden
  - Field is completely removed from form data
  - Backend will use fixability-based stopping points instead (already implemented in backend)

+ Feature Flag OFF (default):
  - Everything works exactly as before