### PR TITLE
ref(cursor): Rename Cursor Background Agent to Cursor Cloud Agent

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -147,7 +147,7 @@ describe('AutofixRootCause', () => {
     await userEvent.click(dropdownTrigger);
 
     // Click the Cursor option in the dropdown
-    await userEvent.click(await screen.findByText('Send to Cursor Background Agent'));
+    await userEvent.click(await screen.findByText('Send to Cursor Cloud Agent'));
 
     expect(JSON.parse(localStorage.getItem('autofix:rootCauseActionPreference')!)).toBe(
       'cursor_background_agent'
@@ -210,7 +210,7 @@ describe('AutofixRootCause', () => {
     render(<AutofixRootCause {...defaultProps} />);
 
     expect(
-      await screen.findByRole('button', {name: 'Send to Cursor Background Agent'})
+      await screen.findByRole('button', {name: 'Send to Cursor Cloud Agent'})
     ).toBeInTheDocument();
 
     // Verify Seer option is in the dropdown
@@ -250,7 +250,7 @@ describe('AutofixRootCause', () => {
     await userEvent.click(dropdownTrigger);
 
     expect(
-      await screen.findByText('Send to Cursor Background Agent')
+      await screen.findByText('Send to Cursor Cloud Agent')
     ).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -249,8 +249,6 @@ describe('AutofixRootCause', () => {
     });
     await userEvent.click(dropdownTrigger);
 
-    expect(
-      await screen.findByText('Send to Cursor Cloud Agent')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Send to Cursor Cloud Agent')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -479,10 +479,10 @@ function AutofixRootCauseDisplay({
                     busy={isLaunchingAgent}
                     disabled={isLoadingAgents}
                     onClick={handleLaunchCodingAgent}
-                    title={t('Send to Cursor Background Agent')}
+                    title={t('Send to Cursor Cloud Agent')}
                     icon={<PluginIcon pluginId="cursor" size={16} />}
                   >
-                    {t('Send to Cursor Background Agent')}
+                    {t('Send to Cursor Cloud Agent')}
                   </Button>
                   <DropdownMenu
                     items={[
@@ -531,7 +531,7 @@ function AutofixRootCauseDisplay({
                         label: (
                           <Flex gap="md" align="center">
                             <PluginIcon pluginId="cursor" size={20} />
-                            <div>{t('Send to Cursor Background Agent')}</div>
+                            <div>{t('Send to Cursor Cloud Agent')}</div>
                           </Flex>
                         ),
                         onAction: handleLaunchCodingAgent,

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -68,7 +68,7 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
   const getProviderName = (provider: CodingAgentProvider) => {
     switch (provider) {
       case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
-        return t('Cursor Background Agent');
+        return t('Cursor Cloud Agent');
       default:
         return t('Coding Agent');
     }

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -121,7 +121,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
           </Heading>
           <Text>
             {tct(
-              'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Background Agents for seamless code fixes. [docsLink:Read the docs] to learn more.',
+              'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Cloud Agents for seamless code fixes. [docsLink:Read the docs] to learn more.',
               {
                 docsLink: (
                   <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />
@@ -151,7 +151,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
           </Heading>
           <Text>
             {tct(
-              'You have the Cursor integration installed. Turn on Seer automation and set up hand off to trigger Cursor Background Agents during automation. [seerProjectSettings:Configure in Seer project settings] or [docsLink:read the docs] to learn more.',
+              'You have the Cursor integration installed. Turn on Seer automation and set up hand off to trigger Cursor Cloud Agents during automation. [seerProjectSettings:Configure in Seer project settings] or [docsLink:read the docs] to learn more.',
               {
                 seerProjectSettings: (
                   <Link to={`/settings/projects/${project.slug}/seer/`} />
@@ -183,7 +183,7 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
         </Heading>
         <Text>
           {tct(
-            'Cursor handoff is active. During automation runs, Seer will automatically trigger Cursor Background Agents. [docsLink:Read the docs] to learn more.',
+            'Cursor handoff is active. During automation runs, Seer will automatically trigger Cursor Cloud Agents. [docsLink:Read the docs] to learn more.',
             {
               docsLink: (
                 <ExternalLink href="https://docs.sentry.io/integrations/cursor/" />

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -801,8 +801,6 @@ describe('SeerDrawer', () => {
     );
 
     // Should not show the step since it was skipped
-    expect(
-      screen.queryByText('Hand Off to Cursor Cloud Agents')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Hand Off to Cursor Cloud Agents')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -720,7 +720,7 @@ describe('SeerDrawer', () => {
     );
 
     expect(
-      await screen.findByText('Hand Off to Cursor Background Agents')
+      await screen.findByText('Hand Off to Cursor Cloud Agents')
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', {name: 'Set Seer to hand off to Cursor'})
@@ -802,7 +802,7 @@ describe('SeerDrawer', () => {
 
     // Should not show the step since it was skipped
     expect(
-      screen.queryByText('Hand Off to Cursor Background Agents')
+      screen.queryByText('Hand Off to Cursor Cloud Agents')
     ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -153,7 +153,7 @@ describe('SeerNotices', () => {
     });
     await waitFor(() => {
       expect(
-        screen.getByText('Hand Off to Cursor Background Agents')
+        screen.getByText('Hand Off to Cursor Cloud Agents')
       ).toBeInTheDocument();
     });
   });
@@ -200,7 +200,7 @@ describe('SeerNotices', () => {
 
     // Should not show the cursor step since it was skipped
     expect(
-      screen.queryByText('Hand Off to Cursor Background Agents')
+      screen.queryByText('Hand Off to Cursor Cloud Agents')
     ).not.toBeInTheDocument();
 
     // Clean up localStorage
@@ -261,7 +261,7 @@ describe('SeerNotices', () => {
 
     // Should not show the cursor step since handoff is already configured
     expect(
-      screen.queryByText('Hand Off to Cursor Background Agents')
+      screen.queryByText('Hand Off to Cursor Cloud Agents')
     ).not.toBeInTheDocument();
   });
 
@@ -294,7 +294,7 @@ describe('SeerNotices', () => {
     expect(screen.queryByText('Unleash Automation')).not.toBeInTheDocument();
     expect(screen.queryByText('Get Some Quick Wins')).not.toBeInTheDocument();
     expect(
-      screen.queryByText('Hand Off to Cursor Background Agents')
+      screen.queryByText('Hand Off to Cursor Cloud Agents')
     ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -152,9 +152,7 @@ describe('SeerNotices', () => {
       },
     });
     await waitFor(() => {
-      expect(
-        screen.getByText('Hand Off to Cursor Cloud Agents')
-      ).toBeInTheDocument();
+      expect(screen.getByText('Hand Off to Cursor Cloud Agents')).toBeInTheDocument();
     });
   });
 
@@ -199,9 +197,7 @@ describe('SeerNotices', () => {
     });
 
     // Should not show the cursor step since it was skipped
-    expect(
-      screen.queryByText('Hand Off to Cursor Cloud Agents')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Hand Off to Cursor Cloud Agents')).not.toBeInTheDocument();
 
     // Clean up localStorage
     localStorage.removeItem(`seer-onboarding-cursor-skipped:${ProjectFixture().id}`);
@@ -260,9 +256,7 @@ describe('SeerNotices', () => {
     });
 
     // Should not show the cursor step since handoff is already configured
-    expect(
-      screen.queryByText('Hand Off to Cursor Cloud Agents')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Hand Off to Cursor Cloud Agents')).not.toBeInTheDocument();
   });
 
   it('does not render guided steps if all onboarding steps are complete', () => {
@@ -293,8 +287,6 @@ describe('SeerNotices', () => {
     expect(screen.queryByText('Pick Repositories to Work In')).not.toBeInTheDocument();
     expect(screen.queryByText('Unleash Automation')).not.toBeInTheDocument();
     expect(screen.queryByText('Get Some Quick Wins')).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('Hand Off to Cursor Cloud Agents')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Hand Off to Cursor Cloud Agents')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -458,7 +458,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                       <CursorPluginIcon>
                         <PluginIcon pluginId="cursor" />
                       </CursorPluginIcon>
-                      {t('Hand Off to Cursor Background Agents')}
+                      {t('Hand Off to Cursor Cloud Agents')}
                     </Flex>
                   }
                   isCompleted={!needsCursorIntegration}
@@ -470,12 +470,12 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                           <Fragment>
                             <span>
                               {t(
-                                'Enable Seer automation and set up handoff to Cursor Background Agents when Seer identifies a root cause.'
+                                'Enable Seer automation and set up handoff to Cursor Cloud Agents when Seer identifies a root cause.'
                               )}
                             </span>
                             <span>
                               {tct(
-                                'During automation, Seer will trigger Cursor Background Agents to generate and submit pull requests directly to your repos. Configure in [seerProjectSettings:Seer project settings] or [docsLink:read the docs] to learn more.',
+                                'During automation, Seer will trigger Cursor Cloud Agents to generate and submit pull requests directly to your repos. Configure in [seerProjectSettings:Seer project settings] or [docsLink:read the docs] to learn more.',
                                 {
                                   seerProjectSettings: (
                                     <Link
@@ -493,7 +493,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                           <Fragment>
                             <span>
                               {t(
-                                'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Background Agents for seamless code fixes.'
+                                'Connect Cursor to automatically hand off Seer root cause analysis to Cursor Cloud Agents for seamless code fixes.'
                               )}
                             </span>
                             <span>

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -521,9 +521,9 @@ describe('ProjectSeer', () => {
       select.focus();
     });
 
-    // Open the menu and select 'Hand off to Cursor Background Agent'
+    // Open the menu and select 'Hand off to Cursor Cloud Agent'
     await userEvent.click(select);
-    const cursorOption = await screen.findByText('Hand off to Cursor Background Agent');
+    const cursorOption = await screen.findByText('Hand off to Cursor Cloud Agent');
     await userEvent.click(cursorOption);
 
     // Form has saveOnBlur=true, so wait for the PUT request

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -161,9 +161,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
             {
               value: 'cursor_handoff',
               label: (
-                <SeerSelectLabel>
-                  {t('Hand off to Cursor Cloud Agent')}
-                </SeerSelectLabel>
+                <SeerSelectLabel>{t('Hand off to Cursor Cloud Agent')}</SeerSelectLabel>
               ),
               details: t(
                 "Seer will identify the root cause and hand off the fix to Cursor's cloud agent."

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -162,11 +162,11 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
               value: 'cursor_handoff',
               label: (
                 <SeerSelectLabel>
-                  {t('Hand off to Cursor Background Agent')}
+                  {t('Hand off to Cursor Cloud Agent')}
                 </SeerSelectLabel>
               ),
               details: t(
-                "Seer will identify the root cause and hand off the fix to Cursor's background agent."
+                "Seer will identify the root cause and hand off the fix to Cursor's cloud agent."
               ),
             },
           ]


### PR DESCRIPTION
Update all frontend references to reflect rebranding from 'Cursor Background Agent' to 'Cursor Cloud Agent'.
