### PR TITLE
feat(explorer): add issue short id hyperlinks in markdown

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -271,11 +271,11 @@ function BlockComponent({
                     text={processedContent}
                     onClick={(e: React.MouseEvent<HTMLDivElement>) => {
                       // Intercept clicks on links to use client-side navigation
-                      const target = e.target as HTMLElement;
-                      if (target.tagName === 'A') {
+                      const anchor = (e.target as HTMLElement).closest('a');
+                      if (anchor) {
                         e.preventDefault();
                         e.stopPropagation();
-                        const href = target.getAttribute('href');
+                        const href = anchor.getAttribute('href');
                         if (href?.startsWith('/')) {
                           navigate(href);
                           onNavigate?.();

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -200,6 +200,40 @@ export function getToolsStringFromBlock(block: Block): string[] {
 }
 
 /**
+ * Converts issue short IDs in text to markdown links.
+ * Examples: INTERNAL-4K, JAVASCRIPT-2SDJ, PROJECT-1
+ */
+function linkifyIssueShortIds(text: string): string {
+  // Pattern matches: PROJECT_SLUG-SHORT_ID (uppercase only, case-sensitive)
+  // Requires at least 2 chars before hyphen and 1+ chars after
+  const shortIdPattern = /\b([A-Z0-9_]{2,}-[A-Z0-9]+)\b/g;
+
+  return text.replace(shortIdPattern, match => {
+    return `[${match}](/issues/${match}/)`;
+  });
+}
+
+/**
+ * Post-processes markdown text from LLM responses.
+ * Applies various transformations to enhance the text with links and formatting.
+ * Add new processing rules to this function as needed.
+ */
+export function postProcessLLMMarkdown(text: string | null | undefined): string {
+  if (!text) {
+    return '';
+  }
+
+  let processed = text;
+
+  // Convert issue short IDs to clickable links
+  processed = linkifyIssueShortIds(processed);
+
+  // Add more processing rules here as needed
+
+  return processed;
+}
+
+/**
  * Build a URL/LocationDescriptor for a tool link based on its kind and params
  */
 export function buildToolLinkUrl(


### PR DESCRIPTION
Use regex to detect issue short IDs in the message content, and turn them into hyperlinks. Can add more rules/links in the future if we think of them.

<img width="735" height="185" alt="Screenshot 2025-11-12 at 10 25 02 AM" src="https://github.com/user-attachments/assets/eb6c13b7-27fd-4a8b-bd08-102446e45631" />
