### PR TITLE
feat(aci): redirect alerts nav to monitors

### DIFF
--- a/static/app/views/detectors/list/allMonitors.tsx
+++ b/static/app/views/detectors/list/allMonitors.tsx
@@ -1,6 +1,7 @@
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import WorkflowEngineListLayout from 'sentry/components/workflowEngine/layout/list';
 import {t} from 'sentry/locale';
+import {AlertsRedirectNotice} from 'sentry/views/detectors/list/common/alertsRedirectNotice';
 import {DetectorListActions} from 'sentry/views/detectors/list/common/detectorListActions';
 import {DetectorListContent} from 'sentry/views/detectors/list/common/detectorListContent';
 import {DetectorListHeader} from 'sentry/views/detectors/list/common/detectorListHeader';
@@ -23,6 +24,9 @@ export default function AllMonitors() {
         description={DESCRIPTION}
         docsUrl={DOCS_URL}
       >
+        <AlertsRedirectNotice>
+          {t('Alert Rules have been moved to Monitors and Alerts.')}
+        </AlertsRedirectNotice>
         <DetectorListHeader />
         <DetectorListContent {...detectorListQuery} />
       </WorkflowEngineListLayout>

--- a/static/app/views/detectors/list/common/alertsRedirectNotice.tsx
+++ b/static/app/views/detectors/list/common/alertsRedirectNotice.tsx
@@ -1,0 +1,37 @@
+import {parseAsBoolean, useQueryState} from 'nuqs';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+export function AlertsRedirectNotice({children}: {children: React.ReactNode}) {
+  const [wasRedirectedFromAlerts, setWasRedirectedFromAlerts] = useQueryState(
+    'alertsRedirect',
+    parseAsBoolean.withOptions({history: 'replace'}).withDefault(false)
+  );
+
+  if (!wasRedirectedFromAlerts) {
+    return null;
+  }
+
+  return (
+    <Alert
+      type="info"
+      trailingItems={
+        <Button
+          size="zero"
+          borderless
+          icon={<IconClose />}
+          aria-label={t('Dismiss')}
+          onClick={() => {
+            setWasRedirectedFromAlerts(false);
+          }}
+        />
+      }
+    >
+      {children}
+    </Alert>
+  );
+}

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
 import {useNavContext} from 'sentry/views/nav/context';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
@@ -81,8 +83,17 @@ export function IssuesSecondaryNav() {
 }
 
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
+  const user = useUser();
+  const organization = useOrganization();
   const {layout} = useNavContext();
   const isSticky = layout === NavLayout.SIDEBAR;
+
+  const shouldRedirectToWorkflowEngineUI =
+    !user.isStaff && organization.features.includes('workflow-engine-ui');
+
+  const alertsLink = shouldRedirectToWorkflowEngineUI
+    ? `${makeMonitorBasePathname(organization.slug)}?alertsRedirect=true`
+    : `${baseUrl}/alerts/rules/`;
 
   return (
     <StickyBottomSection
@@ -92,8 +103,8 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
       isSticky={isSticky}
     >
       <SecondaryNav.Item
-        to={`${baseUrl}/alerts/rules/`}
-        activeTo={`${baseUrl}/alerts/`}
+        to={alertsLink}
+        activeTo={alertsLink}
         analyticsItemName="issues_alerts"
       >
         {t('Alerts')}

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -104,7 +104,7 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
     >
       <SecondaryNav.Item
         to={alertsLink}
-        activeTo={alertsLink}
+        {...(!shouldRedirectToWorkflowEngineUI && {activeTo: `${baseUrl}/alerts/`})}
         analyticsItemName="issues_alerts"
       >
         {t('Alerts')}


### PR DESCRIPTION
similar to https://github.com/getsentry/sentry/pull/103129, redirects users with the `workflow-engine-ui` flag who click on Issues > Alerts to the All Monitors list with a banner

<img width="1381" height="332" alt="Screenshot 2025-11-13 at 11 56 52 AM" src="https://github.com/user-attachments/assets/00194e9e-1f85-4f23-9858-3c54a4c9e09a" />
