### PR TITLE
chore(np): Actually dont use fields for discord embed

### DIFF
--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -24,9 +24,6 @@ from sentry.organizations.services.organization.model import RpcOrganizationSumm
 
 if TYPE_CHECKING:
     from sentry.integrations.discord.message_builder.base.base import DiscordMessage
-    from sentry.integrations.discord.message_builder.base.embed.field import (
-        DiscordMessageEmbedField,
-    )
 
 # TODO(ecosystem): Proper typing - https://discord.com/developers/docs/resources/message#create-message
 type DiscordRenderable = DiscordMessage
@@ -65,7 +62,7 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
         embeds.append(
             DiscordMessageEmbed(
                 title=rendered_template.subject,
-                fields=body_blocks,
+                description=body_blocks,
                 image=(
                     DiscordMessageEmbedImage(url=rendered_template.chart.url)
                     if rendered_template.chart
@@ -94,28 +91,15 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
         return builder.build()
 
     @classmethod
-    def render_body_blocks(
-        cls, body: list[NotificationBodyFormattingBlock]
-    ) -> list[DiscordMessageEmbedField]:
-        from sentry.integrations.discord.message_builder.base.embed.field import (
-            DiscordMessageEmbedField,
-        )
+    def render_body_blocks(cls, body: list[NotificationBodyFormattingBlock]) -> str:
 
-        fields = []
+        description = []
         for block in body:
             if block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
-                fields.append(
-                    DiscordMessageEmbedField(
-                        name=block.type.value, value=cls.render_text_blocks(block.blocks)
-                    )
-                )
+                description.append(f"\n{cls.render_text_blocks(block.blocks)}")
             elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
-                fields.append(
-                    DiscordMessageEmbedField(
-                        name=block.type.value, value=f"```{cls.render_text_blocks(block.blocks)}```"
-                    )
-                )
-        return fields
+                description.append(f"\n```{cls.render_text_blocks(block.blocks)}```")
+        return " ".join(description)
 
     @classmethod
     def render_text_blocks(cls, blocks: list[NotificationBodyTextBlock]) -> str:

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -99,7 +99,7 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
                 description.append(f"\n{cls.render_text_blocks(block.blocks)}")
             elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
                 description.append(f"\n```{cls.render_text_blocks(block.blocks)}```")
-        return " ".join(description)
+        return "".join(description)
 
     @classmethod
     def render_text_blocks(cls, blocks: list[NotificationBodyTextBlock]) -> str:

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -70,11 +70,8 @@ class DiscordRendererTest(TestCase):
         embeds = renderable["embeds"]
         assert len(embeds) == 1
         embed = embeds[0]
-        fields = list(embed["fields"])
-        assert len(fields) == 1
-        field = fields[0]
-        assert field["name"] == "paragraph"
-        assert field["value"] == "test"
+        description = embed["description"]
+        assert description == "\ntest"
         assert embed["title"] == "Mock Notification"
         assert embed["footer"]["text"] == "This is a mock footer"
         assert (


### PR DESCRIPTION
Using fields to store a field of nested embeds lead to 
<img width="685" height="510" alt="image" src="https://github.com/user-attachments/assets/43994bf3-6ede-478b-95e1-31b213d89687" />

Changes so instead of nesting embeds, we just use text formatting
<img width="698" height="421" alt="image" src="https://github.com/user-attachments/assets/956ba823-d7bd-4886-be1a-18005b72c033" />
