### PR TITLE
ref(mcp-insights): Simplify MCP onboarding

### DIFF
--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -580,14 +580,7 @@ Sentry.init({
     const manualContent: ContentBlock[] = [
       {
         type: 'text',
-        text: tct(
-          'If you are not using a supported SDK integration, you can instrument your AI calls manually. See [link:manual instrumentation docs] for details.',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/node/tracing/instrumentation/ai-agents-module/#manual-instrumentation" />
-            ),
-          }
-        ),
+        text: t('Initialize the Sentry SDK in the entry point of your application.'),
       },
       {
         type: 'code',
@@ -597,23 +590,23 @@ Sentry.init({
             language: 'javascript',
             code: `${getImport(packageName).join('\n')}
 
-// Create a span around your AI call
-await Sentry.startSpan({
-  op: "gen_ai.chat",
-  name: "chat gpt-4o",
-  attributes: {
-    "gen_ai.operation.name": "chat",
-    "gen_ai.request.model": "gpt-4o",
-  }
-}, async (span) => {
-  // Call your AI function here
-  // e.g., await generateText(...)
-
-  // Set further span attributes after the AI call
-  span.setAttribute("gen_ai.response.text", "<Your model's response>");
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  tracesSampleRate: 1.0,
 });`,
           },
         ],
+      },
+      {
+        type: 'text',
+        text: tct(
+          'Then follow the [link:manual instrumentation guide] to instrument your AI calls.',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/node/tracing/instrumentation/ai-agents-module/#manual-instrumentation" />
+            ),
+          }
+        ),
       },
     ];
 

--- a/static/app/gettingStartedDocs/python/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/python/agentMonitoring.tsx
@@ -297,21 +297,28 @@ sentry_sdk.init(
       content: [
         {
           type: 'text',
-          text: tct(
-            'If you are not using a supported SDK integration, you can instrument your AI calls manually. See [link:manual instrumentation docs] for details.',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
-              ),
-            }
-          ),
+          text: t('Initialize the Sentry SDK in the entry point of your application.'),
         },
         {
           type: 'code',
           language: 'python',
           code: `import sentry_sdk
 
-sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)`,
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    traces_sample_rate=1.0,
+)`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Then follow the [link:manual instrumentation guide] to instrument your AI calls.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
+              ),
+            }
+          ),
         },
       ],
     };
@@ -676,32 +683,8 @@ print(result.data)
         {
           type: 'text',
           text: t(
-            'Verify that agent monitoring is working correctly by running your manually instrumented code:'
+            'Verify that agent monitoring is working correctly by running your manually instrumented.'
           ),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-import json
-import sentry_sdk
-
-# Invoke Agent span
-with sentry_sdk.start_span(op="gen_ai.invoke_agent", name="invoke_agent Weather Agent") as span:
-    span.set_data("gen_ai.operation.name", "invoke_agent")
-    span.set_data("gen_ai.system", "openai")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.agent.name", "Weather Agent")
-    span.set_data("gen_ai.response.text", json.dumps(["Hello World"]))
-
-# AI Client span
-with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
-    span.set_data("gen_ai.operation.name", "chat")
-    span.set_data("gen_ai.system", "openai")
-    span.set_data("gen_ai.request.model", "o3-mini")
-    span.set_data("gen_ai.request.message", json.dumps([{"role": "user", "content": "Tell me a joke"}]))
-    span.set_data("gen_ai.response.text", json.dumps(["joke..."]))
-`,
         },
       ],
     };

