### PR TITLE
chore: Remove deprecatedRouteProps for /preprod/

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2551,7 +2551,6 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/preprod/index')),
     withOrgPath: true,
     children: preprodChildren,
-    deprecatedRouteProps: true,
   };
 
   const pullRequestChildren: SentryRouteObject[] = [

--- a/static/app/views/preprod/index.tsx
+++ b/static/app/views/preprod/index.tsx
@@ -8,7 +8,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
-function PreprodContainer() {
+export default function PreprodContainer() {
   const organization = useOrganization();
 
   return (
@@ -31,5 +31,3 @@ function PreprodContainer() {
     </Feature>
   );
 }
-
-export default PreprodContainer;


### PR DESCRIPTION
This route doesn't rely on the deprecatedRouteProps, so it's quick to remove.