### PR TITLE
ref(explorer/replay): support short id details query for replay metadata rpc

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -132,7 +132,7 @@ def query_replay_instance_with_short_id(
 
         snuba_response = execute_query(
             query=make_full_aggregation_query_with_short_id(
-                fields=["replay_id"],
+                fields=[],
                 replay_id_prefix=replay_id_prefix,
                 project_ids=project_ids,
                 period_start=window_start,

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -119,7 +119,7 @@ def query_replay_instance_with_short_id(
     end: datetime,
     organization: Organization | None = None,
     request_user_id: int | None = None,
-) -> list[dict[str, Any]] | None:
+) -> list[dict[str, Any]]:
     """
     Query aggregated replay instance with a string prefix filter.
     Date range is chunked into 14 day intervals, newest to oldest, to avoid timeouts.
@@ -149,7 +149,7 @@ def query_replay_instance_with_short_id(
 
         window_end = window_start
 
-    return None
+    return []
 
 
 def query_replay_viewed_by_ids(

--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -457,8 +457,15 @@ def make_full_aggregation_query_with_short_id(
         fields -- if non-empty, used to query a subset of fields. Corresponds to the keys in QUERY_ALIAS_COLUMN_MAP.
     """
 
-    if len(replay_id_prefix) != 8 or not replay_id_prefix.isalnum():
+    if len(replay_id_prefix) != 8:
         raise ValueError("Invalid short ID. Must be 8 hexadecimal characters.")
+
+    try:
+        int(replay_id_prefix, 16)
+    except ValueError as e:
+        raise ValueError("Invalid short ID. Must be 8 hexadecimal characters.") from e
+
+    replay_id_prefix = replay_id_prefix.lower()
 
     from sentry.replays.query import select_from_fields
 

--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -29,7 +29,6 @@ from snuba_sdk import (
     Entity,
     Function,
     Granularity,
-    Limit,
     Op,
     Or,
     OrderBy,
@@ -438,69 +437,6 @@ def make_full_aggregation_query(
         having=[Condition(Function("min", parameters=[Column("segment_id")]), Op.EQ, 0)],
         groupby=[Column("replay_id")],
         granularity=Granularity(3600),
-    )
-
-
-def make_full_aggregation_query_with_short_id(
-    fields: list[str],
-    replay_id_prefix: str,
-    project_ids: list[int],
-    period_start: datetime,
-    period_end: datetime,
-    request_user_id: int | None,
-    limit: int,
-) -> Query:
-    """Return a query to fetch a replay with a short ID - an 8-character replay ID prefix.
-    This query does not make use of the replay_id index and can potentially scan all rows in the time range and project list.
-
-    Arguments:
-        fields -- if non-empty, used to query a subset of fields. Corresponds to the keys in QUERY_ALIAS_COLUMN_MAP.
-    """
-
-    if len(replay_id_prefix) != 8:
-        raise ValueError("Invalid short ID. Must be 8 hexadecimal characters.")
-
-    try:
-        int(replay_id_prefix, 16)
-    except ValueError as e:
-        raise ValueError("Invalid short ID. Must be 8 hexadecimal characters.") from e
-
-    replay_id_prefix = replay_id_prefix.lower()
-
-    from sentry.replays.query import select_from_fields
-
-    select = select_from_fields(fields, user_id=request_user_id)
-
-    return Query(
-        match=Entity("replays"),
-        select=select,
-        where=[
-            Condition(Column("project_id"), Op.IN, project_ids),
-            # Range queries on UUID column don't work as expected due to comparison on the binary representation, and Clickhouse endianness.
-            # It's slower as we're no longer using the replay_id index, but the only way to do this is through a string prefix filter.
-            Condition(
-                Function(
-                    "startsWith",
-                    parameters=[
-                        Function("toString", parameters=[Column("replay_id")]),
-                        replay_id_prefix,
-                    ],
-                ),
-                Op.EQ,
-                1,
-            ),
-            # We can scan an extended time range to account for replays which span either end of
-            # the range.
-            Condition(Column("timestamp"), Op.GTE, period_start - timedelta(hours=1)),
-            Condition(Column("timestamp"), Op.LT, period_end + timedelta(hours=1)),
-        ],
-        # NOTE: Refer to this note: "make_scalar_search_conditions_query".
-        #
-        # This condition ensures that every replay shown to the user is valid.
-        having=[Condition(Function("min", parameters=[Column("segment_id")]), Op.EQ, 0)],
-        groupby=[Column("replay_id")],
-        granularity=Granularity(3600),
-        limit=Limit(limit),
     )
 
 

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -516,7 +516,7 @@ def get_replay_metadata(
     *,
     replay_id: str,
     organization_id: int,
-    project_id: int | None = None,
+    project_slug: str | None = None,
 ) -> dict[str, Any] | None:
     """
     Get the metadata for a replay through an aggregate replay event query.
@@ -524,7 +524,7 @@ def get_replay_metadata(
     Args:
         replay_id: The ID of the replay. Either a valid UUID or a 8-character hex string prefix. If known, the full ID is recommended for performance.
         organization_id: The ID of the organization the replay belongs to.
-        project_id: The projects to query. If not provided, all projects in the organization will be queried.
+        project_slug: The slug of the project to query. If not provided, all projects in the organization will be queried.
 
     Returns:
         A dict containing the metadata for the replay, or None if it's not found.
@@ -556,7 +556,7 @@ def get_replay_metadata(
         Project.objects.filter(
             organization_id=organization.id,
             status=ObjectStatus.ACTIVE,
-            **({"id": project_id} if project_id else {}),
+            **({"slug": project_slug} if project_slug else {}),
         ).values_list("id", "slug")
     )
 

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -1208,7 +1208,7 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
             result = get_replay_metadata(
                 replay_id=replay1_id,
                 organization_id=self.organization.id,
-                project_id=self.project.id,
+                project_slug=self.project.slug,
             )
             assert result is not None
             assert result["id"] == replay1_id
@@ -1220,7 +1220,7 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
             result = get_replay_metadata(
                 replay_id=replay2_id,
                 organization_id=self.organization.id,
-                project_id=self.project.id,
+                project_slug=self.project.slug,
             )
             assert result is not None
             assert result["id"] == replay2_id
@@ -1228,7 +1228,7 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
             assert result["project_slug"] == self.project.slug
             self._ReplayMetadataResponse.parse_obj(result)
 
-            # No project ID
+            # No project slug
             result = get_replay_metadata(
                 replay_id=replay1_id,
                 organization_id=self.organization.id,
@@ -1239,11 +1239,11 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
             assert result["project_slug"] == self.project.slug
             self._ReplayMetadataResponse.parse_obj(result)
 
-            # Different project ID
+            # Different project slug
             result = get_replay_metadata(
                 replay_id=replay1_id,
                 organization_id=self.organization.id,
-                project_id=self.project.id + 1,
+                project_slug="banana",
             )
             assert result is None
 

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -1219,6 +1219,26 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
             assert result["project_slug"] == self.project.slug
             self._ReplayMetadataResponse.parse_obj(result)
 
+            # With dashes
+            result = get_replay_metadata(
+                replay_id=str(uuid.UUID(replay1_id)),
+                organization_id=self.organization.id,
+                project_slug=self.project.slug,
+            )
+            assert result is not None
+            assert result["id"] == replay1_id
+            assert result["project_id"] == str(self.project.id)
+            assert result["project_slug"] == self.project.slug
+            self._ReplayMetadataResponse.parse_obj(result)
+
+            # Invalid
+            result = get_replay_metadata(
+                replay_id=str(uuid.UUID(replay1_id))[:-2] + "gg",
+                organization_id=self.organization.id,
+                project_slug=self.project.slug,
+            )
+            assert result is None
+
             # Replay 2
             result = get_replay_metadata(
                 replay_id=replay2_id,
@@ -1307,21 +1327,19 @@ class TestGetReplayMetadata(ReplaysSnubaTestCase):
             assert result["project_slug"] == self.project.slug
             self._ReplayMetadataResponse.parse_obj(result)
 
-            # Short ID != 8 characters or not hex (should raise)
-            with pytest.raises(ValueError):
+            # Short ID < 8 characters or not hex - returns None
+            assert (
                 get_replay_metadata(
                     replay_id=replay1_id[:7],
                     organization_id=self.organization.id,
                 )
+                is None
+            )
 
-            with pytest.raises(ValueError):
-                get_replay_metadata(
-                    replay_id=replay1_id[:9],
-                    organization_id=self.organization.id,
-                )
-
-            with pytest.raises(ValueError):
+            assert (
                 get_replay_metadata(
                     replay_id=replay1_id[:6] + "gg",
                     organization_id=self.organization.id,
                 )
+                is None
+            )


### PR DESCRIPTION
Supports replay ID prefix -> full ID lookup, for Seer explorer tools. This filter doesn't make use of the replay_id index and isn't very efficient. However we 
- only select the first row and return its full ID
- use the 14d sliding window approach we're doing for trace
- only plan to use it for explorer for now (low volume, unreleased UI feature) 

The agent is instructed to always provide the full ID and/or project ID when known, which improves performance.




--(Outdated, used to do the prefix filter on the aggregate query)--


Tested a 14d range in snuba admin for sentry prod (project id 11276). Execution time < 60ms, quota_used":167443648,"quota_unit":"bytes"

```
MATCH (replays) SELECT anyIf(environment, notEmpty(environment)) AS `agg_environment`,
anyIf(project_id, equals(segment_id, 0)) AS `agg_project_id`,
max(timestamp) AS `finished_at`, 
ifNull(max(is_archived), 0) AS `isArchived`
BY replay_id 
WHERE project_id IN array(11276)
AND startsWith(toString(replay_id), '83527f1f') = 1
AND timestamp >= toDateTime('2025-10-29T19:44:48.827974') 
AND timestamp < toDateTime('2025-11-12T21:44:48.827974') 
HAVING min(segment_id) = 0
LIMIT 1 
GRANULARITY 3600
```

