### PR TITLE
ref(consumer): Enable a few flags by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "rfc3339-validator>=0.1.2",
     "rfc3986-validator>=0.1.1",
     # [end] jsonschema format validators
-    "sentry-arroyo>=2.32.4",
+    "sentry-arroyo>=2.32.5",
     "sentry-forked-email-reply-parser>=0.5.12.post1",
     "sentry-kafka-schemas>=2.1.13",
     "sentry-ophio>=1.1.3",

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -470,6 +470,7 @@ def get_stream_processor(
     profile_consumer_join: bool = False,
     enable_autocommit: bool = False,
     retry_handle_destroyed: bool = False,
+    handle_poll_while_paused: bool = False,
 ) -> StreamProcessor:
     from sentry.utils import kafka_config
 
@@ -637,6 +638,7 @@ def get_stream_processor(
         join_timeout=join_timeout,
         dlq_policy=dlq_policy,
         shutdown_strategy_before_consumer=shutdown_strategy_before_consumer,
+        handle_poll_while_paused=handle_poll_while_paused,
     )
 
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -562,6 +562,12 @@ def taskbroker_send_tasks(
     default=False,
     help="Enable retrying on `KafkaError._DESTROY` during commit.",
 )
+@click.option(
+    "--handle-poll-while-paused",
+    is_flag=True,
+    default=False,
+    help="Enable polling while the consumer is paused to detect rebalancing. Useful for detecting consumer state changes during backpressure.",
+)
 @configuration
 def basic_consumer(
     consumer_name: str,

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -575,7 +575,6 @@ def basic_consumer(
     topic: str | None,
     kafka_slice_id: int | None,
     quantized_rebalance_delay_secs: int | None,
-    enable_autocommit: bool,
     **options: Any,
 ) -> None:
     """
@@ -617,7 +616,6 @@ def basic_consumer(
         topic=topic,
         kafka_slice_id=kafka_slice_id,
         add_global_tags=True,
-        enable_autocommit=enable_autocommit,
         **options,
     )
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -607,6 +607,10 @@ def basic_consumer(
     add_global_tags(
         kafka_topic=topic, consumer_group=options["group_id"], kafka_slice_id=kafka_slice_id
     )
+
+    options["shutdown_strategy_before_consumer"] = True
+    options["enable_autocommit"] = True
+
     processor = get_stream_processor(
         consumer_name,
         consumer_args,

--- a/uv.lock
+++ b/uv.lock
@@ -2165,7 +2165,7 @@ requires-dist = [
     { name = "requests-oauthlib", specifier = ">=1.2.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.2" },
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
-    { name = "sentry-arroyo", specifier = ">=2.32.4" },
+    { name = "sentry-arroyo", specifier = ">=2.32.5" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
     { name = "sentry-kafka-schemas", specifier = ">=2.1.13" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
@@ -2257,13 +2257,13 @@ dev = [
 
 [[package]]
 name = "sentry-arroyo"
-version = "2.32.4"
+version = "2.32.5"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "confluent-kafka", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.32.4-py3-none-any.whl", hash = "sha256:10d366000d4cddc56efea85e0da1db6af7a485712060a84f50c128406dcc11d7" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.32.5-py3-none-any.whl", hash = "sha256:80aadbbc6d5f98036bc74080cf5260bc479a2ba6ff7bfaf663f43d9ed4ade8af" },
 ]
 
 [[package]]


### PR DESCRIPTION
We need to keep the CLI flags because the ops repo references them.
After this PR i'll remove them from YAML
