### PR TITLE
ref(replay): bump max segment limit to 150 for replay summaries

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -26,7 +26,7 @@ from sentry.utils import json
 logger = logging.getLogger(__name__)
 
 
-MAX_SEGMENTS_TO_SUMMARIZE = 100
+MAX_SEGMENTS_TO_SUMMARIZE = 150
 SEER_REQUEST_SIZE_LOG_THRESHOLD = 1e5  # Threshold for logging large Seer requests.
 
 SEER_START_TASK_ENDPOINT_PATH = "/v1/automation/summarize/replay/breadcrumbs/start"
@@ -174,6 +174,7 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
                         "project_id": project.id,
                         "organization_id": project.organization.id,
                         "segment_limit": MAX_SEGMENTS_TO_SUMMARIZE,
+                        "num_segments": num_segments,
                     },
                 )
                 num_segments = MAX_SEGMENTS_TO_SUMMARIZE


### PR DESCRIPTION
bump up to 150. [we haven't seen](https://sentry.sentry.io/explore/logs/?logsFields=timestamp&logsFields=message&logsFields=replay_id&logsFields=release&logsQuery=hit%20max%20segment%20limit.&logsSortBys=-timestamp&project=6178942&project=1&statsPeriod=30d) an overwhelming instance of unique web replays hitting 100+ segments in the past 30 days so it should be safe.

frontend pr to follow