### PR TITLE
fix(spans): Handle device.class better

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1209,10 +1209,9 @@ class SearchResolver:
         if isinstance(value, str) and value in context.value_map:
             value = context.value_map[value]
 
-        # now that we've checked all potential allowed values, we should fall back
+        # now that we've checked all potentially allowed values, we should fall back
         # to using the default
         if context.default_value:
             return context.default_value
 
-        # no default, so not much we can do but try it and see what happens
-        return value
+        raise InvalidSearchQuery(f"Unknown value {value}")

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1214,4 +1214,4 @@ class SearchResolver:
         if context.default_value:
             return context.default_value
 
-        raise InvalidSearchQuery(f"Unknown value {value}")
+        return value

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -552,6 +552,7 @@ def device_class_context_constructor(params: SnubaParams) -> VirtualColumnContex
         from_column_name="sentry.device.class",
         to_column_name="device.class",
         value_map=value_map,
+        default_value="Unknown",
     )
 
 

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -104,6 +104,7 @@ class SnubaParams:
     sampling_mode: SAMPLING_MODES | None = None
     debug: bool = False
     case_insensitive: bool = False
+    supports_virtual_context: bool = False
 
     def __post_init__(self) -> None:
         if self.start:

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -104,7 +104,6 @@ class SnubaParams:
     sampling_mode: SAMPLING_MODES | None = None
     debug: bool = False
     case_insensitive: bool = False
-    supports_virtual_context: bool = False
 
     def __post_init__(self) -> None:
         if self.start:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -189,6 +189,44 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert data[0]["span.description"] == "EXEC *"
         assert meta["dataset"] == "spans"
 
+    def test_device_class_filter_for_empty(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"device.class": "3"}}, start_ts=self.ten_mins_ago
+                ),
+                self.create_span(
+                    {"sentry_tags": {"device.class": "2"}}, start_ts=self.ten_mins_ago
+                ),
+                self.create_span(
+                    {"sentry_tags": {"device.class": "1"}}, start_ts=self.ten_mins_ago
+                ),
+                self.create_span({"sentry_tags": {"device.class": ""}}, start_ts=self.ten_mins_ago),
+                self.create_span({}, start_ts=self.ten_mins_ago),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["device.class", "count()"],
+                "query": 'device.class:""',
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+
+        meta = response.data["meta"]
+        assert meta["dataset"] == "spans"
+
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["device.class"] == "Unknown"
+        assert data[0]["count()"] == 2
+
     def test_device_class_filter_for_unknown(self):
         self.store_spans(
             [

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -1905,6 +1905,31 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
         assert response.status_code == 200
         assert response.data == []
 
+    def test_autocomplete_device_class(self) -> None:
+        self.store_spans(
+            [
+                self.create_span({"sentry_tags": {"device.class": "3"}}),
+                self.create_span({"sentry_tags": {"device.class": "2"}}),
+                self.create_span({"sentry_tags": {"device.class": "1"}}),
+                self.create_span({"sentry_tags": {"device.class": ""}}),
+                self.create_span({}),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(key="device.class")
+        assert response.data == [
+            {
+                "count": mock.ANY,
+                "key": "device.class",
+                "value": device_class,
+                "name": device_class,
+                "firstSeen": mock.ANY,
+                "lastSeen": mock.ANY,
+            }
+            for device_class in sorted(["low", "medium", "high", "Unknown"])
+        ]
+
 
 class OrganizationTraceItemAttributeValuesEndpointTraceMetricsTest(
     OrganizationTraceItemAttributeValuesEndpointBaseTest, TraceMetricsTestCase


### PR DESCRIPTION
This does a few things to improve the handling of device class
1. map the values in the virtual column context when querying timeseries
2. map the values in the virtual column context when autocompleting

Closes EXP-537