### PR TITLE
feat(triage signals): Remove Scan Issues setting [feature flagged]

### DIFF
--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -549,4 +549,38 @@ describe('ProjectSeer', () => {
       );
     });
   });
+
+  it('hides Scan Issues toggle when triage-signals-v0 feature flag is enabled', async () => {
+    const projectWithFeatureFlag = ProjectFixture({
+      features: ['triage-signals-v0'],
+    });
+
+    render(<ProjectSeer />, {
+      organization,
+      outletContext: {project: projectWithFeatureFlag},
+    });
+
+    // Wait for the page to load
+    await screen.findByText(/Automation/i);
+
+    // The Scan Issues toggle should NOT be visible
+    expect(
+      screen.queryByRole('checkbox', {
+        name: /Scan Issues/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Scan Issues toggle when triage-signals-v0 feature flag is disabled', async () => {
+    render(<ProjectSeer />, {
+      organization,
+      outletContext: {project},
+    });
+
+    // The Scan Issues toggle should be visible
+    const toggle = await screen.findByRole('checkbox', {
+      name: /Scan Issues/i,
+    });
+    expect(toggle).toBeInTheDocument();
+  });
 });

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -194,6 +194,8 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
       model?.getValue('autofixAutomationTuning') !== 'off',
   } satisfies FieldObject;
 
+  const isTriageSignalsFeatureOn = project.features.includes('triage-signals-v0');
+
   const seerFormGroups: JsonFormObject[] = [
     {
       title: (
@@ -218,7 +220,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
         </div>
       ),
       fields: [
-        seerScannerAutomationField,
+        ...(isTriageSignalsFeatureOn ? [] : [seerScannerAutomationField]),
         autofixAutomatingTuningField,
         automatedRunStoppingPointField,
       ],


### PR DESCRIPTION
## PR Details
+ Removing the Scan issues setting for projects under the triage signals feature flag.
+ Post launch, new orgs will have it set to True since the default is True and existing orgs that explicitly set it to False will still have it as False
+ Implementation notion doc [link](https://www.notion.so/sentry/Triage-Signals-V0-Technical-Implementation-Details-2a18b10e4b5d8086a7ceddaf4194849a?source=copy_link#2a18b10e4b5d80869424fb52219c3ce9)
