### PR TITLE
ref(groupowner): Optimize CommitFileChange query to prevent timeouts

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -103,9 +103,9 @@ def _get_commit_file_changes(
     # combined with complex LIKE conditions
     all_file_changes: list[CommitFileChange] = []
     commit_ids = [c.id for c in commits]
-    
+
     for i in range(0, len(commit_ids), COMMIT_BATCH_SIZE):
-        batch_commit_ids = commit_ids[i:i + COMMIT_BATCH_SIZE]
+        batch_commit_ids = commit_ids[i : i + COMMIT_BATCH_SIZE]
         commit_file_change_matches = CommitFileChange.objects.filter(
             path_query, commit_id__in=batch_commit_ids
         )

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -27,7 +27,7 @@ from sentry.utils.iterators import chunked
 PATH_SEPARATORS = frozenset(["/", "\\"])
 # Limit the number of commits to batch in a single query to avoid query timeouts
 # from large IN clauses combined with complex LIKE conditions
-COMMIT_BATCH_SIZE = 50
+COMMIT_BATCH_SIZE = 100
 
 
 def tokenize_path(path: str) -> Iterator[str]:
@@ -107,7 +107,7 @@ def _get_commit_file_changes(
     matching_ids: set[int] = set()
 
     # Optimization 1: Batch commit IDs with chunked() to prevent huge IN clauses
-    for commit_batch in chunked(commit_ids, 100):
+    for commit_batch in chunked(commit_ids, COMMIT_BATCH_SIZE):
         # Optimization 2: Split filename queries to eliminate OR conditions
         for filename in filenames:
             # Optimization 3 (Experimental): separate filter calls to hint optimizer to use indexes first

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -26,6 +26,9 @@ from sentry.utils.event_frames import find_stack_frames, munged_filename_and_fra
 from sentry.utils.hashlib import hash_values
 
 PATH_SEPARATORS = frozenset(["/", "\\"])
+# Limit the number of commits to batch in a single query to avoid query timeouts
+# from large IN clauses combined with complex LIKE conditions
+COMMIT_BATCH_SIZE = 50
 
 
 def tokenize_path(path: str) -> Iterator[str]:
@@ -96,11 +99,19 @@ def _get_commit_file_changes(
     # build a single query to get all of the commit file that might match the first n frames
     path_query = reduce(operator.or_, (Q(filename__iendswith=path) for path in filenames))
 
-    commit_file_change_matches = CommitFileChange.objects.filter(
-        path_query, commit_id__in=[c.id for c in commits]
-    )
+    # Batch commits to avoid query timeouts from large IN clauses
+    # combined with complex LIKE conditions
+    all_file_changes: list[CommitFileChange] = []
+    commit_ids = [c.id for c in commits]
+    
+    for i in range(0, len(commit_ids), COMMIT_BATCH_SIZE):
+        batch_commit_ids = commit_ids[i:i + COMMIT_BATCH_SIZE]
+        commit_file_change_matches = CommitFileChange.objects.filter(
+            path_query, commit_id__in=batch_commit_ids
+        )
+        all_file_changes.extend(list(commit_file_change_matches))
 
-    return list(commit_file_change_matches)
+    return all_file_changes
 
 
 def _match_commits_paths(


### PR DESCRIPTION
The `CommitFileChange` query in `_get_commit_file_changes` is timing out (SENTRY-4596) due to:
- Multiple LIKE clauses with leading wildcards (cannot use indexes)
- Large IN clauses with 1000+ commit IDs
- Complex combined query that the optimizer struggles to plan efficiently

Changes:
- Batch commit IDs into groups of 100 to limit IN clause size
- Split filename queries to eliminate complex OR conditions
- Use set operations for efficient deduplication
- Fetch IDs first, then bulk fetch objects to avoid large IN clauses

This reduces query complexity from a single query with 1000+ commit IDs and multiple OR conditions to multiple simpler queries that the PostgreSQL optimizer can handle efficiently.

Fixes SENTRY-4596