### PR TITLE
feat(preprod): Add QR code quiet zone for improved scanning (EME-618)

### DIFF
--- a/static/app/components/quietZoneQRCode.tsx
+++ b/static/app/components/quietZoneQRCode.tsx
@@ -32,12 +32,12 @@ export function QuietZoneQRCode({size, value, ...props}: QuietZoneQRCodeProps) {
   return (
     <Wrapper>
       <StyledQRCodeCanvas
+        {...props}
         size={size}
         value={value}
         bgColor="#FFFFFF"
         fgColor="#000000"
         includeMargin
-        {...props}
       />
     </Wrapper>
   );

--- a/static/app/components/quietZoneQRCode.tsx
+++ b/static/app/components/quietZoneQRCode.tsx
@@ -2,8 +2,6 @@ import type React from 'react';
 import styled from '@emotion/styled';
 import {QRCodeCanvas} from 'qrcode.react';
 
-import {space} from 'sentry/styles/space';
-
 interface QuietZoneQRCodeProps
   extends Omit<
     React.ComponentProps<typeof QRCodeCanvas>,
@@ -46,11 +44,10 @@ export function QuietZoneQRCode({size, value, ...props}: QuietZoneQRCodeProps) {
 }
 
 const Wrapper = styled('div')`
-  background: #ffffff;
-  padding: ${space(2)};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
   display: inline-block;
+  overflow: hidden;
 `;
 
 const StyledQRCodeCanvas = styled(QRCodeCanvas)`

--- a/static/app/components/quietZoneQRCode.tsx
+++ b/static/app/components/quietZoneQRCode.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+import type {QRCodeCanvasProps} from 'qrcode.react';
+import {QRCodeCanvas} from 'qrcode.react';
+
+import {space} from 'sentry/styles/space';
+
+interface QuietZoneQRCodeProps
+  extends Omit<QRCodeCanvasProps, 'bgColor' | 'fgColor' | 'marginSize'> {
+  /**
+   * The size of the QR code in pixels
+   */
+  size: number;
+  /**
+   * The value to encode in the QR code
+   */
+  value: string;
+}
+
+/**
+ * QR code component with proper quiet zone for reliable scanning.
+ *
+ * Implements QR code specification requirements:
+ * - White background for maximum contrast
+ * - Black foreground pattern
+ * - 4X wide quiet zone (white margin) on all sides
+ *
+ * The white background is maintained regardless of theme to ensure
+ * QR codes remain scannable in both light and dark modes.
+ */
+export function QuietZoneQRCode({size, value, ...props}: QuietZoneQRCodeProps) {
+  return (
+    <Wrapper>
+      <StyledQRCodeCanvas
+        size={size}
+        value={value}
+        bgColor="#FFFFFF"
+        fgColor="#000000"
+        marginSize={4}
+        {...props}
+      />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  background: #ffffff;
+  padding: ${space(2)};
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.border};
+  display: inline-block;
+`;
+
+const StyledQRCodeCanvas = styled(QRCodeCanvas)`
+  display: block;
+`;

--- a/static/app/components/quietZoneQRCode.tsx
+++ b/static/app/components/quietZoneQRCode.tsx
@@ -1,11 +1,14 @@
+import type React from 'react';
 import styled from '@emotion/styled';
-import type {QRCodeCanvasProps} from 'qrcode.react';
 import {QRCodeCanvas} from 'qrcode.react';
 
 import {space} from 'sentry/styles/space';
 
 interface QuietZoneQRCodeProps
-  extends Omit<QRCodeCanvasProps, 'bgColor' | 'fgColor' | 'marginSize'> {
+  extends Omit<
+    React.ComponentProps<typeof QRCodeCanvas>,
+    'bgColor' | 'fgColor' | 'includeMargin'
+  > {
   /**
    * The size of the QR code in pixels
    */
@@ -35,7 +38,7 @@ export function QuietZoneQRCode({size, value, ...props}: QuietZoneQRCodeProps) {
         value={value}
         bgColor="#FFFFFF"
         fgColor="#000000"
-        marginSize={4}
+        includeMargin
         {...props}
       />
     </Wrapper>

--- a/static/app/views/preprod/components/installModal.tsx
+++ b/static/app/views/preprod/components/installModal.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import {QRCodeCanvas} from 'qrcode.react';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -9,6 +8,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {QuietZoneQRCode} from 'sentry/components/quietZoneQRCode';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -114,17 +114,15 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
                   {tn('%s download', '%s downloads', installDetails.download_count)}
                 </Text>
               )}
-            <Container background="secondary" padding="lg" radius="md" border="primary">
-              <StyledQRCode
-                aria-label={t('Install QR Code')}
-                value={
-                  installDetails.platform === 'ios'
-                    ? `itms-services://?action=download-manifest&url=${encodeURIComponent(installDetails.install_url)}`
-                    : installDetails.install_url
-                }
-                size={120}
-              />
-            </Container>
+            <QuietZoneQRCode
+              aria-label={t('Install QR Code')}
+              value={
+                installDetails.platform === 'ios'
+                  ? `itms-services://?action=download-manifest&url=${encodeURIComponent(installDetails.install_url)}`
+                  : installDetails.install_url
+              }
+              size={120}
+            />
             {details}
             <Flex direction="column" maxWidth="300px" gap="xl" paddingTop="xl">
               <Text align="center" size="lg">
@@ -158,10 +156,6 @@ function InstallModal({projectId, artifactId, closeModal}: InstallModalProps) {
     </Fragment>
   );
 }
-
-const StyledQRCode = styled(QRCodeCanvas)`
-  display: block;
-`;
 
 export const CodeSignatureInfo = styled('div')`
   text-align: center;

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -1,13 +1,12 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
-import {QRCodeCanvas} from 'qrcode.react';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {QuietZoneQRCode} from 'sentry/components/quietZoneQRCode';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -109,17 +108,15 @@ function InstallContent({
 
         {installDetails.install_url && (
           <Fragment>
-            <Container background="primary" padding="md" radius="sm" border="primary">
-              <StyledQRCode
-                aria-label={t('Install QR Code')}
-                value={
-                  installDetails.platform === 'ios'
-                    ? `itms-services://?action=download-manifest&url=${encodeURIComponent(installDetails.install_url)}`
-                    : installDetails.install_url
-                }
-                size={200}
-              />
-            </Container>
+            <QuietZoneQRCode
+              aria-label={t('Install QR Code')}
+              value={
+                installDetails.platform === 'ios'
+                  ? `itms-services://?action=download-manifest&url=${encodeURIComponent(installDetails.install_url)}`
+                  : installDetails.install_url
+              }
+              size={200}
+            />
 
             {details}
 
