### PR TITLE
ref(grouping): Various stacktrace rule changes

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -432,7 +432,7 @@ category:handler ^-group -group
 category:telemetry -group
 
 category:indirection -group
-category:internals -group
+category:internals -app -group
 category:threadbase v-group -group
 
 # SDK specific rules

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -327,10 +327,10 @@ family:native stack.function:USentrySubsystem::CaptureEventWithScope*      v+app
 family:native stack.function:USentrySubsystem::*execCapture*               v+app -app ^-app
 
 # known well locations for unix paths
-family:native package:/lib/**                                        -app
-family:native package:/usr/lib/**                                    -app
-family:native path:/usr/local/lib/**                                 -app
-family:native path:/usr/local/Cellar/**                              -app
+package:/lib/**                                                   -app
+package:/usr/lib/**                                               -app
+path:/usr/local/lib/**                                            -app
+path:/usr/local/Cellar/**                                         -app
 
 # rust common modules/functions
 family:native function:std::*                                     -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -21,6 +21,8 @@ module:com.android.* category=system
 family:native package:libdispatch.dylib category=system
 family:native package:WebKit category=system
 family:native package:**/libart.so category=system
+family:native package:linux-gate.so* category=system
+family:native package:linux-vdso.so* category=system
 package:/apex/com.android.*/lib*/** category=system
 
 # (Presumably) preinstalled stuff on Lenovo Android devices
@@ -329,7 +331,6 @@ family:native package:/lib/**                                        -app
 family:native package:/usr/lib/**                                    -app
 family:native path:/usr/local/lib/**                                 -app
 family:native path:/usr/local/Cellar/**                              -app
-family:native package:linux-gate.so*                                 -app
 
 # rust common modules/functions
 family:native function:std::*                                     -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -331,6 +331,7 @@ package:/lib/**                                                   -app
 package:/usr/lib/**                                               -app
 path:/usr/local/lib/**                                            -app
 path:/usr/local/Cellar/**                                         -app
+path:**/.local/share/**                                           -app
 
 # rust common modules/functions
 family:native function:std::*                                     -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -432,7 +432,7 @@ category:handler ^-group -group
 
 # Crash reporting tools are noise that can occur outside of signal handlers
 # too, apparently (Apple's GPUSupport module)
-category:telemetry -group
+category:telemetry -app -group
 
 category:indirection -group
 category:internals -app -group

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -208,6 +208,9 @@ category:driver | [ category:driver ] category=internals
 # Only group by top-level malloc op, not any helper function it may have called.
 [ category:malloc ] | category:malloc category=internals
 
+# Python multi-processing creates a fake module to call `spawn_main` and spawn a new process
+function:<module> | [ function:spawn_main ] category=internals
+
 # On Windows, _purecall internally aborts when the function pointer is invalid.
 # We want to treat this the same as a segfault happening before calling
 # _purecall.

--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2025-11-21.txt
@@ -1,131 +1,3 @@
-## * The default configuration of stacktrace grouping enhancers
-
-# iOS known apps
-family:native package:/var/containers/Bundle/Application/**          +app
-family:native package:/private/var/containers/Bundle/Application/**  +app
-
-# iOS apps in simulator
-family:native package:**/Developer/CoreSimulator/Devices/**          +app
-family:native package:**/Containers/Bundle/Application/**            +app
-
-# well known path components for mac paths
-family:native package:**.app/Contents/**                             +app
-family:native package:/Users/**                                      +app
-
-# Unreal Engine
-
-## UE internal fatal log message handling
-
-family:native stack.function:UE::Logging::Private::BasicFatalLog     v+app -app ^-app
-
-## UE internal assertion handling
-family:native stack.function:FDebug::CheckVerifyFailedImpl*                                             v+app -app ^-app
-stack.function:*::Impl::ExecCheckImplInternal | [ stack.function:FDebug::CheckVerifyFailedImpl ]        -app
-stack.function:FDebug::CheckVerifyFailedImpl2 | [ stack.function:FDebug::CheckVerifyFailedImpl2V ]      -app
-
-## UE internal ensure handling
-
-### UE 5.2 and older
-family:native stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse                  v+app -app ^-app
-category:indirection | [ stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse ]     -app
-
-### UE 5.3
-family:native stack.function:DispatchCheckVerify*                          v+app -app ^-app
-
-### UE 5.4 and newer
-family:native stack.function:UE::Assert::Private::ExecCheckImplInternal*   v+app -app ^-app
-
-## UE SDK USentrySubsystem event capturing
-family:native stack.function:USentrySubsystem::CaptureMessage*             v+app -app ^-app
-family:native stack.function:USentrySubsystem::CaptureMessageWithScope*    v+app -app ^-app
-family:native stack.function:USentrySubsystem::CaptureEvent*               v+app -app ^-app
-family:native stack.function:USentrySubsystem::CaptureEventWithScope*      v+app -app ^-app
-family:native stack.function:USentrySubsystem::*execCapture*               v+app -app ^-app
-
-# known well locations for unix paths
-family:native package:/lib/**                                        -app
-family:native package:/usr/lib/**                                    -app
-family:native path:/usr/local/lib/**                                 -app
-family:native path:/usr/local/Cellar/**                              -app
-family:native package:linux-gate.so*                                 -app
-
-# rust common modules/functions
-family:native function:std::*                                     -app
-family:native function:core::*                                    -app
-family:native function:alloc::*                                   -app
-family:native function:__rust_*                                   -app
-family:native function:rust_begin_unwind                          -app
-
-# rust borders
-family:native function:std::panicking::begin_panic                ^-group -group ^-app -app
-family:native function:core::panicking::begin_panic               ^-group -group ^-app -app
-family:native function:failure::backtrace::Backtrace::new         ^-group -group ^-app -app
-family:native function:error_chain::make_backtrace                ^-group -group ^-app -app
-family:native function:std::panicking::panic_fmt                  ^-app -app
-family:native function:core::panicking::panic_fmt                 ^-app -app
-
-# C++ borders
-family:native function:_CxxThrowException                         ^-group -group ^-app -app
-family:native function:__cxa_throw                                ^-group -group ^-app -app
-family:native function:__assert_rtn                               ^-group -group ^-app -app
-
-# Objective-C
-family:native function:_NSRaiseError                              ^-group -group ^-app -app
-family:native function:_mh_execute_header                         -group -app
-
-# Breakpad
-family:native function:google_breakpad::*                         -app -group
-family:native function:google_breakpad::ExceptionHandler::SignalHandler ^-group -group
-family:native function:google_breakpad::ExceptionHandler::WriteMinidumpWithException ^-group -group
-
-# Support frameworks that are not in-app
-family:native package:**/Frameworks/libswift*.dylib                  -app
-family:native package:**/Frameworks/KSCrash.framework/**             -app
-family:native package:**/Frameworks/SentrySwift.framework/**         -app
-family:native package:**/Frameworks/Sentry.framework/**              -app
-
-# Needed for versions < sentry-cocoa 7.0.0 and static linking.
-# Before sentry-cocoa 7.0.0, we marked all packages located inside the application bundle as inApp.
-# Since 7.0.0, the Cocoa SKD only marks the main executable as inApp. This change doesn't impact
-# applications using static libraries, as when using static libraries, all of them end up in the
-# main executable.
-family:native function:kscm_*                                     -app -group
-family:native function:sentrycrashcm_*                            -app -group
-family:native function:kscrash_*                                  -app -group
-family:native function:*sentrycrash_*                             -app -group
-family:native function:"?[[]KSCrash*"                             -app -group
-family:native function:"?[[]RNSentry*"                            -app -group
-family:native function:"__*[[]Sentry*"                            -app -group
-
-# Projects shipping their own class called "SentryFoo" can then easily override this in their
-# own grouping enhancers.
-family:native function:"?[[]Sentry*"                              -app -group
-
-# Mark Dart Flutter Android stacktraces in-app by default, further not in-app rules are applied afterwards below
-family:native stack.package:/data/app/** stack.abs_path:**/*.dart +app
-# Dart/Flutter stacktraces that are not in-app
-family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
-family:javascript module:**/packages/flutter/** -app
-family:native stack.abs_path:**/packages/flutter/** -app
-family:native stack.abs_path:lib/ui/hooks.dart -app
-family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
-# sentry-dart SDK frames are not in app
-stack.abs_path:package:sentry/** -app -group
-stack.abs_path:package:sentry_flutter/** -app -group
-# other sentry-dart packages that are non in app
-stack.abs_path:package:sentry_logging/** -app -group
-stack.abs_path:package:sentry_dio/** -app -group
-stack.abs_path:package:sentry_file/** -app -group
-stack.abs_path:package:sentry_hive/** -app -group
-stack.abs_path:package:sentry_isar/** -app -group
-stack.abs_path:package:sentry_sqflite/** -app -group
-stack.abs_path:package:sentry_drift/** -app -group
-stack.abs_path:package:sentry_isar/** -app
-stack.abs_path:package:sentry_link/** -app
-stack.abs_path:package:sentry_firebase_remote_config/** -app
-# .pub-cache is the node_modules equivalent for Dart
-family:native stack.abs_path:**/.pub-cache/** -app
-
 # Categorization of frames
 family:native package:"/System/Library/Frameworks/**" category=system
 family:native package:"C:/Windows/**" category=system
@@ -328,16 +200,11 @@ family:native function:pthread_mutex_lock category=lock
 category:driver | [ category:driver ] category=internals
 
 # Only group by top-level GL operaton, not any helper functions it may have called.
-
 [ category:gl ] | category:gl category=internals
 [ category:av ] | category:av  category=internals
 
 # Only group by top-level malloc op, not any helper function it may have called.
 [ category:malloc ] | category:malloc category=internals
-
-# abort() and exception raising is technically the culprit for crashes, but not
-# the thing we want to show.
-category:throw ^-group -group ^-app -app
 
 # On Windows, _purecall internally aborts when the function pointer is invalid.
 # We want to treat this the same as a segfault happening before calling
@@ -347,34 +214,12 @@ category:throw ^-group -group ^-app -app
 # raise() called by abort() should only group by abort()
 [ category:throw ] | category:throw category=internals
 
-# Frames from the OS should never be considered in-app
-category:system -app
-
-# Thread bases such as `main()` are just noise and are called by noise.
-category:threadbase -group v-group
-
-# handler frames typically call code for crash reporting, so the frames below
-# are noise and do not represent the actual crash. We usually expect something to
-# be above handler frames that represents the actual crash. The stackwalker
-# has a bug where it cannot walk past _sigtramp on OS X but that is expected to
-# be fixed eventually.
-category:handler ^-group -group
-
-# Crash reporting tools are noise that can occur outside of signal handlers
-# too, apparently (Apple's GPUSupport module)
-category:telemetry -group
-
-category:indirection -group
-category:internals -group
-category:threadbase v-group -group
-
 # system frames starting with underscore are likely garbage
 # unsymbolicated system frames are likely system frames starting with underscore
 # _purecall is an exception as it is often the only important frame in a block of system frames
 family:native category:system function:_* !function:_purecall category=internals
 family:native category:system function:"<unknown>" category=internals
 family:native function:_INTERNAL* category=internals
-
 
 # We should be able to write this, but unfortunately sentry-cocoa 6.x is so
 # buggy with detecting compiler-generated code that we have decided to go with a
@@ -414,6 +259,179 @@ family:native function:*.cold.1 category=indirection
 [ category:runtime ]    | category:runtime category=internals
 [ category:dtor ]       | category:dtor    category=internals
 
+## java
+module:akka.* category=framework
+module:com.fasterxml.* category=framework
+module:com.microsoft.* category=framework
+module:com.sun.* category=framework
+module:feign.* category=framework
+module:io.opentelemetry.* category=framework
+module:io.sentry.* category=framework -group
+module:jdk.* category=framework
+module:oauth.* category=framework
+module:org.apache.* category=framework
+module:org.glassfish.* category=framework
+module:org.jboss.* category=framework
+module:org.jdesktop.* category=framework
+module:org.postgresql.* category=framework
+module:org.springframework.* category=framework
+module:org.web3j.* category=framework
+module:reactor.core.* category=framework
+module:scala.* category=framework
+module:sun.* category=framework
+
+## * The default configuration of stacktrace grouping enhancers
+
+# iOS known apps
+family:native package:/var/containers/Bundle/Application/**          +app
+family:native package:/private/var/containers/Bundle/Application/**  +app
+
+# iOS apps in simulator
+family:native package:**/Developer/CoreSimulator/Devices/**          +app
+family:native package:**/Containers/Bundle/Application/**            +app
+
+# well known path components for mac paths
+family:native package:**.app/Contents/**                             +app
+family:native package:/Users/**                                      +app
+
+# Unreal Engine
+
+## UE internal fatal log message handling
+
+family:native stack.function:UE::Logging::Private::BasicFatalLog     v+app -app ^-app
+
+## UE internal assertion handling
+family:native stack.function:FDebug::CheckVerifyFailedImpl*                                             v+app -app ^-app
+stack.function:*::Impl::ExecCheckImplInternal | [ stack.function:FDebug::CheckVerifyFailedImpl ]        -app
+stack.function:FDebug::CheckVerifyFailedImpl2 | [ stack.function:FDebug::CheckVerifyFailedImpl2V ]      -app
+
+## UE internal ensure handling
+
+### UE 5.2 and older
+family:native stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse                  v+app -app ^-app
+category:indirection | [ stack.function:FDebug::OptionallyLogFormattedEnsureMessageReturningFalse ]     -app
+
+### UE 5.3
+family:native stack.function:DispatchCheckVerify*                          v+app -app ^-app
+
+### UE 5.4 and newer
+family:native stack.function:UE::Assert::Private::ExecCheckImplInternal*   v+app -app ^-app
+
+## UE SDK USentrySubsystem event capturing
+family:native stack.function:USentrySubsystem::CaptureMessage*             v+app -app ^-app
+family:native stack.function:USentrySubsystem::CaptureMessageWithScope*    v+app -app ^-app
+family:native stack.function:USentrySubsystem::CaptureEvent*               v+app -app ^-app
+family:native stack.function:USentrySubsystem::CaptureEventWithScope*      v+app -app ^-app
+family:native stack.function:USentrySubsystem::*execCapture*               v+app -app ^-app
+
+# known well locations for unix paths
+family:native package:/lib/**                                        -app
+family:native package:/usr/lib/**                                    -app
+family:native path:/usr/local/lib/**                                 -app
+family:native path:/usr/local/Cellar/**                              -app
+family:native package:linux-gate.so*                                 -app
+
+# rust common modules/functions
+family:native function:std::*                                     -app
+family:native function:core::*                                    -app
+family:native function:alloc::*                                   -app
+family:native function:__rust_*                                   -app
+family:native function:rust_begin_unwind                          -app
+
+# rust borders
+family:native function:std::panicking::begin_panic                ^-group -group ^-app -app
+family:native function:core::panicking::begin_panic               ^-group -group ^-app -app
+family:native function:failure::backtrace::Backtrace::new         ^-group -group ^-app -app
+family:native function:error_chain::make_backtrace                ^-group -group ^-app -app
+family:native function:std::panicking::panic_fmt                  ^-app -app
+family:native function:core::panicking::panic_fmt                 ^-app -app
+
+# C++ borders
+family:native function:_CxxThrowException                         ^-group -group ^-app -app
+family:native function:__cxa_throw                                ^-group -group ^-app -app
+family:native function:__assert_rtn                               ^-group -group ^-app -app
+
+# Objective-C
+family:native function:_NSRaiseError                              ^-group -group ^-app -app
+family:native function:_mh_execute_header                         -group -app
+
+# Breakpad
+family:native function:google_breakpad::*                         -app -group
+family:native function:google_breakpad::ExceptionHandler::SignalHandler ^-group -group
+family:native function:google_breakpad::ExceptionHandler::WriteMinidumpWithException ^-group -group
+
+# Support frameworks that are not in-app
+family:native package:**/Frameworks/libswift*.dylib                  -app
+family:native package:**/Frameworks/KSCrash.framework/**             -app
+family:native package:**/Frameworks/SentrySwift.framework/**         -app
+family:native package:**/Frameworks/Sentry.framework/**              -app
+
+# Needed for versions < sentry-cocoa 7.0.0 and static linking.
+# Before sentry-cocoa 7.0.0, we marked all packages located inside the application bundle as inApp.
+# Since 7.0.0, the Cocoa SKD only marks the main executable as inApp. This change doesn't impact
+# applications using static libraries, as when using static libraries, all of them end up in the
+# main executable.
+family:native function:kscm_*                                     -app -group
+family:native function:sentrycrashcm_*                            -app -group
+family:native function:kscrash_*                                  -app -group
+family:native function:*sentrycrash_*                             -app -group
+family:native function:"?[[]KSCrash*"                             -app -group
+family:native function:"?[[]RNSentry*"                            -app -group
+family:native function:"__*[[]Sentry*"                            -app -group
+
+# Projects shipping their own class called "SentryFoo" can then easily override this in their
+# own grouping enhancers.
+family:native function:"?[[]Sentry*"                              -app -group
+
+# Mark Dart Flutter Android stacktraces in-app by default, further not in-app rules are applied afterwards below
+family:native stack.package:/data/app/** stack.abs_path:**/*.dart +app
+# Dart/Flutter stacktraces that are not in-app
+family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
+family:javascript module:**/packages/flutter/** -app
+family:native stack.abs_path:**/packages/flutter/** -app
+family:native stack.abs_path:lib/ui/hooks.dart -app
+family:native stack.abs_path:lib/ui/platform_dispatcher.dart -app
+# sentry-dart SDK frames are not in app
+stack.abs_path:package:sentry/** -app -group
+stack.abs_path:package:sentry_flutter/** -app -group
+# other sentry-dart packages that are non in app
+stack.abs_path:package:sentry_logging/** -app -group
+stack.abs_path:package:sentry_dio/** -app -group
+stack.abs_path:package:sentry_file/** -app -group
+stack.abs_path:package:sentry_hive/** -app -group
+stack.abs_path:package:sentry_isar/** -app -group
+stack.abs_path:package:sentry_sqflite/** -app -group
+stack.abs_path:package:sentry_drift/** -app -group
+stack.abs_path:package:sentry_isar/** -app
+stack.abs_path:package:sentry_link/** -app
+stack.abs_path:package:sentry_firebase_remote_config/** -app
+# .pub-cache is the node_modules equivalent for Dart
+family:native stack.abs_path:**/.pub-cache/** -app
+
+# abort() and exception raising is technically the culprit for crashes, but not
+# the thing we want to show.
+category:throw ^-group -group ^-app -app
+
+# Frames from the OS should never be considered in-app
+category:system -app
+
+# Thread bases such as `main()` are just noise and are called by noise.
+category:threadbase -group v-group
+
+# handler frames typically call code for crash reporting, so the frames below
+# are noise and do not represent the actual crash. We usually expect something to
+# be above handler frames that represents the actual crash. The stackwalker
+# has a bug where it cannot walk past _sigtramp on OS X but that is expected to
+# be fixed eventually.
+category:handler ^-group -group
+
+# Crash reporting tools are noise that can occur outside of signal handlers
+# too, apparently (Apple's GPUSupport module)
+category:telemetry -group
+
+category:indirection -group
+category:internals -group
+category:threadbase v-group -group
 
 # SDK specific rules
 
@@ -452,27 +470,6 @@ function:nextTick -app -group
 
 ## go
 path:**/go/pkg/mod/** -app
-
-## java
-module:akka.* category=framework
-module:com.fasterxml.* category=framework
-module:com.microsoft.* category=framework
-module:com.sun.* category=framework
-module:feign.* category=framework
-module:io.opentelemetry.* category=framework
-module:io.sentry.* category=framework -group
-module:jdk.* category=framework
-module:oauth.* category=framework
-module:org.apache.* category=framework
-module:org.glassfish.* category=framework
-module:org.jboss.* category=framework
-module:org.jdesktop.* category=framework
-module:org.postgresql.* category=framework
-module:org.springframework.* category=framework
-module:org.web3j.* category=framework
-module:reactor.core.* category=framework
-module:scala.* category=framework
-module:sun.* category=framework
 
 category:framework -app
 

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/block_invoke.pysnap
@@ -22,7 +22,7 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+    hash: "ad4d21cacbbadddbe1a37535d7dbbba5"
     contributing component: threads
     hint: None
     root_component:
@@ -32,6 +32,3 @@ contributing variants:
             frame* (marked in-app by the client)
               function*
                 "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-            frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
-              function*
-                "__99+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -22,7 +22,7 @@ metrics with tags: {
 ---
 contributing variants:
   system*
-    hash: "6791947bdfd6cf2ca7024f026df974ae"
+    hash: "1bc764ab44acfab9a38f23ae670038bd"
     contributing component: exception
     hint: None
     root_component:
@@ -31,13 +31,6 @@ contributing variants:
           type*
             "TimeoutError"
           stacktrace*
-            frame*
-              module*
-                "__main__"
-              function*
-                "<module>"
-              context_line*
-                "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
             frame*
               module*
                 "multiprocessing.spawn"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/block_invoke.pysnap
@@ -55,8 +55,8 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     ]
                   },
                   {
-                    "contributes": true,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app)",
+                    "contributes": false,
+                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -124,7 +124,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       },
       "contributes": true,
       "description": "thread stacktrace — in-app frames",
-      "hash": "ff6c4ee7c54f118a9647ee86f0c2b0b0",
+      "hash": "ad4d21cacbbadddbe1a37535d7dbbba5",
       "hint": null,
       "key": "app_thread_stacktrace",
       "type": "component"
@@ -205,8 +205,8 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                     ]
                   },
                   {
-                    "contributes": true,
-                    "hint": null,
+                    "contributes": false,
+                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/block_invoke.pysnap
@@ -56,7 +56,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by the client",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/callee_guaranteed.pysnap
@@ -408,7 +408,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -534,7 +534,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -567,7 +567,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored due to recursion",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -726,7 +726,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -759,7 +759,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored due to recursion",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -792,7 +792,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored due to recursion",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -825,7 +825,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored due to recursion",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -858,7 +858,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored due to recursion",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/cocoa_dispatch_client_callout.pysnap
@@ -335,7 +335,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by the client",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -459,7 +459,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by the client",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_125_event_126.pysnap
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -642,7 +642,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -987,7 +987,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1018,7 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_125_event_126.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_200_event_200.pysnap
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -229,7 +229,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -663,7 +663,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -725,7 +725,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -756,7 +756,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_275_event_275.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_275_event_275.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -884,7 +884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_289_event_312.pysnap
@@ -454,7 +454,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -485,7 +485,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -516,7 +516,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -547,7 +547,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -733,7 +733,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -764,7 +764,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_289_event_312.pysnap
@@ -640,7 +640,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_289_event_312.pysnap
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -107,7 +107,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_294.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -134,7 +134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -192,7 +192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -473,7 +473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -572,7 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -605,7 +605,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -671,7 +671,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -704,7 +704,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -737,7 +737,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1018,7 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1235,7 +1235,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_294.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -72,7 +72,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -134,7 +134,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -192,7 +192,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_329.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -512,7 +512,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -545,7 +545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -644,7 +644,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -677,7 +677,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -743,7 +743,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -776,7 +776,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -809,7 +809,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1121,7 +1121,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1152,7 +1152,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1183,7 +1183,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1245,7 +1245,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1276,7 +1276,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_294_event_329.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -198,7 +198,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_307_event_307.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_307_event_657.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -132,7 +132,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -533,7 +533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_307_event_657.pysnap
@@ -533,7 +533,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_313.pysnap
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -642,7 +642,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1543,7 +1543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1572,7 +1572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1601,7 +1601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1630,7 +1630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1659,7 +1659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1688,7 +1688,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1717,7 +1717,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1810,7 +1810,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1841,7 +1841,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_313.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1543,7 +1543,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1572,7 +1572,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1601,7 +1601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1630,7 +1630,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1659,7 +1659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1688,7 +1688,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1717,7 +1717,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1748,7 +1748,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_333.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1421,7 +1421,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1545,7 +1545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1576,7 +1576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1607,7 +1607,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1638,7 +1638,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1669,7 +1669,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_313_event_333.pysnap
@@ -578,7 +578,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1049,7 +1049,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1173,7 +1173,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1452,7 +1452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1545,7 +1545,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1576,7 +1576,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1607,7 +1607,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1638,7 +1638,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1669,7 +1669,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1731,7 +1731,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1762,7 +1762,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_319_event_321.pysnap
@@ -1004,7 +1004,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1035,7 +1035,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1748,7 +1748,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1779,7 +1779,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_319_event_321.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_319_event_321.pysnap
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -694,7 +694,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -818,7 +818,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -849,7 +849,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -911,7 +911,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -942,7 +942,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1314,7 +1314,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1376,7 +1376,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1407,7 +1407,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1438,7 +1438,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1562,7 +1562,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1593,7 +1593,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1624,7 +1624,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1655,7 +1655,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1686,7 +1686,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1872,7 +1872,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_389_event_389.pysnap
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_389_event_389.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_432.pysnap
@@ -1076,7 +1076,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_432.pysnap
@@ -1045,7 +1045,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_453.pysnap
@@ -1076,7 +1076,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_432_event_453.pysnap
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -452,7 +452,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1045,7 +1045,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_445_event_445.pysnap
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -268,7 +268,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -301,7 +301,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -615,7 +615,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1119,7 +1119,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/group_445_event_445.pysnap
@@ -1181,7 +1181,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/in_app_in_ui.pysnap
@@ -766,7 +766,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -931,7 +931,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by the client but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_amd_driver.pysnap
@@ -1434,7 +1434,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_amd_driver.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_amd_driver.pysnap
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -539,7 +539,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -570,7 +570,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -632,7 +632,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1283,7 +1283,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1314,7 +1314,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1345,7 +1345,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1374,7 +1374,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1527,7 +1527,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_intel_driver.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_intel_driver.pysnap
@@ -1025,7 +1025,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1056,7 +1056,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1767,7 +1767,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1798,7 +1798,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:telemetry -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/macos_intel_driver.pysnap
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -384,7 +384,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -415,7 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -446,7 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -535,7 +535,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -564,7 +564,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -593,7 +593,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -622,7 +622,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -715,7 +715,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -839,7 +839,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -870,7 +870,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -901,7 +901,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -932,7 +932,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -963,7 +963,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1149,7 +1149,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1333,7 +1333,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1364,7 +1364,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1395,7 +1395,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1426,7 +1426,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1457,7 +1457,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1581,7 +1581,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1612,7 +1612,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1643,7 +1643,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1674,7 +1674,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1705,7 +1705,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1891,7 +1891,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (category:throw ^-app -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -131,7 +131,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -175,7 +175,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -219,7 +219,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -527,7 +527,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -571,7 +571,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -615,7 +615,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -659,7 +659,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -703,7 +703,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -747,7 +747,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "non app frame",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -997,8 +997,8 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "name": "stacktrace",
                 "values": [
                   {
-                    "contributes": true,
-                    "hint": null,
+                    "contributes": false,
+                    "hint": "ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1884,7 +1884,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       },
       "contributes": true,
       "description": "exception stacktrace — all frames",
-      "hash": "6791947bdfd6cf2ca7024f026df974ae",
+      "hash": "1bc764ab44acfab9a38f23ae670038bd",
       "hint": null,
       "key": "system_exception_stacktrace",
       "type": "component"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_negated_match.pysnap
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust.pysnap
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/stacktrace_rust2.pysnap
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:std::* -app)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1504,7 +1504,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -105,7 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1504,7 +1504,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -43,7 +43,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1442,7 +1442,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -1473,7 +1473,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
@@ -388,7 +388,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app)",
+                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group)",
+                    "hint": "marked out of app by built-in stack trace rule (category:internals -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
@@ -25,7 +25,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                 "values": [
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [
@@ -56,7 +56,7 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
                   },
                   {
                     "contributes": false,
-                    "hint": "marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app)",
+                    "hint": "marked out of app by built-in stack trace rule (package:/usr/lib/** -app)",
                     "id": "frame",
                     "name": null,
                     "values": [

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/block_invoke.pysnap
@@ -2,7 +2,7 @@
 source: tests/sentry/grouping/test_variants.py::test_variants
 ---
 app:
-  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+  hash: "ad4d21cacbbadddbe1a37535d7dbbba5"
   contributing component: threads
   hint: None
   root_component:
@@ -12,7 +12,7 @@ app:
           frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
+          frame (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (marked out of app by the client)
@@ -39,7 +39,7 @@ system:
           frame*
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame*
+          frame (ignored by built-in stack trace rule (category:internals -group))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (ignored by built-in stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/block_invoke.pysnap
@@ -12,7 +12,7 @@ app:
           frame* (marked in-app by the client)
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by the client)
             function*
               "__99+[Something else]_block_invoke_2"
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/callee_guaranteed.pysnap
@@ -49,7 +49,7 @@ app:
           frame (marked out of app by the client)
             function*
               "_dispatch_call_block_and_release"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -63,12 +63,12 @@ app:
           frame (marked in-app by the client but ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked in-app by the client but ignored due to recursion)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -76,7 +76,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -87,27 +87,27 @@ app:
           frame (marked in-app by the client but ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked in-app by the client but ignored due to recursion)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked in-app by the client but ignored due to recursion)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked in-app by the client but ignored due to recursion)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
               "@callee_guaranteed"
-          frame (marked in-app by the client but ignored due to recursion)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/cocoa_dispatch_client_callout.pysnap
@@ -39,7 +39,7 @@ app:
           frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "FudgeLogTaggedError"
-          frame (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by the client)
             function*
               "closure"
           frame* (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
@@ -51,7 +51,7 @@ app:
           frame (marked out of app by the client)
             function*
               "_dispatch_client_callout"
-          frame (marked in-app by built-in stack trace rule (family:native package:**/Containers/Bundle/Application/** +app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by the client)
             function*
               "closure"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_125_event_126.pysnap
@@ -13,10 +13,10 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: EXC_BAD_ACCESS / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -123,22 +123,22 @@ app:
           frame (non app frame)
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dyld::link"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoader::link"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoader::recursiveRebase"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoaderMachOCompressed::rebase"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_125_event_126.pysnap
@@ -75,12 +75,12 @@ app:
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "type_traits"
             function*
@@ -117,28 +117,28 @@ app:
           frame (non app frame)
             function*
               "CFBundleGetFunctionPointerForName"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_CFBundleLoadExecutableAndReturnError"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_CFBundleDlfcnLoadBundle"
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "dyld::link"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoader::link"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoader::recursiveRebase"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoaderMachOCompressed::rebase"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_200_event_200.pysnap
@@ -28,16 +28,16 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "HTTP_ASYNC_OVERLAPPED::OnWorkItem"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "WEBIO_REQUEST::OnIoComplete"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "HTTP_USER_REQUEST::OnSendRequest"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "HTTP_BASE_OBJECT::Dereference"
           frame (non app frame)
@@ -52,37 +52,37 @@ app:
           frame (non app frame)
             function*
               "RtlFreeHeap"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "memset"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpFreeUserBlock"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpFreeUserBlockToHeap"
           frame (non app frame)
             function*
               "RtlFreeHeap"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpFreeHeapInternal"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpFreeHeap"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlEnterCriticalSection"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpEnterCriticalSectionContended"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpWaitOnCriticalSection"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpWaitOnAddress"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RtlpOptimizeWaitOnAddressWaitList"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_275_event_275.pysnap
@@ -13,7 +13,7 @@ app:
         value*
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_dispatch_root_queues_init_once"
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
@@ -25,10 +25,10 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)
@@ -98,7 +98,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_275_event_275.pysnap
@@ -13,22 +13,22 @@ app:
         value*
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
@@ -18,10 +18,10 @@ app:
               "thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
@@ -78,7 +78,7 @@ app:
           frame (non app frame)
             function*
               "gldCreateDevice"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_289_event_312.pysnap
@@ -60,19 +60,19 @@ app:
           frame (non app frame)
             function*
               "glDeleteTextures_Exec"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gleUnbindDeleteHashNamesAndObjects"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gleUnbindTextureObject"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gldUpdateDispatch"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gldUpdateDispatch"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -87,10 +87,10 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_294.pysnap
@@ -13,16 +13,16 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start_wqthread"
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
           frame (non app frame)
             function*
               "stripped_application_code"
@@ -51,27 +51,27 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__tree"
             function*
@@ -81,17 +81,17 @@ app:
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "utility"
             function*
@@ -120,28 +120,28 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "std::__1::thread::~thread"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "std::terminate"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "std::__terminate"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "default_terminate_handler"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "abort_message"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
 --------------------------------------------------------------------------
 system:
   hash: "12f18dcb1efe33b32c7afe5004addaaa"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_294.pysnap
@@ -13,16 +13,16 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_329.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_dispatch_root_queues_init_once"
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
@@ -25,10 +25,10 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)
@@ -62,32 +62,32 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__tree"
             function*
@@ -97,17 +97,17 @@ app:
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "utility"
             function*
@@ -139,22 +139,22 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "std::terminate"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "std::__terminate"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "demangling_terminate_handler"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "abort_message"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_294_event_329.pysnap
@@ -13,22 +13,22 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_wqthread"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_worker_thread2"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_root_queue_drain"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_dispatch_client_callout"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_307.pysnap
@@ -16,10 +16,10 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (non app frame)
@@ -58,7 +58,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "__dynamic_cast"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_657.pysnap
@@ -16,9 +16,9 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
           frame (non app frame)
             function*
               "stripped_application_code"
@@ -55,7 +55,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_307_event_657.pysnap
@@ -55,7 +55,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_313.pysnap
@@ -75,12 +75,12 @@ app:
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "type_traits"
             function*
@@ -126,19 +126,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -168,14 +168,14 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__report_load"
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
@@ -184,10 +184,10 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_313.pysnap
@@ -13,10 +13,10 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -126,19 +126,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -162,23 +162,23 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "__report_load"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "__report_load.cold.1"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_333.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)
@@ -123,19 +123,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -159,31 +159,31 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dyld::runInitializers"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoader::runInitializers"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoader::processInitializers"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoader::recursiveInitialization"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoaderMachO::doInitialization"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "__report_load"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_313_event_333.pysnap
@@ -72,12 +72,12 @@ app:
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "type_traits"
             function*
@@ -123,19 +123,19 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_objc_msgSend_uncached"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "lookUpImpOrForward"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "initializeAndMaybeRelock"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "initializeNonMetaClass"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame (non app frame)
@@ -162,37 +162,37 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "dlopen"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "dlopen_internal"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "dyld::runInitializers"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoader::runInitializers"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoader::processInitializers"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoader::recursiveInitialization"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoaderMachO::doInitialization"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__report_load"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
@@ -106,10 +106,10 @@ app:
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
@@ -178,10 +178,10 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "gpusSubmitDataBuffers"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
@@ -37,37 +37,37 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "-[NSApplication run]"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_DPSNextEvent"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ReceiveNextEventCommon"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RunCurrentEventLoopInMode"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRunLoopDoSources0"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRunLoopDoSource0"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__NSThreadPerformPerform"
           frame (non app frame)
@@ -76,7 +76,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame (non app frame)
@@ -88,19 +88,19 @@ app:
           frame (non app frame)
             function*
               "CGLFlushDrawable"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "glSwap_Exec"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gldPresentFramebufferData"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "SwapFlush"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
           frame (non app frame)
@@ -136,19 +136,19 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "NSRunAlertPanel"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_NSTryRunModal"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CA::Transaction::commit"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CA::Context::commit_transaction"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CA::Layer::display_if_needed"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
@@ -160,19 +160,19 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "CGLTexImageIOSurface2D"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CGLDescribeRenderer"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gliSetInteger"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gldFlushObject"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
@@ -190,7 +190,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_319_event_321.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_389_event_389.pysnap
@@ -40,7 +40,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_pthread_testcancel"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_389_event_389.pysnap
@@ -16,13 +16,13 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_body"
           frame (non app frame)
@@ -40,7 +40,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_testcancel"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_432.pysnap
@@ -122,7 +122,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "raise"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_432.pysnap
@@ -119,7 +119,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "raise"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_453.pysnap
@@ -122,7 +122,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "raise"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_432_event_453.pysnap
@@ -53,12 +53,12 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "xtree"
             function*
               "std::_Tree<T>::insert<T>"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "xtree"
             function*
@@ -119,7 +119,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "raise"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_445_event_445.pysnap
@@ -37,17 +37,17 @@ app:
               "xstring"
             function*
               "std::basic_string<T>::{ctor}"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "xstring"
             function*
@@ -81,7 +81,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "UserCallWinProcCheckWow"
           frame (non app frame)
@@ -137,7 +137,7 @@ app:
               "purevirt.cpp"
             function*
               "_purecall"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "abort"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/group_445_event_445.pysnap
@@ -143,7 +143,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "raise"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/in_app_in_ui.pysnap
@@ -92,7 +92,7 @@ app:
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*
@@ -117,7 +117,7 @@ app:
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame (marked in-app by the client but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
@@ -144,7 +144,7 @@ app:
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
@@ -13,7 +13,7 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_amd_driver.pysnap
@@ -58,19 +58,19 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CFRunLoopRunSpecific"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRunLoopRun"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRunLoopDoSources0"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRunLoopDoSource0"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
           frame (non app frame)
@@ -133,14 +133,14 @@ app:
           frame (non app frame)
             function*
               "glTexSubImage2D"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "glTexSubImage2D_Exec"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gleTextureImagePut"
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -153,7 +153,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
@@ -13,10 +13,10 @@ app:
         value* (stripped event-specific values)
           "Fatal Error: <hex> / <hex>"
         stacktrace (ignored because it contains no in-app frames)
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "start"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
@@ -99,10 +99,10 @@ app:
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
@@ -169,10 +169,10 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "gpusSubmitDataBuffers"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusKillClientExt"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:telemetry -app))
             function*
               "gpusGenerateCrashLog"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/macos_intel_driver.pysnap
@@ -40,27 +40,27 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "-[NSApplication run]"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_DPSNextEvent"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "ReceiveNextEventCommon"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "RunCurrentEventLoopInMode"
-          frame (non app frame)
-          frame (non app frame)
-          frame (non app frame)
-          frame (non app frame)
-          frame (non app frame)
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__NSThreadPerformPerform"
           frame (non app frame)
@@ -69,7 +69,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "-[NSView displayIfNeeded]"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame (non app frame)
@@ -81,19 +81,19 @@ app:
           frame (non app frame)
             function*
               "CGLTexImageIOSurface2D"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CGLDescribeRenderer"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gliSetInteger"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gldFlushObject"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
           frame (non app frame)
@@ -111,7 +111,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "_sigtramp"
@@ -127,19 +127,19 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "NSRunAlertPanel"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "_NSTryRunModal"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CA::Transaction::commit"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CA::Context::commit_transaction"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CA::Layer::display_if_needed"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
@@ -151,19 +151,19 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "CGLTexImageIOSurface2D"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "CGLDescribeRenderer"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gliSetInteger"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "gldFlushObject"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "intelSubmitCommands"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "IntelCommandBuffer::getNew"
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
@@ -181,7 +181,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
             function*
               "abort"
-          frame (marked out of app by built-in stack trace rule (category:throw ^-app -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__pthread_kill"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -13,7 +13,7 @@ app:
         value*
           "timed out"
         stacktrace (ignored because it contains no in-app frames)
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             module*
               "__main__"
             filename (ignored because module takes precedence)
@@ -204,7 +204,7 @@ default:
         "Failed to process pipeline step %s"
 --------------------------------------------------------------------------
 system:
-  hash: "6791947bdfd6cf2ca7024f026df974ae"
+  hash: "1bc764ab44acfab9a38f23ae670038bd"
   contributing component: exception
   hint: None
   root_component:
@@ -215,7 +215,7 @@ system:
         value (ignored because stacktrace takes precedence)
           "timed out"
         stacktrace*
-          frame*
+          frame (ignored by built-in stack trace rule (category:internals -group))
             module*
               "__main__"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/python_hardcoded_values_in_context_line.pysnap
@@ -22,7 +22,7 @@ app:
               "<module>"
             context_line*
               "from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=11, pipe_handle=32)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -31,7 +31,7 @@ app:
               "spawn_main"
             context_line*
               "exitcode = _main(fd, parent_sentinel)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.spawn"
             filename (ignored because module takes precedence)
@@ -40,7 +40,7 @@ app:
               "_main"
             context_line*
               "return self._bootstrap(parent_sentinel)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -49,7 +49,7 @@ app:
               "_bootstrap"
             context_line*
               "self.run()"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "multiprocessing.process"
             filename (ignored because module takes precedence)
@@ -112,7 +112,7 @@ app:
               "run_post_process_job"
             context_line*
               "logger.exception("
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -121,7 +121,7 @@ app:
               "exception"
             context_line*
               "self.error(msg, *args, exc_info=exc_info, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -130,7 +130,7 @@ app:
               "error"
             context_line*
               "self._log(ERROR, msg, args, **kwargs)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -139,7 +139,7 @@ app:
               "_log"
             context_line*
               "self.handle(record)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -148,7 +148,7 @@ app:
               "handle"
             context_line*
               "self.callHandlers(record)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)
@@ -157,7 +157,7 @@ app:
               "callHandlers"
             context_line*
               "hdlr.handle(record)"
-          frame (non app frame)
+          frame (marked out of app by built-in stack trace rule (path:/usr/local/lib/** -app))
             module*
               "logging"
             filename (ignored because module takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_enforce_min_frames.pysnap
@@ -25,7 +25,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
           frame* (marked in-app by custom stack trace rule (function:log_demo::* +app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_negated_match.pysnap
@@ -25,7 +25,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust.pysnap
@@ -25,7 +25,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
           frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/stacktrace_rust2.pysnap
@@ -25,7 +25,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame (marked out of app by built-in stack trace rule (family:native function:std::* -app))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "std::rt::lang_start::{{closure}}"
           frame* (marked in-app by custom stack trace rule (family:native function:log_demo::* +app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -16,7 +16,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -13,7 +13,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "p__commonOp__fn__fn__makeReturn__fn__1823_fn__done > XTUM >\nKERN_INVALID_ADDRESS at <hex>."
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assert_mac.pysnap
@@ -16,7 +16,7 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
@@ -13,7 +13,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "Trap"
         stacktrace*
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__start_thread"
           frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_android.pysnap
@@ -13,7 +13,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "Trap"
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))
             function*
               "__start_thread"
           frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:threadbase -group v-group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
@@ -50,7 +50,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked out of app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))
+          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_assertion_check_fail_on_windows.pysnap
@@ -50,7 +50,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by built-in stack trace rule (family:native function:FDebug::CheckVerifyFailedImpl* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -13,10 +13,10 @@ app:
         value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
@@ -138,10 +138,10 @@ app:
               "-[SentryStacktraceBuilder buildStacktraceForCurrentThread]"
       threads (ignored because app/system exception takes precedence)
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -19,7 +19,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
@@ -144,7 +144,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_mac.pysnap
@@ -19,7 +19,7 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
@@ -144,7 +144,7 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
@@ -50,7 +50,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked out of app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))
+          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_ensure_check_fail_on_windows.pysnap
@@ -50,7 +50,7 @@ app:
           frame (marked out of app by built-in stack trace rule (category:system -app))
             function*
               "DispatchMessageWorker"
-          frame (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "UserCallWinProcCheckWow"
           frame* (marked in-app by built-in stack trace rule (family:native function:UE::Assert::Private::ExecCheckImplInternal* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
@@ -15,7 +15,7 @@ app:
           frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
+          frame (marked out of app by built-in stack trace rule (category:internals -app))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
@@ -15,7 +15,7 @@ app:
           frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_pthread_start"
-          frame (marked out of app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))
+          frame (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))
             function*
               "__NSThread__start__"
           frame* (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2025_11_21/unreal_event_capture_mac.pysnap
@@ -9,10 +9,10 @@ app:
     app*
       threads*
         stacktrace*
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "thread_start"
-          frame (marked out of app by built-in stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked out of app by built-in stack trace rule (package:/usr/lib/** -app))
             function*
               "_pthread_start"
           frame (marked in-app by built-in stack trace rule (family:native function:USentrySubsystem::*execCapture* v+app -app ^-app) but ignored by built-in stack trace rule (category:internals -group))


### PR DESCRIPTION
This makes a number of changes to our built-in stacktrace rules, to take effect in the new grouping config.

- Do all categorization of frames (as system, ui, telemetry, etc) before applying any rules based on categories.
- Add alternate version of linux DSO rule.
- Apply rules for unix internal locations to all platforms, so that Python events can use them, too. Also add another location.
- Mark fake module created by Python multiprocessing as internal. 
- Mark internal and telemetry frames as out of app. 

Note: Though the cumulative effects of all of the changes are included in this PR, each individual change has its own snapshot-update commit, so it's possible to see its effects in isolation should anyone choose. Any change without such a commit had no effect on snapshots.