### PR TITLE
feat(ai-grouping): add secondary stacktrace filtering by token count

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -25,9 +25,9 @@ from sentry.seer.similarity.utils import (
     event_content_has_stacktrace,
     filter_null_from_string,
     get_stacktrace_string,
-    has_too_many_contributing_frames,
     killswitch_enabled,
     record_did_call_seer_metric,
+    stacktrace_exceeds_limits,
 )
 from sentry.services.eventstore.models import Event
 from sentry.utils import metrics
@@ -65,7 +65,7 @@ def should_call_seer_for_grouping(
         # know the other checks have passed.
         or _has_empty_stacktrace_string(event, variants)
         # do this after the empty stacktrace string check because it calculates the stacktrace string
-        or _has_too_many_contributing_frames(event, variants)
+        or _stacktrace_exceeds_limits(event, variants)
         # **Do not add any new checks after this.** The rate limit check MUST remain the last of all
         # the checks.
         #
@@ -155,9 +155,9 @@ def _event_content_is_seer_eligible(event: Event) -> bool:
     return True
 
 
-def _has_too_many_contributing_frames(event: Event, variants: dict[str, BaseVariant]) -> bool:
-    if has_too_many_contributing_frames(event, variants, ReferrerOptions.INGEST):
-        record_did_call_seer_metric(event, call_made=False, blocker="excess-frames")
+def _stacktrace_exceeds_limits(event: Event, variants: dict[str, BaseVariant]) -> bool:
+    if stacktrace_exceeds_limits(event, variants, ReferrerOptions.INGEST):
+        record_did_call_seer_metric(event, call_made=False, blocker="stacktrace-too-long")
         return True
 
     return False

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -26,8 +26,8 @@ from sentry.seer.similarity.utils import (
     ReferrerOptions,
     event_content_has_stacktrace,
     get_stacktrace_string,
-    has_too_many_contributing_frames,
     killswitch_enabled,
+    stacktrace_exceeds_limits,
 )
 from sentry.users.models.user import User
 from sentry.utils.safe import get_path
@@ -92,7 +92,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         if latest_event and event_content_has_stacktrace(latest_event):
             variants = latest_event.get_grouping_variants(normalize_stacktraces=True)
 
-            if not has_too_many_contributing_frames(
+            if not stacktrace_exceeds_limits(
                 latest_event, variants, ReferrerOptions.SIMILAR_ISSUES_TAB
             ):
                 grouping_info = get_grouping_info_from_variants_legacy(variants)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1158,6 +1158,14 @@ register(
     flags=FLAG_MODIFIABLE_BOOL,
 )
 
+# Maximum token count for stacktraces sent to Seer for similarity analysis
+register(
+    "seer.similarity.max_token_count",
+    type=Int,
+    default=7000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # seer nearest neighbour endpoint timeout
 register(
     "embeddings-grouping.seer.nearest-neighbour-timeout",

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -377,9 +377,9 @@ def stacktrace_exceeds_limits(
         metrics.incr(
             "grouping.similarity.stacktrace_length_filter",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={**shared_tags, "outcome": "block"},
+            tags={**shared_tags, "outcome": "block_frames"},
         )
-        report_token_count_metric(event, variants, "block")
+        report_token_count_metric(event, variants, "block_frames")
         return True
 
     # For platforms that filter by frame count, also check token count
@@ -390,9 +390,9 @@ def stacktrace_exceeds_limits(
         metrics.incr(
             "grouping.similarity.stacktrace_length_filter",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={**shared_tags, "outcome": "block_by_token_count"},
+            tags={**shared_tags, "outcome": "block_tokens"},
         )
-        report_token_count_metric(event, variants, "block_by_token_count")
+        report_token_count_metric(event, variants, "block_tokens")
         return True
 
     metrics.incr(

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -24,7 +24,7 @@ from sentry.seer.similarity.utils import (
     event_content_has_stacktrace,
     filter_null_from_string,
     get_stacktrace_string,
-    has_too_many_contributing_frames,
+    stacktrace_exceeds_limits,
 )
 from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
@@ -401,7 +401,7 @@ def get_events_from_nodestore(
         if event and event_content_has_stacktrace(event):
             variants = event.get_grouping_variants(normalize_stacktraces=True)
 
-            if has_too_many_contributing_frames(event, variants, ReferrerOptions.BACKFILL):
+            if stacktrace_exceeds_limits(event, variants, ReferrerOptions.BACKFILL):
                 invalid_event_group_ids.append(group_id)
                 invalid_event_reasons["excess_frames"] += 1
                 continue

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -403,7 +403,7 @@ def get_events_from_nodestore(
 
             if stacktrace_exceeds_limits(event, variants, ReferrerOptions.BACKFILL):
                 invalid_event_group_ids.append(group_id)
-                invalid_event_reasons["excess_frames"] += 1
+                invalid_event_reasons["stacktrace_too_long"] += 1
                 continue
 
             grouping_info = get_grouping_info_from_variants_legacy(variants)

--- a/tests/sentry/grouping/seer_similarity/test_seer_eligibility.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer_eligibility.py
@@ -207,7 +207,7 @@ class ShouldCallSeerTest(TestCase):
 
         for frame_check_result, expected_result in [(True, False), (False, True)]:
             with patch(
-                "sentry.grouping.ingest.seer._has_too_many_contributing_frames",
+                "sentry.grouping.ingest.seer._stacktrace_exceeds_limits",
                 return_value=frame_check_result,
             ):
                 assert (

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -14,7 +14,7 @@ from sentry.seer.similarity.utils import (
     filter_null_from_string,
     get_stacktrace_string,
     get_token_count,
-    has_too_many_contributing_frames,
+    stacktrace_exceeds_limits,
 )
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
@@ -906,7 +906,7 @@ class HasTooManyFramesTest(TestCase):
             variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
             assert (
-                has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
+                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
                 is expected_result
             )
 
@@ -925,7 +925,7 @@ class HasTooManyFramesTest(TestCase):
             variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
             assert (
-                has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
+                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
                 is expected_result
             )
 
@@ -950,7 +950,7 @@ class HasTooManyFramesTest(TestCase):
             variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
             assert (
-                has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
+                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
                 is expected_result
             )
 
@@ -976,7 +976,7 @@ class HasTooManyFramesTest(TestCase):
             variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
             assert (
-                has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
+                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
                 is expected_result
             )
 
@@ -994,7 +994,7 @@ class HasTooManyFramesTest(TestCase):
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
         assert (
-            has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
+            stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
             is False  # Not flagged as too many because only contributing frames are counted
         )
 
@@ -1011,7 +1011,7 @@ class HasTooManyFramesTest(TestCase):
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
         assert (
-            has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
+            stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
             is False  # Not flagged as too many because only in-app frames are counted
         )
 
@@ -1031,10 +1031,7 @@ class HasTooManyFramesTest(TestCase):
             contributing_variant, _ = get_contributing_variant_and_component(variants)
             assert contributing_variant.variant_name == expected_variant_name
 
-            assert (
-                has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
-                is True
-            )
+            assert stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST) is True
 
     def test_ignores_events_not_grouped_on_stacktrace(self) -> None:
         self.event.data["platform"] = "java"
@@ -1049,7 +1046,7 @@ class HasTooManyFramesTest(TestCase):
         assert isinstance(contributing_variant, CustomFingerprintVariant)
 
         assert (
-            has_too_many_contributing_frames(self.event, variants, ReferrerOptions.INGEST)
+            stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
             is False  # Not flagged as too many because it's grouped by fingerprint
         )
 


### PR DESCRIPTION
When checking stacktrace frame count we now add a secondary check for stacktraces which pass the frame count to also filter by token count. This is a first step towards moving to token count only.