### PR TITLE
feat(seer-cursor): add cursor integration to onboarding flow

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -103,6 +103,7 @@ describe('SeerDrawer', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    localStorage.clear();
 
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
@@ -137,10 +138,24 @@ describe('SeerDrawer', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/group-search-views/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/`,
       body: {
         autofixAutomationTuning: 'off',
       },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/autofix-repos/`,
+      body: [],
     });
   });
 
@@ -632,5 +647,162 @@ describe('SeerDrawer', () => {
     expect(
       screen.getByText(/It currently only supports GitHub repositories/)
     ).toBeInTheDocument();
+  });
+
+  it('shows cursor integration onboarding step if integration is installed but handoff not configured', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [{external_id: 'repo-123', name: 'org/repo', provider: 'github'}],
+          automated_run_stopping_point: 'root_cause',
+          // No automation_handoff
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+        seerScannerAutomation: true,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/autofix-repos/`,
+      body: [
+        {
+          name: 'org/repo',
+          provider: 'github',
+          owner: 'org',
+          external_id: 'repo-123',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/group-search-views/starred/`,
+      body: [
+        {
+          id: '1',
+          name: 'Fixability View',
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        },
+      ],
+    });
+
+    render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization: OrganizationFixture({
+        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+      }),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    expect(
+      await screen.findByText('Hand Off to Cursor Background Agents')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Set Seer to hand off to Cursor'})
+    ).toBeInTheDocument();
+  });
+
+  it('does not show cursor integration step if localStorage skip key is set', async () => {
+    // Set skip key BEFORE rendering
+    localStorage.setItem(`seer-onboarding-cursor-skipped:${mockProject.id}`, 'true');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [{external_id: 'repo-123', name: 'org/repo', provider: 'github'}],
+          automated_run_stopping_point: 'root_cause',
+          // No automation_handoff
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+        seerScannerAutomation: true,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${mockProject.organization.slug}/${mockProject.slug}/autofix-repos/`,
+      body: [
+        {
+          name: 'org/repo',
+          provider: 'github',
+          owner: 'org',
+          external_id: 'repo-123',
+          is_readable: true,
+          is_writeable: true,
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/group-search-views/starred/`,
+      body: [
+        {
+          id: '1',
+          name: 'Fixability View',
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        },
+      ],
+    });
+
+    render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization: OrganizationFixture({
+        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+      }),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    // Should not show the step since it was skipped
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -49,6 +49,12 @@ describe('SeerNotices', () => {
       url: `/projects/${organization.slug}/${ProjectFixture().slug}/autofix-repos/`,
       body: [createRepository()],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [],
+      },
+    });
   });
 
   it('shows automation step if automation is allowed and tuning is off', async () => {
@@ -98,6 +104,167 @@ describe('SeerNotices', () => {
     });
   });
 
