### PR TITLE
ref(feedback): update ai privacy tooltip text

### DIFF
--- a/static/app/components/aiPrivacyTooltip.tsx
+++ b/static/app/components/aiPrivacyTooltip.tsx
@@ -16,7 +16,7 @@ export function AiPrivacyTooltip({children, ...tooltipProps}: AiPrivacyTooltipPr
   return (
     <Tooltip
       isHoverable
-      title={tct(`[link:Learn more]`, {
+      title={tct(`Powered by genAI. [link:Learn more].`, {
         link: (
           <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/ai-privacy-and-security/" />
         ),

--- a/static/app/components/aiPrivacyTooltip.tsx
+++ b/static/app/components/aiPrivacyTooltip.tsx
@@ -16,7 +16,7 @@ export function AiPrivacyTooltip({children, ...tooltipProps}: AiPrivacyTooltipPr
   return (
     <Tooltip
       isHoverable
-      title={tct(`Powered by genAI. [link:Learn more].`, {
+      title={tct(`Powered by genAI. [link:Learn more.]`, {
         link: (
           <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/ai-privacy-and-security/" />
         ),


### PR DESCRIPTION
relates to REPLAY-783

Per [this thread](https://sentry.slack.com/archives/C09C63XBMT5/p1762810212463139), update the AI privacy tooltip text from "[Learn more](https://docs.sentry.io/product/ai-in-sentry/ai-privacy-and-security/)" to "Powered by genAI. [Learn more.](https://docs.sentry.io/product/ai-in-sentry/ai-privacy-and-security/)"

### Before
<img width="605" height="182" alt="Screenshot 2025-11-10 at 3 29 51 PM" src="https://github.com/user-attachments/assets/59f10f63-8ded-4577-b46d-cde7833f3b4f" />

<img width="349" height="78" alt="Screenshot 2025-11-10 at 3 29 39 PM" src="https://github.com/user-attachments/assets/b3705552-0ce8-41fa-b908-78fa2b3807c7" />

### After
<img width="640" height="191" alt="Screenshot 2025-11-10 at 3 27 54 PM" src="https://github.com/user-attachments/assets/f8c74f40-5c39-42f2-a6a9-6a8a1da3f2e0" />

<img width="393" height="78" alt="Screenshot 2025-11-10 at 3 28 35 PM" src="https://github.com/user-attachments/assets/893fb551-d928-4fb5-99bc-1a39bfe74182" />
