### PR TITLE
chore(ai-consent): Replace ask seer AI consent flag

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeer/askSeer.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeer.tsx
@@ -20,7 +20,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 export function AskSeer<T>({state}: {state: ComboBoxState<T>}) {
   const organization = useOrganization();
   const hasAskSeerConsentFlowChanges = organization.features.includes(
-    'ask-seer-consent-flow-update'
+    'gen-ai-consent-flow-removal'
   );
   const {gaveSeerConsent, displayAskSeerFeedback} = useSearchQueryBuilder();
 

--- a/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
@@ -25,7 +25,7 @@ export function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
 
   const organization = useOrganization();
   const hasAskSeerConsentFlowChanges = organization.features.includes(
-    'ask-seer-consent-flow-update'
+    'gen-ai-consent-flow-removal'
   );
 
   const [optionDisableOverride, setOptionDisableOverride] = useState(false);

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4861,7 +4861,7 @@ describe('SearchQueryBuilder', () => {
                 'gen-ai-features',
                 'gen-ai-explore-traces',
                 'gen-ai-explore-traces-consent-ui',
-                'ask-seer-consent-flow-update',
+                'gen-ai-consent-flow-removal',
               ],
             },
           }

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -185,7 +185,7 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
 }) {
   const organization = useOrganization();
   const hasAskSeerConsentFlowChanges = organization.features.includes(
-    'ask-seer-consent-flow-update'
+    'gen-ai-consent-flow-removal'
   );
   const {gaveSeerConsent} = useSearchQueryBuilder();
   const hiddenOptions: Set<SelectKey> = useMemo(() => {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -183,7 +183,7 @@ export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
 
   const organization = useOrganization();
   const hasAskSeerConsentFlowChanges = organization.features.includes(
-    'ask-seer-consent-flow-update'
+    'gen-ai-consent-flow-removal'
   );
 
   const filterKeyMenuItems = useMemo(() => {

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -148,7 +148,7 @@ export function useSortedFilterKeyItems({
     'search-query-builder-wildcard-operators'
   );
   const hasAskSeerConsentFlowChanges = organization.features.includes(
-    'ask-seer-consent-flow-update'
+    'gen-ai-consent-flow-removal'
   );
 
   const flatKeys = useMemo(() => Object.values(filterKeys), [filterKeys]);


### PR DESCRIPTION
Replaces the specific flag `ask-seer-consent-flow-update` with the general flag `gen-ai-consent-flow-removal` so we can easily roll everything out with a single flag.