### PR TITLE
fix(explorer): sort nav link order by block idx

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -13,7 +13,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
-import type {Block} from './types';
+import type {Block, ToolCall, ToolLink} from './types';
 import {buildToolLinkUrl, getToolsStringFromBlock, postProcessLLMMarkdown} from './utils';
 
 interface BlockProps {
@@ -90,6 +90,26 @@ function getToolStatus(
   return 'success';
 }
 
+function toolCallMatchesLink(toolCall: ToolCall, link: ToolLink): boolean {
+  if (toolCall.function !== link.kind) {
+    return false;
+  }
+
+  let toolCallArgs: Record<string, any>;
+  try {
+    toolCallArgs = JSON.parse(toolCall.args);
+  } catch {
+    toolCallArgs = {};
+  }
+
+  // If link params has dataset, tool call args must contain the same dataset.
+  if (link.params.dataset && toolCallArgs.dataset !== link.params.dataset) {
+    return false;
+  }
+
+  return true;
+}
+
 function BlockComponent({
   block,
   blockIndex: _blockIndex,
@@ -125,40 +145,45 @@ function BlockComponent({
     selectedLinkIndexRef.current = selectedLinkIndex;
   }, [selectedLinkIndex]);
 
-  // Get valid tool links with their corresponding tool call indices
-  const validToolLinksWithIndices = (block.tool_links || [])
-    .map(link => {
-      const toolCallIndex = block.message.tool_calls?.findIndex(
-        call => link && call.function === link.kind
-      );
-      const canBuildUrl =
-        link && buildToolLinkUrl(link, organization.slug, projects) !== null;
+  // Get valid tool links sorted by their corresponding tool call indices
+  const sortedToolLinks = useMemo(
+    () =>
+      (block.tool_links || [])
+        .map(link => {
+          const toolCallIndex = block.message.tool_calls?.findIndex(
+            call => link && toolCallMatchesLink(call, link)
+          );
+          const canBuildUrl =
+            link && buildToolLinkUrl(link, organization.slug, projects) !== null;
 
-      if (toolCallIndex !== undefined && toolCallIndex >= 0 && canBuildUrl) {
-        return {link, toolCallIndex};
-      }
-      return null;
-    })
-    .filter(
-      (
-        item
-      ): item is {
-        link: {kind: string; params: Record<string, any>};
-        toolCallIndex: number;
-      } => item !== null
-    );
+          if (toolCallIndex !== undefined && toolCallIndex >= 0 && canBuildUrl) {
+            return {link, toolCallIndex};
+          }
+          return null;
+        })
+        .filter(
+          (
+            item
+          ): item is {
+            link: {kind: string; params: Record<string, any>};
+            toolCallIndex: number;
+          } => item !== null
+        )
+        .sort((a, b) => a.toolCallIndex - b.toolCallIndex)
+        .map(item => item.link),
+    [block.tool_links, block.message.tool_calls, organization.slug, projects]
+  );
 
-  const validToolLinks = validToolLinksWithIndices.map(item => item.link);
-  const hasValidLinks = validToolLinks.length > 0;
+  const hasValidLinks = sortedToolLinks.length > 0;
 
   // Reset selected index when block changes or when there are no valid links
   useEffect(() => {
     if (!hasValidLinks) {
       setSelectedLinkIndex(0);
-    } else if (selectedLinkIndex >= validToolLinks.length) {
+    } else if (selectedLinkIndex >= sortedToolLinks.length) {
       setSelectedLinkIndex(0);
     }
-  }, [hasValidLinks, selectedLinkIndex, validToolLinks.length]);
+  }, [hasValidLinks, selectedLinkIndex, sortedToolLinks.length]);
 
   // Register the key handler with the parent
   useEffect(() => {
@@ -182,7 +207,7 @@ function BlockComponent({
       if (key === 'ArrowDown') {
         // Move to next link
         const currentIndex = selectedLinkIndexRef.current;
-        if (currentIndex < validToolLinks.length - 1) {
+        if (currentIndex < sortedToolLinks.length - 1) {
           // Can move down within this block's links
           setSelectedLinkIndex(prev => prev + 1);
           return true;
@@ -194,7 +219,7 @@ function BlockComponent({
       if (key === 'Enter') {
         // Navigate to selected link using ref to get current value
         const currentIndex = selectedLinkIndexRef.current;
-        const selectedLink = validToolLinks[currentIndex];
+        const selectedLink = sortedToolLinks[currentIndex];
         if (selectedLink) {
           const url = buildToolLinkUrl(selectedLink, organization.slug, projects);
           if (url) {
@@ -209,7 +234,7 @@ function BlockComponent({
     onRegisterEnterHandler?.(handler);
   }, [
     hasValidLinks,
-    validToolLinks,
+    sortedToolLinks,
     organization.slug,
     projects,
     navigate,
@@ -223,12 +248,12 @@ function BlockComponent({
 
   const handleNavigateClick = (e: React.MouseEvent, linkIndex: number) => {
     e.stopPropagation();
-    if (validToolLinks.length === 0) {
+    if (sortedToolLinks.length === 0) {
       return;
     }
 
     // Navigate to the clicked link
-    const selectedLink = validToolLinks[linkIndex];
+    const selectedLink = sortedToolLinks[linkIndex];
     if (selectedLink) {
       const url = buildToolLinkUrl(selectedLink, organization.slug, projects);
       if (url) {
@@ -321,7 +346,7 @@ function BlockComponent({
                   )}
                   {hasValidLinks && (
                     <ButtonBar merged gap="0">
-                      {validToolLinks.map((_, idx) => (
+                      {sortedToolLinks.map((_, idx) => (
                         <Button
                           key={idx}
                           size="xs"
@@ -329,7 +354,7 @@ function BlockComponent({
                           onClick={e => handleNavigateClick(e, idx)}
                         >
                           {idx === 0
-                            ? validToolLinks.length === 1
+                            ? sortedToolLinks.length === 1
                               ? 'Navigate'
                               : 'Navigate #1'
                             : `#${idx + 1}`}

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -11,13 +11,13 @@ export interface ToolLink {
   params: Record<string, any>;
 }
 
-interface Message {
+export interface Message {
   content: string;
   role: 'user' | 'assistant' | 'tool_use';
   tool_calls?: ToolCall[];
 }
 
-interface ToolCall {
+export interface ToolCall {
   args: string;
   function: string;
 }

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -4,6 +4,7 @@ export interface Block {
   timestamp: string;
   loading?: boolean;
   tool_links?: Array<ToolLink | null>;
+  tool_results?: Array<ToolResult | null>;
 }
 
 export interface ToolLink {
@@ -11,15 +12,21 @@ export interface ToolLink {
   params: Record<string, any>;
 }
 
+interface ToolResult {
+  tool_call_id: string;
+  // other fields are unused for now.
+}
+
+interface ToolCall {
+  args: string;
+  function: string;
+  id: string;
+}
+
 interface Message {
   content: string;
   role: 'user' | 'assistant' | 'tool_use';
   tool_calls?: ToolCall[];
-}
-
-export interface ToolCall {
-  args: string;
-  function: string;
 }
 
 export type PanelSize = 'max' | 'med';

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -11,7 +11,7 @@ export interface ToolLink {
   params: Record<string, any>;
 }
 
-export interface Message {
+interface Message {
   content: string;
   role: 'user' | 'assistant' | 'tool_use';
   tool_calls?: ToolCall[];


### PR DESCRIPTION
Seems like the order of a block's tool calls can be sometimes be out of sync from the tool links. This PR reorders the validToolLinks (which are rendered as nav buttons) based on the corresponding tool call, which we get from the aligned tool_results.
Before this PR, tool/nav link order is random

[AIML-1580: UI: buggy navigate buttons / button order](https://linear.app/getsentry/issue/AIML-1580/ui-buggy-navigate-buttons-button-order)