### PR TITLE
fix(seer-rpc): repo check ignores integration_id + returns it

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1076,17 +1076,17 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
     Returns:
         dict: {
             "statuses": list of booleans indicating if each repository exists and is active,
-            "integration_ids": list of integration IDs from the database,
+            "integration_ids": list of integration IDs (as integers) from the database,
                               or None if repository doesn't exist / doesn't have an integration id
         }
-        e.g., {"statuses": [True, False, True], "integration_ids": ["123", None, "456"]}
+        e.g., {"statuses": [True, False, True], "integration_ids": [123, None, 456]}
         Only repositories with supported SCM providers will return True.
         The integration_ids are returned so Seer can store them for future reference.
 
     Note:
         - Repositories are matched by (organization_id, provider, external_id) which has a unique constraint
         - integration_id is NOT required in the request and NOT used in matching
-        - integration_id from the database is returned as a string so Seer can store it for future reference
+        - integration_id from the database is returned as an integer so Seer can store it for future reference
     """
 
     if not repository_integrations:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1075,12 +1075,11 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
 
     Returns:
         dict: {
-            "statuses": list of booleans indicating if each repository exists and is active,
             "integration_ids": list of integration IDs (as integers) from the database,
-                              or None if repository doesn't exist / doesn't have an integration id
+                              or None if repository doesn't exist/isn't active/doesn't have an integration id
         }
-        e.g., {"statuses": [True, False, True], "integration_ids": [123, None, 456]}
-        Only repositories with supported SCM providers will return True.
+        e.g., {"integration_ids": [123, None, 456]}
+        None indicates repository not found, inactive, or has unsupported SCM provider.
         The integration_ids are returned so Seer can store them for future reference.
 
     Note:
@@ -1090,7 +1089,7 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
     """
 
     if not repository_integrations:
-        return {"statuses": [], "integration_ids": []}
+        return {"integration_ids": []}
 
     logger.info(
         "seer_rpc.check_repository_integrations_status.called",
@@ -1126,7 +1125,6 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
         if key not in existing_map:
             existing_map[key] = integration_id
 
-    statuses = []
     integration_ids = []
 
     for item in repository_integrations:
@@ -1145,15 +1143,14 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
             repo_tuple_without_prefix
         )
 
-        statuses.append(found_integration_id is not None)
         integration_ids.append(found_integration_id)
 
     logger.info(
         "seer_rpc.check_repository_integrations_status.completed",
-        extra={"statuses": statuses, "integration_ids": integration_ids},
+        extra={"integration_ids": integration_ids},
     )
 
-    return {"statuses": statuses, "integration_ids": integration_ids}
+    return {"integration_ids": integration_ids}
 
 
 seer_method_registry: dict[str, Callable] = {  # return type must be serialized

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1076,8 +1076,8 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
     Returns:
         dict: {
             "statuses": list of booleans indicating if each repository exists and is active,
-            "integration_ids": list of integration IDs (as strings) from the database,
-                              or None if repository doesn't exist
+            "integration_ids": list of integration IDs from the database,
+                              or None if repository doesn't exist / doesn't have an integration id
         }
         e.g., {"statuses": [True, False, True], "integration_ids": ["123", None, "456"]}
         Only repositories with supported SCM providers will return True.
@@ -1118,14 +1118,13 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
         q_objects, status=ObjectStatus.ACTIVE, provider__in=SEER_SUPPORTED_SCM_PROVIDERS
     ).values_list("organization_id", "provider", "integration_id", "external_id")
 
-    existing_map: dict[tuple, str] = {}
+    existing_map: dict[tuple, int | None] = {}
 
     for org_id, provider, integration_id, external_id in existing_repos:
-        integration_id_str = str(integration_id) if integration_id is not None else None
         key = (org_id, provider, external_id)
         # If multiple repos match (shouldn't happen), keep the first one
         if key not in existing_map:
-            existing_map[key] = integration_id_str
+            existing_map[key] = integration_id
 
     statuses = []
     integration_ids = []

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -952,7 +952,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}
+        assert result == {"statuses": [True], "integration_ids": [integration.id]}
 
     def test_check_repository_integrations_status_single_non_existing_repo(self) -> None:
         """Test when repository does not exist"""
@@ -1019,7 +1019,7 @@ class TestSeerRpcMethods(APITestCase):
 
         assert result == {
             "statuses": [True, False, True],
-            "integration_ids": [str(integration.id), None, str(integration.id)],
+            "integration_ids": [integration.id, None, integration.id],
         }
 
     def test_check_repository_integrations_status_inactive_repo(self) -> None:
