### PR TITLE
fix(trace-eap-waterfall): Using span.description over span.name in au…

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.autogrouping.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.autogrouping.spec.tsx
@@ -623,7 +623,6 @@ describe('autogrouping', () => {
                 makeEAPSpan({
                   event_id: '0001',
                   op: 'db',
-                  description: 'redis GET x1',
                   name: 'GET',
                   start_timestamp: start,
                   end_timestamp: start + 1,
@@ -632,7 +631,6 @@ describe('autogrouping', () => {
                 makeEAPSpan({
                   event_id: '0002',
                   op: 'db',
-                  description: 'redis GET x2',
                   name: 'GET',
                   start_timestamp: start,
                   end_timestamp: start + 1,
@@ -641,7 +639,6 @@ describe('autogrouping', () => {
                 makeEAPSpan({
                   event_id: '0003',
                   op: 'db',
-                  description: 'redis GET x3',
                   name: 'GET',
                   start_timestamp: start,
                   end_timestamp: start + 1,
@@ -650,7 +647,6 @@ describe('autogrouping', () => {
                 makeEAPSpan({
                   event_id: '0003',
                   op: 'db',
-                  description: 'redis GET x4',
                   name: 'GET',
                   start_timestamp: start,
                   end_timestamp: start + 1,
@@ -659,7 +655,6 @@ describe('autogrouping', () => {
                 makeEAPSpan({
                   event_id: '0003',
                   op: 'db',
-                  description: 'redis GET x5',
                   name: 'GET',
                   start_timestamp: start,
                   end_timestamp: start + 1,

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1275,11 +1275,9 @@ export class TraceTree extends TraceTreeEventDispatcher {
           | TraceTreeNode<TraceTree.EAPSpan>
           | undefined;
 
-        const areSpanLabelsMatching = options.organization.features.includes(
+        const shouldUseOTelFriendlyUI = options.organization.features.includes(
           'performance-otel-friendly-ui'
-        )
-          ? areSpanNamesMatching
-          : areSpanDescriptionsMatching;
+        );
 
         if (
           next &&
@@ -1289,7 +1287,10 @@ export class TraceTree extends TraceTreeEventDispatcher {
           // skip `op: default` spans as `default` is added to op-less spans
           next.value.op !== 'default' &&
           next.value.op === current.value.op &&
-          areSpanLabelsMatching(next, current)
+          // If OTEL friendly UI is enabled, we only match on span name if the description is not present
+          (shouldUseOTelFriendlyUI && !next.value.description
+            ? areSpanNamesMatching(next, current)
+            : areSpanDescriptionsMatching(next, current))
           // next.value.description === current.value.description
         ) {
           // console.log('are matching');


### PR DESCRIPTION
In this PR we started preferring span.description over span.name in the trace view waterfall rows: https://github.com/getsentry/sentry/pull/101562

However, the auto-grouping logic still uses span.name, making it seem like we are autogrouping unrelated rows in the waterfall. Autogrouping should also prefer span.description if it exists, over name. 

Before: 
<img width="458" height="391" alt="Screenshot 2025-11-12 at 10 20 51 AM" src="https://github.com/user-attachments/assets/bb04faa6-13a3-4abd-a5e7-7b2092237c3d" />

After:
<img width="565" height="350" alt="Screenshot 2025-11-12 at 10 20 21 AM" src="https://github.com/user-attachments/assets/06c2f113-7462-449a-b0ea-cfbc2a45ec50" />


Note: This will be centralized with the new trace tree node class implementation work that is in progress.
