### PR TITLE
ref(eap): Start unifying EAP utils

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -10,20 +10,18 @@ from arroyo.backends.kafka import build_kafka_producer_configuration
 from confluent_kafka import KafkaError
 from confluent_kafka import Message as KafkaMessage
 from confluent_kafka import Producer
-from sentry_kafka_schemas.codecs import Codec
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry import options
-from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.conf.types.kafka_definition import Topic
 from sentry.eventstream.base import GroupStates
 from sentry.eventstream.snuba import KW_SKIP_SEMANTIC_PARTITIONING, SnubaProtocolEventStream
 from sentry.eventstream.types import EventStreamEventType
 from sentry.killswitches import killswitch_matches_context
 from sentry.utils import json
 from sentry.utils.confluent_producer import get_confluent_producer
+from sentry.utils.eap import EAP_ITEMS_CODEC
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
-
-EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -1,31 +1,10 @@
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import Topic as ArroyoTopic
-from sentry_kafka_schemas.codecs import Codec
-from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
-from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.conf.types.kafka_definition import Topic
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.utils.pubsub import KafkaPublisher
-
-#
-# EAP PRODUCER
-#
-
-
-EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
-
-
-def _get_eap_items_producer():
-    """Get a Kafka producer for EAP TraceItems."""
-    return get_arroyo_producer(
-        name="sentry.replays.lib.kafka.eap_items",
-        topic=Topic.SNUBA_ITEMS,
-    )
-
-
-eap_producer = SingletonProducer(_get_eap_items_producer)
-
 
 #
 # REPLAY PRODUCER

--- a/src/sentry/uptime/consumers/eap_producer.py
+++ b/src/sentry/uptime/consumers/eap_producer.py
@@ -2,33 +2,17 @@ import logging
 
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaPayload
-from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult
-from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
-from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.conf.types.kafka_definition import Topic
 from sentry.uptime.consumers.eap_converter import convert_uptime_result_to_trace_items
 from sentry.uptime.types import IncidentStatus
 from sentry.utils import metrics
-from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.eap import EAP_ITEMS_CODEC, eap_items_producer
 from sentry.utils.kafka_config import get_topic_definition
 from sentry.workflow_engine.models.detector import Detector
 
 logger = logging.getLogger(__name__)
