### PR TITLE
fix(llm-detector): Fix transaction row in span evidence

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -354,9 +354,6 @@ function AIDetectedSpanEvidence({
   projectSlug,
 }: SpanEvidenceKeyValueListProps) {
   const evidenceData = event?.occurrence?.evidenceData ?? {};
-  // LLM detected issues create synthetic events, not real transaction events.
-  // event.title contains the issue title (e.g., "Unhandled Exception in API Call"),
-  // so we must use evidenceData.transaction for the actual transaction name.
   const transactionName = evidenceData.transaction ?? event.title;
 
   const transactionSummaryLocation = transactionSummaryRouteWithQuery({


### PR DESCRIPTION
llm detected issues have different event payloads than the other performance issues so the default transaction row function doesn't work properly. updates it to work correctly for these issues . 
fixes https://linear.app/getsentry/issue/ID-1087/transaction-in-span-evidence-is-incorrect