### PR TITLE
ref(replay): add logging for timeout on frontend for replay summaries

### DIFF
--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -20,9 +20,7 @@ const START_TIMEOUT_MS = 15_000; // Max time to wait for processing to start aft
 const TOTAL_TIMEOUT_MS = 100_000; // Max time to wait for results after a start request. Task timeout in Seer (90s) + 10s buffer.
 
 function logReplaySummaryTimeout({extra}: {extra: Record<string, string>}) {
-  Sentry.logger.info('Replay summary poll timed out', {
-    extra,
-  });
+  Sentry.logger.info('Replay summary poll timed out', extra);
 }
 export interface UseReplaySummaryResult {
   /**

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery, useMutation, useQueryClient} from 'sentry/utils/queryClient';
@@ -18,6 +19,11 @@ const ERROR_POLL_INTERVAL_MS = 5000;
 const START_TIMEOUT_MS = 15_000; // Max time to wait for processing to start after a start request.
 const TOTAL_TIMEOUT_MS = 100_000; // Max time to wait for results after a start request. Task timeout in Seer (90s) + 10s buffer.
 
+function logReplaySummaryTimeout({extra}: {extra: Record<string, string>}) {
+  Sentry.logger.info('Replay summary poll timed out', {
+    extra,
+  });
+}
 export interface UseReplaySummaryResult {
   /**
    * Whether there was an error with the initial query or summary generation,
@@ -97,6 +103,14 @@ export function useReplaySummary(
     timeMs: TOTAL_TIMEOUT_MS,
     onTimeout: () => {
       setDidTimeout(true);
+      logReplaySummaryTimeout({
+        extra: {
+          reason: 'Total timeout',
+          orgSlug: organization.slug,
+          replayId: replayRecord?.id ?? '',
+          segmentCount: segmentCount.toString(),
+        },
+      });
     },
   });
 
@@ -105,6 +119,14 @@ export function useReplaySummary(
     onTimeout: () => {
       setDidTimeout(true);
       cancelTotalTimeout();
+      logReplaySummaryTimeout({
+        extra: {
+          reason: 'Start timeout',
+          orgSlug: organization.slug,
+          replayId: replayRecord?.id ?? '',
+          segmentCount: segmentCount.toString(),
+        },
+      });
     },
   });
 


### PR DESCRIPTION
add Sentry logging on frontend when replay summary polling times out.