### PR TITLE
ref(crons): Implement bidirectional dual-write for Monitor.is_muted (stage 1)

### DIFF
--- a/src/sentry/monitors/endpoints/base_monitor_environment_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_environment_details.py
@@ -22,6 +22,8 @@ class MonitorEnvironmentDetailsMixin(BaseEndpointMixin):
         is_muted = request.data.get("isMuted")
         if type(is_muted) is bool:
             monitor_environment.update(is_muted=is_muted)
+            # Dual-write: Sync is_muted back to monitor if all environments are muted
+            monitor.ensure_is_muted()
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -243,6 +243,8 @@ def detect_broken_monitor_envs_for_org(org_id: int):
             with transaction.atomic(router.db_for_write(MonitorEnvBrokenDetection)):
                 open_incident.monitor_environment.update(is_muted=True)
                 detection.update(env_muted_timestamp=django_timezone.now())
+                # Dual-write: Sync is_muted back to monitor if all environments are muted
+                open_incident.monitor.ensure_is_muted()
 
             for email in get_user_emails_from_monitor(open_incident.monitor, project):
                 if not email:

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -469,6 +469,12 @@ class MonitorValidator(CamelSnakeSerializer):
                 data=instance.get_audit_log_data(),
             )
 
+        # Dual-write is_muted to all monitor environments when changed
+        if "is_muted" in params:
+            MonitorEnvironment.objects.filter(monitor_id=instance.id).update(
+                is_muted=params["is_muted"]
+            )
+
         # Update monitor slug in billing
         if "slug" in params:
             quotas.backend.update_monitor_slug(existing_slug, params["slug"], instance.project_id)

--- a/tests/sentry/monitors/endpoints/test_base_monitor_environment_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_environment_details.py
@@ -64,6 +64,75 @@ class BaseUpdateMonitorEnvironmentTest(MonitorTestCase):
         monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
         assert monitor_environment.status == MonitorStatus.ACTIVE
 
+    def test_muting_all_environments_mutes_monitor(self) -> None:
+        """Test that muting all environments also mutes the monitor."""
+        monitor = self._create_monitor(status=MonitorStatus.ACTIVE)
+        env1 = self._create_monitor_environment(monitor, name="production")
+        env2 = self._create_monitor_environment(monitor, name="staging")
+
+        # Initially monitor should be unmuted
+        monitor.refresh_from_db()
+        assert monitor.is_muted is False
+
+        # Mute first environment
+        self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            env1.get_environment().name,
+            method="PUT",
+            **{"isMuted": True},
+        )
+
+        # Monitor should still be unmuted (one environment is unmuted)
+        monitor.refresh_from_db()
+        assert monitor.is_muted is False
+
+        # Mute second environment
+        self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            env2.get_environment().name,
+            method="PUT",
+            **{"isMuted": True},
+        )
+
+        # Now monitor should be muted (all environments are muted)
+        monitor.refresh_from_db()
+        assert monitor.is_muted is True
+
+    def test_unmuting_one_environment_unmutes_monitor(self) -> None:
+        """Test that unmuting one environment when all were muted also unmutes the monitor."""
+        # Start with a muted monitor
+        monitor = self._create_monitor(status=MonitorStatus.ACTIVE)
+        monitor.update(is_muted=True)
+
+        # Create two muted environments
+        env1 = self._create_monitor_environment(monitor, name="production")
+        env1.update(is_muted=True)
+        env2 = self._create_monitor_environment(monitor, name="staging")
+        env2.update(is_muted=True)
+
+        # Verify initial state
+        monitor.refresh_from_db()
+        assert monitor.is_muted is True
+
+        # Unmute one environment via the endpoint
+        self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            env1.get_environment().name,
+            method="PUT",
+            **{"isMuted": False},
+        )
+
+        # Monitor should now be unmuted
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.is_muted is False
+        env1.refresh_from_db()
+        assert env1.is_muted is False
+        env2.refresh_from_db()
+        assert env2.is_muted is True
+
 
 class BaseDeleteMonitorTest(MonitorTestCase):
     __test__ = False

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -313,6 +313,40 @@ class MonitorEnvironmentTestCase(TestCase):
         assert fingerprint1 == f"crons:{monitor_env1.id}"
         assert fingerprint2 == f"crons:{monitor_env2.id}"
 
