### PR TITLE
test(ui): Migrate deprecated router mocks to memory router

### DIFF
--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -1,5 +1,4 @@
 import {IncidentFixture} from 'sentry-fixture/incident';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MetricRuleFixture} from 'sentry-fixture/metricRule';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -7,13 +6,13 @@ import {ProjectAlertRuleFixture} from 'sentry-fixture/projectAlertRule';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   act,
   render,
   renderGlobalModal,
   screen,
   userEvent,
+  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import OrganizationStore from 'sentry/stores/organizationStore';
@@ -94,11 +93,8 @@ describe('AlertRulesList', () => {
   });
 
   it('displays list', async () => {
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
 
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
@@ -118,11 +114,8 @@ describe('AlertRulesList', () => {
       url: '/organizations/org-slug/combined-rules/',
       body: [],
     });
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
 
     expect(
@@ -133,11 +126,8 @@ describe('AlertRulesList', () => {
   });
 
   it('displays team dropdown context if unassigned', async () => {
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     const btn = (await screen.findAllByRole('button', {name: 'Unassigned'}))[0]!;
 
@@ -154,11 +144,8 @@ describe('AlertRulesList', () => {
       url: '/projects/org-slug/earth/rules/123/',
       body: [],
     });
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
 
     const btn = (await screen.findAllByRole('button', {name: 'Unassigned'}))[0]!;
@@ -177,11 +164,8 @@ describe('AlertRulesList', () => {
   });
 
   it('displays dropdown context menu with actions', async () => {
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     const actions = (await screen.findAllByRole('button', {name: 'Actions'}))[0]!;
     expect(actions).toBeInTheDocument();
@@ -197,7 +181,7 @@ describe('AlertRulesList', () => {
     const deletedRuleName = 'Issue Rule';
     const issueRule = ProjectAlertRuleFixture({
       name: deletedRuleName,
-      projects: ['project-slug'],
+      projects: ['earth'],
     });
 
     MockApiClient.addMockResponse({
@@ -206,16 +190,13 @@ describe('AlertRulesList', () => {
       body: [{...issueRule, type: CombinedAlertType.ISSUE}],
     });
 
-    const {router, project, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     renderGlobalModal();
 
     const deleteMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/rules/${issueRule.id}/`,
+      url: `/projects/${defaultOrg.slug}/earth/rules/${issueRule.id}/`,
       method: 'DELETE',
       body: {},
     });
@@ -251,16 +232,13 @@ describe('AlertRulesList', () => {
       body: [{...metricRule, type: CombinedAlertType.METRIC}],
     });
 
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     renderGlobalModal();
 
     const deleteMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/alert-rules/${metricRule.id}/`,
+      url: `/organizations/${defaultOrg.slug}/alert-rules/${metricRule.id}/`,
       method: 'DELETE',
       body: {},
     });
@@ -285,13 +263,8 @@ describe('AlertRulesList', () => {
   });
 
   it('sends user to new alert page on duplicate action', async () => {
-    const {organization, router} = initializeOrg({
+    const {router} = render(<AlertRulesList />, {
       organization: defaultOrg,
-    });
-    render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
     });
     const actions = (await screen.findAllByRole('button', {name: 'Actions'}))[0]!;
     expect(actions).toBeInTheDocument();
@@ -303,32 +276,30 @@ describe('AlertRulesList', () => {
 
     await userEvent.click(duplicate);
 
-    expect(router.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/issues/alerts/new/issue/',
-      query: {
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/issues/alerts/new/issue/'
+      );
+    });
+    await waitFor(() => {
+      expect(router.location.query).toEqual({
         createFromDuplicate: 'true',
         duplicateRuleId: '123',
         project: 'earth',
         referrer: 'alert_stream',
-      },
+      });
     });
   });
 
   it('sorts by name', async () => {
-    const {router, organization} = initializeOrg({
-      organization: defaultOrg,
-      router: {
-        location: LocationFixture({
-          query: {asc: '1', sort: 'name'},
-          // Sort by the name column
-          search: '?asc=1&sort=name`',
-        }),
-      },
-    });
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/rules/',
+          query: {asc: '1', sort: 'name'},
+        },
+      },
     });
 
     expect(await screen.findByText('Alert Rule')).toHaveAttribute(
@@ -350,11 +321,8 @@ describe('AlertRulesList', () => {
       ...defaultOrg,
       access: [],
     };
-    const {router, organization} = initializeOrg({organization: noAccessOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: noAccessOrg,
     });
 
     expect(await screen.findByLabelText('Create Alert')).toHaveAttribute(
@@ -364,11 +332,8 @@ describe('AlertRulesList', () => {
   });
 
   it('searches by name', async () => {
-    const {organization, router} = initializeOrg();
-    render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+    const {router} = render(<AlertRulesList />, {
+      organization: defaultOrg,
     });
 
     const search = await screen.findByPlaceholderText('Search by name');
@@ -377,28 +342,24 @@ describe('AlertRulesList', () => {
     const testQuery = 'test name';
     await userEvent.type(search, `${testQuery}{enter}`);
 
-    expect(router.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: {
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({
           name: testQuery,
-        },
-      })
-    );
+        })
+      );
+    });
   });
 
   it('uses empty team query parameter when removing all teams', async () => {
-    const {organization, router} = initializeOrg({
-      router: {
-        location: LocationFixture({
+    const {router} = render(<AlertRulesList />, {
+      organization: defaultOrg,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/alerts/rules/',
           query: {team: 'myteams'},
-          search: '?team=myteams`',
-        }),
+        },
       },
-    });
-    render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
     });
 
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
@@ -409,21 +370,18 @@ describe('AlertRulesList', () => {
     const myTeams = await screen.findAllByText('My Teams');
     await userEvent.click(myTeams[1]!);
 
-    expect(router.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: {
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({
           team: '',
-        },
-      })
-    );
+        })
+      );
+    });
   });
 
   it('displays metric alert status', async () => {
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     const rules = await screen.findAllByText('My Incident Rule');
 
@@ -450,11 +408,8 @@ describe('AlertRulesList', () => {
         },
       ],
     });
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
     expect(screen.getByText('Disabled')).toBeInTheDocument();
@@ -477,11 +432,8 @@ describe('AlertRulesList', () => {
         },
       ],
     });
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
     expect(screen.getByText('Disabled')).toBeInTheDocument();
@@ -503,11 +455,8 @@ describe('AlertRulesList', () => {
         },
       ],
     });
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
     expect(screen.getByText('Muted')).toBeInTheDocument();
