### PR TITLE
feat(fixability): Remove fixability from run_automation function

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -378,31 +378,33 @@ def _generate_summary(
         trace_tree,
     )
 
-    # Generate fixability score and run automation
-    fixability_score = None
-    try:
-        with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
-            fixability_response = _generate_fixability_score(group)
-
-        if not fixability_response.scores:
-            raise ValueError("Issue summary scores is None or empty.")
-        if fixability_response.scores.fixability_score is None:
-            raise ValueError("Issue summary fixability score is None.")
-
-        fixability_score = fixability_response.scores.fixability_score
-        group.update(seer_fixability_score=fixability_score)
-    except Exception:
-        logger.exception(
-            "Error generating fixability score for issue summary", extra={"group_id": group.id}
-        )
-
-    if fixability_score is not None:
+    # Only generate fixability score and run automation for post-process flows
+    # Don't do this for user-requested summaries from issue details page
+    if source == SeerAutomationSource.POST_PROCESS:
+        fixability_score = None
         try:
-            _run_automation(group, user, event, source, fixability_score)
+            with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
+                fixability_response = _generate_fixability_score(group)
+
+            if not fixability_response.scores:
+                raise ValueError("Issue summary scores is None or empty.")
+            if fixability_response.scores.fixability_score is None:
+                raise ValueError("Issue summary fixability score is None.")
+
+            fixability_score = fixability_response.scores.fixability_score
+            group.update(seer_fixability_score=fixability_score)
         except Exception:
             logger.exception(
-                "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}
+                "Error generating fixability score for issue summary", extra={"group_id": group.id}
             )
+
+        if fixability_score is not None:
+            try:
+                _run_automation(group, user, event, source, fixability_score)
+            except Exception:
+                logger.exception(
+                    "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}
+                )
 
     summary_dict = issue_summary.dict()
     summary_dict["event_id"] = event.event_id

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -285,6 +285,7 @@ def _run_automation(
     user: User | RpcUser | AnonymousUser,
     event: GroupEvent,
     source: SeerAutomationSource,
+    fixability_score: float,
 ) -> None:
     if source == SeerAutomationSource.ISSUE_DETAILS:
         return
@@ -303,18 +304,8 @@ def _run_automation(
         }
     )
 
-    with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
-        issue_summary = _generate_fixability_score(group)
-
-    if not issue_summary.scores:
-        raise ValueError("Issue summary scores is None or empty.")
-    if issue_summary.scores.fixability_score is None:
-        raise ValueError("Issue summary fixability score is None.")
-
-    group.update(seer_fixability_score=issue_summary.scores.fixability_score)
-
     if (
-        not _is_issue_fixable(group, issue_summary.scores.fixability_score)
+        not _is_issue_fixable(group, fixability_score)
         and not group.issue_type.always_trigger_seer_automation
     ):
         return
@@ -336,9 +327,7 @@ def _run_automation(
 
     stopping_point = None
     if features.has("projects:triage-signals-v0", group.project):
-        fixability_stopping_point = _get_stopping_point_from_fixability(
-            issue_summary.scores.fixability_score
-        )
+        fixability_stopping_point = _get_stopping_point_from_fixability(fixability_score)
         logger.info("Fixability-based stopping point: %s", fixability_stopping_point)
 
         # Fetch user preference and apply as upper bound
@@ -389,8 +378,20 @@ def _generate_summary(
         trace_tree,
     )
 
+    # Generate fixability score and run automation
+    with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
+        fixability_response = _generate_fixability_score(group)
+
+    if not fixability_response.scores:
+        raise ValueError("Issue summary scores is None or empty.")
+    if fixability_response.scores.fixability_score is None:
+        raise ValueError("Issue summary fixability score is None.")
+
+    fixability_score = fixability_response.scores.fixability_score
+    group.update(seer_fixability_score=fixability_score)
+
     try:
-        _run_automation(group, user, event, source)
+        _run_automation(group, user, event, source, fixability_score)
     except Exception:
         logger.exception(
             "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -683,8 +683,10 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         # Make _run_automation raise an exception
         mock_run_automation.side_effect = Exception("Automation failed")
 
-        # Call get_issue_summary and verify it still returns successfully
-        summary_data, status_code = get_issue_summary(self.group, self.user)
+        # Call get_issue_summary with POST_PROCESS source to trigger automation
+        summary_data, status_code = get_issue_summary(
+            self.group, self.user, source=SeerAutomationSource.POST_PROCESS
+        )
 
         assert status_code == 200
         expected_response = mock_summary.dict()


### PR DESCRIPTION
## PR Details 
+ To implement, fixability + event count based automation triggers we have to stop using issue summary as an automation trigger. This is first PR (probably 1 of 3) in that direction.
+ There is no logic change in this P. It just takes generate_fixability out of run_automation and ties it with issue summary. 
+ Also tbh implementing would just be good in terms of code separation. 
+ More details: https://www.notion.so/sentry/Triage-Signals-Sync-2aa8b10e4b5d809c8c49f321c0236dea?source=copy_link#2aa8b10e4b5d803787c1e93dd0c5b0dd
