### PR TITLE
cleanup: remove retry-handle-destroyed consumer flag

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -469,7 +469,6 @@ def get_stream_processor(
     add_global_tags: bool = False,
     profile_consumer_join: bool = False,
     enable_autocommit: bool = False,
-    retry_handle_destroyed: bool = False,
     handle_poll_while_paused: bool = False,
 ) -> StreamProcessor:
     from sentry.utils import kafka_config
@@ -529,7 +528,6 @@ def get_stream_processor(
             auto_offset_reset=auto_offset_reset,
             strict_offset_reset=strict_offset_reset,
             enable_auto_commit=enable_autocommit,
-            retry_handle_destroyed=retry_handle_destroyed,
         )
 
         if max_poll_interval_ms is not None:

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -557,12 +557,6 @@ def taskbroker_send_tasks(
     help="Enable Kafka autocommit mode with 1s commit interval. Offsets are stored via store_offsets and rdkafka commits them automatically.",
 )
 @click.option(
-    "--retry-handle-destroyed",
-    is_flag=True,
-    default=False,
-    help="Enable retrying on `KafkaError._DESTROY` during commit.",
-)
-@click.option(
     "--handle-poll-while-paused",
     is_flag=True,
     default=False,


### PR DESCRIPTION
Instead of retrying on `KafakError._DESTROY`, we're just going to enable autocommit from rdkafka which makes the error not happen at all: https://github.com/getsentry/arroyo/pull/508