### PR TITLE
fix(preprod): Update existing GitHub check runs instead of creating duplicates (EME-610)

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -732,6 +732,15 @@ class GitHubBaseClient(
         endpoint = f"/repos/{repo}/commits/{sha}/check-runs"
         return self.get(endpoint)
 
+    def update_check_run(self, repo: str, check_run_id: str, data: dict[str, Any]) -> Any:
+        """
+        https://docs.github.com/en/rest/checks/runs#update-a-check-run
+
+        The repo must be in the format of "owner/repo".
+        """
+        endpoint = f"/repos/{repo}/check-runs/{check_run_id}"
+        return self.patch(endpoint, data=data)
+
 
 class _IntegrationIdParams(TypedDict, total=False):
     integration_id: int

--- a/src/sentry/integrations/source_code_management/status_check.py
+++ b/src/sentry/integrations/source_code_management/status_check.py
@@ -27,3 +27,7 @@ class StatusCheckClient(ABC):
     @abstractmethod
     def get_check_runs(self, repo: str, sha: str) -> Any:
         raise NotImplementedError
+
+    @abstractmethod
+    def update_check_run(self, repo: str, check_run_id: str, data: dict[str, Any]) -> Any:
+        raise NotImplementedError


### PR DESCRIPTION
## Problem

Fixes [EME-610](https://linear.app/getsentry/issue/EME-610)

When a preprod artifact is reprocessed, the status check task creates a **new** "Size Analysis" check run on the PR instead of updating the existing one. This results in multiple status checks appearing on the same commit, with old ones stuck showing "Processing...".

## Solution

Modified the status check system to search for existing check runs before creating new ones, and update them when found.

## Changes

### Core Logic
- **Added** `update_check_run()` method to GitHub client for PATCH requests to `/repos/{repo}/check-runs/{id}`
- **Added** `_find_existing_check_run()` helper that searches GitHub for existing check runs matching the commit SHA, check name, and external_id
- **Renamed** `create_status_check()` → `create_or_update_status_check()` to reflect new behavior
- **Enhanced** logic flow:
  1. Call `get_check_runs()` to list existing check runs for the commit
  2. Search for matching check run (by name "Size Analysis" AND external_id)
  3. If found → PATCH to update existing check run
  4. If not found → POST to create new check run
  5. Gracefully falls back to creating if search fails

## Behavior

### Before
```
Reprocess artifact → POST /check-runs → Duplicate check run created ❌
```

### After
```
Reprocess artifact → GET /commits/{sha}/check-runs → Search for existing
                  ↓                                   ↓
                  Found                              Not found
                  ↓                                   ↓
                  PATCH /check-runs/{id}             POST /check-runs
                  ↓                                   ↓
                  Update existing ✅                 Create new ✅
```