### PR TITLE
chore(preprod): Add analysis_duration to the extras col for dev debugging

### DIFF
--- a/src/sentry/preprod/size_analysis/models.py
+++ b/src/sentry/preprod/size_analysis/models.py
@@ -34,6 +34,7 @@ class TreemapResults(BaseModel):
 
 # Keep in sync with https://github.com/getsentry/launchpad/blob/main/src/launchpad/size/models/common.py#L92
 class SizeAnalysisResults(BaseModel):
+    analysis_duration: float
     download_size: int
     install_size: int
     treemap: TreemapResults | None

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -409,6 +409,14 @@ def _assemble_preprod_artifact_size_analysis(
                 },
             )
 
+            if size_analysis_results.analysis_duration is not None:
+                if preprod_artifact.extras is None:
+                    preprod_artifact.extras = {}
+                preprod_artifact.extras.update(
+                    {"analysis_duration": size_analysis_results.analysis_duration}
+                )
+                preprod_artifact.save(update_fields=["extras"])
+
         # Trigger size analysis comparison if eligible
         logger.info(
             "Created or updated preprod artifact size metrics with analysis file",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -409,7 +409,8 @@ def _assemble_preprod_artifact_size_analysis(
                 },
             )
 
-            if size_analysis_results.analysis_duration is not None:
+        if size_analysis_results.analysis_duration is not None:
+            with transaction.atomic(router.db_for_write(PreprodArtifact)):
                 if preprod_artifact.extras is None:
                     preprod_artifact.extras = {}
                 preprod_artifact.extras.update(

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -411,6 +411,7 @@ def _assemble_preprod_artifact_size_analysis(
 
         if size_analysis_results.analysis_duration is not None:
             with transaction.atomic(router.db_for_write(PreprodArtifact)):
+                preprod_artifact.refresh_from_db()
                 if preprod_artifact.extras is None:
                     preprod_artifact.extras = {}
                 preprod_artifact.extras.update(

--- a/tests/sentry/preprod/size_analysis/test_compare.py
+++ b/tests/sentry/preprod/size_analysis/test_compare.py
@@ -44,6 +44,7 @@ class CompareSizeAnalysisTest(TestCase):
             )
 
         return SizeAnalysisResults(
+            analysis_duration=1.0,
             download_size=download_size,
             install_size=install_size,
             treemap=treemap,
@@ -535,6 +536,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
     def _create_size_analysis_results(self, analysis_version=None):
         """Helper to create SizeAnalysisResults with specified analysis_version."""
         return SizeAnalysisResults(
+            analysis_duration=1.0,
             download_size=500,
             install_size=1000,
             treemap=None,
@@ -680,6 +682,7 @@ class CompareWithVersionSkippingTest(TestCase):
             )
 
         return SizeAnalysisResults(
+            analysis_duration=1.0,
             download_size=download_size,
             install_size=install_size,
             treemap=treemap,

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -126,6 +126,7 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
 
         # Create size analysis data
         head_analysis_data = {
+            "analysis_duration": 0.5,
             "download_size": 1000,
             "install_size": 2000,
             "treemap": {
@@ -150,6 +151,7 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             },
         }
         base_analysis_data = {
+            "analysis_duration": 0.4,
             "download_size": 800,
             "install_size": 1500,
             "treemap": {
@@ -254,6 +256,7 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
 
         # Create size analysis data
         analysis_data = {
+            "analysis_duration": 0.5,
             "download_size": 1000,
             "install_size": 2000,
             "treemap": {
@@ -683,6 +686,7 @@ class RunSizeAnalysisComparisonTest(TestCase):
         """Test _run_size_analysis_comparison with successful comparison."""
         # Create analysis data
         head_analysis_data = {
+            "analysis_duration": 0.5,
             "download_size": 1000,
             "install_size": 2000,
             "treemap": {
@@ -707,6 +711,7 @@ class RunSizeAnalysisComparisonTest(TestCase):
             },
         }
         base_analysis_data = {
+            "analysis_duration": 0.4,
             "download_size": 800,
             "install_size": 1500,
             "treemap": {
@@ -775,10 +780,10 @@ class RunSizeAnalysisComparisonTest(TestCase):
         """Test _run_size_analysis_comparison with existing processing comparison."""
         # Create size metrics
         head_size_metrics = self._create_size_metrics_with_analysis_file(
-            {"download_size": 1000, "install_size": 2000}
+            {"analysis_duration": 0.5, "download_size": 1000, "install_size": 2000}
         )
         base_size_metrics = self._create_size_metrics_with_analysis_file(
-            {"download_size": 800, "install_size": 1500}
+            {"analysis_duration": 0.4, "download_size": 800, "install_size": 1500}
         )
 
         # Create existing comparison in processing state
@@ -813,10 +818,10 @@ class RunSizeAnalysisComparisonTest(TestCase):
         """Test _run_size_analysis_comparison with existing successful comparison."""
         # Create size metrics
         head_size_metrics = self._create_size_metrics_with_analysis_file(
-            {"download_size": 1000, "install_size": 2000}
+            {"analysis_duration": 0.5, "download_size": 1000, "install_size": 2000}
         )
         base_size_metrics = self._create_size_metrics_with_analysis_file(
-            {"download_size": 800, "install_size": 1500}
+            {"analysis_duration": 0.4, "download_size": 800, "install_size": 1500}
         )
 
         # Create existing comparison in success state
@@ -863,7 +868,7 @@ class RunSizeAnalysisComparisonTest(TestCase):
         )
 
         base_size_metrics = self._create_size_metrics_with_analysis_file(
-            {"download_size": 800, "install_size": 1500}
+            {"analysis_duration": 0.4, "download_size": 800, "install_size": 1500}
         )
 
         _run_size_analysis_comparison(
@@ -883,7 +888,7 @@ class RunSizeAnalysisComparisonTest(TestCase):
     def test_run_size_analysis_comparison_missing_base_analysis_file(self):
         """Test _run_size_analysis_comparison with missing base analysis file."""
         head_size_metrics = self._create_size_metrics_with_analysis_file(
-            {"download_size": 1000, "install_size": 2000}
+            {"analysis_duration": 0.5, "download_size": 1000, "install_size": 2000}
         )
 
         # Create size metrics without analysis file

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -522,7 +522,7 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
 
     def test_assemble_preprod_artifact_size_analysis_success(self) -> None:
         status, details = self._run_task_and_verify_status(
-            b'{"download_size": 1000, "install_size": 2000}'
+            b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null}'
         )
 
         assert status == ChunkFileState.OK
@@ -554,7 +554,7 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
         )
 
         status, details = self._run_task_and_verify_status(
-            b'{"download_size": 1000, "install_size": 2000}'
+            b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null}'
         )
 
         assert status == ChunkFileState.OK


### PR DESCRIPTION
This will allow us to easily see how long each build took for debugging purposes when we see spikes in latency