### PR TITLE
fix(frontend): Overflow issue on streamlinedExternalIssueList

### DIFF
--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -91,7 +91,7 @@ export function StreamlinedExternalIssueList({
   }
 
   return (
-    <Flex direction="row" gap="md">
+    <Flex direction="row" gap="md" wrap="wrap">
       {linkedIssues.length > 0 && (
         <IssueActionWrapper>
           {linkedIssues.map(linkedIssue => (


### PR DESCRIPTION
<!-- Describe your PR here. -->

<img width="528" height="390" alt="image" src="https://github.com/user-attachments/assets/5684e6eb-280d-4d47-9fc1-1322a482a15f" />


I'm recreating [this](https://github.com/getsentry/sentry/pull/102833) PR; I had closed it because I thought it had been solved. Flex wrap is set on the IssueActionWrappers, so it wraps correctly initially:

<img width="804" height="595" alt="image" src="https://github.com/user-attachments/assets/2f0aebe2-7553-444c-91c9-5567e4218e89" />


But once you've linked to an external service, the second list appears, and you get the overflow issue:

<img width="794" height="622" alt="image" src="https://github.com/user-attachments/assets/00227ddb-8817-49c5-8e76-54be7749574e" />



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
