### PR TITLE
chore(auth): Clean up killswitch for treating demo user as anon

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -21,7 +21,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from sentry import audit_log, features, options
+from sentry import audit_log, features
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
@@ -451,11 +451,7 @@ class AuthIdentityHandler:
     @property
     def _logged_in_user(self) -> User | None:
         """The user, if they have authenticated on this session."""
-        if (
-            options.get("demo-user.auth.pipelines.always.unauthenticated.enabled")
-            and is_demo_mode_enabled()
-            and is_demo_user(self.request.user)
-        ):
+        if is_demo_mode_enabled() and is_demo_user(self.request.user):
             return None
 
         return self.request.user if self.request.user.is_authenticated else None

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3566,14 +3566,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Killswitch for treating demo user as unauthenticated
-# in our auth pipelines.
-register(
-    "demo-user.auth.pipelines.always.unauthenticated.enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Rate at which to forward events to eap_items. 1.0
 # means that 100% of projects will forward events to eap_items.

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -1349,7 +1349,6 @@ class OrganizationAuthLoginDemoModeTest(AuthProviderTestCase):
                 "demo-mode.enabled": True,
                 "demo-mode.users": [self.demo_user.id],
                 "demo-mode.orgs": [self.demo_org.id],
-                "demo-user.auth.pipelines.always.unauthenticated.enabled": True,
             }
         ):
             sso_org = self.create_organization(name="sso-org", owner=self.normal_user)


### PR DESCRIPTION
No need for a killswitch anymore, this has been in production for over a month without any problems.

Part of TET-1350