### PR TITLE
ref(tests): Refactor snapshotter and simplify header

### DIFF
--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -276,12 +276,13 @@ def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter
         if _snapshot_writeback is not None and is_unequal:
             os.makedirs(os.path.dirname(reference_file), exist_ok=True)
             test_file = os.path.realpath(str(request.node.fspath))
+            test_name = request.node.originalname
             if test_file.startswith(repo_abs_path + os.path.sep):
                 test_file = test_file.replace(repo_abs_path + os.path.sep, "")
             if _snapshot_writeback == "new":
                 reference_file += ".new"
             with open(reference_file, "w") as f:
-                header = f"---\nsource: {test_file}\n---"
+                header = f"---\nsource: {test_file}::{test_name}\n---"
                 f.write(f"{header}\n{output}\n")
         elif is_unequal:
             __tracebackhide__ = True

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -277,9 +277,9 @@ def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter
 
         if _snapshot_writeback is not None and is_unequal:
             os.makedirs(os.path.dirname(reference_file), exist_ok=True)
-            source = os.path.realpath(str(request.node.fspath))
-            if source.startswith(repo_abs_path + os.path.sep):
-                source = source[len(repo_abs_path) + 1 :]
+            test_file = os.path.realpath(str(request.node.fspath))
+            if test_file.startswith(repo_abs_path + os.path.sep):
+                test_file = test_file[len(repo_abs_path) + 1 :]
             if _snapshot_writeback == "new":
                 reference_file += ".new"
             with open(reference_file, "w") as f:
@@ -290,7 +290,7 @@ def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter
                             {
                                 "created": timezone.now().isoformat(),
                                 "creator": "sentry",
-                                "source": source,
+                                "source": test_file,
                             },
                             indent=2,
                             default_flow_style=False,

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -182,7 +182,7 @@ elif _snapshot_writeback != "new":
 repo_abs_path = os.path.realpath(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(sentry.__file__))))
 )
-SNAPSHOT_REGEX = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n(.*)$", re.DOTALL)
+SNAPSHOT_REGEX = re.compile(r"^---\r?\n.*?\r?\n---\r?\n(.*)$", re.DOTALL)
 
 
 @pytest.fixture

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -18,7 +18,6 @@ import pytest
 import requests
 import yaml
 from django.core.cache import cache
-from django.utils import timezone
 
 import sentry
 from sentry.types.activity import ActivityType
@@ -282,21 +281,8 @@ def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter
             if _snapshot_writeback == "new":
                 reference_file += ".new"
             with open(reference_file, "w") as f:
-                f.write(
-                    "---\n%s\n---\n%s\n"
-                    % (
-                        yaml.safe_dump(
-                            {
-                                "created": timezone.now().isoformat(),
-                                "creator": "sentry",
-                                "source": test_file,
-                            },
-                            indent=2,
-                            default_flow_style=False,
-                        ).rstrip(),
-                        output,
-                    )
-                )
+                header = f"---\nsource: {test_file}\n---"
+                f.write(f"{header}\n{output}\n")
         elif is_unequal:
             __tracebackhide__ = True
             if isinstance(is_unequal, str):

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -200,14 +200,13 @@ class ReadableYamlDumper(yaml.dumper.SafeDumper):
         return True
 
 
-def read_snapshot_file(reference_file: str) -> tuple[str, str]:
+def read_snapshot_file(reference_file: str) -> str:
     with open(reference_file, encoding="utf-8") as f:
         match = SNAPSHOT_REGEX.match(f.read())
         if match is None:
             raise OSError()
 
-        header, refval = match.groups()
-        return (header, refval)
+        return match.group(1)
 
 
 InequalityComparator = Callable[[str, str], bool | str]
@@ -267,7 +266,7 @@ def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter
             )
 
         try:
-            _, refval = read_snapshot_file(reference_file)
+            refval = read_snapshot_file(reference_file)
         except OSError:
             refval = ""
 

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -182,7 +182,7 @@ elif _snapshot_writeback != "new":
 repo_abs_path = os.path.realpath(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(sentry.__file__))))
 )
-_yaml_snap_re = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n(.*)$", re.DOTALL)
+SNAPSHOT_REGEX = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n(.*)$", re.DOTALL)
 
 
 @pytest.fixture
@@ -202,7 +202,7 @@ class ReadableYamlDumper(yaml.dumper.SafeDumper):
 
 def read_snapshot_file(reference_file: str) -> tuple[str, str]:
     with open(reference_file, encoding="utf-8") as f:
-        match = _yaml_snap_re.match(f.read())
+        match = SNAPSHOT_REGEX.match(f.read())
         if match is None:
             raise OSError()
 

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -179,7 +179,7 @@ if _snapshot_writeback in ("true", "1", "overwrite"):
     _snapshot_writeback = "overwrite"
 elif _snapshot_writeback != "new":
     _snapshot_writeback = None
-_test_base = os.path.realpath(
+repo_abs_path = os.path.realpath(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(sentry.__file__))))
 )
 _yaml_snap_re = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n(.*)$", re.DOTALL)
@@ -278,8 +278,8 @@ def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter
         if _snapshot_writeback is not None and is_unequal:
             os.makedirs(os.path.dirname(reference_file), exist_ok=True)
             source = os.path.realpath(str(request.node.fspath))
-            if source.startswith(_test_base + os.path.sep):
-                source = source[len(_test_base) + 1 :]
+            if source.startswith(repo_abs_path + os.path.sep):
+                source = source[len(repo_abs_path) + 1 :]
             if _snapshot_writeback == "new":
                 reference_file += ".new"
             with open(reference_file, "w") as f:

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -278,7 +278,7 @@ def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter
             os.makedirs(os.path.dirname(reference_file), exist_ok=True)
             test_file = os.path.realpath(str(request.node.fspath))
             if test_file.startswith(repo_abs_path + os.path.sep):
-                test_file = test_file[len(repo_abs_path) + 1 :]
+                test_file = test_file.replace(repo_abs_path + os.path.sep, "")
             if _snapshot_writeback == "new":
                 reference_file += ".new"
             with open(reference_file, "w") as f:


### PR DESCRIPTION
This is a small refactor to the snapshotter we use in tests, including the following changes:

- Rename a few variables for clarity.
- Stop capturing the header when reading a snapshot file, since we never use it.
- Remove timestamp and creator from the header. The timestamp often causes merge conflicts (and the same information can be gleaned from the commit date), and the creator is hard-coded as 'sentry', which... yeah, okay, but is that news?
- Add test name to `source` entry in header. Yes, by default the test name is included in the snapshot file's path, but that's configurable, so might not always be true. Putting it in the header guarantees the information is easily available.

Note that this PR doesn't actually change the contents of any snapshots. Because snapshot files are only written when they change, and the header isn't actually anything we match on, we have the option to let the dates be removed organically, or to remove them in batches in separate PRs, but either way, this change won't make any current snapshot tests fail in the meantime.