@@ -1114,7 +1114,7 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         # Should find the repo and return the ACTUAL integration_id from the database
-        assert result == {"statuses": [True], "integration_ids": [str(integration1.id)]}
+        assert result == {"statuses": [True], "integration_ids": [integration1.id]}
 
     def test_check_repository_integrations_status_wrong_external_id(self) -> None:
         """Test that repositories with different external_id are not matched"""
@@ -1203,7 +1203,7 @@ class TestSeerRpcMethods(APITestCase):
 
         assert result == {
             "statuses": [True, True, True],
-            "integration_ids": [str(integration.id), str(integration.id), str(integration.id)],
+            "integration_ids": [integration.id, integration.id, integration.id],
         }
 
     def test_check_repository_integrations_status_multiple_orgs(self) -> None:
@@ -1256,7 +1256,7 @@ class TestSeerRpcMethods(APITestCase):
 
         assert result == {
             "statuses": [True, True],
-            "integration_ids": [str(integration1.id), str(integration2.id)],
+            "integration_ids": [integration1.id, integration2.id],
         }
 
     def test_check_repository_integrations_status_unsupported_provider(self) -> None:
@@ -1340,7 +1340,7 @@ class TestSeerRpcMethods(APITestCase):
 
         assert result == {
             "statuses": [True, False],
-            "integration_ids": [str(github_integration.id), None],
+            "integration_ids": [github_integration.id, None],
         }
 
     def test_check_repository_integrations_status_integration_id_as_string(self) -> None:
@@ -1371,7 +1371,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}
+        assert result == {"statuses": [True], "integration_ids": [integration.id]}
 
     def test_check_repository_integrations_status_integration_id_none(self) -> None:
         """Test that integration_id=None is ignored in matching"""
@@ -1402,7 +1402,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}
+        assert result == {"statuses": [True], "integration_ids": [integration.id]}
 
     def test_check_repository_integrations_status_no_integration_id_in_request(self) -> None:
         """Test that integration_id is completely optional - Seer doesn't need to send it"""
@@ -1432,4 +1432,4 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}
+        assert result == {"statuses": [True], "integration_ids": [integration.id]}

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -924,7 +924,7 @@ class TestSeerRpcMethods(APITestCase):
     def test_check_repository_integrations_status_empty_list(self) -> None:
         """Test with empty input list"""
         result = check_repository_integrations_status(repository_integrations=[])
-        assert result == {"statuses": []}
+        assert result == {"statuses": [], "integration_ids": []}
 
     def test_check_repository_integrations_status_single_existing_repo(self) -> None:
         """Test when a single repository exists and is active"""
@@ -952,7 +952,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True]}
+        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}
 
     def test_check_repository_integrations_status_single_non_existing_repo(self) -> None:
         """Test when repository does not exist"""
@@ -967,10 +967,10 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False]}
+        assert result == {"statuses": [False], "integration_ids": [None]}
 
     def test_check_repository_integrations_status_mixed_existing_and_non_existing(self) -> None:
-        """Test with a mix of existing and non-existing repositories"""
+        """Test with a mix of existing and non-existing repositories (integration_id ignored)"""
         integration = self.create_integration(
             organization=self.organization, provider="github", external_id="github:1"
         )
@@ -993,7 +993,7 @@ class TestSeerRpcMethods(APITestCase):
             integration_id=integration.id,
         )
 
-        # Check 4 repos: 2 exist, 2 don't
+        # Check 3 repos: 2 exist, 1 doesn't
         result = check_repository_integrations_status(
             repository_integrations=[
                 {
@@ -1014,16 +1014,13 @@ class TestSeerRpcMethods(APITestCase):
                     "external_id": "456",
                     "provider": "github",
                 },  # exists
-                {
-                    "organization_id": self.organization.id,
-                    "integration_id": 888,
-                    "external_id": "123",
-                    "provider": "github",
-                },  # wrong integration_id
             ]
         )
 
-        assert result == {"statuses": [True, False, True, False]}
+        assert result == {
+            "statuses": [True, False, True],
+            "integration_ids": [str(integration.id), None, str(integration.id)],
+        }
 
     def test_check_repository_integrations_status_inactive_repo(self) -> None:
         """Test that inactive repositories are not matched"""
@@ -1052,7 +1049,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False]}
+        assert result == {"statuses": [False], "integration_ids": [None]}
 
     def test_check_repository_integrations_status_wrong_organization_id(self) -> None:
         """Test that repositories from different organizations are not matched"""
