### PR TITLE
chore(preprod): change diff text colors (eme-510)

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -336,11 +336,10 @@ const ChangeAmountCell = styled(SimpleTable.RowCell)<{changeType: DiffType}>`
   color: ${p => {
     switch (p.changeType) {
       case 'increased':
-      case 'decreased':
-        return p.theme.warningText;
       case 'added':
         return p.theme.dangerText;
       case 'removed':
+      case 'decreased':
         return p.theme.successText;
       default:
         throw new Error(`Invalid change type: ${p.changeType}`);


### PR DESCRIPTION
make diff text more scannable, before it was yellow for increase or decrease which was confusuing
<img width="962" height="591" alt="image" src="https://github.com/user-attachments/assets/8117752b-9670-4281-a8c0-24dccf9f0242" />

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
