### PR TITLE
chore(explore): Fix incorrect import of `useEffectEvent`

### DIFF
--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -1,5 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
-import {useEffectEvent} from '@react-aria/utils';
+import {useEffect, useEffectEvent, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import isEmpty from 'lodash/isEmpty';
 import isEqualWith from 'lodash/isEqualWith';


### PR DESCRIPTION
The previous import was an oversight, it got auto-added from the wrong place.
