### PR TITLE
fix(reprocessing): Fix reprocessing form UI bug

### DIFF
--- a/static/app/components/modals/reprocessEventModal.tsx
+++ b/static/app/components/modals/reprocessEventModal.tsx
@@ -93,9 +93,10 @@ export function ReprocessingEventModal({
             label={t('Number of events to be reprocessed')}
             help={t('If you set a limit, we will reprocess your most recent events.')}
             placeholder={t('Reprocess all events')}
-            onChange={(value: any) =>
-              setMaxEvents(isNaN(value) ? undefined : Number(value))
-            }
+            onChange={(value: any) => {
+              const num = Number(value);
+              setMaxEvents(value === '' || isNaN(num) ? undefined : num);
+            }}
             min={1}
           />
 


### PR DESCRIPTION
**Before**
- Entering a "Number of events to be reprocessed" value and then deleting it leaves the "Remaining events" section enabled
<img width="582" height="180" alt="image" src="https://github.com/user-attachments/assets/be7453e2-d276-4059-89aa-9af8267159f3" />

**After**
- The "Remaining events" section is enabled only if the "Number of events to be reprocessed" field has a value in it
<img width="575" height="181" alt="image" src="https://github.com/user-attachments/assets/c6caf554-1754-4218-b4d0-d12158ca520a" />