### PR TITLE
feat(ACI): Delete data in Seer when dynamic detector type is changed

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -303,50 +303,38 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
             ),
         )
 
-    def update_anomaly_detection(self, instance: Detector, validated_data: dict[str, Any]) -> None:
+    def update_anomaly_detection(self, instance: Detector, validated_data: dict[str, Any]) -> bool:
         """
         When data changes on a detector we may need to tell Seer to update or remove their data for the detector
         """
-        if (
-            not instance.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC
-            and validated_data.get("config", {}).get("detection_type")
-            == AlertRuleDetectionType.DYNAMIC
-        ):
-            # Detector has been changed to become a dynamic detector
-            try:
-                update_detector_data(instance, validated_data)
-            except Exception:
-                # Don't update if we failed to send data to Seer
-                raise serializers.ValidationError(
-                    "Failed to send data to Seer, cannot update detector"
-                )
-
-        elif (
-            instance.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC
-            and validated_data.get("config", {}).get("detection_type")
-            != AlertRuleDetectionType.DYNAMIC
-        ):
-            # Detector has been changed from a dynamic detector to another type
-            delete_data_in_seer_for_detector(instance)
-        
-    def update(self, instance: Detector, validated_data: dict[str, Any]):
         seer_updated = False
-        # Handle anomaly detection changes first in case we need to exit before saving
-        if (
-            not instance.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC
-            and validated_data.get("config", {}).get("detection_type")
-            == AlertRuleDetectionType.DYNAMIC
-        ):
+        is_currently_dynamic_detector = (
+            instance.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC
+        )
+        is_update_dynamic_detector = (
+            validated_data.get("config", {}).get("detection_type") == AlertRuleDetectionType.DYNAMIC
+        )
+
+        if not is_currently_dynamic_detector and is_update_dynamic_detector:
             # Detector has been changed to become a dynamic detector
             try:
                 update_detector_data(instance, validated_data)
                 seer_updated = True
-
             except Exception:
                 # Don't update if we failed to send data to Seer
                 raise serializers.ValidationError(
                     "Failed to send data to Seer, cannot update detector"
                 )
+
+        elif is_currently_dynamic_detector and not is_update_dynamic_detector:
+            # Detector has been changed from a dynamic detector to another type
+            delete_data_in_seer_for_detector(instance)
+
+        return seer_updated
+
+    def update(self, instance: Detector, validated_data: dict[str, Any]):
+        # Handle anomaly detection changes first in case we need to exit before saving so that the instance values do not get updated
+        seer_updated = self.update_anomaly_detection(instance, validated_data)
 
         super().update(instance, validated_data)
 

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -314,7 +314,6 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
         is_update_dynamic_detector = (
             validated_data.get("config", {}).get("detection_type") == AlertRuleDetectionType.DYNAMIC
         )
-
         if not is_currently_dynamic_detector and is_update_dynamic_detector:
             # Detector has been changed to become a dynamic detector
             try:
@@ -326,7 +325,11 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                     "Failed to send data to Seer, cannot update detector"
                 )
 
-        elif is_currently_dynamic_detector and not is_update_dynamic_detector:
+        elif (
+            validated_data.get("config")
+            and is_currently_dynamic_detector
+            and not is_update_dynamic_detector
+        ):
             # Detector has been changed from a dynamic detector to another type
             delete_data_in_seer_for_detector(instance)
 

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -643,6 +643,47 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         updated_detector = update_validator.save()
         assert updated_detector.name == new_name
 
