### PR TITLE
chore(events): Clean up preprocess option (3/3)

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -842,7 +842,6 @@ register(
 )
 register("snuba.search.hits-sample-size", default=100, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("snuba.track-outcomes-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("snuba.preprocess-group-redirects", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -27,7 +27,6 @@ from snuba_sdk import Column, DeleteQuery, Function, MetricsQuery, Request
 from snuba_sdk.legacy import json_to_snql
 from snuba_sdk.query import SelectableExpression
 
-from sentry import options
 from sentry.api.helpers.error_upsampling import (
     UPSAMPLED_ERROR_AGGREGATION,
     are_any_projects_error_upsampled,
@@ -928,7 +927,7 @@ class SnubaQueryParams:
         # account for merges, here we expand queries to include all group IDs that have
         # been merged together.
 
-        if options.get("snuba.preprocess-group-redirects") and self.dataset in {
+        if self.dataset in {
             Dataset.Events,
             Dataset.IssuePlatform,
         }:

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -9,7 +9,6 @@ from urllib3 import HTTPConnectionPool
 from urllib3.exceptions import HTTPError, ReadTimeoutError
 from urllib3.response import HTTPResponse
 
-from sentry import options
 from sentry.models.groupredirect import GroupRedirect
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.project import Project
@@ -325,8 +324,6 @@ class PrepareQueryParamsTest(TestCase):
             group_id=g1.id,
             previous_group_id=g3.id,
         )
-
-        options.set("snuba.preprocess-group-redirects", True)
 
         params = SnubaQueryParams(dataset=Dataset.Events, filter_keys={"group_id": {g1.id}})
         assert params.conditions[0] == ["group_id", "IN", {g1.id, g2.id, g3.id}]


### PR DESCRIPTION
Putting up PRs to clean up the preprocess option. I'll probably let the option sit for a day or two longer just to be safe, but wanted to get this out of the way.

Steps:
1. Clean up usages: [#103192](https://github.com/getsentry/sentry/pull/103192)
2. Clean up options-automator declaration: [#5703](https://github.com/getsentry/sentry-options-automator/pull/5703)
3. Clean up sentry declaration: THIS PR

This is PR 3/3.