### PR TITLE
chore(aci milestone 3): open period -> incident serializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -1,31 +1,132 @@
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Any
+from datetime import datetime
+from typing import Any, ClassVar, DefaultDict
 
 from django.contrib.auth.models import AnonymousUser
 
-from sentry.api.serializers import Serializer
+from sentry.api.serializers import Serializer, serialize
 from sentry.incidents.endpoints.serializers.incident import (
     DetailedIncidentSerializerResponse,
     IncidentSerializerResponse,
 )
-from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
-from sentry.incidents.models.incident import IncidentStatusMethod, IncidentType
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod, IncidentType
 from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
 from sentry.snuba.entity_subscription import apply_dataset_query_conditions
 from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.types.group import PriorityLevel
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
-from sentry.workflow_engine.models import DataSourceDetector, Detector, IncidentGroupOpenPeriod
+from sentry.workflow_engine.endpoints.serializers.group_open_period_serializer import (
+    GroupOpenPeriodActivitySerializer,
+)
+from sentry.workflow_engine.models import (
+    AlertRuleDetector,
+    DataSourceDetector,
+    Detector,
+    DetectorGroup,
+    IncidentGroupOpenPeriod,
+)
 
 
 class WorkflowEngineIncidentSerializer(Serializer):
     def __init__(self, expand=None):
         self.expand = expand or []
 
+    priority_to_incident_status: ClassVar[dict[int, int]] = {
+        PriorityLevel.HIGH.value: IncidentStatus.CRITICAL.value,
+        PriorityLevel.MEDIUM.value: IncidentStatus.WARNING.value,
+    }
+
+    def get_incident_status(self, priority: int | None, date_ended: datetime | None) -> int:
+        if priority is None:
+            raise ValueError("Priority is required to get an incident status")
+
+        if date_ended:
+            return IncidentStatus.CLOSED.value
+
+        return self.priority_to_incident_status[priority]
+
+    def get_attrs(
+        self,
+        item_list: Sequence[GroupOpenPeriod],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> defaultdict[GroupOpenPeriod, dict[str, Any]]:
+
+        from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
+            WorkflowEngineDetectorSerializer,
+        )
+
+        results: DefaultDict[GroupOpenPeriod, dict[str, Any]] = defaultdict()
+        open_periods_to_detectors = self.get_open_periods_to_detectors(item_list)
+        alert_rules = {
+            alert_rule["id"]: alert_rule  # we are serializing detectors to look like alert rules
+            for alert_rule in serialize(
+                list(open_periods_to_detectors.values()),
+                user,
+                WorkflowEngineDetectorSerializer(expand=self.expand),
+            )
+        }
+        alert_rule_detectors = AlertRuleDetector.objects.filter(
+            detector__in=list(open_periods_to_detectors.values())
+        ).values_list("alert_rule_id", "detector_id")
+        detector_ids_to_alert_rule_ids = {}
+        for alert_rule_id, detector_id in alert_rule_detectors:
+            detector_ids_to_alert_rule_ids[detector_id] = alert_rule_id
+
+        for open_period in item_list:
+            detector_id = open_periods_to_detectors[open_period].id
+            if detector_id in detector_ids_to_alert_rule_ids:
+                alert_rule_id = detector_ids_to_alert_rule_ids[detector_id]
+            else:
+                alert_rule_id = get_fake_id_from_object_id(detector_id)
+
+            results[open_period] = {"projects": [open_period.project.slug]}
+            results[open_period]["alert_rule"] = alert_rules.get(alert_rule_id)
+
+        if "activities" in self.expand:
+            gopas = list(
+                GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list)[:1000]
+            )
+            open_period_activities = defaultdict(list)
+            # XXX: the incident endpoint is undocumented, so we aren' on the hook for supporting
+            # any specific payloads. Since this isn't used on the Sentry side for notification charts,
+            # I've opted to just use the GroupOpenPeriodActivity serializer.
+            for gopa, serialized_activity in zip(
+                gopas,
+                serialize(gopas, user=user, serializer=GroupOpenPeriodActivitySerializer()),
+            ):
+                open_period_activities[gopa.group_open_period_id].append(serialized_activity)
+            for open_period in item_list:
+                results[open_period]["activities"] = open_period_activities[open_period.id]
+
+        return results
+
     def get_open_periods_to_detectors(
         self, open_periods: Sequence[GroupOpenPeriod]
     ) -> dict[GroupOpenPeriod, Detector]:
