### PR TITLE
fix(aci): Fix Stateful Detector counter reset

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -403,7 +403,7 @@ class StatefulDetectorHandler(
                 # Reset counters if any were incremented while evaluating a
                 # different priority (but not reaching thresholds)
                 if any(state_data.counter_updates.values()):
-                    self.state_manager.enqueue_counter_reset()
+                    self.state_manager.enqueue_counter_reset(group_key)
 
                 continue
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -403,6 +403,26 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         assert state_data.is_triggered is True
         assert state_data.status == Level.LOW
 
+    def test_evaluate__counter_reset_for_non_none_group_key(self) -> None:
+        self.group_key = "group1"
+
+        # Trigger HIGH priority
+        result = self.handler.evaluate(self.packet(1, Level.HIGH))
+        assert result == {}
+        result = self.handler.evaluate(self.packet(2, Level.HIGH))
+        assert result[self.group_key].priority == Level.HIGH
+
+        # Evaluate again at HIGH priority (same as current state)
+        result = self.handler.evaluate(self.packet(3, Level.HIGH))
+        assert result == {}
+
+        # Evaluate at MEDIUM priority - should require 2 evaluations to trigger
+        result = self.handler.evaluate(self.packet(4, Level.MEDIUM))
+        assert result == {}
+
+        result = self.handler.evaluate(self.packet(5, Level.MEDIUM))
+        assert result[self.group_key].priority == Level.MEDIUM
+
     def test_evaluate__condition_hole(self):
         detector = self.create_detector(
             name="Stateful Detector",


### PR DESCRIPTION
When operating on a particular group key, the counter reset should only target that group key.