@@ -1083,10 +1080,10 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False]}
+        assert result == {"statuses": [False], "integration_ids": [None]}
 
     def test_check_repository_integrations_status_wrong_integration_id(self) -> None:
-        """Test that repositories with different integration_id are not matched"""
+        """Test that integration_id in request is ignored - only (org, provider, external_id) matter"""
         integration1 = self.create_integration(
             organization=self.organization, provider="github", external_id="github:1"
         )
@@ -1104,19 +1101,20 @@ class TestSeerRpcMethods(APITestCase):
             integration_id=integration1.id,
         )
 
-        # Try to find it with integration2's ID
+        # Query with integration2's ID - should still find the repo and return integration1's ID
         result = check_repository_integrations_status(
             repository_integrations=[
                 {
                     "organization_id": self.organization.id,
-                    "integration_id": integration2.id,
+                    "integration_id": integration2.id,  # Different from DB, but ignored
                     "external_id": "123",
                     "provider": "github",
                 }
             ]
         )
 
-        assert result == {"statuses": [False]}
+        # Should find the repo and return the ACTUAL integration_id from the database
+        assert result == {"statuses": [True], "integration_ids": [str(integration1.id)]}
 
     def test_check_repository_integrations_status_wrong_external_id(self) -> None:
         """Test that repositories with different external_id are not matched"""
@@ -1146,7 +1144,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False]}
+        assert result == {"statuses": [False], "integration_ids": [None]}
 
     def test_check_repository_integrations_status_multiple_all_exist(self) -> None:
         """Test when all queried repositories exist"""
@@ -1203,7 +1201,10 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True, True, True]}
+        assert result == {
+            "statuses": [True, True, True],
+            "integration_ids": [str(integration.id), str(integration.id), str(integration.id)],
+        }
 
     def test_check_repository_integrations_status_multiple_orgs(self) -> None:
         """Test with repositories from multiple organizations"""
@@ -1253,7 +1254,10 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True, True]}
+        assert result == {
+            "statuses": [True, True],
+            "integration_ids": [str(integration1.id), str(integration2.id)],
+        }
 
     def test_check_repository_integrations_status_unsupported_provider(self) -> None:
         """Test that repositories with unsupported providers are not matched"""
@@ -1283,7 +1287,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False]}
+        assert result == {"statuses": [False], "integration_ids": [None]}
 
     def test_check_repository_integrations_status_mixed_supported_and_unsupported_providers(
         self,
@@ -1334,4 +1338,98 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True, False]}
+        assert result == {
+            "statuses": [True, False],
+            "integration_ids": [str(github_integration.id), None],
+        }
+
+    def test_check_repository_integrations_status_integration_id_as_string(self) -> None:
+        """Test that integration_id as string is properly handled (type mismatch)"""
+        integration = self.create_integration(
+            organization=self.organization, provider="github", external_id="github:1"
+        )
+
+        # Create repository with integration_id as integer
+        Repository.objects.create(
+            name="test/repo",
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            external_id="123",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        # Query with integration_id as string (like from Seer)
+        result = check_repository_integrations_status(
+            repository_integrations=[
+                {
+                    "organization_id": self.organization.id,
+                    "integration_id": str(integration.id),  # String instead of int
+                    "external_id": "123",
+                    "provider": "github",
+                }
+            ]
+        )
+
+        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}
+
+    def test_check_repository_integrations_status_integration_id_none(self) -> None:
+        """Test that integration_id=None is ignored in matching"""
+        integration = self.create_integration(
+            organization=self.organization, provider="github", external_id="github:1"
+        )
+
+        # Create repository with an integration_id
+        Repository.objects.create(
+            name="test/repo",
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            external_id="456",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        # Query with integration_id=None should still match by org_id, provider, external_id
+        # and return the actual integration_id from the database
+        result = check_repository_integrations_status(
+            repository_integrations=[
+                {
+                    "organization_id": self.organization.id,
+                    "integration_id": None,
+                    "external_id": "456",
+                    "provider": "github",
+                }
+            ]
+        )
+
+        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}
+
+    def test_check_repository_integrations_status_no_integration_id_in_request(self) -> None:
+        """Test that integration_id is completely optional - Seer doesn't need to send it"""
+        integration = self.create_integration(
+            organization=self.organization, provider="github", external_id="github:1"
+        )
+
+        # Create repository with an integration_id
+        Repository.objects.create(
+            name="test/repo",
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            external_id="789",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        # Query WITHOUT integration_id field at all - should still match and return it
+        result = check_repository_integrations_status(
+            repository_integrations=[
+                {
+                    "organization_id": self.organization.id,
+                    "external_id": "789",
+                    "provider": "github",
+                    # No integration_id field at all
+                }
+            ]
+        )
+
+        assert result == {"statuses": [True], "integration_ids": [str(integration.id)]}

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -924,7 +924,7 @@ class TestSeerRpcMethods(APITestCase):
     def test_check_repository_integrations_status_empty_list(self) -> None:
         """Test with empty input list"""
         result = check_repository_integrations_status(repository_integrations=[])
-        assert result == {"statuses": [], "integration_ids": []}
+        assert result == {"integration_ids": []}
 
     def test_check_repository_integrations_status_single_existing_repo(self) -> None:
         """Test when a single repository exists and is active"""
@@ -952,7 +952,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [integration.id]}
+        assert result == {"integration_ids": [integration.id]}
 
     def test_check_repository_integrations_status_single_non_existing_repo(self) -> None:
         """Test when repository does not exist"""
