### PR TITLE
feat(ai-insights): Add nav section heading

### DIFF
--- a/static/app/views/insights/pages/agents/agentsPageHeader.tsx
+++ b/static/app/views/insights/pages/agents/agentsPageHeader.tsx
@@ -2,7 +2,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   AGENTS_LANDING_SUB_PATH,
-  AI_SIDEBAR_LABEL,
+  AGENTS_SIDEBAR_LABEL,
   MODULES,
 } from 'sentry/views/insights/pages/agents/settings';
 import {
@@ -36,7 +36,7 @@ export function AgentsPageHeader({
   return (
     <DomainViewHeader
       domainBaseUrl={agentsBaseUrl}
-      domainTitle={AI_SIDEBAR_LABEL}
+      domainTitle={AGENTS_SIDEBAR_LABEL}
       modules={MODULES}
       selectedModule={module}
       additonalHeaderActions={headerActions}

--- a/static/app/views/insights/pages/agents/settings.ts
+++ b/static/app/views/insights/pages/agents/settings.ts
@@ -2,8 +2,8 @@ import {t} from 'sentry/locale';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export const AGENTS_LANDING_SUB_PATH = 'ai-agents';
-export const AGENTS_LANDING_TITLE = t('AI Agents');
-export const AI_SIDEBAR_LABEL = t('AI Agents');
+export const AGENTS_LANDING_TITLE = t('Agents');
+export const AGENTS_SIDEBAR_LABEL = t('Agents');
 
 export const MODULES = [
   ModuleName.AGENT_MODELS,

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -8,7 +8,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {
   AGENTS_LANDING_SUB_PATH,
-  AI_SIDEBAR_LABEL,
+  AGENTS_SIDEBAR_LABEL,
 } from 'sentry/views/insights/pages/agents/settings';
 import {
   BACKEND_LANDING_SUB_PATH,
@@ -72,12 +72,14 @@ export function InsightsSecondaryNav() {
           >
             {MOBILE_SIDEBAR_LABEL}
           </SecondaryNav.Item>
+        </SecondaryNav.Section>
+        <SecondaryNav.Section id="insights-ai" title={t('AI')}>
           <SecondaryNav.Item
             to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
             analyticsItemName="insights_agents"
             trailingItems={<FeatureBadge type="new" />}
           >
-            {AI_SIDEBAR_LABEL}
+            {AGENTS_SIDEBAR_LABEL}
           </SecondaryNav.Item>
           <SecondaryNav.Item
             to={`${baseUrl}/${MCP_LANDING_SUB_PATH}/`}


### PR DESCRIPTION
Wrap AI insights pages in their separate nav section + heading.
<img width="569" height="454" alt="Screenshot 2025-11-11 at 16 56 17" src="https://github.com/user-attachments/assets/6f1edd72-8fc4-4d97-852e-0b02a01d7810" />

