### PR TITLE
ref(preprod): Improve unsupported VCS provider error message (EME-615)

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -164,7 +164,13 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             # Support a limited subset of providers
             provider = data.get("provider")
             if provider is not None and provider not in SUPPORTED_VCS_PROVIDERS:
-                return Response({"error": "Unsupported provider"}, status=400)
+                supported_providers = ", ".join(SUPPORTED_VCS_PROVIDERS)
+                return Response(
+                    {
+                        "error": f"Unsupported VCS provider '{provider}'. Supported providers are: {supported_providers}"
+                    },
+                    status=400,
+                )
 
             checksum = str(data.get("checksum", ""))
             chunks = data.get("chunks", [])

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -355,7 +355,9 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 400, response.content
-        assert response.data["error"] == "Unsupported provider"
+        assert "Unsupported VCS provider 'invalid'" in response.data["error"]
+        assert "Supported providers are:" in response.data["error"]
+        assert "github" in response.data["error"]
 
     def test_assemble_json_schema_missing_checksum(self) -> None:
         """Test that missing checksum field is rejected."""


### PR DESCRIPTION
## Summary

Improves the error message for unsupported VCS providers in the preprod artifact upload endpoint.

**Before:**
```json
{"error": "Unsupported provider"}
```

**After:**
```json
{"error": "Unsupported VCS provider 'git'. Supported providers are: github, gitlab, github_enterprise, bitbucket, bitbucket_server"}
```

This makes it clear:
- What provider value was actually sent
- What providers are supported
- How to fix the issue

Fixes EME-615