### PR TITLE
feat(aci): Allow empty monitor/alert names

### DIFF
--- a/static/app/components/editableText.spec.tsx
+++ b/static/app/components/editableText.spec.tsx
@@ -44,6 +44,21 @@ describe('EditableText', () => {
     expect(handleChange).toHaveBeenCalledTimes(0);
   });
 
+  it('reverts to previous value when allowEmpty is true', async () => {
+    const handleChange = jest.fn();
+
+    render(
+      <EditableText value="foo" onChange={handleChange} allowEmpty errorMessage="error" />
+    );
+
+    await userEvent.click(screen.getByText('foo'));
+    await userEvent.clear(screen.getByRole('textbox'));
+    await userEvent.click(document.body);
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.getByText('foo')).toBeInTheDocument();
+  });
+
   it('displays a disabled value', async () => {
     render(<EditableText value="foo" onChange={jest.fn()} isDisabled />);
 

--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -7,8 +7,6 @@ import {Input} from 'sentry/components/core/input';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconEdit} from 'sentry/icons/iconEdit';
 import {space} from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
-import useKeypress from 'sentry/utils/useKeyPress';
 import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 
 type Props = {
@@ -48,138 +46,167 @@ function EditableText({
   allowEmpty = false,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState(value);
+  // Immediately reflect the last committed value while we wait for the parent prop update
+  const [optimisticValue, setOptimisticValue] = useState<string | null>(null);
+  // Current keystrokes while editing; cleared whenever editing ends
+  const [draftValue, setDraftValue] = useState<string | null>(null);
 
-  const isEmpty = !inputValue.trim();
+  const currentValue = optimisticValue ?? value;
+  const currentDraft = draftValue ?? currentValue;
+  const isDraftEmpty = !currentDraft.trim();
 
   const innerWrapperRef = useRef<HTMLDivElement>(null);
   const labelRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const previousValueRef = useRef(value);
 
-  const enter = useKeypress('Enter');
-  const esc = useKeypress('Escape');
+  const showStatusMessage = useCallback(
+    (status: 'error' | 'success') => {
+      if (status === 'error') {
+        if (errorMessage) {
+          addErrorMessage(errorMessage);
+        }
+        return;
+      }
 
-  function revertValueAndCloseEditor() {
-    if (value !== inputValue) {
-      setInputValue(value);
+      if (successMessage) {
+        addSuccessMessage(successMessage);
+      }
+    },
+    [errorMessage, successMessage]
+  );
+
+  const exitEditing = useCallback(() => {
+    setIsEditing(false);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setDraftValue(null);
+    exitEditing();
+  }, [exitEditing]);
+
+  const handleCommit = useCallback(() => {
+    if (isDraftEmpty) {
+      showStatusMessage('error');
+      return false;
     }
+
+    if (currentDraft !== currentValue) {
+      onChange(currentDraft);
+      showStatusMessage('success');
+    }
+
+    exitEditing();
+    setOptimisticValue(currentDraft);
+    setDraftValue(null);
+    return true;
+  }, [
+    currentDraft,
+    currentValue,
+    exitEditing,
+    isDraftEmpty,
+    onChange,
+    showStatusMessage,
+  ]);
+
+  const handleEmptyBlur = useCallback(() => {
+    if (allowEmpty) {
+      handleCancel();
+    } else {
+      showStatusMessage('error');
+    }
+  }, [allowEmpty, handleCancel, showStatusMessage]);
+
+  // Close editing if the field becomes disabled (e.g. form revalidation)
+  useEffect(() => {
+    if (isDisabled) {
+      handleCancel();
+    }
+  }, [handleCancel, isDisabled]);
+
+  // Reset our optimistic/draft state whenever the controlled value changes externally
+  useEffect(() => {
+    if (previousValueRef.current === value) {
+      return;
+    }
+
+    previousValueRef.current = value;
+    setOptimisticValue(null);
 
     if (isEditing) {
-      setIsEditing(false);
+      setDraftValue(null);
+      exitEditing();
     }
-  }
+  }, [exitEditing, isEditing, value]);
 
-  // check to see if the user clicked outside of this component
-  useOnClickOutside(innerWrapperRef, () => {
+  // Focus the input whenever we enter editing mode
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+    }
+  }, [isEditing]);
+
+  const handleClickOutside = useCallback(() => {
     if (!isEditing) {
       return;
     }
 
-    if (isEmpty) {
-      if (allowEmpty) {
-        revertValueAndCloseEditor();
-      } else {
-        displayStatusMessage('error');
-      }
+    if (isDraftEmpty) {
+      handleEmptyBlur();
       return;
     }
 
-    if (inputValue !== value) {
-      onChange(inputValue);
-      displayStatusMessage('success');
-    }
+    handleCommit();
+  }, [handleCommit, handleEmptyBlur, isDraftEmpty, isEditing]);
 
-    setIsEditing(false);
-  });
+  useOnClickOutside(innerWrapperRef, handleClickOutside);
 
-  const onEnter = useCallback(() => {
-    if (enter) {
-      if (isEmpty) {
-        displayStatusMessage('error');
-        return;
-      }
+  const handleInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setDraftValue(event.target.value);
+  }, []);
 
-      if (inputValue !== value) {
-        onChange(inputValue);
-        displayStatusMessage('success');
-      }
-
-      setIsEditing(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enter, inputValue, onChange]);
-
-  const onEsc = useCallback(() => {
-    if (esc) {
-      revertValueAndCloseEditor();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [esc]);
-
-  useEffect(() => {
-    revertValueAndCloseEditor();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDisabled, value]);
-
-  // focus the cursor in the input field on edit start
-  useEffect(() => {
-    if (isEditing) {
-      const inputElement = inputRef.current;
-      if (defined(inputElement)) {
-        inputElement.focus();
-      }
-    }
-  }, [isEditing]);
-
-  useEffect(() => {
-    if (isEditing) {
-      // if Enter is pressed, save the value and close the editor
-      onEnter();
-      // if Escape is pressed, revert the value and close the editor
-      onEsc();
-    }
-  }, [onEnter, onEsc, isEditing]); // watch the Enter and Escape key presses
-
-  function displayStatusMessage(status: 'error' | 'success') {
-    if (status === 'error') {
-      if (errorMessage) {
-        addErrorMessage(errorMessage);
-      }
+  const handleEditClick = useCallback(() => {
+    if (isDisabled) {
       return;
     }
 
-    if (successMessage) {
-      addSuccessMessage(successMessage);
-    }
-  }
-
-  function handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
-    setInputValue(event.target.value);
-  }
-
-  function handleEditClick() {
+    setDraftValue(currentValue);
     setIsEditing(true);
-  }
+  }, [currentValue, isDisabled]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleCommit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel, handleCommit]
+  );
 
   return (
     <Wrapper isDisabled={isDisabled} isEditing={isEditing} className={className}>
       {isEditing ? (
         <InputWrapper
           ref={innerWrapperRef}
-          isEmpty={isEmpty}
+          isEmpty={isDraftEmpty}
           data-test-id="editable-text-input"
         >
           <StyledInput
             aria-label={ariaLabel}
             name={name}
             ref={inputRef}
-            value={inputValue}
+            value={currentDraft}
             onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
             onFocus={event => autoSelect && event.target.select()}
             maxLength={maxLength}
             placeholder={placeholder}
           />
-          <InputLabel>{inputValue}</InputLabel>
+          <InputLabel>{currentDraft}</InputLabel>
         </InputWrapper>
       ) : (
         <Label
@@ -188,7 +215,7 @@ function EditableText({
           isDisabled={isDisabled}
           data-test-id="editable-text-label"
         >
-          <InnerLabel>{inputValue || placeholder}</InnerLabel>
+          <InnerLabel>{currentValue || placeholder}</InnerLabel>
           {!isDisabled && <IconEdit />}
         </Label>
       )}

--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -14,6 +14,11 @@ import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 type Props = {
   onChange: (value: string) => void;
   value: string;
+  /**
+   * When true, clearing the input and blurring cancels the edit and restores
+   * the previous value instead of showing an error toast.
+   */
+  allowEmpty?: boolean;
   'aria-label'?: string;
   autoSelect?: boolean;
   className?: string;
@@ -40,6 +45,7 @@ function EditableText({
   className,
   'aria-label': ariaLabel,
   placeholder,
+  allowEmpty = false,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(value);
@@ -70,7 +76,11 @@ function EditableText({
     }
 
     if (isEmpty) {
-      displayStatusMessage('error');
+      if (allowEmpty) {
+        revertValueAndCloseEditor();
+      } else {
+        displayStatusMessage('error');
+      }
       return;
     }
 

--- a/static/app/views/automations/components/editableAutomationName.tsx
+++ b/static/app/views/automations/components/editableAutomationName.tsx
@@ -10,7 +10,7 @@ export function EditableAutomationName() {
     <FormField name="name" inline={false} flexibleControlStateSize stacked>
       {({onChange, value}) => (
         <EditableText
-          isDisabled={false}
+          allowEmpty
           value={value || ''}
           onChange={newValue => {
             // Mark that the user has manually set the automation name
@@ -21,7 +21,6 @@ export function EditableAutomationName() {
               },
             });
           }}
-          errorMessage={t('Please set a name for your alert.')}
           placeholder={t('New Alert')}
         />
       )}

--- a/static/app/views/automations/components/forms/automationNameUtils.spec.tsx
+++ b/static/app/views/automations/components/forms/automationNameUtils.spec.tsx
@@ -78,9 +78,9 @@ describe('automationNameUtils', () => {
         actionFilters: [ActionFilterFixture({actions})],
       }) as AutomationBuilderState;
 
-    it('should return "New Alert" for empty actions', () => {
+    it('should return "" for empty actions', () => {
       const builderState = createBuilderState([]);
-      expect(getAutomationName(builderState)).toBe('New Alert');
+      expect(getAutomationName(builderState)).toBe('');
     });
 
     it('should return single action description', () => {

--- a/static/app/views/automations/components/forms/automationNameUtils.tsx
+++ b/static/app/views/automations/components/forms/automationNameUtils.tsx
@@ -45,7 +45,7 @@ export function getAutomationName(builderState: AutomationBuilderState): string 
   const allActions = builderState.actionFilters.flatMap(group => group.actions || []);
 
   if (allActions.length === 0) {
-    return 'New Alert';
+    return '';
   }
 
   const count = allActions.length;
@@ -78,7 +78,7 @@ export function getAutomationName(builderState: AutomationBuilderState): string 
   // Fallback if even a single action is too long
   if (actionsToInclude === 0) {
     if (count === 0) {
-      automationName = 'New Alert';
+      automationName = '';
     } else {
       automationName = t('New Alert (%s actions)', count);
     }

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -75,16 +75,17 @@ export function cronFormDataToEndpointPayload(
           schedule_type: ScheduleType.INTERVAL,
         };
 
+  const name = data.name || 'New Monitor';
   return {
     type: 'monitor_check_in_failure',
-    name: data.name,
+    name,
     description: data.description || null,
     owner: data.owner,
     projectId: data.projectId,
     workflowIds: data.workflowIds,
     dataSources: [
       {
-        name: data.name,
+        name,
         config,
       },
     ],

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -45,7 +45,6 @@ export function NewCronDetectorForm() {
       formDataToEndpointPayload={cronFormDataToEndpointPayload}
       initialFormData={{
         scheduleType: CRON_DEFAULT_SCHEDULE_TYPE,
-        name: 'New Monitor',
       }}
     >
       <CronDetectorForm />

--- a/static/app/views/detectors/components/forms/detectorBaseFields.tsx
+++ b/static/app/views/detectors/components/forms/detectorBaseFields.tsx
@@ -21,7 +21,7 @@ export function DetectorBaseFields() {
         <FormField name="name" inline={false} flexibleControlStateSize stacked>
           {({onChange, value}) => (
             <EditableText
-              isDisabled={false}
+              allowEmpty
               value={value || ''}
               onChange={newValue => {
                 onChange(newValue, {
@@ -31,7 +31,6 @@ export function DetectorBaseFields() {
                 });
                 setHasSetDetectorName(true);
               }}
-              errorMessage={t('Please set a title')}
               placeholder={t('New Monitor')}
               aria-label={t('Monitor Name')}
             />

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -31,7 +31,7 @@ export function uptimeFormDataToEndpointPayload(
 ): UptimeDetectorUpdatePayload {
   return {
     type: 'uptime_domain_failure',
-    name: data.name,
+    name: data.name || 'New Monitor',
     owner: data.owner,
     projectId: data.projectId,
     workflowIds: data.workflowIds,

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -52,7 +52,7 @@ export function NewUptimeDetectorForm() {
     <NewDetectorLayout
       detectorType="uptime_domain_failure"
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
-      initialFormData={{name: 'New Monitor'}}
+      initialFormData={{}}
     >
       <UptimeDetectorForm />
     </NewDetectorLayout>

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -718,7 +718,7 @@ describe('DetectorEdit', () => {
                 url: 'https://uptime.example.com',
               },
             ],
-            name: 'New MonitorUptime Monitor',
+            name: 'Uptime Monitor',
             description: 'This is my uptime monitor description',
             projectId: '2',
             type: 'uptime_domain_failure',


### PR DESCRIPTION
When clicking into the form field by default it should act like a blank input field. Allows submitting without typing a name, defaults to "new monitor" or any automatically created name.

Refactors EditableText to not use global event listeners and create 
