### PR TITLE
fix(issue-details): Do not show since first seen when config is disabled

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -61,6 +61,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
   const hasSetStatsPeriod =
     location.query.statsPeriod || location.query.start || location.query.end;
   const defaultStatsPeriod = useGroupDefaultStatsPeriod(group, project);
+  const shouldShowSinceFirstSeenOption = issueTypeConfig.defaultTimePeriod.sinceFirstSeen;
   const period = hasSetStatsPeriod
     ? getPeriod({
         start: location.query.start as string,
@@ -132,7 +133,8 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
                       return {
                         ...props.arbitraryOptions,
                         // Always display arbitrary issue open period
-                        ...(defaultStatsPeriod?.statsPeriod
+                        ...(defaultStatsPeriod?.statsPeriod &&
+                        shouldShowSinceFirstSeenOption
                           ? {
                               [defaultStatsPeriod.statsPeriod]: t(
                                 '%s (since first seen)',
@@ -162,7 +164,8 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
                     triggerProps={{
                       children:
                         period === defaultStatsPeriod &&
-                        !defaultStatsPeriod.isMaxRetention
+                        !defaultStatsPeriod.isMaxRetention &&
+                        shouldShowSinceFirstSeenOption
                           ? t('Since First Seen')
                           : undefined,
                       style: {


### PR DESCRIPTION
There is a config option show `sinceFirstSeen`, which is used to determine the default stats period, but we don't remove the option from the time range selector. This fixes that.

You can see this issue on replay issues (and the new metric issues)

Before (14d interval, but shows "since first seen")

<img width="986" height="180" alt="CleanShot 2025-11-11 at 11 32 16" src="https://github.com/user-attachments/assets/17048045-b3f7-4ee7-9047-69e57e751e01" />

After

<img width="992" height="217" alt="CleanShot 2025-11-11 at 11 32 03" src="https://github.com/user-attachments/assets/19257f76-1b77-4d2d-8745-f4f59d687302" />
