### PR TITLE
Fix Non-Admin Add GH Org button for org selector

### DIFF
--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -47,7 +47,10 @@ function OrgFooterMessage() {
       }
     );
 
+  const {data: installedIntegrations = []} = useGetActiveIntegratedOrgs({organization});
+
   const provider = integrationInfo?.providers[0];
+  const hasInstalledIntegration = installedIntegrations.length > 0;
 
   return (
     <Flex gap="sm" direction="column" align="start">
@@ -75,10 +78,10 @@ function OrgFooterMessage() {
           value={{
             provider,
             type: 'first_party',
-            installStatus: 'Installed',
+            installStatus: hasInstalledIntegration ? 'Installed' : 'Not Installed',
             analyticsParams: {
               view: 'test_analytics_org_selector',
-              already_installed: true,
+              already_installed: hasInstalledIntegration,
             },
           }}
         >

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -2,7 +2,6 @@ import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import Access from 'sentry/components/acl/access';
-import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
@@ -15,20 +14,20 @@ import {usePreventContext} from 'sentry/components/prevent/context/preventContex
 import {integratedOrgIdToName} from 'sentry/components/prevent/utils';
 import {IconAdd, IconBuilding, IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {IntegrationWithConfig} from 'sentry/types/integrations';
+import type {Integration} from 'sentry/types/integrations';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
-import AddIntegration from 'sentry/views/settings/organizationIntegrations/addIntegration';
+import IntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationButton';
+import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 import type {IntegrationInformation} from 'sentry/views/settings/organizationIntegrations/integrationDetailedView';
-import RequestIntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
 
 const DEFAULT_ORG_LABEL = 'Select GitHub Org';
 
 function OrgFooterMessage() {
   const organization = useOrganization();
 
-  const handleAddIntegration = useCallback((_integration: IntegrationWithConfig) => {
+  const handleAddIntegration = useCallback((_integration: Integration) => {
     window.location.reload();
   }, []);
 
@@ -72,34 +71,33 @@ function OrgFooterMessage() {
       {isIntegrationInfoPending ? (
         <LoadingIndicator />
       ) : provider ? (
-        <Access access={['org:integrations']} organization={organization}>
-          {({hasAccess}) =>
-            hasAccess ? (
-              <AddIntegration
-                provider={provider}
-                onInstall={handleAddIntegration}
-                organization={organization}
-              >
-                {openDialog => (
-                  <Button
-                    size="xs"
-                    icon={<IconAdd />}
-                    priority="default"
-                    onClick={() => openDialog()}
-                  >
-                    {t('GitHub Organization')}
-                  </Button>
-                )}
-              </AddIntegration>
-            ) : (
-              <RequestIntegrationButton
-                name={provider.name}
-                slug={provider.slug}
-                type="first_party"
+        <IntegrationContext
+          value={{
+            provider,
+            type: 'first_party',
+            installStatus: 'Installed',
+            analyticsParams: {
+              view: 'test_analytics_org_selector',
+              already_installed: true,
+            },
+          }}
+        >
+          <Access access={['org:integrations']} organization={organization}>
+            {({hasAccess}) => (
+              <IntegrationButton
+                userHasAccess={hasAccess}
+                onAddIntegration={handleAddIntegration}
+                onExternalClick={() => {}}
+                buttonProps={{
+                  size: 'sm',
+                  priority: 'primary',
+                  buttonText: t('GitHub Organization'),
+                  icon: <IconAdd />,
+                }}
               />
-            )
-          }
-        </Access>
+            )}
+          </Access>
+        </IntegrationContext>
       ) : (
         <LinkButton
           href="https://github.com/apps/sentry/installations/select_target"

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -91,8 +91,6 @@ function OrgFooterMessage() {
                 buttonProps={{
                   size: 'sm',
                   priority: 'primary',
-                  buttonText: t('GitHub Organization'),
-                  icon: <IconAdd />,
                 }}
               />
             )}

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import Access from 'sentry/components/acl/access';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import type {SelectOption} from 'sentry/components/core/compactSelect';
@@ -20,6 +21,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
 import AddIntegration from 'sentry/views/settings/organizationIntegrations/addIntegration';
 import type {IntegrationInformation} from 'sentry/views/settings/organizationIntegrations/integrationDetailedView';
+import RequestIntegrationButton from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
 
 const DEFAULT_ORG_LABEL = 'Select GitHub Org';
 
@@ -70,22 +72,34 @@ function OrgFooterMessage() {
       {isIntegrationInfoPending ? (
         <LoadingIndicator />
       ) : provider ? (
-        <AddIntegration
-          provider={provider}
-          onInstall={handleAddIntegration}
-          organization={organization}
-        >
-          {openDialog => (
-            <Button
-              size="xs"
-              icon={<IconAdd />}
-              priority="default"
-              onClick={() => openDialog()}
-            >
-              {t('GitHub Organization')}
-            </Button>
-          )}
-        </AddIntegration>
+        <Access access={['org:integrations']} organization={organization}>
+          {({hasAccess}) =>
+            hasAccess ? (
+              <AddIntegration
+                provider={provider}
+                onInstall={handleAddIntegration}
+                organization={organization}
+              >
+                {openDialog => (
+                  <Button
+                    size="xs"
+                    icon={<IconAdd />}
+                    priority="default"
+                    onClick={() => openDialog()}
+                  >
+                    {t('GitHub Organization')}
+                  </Button>
+                )}
+              </AddIntegration>
+            ) : (
+              <RequestIntegrationButton
+                name={provider.name}
+                slug={provider.slug}
+                type="first_party"
+              />
+            )
+          }
+        </Access>
       ) : (
         <LinkButton
           href="https://github.com/apps/sentry/installations/select_target"

--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -19,7 +19,8 @@ export type IntegrationView = {
     | 'project_creation'
     | 'developer_settings'
     | 'new_integration_modal'
-    | 'test_analytics_onboarding';
+    | 'test_analytics_onboarding'
+    | 'test_analytics_org_selector';
 };
 
 type SingleIntegrationEventParams = {

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -23,7 +23,8 @@ type Props = {
       | 'integrations_directory'
       | 'onboarding'
       | 'project_creation'
-      | 'test_analytics_onboarding';
+      | 'test_analytics_onboarding'
+      | 'test_analytics_org_selector';
   };
   modalParams?: Record<string, string>;
 };

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -17,9 +17,7 @@ type Props = {
 };
 
 type ButtonProps = {
-  buttonText?: string;
   disabled?: any;
-  icon?: React.ReactNode;
   priority?: any;
   size?: any;
   style?: any;

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -17,7 +17,9 @@ type Props = {
 };
 
 type ButtonProps = {
+  buttonText?: string;
   disabled?: any;
+  icon?: React.ReactNode;
   priority?: any;
   size?: any;
   style?: any;

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -12,7 +12,8 @@ type IntegrationContextProps = {
       | 'integrations_directory'
       | 'onboarding'
       | 'project_creation'
-      | 'test_analytics_onboarding';
+      | 'test_analytics_onboarding'
+      | 'test_analytics_org_selector';
     referrer?: string;
   };
   installStatus: string;


### PR DESCRIPTION
This PR refactors the recent change of updating the org selector's link button to match the integration settings page's GH app installation button (https://github.com/getsentry/sentry/pull/102680). The most recent change used inner components of the IntegrationButton component in order to use the integration settings "Add installation" button and modified the styling to be the clear button designated in the Figma. However, for non-admins who did not have access, clicking on the button would just pop out the new window and redirect back to the prevent/tests page with a error toast (if they were already GH authenticated) since they wouldn't have proper permissions.

Ex of undesired behavior: 
<img width="1720" height="1077" alt="Screenshot 2025-11-10 at 1 44 47 PM" src="https://github.com/user-attachments/assets/3078ae4f-6513-4be5-854c-4afa5e0b863f" />


With this change, we are just using the whole IntegrationButton which handles switching between the "Add" button for admins and the "Request" button for non-admins. I've talked to Adalene and we agreed that we are fine with changing the styling to primary button styling for both. 

Admin:
<img width="411" height="408" alt="Screenshot 2025-11-12 at 1 35 52 PM" src="https://github.com/user-attachments/assets/63d2d53b-5265-4584-8ea6-29092de00128" />


Non-admin:
<img width="384" height="334" alt="Screenshot 2025-11-11 at 11 32 31 AM" src="https://github.com/user-attachments/assets/31f2a12f-54bc-4e2d-adf6-8d256c659215" />