@@ -527,22 +476,16 @@ describe('AlertRulesList', () => {
         },
       ],
     });
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     expect(await screen.findByText('My Incident Rule')).toBeInTheDocument();
     expect(screen.getByText('Muted')).toBeInTheDocument();
   });
 
   it('sorts by alert rule', async () => {
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
 
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
@@ -560,26 +503,21 @@ describe('AlertRulesList', () => {
   });
 
   it('preserves empty team query parameter on pagination', async () => {
-    const {organization, router} = initializeOrg({
+    const {router} = render(<AlertRulesList />, {
       organization: defaultOrg,
-    });
-    render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
 
     await userEvent.click(screen.getByLabelText('Next'));
 
-    expect(router.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: {
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({
           team: '',
           cursor: '0:100:0',
-        },
-      })
-    );
+        })
+      );
+    });
   });
 
   it('renders uptime alert rules', async () => {
@@ -594,11 +532,8 @@ describe('AlertRulesList', () => {
       ],
     });
 
-    const {router, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
 
     expect(await screen.findByText('Uptime Rule')).toBeInTheDocument();
@@ -615,16 +550,13 @@ describe('AlertRulesList', () => {
       body: [{...uptimeRule, type: CombinedAlertType.UPTIME}],
     });
 
-    const {router, project, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
+      organization: defaultOrg,
     });
     renderGlobalModal();
 
     const deleteMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/${uptimeRule.id}/`,
+      url: `/projects/${defaultOrg.slug}/project-slug/uptime/${uptimeRule.id}/`,
       method: 'DELETE',
       body: {},
     });

--- a/static/app/views/auth/loginForm.spec.tsx
+++ b/static/app/views/auth/loginForm.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -32,16 +30,13 @@ describe('LoginForm', () => {
       },
     });
 
-    render(<LoginForm authConfig={emptyAuthConfig} />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<LoginForm authConfig={emptyAuthConfig} />);
     await doLogin();
 
     expect(await screen.findByText('Bad username password')).toBeInTheDocument();
   });
 
   it('handles success', async () => {
-    const router = RouterFixture();
     const userObject = {
       id: 1,
       name: 'Joe',
@@ -57,10 +52,7 @@ describe('LoginForm', () => {
       },
     });
 
-    render(<LoginForm authConfig={emptyAuthConfig} />, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    const {router} = render(<LoginForm authConfig={emptyAuthConfig} />);
     await doLogin();
 
     expect(mockRequest).toHaveBeenCalledWith(
@@ -71,7 +63,7 @@ describe('LoginForm', () => {
     );
 
     await waitFor(() => expect(ConfigStore.get('user')).toEqual(userObject));
-    expect(router.push).toHaveBeenCalledWith({pathname: '/next/'});
+    expect(router.location.pathname).toBe('/next/');
   });
 
   it('renders login provider buttons', () => {
@@ -81,9 +73,7 @@ describe('LoginForm', () => {
       githubLoginLink: '/githubLogin',
     };
 
-    render(<LoginForm authConfig={authConfig} />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<LoginForm authConfig={authConfig} />);
 
     expect(screen.getByText('Sign in with GitHub')).toBeInTheDocument();
     expect(screen.getByText('Sign in with Azure DevOps')).toBeInTheDocument();

--- a/static/app/views/auth/registerForm.spec.tsx
+++ b/static/app/views/auth/registerForm.spec.tsx
@@ -1,5 +1,3 @@
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -46,16 +44,13 @@ describe('Register', () => {
       },
     });
 
-    render(<RegisterForm authConfig={emptyAuthConfig} />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<RegisterForm authConfig={emptyAuthConfig} />);
     await doLogin(mockRequest);
 
     expect(await screen.findByText('Registration failed')).toBeInTheDocument();
   });
 
   it('handles success', async () => {
-    const router = RouterFixture();
     const userObject = {
       id: 1,
       name: 'Joe',
@@ -71,13 +66,10 @@ describe('Register', () => {
       },
     });
 
-    render(<RegisterForm authConfig={emptyAuthConfig} />, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    const {router} = render(<RegisterForm authConfig={emptyAuthConfig} />);
     await doLogin(mockRequest);
 
     await waitFor(() => expect(ConfigStore.get('user')).toEqual(userObject));
-    expect(router.push).toHaveBeenCalledWith({pathname: '/next/'});
+    expect(router.location.pathname).toBe('/next/');
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -14,13 +13,6 @@ jest.mock('sentry/utils/useNavigate', () => ({
 const mockUseNavigate = jest.mocked(useNavigate);
 
 describe('DatasetSelector', () => {
-  let router!: ReturnType<typeof RouterFixture>;
-  let organization!: ReturnType<typeof OrganizationFixture>;
-  beforeEach(() => {
-    router = RouterFixture();
-    organization = OrganizationFixture();
-  });
-
   it('changes the dataset', async () => {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);
@@ -28,19 +20,13 @@ describe('DatasetSelector', () => {
     render(
       <WidgetBuilderProvider>
         <DatasetSelector />
-      </WidgetBuilderProvider>,
-      {
-        router,
-        organization,
-        deprecatedRouterMocks: true,
-      }
+      </WidgetBuilderProvider>
     );
 
     await userEvent.click(await screen.findByLabelText('Issues'));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
-        ...router.location,
         query: expect.objectContaining({dataset: 'issue'}),
       }),
       expect.anything()
@@ -60,9 +46,7 @@ describe('DatasetSelector', () => {
         <DatasetSelector />
       </WidgetBuilderProvider>,
       {
-        router,
         organization: organizationWithDeprecation,
-        deprecatedRouterMocks: true,
       }
     );
 
@@ -83,7 +67,6 @@ describe('DatasetSelector', () => {
     // Verify navigation to spans dataset
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
-        ...router.location,
         query: expect.objectContaining({dataset: 'spans'}),
       }),
       expect.anything()
@@ -103,9 +86,7 @@ describe('DatasetSelector', () => {
         <DatasetSelector />
       </WidgetBuilderProvider>,
       {
-        router,
         organization: organizationWithoutDeprecation,
-        deprecatedRouterMocks: true,
       }
     );
 
@@ -117,7 +98,6 @@ describe('DatasetSelector', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
-        ...router.location,
         query: expect.objectContaining({dataset: 'transaction-like'}),
       }),
       expect.anything()

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
@@ -1,6 +1,4 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -117,16 +115,17 @@ describe('WidgetBuilderGroupBySelector', () => {
         </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
-        organization: organizationWithFeature,
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          route: '/organizations/:orgId/dashboard/:dashboardId/',
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-        deprecatedRouterMocks: true,
+          },
+        },
+        organization: organizationWithFeature,
       }
     );
 
@@ -150,16 +149,17 @@ describe('WidgetBuilderGroupBySelector', () => {
         </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
-        organization: organizationWithoutFeature,
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          route: '/organizations/:orgId/dashboard/:dashboardId/',
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
             query: {
               dataset: WidgetType.TRANSACTIONS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-        deprecatedRouterMocks: true,
+          },
+        },
+        organization: organizationWithoutFeature,
       }
     );
 
@@ -182,16 +182,17 @@ describe('WidgetBuilderGroupBySelector', () => {
         </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
-        organization: organizationWithFeature,
-        router: RouterFixture({
-          location: LocationFixture({
+        initialRouterConfig: {
+          route: '/organizations/:orgId/dashboard/:dashboardId/',
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
             query: {
               dataset: WidgetType.ERRORS,
               displayType: DisplayType.LINE,
             },
-          }),
-        }),
-        deprecatedRouterMocks: true,
+          },
+        },
+        organization: organizationWithFeature,
       }
     );
 

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -1,44 +1,24 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {useNavigate} from 'sentry/utils/useNavigate';
 import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 
-jest.mock('sentry/utils/useNavigate', () => ({
-  useNavigate: jest.fn(),
-}));
-
-const mockUseNavigate = jest.mocked(useNavigate);
-
 describe('WidgetBuilder', () => {
-  let router!: ReturnType<typeof RouterFixture>;
-  let organization!: ReturnType<typeof OrganizationFixture>;
-  beforeEach(() => {
-    router = RouterFixture({
-      location: {
-        pathname: '/organizations/org-slug/dashboard/1/',
-        query: {project: '-1'},
-      },
-      params: {},
-    });
-    organization = OrganizationFixture();
-  });
+  const initialRouterConfig = {
+    route: '/organizations/:orgId/dashboard/:dashboardId/',
+    location: {
+      pathname: '/organizations/org-slug/dashboard/1/',
+      query: {project: '-1'},
+    },
+  };
 
   it('edits name and description', async () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetBuilderNameAndDescription />
       </WidgetBuilderProvider>,
       {
-        router,
-        organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig,
       }
     );
 
@@ -46,12 +26,11 @@ describe('WidgetBuilder', () => {
 
     // trigger blur
     await userEvent.tab();
-    expect(mockNavigate).toHaveBeenLastCalledWith(
+    expect(router.location).toEqual(
       expect.objectContaining({
-        ...router.location,
+        ...initialRouterConfig.location,
         query: expect.objectContaining({title: 'some name'}),
-      }),
-      expect.anything()
+      })
     );
 
     await userEvent.click(await screen.findByTestId('add-description'));
@@ -63,12 +42,11 @@ describe('WidgetBuilder', () => {
 
     // trigger blur
     await userEvent.tab();
-    expect(mockNavigate).toHaveBeenLastCalledWith(
+    expect(router.location).toEqual(
       expect.objectContaining({
-        ...router.location,
+        ...initialRouterConfig.location,
         query: expect.objectContaining({description: 'some description'}),
-      }),
-      expect.anything()
+      })
     );
   });
 
@@ -80,9 +58,7 @@ describe('WidgetBuilder', () => {
         />
       </WidgetBuilderProvider>,
       {
-        router,
-        organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig,
       }
     );
 

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -46,7 +46,7 @@ describe('ResourcesLandingPage', () => {
   });
 
   it('renders a list of resources', async () => {
-    render(<ResourcesLandingPage />, {organization, deprecatedRouterMocks: true});
+    render(<ResourcesLandingPage />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(
@@ -59,7 +59,7 @@ describe('ResourcesLandingPage', () => {
   });
 
   it('fetches domain data', async () => {
-    render(<ResourcesLandingPage />, {organization, deprecatedRouterMocks: true});
+    render(<ResourcesLandingPage />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(requestMocks.domainSelector!.mock.calls).toMatchInlineSnapshot(`
@@ -93,7 +93,7 @@ describe('ResourcesLandingPage', () => {
   });
 
   it('contains correct query in charts', async () => {
-    render(<ResourcesLandingPage />, {organization, deprecatedRouterMocks: true});
+    render(<ResourcesLandingPage />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(requestMocks.mainTable!.mock.calls).toMatchInlineSnapshot(`

--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -1,7 +1,6 @@
 import pick from 'lodash/pick';
 import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {VercelProviderFixture} from 'sentry-fixture/vercelIntegration';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -46,9 +45,12 @@ describe('IntegrationOrganizationLink', () => {
   });
   let getOrgsMock: jest.Mock;
 
-  const router = RouterFixture({
-    params: {integrationSlug: 'vercel'},
-  });
+  const initialRouterConfig = {
+    location: {
+      pathname: '/extensions/vercel/link/',
+    },
+    route: '/extensions/:integrationSlug/link/',
+  };
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -83,8 +85,7 @@ describe('IntegrationOrganizationLink', () => {
     });
 
     render(<IntegrationOrganizationLink />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -113,8 +114,7 @@ describe('IntegrationOrganizationLink', () => {
     });
 
     render(<IntegrationOrganizationLink />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -318,10 +318,7 @@ describe('Performance > Table', () => {
           setError={jest.fn()}
           summaryConditions=""
           projects={data.projects}
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();

--- a/static/app/views/settings/account/apiApplications/details.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/details.spec.tsx
@@ -25,13 +25,12 @@ describe('ApiApplications', () => {
     });
 
     render(<ApiApplicationDetails />, {
-      router: {
-        params: {
-          appId: 'abcd',
+      initialRouterConfig: {
+        route: '/settings/account/api-applications/:appId/',
+        location: {
+          pathname: '/settings/account/api-applications/abcd/',
         },
       },
-
-      deprecatedRouterMocks: true,
     });
 
     expect(
@@ -81,13 +80,12 @@ describe('ApiApplications', () => {
     });
 
     render(<ApiApplicationDetails />, {
-      router: {
-        params: {
-          appId: 'abcd',
+      initialRouterConfig: {
+        route: '/settings/account/api-applications/:appId/',
+        location: {
+          pathname: '/settings/account/api-applications/abcd/',
         },
       },
-
-      deprecatedRouterMocks: true,
     });
     renderGlobalModal();
 

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -3,7 +3,6 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {GitLabIntegrationFixture} from 'sentry-fixture/gitlabIntegration';
 import {GitLabIntegrationProviderFixture} from 'sentry-fixture/gitlabIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -14,6 +13,16 @@ describe('IntegrationDetailedView', () => {
   const organization = OrganizationFixture({
     access: ['org:integrations', 'org:write'],
   });
+
+  function createRouterConfig(integrationSlug: string, query?: Record<string, any>) {
+    return {
+      route: '/settings/:orgId/integrations/:integrationSlug/',
+      location: {
+        pathname: `/settings/org-slug/integrations/${integrationSlug}/`,
+        ...(query && {query}),
+      },
+    };
+  }
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -105,11 +114,9 @@ describe('IntegrationDetailedView', () => {
   });
 
   it('shows integration name, status, and install button', async () => {
-    const router = RouterFixture({params: {integrationSlug: 'bitbucket'}});
     render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('bitbucket'),
       organization,
-      router,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(screen.getByText('Bitbucket')).toBeInTheDocument();
@@ -118,14 +125,9 @@ describe('IntegrationDetailedView', () => {
   });
 
   it('view configurations', async () => {
-    const router = RouterFixture({
-      params: {integrationSlug: 'bitbucket'},
-      location: {query: {tab: 'configurations'}},
-    });
     render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('bitbucket', {tab: 'configurations'}),
       organization,
-      router,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -136,15 +138,16 @@ describe('IntegrationDetailedView', () => {
   });
 
   it('disables configure for members without access', async () => {
-    const router = RouterFixture({
-      params: {integrationSlug: 'bitbucket'},
-      location: {query: {tab: 'configurations'}},
-    });
-    const lowerAccessOrganization = OrganizationFixture({access: ['org:read']});
+    const lowerAccessOrg = OrganizationFixture({access: ['org:read']});
     render(<IntegrationDetailedView />, {
-      organization: lowerAccessOrganization,
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        route: '/settings/:orgId/integrations/:integrationSlug/',
+        location: {
+          pathname: `/settings/${lowerAccessOrg.slug}/integrations/bitbucket/`,
+          query: {tab: 'configurations'},
+        },
+      },
+      organization: lowerAccessOrg,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -155,15 +158,16 @@ describe('IntegrationDetailedView', () => {
   });
 
   it('allows members to configure github/gitlab', async () => {
-    const router = RouterFixture({
-      params: {integrationSlug: 'github'},
-      location: {query: {tab: 'configurations'}},
-    });
     const lowerAccessOrganization = OrganizationFixture({access: ['org:read']});
     render(<IntegrationDetailedView />, {
+      initialRouterConfig: {
+        route: '/settings/:orgId/integrations/:integrationSlug/',
+        location: {
+          pathname: `/settings/${lowerAccessOrganization.slug}/integrations/github/`,
+          query: {tab: 'configurations'},
+        },
+      },
       organization: lowerAccessOrganization,
-      router,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -171,13 +175,9 @@ describe('IntegrationDetailedView', () => {
   });
 
   it('shows features tab for github only', async () => {
-    const router = RouterFixture({
-      params: {integrationSlug: 'github'},
-    });
     render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('github'),
       organization,
-      router,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(screen.getByText('features')).toBeInTheDocument();
@@ -189,13 +189,9 @@ describe('IntegrationDetailedView', () => {
       match: [MockApiClient.matchQuery({provider_key: 'github', includeConfig: 0})],
       body: [],
     });
-    const router = RouterFixture({
-      params: {integrationSlug: 'github'},
-    });
     render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('github'),
       organization,
-      router,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -211,13 +207,9 @@ describe('IntegrationDetailedView', () => {
   });
 
   it('can enable github features', async () => {
-    const router = RouterFixture({
-      params: {integrationSlug: 'github'},
-    });
     render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('github'),
       organization,
-      router,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -269,13 +261,9 @@ describe('IntegrationDetailedView', () => {
   });
 
   it('can enable gitlab features', async () => {
-    const router = RouterFixture({
-      params: {integrationSlug: 'gitlab'},
-    });
     render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('gitlab'),
       organization,
-      router,
-      deprecatedRouterMocks: true,
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.spec.tsx
@@ -1,7 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PluginFixture} from 'sentry-fixture/plugin';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -37,13 +36,14 @@ describe('PluginDetailedView', () => {
   });
 
   it('shows the Integration name and install status', async () => {
-    const router = RouterFixture({
-      params: {orgId: organization.slug, integrationSlug: plugin.slug},
-    });
     render(<PluginDetailedView />, {
+      initialRouterConfig: {
+        route: '/settings/:orgId/integrations/:integrationSlug/',
+        location: {
+          pathname: `/settings/${organization.slug}/integrations/${plugin.slug}/`,
+        },
+      },
       organization,
-      router,
-      deprecatedRouterMocks: true,
     });
 
     expect(await screen.findByText(plugin.name)).toBeInTheDocument();
@@ -51,15 +51,15 @@ describe('PluginDetailedView', () => {
   });
 
   it('view configurations', async () => {
-    const router = RouterFixture({
-      params: {orgId: organization.slug, integrationSlug: plugin.slug},
-      location: {query: {tab: 'configurations'}},
-    });
-
     render(<PluginDetailedView />, {
-      router,
+      initialRouterConfig: {
+        route: '/settings/:orgId/integrations/:integrationSlug/',
+        location: {
+          pathname: `/settings/${organization.slug}/integrations/${plugin.slug}/`,
+          query: {tab: 'configurations'},
+        },
+      },
       organization,
-      deprecatedRouterMocks: true,
     });
 
     expect(await screen.findByText(plugin.name)).toBeInTheDocument();

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -31,9 +30,13 @@ describe('SentryAppDetailedView', () => {
     integrationSlug: string;
   }) {
     render(<SentryAppDetailedView />, {
-      router: {...RouterFixture(), params: {integrationSlug}},
+      initialRouterConfig: {
+        route: '/settings/:orgId/integrations/:integrationSlug/',
+        location: {
+          pathname: `/settings/${organization.slug}/integrations/${integrationSlug}/`,
+        },
+      },
       organization,
-      deprecatedRouterMocks: true,
     });
     renderGlobalModal();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();

--- a/static/app/views/settings/organizationProjects/index.spec.tsx
+++ b/static/app/views/settings/organizationProjects/index.spec.tsx
@@ -1,5 +1,4 @@
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -10,7 +9,6 @@ describe('OrganizationProjects', () => {
   let statsGetMock: jest.Mock;
   let projectsPutMock: jest.Mock;
   const project = ProjectFixture();
-  const router = RouterFixture();
 
   beforeEach(() => {
     projectsGetMock = MockApiClient.addMockResponse({
@@ -34,10 +32,7 @@ describe('OrganizationProjects', () => {
   });
 
   it('should render the projects in the store', async () => {
-    render(<OrganizationProjectsContainer />, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    render(<OrganizationProjectsContainer />);
 
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
 
@@ -66,10 +61,7 @@ describe('OrganizationProjects', () => {
   });
 
   it('should search organization projects', async () => {
-    render(<OrganizationProjectsContainer />, {
-      router,
-      deprecatedRouterMocks: true,
-    });
+    const {router} = render(<OrganizationProjectsContainer />);
 
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
 
@@ -77,10 +69,12 @@ describe('OrganizationProjects', () => {
     await userEvent.type(searchBox, 'random');
 
     await waitFor(() => {
-      expect(router.replace).toHaveBeenLastCalledWith({
-        pathname: '/mock-pathname/',
-        query: {query: 'random'},
-      });
+      expect(router.location).toEqual(
+        expect.objectContaining({
+          pathname: '/mock-pathname/',
+          query: expect.objectContaining({query: 'random'}),
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
Doing a batch of various files that cursor was able to do automatically.