### PR TITLE
feat(aci): add issue stream detectors to Connect Monitors drawer

### DIFF
--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -11,7 +11,7 @@ import type {StatusWarning} from 'sentry/types/workflowEngine/automations';
 import {defined} from 'sentry/utils';
 
 export type TitleCellProps = {
-  link: string;
+  link: string | null;
   name: string;
   className?: string;
   details?: React.ReactNode;
@@ -57,6 +57,14 @@ export function TitleCell({
     </Fragment>
   );
 
+  if (!link) {
+    return (
+      <TitleBase className={className} noHover>
+        {content}
+      </TitleBase>
+    );
+  }
+
   if (openInNewTab) {
     return (
       <TitleWrapperAnchor
@@ -98,7 +106,7 @@ const CreatedBySentryIcon = styled(IconSentry)`
   flex-shrink: 0;
 `;
 
-const TitleBase = styled('div')`
+const TitleBase = styled('div')<{noHover?: boolean}>`
   display: flex;
   flex-direction: column;
   gap: ${space(0.5)};
@@ -106,11 +114,15 @@ const TitleBase = styled('div')`
   overflow: hidden;
   min-height: 20px;
 
-  &:hover {
-    ${NameText} {
-      text-decoration: underline;
+  ${p =>
+    !p.noHover &&
+    `
+    &:hover {
+      ${NameText} {
+        text-decoration: underline;
+      }
     }
-  }
+  `}
 `;
 
 const TitleWrapper = TitleBase.withComponent(Link);

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -155,7 +155,7 @@ export interface ErrorDetector extends BaseDetector {
 }
 
 interface IssueStreamDetector extends BaseDetector {
-  // TODO: Add error detector type fields
+  // TODO: Add issue stream detector type fields
   readonly type: 'issue_stream';
 }
 

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -154,7 +154,17 @@ export interface ErrorDetector extends BaseDetector {
   readonly type: 'error';
 }
 
-export type Detector = MetricDetector | UptimeDetector | CronDetector | ErrorDetector;
+interface IssueStreamDetector extends BaseDetector {
+  // TODO: Add error detector type fields
+  readonly type: 'issue_stream';
+}
+
+export type Detector =
+  | MetricDetector
+  | UptimeDetector
+  | CronDetector
+  | ErrorDetector
+  | IssueStreamDetector;
 
 interface UpdateConditionGroupPayload {
   conditions: Array<Omit<MetricCondition, 'id'>>;

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -86,7 +86,13 @@ export default function ConnectedMonitorsList({
     isSuccess,
     getResponseHeader,
   } = useDetectorsQuery(
-    {ids: detectorIds ?? undefined, limit: limit ?? undefined, cursor, query},
+    {
+      ids: detectorIds ?? undefined,
+      limit: limit ?? undefined,
+      cursor,
+      query,
+      includeIssueStreamDetectors: true,
+    },
     {enabled: detectorIds === null || detectorIds.length > 0}
   );
 

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -149,6 +149,7 @@ export default function ConnectedMonitorsList({
           <SimpleTable.Empty>{emptyMessage}</SimpleTable.Empty>
         )}
         {isSuccess &&
+          (detectorIds === null || detectorIds.length > 0) &&
           detectors.map(detector => (
             <SimpleTable.Row key={detector.id}>
               <SimpleTable.RowCell>

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -110,6 +110,7 @@ function ConnectMonitorsDrawer({
         makeDetectorListQueryKey({
           orgSlug: organization.slug,
           ids: localDetectorIds,
+          includeIssueStreamDetectors: true,
         })
       ) ?? [];
 
@@ -126,6 +127,7 @@ function ConnectMonitorsDrawer({
       makeDetectorListQueryKey({
         orgSlug: organization.slug,
         ids: newDetectorIds,
+        includeIssueStreamDetectors: true,
       }),
       newDetectors
     );

--- a/static/app/views/detectors/components/details/index.tsx
+++ b/static/app/views/detectors/components/details/index.tsx
@@ -1,4 +1,6 @@
+import {Alert} from 'sentry/components/core/alert';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
@@ -36,6 +38,14 @@ export function DetectorDetailsContent({detector, project}: DetectorDetailsConte
         <PageFiltersContainer>
           <CronDetectorDetails detector={detector} project={project} />
         </PageFiltersContainer>
+      );
+    case 'issue_stream':
+      return (
+        <Alert.Container>
+          <Alert type="error">
+            {t('Issue stream monitors do not support detail views.')}
+          </Alert>
+        </Alert.Container>
       );
     default:
       unreachable(detectorType);

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -197,6 +197,7 @@ function Details({detector}: {detector: Detector}) {
     case 'monitor_check_in_failure':
       return <CronDetectorDetails detector={detector} />;
     case 'error':
+    case 'issue_stream':
       return null;
     default:
       unreachable(detectorType);
@@ -208,11 +209,21 @@ export function DetectorLink({detector, className, openInNewTab}: DetectorLinkPr
   const org = useOrganization();
   const project = useProjectFromId({project_id: detector.projectId});
 
+  const detectorName =
+    detector.type === 'issue_stream'
+      ? t('All Issues in %s', project?.name || 'project')
+      : detector.name;
+
+  const detectorLink =
+    detector.type === 'issue_stream'
+      ? null
+      : makeMonitorDetailsPathname(org.slug, detector.id);
+
   return (
     <TitleCell
       className={className}
-      name={detector.name}
-      link={makeMonitorDetailsPathname(org.slug, detector.id)}
+      name={detectorName}
+      link={detectorLink}
       systemCreated={getDetectorSystemCreatedNotice(detector)}
       disabled={!detector.enabled}
       openInNewTab={openInNewTab}

--- a/static/app/views/detectors/components/forms/index.tsx
+++ b/static/app/views/detectors/components/forms/index.tsx
@@ -1,3 +1,4 @@
+import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
 import {t} from 'sentry/locale';
@@ -61,6 +62,12 @@ export function EditExistingDetectorForm({detector}: {detector: Detector}) {
       return <EditExistingErrorDetectorForm detector={detector} />;
     case 'monitor_check_in_failure':
       return <EditExistingCronDetectorForm detector={detector} />;
+    case 'issue_stream':
+      return (
+        <Alert.Container>
+          <Alert type="error">{t('Issue stream monitors can not be edited.')}</Alert>
+        </Alert.Container>
+      );
     default:
       unreachable(detectorType);
       return <PlaceholderForm />;

--- a/static/app/views/detectors/utils/detectorTypeConfig.tsx
+++ b/static/app/views/detectors/utils/detectorTypeConfig.tsx
@@ -34,6 +34,7 @@ const DETECTOR_TYPE_CONFIG: Record<DetectorType, DetectorTypeConfig> = {
   issue_stream: {
     userCreateable: false,
     label: t('Issue Stream'),
+    systemCreatedNotice: () => t('This monitor is managed by Sentry'),
   },
 };
 

--- a/static/app/views/detectors/utils/getDetectorEnvironment.tsx
+++ b/static/app/views/detectors/utils/getDetectorEnvironment.tsx
@@ -15,6 +15,7 @@ export function getDetectorEnvironment(detector: Detector): string | null {
       // Crons can have multiple environments
       return null;
     case 'error':
+    case 'issue_stream':
       return null;
     default:
       unreachable(detectorType);


### PR DESCRIPTION
adds issue stream detectors to the connected monitors table. these rows can not be clicked (the details views for these are not very useful), but there is still a tooltip on hover.

<img width="692" height="76" alt="Screenshot 2025-11-11 at 3 29 05 PM" src="https://github.com/user-attachments/assets/a2f70032-a2c3-4a48-89dc-974bf168e7cc" />

<img width="305" height="102" alt="Screenshot 2025-11-11 at 3 30 32 PM" src="https://github.com/user-attachments/assets/8f0e10dd-cb1b-4e95-8949-068f440c3d78" />
