### PR TITLE
feat(aci): Add reporting for associate_new_group_with_detector outcome

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -255,7 +255,8 @@ def save_issue_from_occurrence(
             )
             if is_new:
                 associate_new_group_with_detector(
-                    group, occurrence.evidence_data.get("detector_id")
+                    group,
+                    (occurrence.evidence_data and occurrence.evidence_data.get("detector_id")),
                 )
 
             open_period = get_latest_open_period(group)

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -256,7 +256,7 @@ def save_issue_from_occurrence(
             if is_new:
                 detector_id = None
                 if occurrence.evidence_data:
-                    detector_id = occurrence.evidence_data["detector_id"]
+                    detector_id = occurrence.evidence_data.get("detector_id")
                 associate_new_group_with_detector(group, detector_id)
 
             open_period = get_latest_open_period(group)

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -254,10 +254,10 @@ def save_issue_from_occurrence(
                 project, event, primary_hash, **issue_kwargs
             )
             if is_new:
-                associate_new_group_with_detector(
-                    group,
-                    (occurrence.evidence_data and occurrence.evidence_data.get("detector_id")),
-                )
+                detector_id = None
+                if occurrence.evidence_data:
+                    detector_id = occurrence.evidence_data["detector_id"]
+                associate_new_group_with_detector(group, detector_id)
 
             open_period = get_latest_open_period(group)
             if open_period is not None:

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -253,8 +253,10 @@ def save_issue_from_occurrence(
             group, is_new, primary_grouphash = save_grouphash_and_group(
                 project, event, primary_hash, **issue_kwargs
             )
-            if is_new and occurrence.evidence_data and "detector_id" in occurrence.evidence_data:
-                associate_new_group_with_detector(group, occurrence.evidence_data["detector_id"])
+            if is_new:
+                associate_new_group_with_detector(
+                    group, occurrence.evidence_data.get("detector_id")
+                )
 
             open_period = get_latest_open_period(group)
             if open_period is not None:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -370,9 +370,23 @@ def associate_new_group_with_detector(group: Group, detector_id: int | None = No
                 return False
             detector_id = Detector.get_error_detector_for_project(group.project.id).id
         else:
+            metrics.incr(
+                "workflow_engine.associate_new_group_with_detector_failed",
+                tags={"group_type": group.type},
+            )
+            logger.warning(
+                "associate_new_group_with_detector_failed",
+                extra={
+                    "group_id": group.id,
+                    "group_type": group.type,
+                },
+            )
             return False
     DetectorGroup.objects.get_or_create(
         detector_id=detector_id,
         group_id=group.id,
+    )
+    metrics.incr(
+        "workflow_engine.associate_new_group_with_detector", tags={"group_type": group.type}
     )
     return True

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -371,8 +371,8 @@ def associate_new_group_with_detector(group: Group, detector_id: int | None = No
             detector_id = Detector.get_error_detector_for_project(group.project.id).id
         else:
             metrics.incr(
-                "workflow_engine.associate_new_group_with_detector_failed",
-                tags={"group_type": group.type},
+                "workflow_engine.associate_new_group_with_detector",
+                tags={"group_type": group.type, "result": "failure"},
             )
             logger.warning(
                 "associate_new_group_with_detector_failed",
@@ -387,6 +387,7 @@ def associate_new_group_with_detector(group: Group, detector_id: int | None = No
         group_id=group.id,
     )
     metrics.incr(
-        "workflow_engine.associate_new_group_with_detector", tags={"group_type": group.type}
+        "workflow_engine.associate_new_group_with_detector",
+        tags={"group_type": group.type, "result": "success"},
     )
     return True


### PR DESCRIPTION
We intend for there to be DetectorGroup for any newly generated Group.
To better validate this, we make associate_new_group_with_detector log a warning when we can't associate, and report a metric to track group type-specific success rate.