### PR TITLE
ref(crons): Refresh detector when environment is muted/unmuted

### DIFF
--- a/static/app/actionCreators/monitors.tsx
+++ b/static/app/actionCreators/monitors.tsx
@@ -102,7 +102,7 @@ export async function setEnvironmentIsMuted(
 
   try {
     const resp = await api.requestPromise(
-      `/projects/${orgId}/${monitor.project.slug}/monitors/${monitor.slug}/environments/${environment}`,
+      `/projects/${orgId}/${monitor.project.slug}/monitors/${monitor.slug}/environments/${environment}/`,
       {method: 'PUT', data: {isMuted}}
     );
     clearIndicators();

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -22,6 +22,7 @@ import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
 import toArray from 'sentry/utils/array/toArray';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -35,7 +36,10 @@ import {DisabledAlert} from 'sentry/views/detectors/components/details/common/di
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
-import {useDetectorQuery} from 'sentry/views/detectors/hooks';
+import {
+  makeDetectorDetailsQueryKey,
+  useDetectorQuery,
+} from 'sentry/views/detectors/hooks';
 import {DetailsTimeline} from 'sentry/views/insights/crons/components/detailsTimeline';
 import {DetailsTimelineLegend} from 'sentry/views/insights/crons/components/detailsTimelineLegend';
 import {MonitorCheckIns} from 'sentry/views/insights/crons/components/monitorCheckIns';
@@ -69,6 +73,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
   const userTimezone = useTimezone();
   const [timezoneOverride, setTimezoneOverride] = useState(userTimezone);
   const openDocsPanel = useDocsPanel(dataSource.queryObj.slug, project);
+  const queryClient = useQueryClient();
 
   useDetectorQuery<CronDetector>(detector.id, {
     staleTime: 0,
@@ -82,6 +87,14 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
       return getMonitorRefetchInterval(monitor, new Date());
     },
   });
+
+  const handleEnvironmentUpdated = useCallback(() => {
+    const queryKey = makeDetectorDetailsQueryKey({
+      orgSlug: organization.slug,
+      detectorId: detector.id,
+    });
+    queryClient.invalidateQueries({queryKey});
+  }, [queryClient, organization.slug, detector.id]);
 
   const {checkinErrors, handleDismissError} = useMonitorProcessingErrors({
     organization,
@@ -174,6 +187,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
                 <DetailsTimeline
                   monitor={filteredMonitor}
                   onStatsLoaded={checkHasUnknown}
+                  onEnvironmentUpdated={handleEnvironmentUpdated}
                 />
                 <ErrorBoundary mini>
                   <DetectorDetailsOpenPeriodIssues

--- a/static/app/views/insights/crons/components/detailsTimeline.tsx
+++ b/static/app/views/insights/crons/components/detailsTimeline.tsx
@@ -31,12 +31,16 @@ import {CronServiceIncidents} from './serviceIncidents';
 interface Props {
   monitor: Monitor;
   /**
+   * Called when an environment is updated (muted/unmuted/deleted).
+   */
+  onEnvironmentUpdated?: () => void;
+  /**
    * Called when monitor stats have been loaded for this timeline.
    */
   onStatsLoaded?: (stats: MonitorBucket[]) => void;
 }
 
-export function DetailsTimeline({monitor, onStatsLoaded}: Props) {
+export function DetailsTimeline({monitor, onStatsLoaded, onEnvironmentUpdated}: Props) {
   const organization = useOrganization();
   const location = useLocation();
   const api = useApi();
@@ -89,6 +93,8 @@ export function DetailsTimeline({monitor, onStatsLoaded}: Props) {
           }
         : undefined;
     });
+
+    onEnvironmentUpdated?.();
   };
 
   const handleToggleMuteEnvironment = async (env: string, isMuted: boolean) => {
@@ -119,6 +125,8 @@ export function DetailsTimeline({monitor, onStatsLoaded}: Props) {
           }
         : undefined;
     });
+
+    onEnvironmentUpdated?.();
   };
 
   return (


### PR DESCRIPTION
When muting/unmuting or deleting a cron monitor environment from the detector details page, the parent detector state wasn't being refreshed, causing stale data to display.

Added onEnvironmentUpdated callback to DetailsTimeline component that invalidates the detector query when environment status changes, ensuring the UI stays in sync with the backend state.

Fixes [NEW-592: Muting cron environment does not refresh detector](https://linear.app/getsentry/issue/NEW-592/muting-cron-environment-does-not-refresh-detector)