### PR TITLE
chore(lllm-detector): Make fingerprint case insensitive

### DIFF
--- a/src/sentry/tasks/llm_issue_detection.py
+++ b/src/sentry/tasks/llm_issue_detection.py
@@ -82,8 +82,8 @@ def create_issue_occurrence_from_detection(
     occurrence_id = uuid4().hex
     detection_time = datetime.now(UTC)
     project = Project.objects.get_from_cache(id=project_id)
-
-    fingerprint = [f"llm-detected-{detected_issue.title}-{transaction_name}"]
+    title = detected_issue.title.lower().replace(" ", "-")
+    fingerprint = [f"llm-detected-{title}-{transaction_name}"]
 
     evidence_data = {
         "trace_id": trace.trace_id,

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -83,7 +83,7 @@ class LLMIssueDetectionTest(TestCase):
         assert len(occurrence.fingerprint) == 1
         assert (
             occurrence.fingerprint[0]
-            == "llm-detected-Database Connection Pool Exhaustion-test_transaction"
+            == "llm-detected-database-connection-pool-exhaustion-test_transaction"
         )
 
         assert occurrence.evidence_data["trace_id"] == "abc123xyz"


### PR DESCRIPTION
one thing we can do to make grouping better is making the issue title in the fingerprint case insensitive - the prompt will also need to be tweaked to be less volatile but we should do this anyway

fixes https://linear.app/getsentry/issue/ID-1094/update-fingerprint-to-be-case-insensitive