+    def test_ensure_environment_inherits_muted_state(self):
+        """Test that new environments inherit is_muted from their monitor."""
+        # Test with muted monitor
+        muted_monitor = self.create_monitor(is_muted=True)
+        muted_env = MonitorEnvironment.objects.ensure_environment(
+            self.project, muted_monitor, "production"
+        )
+        assert muted_env.is_muted is True
+
+        # Test with unmuted monitor
+        unmuted_monitor = self.create_monitor(is_muted=False)
+        unmuted_env = MonitorEnvironment.objects.ensure_environment(
+            self.project, unmuted_monitor, "staging"
+        )
+        assert unmuted_env.is_muted is False
+
+    def test_ensure_environment_does_not_override_existing(self):
+        """Test that ensure_environment doesn't override existing environment's is_muted."""
+        monitor = self.create_monitor(is_muted=True)
+
+        # Create an environment with is_muted=False
+        existing_env = self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=self.environment.id,
+            is_muted=False,
+        )
+
+        # Call ensure_environment again - should return existing
+        env = MonitorEnvironment.objects.ensure_environment(
+            self.project, monitor, self.environment.name
+        )
+        assert env.id == existing_env.id
+        assert env.is_muted is False  # Should not be overridden
+
 
 class CronMonitorDataSourceHandlerTest(TestCase):
     def setUp(self) -> None:
@@ -402,3 +436,160 @@ class CronMonitorDataSourceHandlerTest(TestCase):
     def test_get_current_instance_count(self) -> None:
         with pytest.raises(NotImplementedError):
             CronMonitorDataSourceHandler.get_current_instance_count(self.organization)
