### PR TITLE
chore(llm-detector): Add limits to # of spans in trace

### DIFF
--- a/src/sentry/tasks/llm_issue_detection.py
+++ b/src/sentry/tasks/llm_issue_detection.py
@@ -30,6 +30,8 @@ SEER_TIMEOUT_S = 120
 SEER_RETRIES = 1
 
 NUM_TRANSACTIONS_TO_PROCESS = 10
+LOWER_SPAN_LIMIT = 20
+UPPER_SPAN_LIMIT = 500
 
 
 seer_issue_detection_connection_pool = connection_from_url(
@@ -193,7 +195,11 @@ def detect_llm_issues_for_project(project_id: int) -> None:
             trace: TraceData | None = get_trace_for_transaction(
                 transaction.name, transaction.project_id
             )
-            if not trace:
+            if (
+                not trace
+                or trace.total_spans < LOWER_SPAN_LIMIT
+                or trace.total_spans > UPPER_SPAN_LIMIT
+            ):
                 continue
 
             logger.info(

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -162,6 +162,7 @@ class LLMIssueDetectionTest(TestCase):
 
         mock_trace = Mock()
         mock_trace.trace_id = "trace-abc-123"
+        mock_trace.total_spans = 100
         mock_trace.dict.return_value = {
             "trace_id": "trace-abc-123",
             "spans": [{"op": "db.query", "duration": 1.5}],


### PR DESCRIPTION
this pr adds a limit to the # of spans in a trace that we will send in the LLM request - these are rough estimates of what would be useful (can easily update later). Anything less might not have enough information, anything more might have too much context and make it too difficult to find any real problems. 

fixes https://linear.app/getsentry/issue/ID-1081/limit-of-spans-in-trace