### PR TITLE
feat(detectors): Handle config field updates in base detector validator

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -133,6 +133,14 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                     group_validator = BaseDataConditionGroupValidator()
                     group_validator.update(instance.workflow_condition_group, condition_group)
 
+            # Handle config field update
+            if "config" in validated_data:
+                instance.config = validated_data.get("config", instance.config)
+                try:
+                    enforce_config_schema(instance)
+                except JSONSchemaValidationError as error:
+                    raise serializers.ValidationError({"config": [str(error)]})
+
             instance.save()
 
         create_audit_entry(


### PR DESCRIPTION
Previously, the base detector validator update() method did not handle config field updates at all. This adds proper support for updating the config field with JSON schema validation using enforce_config_schema().

Adds tests to verify:
- Valid config updates are applied correctly
- Invalid config updates that violate the schema are rejected with appropriate error messages