### PR TITLE
fix(tracemetrics): Add observed and fix internal times

### DIFF
--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -38,7 +38,9 @@ function TimestampTooltipBody({
     : null;
   const timestampToUse = preciseTimestampMs ? new Date(preciseTimestampMs) : timestamp;
 
-  const observedTimeNanos = attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE];
+  const observedTimeNanos =
+    attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE] ??
+    attributes['sentry.observed_timestamp_nanos']; // Deprecated, should be removed in the future once the alias is fixed in metrics.
   const observedTimeMs =
     observedTimeNanos && typeof observedTimeNanos === 'string'
       ? Math.floor(Number(observedTimeNanos) / 1_000_000)

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -23,6 +23,7 @@ export const AlwaysPresentTraceMetricFields: TraceMetricFieldKey[] = [
   TraceMetricKnownFieldKey.METRIC_TYPE,
   TraceMetricKnownFieldKey.METRIC_NAME,
   TraceMetricKnownFieldKey.TIMESTAMP,
+  TraceMetricKnownFieldKey.OBSERVED_TIMESTAMP_NANOS,
 ];
 
 /**

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.spec.tsx
@@ -134,6 +134,8 @@ describe('useMetricSamplesTable', () => {
           dataset: 'tracemetrics',
           disableAggregateExtrapolation: undefined,
           environment: ['prod'],
+          start: expect.any(String),
+          end: expect.any(String),
           field: [
             'id',
             'project.id',
@@ -143,6 +145,7 @@ describe('useMetricSamplesTable', () => {
             'metric.type',
             'metric.name',
             'timestamp',
+            'sentry.observed_timestamp_nanos',
           ],
           orderby: ['-timestamp'],
           per_page: 50,

--- a/static/app/views/explore/metrics/metricInfoTabs/metricDetails.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricDetails.tsx
@@ -74,7 +74,10 @@ export function MetricDetails({
                   renderers={LogAttributesRendererMap}
                   rendererExtra={{
                     attributeTypes: {},
-                    attributes: {},
+                    attributes: data.attributes.reduce(
+                      (it, {name, value}) => ({...it, [name]: value}),
+                      {}
+                    ),
                     highlightTerms: [],
                     logColors: getLogColors(SeverityLevel.INFO, theme),
                     location,


### PR DESCRIPTION
Observed isn't aliased properly, but for now we can use the unaliased version and to have observed appear in the tooltip, and internal needs attributes passed to it can be used.

