### PR TITLE
fix(seer): Remove pagination from anomaly detection

### DIFF
--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -9,7 +9,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAlertRulePermission
 from sentry.api.bases.organization_events import OrganizationEventsV2EndpointBase
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers.base import serialize
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -97,9 +96,4 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsV2EndpointBase):
         if anomalies is None:
             return Response("Unable to get historical anomaly data", status=400)
         # NOTE: returns empty list if there is not enough event data
-        return self.paginate(
-            request=request,
-            queryset=anomalies,
-            paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
-        )
+        return Response(serialize(anomalies, request.user))


### PR DESCRIPTION
We send this endpoint the entire payload and it has the full response from seer, instead of paginating, return the entire response.

fixes https://getsentry.atlassian.net/browse/ACI-532