### PR TITLE
feat(Replay): Add Flag for EAP Query for Replay Details Page

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -361,6 +361,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:replay-ai-summaries-mobile", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable replay AI summaries for web replays
     manager.add("organizations:replay-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable reading replay details using EAP query
+    manager.add("organizations:replay-details-eap-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable version 2 of release serializer
     manager.add("organizations:releases-serializer-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable version 2 of reprocessing (completely distinct from v1)

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -30,7 +30,7 @@ def query_replay_instance_eap(
     start: datetime,
     end: datetime,
     organization_id: int,
-    request_user_id: int | None,
+    request_user_id: int,
     referrer: str = "replays.query.details_query",
 ):
     select = [

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -30,7 +30,7 @@ def query_replay_instance_eap(
     start: datetime,
     end: datetime,
     organization_id: int,
-    request_user_id: int,
+    request_user_id: int | None,
     referrer: str = "replays.query.details_query",
 ):
     select = [

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -168,7 +168,7 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
                 end=filter_params["end"],
                 organization_id=organization.id,
                 request_user_id=request.user.id,
-            )
+            )["data"]
         else:
             snuba_response = query_replay_instance(
                 project_id=project_ids,


### PR DESCRIPTION
In this [previous PR](https://github.com/getsentry/sentry/pull/102416), a new helper function for querying EAP for replay details given a replay ID was added to the organization details file. This PR calls this new function behind a new feature flag organizations:replay-details-eap-query. 

Relates To: https://linear.app/getsentry/issue/REPLAY-825/add-flag-for-reading-from-eap-for-replay-details

