### PR TITLE
fix(crons): Make CheckInTimeline grid lines timezone-aware

### DIFF
--- a/static/app/components/checkInTimeline/checkInTooltip.spec.tsx
+++ b/static/app/components/checkInTimeline/checkInTooltip.spec.tsx
@@ -18,6 +18,7 @@ const tickConfig: TimeWindowConfig = {
     minimumMarkerInterval: 5,
   },
   timelineWidth: 1000,
+  timezone: 'UTC',
   dateTimeProps: {timeOnly: true},
   rollupConfig: {
     bucketPixels: 0,

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -55,8 +55,15 @@ function alignDateToBoundary(date: moment.Moment, minuteInterval: number) {
 }
 
 function getTimeMarkersFromConfig(config: TimeWindowConfig) {
-  const {periodStart, end, elapsedMinutes, intervals, dateTimeProps, timelineWidth} =
-    config;
+  const {
+    periodStart,
+    end,
+    elapsedMinutes,
+    intervals,
+    dateTimeProps,
+    timelineWidth,
+    timezone,
+  } = config;
 
   const {referenceMarkerInterval, minimumMarkerInterval, normalMarkerInterval} =
     intervals;
@@ -78,19 +85,26 @@ function getTimeMarkersFromConfig(config: TimeWindowConfig) {
 
   // The mark after the first mark will be aligned to a boundary to make it
   // easier to understand the rest of the marks
-  const currentMark = alignDateToBoundary(moment(periodStart), normalMarkerInterval);
+  const currentMark = alignDateToBoundary(
+    moment.tz(periodStart, timezone),
+    normalMarkerInterval
+  );
 
   // The first label is larger since we include the date, time, and timezone.
 
   while (
-    currentMark.isBefore(moment(periodStart).add(referenceMarkerInterval, 'minutes'))
+    currentMark.isBefore(
+      moment.tz(periodStart, timezone).add(referenceMarkerInterval, 'minutes')
+    )
   ) {
     currentMark.add(normalMarkerInterval, 'minute');
   }
 
   // Generate time markers which represent location of grid lines/time labels.
   // Stop adding markers once there's no more room for more markers
-  while (moment(currentMark).add(minimumMarkerInterval, 'minutes').isBefore(end)) {
+  while (
+    moment.tz(currentMark, timezone).add(minimumMarkerInterval, 'minutes').isBefore(end)
+  ) {
     const position =
       startOffset + (currentMark.valueOf() - periodStart.valueOf()) / msPerPixel;
     markers.push({date: currentMark.toDate(), position, dateTimeProps});
@@ -215,7 +229,8 @@ export function GridLineOverlay({
   resetPaginationOnZoom,
 }: GridLineOverlayProps) {
   const router = useRouter();
-  const {periodStart, timelineWidth, dateLabelFormat, rollupConfig} = timeWindowConfig;
+  const {periodStart, timelineWidth, dateLabelFormat, rollupConfig, timezone} =
+    timeWindowConfig;
   const {timelineUnderscanWidth} = rollupConfig;
 
   const msPerPixel = (timeWindowConfig.elapsedMinutes * 60 * 1000) / timelineWidth;
@@ -224,8 +239,11 @@ export function GridLineOverlay({
   // to the pixel value after the timelineUnderscanWidth.
   const dateFromPosition = useCallback(
     (position: number) =>
-      moment(periodStart.getTime() + msPerPixel * (position - timelineUnderscanWidth)),
-    [msPerPixel, periodStart, timelineUnderscanWidth]
+      moment.tz(
+        periodStart.getTime() + msPerPixel * (position - timelineUnderscanWidth),
+        timezone
+      ),
+    [msPerPixel, periodStart, timelineUnderscanWidth, timezone]
   );
 
   const makeCursorLabel = useCallback(

--- a/static/app/components/checkInTimeline/hooks/useTimeWindowConfig.tsx
+++ b/static/app/components/checkInTimeline/hooks/useTimeWindowConfig.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import {getConfigFromTimeRange} from 'sentry/components/checkInTimeline/utils/getConfigFromTimeRange';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 
 import {usePageFilterDates} from './useMonitorDates';
 
@@ -30,6 +31,7 @@ export function useTimeWindowConfig({
   recomputeOnWindowFocus,
   recomputeQueryKey,
 }: Options) {
+  const timezone = useTimezone();
   const {since, until} = usePageFilterDates({
     recomputeInterval,
     recomputeOnWindowFocus,
@@ -37,7 +39,7 @@ export function useTimeWindowConfig({
   });
 
   return useMemo(
-    () => getConfigFromTimeRange(since, until, timelineWidth),
-    [since, until, timelineWidth]
+    () => getConfigFromTimeRange(since, until, timelineWidth, timezone),
+    [since, until, timelineWidth, timezone]
   );
 }

--- a/static/app/components/checkInTimeline/types.tsx
+++ b/static/app/components/checkInTimeline/types.tsx
@@ -94,6 +94,10 @@ export interface TimeWindowConfig {
    * underscan. See the RollupConfig for more details.
    */
   timelineWidth: number;
+  /**
+   * The timezone to use for grid line calculations and date formatting
+   */
+  timezone: string;
 }
 
 interface StatusStyle {

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.spec.tsx
@@ -6,11 +6,12 @@ import {getConfigFromTimeRange} from './getConfigFromTimeRange';
 
 describe('getConfigFromTimeRange', () => {
   const timelineWidth = 800;
+  const timezone = 'UTC';
 
   it('divides into minutes for small intervals', () => {
     const start = new Date('2023-06-15T11:00:00Z');
     const end = new Date('2023-06-15T11:05:00Z');
-    const config = getConfigFromTimeRange(start, end, timelineWidth);
+    const config = getConfigFromTimeRange(start, end, timelineWidth, timezone);
     expect(config).toEqual({
       periodStart: start,
       start,
@@ -32,13 +33,14 @@ describe('getConfigFromTimeRange', () => {
       },
       dateTimeProps: {timeOnly: true},
       timelineWidth,
+      timezone,
     });
   });
 
   it('displays dates when more than 1 day window size', () => {
     const start = new Date('2023-06-15T11:00:00Z');
     const end = new Date('2023-06-16T11:05:00Z');
-    const config = getConfigFromTimeRange(start, end, timelineWidth);
+    const config = getConfigFromTimeRange(start, end, timelineWidth, timezone);
     expect(config).toEqual({
       periodStart: start,
       start: moment(start)
@@ -62,13 +64,14 @@ describe('getConfigFromTimeRange', () => {
       },
       dateTimeProps: {timeOnly: false},
       timelineWidth: 723,
+      timezone,
     });
   });
 
   it('divides into minutes without showing seconds for medium intervals', () => {
     const start = new Date('2023-06-15T08:00:00Z');
     const end = new Date('2023-06-15T23:00:00Z');
-    const config = getConfigFromTimeRange(start, end, timelineWidth);
+    const config = getConfigFromTimeRange(start, end, timelineWidth, timezone);
     expect(config).toEqual({
       periodStart: start,
       start: moment(start)
@@ -92,13 +95,14 @@ describe('getConfigFromTimeRange', () => {
       },
       dateTimeProps: {timeOnly: true},
       timelineWidth: 780,
+      timezone,
     });
   });
 
   it('divides into days for larger intervals', () => {
     const start = new Date('2023-05-15T11:00:00Z');
     const end = new Date('2023-06-15T11:00:00Z');
-    const config = getConfigFromTimeRange(start, end, timelineWidth);
+    const config = getConfigFromTimeRange(start, end, timelineWidth, timezone);
     expect(config).toEqual({
       periodStart: start,
       start: moment(start)
@@ -124,13 +128,14 @@ describe('getConfigFromTimeRange', () => {
       },
       dateTimeProps: {dateOnly: true},
       timelineWidth: 744,
+      timezone,
     });
   });
 
   it('Includes dates when the window spans days', () => {
     const start = new Date('2023-05-14T20:00:00Z');
     const end = new Date('2023-05-15T10:00:00Z');
-    const config = getConfigFromTimeRange(start, end, timelineWidth);
+    const config = getConfigFromTimeRange(start, end, timelineWidth, timezone);
     expect(config).toEqual({
       periodStart: start,
       start: moment(start)
@@ -155,6 +160,7 @@ describe('getConfigFromTimeRange', () => {
       },
       dateTimeProps: {timeOnly: false},
       timelineWidth: 784,
+      timezone,
     });
   });
 });

--- a/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
+++ b/static/app/components/checkInTimeline/utils/getConfigFromTimeRange.tsx
@@ -196,7 +196,8 @@ function computeRollup(elapsedSeconds: number, timelineWidth: number) {
 export function getConfigFromTimeRange(
   start: Date,
   end: Date,
-  containerWidth: number
+  containerWidth: number,
+  timezone: string
 ): TimeWindowConfig {
   const elapsedMinutes = (end.getTime() - start.getTime()) / (1000 * 60);
   const elapsedSeconds = elapsedMinutes * 60;
@@ -249,6 +250,7 @@ export function getConfigFromTimeRange(
       intervals: {...intervals, normalMarkerInterval: minutes},
       dateTimeProps: {timeOnly},
       dateLabelFormat: getFormat({timeOnly, seconds: displaySeconds}),
+      timezone,
     };
   }
 
@@ -265,5 +267,6 @@ export function getConfigFromTimeRange(
     intervals: {...intervals, normalMarkerInterval},
     dateTimeProps: {dateOnly: true},
     dateLabelFormat: getFormat(),
+    timezone,
   };
 }

--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -14,6 +14,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Overlay} from 'sentry/components/overlay';
 import Panel from 'sentry/components/panels/panel';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
@@ -55,8 +56,9 @@ export function CronTimelineSection({event, organization, project}: Props) {
   const {start, end} = getTimeRangeFromEvent(event, nowRef.current, timeWindow);
   const elementRef = useRef<HTMLDivElement>(null);
   const {width: timelineWidth} = useDimensions<HTMLDivElement>({elementRef});
+  const timezone = useTimezone();
 
-  const timeWindowConfig = getConfigFromTimeRange(start, end, timelineWidth);
+  const timeWindowConfig = getConfigFromTimeRange(start, end, timelineWidth, timezone);
 
   const {data: monitorStats, isPending} = useMonitorStats({
     timeWindowConfig,

--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
@@ -17,6 +17,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
 import Panel from 'sentry/components/panels/panel';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
@@ -112,14 +113,15 @@ export function UptimeDataSection({group, event, project}: Props) {
   const timelineWidth = useDebouncedValue(containerWidth, 500);
   const timeWindow = location.query?.timeWindow as TimeWindow;
   const {since, until} = usePageFilterDates();
+  const timezone = useTimezone();
 
   const timeWindowConfig = useMemo(() => {
     if (defined(timeWindow)) {
       const {start, end} = getTimeRangeFromEvent(event, now, timeWindow);
-      return getConfigFromTimeRange(start, end, timelineWidth);
+      return getConfigFromTimeRange(start, end, timelineWidth, timezone);
     }
-    return getConfigFromTimeRange(since, until, timelineWidth);
-  }, [timeWindow, timelineWidth, since, until, event, now]);
+    return getConfigFromTimeRange(since, until, timelineWidth, timezone);
+  }, [timeWindow, timelineWidth, since, until, event, now, timezone]);
 
   const {data: uptimeStats, isPending} = useUptimeMonitorStats({
     detectorIds: detectorId ? [String(detectorId)] : [],

--- a/static/app/views/insights/crons/components/mockTimelineVisualization.tsx
+++ b/static/app/views/insights/crons/components/mockTimelineVisualization.tsx
@@ -12,6 +12,7 @@ import FormContext from 'sentry/components/forms/formContext';
 import type {FieldValue} from 'sentry/components/forms/model';
 import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useDimensions} from 'sentry/utils/useDimensions';
@@ -28,7 +29,7 @@ interface ScheduleConfig {
   intervalFrequency?: FieldValue;
   intervalUnit?: FieldValue;
   scheduleType?: FieldValue;
-  timezone?: FieldValue;
+  timezone?: string;
 }
 
 const NUM_SAMPLE_TICKS = 9;
@@ -91,11 +92,16 @@ export function MockTimelineVisualization({schedule}: Props) {
     }
   }, [errorMessage, form, scheduleType]);
 
+  const userTimezone = useTimezone();
+  const selectedTimezone = timezone ?? userTimezone;
+
   const mockTimestamps = data?.map(ts => new Date(ts * 1000));
   const start = mockTimestamps?.[0];
   const end = mockTimestamps?.[mockTimestamps.length - 1];
   const timeWindowConfig =
-    start && end ? getConfigFromTimeRange(start, end, timelineWidth) : undefined;
+    start && end
+      ? getConfigFromTimeRange(start, end, timelineWidth, selectedTimezone)
+      : undefined;
 
   return (
     <TimelineContainer>

--- a/static/app/views/insights/crons/components/monitorCreateForm.tsx
+++ b/static/app/views/insights/crons/components/monitorCreateForm.tsx
@@ -222,10 +222,10 @@ export default function MonitorCreateForm() {
 
             const schedule = {
               scheduleType,
-              timezone,
               cronSchedule,
               intervalFrequency,
               intervalUnit,
+              timezone: typeof timezone === 'string' ? timezone : undefined,
             };
 
             return <MockTimelineVisualization schedule={schedule} />;

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.spec.tsx
@@ -25,7 +25,8 @@ jest
     getConfigFromTimeRange(
       startTime,
       new Date(startTime.getTime() + 1000 * 60 * 60),
-      1000
+      1000,
+      'UTC'
     )
   );
 

--- a/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.spec.tsx
@@ -24,7 +24,8 @@ jest
     getConfigFromTimeRange(
       startTime,
       new Date(startTime.getTime() + 1000 * 60 * 60),
-      1000
+      1000,
+      'UTC'
     )
   );
 

--- a/static/app/views/issueDetails/streamline/useIssueTimeWindowConfig.tsx
+++ b/static/app/views/issueDetails/streamline/useIssueTimeWindowConfig.tsx
@@ -3,6 +3,7 @@ import moment from 'moment-timezone';
 
 import {usePageFilterDates as useCronsPageFilterDates} from 'sentry/components/checkInTimeline/hooks/useMonitorDates';
 import {getConfigFromTimeRange} from 'sentry/components/checkInTimeline/utils/getConfigFromTimeRange';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import type {Group} from 'sentry/types/group';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -21,6 +22,7 @@ export function useIssueTimeWindowConfig({
   const location = useLocation();
   const {since: pageFilterSince, until: pageFilterUntil} = useCronsPageFilterDates();
   const defaultStatsPeriod = useGroupDefaultStatsPeriod(group, group.project);
+  const timezone = useTimezone();
 
   const hasSetStatsPeriod =
     location.query.statsPeriod || location.query.start || location.query.end;
@@ -38,7 +40,7 @@ export function useIssueTimeWindowConfig({
   }
 
   return useMemo(
-    () => getConfigFromTimeRange(since, until, timelineWidth),
-    [since, until, timelineWidth]
+    () => getConfigFromTimeRange(since, until, timelineWidth, timezone),
+    [since, until, timelineWidth, timezone]
   );
 }


### PR DESCRIPTION
Grid line positions and cursor labels were not updating when users changed their timezone display setting. The grid lines were being calculated using moment's default timezone (the user's configured timezone) while labels displayed the overridden timezone from TimezoneProvider, causing misalignment when timelines were rendered within a TimezoneProvider that overrode the timezone.

Changes:
- Add timezone parameter to TimeWindowConfig and getConfigFromTimeRange
- Update grid line boundary calculations to use timezone from useTimezone()
- Update cursor position calculations to respect timezone from useTimezone()
- Pass useTimezone() value through all callers of getConfigFromTimeRange
- Update all test files to pass timezone parameter

Now all date calculations (grid lines, cursor, labels) use the same timezone from useTimezone(), which correctly respects TimezoneProvider overrides.

Fixed [NEW-631: Check In Timeline grid lines do not move when changing timezones](https://linear.app/getsentry/issue/NEW-631/check-in-timeline-grid-lines-do-not-move-when-changing-timezones)