### PR TITLE
feat(grouping): Add python multiprocessing grouping input

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/python-hardcoded-values-in-context-line.json
+++ b/tests/sentry/grouping/grouping_inputs/python-hardcoded-values-in-context-line.json
@@ -1,0 +1,166 @@
+{
+  "platform": "python",
+  "message": "Failed to process pipeline step process_rules",
+  "exception": {
+    "values": [
+      {
+        "type": "TimeoutError",
+        "value": "timed out",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "<module>",
+              "module": "__main__",
+              "filename": "<string>",
+              "abs_path": "/usr/src/getsentry/<string>",
+              "context_line": "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+            },
+            {
+              "function": "spawn_main",
+              "module": "multiprocessing.spawn",
+              "filename": "multiprocessing/spawn.py",
+              "abs_path": "/usr/local/lib/python3.13/multiprocessing/spawn.py",
+              "context_line": "exitcode = _main(fd, parent_sentinel)"
+            },
+            {
+              "function": "_main",
+              "module": "multiprocessing.spawn",
+              "filename": "multiprocessing/spawn.py",
+              "abs_path": "/usr/local/lib/python3.13/multiprocessing/spawn.py",
+              "context_line": "return self._bootstrap(parent_sentinel)"
+            },
+            {
+              "function": "_bootstrap",
+              "module": "multiprocessing.process",
+              "filename": "multiprocessing/process.py",
+              "abs_path": "/usr/local/lib/python3.13/multiprocessing/process.py",
+              "context_line": "self.run()"
+            },
+            {
+              "function": "run",
+              "module": "multiprocessing.process",
+              "filename": "multiprocessing/process.py",
+              "abs_path": "/usr/local/lib/python3.13/multiprocessing/process.py",
+              "context_line": "self._target(*self._args, **self._kwargs)"
+            },
+            {
+              "function": "child_process",
+              "module": "sentry.taskworker.workerchild",
+              "filename": "sentry/taskworker/workerchild.py",
+              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
+              "context_line": "run_worker("
+            },
+            {
+              "function": "run_worker",
+              "module": "sentry.taskworker.workerchild",
+              "filename": "sentry/taskworker/workerchild.py",
+              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
+              "context_line": "_execute_activation(task_func, inflight.activation)"
+            },
+            {
+              "function": "_execute_activation",
+              "module": "sentry.taskworker.workerchild",
+              "filename": "sentry/taskworker/workerchild.py",
+              "abs_path": "/usr/src/sentry/src/sentry/taskworker/workerchild.py",
+              "context_line": "task_func(*args, **kwargs)"
+            },
+            {
+              "function": "__call__",
+              "module": "sentry.taskworker.task",
+              "filename": "sentry/taskworker/task.py",
+              "abs_path": "/usr/src/sentry/src/sentry/taskworker/task.py",
+              "context_line": "return self._func(*args, **kwargs)"
+            },
+            {
+              "function": "post_process_group",
+              "module": "sentry.tasks.post_process",
+              "filename": "sentry/tasks/post_process.py",
+              "abs_path": "/usr/src/sentry/src/sentry/tasks/post_process.py",
+              "context_line": "run_post_process_job("
+            },
+            {
+              "function": "run_post_process_job",
+              "module": "sentry.tasks.post_process",
+              "filename": "sentry/tasks/post_process.py",
+              "abs_path": "/usr/src/sentry/src/sentry/tasks/post_process.py",
+              "context_line": "logger.exception("
+            },
+            {
+              "function": "exception",
+              "module": "logging",
+              "filename": "__init__.py",
+              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "context_line": "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+            },
+            {
+              "function": "error",
+              "module": "logging",
+              "filename": "__init__.py",
+              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "context_line": "self._log(ERROR, msg, args, **kwargs)"
+            },
+            {
+              "function": "_log",
+              "module": "logging",
+              "filename": "__init__.py",
+              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "context_line": "self.handle(record)"
+            },
+            {
+              "function": "handle",
+              "module": "logging",
+              "filename": "__init__.py",
+              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "context_line": "self.callHandlers(record)"
+            },
+            {
+              "function": "callHandlers",
+              "module": "logging",
+              "filename": "__init__.py",
+              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "context_line": "hdlr.handle(record)"
+            },
+            {
+              "function": "handle",
+              "module": "logging",
+              "filename": "__init__.py",
+              "abs_path": "/usr/local/lib/python3.13/logging/__init__.py",
+              "context_line": "self.emit(record)"
+            },
+            {
+              "function": "connect",
+              "module": "redis.connection",
+              "filename": "redis/connection.py",
+              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
+              "context_line": "sock = self._connect()"
+            },
+            {
+              "function": "_connect",
+              "module": "redis.connection",
+              "filename": "redis/connection.py",
+              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
+              "context_line": "raise err"
+            },
+            {
+              "function": "_connect",
+              "module": "redis.connection",
+              "filename": "redis/connection.py",
+              "abs_path": "/.venv/lib/python3.13/site-packages/redis/connection.py",
+              "context_line": "sock.connect(socket_address)"
+            }
+          ]
+        },
+        "mechanism": {
+          "type": "logging",
+          "handled": true
+        }
+      }
+    ]
+  },
+  "logentry": {
+    "message": "Failed to process pipeline step %s",
+    "formatted": "Failed to process pipeline step process_rules",
+    "params": ["process_rules"]
+  },
+  "logger": "sentry.tasks.post_process"
+}

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_hardcoded_values_in_context_line.pysnap
@@ -1,0 +1,168 @@
+---
+created: '2025-11-11T21:47:58.392208+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "ab3e0802023eb2405b7bed0de8eb227d"
+    contributing component: exception
+    hint: None
+    root_component:
+      system*
+        exception*
+          stacktrace*
+            frame*
+              module*
+                "__main__"
+              function*
+                "<module>"
+              context_line*
+                "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+            frame*
+              module*
+                "multiprocessing.spawn"
+              function*
+                "spawn_main"
+              context_line*
+                "exitcode = _main(fd, parent_sentinel)"
+            frame*
+              module*
+                "multiprocessing.spawn"
+              function*
+                "_main"
+              context_line*
+                "return self._bootstrap(parent_sentinel)"
+            frame*
+              module*
+                "multiprocessing.process"
+              function*
+                "_bootstrap"
+              context_line*
+                "self.run()"
+            frame*
+              module*
+                "multiprocessing.process"
+              function*
+                "run"
+              context_line*
+                "self._target(*self._args, **self._kwargs)"
+            frame*
+              module*
+                "sentry.taskworker.workerchild"
+              function*
+                "child_process"
+              context_line*
+                "run_worker("
+            frame*
+              module*
+                "sentry.taskworker.workerchild"
+              function*
+                "run_worker"
+              context_line*
+                "_execute_activation(task_func, inflight.activation)"
+            frame*
+              module*
+                "sentry.taskworker.workerchild"
+              function*
+                "_execute_activation"
+              context_line*
+                "task_func(*args, **kwargs)"
+            frame*
+              module*
+                "sentry.taskworker.task"
+              function*
+                "__call__"
+              context_line*
+                "return self._func(*args, **kwargs)"
+            frame*
+              module*
+                "sentry.tasks.post_process"
+              function*
+                "post_process_group"
+              context_line*
+                "run_post_process_job("
+            frame*
+              module*
+                "sentry.tasks.post_process"
+              function*
+                "run_post_process_job"
+              context_line*
+                "logger.exception("
+            frame*
+              module*
+                "logging"
+              function*
+                "exception"
+              context_line*
+                "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+            frame*
+              module*
+                "logging"
+              function*
+                "error"
+              context_line*
+                "self._log(ERROR, msg, args, **kwargs)"
+            frame*
+              module*
+                "logging"
+              function*
+                "_log"
+              context_line*
+                "self.handle(record)"
+            frame*
+              module*
+                "logging"
+              function*
+                "handle"
+              context_line*
+                "self.callHandlers(record)"
+            frame*
+              module*
+                "logging"
+              function*
+                "callHandlers"
+              context_line*
+                "hdlr.handle(record)"
+            frame*
+              module*
+                "logging"
+              function*
+                "handle"
+              context_line*
+                "self.emit(record)"
+            frame*
+              module*
+                "redis.connection"
+              function*
+                "connect"
+              context_line*
+                "sock = self._connect()"
+            frame*
+              module*
+                "redis.connection"
+              function*
+                "_connect"
+              context_line*
+                "raise err"
+          type*
+            "TimeoutError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -1,0 +1,168 @@
+---
+created: '2025-11-11T21:47:54.847227+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: stacktrace
+hashing_metadata: {
+  "num_stacktraces": 1,
+  "stacktrace_location": "exception",
+  "stacktrace_type": "system"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "stacktrace",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.stacktrace": {
+    "chained_exception": "False",
+    "stacktrace_location": "exception",
+    "stacktrace_type": "system"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "6791947bdfd6cf2ca7024f026df974ae"
+    contributing component: exception
+    hint: None
+    root_component:
+      system*
+        exception*
+          type*
+            "TimeoutError"
+          stacktrace*
+            frame*
+              module*
+                "__main__"
+              function*
+                "<module>"
+              context_line*
+                "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+            frame*
+              module*
+                "multiprocessing.spawn"
+              function*
+                "spawn_main"
+              context_line*
+                "exitcode = _main(fd, parent_sentinel)"
+            frame*
+              module*
+                "multiprocessing.spawn"
+              function*
+                "_main"
+              context_line*
+                "return self._bootstrap(parent_sentinel)"
+            frame*
+              module*
+                "multiprocessing.process"
+              function*
+                "_bootstrap"
+              context_line*
+                "self.run()"
+            frame*
+              module*
+                "multiprocessing.process"
+              function*
+                "run"
+              context_line*
+                "self._target(*self._args, **self._kwargs)"
+            frame*
+              module*
+                "sentry.taskworker.workerchild"
+              function*
+                "child_process"
+              context_line*
+                "run_worker("
+            frame*
+              module*
+                "sentry.taskworker.workerchild"
+              function*
+                "run_worker"
+              context_line*
+                "_execute_activation(task_func, inflight.activation)"
+            frame*
+              module*
+                "sentry.taskworker.workerchild"
+              function*
+                "_execute_activation"
+              context_line*
+                "task_func(*args, **kwargs)"
+            frame*
+              module*
+                "sentry.taskworker.task"
+              function*
+                "__call__"
+              context_line*
+                "return self._func(*args, **kwargs)"
+            frame*
+              module*
+                "sentry.tasks.post_process"
+              function*
+                "post_process_group"
+              context_line*
+                "run_post_process_job("
+            frame*
+              module*
+                "sentry.tasks.post_process"
+              function*
+                "run_post_process_job"
+              context_line*
+                "logger.exception("
+            frame*
+              module*
+                "logging"
+              function*
+                "exception"
+              context_line*
+                "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+            frame*
+              module*
+                "logging"
+              function*
+                "error"
+              context_line*
+                "self._log(ERROR, msg, args, **kwargs)"
+            frame*
+              module*
+                "logging"
+              function*
+                "_log"
+              context_line*
+                "self.handle(record)"
+            frame*
+              module*
+                "logging"
+              function*
+                "handle"
+              context_line*
+                "self.callHandlers(record)"
+            frame*
+              module*
+                "logging"
+              function*
+                "callHandlers"
+              context_line*
+                "hdlr.handle(record)"
+            frame*
+              module*
+                "logging"
+              function*
+                "handle"
+              context_line*
+                "self.emit(record)"
+            frame*
+              module*
+                "redis.connection"
+              function*
+                "connect"
+              context_line*
+                "sock = self._connect()"
+            frame*
+              module*
+                "redis.connection"
+              function*
+                "_connect"
+              context_line*
+                "raise err"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_hardcoded_values_in_context_line.pysnap
@@ -1,0 +1,1895 @@
+---
+created: '2025-11-11T21:46:35.676948+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouping_info.py
+---
+{
+  "grouping_config": "newstyle:2023-01-11",
+  "variants": {
+    "app_exception_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system exception takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because this variant does not have a contributing stacktrace, but the system variant does",
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "TimeoutError"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "value",
+                "name": null,
+                "values": [
+                  "timed out"
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": "ignored because it contains no in-app frames",
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "__main__"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "<string>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "<module>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "spawn_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "exitcode = _main(fd, parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._bootstrap(parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_bootstrap"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._target(*self._args, **self._kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "child_process"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_worker("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_worker"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "_execute_activation(task_func, inflight.activation)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_execute_activation"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "task_func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.task"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "task.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "post_process_group"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "logger.exception("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "exception"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "error"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._log(ERROR, msg, args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.callHandlers(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "callHandlers"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "hdlr.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.emit(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock = self._connect()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "raise err"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock.connect(socket_address)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "exception stacktrace — in-app frames",
+      "hash": null,
+      "hint": "ignored because system exception takes precedence",
+      "key": "app_exception_stacktrace",
+      "type": "component"
+    },
+    "message": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system exception takes precedence",
+        "id": "default",
+        "name": null,
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because system exception takes precedence",
+            "id": "message",
+            "name": "message",
+            "values": [
+              "Failed to process pipeline step %s"
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "message",
+      "hash": null,
+      "hint": "ignored because system exception takes precedence",
+      "key": "message",
+      "type": "component"
+    },
+    "system_exception_stacktrace": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "TimeoutError"
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": "ignored because stacktrace takes precedence",
+                "id": "value",
+                "name": null,
+                "values": [
+                  "timed out"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "__main__"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "<string>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "<module>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "spawn_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "exitcode = _main(fd, parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._bootstrap(parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_bootstrap"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._target(*self._args, **self._kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "child_process"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_worker("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_worker"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "_execute_activation(task_func, inflight.activation)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_execute_activation"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "task_func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.task"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "task.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "post_process_group"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "logger.exception("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "exception"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "error"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._log(ERROR, msg, args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.callHandlers(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "callHandlers"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "hdlr.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.emit(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock = self._connect()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "raise err"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock.connect(socket_address)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "exception stacktrace — all frames",
+      "hash": "ab3e0802023eb2405b7bed0de8eb227d",
+      "hint": null,
+      "key": "system_exception_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -1,0 +1,1895 @@
+---
+created: '2025-11-11T21:46:31.736096+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouping_info.py
+---
+{
+  "grouping_config": "newstyle:2025-11-21",
+  "variants": {
+    "app_exception_stacktrace": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system exception takes precedence",
+        "id": "app",
+        "name": "in-app",
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because this variant does not have a contributing stacktrace, but the system variant does",
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "TimeoutError"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "value",
+                "name": null,
+                "values": [
+                  "timed out"
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": "ignored because it contains no in-app frames",
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": [
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "__main__"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "<string>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "<module>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "spawn_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "exitcode = _main(fd, parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._bootstrap(parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_bootstrap"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._target(*self._args, **self._kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "child_process"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_worker("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_worker"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "_execute_activation(task_func, inflight.activation)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_execute_activation"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "task_func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.task"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "task.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "post_process_group"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "logger.exception("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "exception"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "error"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._log(ERROR, msg, args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.callHandlers(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "callHandlers"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "hdlr.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "non app frame",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.emit(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock = self._connect()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "raise err"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "marked out of app by stack trace rule (path:**/site-packages/** -app)",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock.connect(socket_address)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "exception stacktrace — in-app frames",
+      "hash": null,
+      "hint": "ignored because system exception takes precedence",
+      "key": "app_exception_stacktrace",
+      "type": "component"
+    },
+    "message": {
+      "component": {
+        "contributes": false,
+        "hint": "ignored because system exception takes precedence",
+        "id": "default",
+        "name": null,
+        "values": [
+          {
+            "contributes": false,
+            "hint": "ignored because system exception takes precedence",
+            "id": "message",
+            "name": "message",
+            "values": [
+              "Failed to process pipeline step %s"
+            ]
+          }
+        ]
+      },
+      "contributes": false,
+      "description": "message",
+      "hash": null,
+      "hint": "ignored because system exception takes precedence",
+      "key": "message",
+      "type": "component"
+    },
+    "system_exception_stacktrace": {
+      "component": {
+        "contributes": true,
+        "hint": null,
+        "id": "system",
+        "name": null,
+        "values": [
+          {
+            "contributes": true,
+            "hint": null,
+            "id": "exception",
+            "name": "exception",
+            "values": [
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "type",
+                "name": null,
+                "values": [
+                  "TimeoutError"
+                ]
+              },
+              {
+                "contributes": false,
+                "hint": "ignored because stacktrace takes precedence",
+                "id": "value",
+                "name": null,
+                "values": [
+                  "timed out"
+                ]
+              },
+              {
+                "contributes": true,
+                "hint": null,
+                "id": "stacktrace",
+                "name": "stacktrace",
+                "values": [
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "__main__"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "<string>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "<module>"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "spawn_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "exitcode = _main(fd, parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.spawn"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "spawn.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_main"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._bootstrap(parent_sentinel)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_bootstrap"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.run()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "multiprocessing.process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._target(*self._args, **self._kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "child_process"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_worker("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_worker"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "_execute_activation(task_func, inflight.activation)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.workerchild"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "workerchild.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_execute_activation"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "task_func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.taskworker.task"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "task.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "__call__"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "return self._func(*args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "post_process_group"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "sentry.tasks.post_process"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "post_process.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "run_post_process_job"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "logger.exception("
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "exception"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "error"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self._log(ERROR, msg, args, **kwargs)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_log"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.callHandlers(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "callHandlers"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "hdlr.handle(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "logging"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "__init__.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "handle"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "self.emit(record)"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock = self._connect()"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": true,
+                    "hint": null,
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "raise err"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "contributes": false,
+                    "hint": "ignored due to recursion",
+                    "id": "frame",
+                    "name": null,
+                    "values": [
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "module",
+                        "name": null,
+                        "values": [
+                          "redis.connection"
+                        ]
+                      },
+                      {
+                        "contributes": false,
+                        "hint": "ignored because module takes precedence",
+                        "id": "filename",
+                        "name": null,
+                        "values": [
+                          "connection.py"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "function",
+                        "name": null,
+                        "values": [
+                          "_connect"
+                        ]
+                      },
+                      {
+                        "contributes": true,
+                        "hint": null,
+                        "id": "context_line",
+                        "name": null,
+                        "values": [
+                          "sock.connect(socket_address)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "contributes": true,
+      "description": "exception stacktrace — all frames",
+      "hash": "6791947bdfd6cf2ca7024f026df974ae",
+      "hint": null,
+      "key": "system_exception_stacktrace",
+      "type": "component"
+    }
+  }
+}

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_hardcoded_values_in_context_line.pysnap
@@ -1,0 +1,399 @@
+---
+created: '2025-11-11T21:46:12.284330+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  contributing component: null
+  hint: ignored because system exception takes precedence
+  root_component:
+    app (ignored because system exception takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (ignored because it contains no in-app frames)
+          frame (non app frame)
+            module*
+              "__main__"
+            filename (ignored because module takes precedence)
+              "<string>"
+            function*
+              "<module>"
+            context_line*
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+          frame (non app frame)
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "spawn_main"
+            context_line*
+              "exitcode = _main(fd, parent_sentinel)"
+          frame (non app frame)
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "_main"
+            context_line*
+              "return self._bootstrap(parent_sentinel)"
+          frame (non app frame)
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "_bootstrap"
+            context_line*
+              "self.run()"
+          frame (non app frame)
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "run"
+            context_line*
+              "self._target(*self._args, **self._kwargs)"
+          frame (non app frame)
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "child_process"
+            context_line*
+              "run_worker("
+          frame (non app frame)
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "run_worker"
+            context_line*
+              "_execute_activation(task_func, inflight.activation)"
+          frame (non app frame)
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "_execute_activation"
+            context_line*
+              "task_func(*args, **kwargs)"
+          frame (non app frame)
+            module*
+              "sentry.taskworker.task"
+            filename (ignored because module takes precedence)
+              "task.py"
+            function*
+              "__call__"
+            context_line*
+              "return self._func(*args, **kwargs)"
+          frame (non app frame)
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "post_process_group"
+            context_line*
+              "run_post_process_job("
+          frame (non app frame)
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "run_post_process_job"
+            context_line*
+              "logger.exception("
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "exception"
+            context_line*
+              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "error"
+            context_line*
+              "self._log(ERROR, msg, args, **kwargs)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "_log"
+            context_line*
+              "self.handle(record)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.callHandlers(record)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "callHandlers"
+            context_line*
+              "hdlr.handle(record)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.emit(record)"
+          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "connect"
+            context_line*
+              "sock = self._connect()"
+          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "raise err"
+          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "sock.connect(socket_address)"
+        type*
+          "TimeoutError"
+        value*
+          "timed out"
+--------------------------------------------------------------------------
+default:
+  hash: null
+  contributing component: null
+  hint: ignored because system exception takes precedence
+  root_component:
+    default (ignored because system exception takes precedence)
+      message (ignored because system exception takes precedence)
+        "Failed to process pipeline step %s"
+--------------------------------------------------------------------------
+system:
+  hash: "ab3e0802023eb2405b7bed0de8eb227d"
+  contributing component: exception
+  hint: None
+  root_component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            module*
+              "__main__"
+            filename (ignored because module takes precedence)
+              "<string>"
+            function*
+              "<module>"
+            context_line*
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+          frame*
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "spawn_main"
+            context_line*
+              "exitcode = _main(fd, parent_sentinel)"
+          frame*
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "_main"
+            context_line*
+              "return self._bootstrap(parent_sentinel)"
+          frame*
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "_bootstrap"
+            context_line*
+              "self.run()"
+          frame*
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "run"
+            context_line*
+              "self._target(*self._args, **self._kwargs)"
+          frame*
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "child_process"
+            context_line*
+              "run_worker("
+          frame*
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "run_worker"
+            context_line*
+              "_execute_activation(task_func, inflight.activation)"
+          frame*
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "_execute_activation"
+            context_line*
+              "task_func(*args, **kwargs)"
+          frame*
+            module*
+              "sentry.taskworker.task"
+            filename (ignored because module takes precedence)
+              "task.py"
+            function*
+              "__call__"
+            context_line*
+              "return self._func(*args, **kwargs)"
+          frame*
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "post_process_group"
+            context_line*
+              "run_post_process_job("
+          frame*
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "run_post_process_job"
+            context_line*
+              "logger.exception("
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "exception"
+            context_line*
+              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "error"
+            context_line*
+              "self._log(ERROR, msg, args, **kwargs)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "_log"
+            context_line*
+              "self.handle(record)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.callHandlers(record)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "callHandlers"
+            context_line*
+              "hdlr.handle(record)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.emit(record)"
+          frame*
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "connect"
+            context_line*
+              "sock = self._connect()"
+          frame*
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "raise err"
+          frame (ignored due to recursion)
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "sock.connect(socket_address)"
+        type*
+          "TimeoutError"
+        value (ignored because stacktrace takes precedence)
+          "timed out"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -1,0 +1,399 @@
+---
+created: '2025-11-11T21:46:08.525748+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  contributing component: null
+  hint: ignored because system exception takes precedence
+  root_component:
+    app (ignored because system exception takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        type*
+          "TimeoutError"
+        value*
+          "timed out"
+        stacktrace (ignored because it contains no in-app frames)
+          frame (non app frame)
+            module*
+              "__main__"
+            filename (ignored because module takes precedence)
+              "<string>"
+            function*
+              "<module>"
+            context_line*
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+          frame (non app frame)
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "spawn_main"
+            context_line*
+              "exitcode = _main(fd, parent_sentinel)"
+          frame (non app frame)
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "_main"
+            context_line*
+              "return self._bootstrap(parent_sentinel)"
+          frame (non app frame)
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "_bootstrap"
+            context_line*
+              "self.run()"
+          frame (non app frame)
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "run"
+            context_line*
+              "self._target(*self._args, **self._kwargs)"
+          frame (non app frame)
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "child_process"
+            context_line*
+              "run_worker("
+          frame (non app frame)
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "run_worker"
+            context_line*
+              "_execute_activation(task_func, inflight.activation)"
+          frame (non app frame)
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "_execute_activation"
+            context_line*
+              "task_func(*args, **kwargs)"
+          frame (non app frame)
+            module*
+              "sentry.taskworker.task"
+            filename (ignored because module takes precedence)
+              "task.py"
+            function*
+              "__call__"
+            context_line*
+              "return self._func(*args, **kwargs)"
+          frame (non app frame)
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "post_process_group"
+            context_line*
+              "run_post_process_job("
+          frame (non app frame)
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "run_post_process_job"
+            context_line*
+              "logger.exception("
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "exception"
+            context_line*
+              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "error"
+            context_line*
+              "self._log(ERROR, msg, args, **kwargs)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "_log"
+            context_line*
+              "self.handle(record)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.callHandlers(record)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "callHandlers"
+            context_line*
+              "hdlr.handle(record)"
+          frame (non app frame)
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.emit(record)"
+          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "connect"
+            context_line*
+              "sock = self._connect()"
+          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "raise err"
+          frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "sock.connect(socket_address)"
+--------------------------------------------------------------------------
+default:
+  hash: null
+  contributing component: null
+  hint: ignored because system exception takes precedence
+  root_component:
+    default (ignored because system exception takes precedence)
+      message (ignored because system exception takes precedence)
+        "Failed to process pipeline step %s"
+--------------------------------------------------------------------------
+system:
+  hash: "6791947bdfd6cf2ca7024f026df974ae"
+  contributing component: exception
+  hint: None
+  root_component:
+    system*
+      exception*
+        type*
+          "TimeoutError"
+        value (ignored because stacktrace takes precedence)
+          "timed out"
+        stacktrace*
+          frame*
+            module*
+              "__main__"
+            filename (ignored because module takes precedence)
+              "<string>"
+            function*
+              "<module>"
+            context_line*
+              "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
+          frame*
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "spawn_main"
+            context_line*
+              "exitcode = _main(fd, parent_sentinel)"
+          frame*
+            module*
+              "multiprocessing.spawn"
+            filename (ignored because module takes precedence)
+              "spawn.py"
+            function*
+              "_main"
+            context_line*
+              "return self._bootstrap(parent_sentinel)"
+          frame*
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "_bootstrap"
+            context_line*
+              "self.run()"
+          frame*
+            module*
+              "multiprocessing.process"
+            filename (ignored because module takes precedence)
+              "process.py"
+            function*
+              "run"
+            context_line*
+              "self._target(*self._args, **self._kwargs)"
+          frame*
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "child_process"
+            context_line*
+              "run_worker("
+          frame*
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "run_worker"
+            context_line*
+              "_execute_activation(task_func, inflight.activation)"
+          frame*
+            module*
+              "sentry.taskworker.workerchild"
+            filename (ignored because module takes precedence)
+              "workerchild.py"
+            function*
+              "_execute_activation"
+            context_line*
+              "task_func(*args, **kwargs)"
+          frame*
+            module*
+              "sentry.taskworker.task"
+            filename (ignored because module takes precedence)
+              "task.py"
+            function*
+              "__call__"
+            context_line*
+              "return self._func(*args, **kwargs)"
+          frame*
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "post_process_group"
+            context_line*
+              "run_post_process_job("
+          frame*
+            module*
+              "sentry.tasks.post_process"
+            filename (ignored because module takes precedence)
+              "post_process.py"
+            function*
+              "run_post_process_job"
+            context_line*
+              "logger.exception("
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "exception"
+            context_line*
+              "self.error(msg, *args, exc_info=exc_info, **kwargs)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "error"
+            context_line*
+              "self._log(ERROR, msg, args, **kwargs)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "_log"
+            context_line*
+              "self.handle(record)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.callHandlers(record)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "callHandlers"
+            context_line*
+              "hdlr.handle(record)"
+          frame*
+            module*
+              "logging"
+            filename (ignored because module takes precedence)
+              "__init__.py"
+            function*
+              "handle"
+            context_line*
+              "self.emit(record)"
+          frame*
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "connect"
+            context_line*
+              "sock = self._connect()"
+          frame*
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "raise err"
+          frame (ignored due to recursion)
+            module*
+              "redis.connection"
+            filename (ignored because module takes precedence)
+              "connection.py"
+            function*
+              "_connect"
+            context_line*
+              "sock.connect(socket_address)"


### PR DESCRIPTION
This adds a new grouping input for our snapshot tests, which includes the hard-coded-value-containing context line generated by the Python multiprocessing module, the one which is causing issues to [under-group in our backend project](https://github.com/getsentry/sentry-python/issues/4744). Having the snapshots already in place will make it easier to see what changes when we fix the grouping algorithm to handle that situation.