### PR TITLE
feat(issue-details): Add config for hiding search bar

### DIFF
--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -46,7 +46,7 @@ const BASE_CONFIG: IssueTypeConfig = {
   },
   defaultTimePeriod: {sinceFirstSeen: true},
   header: {
-    filterBar: {enabled: true, fixedEnvironment: false},
+    filterBar: {enabled: true, fixedEnvironment: false, searchBar: {enabled: true}},
     graph: {enabled: true, type: 'discover-events'},
     tagDistribution: {enabled: true},
     occurrenceSummary: {enabled: false},

--- a/static/app/utils/issueTypeConfig/metricConfig.tsx
+++ b/static/app/utils/issueTypeConfig/metricConfig.tsx
@@ -105,7 +105,7 @@ const metricConfig: IssueCategoryConfigMapping = {
       ctaText: t('View monitor details'),
     },
     header: {
-      filterBar: {enabled: true, fixedEnvironment: true},
+      filterBar: {enabled: true, fixedEnvironment: true, searchBar: {enabled: false}},
       graph: {enabled: true, type: 'detector-history'},
       tagDistribution: {enabled: false},
       occurrenceSummary: {enabled: false},

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -71,6 +71,8 @@ export type IssueTypeConfig = {
     filterBar: DisabledWithReasonConfig & {
       // Display the environment filter in an inactive, locked state
       fixedEnvironment?: boolean;
+      // The search bar can be hidden if the issue type does not support event filtering
+      searchBar?: DisabledWithReasonConfig;
     };
     graph: DisabledWithReasonConfig & {
       type?: 'detector-history' | 'discover-events' | 'cron-checks' | 'uptime-checks';

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -95,6 +95,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
   }
 
   const FilterBar = theme.isChonk ? PageFilterBar : StyledPageFilterBar;
+  const searchBarEnabled = issueTypeConfig.header.filterBar.searchBar?.enabled !== false;
 
   return (
     <PageErrorBoundary mini message={t('There was an error loading the event filters')}>
@@ -171,22 +172,24 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
                     }}
                   />
                 </FilterBar>
-                <EventSearch
-                  group={group}
-                  handleSearch={query => {
-                    navigate(
-                      {...location, query: {...location.query, query}},
-                      {replace: true}
-                    );
-                  }}
-                  environments={environments}
-                  query={searchQuery}
-                  queryBuilderProps={{
-                    disallowFreeText: true,
-                    placeholder: searchText,
-                    label: searchText,
-                  }}
-                />
+                {searchBarEnabled && (
+                  <EventSearch
+                    group={group}
+                    handleSearch={query => {
+                      navigate(
+                        {...location, query: {...location.query, query}},
+                        {replace: true}
+                      );
+                    }}
+                    environments={environments}
+                    query={searchQuery}
+                    queryBuilderProps={{
+                      disallowFreeText: true,
+                      placeholder: searchText,
+                      label: searchText,
+                    }}
+                  />
+                )}
               </Grid>
               <ToggleSidebar />
             </Flex>


### PR DESCRIPTION
Searching open periods was not hooked up (and isn't useful anyway), so this allows us to hide the search bar altogether.

<img width="1163" height="262" alt="CleanShot 2025-11-11 at 15 25 22" src="https://github.com/user-attachments/assets/c719d7a6-b477-4587-88b8-3b975f690f77" />