--- a/static/app/gettingStartedDocs/python/mcp.tsx
+++ b/static/app/gettingStartedDocs/python/mcp.tsx
@@ -1,14 +1,16 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
 import type {
   OnboardingConfig,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 
 import {getPythonInstallCodeBlock} from './utils';
 
 export const mcp: OnboardingConfig = {
-  install: () => {
+  install: params => {
     const packageName = 'sentry-sdk';
 
     return [
@@ -17,9 +19,20 @@ export const mcp: OnboardingConfig = {
         content: [
           {
             type: 'text',
-            text: t(
-              'To enable MCP monitoring, you need to install the Sentry SDK with a minimum version of 2.43.0 or higher.'
-            ),
+            text:
+              params.platformOptions?.integration === 'mcp_sdk'
+                ? tct(
+                    'To enable MCP monitoring for the [code:fastmcp] and [code:mcp] packages, you need to install the Sentry SDK with a minimum version of [code:2.43.0] or higher.',
+                    {
+                      code: <code />,
+                    }
+                  )
+                : tct(
+                    'To enable MCP monitoring, you need to install the Sentry SDK with a minimum version of [code:2.43.0] or higher.',
+                    {
+                      code: <code />,
+                    }
+                  ),
           },
           getPythonInstallCodeBlock({packageName}),
         ],
@@ -27,7 +40,7 @@ export const mcp: OnboardingConfig = {
     ];
   },
   configure: params => {
-    const mcpLowLevelStep: OnboardingStep = {
+    const mcpSdkStep: OnboardingStep = {
       type: StepType.CONFIGURE,
       content: [
         {
@@ -51,95 +64,6 @@ sentry_sdk.init(
         MCPIntegration(),
     ],
 )`,
-        },
-        {
-          type: 'text',
-          text: t('Set up your Low-level MCP server:'),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-from mcp.server.lowlevel import Server
-from mcp.types import Tool, TextContent
-
-server = Server("mcp-server")
-
-@server.list_tools()
-async def list_tools() -> list[Tool]:
-    """List all available tools."""
-    return [
-        Tool(
-            name="calculate_sum",
-            description="Add two numbers together",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "a": {"type": "number", "description": "First number"},
-                    "b": {"type": "number", "description": "Second number"},
-                },
-                "required": ["a", "b"],
-            },
-        )
-    ]
-@server.call_tool()
-async def call_tool(name: str, arguments) -> list[TextContent]:
-    """Handle tool execution based on tool name."""
-
-    if name == "calculate_sum":
-        a = arguments.get("a", 0)
-        b = arguments.get("b", 0)
-        result = a + b
-        return [TextContent(type="text", text=f"The sum of {a} and {b} is {result}")]
-
-`,
-        },
-      ],
-    };
-
-    const mcpFastMcpStep: OnboardingStep = {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: t('Configure Sentry for MCP low-level monitoring:'),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-import sentry_sdk
-from sentry_sdk.integrations.mcp import MCPIntegration
-
-sentry_sdk.init(
-    dsn="${params.dsn.public}",
-    traces_sample_rate=1.0,
-    # Add data like inputs and responses to/from MCP servers;
-    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    send_default_pii=True,
-    integrations=[
-        MCPIntegration(),
-    ],
-)`,
-        },
-        {
-          type: 'text',
-          text: t('Set up your FastMCP server:'),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-from mcp.server.fastmcp import FastMCP
-# from fastmcp import FastMCP if you are using the standalone version
-
-mcp = FastMCP("mcp-server")
-
-@mcp.tool()
-async def calculate_sum(a: int, b: int) -> int:
-    """Add two numbers together."""
-    return a + b
-`,
         },
       ],
     };
@@ -149,7 +73,7 @@ async def calculate_sum(a: int, b: int) -> int:
       content: [
         {
           type: 'text',
-          text: t('Configure Sentry for manual MCP instrumentation:'),
+          text: t('Initialize the Sentry SDK in the entry point of your application:'),
         },
         {
           type: 'code',
@@ -163,20 +87,31 @@ sentry_sdk.init(
 )
 `,
         },
+        {
+          type: 'text',
+          text: tct(
+            'Then follow the [link:manual instrumentation guide] to instrument your MCP server.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/mcp-module/#manual-instrumentation" />
+              ),
+            }
+          ),
+        },
       ],
     };
 
-    const selected = (params.platformOptions as any)?.integration ?? 'mcp_fastmcp';
-    if (selected === 'mcp_fastmcp') {
-      return [mcpFastMcpStep];
+    const selected = (params.platformOptions as any)?.integration ?? 'mcp_sdk';
+    if (selected === 'mcp_sdk') {
+      return [mcpSdkStep];
     }
     if (selected === 'manual') {
       return [manualStep];
     }
-    return [mcpLowLevelStep];
+    return [mcpSdkStep];
   },
-  verify: params => {
-    const mcpVerifyStep: OnboardingStep = {
+  verify: () => [
+    {
       type: StepType.VERIFY,
       content: [
         {
@@ -186,43 +121,7 @@ sentry_sdk.init(
           ),
         },
       ],
-    };
-
-    const manualVerifyStep: OnboardingStep = {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            'Verify that MCP monitoring is working correctly by running your manually instrumented code:'
-          ),
-        },
-        {
-          type: 'code',
-          language: 'python',
-          code: `
-import json
-import sentry_sdk
-
-# Invoke Agent span
-with sentry_sdk.start_span(op="mcp.server", name="tools/call calculate_sum") as span:
-    span.set_data("mcp.method.name", "tools/call")
-    span.set_data("mcp.request.argument.a", "1")
-    span.set_data("mcp.request.argument.b", "2")
-    span.set_data("mcp.request.id", 123)
-    span.set_data("mcp.session.id", "c6d1c6a4c35843d5bdf0f9d88d11c183")
-    span.set_data("mcp.tool.name", "calculate_sum")
-    span.set_data("mcp.tool.result.content_count", 1)
-    span.set_data("mcp.transport", "stdio")
-`,
-        },
-      ],
-    };
-    const selected = (params.platformOptions as any)?.integration ?? 'mcp_fastmcp';
-    if (selected === 'manual') {
-      return [manualVerifyStep];
-    }
-    return [mcpVerifyStep];
-  },
+    },
+  ],
   nextSteps: () => [],
 };

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -223,7 +223,7 @@ export function Onboarding() {
             {label: 'LangGraph', value: 'langgraph'},
             {label: 'LiteLLM', value: 'litellm'},
             {label: 'Pydantic AI', value: 'pydantic_ai'},
-            {label: 'Manual', value: 'manual'},
+            {label: 'Other', value: 'manual'},
           ]
         : [
             {label: 'Vercel AI SDK', value: 'vercel_ai'},
@@ -232,7 +232,7 @@ export function Onboarding() {
             {label: 'Google Gen AI SDK', value: 'google_genai'},
             {label: 'LangChain', value: 'langchain'},
             {label: 'LangGraph', value: 'langgraph'},
-            {label: 'Manual', value: 'manual'},
+            {label: 'Other', value: 'manual'},
           ],
     },
   };

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -217,9 +217,8 @@ export function Onboarding() {
       label: t('Integration'),
       items: isPythonPlatform
         ? [
-            {label: 'FastMCP', value: 'mcp_fastmcp'},
-            {label: 'Low-level', value: 'mcp_lowlevel'},
-            {label: 'Manual', value: 'manual'},
+            {label: 'FastMCP / MCP SDK', value: 'mcp_sdk'},
+            {label: 'Other', value: 'manual'},
           ]
         : [{label: 'MCP SDK', value: 'mcp_sdk'}],
     },


### PR DESCRIPTION
Merge MCP onboarding infos for FastMcp and the MCP SDK into one to reduce the choices the user has to make. They are either way using the same SDK integration.
Rename `Manual` to `Other` as it fits the context better.
Streamline manual instructions in agent and mcp monitoring.
Reduce content for manual instructions and link to the docs.

**Note:** We are still missing manual instrumentation docs content for MCP on node. I created a follow-up ticket for this.

### Fast MCP / MCP SDK
<img width="676" height="294" alt="Screenshot 2025-11-13 at 19 19 31" src="https://github.com/user-attachments/assets/17a4960b-ccf9-4fa2-982e-7c2a6629eca3" />
<img width="683" height="385" alt="Screenshot 2025-11-13 at 19 33 06" src="https://github.com/user-attachments/assets/b5531274-c0b4-43a5-8b51-1ca348c30576" />


### Manual instrumentation
Streamlined to a simple init snippet + link to docs.
<img width="676" height="296" alt="Screenshot 2025-11-13 at 19 19 07" src="https://github.com/user-attachments/assets/5ab075f6-f17b-4228-ac7e-4c54017c7852" />
