### PR TITLE
fix(snuba): don't mutate filter_keys

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -940,6 +940,7 @@ class SnubaQueryParams:
         in_groups = None
         out_groups: set[int | str] = set()
         if "group_id" in self.filter_keys:
+            self.filter_keys = self.filter_keys.copy()
             in_groups = get_all_merged_group_ids(self.filter_keys["group_id"])
             del self.filter_keys["group_id"]
 


### PR DESCRIPTION
Some callsites are re-using the same dictionary. It causes problems when we `del filter_keys["group_id"]` (because that mutates the input dict).

This PR runs a copy before mutating, so the original input should not be mutated.
