### PR TITLE
fix(sdk): Disable browserProfilingIntegration in development

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -8,7 +8,7 @@ import {
 import type {Event} from '@sentry/core';
 import * as Sentry from '@sentry/react';
 
-import {SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
+import {NODE_ENV, SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import type {Config} from 'sentry/types/system';
 import {addExtraMeasurements, addUIElementTag} from 'sentry/utils/performanceForSentry';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
@@ -69,7 +69,7 @@ function getSentryIntegrations() {
       },
       linkPreviousTrace: 'session-storage',
     }),
-    Sentry.browserProfilingIntegration(),
+    ...(NODE_ENV === 'production' ? [Sentry.browserProfilingIntegration()] : []),
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: ['sentry-spa'],
       behaviour: 'apply-tag-if-contains-third-party-frames',


### PR DESCRIPTION
if you’re profiling Sentry’s UI in Chrome, remember to turn off browserProfilingIntegration in the SDK configuration, or Chrome will incorrectly attribute regular rendering work as “Profiling Overhead” @gggritso 