### PR TITLE
fix(billing): Fix credit card expiration date display

### DIFF
--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
 import type {Location} from 'history';
-import moment from 'moment-timezone';
 
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
@@ -189,7 +188,7 @@ function CreditCardPanel({
           />
         ) : subscription.paymentSource ? (
           <Fragment>
-            <Text>{`****${subscription.paymentSource.last4} ${moment(new Date(subscription.paymentSource.expYear, subscription.paymentSource.expMonth - 1)).format('MM/YY')}`}</Text>
+            <Text>{`****${subscription.paymentSource.last4} ${String(subscription.paymentSource.expMonth).padStart(2, '0')}/${String(subscription.paymentSource.expYear).slice(-2)}`}</Text>
             <Text>{`${countryName ? `${countryName} ` : ''} ${subscription.paymentSource.zipCode}`}</Text>
           </Fragment>
         ) : (

--- a/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
@@ -615,4 +615,40 @@ describe('Billing details form', () => {
       inModal.queryByRole('textbox', {name: 'Street Address 1'})
     ).not.toBeInTheDocument();
   });
+
+  it('displays credit card expiration date', async () => {
+    organization.features = ['subscriptions-v3'];
+
+    const subscriptionWithCard = SubscriptionFixture({
+      organization,
+      paymentSource: {
+        last4: '4242',
+        countryCode: 'US',
+        zipCode: '94242',
+        expMonth: 8,
+        expYear: 2030,
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/subscriptions/${organization.slug}/`,
+      method: 'GET',
+      body: subscriptionWithCard,
+    });
+
+    render(
+      <BillingInformation
+        organization={organization}
+        subscription={subscriptionWithCard}
+        location={router.location}
+      />
+    );
+
+    await screen.findByText('Billing Information');
+
+    const cardPanel = await screen.findByTestId('credit-card-panel');
+
+    // Verify payment method displays with correct expiration date format (MM/YY)
+    expect(within(cardPanel).getByText(/\*\*\*\*4242 08\/30/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Replace timezone-dependent Date/moment formatting with direct string formatting to ensure expiration dates display correctly for all users regardless of browser or account timezone settings.

Previous implementation created Date objects at browser-local midnight and formatted them using the user's account timezone preference (set via moment.tz.setDefault), causing month shifts when browser timezone was ahead of account timezone.

----

**Root cause:**

1. Source: https://github.com/getsentry/sentry/blob/08aa2d815eed31a9c782ca53a85d60e5188051d6/static/gsApp/components/creditCardEdit/panel.tsx#L192
2. We create `new Date(2030, 7)` in the browser's local timezone. So `moment()` will parse Date objects in the browser's local timezone.
3. Set `moment.tz.setDefault(userTimeZone);` using the user's timezone preferences (populated from backend) https://github.com/getsentry/sentry/blob/08aa2d815eed31a9c782ca53a85d60e5188051d6/static/app/stores/configStore.tsx#L64
4. We display the moment objects in the user's timezone preferences.