### PR TITLE
chore(aci): add analytics for creating notification rules on project creation

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -150,6 +150,7 @@ export type TeamInsightsEventParameters = {
   'issue_stream.updated_empty_state_viewed': {platform: string};
   'project_creation_page.created': {
     issue_alert: 'Default' | 'Custom' | 'No Rule';
+    notification_rule_created: boolean;
     platform: string;
     project_id: string;
     rule_ids: string[];

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -291,6 +291,7 @@ export function CreateProject() {
           project_id: project.id,
           platform: selectedPlatform.key,
           rule_ids: ruleIds,
+          notification_rule_created: !!notificationRule,
         });
 
         addSuccessMessage(


### PR DESCRIPTION
Curious how many people are using this option to get notified via an integration during project creation.

We're soon going to need to update project creation to create additional Workflows instead of Rules, but if not that many people are creating custom/notification rules then maybe we could simplify the form and remove these options.