-
-EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
-
-
-def _get_eap_items_producer():
-    """Get a Kafka producer for EAP TraceItems."""
-    return get_arroyo_producer(
-        "sentry.uptime.consumers.eap_producer",
-        Topic.SNUBA_ITEMS,
-        exclude_config_keys=["compression.type", "message.max.bytes"],
-    )
-
-
-_eap_items_producer = SingletonProducer(_get_eap_items_producer)
 
 
 def produce_eap_uptime_result(
@@ -56,7 +40,7 @@ def produce_eap_uptime_result(
 
         for trace_item in trace_items:
             payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
-            _eap_items_producer.produce(ArroyoTopic(topic), payload)
+            eap_items_producer.produce(ArroyoTopic(topic), payload)
 
         metrics.incr(
             "uptime.result_processor.eap_message_produced",

--- a/src/sentry/utils/eap.py
+++ b/src/sentry/utils/eap.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Any
+
+import orjson
+from sentry_kafka_schemas.codecs import Codec
+from sentry_protos.snuba.v1.trace_item_pb2 import (
+    AnyValue,
+    ArrayValue,
+    KeyValue,
+    KeyValueList,
+    TraceItem,
+)
+
+from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.db.models.fields.bounded import I64_MAX
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+
+logger = logging.getLogger(__name__)
+
+EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
+
+
+def _get_eap_items_producer():
+    """Get a Kafka producer for EAP TraceItems."""
+    return get_arroyo_producer(
+        "sentry.utils.eap_producer",
+        Topic.SNUBA_ITEMS,
+        exclude_config_keys=["compression.type", "message.max.bytes"],
+    )
+
+
+eap_items_producer = SingletonProducer(_get_eap_items_producer)
+
+
+def encode_value(value: Any, *, dump_arrays: bool = False, expand_arrays: bool = False) -> AnyValue:
+    if isinstance(value, str):
+        return AnyValue(string_value=value)
+    elif isinstance(value, bool):
+        # Note: bool check must come before int check since bool is a subclass of int
+        return AnyValue(bool_value=value)
+    elif isinstance(value, int):
+        if value > I64_MAX:
+            return AnyValue(double_value=float(value))
+        return AnyValue(int_value=value)
+    elif isinstance(value, float):
+        return AnyValue(double_value=value)
+    elif isinstance(value, bytes):
+        return AnyValue(bytes_value=value)
+    elif dump_arrays and isinstance(value, (list, tuple, dict)):
+        return AnyValue(string_value=orjson.dumps(value).decode())
+    elif expand_arrays and isinstance(value, dict):
+        return AnyValue(**value)
+    elif isinstance(value, list) or isinstance(value, tuple):
+        # Not yet processed on EAP side
+        return AnyValue(
+            array_value=ArrayValue(values=[encode_value(v) for v in value if v is not None])
+        )
+    elif isinstance(value, dict):
+        # Not yet processed on EAP side
+        return AnyValue(
+            kvlist_value=KeyValueList(
+                values=[
+                    KeyValue(key=str(kv[0]), value=encode_value(kv[1]))
+                    for kv in value.items()
+                    if kv[1] is not None
+                ]
+            )
+        )
+    else:
+        raise NotImplementedError(f"encode not supported for {type(value)}")

--- a/tests/sentry/uptime/consumers/test_eap_converter.py
+++ b/tests/sentry/uptime/consumers/test_eap_converter.py
@@ -6,34 +6,34 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.testutils.cases import TestCase as SentryTestCase
 from sentry.uptime.consumers.eap_converter import (
-    _anyvalue,
     convert_uptime_request_to_trace_item,
     convert_uptime_result_to_trace_items,
     ms_to_us,
 )
 from sentry.uptime.types import IncidentStatus
+from sentry.utils.eap import encode_value
 
 
 class TestHelperFunctions(TestCase):
     def test_anyvalue_string(self) -> None:
-        result = _anyvalue("test")
+        result = encode_value("test")
         assert result.string_value == "test"
 
     def test_anyvalue_int(self) -> None:
-        result = _anyvalue(123)
+        result = encode_value(123)
         assert result.int_value == 123
 
     def test_anyvalue_float(self) -> None:
-        result = _anyvalue(123.45)
+        result = encode_value(123.45)
         assert result.double_value == 123.45
 
     def test_anyvalue_bool(self) -> None:
-        result = _anyvalue(True)
+        result = encode_value(True)
         assert result.bool_value is True
 
     def test_anyvalue_fallback(self) -> None:
-        with pytest.raises(ValueError):
-            _anyvalue([1, 2, 3])  # type: ignore[arg-type] # Test with unsupported type
+        with pytest.raises(NotImplementedError):
+            encode_value({1, 2, 3})  # Test with unsupported type
 
     def test_microseconds_conversion(self) -> None:
         assert ms_to_us(1000) == 1000000

--- a/tests/sentry/uptime/consumers/test_eap_producer.py
+++ b/tests/sentry/uptime/consumers/test_eap_producer.py
@@ -40,7 +40,7 @@ class EAPProducerIntegrationTestCase(TestCase):
         }
         return result
 
-    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    @patch("sentry.uptime.consumers.eap_producer.eap_items_producer")
     @patch("sentry.uptime.consumers.eap_producer.get_topic_definition")
     def test_produce_eap_uptime_result_success(
         self, mock_get_topic: MagicMock, mock_producer: MagicMock
@@ -72,7 +72,7 @@ class EAPProducerIntegrationTestCase(TestCase):
         codec = get_topic_codec(Topic.SNUBA_ITEMS)
         assert [codec.decode(payload.value)] == expected_trace_items
 
-    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    @patch("sentry.uptime.consumers.eap_producer.eap_items_producer")
     @patch("sentry.uptime.consumers.eap_producer.logger")
     def test_produce_eap_uptime_result_error_handling(
         self, mock_logger: MagicMock, mock_producer: MagicMock
@@ -90,7 +90,7 @@ class EAPProducerIntegrationTestCase(TestCase):
         )
 
     @patch("sentry.uptime.consumers.eap_producer.metrics")
-    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    @patch("sentry.uptime.consumers.eap_producer.eap_items_producer")
     def test_metrics_tracking(self, mock_producer: MagicMock, mock_metrics: MagicMock) -> None:
         result = self.create_check_result()
         metric_tags = {"status": "success", "region": "us-east-1"}
@@ -106,7 +106,7 @@ class EAPProducerIntegrationTestCase(TestCase):
         )
 
     @patch("sentry.uptime.consumers.eap_producer.metrics")
-    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    @patch("sentry.uptime.consumers.eap_producer.eap_items_producer")
     def test_error_metrics_tracking(
         self, mock_producer: MagicMock, mock_metrics: MagicMock
     ) -> None:
@@ -124,7 +124,7 @@ class EAPProducerIntegrationTestCase(TestCase):
             tags=metric_tags,
         )
 
-    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    @patch("sentry.uptime.consumers.eap_producer.eap_items_producer")
     @patch("sentry.uptime.consumers.eap_producer.get_topic_definition")
     def test_produce_with_triggered_detector_state(
         self, mock_get_topic: MagicMock, mock_producer: MagicMock

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -374,7 +374,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 extra={"num_missed_checks": 1, **result},
             )
 
-    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    @mock.patch("sentry.utils.eap.eap_items_producer.produce")
     def test_no_missed_check_for_disabled(self, mock_produce: MagicMock) -> None:
         result = self.create_uptime_result(self.subscription.subscription_id)
 
@@ -405,7 +405,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
 
             assert check.attributes["check_status"].string_value == "failure"
 
-    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    @mock.patch("sentry.utils.eap.eap_items_producer.produce")
     def test_missed_check_true_positive(self, mock_produce: MagicMock) -> None:
         result = self.create_uptime_result(self.subscription.subscription_id)
 
@@ -1079,7 +1079,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
 
-    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    @mock.patch("sentry.utils.eap.eap_items_producer.produce")
     def test_produces_snuba_uptime_results(self, mock_produce: MagicMock) -> None:
         """
         Validates that the consumer produces a message to Snuba's Kafka topic for uptime check results
@@ -1100,7 +1100,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         assert trace_item.attributes["incident_status"].int_value == 0
         assert trace_item.retention_days == 90
 
-    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    @mock.patch("sentry.utils.eap.eap_items_producer.produce")
     def test_produces_snuba_uptime_results_in_incident(self, mock_produce: MagicMock) -> None:
         """
         Validates that the consumer produces a message to Snuba's Kafka topic for uptime check results
@@ -1120,7 +1120,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         trace_item = self.decode_trace_item(mock_produce.call_args.args[1].value)
         assert trace_item.attributes["incident_status"].int_value == 1
 
-    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    @mock.patch("sentry.utils.eap.eap_items_producer.produce")
     def test_produces_eap_uptime_results(self, mock_produce: MagicMock) -> None:
         """
         Validates that the consumer produces TraceItems to EAP's Kafka topic for uptime check results


### PR DESCRIPTION
We've got a couple redundant-implementations of EAP utils, most notably the `encode_value` function.

This PR unifies these into `sentry.utils.eap`.