+        # open period -> group -> detector via detectorgroup
+        groups = [op.group for op in open_periods]
+        group_to_open_periods = defaultdict(list)
+
+        for op in open_periods:
+            group_to_open_periods[op.group].append(op)
+
+        detector_groups = DetectorGroup.objects.filter(group__in=groups).select_related(
+            "group", "detector"
+        )
+
+        groups_to_detectors = {}
+        for dg in detector_groups:
+            groups_to_detectors[dg.group] = dg.detector
+
         open_periods_to_detectors = {}
+        for group in group_to_open_periods:
+            for op in group_to_open_periods[group]:
+                open_periods_to_detectors[op] = groups_to_detectors[group]
 
         return open_periods_to_detectors
 
@@ -44,7 +145,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
             incident_id = igop.incident_id
             incident_identifier = igop.incident_identifier
         except IncidentGroupOpenPeriod.DoesNotExist:
-            incident_id = get_object_id_from_fake_id(obj.id)
+            incident_id = get_fake_id_from_object_id(obj.id)
             incident_identifier = incident_id
 
         # TODO: get event time using offset

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -85,7 +85,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
                 alert_rule_id = get_fake_id_from_object_id(detector_id)
 
             results[open_period] = {"projects": [open_period.project.slug]}
-            results[open_period]["alert_rule"] = alert_rules.get(alert_rule_id)
+            results[open_period]["alert_rule"] = alert_rules.get(str(alert_rule_id))
 
         if "activities" in self.expand:
             gopas = list(

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -148,7 +148,6 @@ class WorkflowEngineIncidentSerializer(Serializer):
             incident_id = get_fake_id_from_object_id(obj.id)
             incident_identifier = incident_id
 
-        # TODO: get event time using offset
         date_closed = obj.date_ended.replace(second=0, microsecond=0) if obj.date_ended else None
         return {
             "id": str(incident_id),

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -62,6 +62,7 @@ class TestWorkflowEngineSerializer(TestCase):
             self.alert_rule
         )
 
+        self.create_detector_group(detector=self.detector, group=self.group)
         self.expected_critical_action = [
             {
                 "id": str(self.critical_trigger_action.id),

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -1,9 +1,17 @@
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.utils import OFFSET
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineDetailedIncidentSerializer,
     WorkflowEngineIncidentSerializer,
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod, IncidentType
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.models import (
+    ActionAlertRuleTriggerAction,
+    AlertRuleDetector,
+    DataConditionAlertRuleTrigger,
+)
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
 )
@@ -47,5 +55,66 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
 
     def test_no_incident(self) -> None:
         """
-        Assert that nothing breaks if the IGOP does not exist.
+        Assert that nothing breaks if the legacy models do not exist.
         """
+        self.incident_group_open_period.delete()
+        ard = AlertRuleDetector.objects.filter(detector_id=self.detector.id)
+        dcart = DataConditionAlertRuleTrigger.objects.filter(
+            data_condition_id=self.critical_detector_trigger.id
+        )
+        aarta = ActionAlertRuleTriggerAction.objects.filter(action_id=self.critical_action.id)
+
+        ard.delete()
+        dcart.delete()
+        aarta.delete()
+
+        serialized_incident = serialize(
+            self.group_open_period, self.user, WorkflowEngineIncidentSerializer()
+        )
+        self.expected.update({"id": str(self.detector.id + OFFSET)})
+        self.expected["triggers"][0].update(
+            {
+                "id": str(self.critical_detector_trigger.id + OFFSET),
+                "alertRuleId": str(self.detector.id + OFFSET),
+            }
+        )
+        self.expected["triggers"][1].update(
+            {
+                "alertRuleId": str(self.detector.id + OFFSET),
+            }
+        )
+        self.expected["triggers"][0]["actions"][0].update(
+            {
+                "id": str(self.critical_action.id + OFFSET),
+                "alertRuleTriggerId": str(self.critical_detector_trigger.id + OFFSET),
+            }
+        )
+
+        self.incident_expected.update(
+            {
+                "id": str(self.group_open_period.id + OFFSET),
+                "identifier": str(self.group_open_period.id + OFFSET),
+            }
+        )
+        assert serialized_incident == self.incident_expected
+
+    def test_with_activities(self) -> None:
+        gopa = GroupOpenPeriodActivity.objects.create(
+            date_added=self.group_open_period.date_added,
+            group_open_period=self.group_open_period,
+            type=OpenPeriodActivityType.OPENED,
+            value=self.group.priority,
+        )
+        serialized_incident = serialize(
+            self.group_open_period,
+            self.user,
+            WorkflowEngineIncidentSerializer(expand=["activities"]),
+        )
+        assert len(serialized_incident["activities"]) == 1
+        serialized_activity = serialized_incident["activities"][0]
+        assert serialized_activity == {
+            "id": str(gopa.id),
+            "type": OpenPeriodActivityType.OPENED.to_str(),
+            "value": PriorityLevel(self.group.priority).to_str(),
+            "dateCreated": gopa.date_added,
+        }

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -14,7 +14,6 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
         super().setUp()
         self.add_warning_trigger()
         self.add_incident_data()
-        self.create_detector_group(detector=self.detector, group=self.group_open_period.group)
         self.incident_identifier = str(self.incident_group_open_period.incident_identifier)
         self.incident_expected = {
             "id": str(self.incident_group_open_period.incident_id),
@@ -45,3 +44,8 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
         )
         self.incident_expected["discoverQuery"] = "(event.type:error) AND (level:error)"
         assert serialized_incident == self.incident_expected
+
+    def test_no_incident(self) -> None:
+        """
+        Assert that nothing breaks if the IGOP does not exist.
+        """

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -1,5 +1,5 @@
 from sentry.api.serializers import serialize
-from sentry.incidents.endpoints.serializers.utils import OFFSET
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineDetailedIncidentSerializer,
     WorkflowEngineIncidentSerializer,
@@ -71,29 +71,33 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
         serialized_incident = serialize(
             self.group_open_period, self.user, WorkflowEngineIncidentSerializer()
         )
-        self.expected.update({"id": str(self.detector.id + OFFSET)})
+        fake_alert_rule_id = get_fake_id_from_object_id(self.detector.id)
+        fake_incident_id = get_fake_id_from_object_id(self.group_open_period.id)
+        self.expected.update({"id": str(fake_alert_rule_id)})
         self.expected["triggers"][0].update(
             {
-                "id": str(self.critical_detector_trigger.id + OFFSET),
-                "alertRuleId": str(self.detector.id + OFFSET),
+                "id": str(get_fake_id_from_object_id(self.critical_detector_trigger.id)),
+                "alertRuleId": str(fake_alert_rule_id),
             }
         )
         self.expected["triggers"][1].update(
             {
-                "alertRuleId": str(self.detector.id + OFFSET),
+                "alertRuleId": str(fake_alert_rule_id),
             }
         )
         self.expected["triggers"][0]["actions"][0].update(
             {
-                "id": str(self.critical_action.id + OFFSET),
-                "alertRuleTriggerId": str(self.critical_detector_trigger.id + OFFSET),
+                "id": str(get_fake_id_from_object_id(self.critical_action.id)),
+                "alertRuleTriggerId": str(
+                    get_fake_id_from_object_id(self.critical_detector_trigger.id)
+                ),
             }
         )
 
         self.incident_expected.update(
             {
-                "id": str(self.group_open_period.id + OFFSET),
-                "identifier": str(self.group_open_period.id + OFFSET),
+                "id": str(fake_incident_id),
+                "identifier": str(fake_incident_id),
             }
         )
         assert serialized_incident == self.incident_expected

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -138,6 +138,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
 
         self.group.priority = PriorityLevel.HIGH.value
         self.group.save()
+        self.create_detector_group(detector=self.detector, group=self.group)
         self.open_period, _ = GroupOpenPeriod.objects.get_or_create(
             group=self.group,
             project=self.project,


### PR DESCRIPTION
Previously, this serializer took in an open period, fetched the incident via the IGOP lookup table, and serialized the incident. With the incident no longer guaranteed to exist, create a serializer that will populate an incident response using only the open period model.