+  it('shows cursor integration step if integration is installed but handoff not configured', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [],
+          automated_run_stopping_point: 'root_cause',
+          // No automation_handoff - handoff is not configured
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [
+        GroupSearchViewFixture({
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        }),
+      ],
+    });
+    const project = getProjectWithAutomation('medium');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization: {
+        ...organization,
+        features: ['integrations-cursor'],
+      },
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText('Hand Off to Cursor Background Agents')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('does not show cursor integration step if localStorage skip key is set', () => {
+    // Set localStorage skip key
+    localStorage.setItem(`seer-onboarding-cursor-skipped:${ProjectFixture().id}`, 'true');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [
+        GroupSearchViewFixture({
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        }),
+      ],
+    });
+    const project = getProjectWithAutomation('medium');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization: {
+        ...organization,
+        features: ['integrations-cursor'],
+      },
+    });
+
+    // Should not show the cursor step since it was skipped
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
+
+    // Clean up localStorage
+    localStorage.removeItem(`seer-onboarding-cursor-skipped:${ProjectFixture().id}`);
+  });
+
+  it('does not show cursor integration step if handoff is already configured', () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {
+        integrations: [
+          {
+            id: '123',
+            provider: 'cursor',
+            name: 'Cursor',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/seer/preferences/`,
+      body: {
+        code_mapping_repos: [],
+        preference: {
+          repositories: [],
+          automated_run_stopping_point: 'root_cause',
+          automation_handoff: {
+            handoff_point: 'root_cause',
+            target: 'cursor_background_agent',
+            integration_id: 123,
+          },
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/`,
+      body: {
+        autofixAutomationTuning: 'medium',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [
+        GroupSearchViewFixture({
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        }),
+      ],
+    });
+    const project = getProjectWithAutomation('medium');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization: {
+        ...organization,
+        features: ['integrations-cursor'],
+      },
+    });
+
+    // Should not show the cursor step since handoff is already configured
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
+  });
+
   it('does not render guided steps if all onboarding steps are complete', () => {
     MockApiClient.addMockResponse({
       method: 'GET',
@@ -126,5 +293,8 @@ describe('SeerNotices', () => {
     expect(screen.queryByText('Pick Repositories to Work In')).not.toBeInTheDocument();
     expect(screen.queryByText('Unleash Automation')).not.toBeInTheDocument();
     expect(screen.queryByText('Get Some Quick Wins')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Hand Off to Cursor Background Agents')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -158,7 +158,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   );
 
   const needsCursorIntegration =
-    (!isCursorHandoffConfigured || !cursorIntegration) && !cursorStepSkipped;
+    hasCursorFeatureFlagEnabled &&
+    (!isCursorHandoffConfigured || !cursorIntegration) &&
+    !cursorStepSkipped;
 
   // Calculate incomplete steps
   const stepConditions = [

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -1,25 +1,37 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
+import {useQueryClient} from '@tanstack/react-query';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import addIntegrationProvider from 'sentry-images/spot/add-integration-provider.svg';
+import alertsEmptyStateImg from 'sentry-images/spot/alerts-empty-state.svg';
 import feedbackOnboardingImg from 'sentry-images/spot/feedback-onboarding.svg';
 import onboardingCompass from 'sentry-images/spot/onboarding-compass.svg';
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {ExternalLink} from 'sentry/components/core/link';
-import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {ExternalLink, Link} from 'sentry/components/core/link';
+import {
+  makeProjectSeerPreferencesQueryKey,
+  useProjectSeerPreferences,
+} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import StarFixabilityViewButton from 'sentry/components/events/autofix/seerCreateViewButton';
-import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
+import {
+  useAutofixRepos,
+  useCodingAgentIntegrations,
+} from 'sentry/components/events/autofix/useAutofix';
 import {
   GuidedSteps,
   useGuidedStepsContext,
 } from 'sentry/components/guidedSteps/guidedSteps';
 import {IconChevron, IconSeer} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
 import {FieldKey} from 'sentry/utils/fields';
@@ -82,12 +94,15 @@ function CustomStepButtons({
 
 export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNoticesProps) {
   const organization = useOrganization();
+  const queryClient = useQueryClient();
   const {repos} = useAutofixRepos(groupId);
   const {
     preference,
     isLoading: isLoadingPreferences,
     codeMappingRepos,
   } = useProjectSeerPreferences(project);
+  const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
+  const {data: codingAgentIntegrations} = useCodingAgentIntegrations();
   const {starredViews: views} = useStarredIssueViews();
 
   const detailedProject = useDetailedProject({
@@ -97,6 +112,14 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
 
   const hasIssueViews = useHasIssueViews();
   const isStarredViewAllowed = hasIssueViews;
+
+  const cursorIntegration = codingAgentIntegrations?.integrations.find(
+    integration => integration.provider === 'cursor'
+  );
+  const hasCursorFeatureFlagEnabled = Boolean(
+    organization.features.includes('integrations-cursor')
+  );
+  const isCursorHandoffConfigured = Boolean(preference?.automation_handoff);
 
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
   const githubRepos = unreadableRepos.filter(repo => repo.provider.includes('github'));
@@ -122,11 +145,18 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const hasMultipleUnreadableRepos = unreadableRepos.length > 1;
   const hasSingleUnreadableRepo = unreadableRepos.length === 1;
 
-  // Use localStorage for collapsed state
+  // Use localStorage for collapsed state and cursor step skip
   const [stepsCollapsed, setStepsCollapsed] = useLocalStorageState(
     `seer-onboarding-collapsed:${project.id}`,
     false
   );
+  const [cursorStepSkipped, setCursorStepSkipped] = useLocalStorageState(
+    `seer-onboarding-cursor-skipped:${project.id}`,
+    false
+  );
+
+  const needsCursorIntegration =
+    (!isCursorHandoffConfigured || !cursorIntegration) && !cursorStepSkipped;
 
   // Calculate incomplete steps
   const stepConditions = [
@@ -134,7 +164,46 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     needsRepoSelection,
     needsAutomation,
     needsFixabilityView,
+    needsCursorIntegration,
   ];
+
+  const handleSetupCursorHandoff = useCallback(() => {
+    if (!cursorIntegration) {
+      return;
+    }
+    updateProjectSeerPreferences(
+      {
+        repositories: preference?.repositories || [],
+        automated_run_stopping_point: 'root_cause',
+        automation_handoff: {
+          handoff_point: 'root_cause',
+          target: 'cursor_background_agent',
+          integration_id: parseInt(cursorIntegration.id, 10),
+        },
+      },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: [
+              makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
+            ],
+          });
+        },
+      }
+    );
+  }, [
+    cursorIntegration,
+    updateProjectSeerPreferences,
+    preference?.repositories,
+    queryClient,
+    organization.slug,
+    project.slug,
+  ]);
+
+  const handleSkipCursorStep = useCallback(() => {
+    setCursorStepSkipped(true);
+    setStepsCollapsed(true);
+  }, [setCursorStepSkipped, setStepsCollapsed]);
   const incompleteStepIndices = stepConditions
     .map((needed, idx) => (needed ? idx : null))
     .filter(idx => idx !== null);
@@ -349,13 +418,112 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                   <CustomStepButtons
                     showBack={firstIncompleteIdx !== 3}
                     showNext={lastIncompleteIdx !== 3}
-                    showSkip={lastIncompleteIdx === 3}
+                    showSkip={lastIncompleteIdx === 3 && !needsCursorIntegration}
                     onSkip={() => setStepsCollapsed(true)}
                   >
                     <StarFixabilityViewButton
                       isCompleted={!needsFixabilityView}
                       project={project}
                     />
+                  </CustomStepButtons>
+                </GuidedSteps.Step>
+              )}
+
+              {/* Step 5: Cursor Integration */}
+              {hasCursorFeatureFlagEnabled && (
+                <GuidedSteps.Step
+                  key="cursor-integration"
+                  stepKey="cursor-integration"
+                  title={
+                    <Flex align="baseline" gap="sm" display="inline-flex">
+                      <CursorPluginIcon>
+                        <PluginIcon pluginId="cursor" />
+                      </CursorPluginIcon>
+                      {t('Hand Off to Cursor Background Agents')}
+                    </Flex>
+                  }
+                  isCompleted={!needsCursorIntegration}
+                >
+                  <StepContentRow>
+                    <StepTextCol>
+                      <CardDescription>
+                        {cursorIntegration ? (
+                          <Fragment>
+                            <span>
+                              {t(
+                                'Enable automatic handoff to Cursor Background Agents when Seer identifies a root cause.'
+                              )}
+                            </span>
+                            <span>
+                              {tct(
+                                'During automation, Seer will trigger Cursor Background Agents to generate and submit pull requests directly to your repos. Configure in [seerProjectSettings:Seer project settings] or [docsLink:read the docs] to learn more.',
+                                {
+                                  seerProjectSettings: (
+                                    <Link
+                                      to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+                                    />
+                                  ),
+                                  docsLink: (
+                                    <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
+                                  ),
+                                }
+                              )}
+                            </span>
+                          </Fragment>
+                        ) : (
+                          <Fragment>
+                            <span>
+                              {t(
+                                'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Background Agents for seamless code fixes.'
+                              )}
+                            </span>
+                            <span>
+                              {tct(
+                                'Set up the [integrationLink:Cursor Integration] to enable automatic handoff. [docsLink:Read the docs] to learn more.',
+                                {
+                                  integrationLink: (
+                                    <Link to="/settings/integrations/cursor/" />
+                                  ),
+                                  docsLink: (
+                                    <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
+                                  ),
+                                }
+                              )}
+                            </span>
+                          </Fragment>
+                        )}
+                      </CardDescription>
+                    </StepTextCol>
+                    <StepImageCol>
+                      <CursorCardIllustration
+                        src={alertsEmptyStateImg}
+                        alt="Cursor Integration"
+                      />
+                    </StepImageCol>
+                  </StepContentRow>
+                  <CustomStepButtons
+                    showBack={firstIncompleteIdx !== 4}
+                    showNext={false}
+                    showSkip={lastIncompleteIdx === 4}
+                    onSkip={handleSkipCursorStep}
+                  >
+                    {cursorIntegration ? (
+                      <Button
+                        onClick={handleSetupCursorHandoff}
+                        size="sm"
+                        priority="primary"
+                      >
+                        {t('Set Seer to hand off to Cursor')}
+                      </Button>
+                    ) : (
+                      <LinkButton
+                        to="/settings/integrations/cursor/"
+                        size="sm"
+                        priority="primary"
+                      >
+                        {t('Install Cursor Integration')}
+                      </LinkButton>
+                    )}
                   </CustomStepButtons>
                 </GuidedSteps.Step>
               )}
@@ -442,6 +610,14 @@ const CardIllustration = styled('img')`
   object-fit: contain;
   margin-bottom: -6px;
   margin-right: 10px;
+`;
+
+const CursorCardIllustration = styled(CardIllustration)`
+  max-width: 160px;
+`;
+
+const CursorPluginIcon = styled('div')`
+  transform: translateY(3px);
 `;
 
 const StepContentRow = styled('div')`


### PR DESCRIPTION
Makes the cursor agent integration more discoverable by adding another seer onboarding step.

The main difference between this step and other seer steps is that it will not keep the onboarding steps around if you skip it (because not everyone has the cursor integration, so we make it truly skippable and not naggy)

Without integration set up:
<img width="1800" height="518" alt="image" src="https://github.com/user-attachments/assets/7ca2f19a-739d-4851-a438-952fc0401221" />
With integration set up but without handoff set:
<img width="2040" height="526" alt="image" src="https://github.com/user-attachments/assets/d260cc90-4179-45eb-8a39-59c7d46bf82a" />
With handoff setup or onboarding step skipped:
<img width="1066" height="236" alt="image" src="https://github.com/user-attachments/assets/582e4017-cdcd-4f36-8d96-ecaccb282e49" />

