### PR TITLE
feat(seer setting): Auto-Trigger Autofix turned into toggle [feature flagged]

### DIFF
--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -94,7 +94,7 @@ const autofixAutomationToggleField = {
   type: 'boolean',
   saveOnBlur: true,
   saveMessage: t('Automatic Seer settings updated'),
-  getData: (data: Record<string, boolean>) => ({
+  getData: (data: Record<PropertyKey, unknown>) => ({
     autofixAutomationTuning: data.autofixAutomationTuning ? 'always' : 'off',
   }),
 } satisfies FieldObject;

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -84,6 +84,21 @@ export const autofixAutomatingTuningField = {
   visible: ({model}) => model?.getValue('seerScannerAutomation') === true,
 } satisfies FieldObject;
 
+export const autofixAutomationToggleField = {
+  name: 'autofixAutomationTuning',
+  label: t('Auto-Trigger Fixes'),
+  help: () =>
+    t(
+      'When enabled, Seer will automatically analyze actionable issues in the background based on fixability analysis.'
+    ),
+  type: 'boolean',
+  saveOnBlur: true,
+  saveMessage: t('Automatic Seer settings updated'),
+  getData: (data: Record<string, boolean>) => ({
+    autofixAutomationTuning: data.autofixAutomationTuning ? 'always' : 'off',
+  }),
+} satisfies FieldObject;
+
 function ProjectSeerGeneralForm({project}: {project: Project}) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
@@ -222,7 +237,9 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
       ),
       fields: [
         ...(isTriageSignalsFeatureOn ? [] : [seerScannerAutomationField]),
-        autofixAutomatingTuningField,
+        isTriageSignalsFeatureOn
+          ? autofixAutomationToggleField
+          : autofixAutomatingTuningField,
         automatedRunStoppingPointField,
       ],
     },
@@ -235,14 +252,16 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           preference?.automation_handoff
             ? 'cursor_handoff'
             : (preference?.automated_run_stopping_point ?? 'root_cause')
-        }`}
+        }-${isTriageSignalsFeatureOn}`}
         saveOnBlur
         apiMethod="PUT"
         apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
         allowUndo
         initialData={{
           seerScannerAutomation: project.seerScannerAutomation ?? false,
-          autofixAutomationTuning: project.autofixAutomationTuning ?? 'off',
+          autofixAutomationTuning: isTriageSignalsFeatureOn
+            ? (project.autofixAutomationTuning ?? 'off') !== 'off'
+            : (project.autofixAutomationTuning ?? 'off'),
           automated_run_stopping_point: preference?.automation_handoff
             ? 'cursor_handoff'
             : (preference?.automated_run_stopping_point ?? 'root_cause'),

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -205,9 +205,14 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     saveOnBlur: true,
     saveMessage: t('Stopping point updated'),
     onChange: handleStoppingPointChange,
-    visible: ({model}) =>
-      model?.getValue('seerScannerAutomation') === true &&
-      model?.getValue('autofixAutomationTuning') !== 'off',
+    visible: ({model}) => {
+      const scannerEnabled = model?.getValue('seerScannerAutomation') === true;
+      const tuningValue = model?.getValue('autofixAutomationTuning');
+      // Handle both boolean (toggle) and string (dropdown) values
+      const automationEnabled =
+        typeof tuningValue === 'boolean' ? tuningValue : tuningValue !== 'off';
+      return scannerEnabled && automationEnabled;
+    },
   } satisfies FieldObject;
 
   const isTriageSignalsFeatureOn = project.features.includes('triage-signals-v0');

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -84,7 +84,7 @@ export const autofixAutomatingTuningField = {
   visible: ({model}) => model?.getValue('seerScannerAutomation') === true,
 } satisfies FieldObject;
 
-export const autofixAutomationToggleField = {
+const autofixAutomationToggleField = {
   name: 'autofixAutomationTuning',
   label: t('Auto-Trigger Fixes'),
   help: () =>

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -89,7 +89,7 @@ export const autofixAutomationToggleField = {
   label: t('Auto-Trigger Fixes'),
   help: () =>
     t(
-      'When enabled, Seer will automatically analyze actionable issues in the background based on fixability analysis.'
+      'When enabled, Seer will automatically analyze actionable issues in the background.'
     ),
   type: 'boolean',
   saveOnBlur: true,
@@ -259,6 +259,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
         allowUndo
         initialData={{
           seerScannerAutomation: project.seerScannerAutomation ?? false,
+          // Same DB field, different UI: toggle (boolean) vs dropdown (string)
           autofixAutomationTuning: isTriageSignalsFeatureOn
             ? (project.autofixAutomationTuning ?? 'off') !== 'off'
             : (project.autofixAutomationTuning ?? 'off'),

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -106,6 +106,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
   const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
   const {data: codingAgentIntegrations} = useCodingAgentIntegrations();
 
+  const isTriageSignalsFeatureOn = project.features.includes('triage-signals-v0');
   const canWriteProject = hasEveryAccess(['project:read'], {organization, project});
 
   const cursorIntegration = codingAgentIntegrations?.integrations.find(
@@ -206,16 +207,21 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     saveMessage: t('Stopping point updated'),
     onChange: handleStoppingPointChange,
     visible: ({model}) => {
-      const scannerEnabled = model?.getValue('seerScannerAutomation') === true;
       const tuningValue = model?.getValue('autofixAutomationTuning');
       // Handle both boolean (toggle) and string (dropdown) values
       const automationEnabled =
         typeof tuningValue === 'boolean' ? tuningValue : tuningValue !== 'off';
+
+      // When feature flag is ON (toggle mode): only check automation
+      // When feature flag is OFF (dropdown mode): check both scanner and automation
+      if (isTriageSignalsFeatureOn) {
+        return automationEnabled;
+      }
+
+      const scannerEnabled = model?.getValue('seerScannerAutomation') === true;
       return scannerEnabled && automationEnabled;
     },
   } satisfies FieldObject;
-
-  const isTriageSignalsFeatureOn = project.features.includes('triage-signals-v0');
 
   const seerFormGroups: JsonFormObject[] = [
     {


### PR DESCRIPTION
## PR Details
+ Change Auto Trigger Autofix from a dropdown to a toggle behind feature flag.
+ Backend remains the same:  Off maps to "off" and On maps to "always" since we want to run of all issues depending on the fixability score. 
+ Notion doc [reference](https://www.notion.so/sentry/Triage-Signals-V0-Technical-Implementation-Details-2a18b10e4b5d8086a7ceddaf4194849a?source=copy_link#2a18b10e4b5d8068a296e9109a9629f8)