@@ -174,7 +171,3 @@ export default function InstallPage() {
     </SentryDocumentTitle>
   );
 }
-
-const StyledQRCode = styled(QRCodeCanvas)`
-  display: block;
-`;

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import {QRCodeCanvas} from 'qrcode.react';
 
 import {
   addErrorMessage,
@@ -25,12 +24,12 @@ import type {FieldObject} from 'sentry/components/forms/types';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelItem from 'sentry/components/panels/panelItem';
+import {QuietZoneQRCode} from 'sentry/components/quietZoneQRCode';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {WebAuthnEnroll} from 'sentry/components/webAuthn/webAuthnEnroll';
 import {t} from 'sentry/locale';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
-import {space} from 'sentry/styles/space';
 import type {Authenticator} from 'sentry/types/auth';
 import {generateOrgSlugUrl} from 'sentry/utils';
 import getPendingInvite from 'sentry/utils/getPendingInvite';
@@ -80,7 +79,7 @@ const getFields = ({
     return [
       () => (
         <CodeContainer key="qrcode">
-          <StyledQRCode
+          <QuietZoneQRCode
             aria-label={t('Enrollment QR Code')}
             value={authenticator.qrcode}
             size={228}
@@ -481,9 +480,4 @@ const CodeContainer = styled(PanelItem)`
 
 const Actions = styled(PanelItem)`
   justify-content: flex-end;
-`;
-
-const StyledQRCode = styled(QRCodeCanvas)`
-  background: white;
-  padding: ${space(2)};
 `;


### PR DESCRIPTION
## Summary

Fixes EME-618: QR codes now display with proper quiet zone (white margin) in dark mode for improved scanning reliability.

QR codes require a 4-module wide white margin (quiet zone) around all sides per the [QR code specification](https://digitalproc.github.io/2021/11/11/qrCode/qr_standard.pdf). Previously, theme-aware Container backgrounds would turn dark in dark mode, obscuring the quiet zone and making scanning slower.

<img width="307" alt="qr-code" src="https://github.com/user-attachments/assets/c143139c-7fd3-4fab-ae1a-06fd322bdbea" />
<img width="307" height="329" alt="Screenshot 2025-11-11 at 15 38 52" src="https://github.com/user-attachments/assets/55c13ead-a7dd-472c-8e1e-ef104a72ba4f" />


## Changes

### New Shared Component
Created `QuietZoneQRCode` component at `static/app/components/quietZoneQRCode.tsx` that:
- Encapsulates QR code spec requirements (white background, black foreground, 4-module quiet zone)
- Maintains white background regardless of theme for maximum contrast
- Eliminates code duplication across the codebase

### Updated QR Code Usage
Replaced all QR code implementations with the shared component in:
- Preprod install page (`static/app/views/preprod/install/installPage.tsx`)
- Preprod install modal (`static/app/views/preprod/components/installModal.tsx`)
- 2FA enrollment page (`static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx`)

### Technical Details
- Uses `includeMargin` prop to add the 4-module quiet zone per QR spec
- Sets `bgColor="#FFFFFF"` and `fgColor="#000000"` for maximum contrast
- Wrapper provides subtle border for visual definition
- TypeScript types use `React.ComponentProps<typeof QRCodeCanvas>` for type safety

Closes EME-618