### PR TITLE
test(ui): Migrate deprecated router mocks to memory router

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
@@ -12,12 +12,17 @@ import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 describe('Breadcrumb Data Exception', () => {
   const project = ProjectFixture({id: '0'});
 
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {query: {project: project.id}},
-    },
+  const {organization} = initializeOrg({
     projects: [project],
   });
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/issues/123/`,
+      query: {project: project.id},
+    },
+    route: '/organizations/:orgId/issues/:groupId/',
+  };
 
   beforeEach(() => {
     const projectDetails = ProjectFixture({
@@ -65,8 +70,7 @@ describe('Breadcrumb Data Exception', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig,
       }
     );
 
@@ -106,8 +110,7 @@ describe('Breadcrumb Data Exception', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig,
       }
     );
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
@@ -12,12 +12,17 @@ import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 describe('Breadcrumb Data Http', () => {
   const project = ProjectFixture({id: '0'});
 
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {query: {project: project.id}},
-    },
+  const {organization} = initializeOrg({
     projects: [project],
   });
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/issues/123/`,
+      query: {project: project.id},
+    },
+    route: '/organizations/:orgId/issues/:groupId/',
+  };
 
   beforeEach(() => {
     const projectDetails = ProjectFixture({
@@ -65,8 +70,7 @@ describe('Breadcrumb Data Http', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig,
       }
     );
 
@@ -101,8 +105,7 @@ describe('Breadcrumb Data Http', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig,
       }
     );
 

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -329,7 +329,6 @@ describe('GroupActions', () => {
       <GroupActions group={group} project={project} disabled={false} event={null} />,
       {
         organization,
-        deprecatedRouterMocks: true,
       }
     );
 

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -112,7 +112,7 @@ describe('IssueViewsList', () => {
       ],
     });
 
-    render(<IssueViewsList />, {organization, deprecatedRouterMocks: false});
+    render(<IssueViewsList />, {organization});
 
     // By default, sorts by popularity (desc) then visited (desc) then created (desc)
     await waitFor(() => {

--- a/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/commits.spec.tsx
@@ -15,9 +15,7 @@ import Commits from './commits';
 describe('Commits', () => {
   const release = ReleaseFixture();
   const project = ReleaseProjectFixture() as Required<ReleaseProject>;
-  const {router, organization} = initializeOrg({
-    router: {params: {release: release.version}},
-  });
+  const {organization} = initializeOrg();
   const repos = [RepositoryFixture({integrationId: '1'})];
 
   function renderComponent() {
@@ -36,8 +34,12 @@ describe('Commits', () => {
         <Commits />
       </ReleaseContext>,
       {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/releases/${release.version}/commits/`,
+          },
+          route: '/organizations/:orgId/releases/:release/commits/',
+        },
       }
     );
   }
@@ -140,12 +142,6 @@ describe('Commits', () => {
       integrationId: '1',
     });
     // Current repo is stored in query parameter activeRepo
-    const {router: newRouterContext} = initializeOrg({
-      router: {
-        params: {release: release.version},
-        location: {query: {activeRepo: otherRepo.name}},
-      },
-    });
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/releases/${encodeURIComponent(
         release.version
@@ -178,8 +174,13 @@ describe('Commits', () => {
         <Commits />
       </ReleaseContext>,
       {
-        router: newRouterContext,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/releases/${release.version}/commits/`,
+            query: {activeRepo: otherRepo.name},
+          },
+          route: '/organizations/:orgId/releases/:release/commits/',
+        },
       }
     );
     expect(await screen.findByRole('button')).toHaveTextContent(otherRepo.name);

--- a/static/app/views/releases/detail/commitsAndFiles/filesChanged.spec.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/filesChanged.spec.tsx
@@ -29,9 +29,7 @@ function CommitFileFixture(params: Partial<CommitFile> = {}): CommitFile {
 describe('FilesChanged', () => {
   const release = ReleaseFixture();
   const project = ReleaseProjectFixture() as Required<ReleaseProject>;
-  const {router, organization} = initializeOrg({
-    router: {params: {release: release.version}},
-  });
+  const {organization} = initializeOrg();
   const repos = [RepositoryFixture({integrationId: '1'})];
 
   function renderComponent() {
@@ -50,8 +48,12 @@ describe('FilesChanged', () => {
         <FilesChanged />
       </ReleaseContext>,
       {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/releases/${release.version}/files-changed/`,
+          },
+          route: '/organizations/:orgId/releases/:release/files-changed/',
+        },
       }
     );
   }

--- a/static/app/views/settings/components/dataScrubbing/index.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.spec.tsx
@@ -7,8 +7,15 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import GlobalModal from 'sentry/components/globalModal';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import {DataScrubbing} from 'sentry/views/settings/components/dataScrubbing';
+
+jest.mock('sentry/utils/useNavigate', () => ({
+  useNavigate: jest.fn(),
+}));
+
+const mockUseNavigate = jest.mocked(useNavigate);
 
 const relayPiiConfig = JSON.stringify(DataScrubbingRelayPiiConfigFixture());
 
@@ -26,10 +33,7 @@ describe('Data Scrubbing', () => {
           relayPiiConfig={relayPiiConfig}
           organization={organization}
           onSubmitSuccess={jest.fn()}
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       // Header
@@ -69,10 +73,7 @@ describe('Data Scrubbing', () => {
           relayPiiConfig={undefined}
           organization={organization}
           onSubmitSuccess={jest.fn()}
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       expect(screen.getByText('You have no data scrubbing rules')).toBeInTheDocument();
@@ -87,10 +88,7 @@ describe('Data Scrubbing', () => {
           organization={organization}
           onSubmitSuccess={jest.fn()}
           disabled
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       // Read Docs is the only enabled action
@@ -120,10 +118,7 @@ describe('Data Scrubbing', () => {
           organization={organization}
           onSubmitSuccess={jest.fn()}
           project={project}
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       // Header
@@ -149,7 +144,6 @@ describe('Data Scrubbing', () => {
         />,
         {
           organization,
-          deprecatedRouterMocks: true,
         }
       );
 
@@ -171,10 +165,7 @@ describe('Data Scrubbing', () => {
             organization={organization}
             onSubmitSuccess={jest.fn()}
           />
-        </Fragment>,
-        {
-          deprecatedRouterMocks: true,
-        }
+        </Fragment>
       );
 
       await userEvent.click(screen.getAllByLabelText('Delete Rule')[0]!);
@@ -198,10 +189,7 @@ describe('Data Scrubbing', () => {
             organization={organization}
             onSubmitSuccess={jest.fn()}
           />
-        </Fragment>,
-        {
-          deprecatedRouterMocks: true,
-        }
+        </Fragment>
       );
 
       await userEvent.click(screen.getByRole('button', {name: 'Add Rule'}));
@@ -212,7 +200,10 @@ describe('Data Scrubbing', () => {
     });
 
     it('Open Edit Rule Modal', async () => {
-      const {organization, router, project} = initializeOrg();
+      const mockNavigate = jest.fn();
+      mockUseNavigate.mockReturnValue(mockNavigate);
+
+      const {organization, project} = initializeOrg();
 
       render(
         <Fragment>
@@ -225,20 +216,14 @@ describe('Data Scrubbing', () => {
             organization={organization}
             onSubmitSuccess={jest.fn()}
           />
-        </Fragment>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
+        </Fragment>
       );
 
       await userEvent.click(screen.getAllByRole('button', {name: 'Edit Rule'})[0]!);
 
-      // Verify the router to open the modal was called
-      expect(router.push).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pathname: `/settings/${organization.slug}/projects/${project.slug}/security-and-privacy/advanced-data-scrubbing/0/`,
-        })
+      // Verify navigate was called to open the modal
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/settings/${organization.slug}/projects/${project.slug}/security-and-privacy/advanced-data-scrubbing/0/`
       );
     });
   });
@@ -279,10 +264,7 @@ describe('Data Scrubbing', () => {
               onSubmitSuccess={jest.fn()}
             />
           </Fragment>
-        </OrganizationContext.Provider>,
-        {
-          deprecatedRouterMocks: true,
-        }
+        </OrganizationContext.Provider>
       );
 
       await userEvent.click(screen.getByRole('button', {name: 'Add Rule'}));

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.tsx
@@ -1,5 +1,4 @@
 import {DeprecatedApiKeyFixture} from 'sentry-fixture/deprecatedApiKey';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -7,11 +6,7 @@ import OrganizationApiKeyDetails from 'sentry/views/settings/organizationApiKeys
 
 describe('OrganizationApiKeyDetails', () => {
   const apiKey = DeprecatedApiKeyFixture();
-  const router = RouterFixture({
-    params: {
-      apiKey: apiKey.id,
-    },
-  });
+
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -23,8 +18,12 @@ describe('OrganizationApiKeyDetails', () => {
 
   it('renders', async () => {
     render(<OrganizationApiKeyDetails />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/org-slug/api-keys/${apiKey.id}/`,
+        },
+        route: '/organizations/:orgId/api-keys/:apiKey/',
+      },
     });
 
     expect(await screen.findByRole('textbox', {name: 'API Key'})).toBeInTheDocument();

--- a/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
@@ -1,6 +1,5 @@
 import {DocIntegrationFixture} from 'sentry-fixture/docIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -9,9 +8,6 @@ import DocIntegrationDetailedView from 'sentry/views/settings/organizationIntegr
 describe('DocIntegrationDetailedView', () => {
   const organization = OrganizationFixture();
   const doc = DocIntegrationFixture();
-  const router = RouterFixture({
-    params: {orgId: organization.slug, integrationSlug: doc.slug},
-  });
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -24,8 +20,12 @@ describe('DocIntegrationDetailedView', () => {
     });
     render(<DocIntegrationDetailedView />, {
       organization,
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/integrations/doc/${doc.slug}/`,
+        },
+        route: '/organizations/:orgId/integrations/doc/:integrationSlug/',
+      },
     });
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();


### PR DESCRIPTION
Doing a batch of various files that cursor was able to do automatically.