### PR TITLE
chore: Remove deprecatedRouteProps for /pull/

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2568,7 +2568,6 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/pullRequest/index')),
     withOrgPath: true,
     children: pullRequestChildren,
-    deprecatedRouteProps: true,
   };
 
   const feedbackV2Children: SentryRouteObject[] = [

--- a/static/app/views/pullRequest/index.tsx
+++ b/static/app/views/pullRequest/index.tsx
@@ -1,3 +1,5 @@
+import {Outlet} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -6,11 +8,7 @@ import {t} from 'sentry/locale';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
 import useOrganization from 'sentry/utils/useOrganization';
 
-type Props = {
-  children: NonNullable<React.ReactNode>;
-};
-
-function PullRequestContainer({children}: Props) {
+export default function PullRequestContainer() {
   const organization = useOrganization();
 
   return (
@@ -28,10 +26,10 @@ function PullRequestContainer({children}: Props) {
       )}
     >
       <NoProjectMessage organization={organization}>
-        <UrlParamBatchProvider>{children}</UrlParamBatchProvider>
+        <UrlParamBatchProvider>
+          <Outlet />
+        </UrlParamBatchProvider>
       </NoProjectMessage>
     </Feature>
   );
 }
-
-export default PullRequestContainer;


### PR DESCRIPTION
This route only uses `children`, so it's quick to convert to `<Outlet>`