### PR TITLE
fix(aci): Encode owner as string when triggering find_channel_id_for_rule

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -295,7 +295,11 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             if data.get("pending_save"):
                 client = RedisRuleStatus()
                 kwargs.update({"uuid": client.uuid, "rule_id": rule.id})
-                find_channel_id_for_rule.apply_async(kwargs=kwargs)
+                # Serialize Actor object to string identifier for task queueing
+                task_kwargs = kwargs.copy()
+                if owner:
+                    task_kwargs["owner"] = owner.identifier
+                find_channel_id_for_rule.apply_async(kwargs=task_kwargs)
 
                 context = {"uuid": client.uuid}
                 return Response(context, status=202)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -833,7 +833,11 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             client = RedisRuleStatus()
             uuid_context = {"uuid": client.uuid}
             kwargs.update(uuid_context)
-            find_channel_id_for_rule.apply_async(kwargs=kwargs)
+            # Serialize Actor object to string identifier for task queueing
+            task_kwargs = kwargs.copy()
+            if owner:
+                task_kwargs["owner"] = owner.identifier
+            find_channel_id_for_rule.apply_async(kwargs=task_kwargs)
             return Response(uuid_context, status=202)
 
         try:

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -19,6 +19,7 @@ from sentry.shared_integrations.exceptions import ApiRateLimitedError, Duplicate
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
+from sentry.types.actor import Actor
 
 logger = logging.getLogger("sentry.integrations.slack.tasks")
 
@@ -108,6 +109,11 @@ def find_channel_id_for_rule(
 
         kwargs["actions"] = actions
         kwargs["project"] = project
+
+        # Deserialize owner string identifier back to Actor object
+        owner = kwargs.get("owner")
+        if owner and isinstance(owner, str):
+            kwargs["owner"] = Actor.from_identifier(owner)
 
         if rule_id:
             rule = Rule.objects.get(id=rule_id)

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -21,7 +21,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.types.actor import Actor
 from sentry.users.models.user import User
 
 
@@ -751,7 +750,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             "actions": payload.get("actions", []),
             "frequency": payload.get("frequency"),
             "user_id": self.user.id,
-            "owner": Actor.from_id(user_id=self.user.id),
+            "owner": f"user:{self.user.id}",
             "uuid": "abc123",
         }
         call_args = mock_find_channel_id_for_alert_rule.call_args[1]["kwargs"]


### PR DESCRIPTION
It's unclear that this ever worked properly, but presumably this is a narrow enough case that it hasn't been terribly noticeable. 
Fixes SENTRY-54ZZ.