@@ -967,7 +967,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False], "integration_ids": [None]}
+        assert result == {"integration_ids": [None]}
 
     def test_check_repository_integrations_status_mixed_existing_and_non_existing(self) -> None:
         """Test with a mix of existing and non-existing repositories (integration_id ignored)"""
@@ -1018,7 +1018,6 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         assert result == {
-            "statuses": [True, False, True],
             "integration_ids": [integration.id, None, integration.id],
         }
 
@@ -1049,7 +1048,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False], "integration_ids": [None]}
+        assert result == {"integration_ids": [None]}
 
     def test_check_repository_integrations_status_wrong_organization_id(self) -> None:
         """Test that repositories from different organizations are not matched"""
@@ -1080,7 +1079,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False], "integration_ids": [None]}
+        assert result == {"integration_ids": [None]}
 
     def test_check_repository_integrations_status_wrong_integration_id(self) -> None:
         """Test that integration_id in request is ignored - only (org, provider, external_id) matter"""
@@ -1114,7 +1113,7 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         # Should find the repo and return the ACTUAL integration_id from the database
-        assert result == {"statuses": [True], "integration_ids": [integration1.id]}
+        assert result == {"integration_ids": [integration1.id]}
 
     def test_check_repository_integrations_status_wrong_external_id(self) -> None:
         """Test that repositories with different external_id are not matched"""
@@ -1144,7 +1143,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False], "integration_ids": [None]}
+        assert result == {"integration_ids": [None]}
 
     def test_check_repository_integrations_status_multiple_all_exist(self) -> None:
         """Test when all queried repositories exist"""
@@ -1202,7 +1201,6 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         assert result == {
-            "statuses": [True, True, True],
             "integration_ids": [integration.id, integration.id, integration.id],
         }
 
@@ -1255,7 +1253,6 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         assert result == {
-            "statuses": [True, True],
             "integration_ids": [integration1.id, integration2.id],
         }
 
@@ -1287,7 +1284,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [False], "integration_ids": [None]}
+        assert result == {"integration_ids": [None]}
 
     def test_check_repository_integrations_status_mixed_supported_and_unsupported_providers(
         self,
@@ -1339,7 +1336,6 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         assert result == {
-            "statuses": [True, False],
             "integration_ids": [github_integration.id, None],
         }
 
@@ -1371,7 +1367,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [integration.id]}
+        assert result == {"integration_ids": [integration.id]}
 
     def test_check_repository_integrations_status_integration_id_none(self) -> None:
         """Test that integration_id=None is ignored in matching"""
@@ -1402,7 +1398,7 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [integration.id]}
+        assert result == {"integration_ids": [integration.id]}
 
     def test_check_repository_integrations_status_no_integration_id_in_request(self) -> None:
         """Test that integration_id is completely optional - Seer doesn't need to send it"""
@@ -1432,4 +1428,4 @@ class TestSeerRpcMethods(APITestCase):
             ]
         )
 
-        assert result == {"statuses": [True], "integration_ids": [integration.id]}
+        assert result == {"integration_ids": [integration.id]}


### PR DESCRIPTION
originally this was failing because we were sending `str` integration_ids when we needed `int` here.

but turns out there is a unique constraint on `organization_id, provider, external_id` so we can just use this to get the integration_id as well to backfill repo records from seer that don't have integration_id.

so the main change is we no longer call this with the integration id, use it to validate this org still has this repo, if yes, return the integration id