### PR TITLE
fix(cursor-integration): hide key value from toast

### DIFF
--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -131,6 +131,7 @@ class CursorAgentIntegration(CodingAgentIntegration):
                 "help": _("Update the API key used by Cursor Cloud Agents."),
                 "required": True,
                 "placeholder": "***********************",
+                "formatMessageValue": False,
             }
         ]
 


### PR DESCRIPTION
When we were changing the API key for Cursor Agent, we were showing the full key in the toast... this hides that.