### PR TITLE
ref(grouping): More small new grouping config refactors

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -58,6 +58,8 @@ VALID_PROFILING_ACTIONS_SET = frozenset(["+app", "-app"])
 
 @dataclass
 class EnhancementsConfigData:
+    # Note: This is not an actual config, just a container to make it easier to pass data between
+    # functions while loading a config.
     rules: list[EnhancementRule]
     rust_enhancements: RustEnhancements
     version: int | None = None

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -55,15 +55,15 @@ def _calculate_event_grouping(
     with metrics.timer("save_event._calculate_event_grouping", tags=metric_tags):
         loaded_grouping_config = load_grouping_config(grouping_config)
 
-        with metrics.timer("event_manager.normalize_stacktraces_for_grouping", tags=metric_tags):
-            with sentry_sdk.start_span(op="event_manager.normalize_stacktraces_for_grouping"):
-                event.normalize_stacktraces_for_grouping(loaded_grouping_config)
-
         with metrics.timer("event_manager.apply_server_fingerprinting", tags=metric_tags):
             event.data["fingerprint"] = event.data.data.get("fingerprint") or ["{{ default }}"]
             apply_server_side_fingerprinting(
                 event.data.data, get_fingerprinting_config_for_project(project)
             )
+
+        with metrics.timer("event_manager.normalize_stacktraces_for_grouping", tags=metric_tags):
+            with sentry_sdk.start_span(op="event_manager.normalize_stacktraces_for_grouping"):
+                event.normalize_stacktraces_for_grouping(loaded_grouping_config)
 
         with metrics.timer("event_manager.event.get_hashes", tags=metric_tags):
             hashes, variants = event.get_hashes_and_variants(loaded_grouping_config)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -60,11 +60,6 @@ def _calculate_event_grouping(
                 event.normalize_stacktraces_for_grouping(loaded_grouping_config)
 
         with metrics.timer("event_manager.apply_server_fingerprinting", tags=metric_tags):
-            # The active grouping config was put into the event in the
-            # normalize step before.  We now also make sure that the
-            # fingerprint was set to `'{{ default }}' just in case someone
-            # removed it from the payload.  The call to `get_hashes_and_variants` will then
-            # look at `grouping_config` to pick the right parameters.
             event.data["fingerprint"] = event.data.data.get("fingerprint") or ["{{ default }}"]
             apply_server_side_fingerprinting(
                 event.data.data, get_fingerprinting_config_for_project(project)

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -510,11 +510,12 @@ def _single_stacktrace_variant(
         and frame_components[0].contributes
         and get_behavior_family_for_platform(frames[0].platform or event.platform) == "javascript"
         and not frames[0].function
-        and has_url_origin(frames[0].abs_path, files_count_as_urls=True)
     ):
-        frame_components[0].update(
-            contributes=False, hint="ignored single non-URL JavaScript frame"
-        )
+        should_ignore_frame = has_url_origin(frames[0].abs_path, files_count_as_urls=True)
+        if should_ignore_frame:
+            frame_components[0].update(
+                contributes=False, hint="ignored single non-URL JavaScript frame"
+            )
 
     stacktrace_component = context.config.enhancements.assemble_stacktrace_component(
         variant_name,

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -328,7 +328,7 @@ def normalize_stacktraces_for_grouping(
         stripped_querystring = False
         for frames in stacktrace_frames:
             for frame in frames:
-                _update_frame(frame, platform)
+                _trim_function_name(frame, platform)
 
                 # Restore the original in_app value before applying in-app stacktrace rules. This
                 # lets us run grouping enhancers on the stacktrace multiple times, as would happen
@@ -386,7 +386,7 @@ def normalize_stacktraces_for_grouping(
     data["metadata"] = event_metadata
 
 
-def _update_frame(frame: dict[str, Any], platform: str | None) -> None:
+def _trim_function_name(frame: dict[str, Any], platform: str | None) -> None:
 
     if frame.get("raw_function") is not None:
         return

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -330,6 +330,13 @@ def normalize_stacktraces_for_grouping(
             for frame in frames:
                 _update_frame(frame, platform)
 
+                # Restore the original in_app value before applying in-app stacktrace rules. This
+                # lets us run grouping enhancers on the stacktrace multiple times, as would happen
+                # during a grouping config transition, for example.
+                orig_in_app = get_path(frame, "data", "orig_in_app")
+                if orig_in_app is not None:
+                    frame["in_app"] = None if orig_in_app == -1 else bool(orig_in_app)
+
                 # Track the incoming `in_app` value, before we make any changes. This is different
                 # from the `orig_in_app` value which may be set by
                 # `apply_category_and_updated_in_app_to_frames`, because it's not tied to the value
@@ -380,13 +387,6 @@ def normalize_stacktraces_for_grouping(
 
 
 def _update_frame(frame: dict[str, Any], platform: str | None) -> None:
-    """Restore the original in_app value before the first grouping
-    enhancers have been run. This allows to re-apply grouping
-    enhancers on the original frame data.
-    """
-    orig_in_app = get_path(frame, "data", "orig_in_app")
-    if orig_in_app is not None:
-        frame["in_app"] = None if orig_in_app == -1 else bool(orig_in_app)
 
     if frame.get("raw_function") is not None:
         return

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -387,16 +387,17 @@ def normalize_stacktraces_for_grouping(
 
 
 def _trim_function_name(frame: dict[str, Any], platform: str | None) -> None:
+    function = frame.get("function")
+    raw_function = frame.get("raw_function")
 
-    if frame.get("raw_function") is not None:
+    # Nothing to trim or trimming has already been done
+    if not function or raw_function is not None:
         return
-    raw_func = frame.get("function")
-    if not raw_func:
-        return
-    function_name = trim_function_name(raw_func, frame.get("platform") or platform)
-    if function_name != raw_func:
-        frame["raw_function"] = raw_func
-        frame["function"] = function_name
+
+    trimmed_function = trim_function_name(function, frame.get("platform", platform))
+    if trimmed_function != function:
+        frame["raw_function"] = function
+        frame["function"] = trimmed_function
 
 
 def should_process_for_stacktraces(data):

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -166,7 +166,7 @@ def with_grouping_configs(config_ids: Iterable[str]) -> pytest.MarkDecorator:
         return pytest.mark.skip("no configs to test")
 
     return pytest.mark.parametrize(
-        "config_name", config_ids, ids=lambda config_name: config_name.replace("-", "_")
+        "config_name", sorted(config_ids), ids=lambda config_name: config_name.replace("-", "_")
     )
 
 


### PR DESCRIPTION
This is various bits of refactoring pulled from upcoming PRs to keep them focused and easy to review. No behavior changes.

- Server-side fingerprinting is unrelated to stacktrace normalization for enhancements rule processing. Remove a comment which suggests otherwise, and move server-side fingerprinting to happen before the normalization, so both stacktrace processes happen together.
- Refactor the `_update_frame` helper used in normalization by moving the few in-app-related lines directly into the normalization function and simplifying the rest. Rename the function from `_update_frame` to `_trim_function_name` to reflect it's now-singular purpose.
- Separate out one of the conditionals in the stacktrace strategy code, so it can be handled differently by different configs.
- Add a comment about the `EnhancementsConfigData` type.
- In grouping snapshot tests, always test configs in the same order.