### PR TITLE
chore(auth): Clean up identity linking quick inc fix

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3520,13 +3520,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Killswitch for linking identities for demo users
-register(
-    "identity.prevent-link-identity-for-demo-users.enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "sentry.send_onboarding_task_metrics",

--- a/tests/sentry/users/models/test_identity.py
+++ b/tests/sentry/users/models/test_identity.py
@@ -1,9 +1,7 @@
 from sentry.identity import register
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test
-from sentry.users.models.identity import Identity
 
 
 @control_silo_test
@@ -21,30 +19,3 @@ class IdentityTestCase(TestCase):
         provider = identity_model.get_provider()
         assert provider.name == "Dummy"
         assert provider.key == "dummy"
-
-    def test_link_identity_for_demo_users(self) -> None:
-        user = self.create_user()
-        idp = self.create_identity_provider(type="dummy", external_id="1234")
-
-        # if the setting is disabled, the identity should be linked even for demo users
-        with override_options({"demo-mode.enabled": True, "demo-mode.users": [user.id]}):
-            assert Identity.objects.link_identity(user, idp, "1234") is not None
-
-        # if the setting is enabled, the identity should not be linked for demo users
-        with override_options(
-            {
-                "identity.prevent-link-identity-for-demo-users.enabled": True,
-                "demo-mode.enabled": True,
-                "demo-mode.users": [user.id],
-            }
-        ):
-            assert Identity.objects.link_identity(user, idp, "1234") is None
-
-        # if the setting is enabled, the identity should still be linked for non-demo users
-        with override_options(
-            {
-                "identity.prevent-link-identity-for-demo-users.enabled": True,
-                "demo-mode.enabled": True,
-            }
-        ):
-            assert Identity.objects.link_identity(user, idp, "1234") is not None


### PR DESCRIPTION
Cleans up `identity.prevent-link-identity-for-demo-users.enabled` option which was introduce to stop the leak for the #inc-1373

The proper fix has been implemented in the mean time, and this quick fix is no longer required.

Part of TET-1350
