### PR TITLE
feat(aci): associate groups without matching detector to the issue stream detector

### DIFF
--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -24,6 +24,7 @@ from sentry.models.owner_base import OwnerModel
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models import DataCondition
 from sentry.workflow_engine.types import DetectorSettings
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 from .json_config import JSONConfigBase
 
@@ -97,16 +98,24 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         return f"detector:by_proj_type:{project_id}:{detector_type}"
 
     @classmethod
-    def get_error_detector_for_project(cls, project_id: int) -> Detector:
-        from sentry.grouping.grouptype import ErrorGroupType
-
-        detector_type = ErrorGroupType.slug
+    def fetch_default_detector_for_project(cls, project_id: int, detector_type: str) -> Detector:
         cache_key = cls._get_detector_project_type_cache_key(project_id, detector_type)
         detector = cache.get(cache_key)
         if detector is None:
-            detector = cls.objects.get(project_id=project_id, type=ErrorGroupType.slug)
+            detector = cls.objects.get(project_id=project_id, type=detector_type)
             cache.set(cache_key, detector, cls.CACHE_TTL)
+
         return detector
+
+    @classmethod
+    def get_error_detector_for_project(cls, project_id: int) -> Detector:
+        from sentry.grouping.grouptype import ErrorGroupType
+
+        return cls.fetch_default_detector_for_project(project_id, ErrorGroupType.slug)
+
+    @classmethod
+    def get_issue_stream_detector_for_project(cls, project_id: int) -> Detector:
+        return cls.fetch_default_detector_for_project(project_id, IssueStreamGroupType.slug)
 
     @property
     def group_type(self) -> builtins.type[GroupType]:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -373,7 +373,9 @@ def associate_new_group_with_detector(group: Group, detector_id: int | None = No
                 return False
             detector_id = Detector.get_error_detector_for_project(group.project.id).id
         else:
-            return False
+            # We find the issue stream detector for the project
+            detector_id = Detector.get_issue_stream_detector_for_project(group.project.id).id
+
     DetectorGroup.objects.get_or_create(
         detector_id=detector_id,
         group_id=group.id,

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1023,6 +1023,7 @@ class TestAssociateNewGroupWithDetector(TestCase):
         super().setUp()
         self.metric_detector = self.create_detector(project=self.project, type="metric_issue")
         self.error_detector = self.create_detector(project=self.project, type="error")
+        self.issue_stream_detector = self.create_detector(project=self.project, type="issue_stream")
 
     def test_metrics_group_with_known_detector(self) -> None:
         group = self.create_group(project=self.project, type=MetricIssue.type_id)
@@ -1049,7 +1050,9 @@ class TestAssociateNewGroupWithDetector(TestCase):
                 detector_id=self.error_detector.id, group_id=group.id
             ).exists()
 
-    def test_feedback_group_returns_false(self) -> None:
+    def test_feedback_group_uses_issue_stream_detector(self) -> None:
         group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
-        assert not associate_new_group_with_detector(group)
-        assert not DetectorGroup.objects.filter(group_id=group.id).exists()
+        assert associate_new_group_with_detector(group)
+        assert DetectorGroup.objects.filter(
+            detector_id=self.issue_stream_detector.id, group_id=group.id
+        ).exists()


### PR DESCRIPTION
We expect all Groups to have an entry in the DetectorGroup table so we can easily look up the detector for a group. For groups that have types that haven't been moved over to workflow engine, we can associate them with the issue stream detector.

When new Detectors are created and start emitting issues, this will need to be changed via backfill.

We need DetectorGroup entries for Groups because we want to look up the detector that fired for a group in the WorkflowFireHistory API without populating the detector field on WorkflowFireHistory (decoupling detector from WFH) -- see https://github.com/getsentry/sentry/pull/102918.

This will also be used to figure out which detector an Activity is associated with for activity notifications in workflow engine -- see https://github.com/getsentry/sentry/pull/103099