+
+
+class MonitorEnsureIsMutedTestCase(TestCase):
+    """Test the ensure_is_muted() dual-write logic for Monitor."""
+
+    def test_ensure_is_muted_all_environments_muted(self):
+        """Test that monitor becomes muted when all environments are muted."""
+        monitor = self.create_monitor(is_muted=False)
+        env1 = self.create_environment(name="production")
+        env2 = self.create_environment(name="staging")
+
+        # Create two muted environments
+        self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env1.id,
+            is_muted=True,
+        )
+        self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env2.id,
+            is_muted=True,
+        )
+
+        # Call ensure_is_muted
+        monitor.ensure_is_muted()
+
+        # Verify monitor is now muted
+        monitor.refresh_from_db()
+        assert monitor.is_muted is True
+
+    def test_ensure_is_muted_some_environments_unmuted(self):
+        """Test that monitor becomes unmuted when any environment is unmuted."""
+        monitor = self.create_monitor(is_muted=True)
+        env1 = self.create_environment(name="production")
+        env2 = self.create_environment(name="staging")
+
+        # Create one muted and one unmuted environment
+        self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env1.id,
+            is_muted=True,
+        )
+        self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env2.id,
+            is_muted=False,
+        )
+
+        # Call ensure_is_muted
+        monitor.ensure_is_muted()
+
+        # Verify monitor is now unmuted
+        monitor.refresh_from_db()
+        assert monitor.is_muted is False
+
+    def test_ensure_is_muted_all_environments_unmuted(self):
+        """Test that monitor becomes unmuted when all environments are unmuted."""
+        monitor = self.create_monitor(is_muted=True)
+        env1 = self.create_environment(name="production")
+        env2 = self.create_environment(name="staging")
+
+        # Create two unmuted environments
+        self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env1.id,
+            is_muted=False,
+        )
+        self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env2.id,
+            is_muted=False,
+        )
+
+        # Call ensure_is_muted
+        monitor.ensure_is_muted()
+
+        # Verify monitor is unmuted
+        monitor.refresh_from_db()
+        assert monitor.is_muted is False
+
+    def test_ensure_is_muted_no_environments(self):
+        """Test that monitor is_muted remains unchanged when there are no environments."""
+        monitor = self.create_monitor(is_muted=True)
+
+        # Call ensure_is_muted with no environments
+        monitor.ensure_is_muted()
+
+        # Verify monitor is_muted is unchanged
+        monitor.refresh_from_db()
+        assert monitor.is_muted is True
+
+        # Also test with an unmuted monitor
+        monitor2 = self.create_monitor(is_muted=False)
+        monitor2.ensure_is_muted()
+        monitor2.refresh_from_db()
+        assert monitor2.is_muted is False
+
+    def test_ensure_is_muted_single_environment(self):
+        """Test ensure_is_muted works correctly with a single environment."""
+        # Test with muted environment
+        monitor = self.create_monitor(is_muted=False)
+        env = self.create_environment(name="production")
+        self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env.id,
+            is_muted=True,
+        )
+
+        monitor.ensure_is_muted()
+        monitor.refresh_from_db()
+        assert monitor.is_muted is True
+
+        # Test with unmuted environment
+        monitor2 = self.create_monitor(is_muted=True)
+        env2 = self.create_environment(name="staging")
+        self.create_monitor_environment(
+            monitor=monitor2,
+            environment_id=env2.id,
+            is_muted=False,
+        )
+
+        monitor2.ensure_is_muted()
+        monitor2.refresh_from_db()
+        assert monitor2.is_muted is False
+
+    def test_ensure_is_muted_unmuting_one_environment_unmutes_monitor(self):
+        """Test that unmuting one environment when all were muted also unmutes the monitor."""
+        # Start with monitor and all environments muted
+        monitor = self.create_monitor(is_muted=True)
+        env1 = self.create_environment(name="production")
+        env2 = self.create_environment(name="staging")
+
+        monitor_env1 = self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env1.id,
+            is_muted=True,
+        )
+        monitor_env2 = self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env2.id,
+            is_muted=True,
+        )
+
+        # Verify initial state - all muted
+        assert monitor.is_muted is True
+        assert monitor_env1.is_muted is True
+        assert monitor_env2.is_muted is True
+
+        # Unmute one environment
+        monitor_env1.update(is_muted=False)
+
+        # Call ensure_is_muted
+        monitor.ensure_is_muted()
+
+        # Verify monitor is now unmuted
+        monitor.refresh_from_db()
+        assert monitor.is_muted is False


### PR DESCRIPTION
Implements Step 1 of the migration plan from [NEW-564: There needs to be some way to mute the entire cron detector](https://linear.app/getsentry/issue/NEW-564/there-needs-to-be-some-way-to-mute-the-entire-cron-detector)

This change establishes bidirectional dual-writing between Monitor.is_muted and MonitorEnvironment.is_muted:

**Forward propagation (Monitor → Environments):**
- When Monitor.is_muted changes via the validator, all associated
  MonitorEnvironments are updated to match

**Reverse propagation (Environments → Monitor):**
- Added Monitor.ensure_is_muted() method that syncs is_muted from environments back to the monitor
- Monitor becomes muted when ALL environments are muted
- Monitor becomes unmuted when ANY environment is unmuted
- Called after environment mute/unmute in API endpoint and auto-mute task

**New environment inheritance:**
- New MonitorEnvironments inherit is_muted from their parent Monitor

Changes:
- src/sentry/monitors/validators.py: Added dual-write in update()
- src/sentry/monitors/models.py: Added ensure_is_muted() and inheritance
- src/sentry/monitors/endpoints/base_monitor_environment_details.py: Call ensure_is_muted()
- src/sentry/monitors/tasks/detect_broken_monitor_envs.py: Call ensure_is_muted()

Tests added (12 total):
- Forward propagation tests in test_validators.py
- Reverse propagation unit tests in test_models.py
- New environment inheritance tests in test_models.py
- Integration tests via API endpoints in test_base_monitor_environment_details.py