+    @mock.patch("sentry.seer.anomaly_detection.delete_rule.delete_rule_in_seer")
+    @mock.patch(
+        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
+    def test_update_anomaly_detection_to_static(
+        self,
+        mock_audit: mock.MagicMock,
+        mock_seer_store_request: mock.MagicMock,
+        mock_seer_delete_request: mock.MagicMock,
+    ) -> None:
+        """
+        Test that if a dynamic detector is changed to become a static one
+        we tell Seer to delete the data for that detector
+        """
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
+        mock_seer_delete_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
+
+        dynamic_detector = self.create_dynamic_detector()
+
+        # Verify detector in DB
+        self.assert_validated(dynamic_detector)
+
+        assert mock_seer_store_request.call_count == 1
+
+        update_validator = MetricIssueDetectorValidator(
+            instance=dynamic_detector,
+            data=self.valid_data,
+            context=self.context,
+            partial=True,
+        )
+        assert update_validator.is_valid(), update_validator.errors
+        update_validator.save()
+
+        assert mock_seer_delete_request.call_count == 1
+
     @mock.patch(
         "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
     )

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -190,8 +190,8 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
                 ],
             },
             "config": {
-                "threshold_period": 1,
-                "detection_type": AlertRuleDetectionType.DYNAMIC.value,
+                "thresholdPeriod": 1,
+                "detectionType": AlertRuleDetectionType.DYNAMIC.value,
             },
         }
 
@@ -870,6 +870,81 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         dynamic_detector = update_validator.save()
 
         assert mock_seer_request.call_count == 1
+
+        # Verify snuba query changes
+        data_source = DataSource.objects.get(detector=dynamic_detector)
+        query_subscription = QuerySubscription.objects.get(id=data_source.source_id)
+        snuba_query = SnubaQuery.objects.get(id=query_subscription.snuba_query_id)
+        assert snuba_query.aggregate == "count_unique(tags[sentry:user])"
+
+        mock_audit.assert_called_once_with(
+            request=self.context["request"],
+            organization=self.project.organization,
+            target_object=dynamic_detector.id,
+            event=audit_log.get_event_id("DETECTOR_EDIT"),
+            data=dynamic_detector.get_audit_log_data(),
+        )
+
+    @mock.patch("sentry.seer.anomaly_detection.delete_rule.delete_rule_in_seer")
+    @mock.patch(
+        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
+    def test_update_anomaly_detection_no_config(
+        self,
+        mock_audit: mock.MagicMock,
+        mock_seer_request: mock.MagicMock,
+        mock_seer_delete_request: mock.MagicMock,
+    ) -> None:
+        """
+        Test that when we update the snuba query aggregate in dataSources ONLY (not passing other data) it works as expected
+        """
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+
+        detector = self.create_dynamic_detector()
+
+        # Verify detector in DB
+        self.assert_validated(detector)
+
+        assert mock_seer_request.call_count == 1
+        mock_seer_request.reset_mock()
+
+        # Verify audit log
+        mock_audit.assert_called_once_with(
+            request=self.context["request"],
+            organization=self.project.organization,
+            target_object=detector.id,
+            event=audit_log.get_event_id("DETECTOR_ADD"),
+            data=detector.get_audit_log_data(),
+        )
+        mock_audit.reset_mock()
+
+        # Change the aggregate which should call Seer
+        updated_aggregate = "count_unique(user)"
+        update_data = {
+            "dataSources": [
+                {
+                    # note we are NOT passing **self.valid_anomaly_detection_data
+                    "queryType": SnubaQuery.Type.ERROR.value,
+                    "dataset": Dataset.Events.value,
+                    "query": "updated_query",
+                    "aggregate": updated_aggregate,  # this is what's changing
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                }
+            ],
+        }
+        update_validator = MetricIssueDetectorValidator(
+            instance=detector, data=update_data, context=self.context, partial=True
+        )
+        assert update_validator.is_valid(), update_validator.errors
+        dynamic_detector = update_validator.save()
+
+        assert mock_seer_request.call_count == 1
+        # ensure we did not enter the delete path
+        assert mock_seer_delete_request.call_count == 0
 
         # Verify snuba query changes
         data_source = DataSource.objects.get(detector=dynamic_detector)


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/101843 to delete data in Seer if a dynamic detector is changed to become a static or percent type detector. In this case Seer no longer needs to track it.