### PR TITLE
ref(workflow_engine): Update workflow evaluation log data

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 import logging
 from enum import StrEnum
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.db import models
 from django.db.models import Q
@@ -111,6 +111,12 @@ class Action(DefaultFieldsModel, JSONConfigBase):
                 name="action_sentry_app_lookup",
             ),
         ]
+
+    def get_snapshot(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+        }
 
     def get_handler(self) -> builtins.type[ActionHandler]:
         action_type = Action.Type(self.type)

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 import logging
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar, TypedDict
 
 from django.db import models
 from django.db.models import Q
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+class ActionSnapshot(TypedDict):
+    id: int
+    type: Action.Type
 
 
 class ActionManager(BaseManager["Action"]):
@@ -112,10 +117,10 @@ class Action(DefaultFieldsModel, JSONConfigBase):
             ),
         ]
 
-    def get_snapshot(self) -> dict[str, Any]:
+    def get_snapshot(self) -> ActionSnapshot:
         return {
             "id": self.id,
-            "type": self.type,
+            "type": Action.Type(self.type),
         }
 
     def get_handler(self) -> builtins.type[ActionHandler]:

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -3,7 +3,7 @@ import operator
 import time
 from datetime import timedelta
 from enum import StrEnum
-from typing import Any, TypeVar, cast
+from typing import Any, TypedDict, TypeVar, cast
 
 from django.db import models
 from django.db.models.signals import pre_save
@@ -111,6 +111,13 @@ T = TypeVar("T")
 FAST_CONDITION_TOO_SLOW_THRESHOLD = timedelta(milliseconds=500)
 
 
+class DataConditionSnapshot(TypedDict):
+    id: int
+    type: str
+    comparison: str
+    condition_result: DataConditionResult
+
+
 @region_silo_model
 class DataCondition(DefaultFieldsModel):
     """
@@ -137,7 +144,7 @@ class DataCondition(DefaultFieldsModel):
         on_delete=models.CASCADE,
     )
 
-    def get_snapshot(self) -> dict[str, Any]:
+    def get_snapshot(self) -> DataConditionSnapshot:
         return {
             "id": self.id,
             "type": self.type,

--- a/src/sentry/workflow_engine/models/data_condition_group.py
+++ b/src/sentry/workflow_engine/models/data_condition_group.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
 from enum import StrEnum
-from typing import Any, ClassVar, Self
+from typing import ClassVar, Self, TypedDict
 
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, region_silo_model, sane_repr
 from sentry.db.models.manager.base import BaseManager
+from sentry.workflow_engine.models.data_condition import DataConditionSnapshot
+
+
+class DataConditionGroupSnapshot(TypedDict):
+    id: int
+    logic_type: DataConditionGroup.Type
+    conditions: list[DataConditionSnapshot]
 
 
 @region_silo_model
@@ -37,13 +46,13 @@ class DataConditionGroup(DefaultFieldsModel):
     )
     organization = models.ForeignKey("sentry.Organization", on_delete=models.CASCADE)
 
-    def get_snapshot(self) -> dict[str, Any]:
+    def get_snapshot(self) -> DataConditionGroupSnapshot:
         conditions = []
         if hasattr(self, "conditions"):
             conditions = [cond.get_snapshot() for cond in self.conditions.all()]
 
         return {
             "id": self.id,
-            "logic_type": self.logic_type,
+            "logic_type": DataConditionGroup.Type(self.logic_type),
             "conditions": conditions,
         }

--- a/src/sentry/workflow_engine/models/data_condition_group.py
+++ b/src/sentry/workflow_engine/models/data_condition_group.py
@@ -8,6 +8,7 @@ from django.db import models
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, region_silo_model, sane_repr
 from sentry.db.models.manager.base import BaseManager
+from sentry.db.models.utils import is_model_attr_cached
 from sentry.workflow_engine.models.data_condition import DataConditionSnapshot
 
 
@@ -48,7 +49,7 @@ class DataConditionGroup(DefaultFieldsModel):
 
     def get_snapshot(self) -> DataConditionGroupSnapshot:
         conditions = []
-        if hasattr(self, "conditions"):
+        if is_model_attr_cached(self, "conditions"):
             conditions = [cond.get_snapshot() for cond in self.conditions.all()]
 
         return {

--- a/src/sentry/workflow_engine/models/data_condition_group.py
+++ b/src/sentry/workflow_engine/models/data_condition_group.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import ClassVar, Self
+from typing import Any, ClassVar, Self
 
 from django.db import models
 
@@ -36,3 +36,14 @@ class DataConditionGroup(DefaultFieldsModel):
         max_length=200, choices=[(t.value, t.value) for t in Type], default=Type.ANY
     )
     organization = models.ForeignKey("sentry.Organization", on_delete=models.CASCADE)
+
+    def get_snapshot(self) -> dict[str, Any]:
+        conditions = []
+        if hasattr(self, "conditions"):
+            conditions = [cond.get_snapshot() for cond in self.conditions.all()]
+
+        return {
+            "id": self.id,
+            "logic_type": self.logic_type,
+            "conditions": conditions,
+        }

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -141,6 +141,18 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
 
         return settings
 
+    def get_snapshot(self) -> dict[str, Any]:
+        trigger_conditions = None
+        if self.workflow_condition_group:
+            trigger_conditions = self.workflow_condition_group.get_snapshot()
+
+        return {
+            "id": self.id,
+            "enabled": self.enabled,
+            "status": self.status,
+            "trigger_conditions": trigger_conditions,
+        }
+
     def get_audit_log_data(self) -> dict[str, Any]:
         return {"name": self.name}
 

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from django.conf import settings
 from django.db import models
@@ -29,8 +29,16 @@ from .json_config import JSONConfigBase
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.handlers.detector import DetectorHandler
+    from sentry.workflow_engine.models.data_condition_group import DataConditionGroupSnapshot
 
 logger = logging.getLogger(__name__)
+
+
+class DetectorSnapshot(TypedDict):
+    id: int
+    enabled: bool
+    status: int
+    trigger_condition: DataConditionGroupSnapshot | None
 
 
 class DetectorManager(BaseManager["Detector"]):
@@ -141,16 +149,16 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
 
         return settings
 
-    def get_snapshot(self) -> dict[str, Any]:
-        trigger_conditions = None
+    def get_snapshot(self) -> DetectorSnapshot:
+        trigger_condition = None
         if self.workflow_condition_group:
-            trigger_conditions = self.workflow_condition_group.get_snapshot()
+            trigger_condition = self.workflow_condition_group.get_snapshot()
 
         return {
             "id": self.id,
             "enabled": self.enabled,
             "status": self.status,
-            "trigger_conditions": trigger_conditions,
+            "trigger_condition": trigger_condition,
         }
 
     def get_audit_log_data(self) -> dict[str, Any]:

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypedDict
 
 from django.conf import settings
 from django.db import models
@@ -17,13 +17,24 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.models.owner_base import OwnerModel
 from sentry.workflow_engine.models.data_condition import DataCondition, is_slow_condition
-from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.models.data_condition_group import (
+    DataConditionGroup,
+    DataConditionGroupSnapshot,
+)
 from sentry.workflow_engine.processors.data_condition_group import TriggerResult
 from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 
 from .json_config import JSONConfigBase
 
 logger = logging.getLogger(__name__)
+
+
+class WorkflowSnapshot(TypedDict):
+    id: int
+    enabled: bool
+    environment_id: int | None
+    status: int
+    triggers: DataConditionGroupSnapshot | None
 
 
 class WorkflowManager(BaseManager["Workflow"]):
@@ -92,7 +103,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     def get_audit_log_data(self) -> dict[str, Any]:
         return {"name": self.name}
 
-    def get_snapshot(self) -> dict[str, Any]:
+    def get_snapshot(self) -> WorkflowSnapshot:
         when_condition_group = None
         if self.when_condition_group:
             when_condition_group = self.when_condition_group.get_snapshot()

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -83,7 +83,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         "additionalProperties": False,
     }
 
-    __repr__ = sane_repr("name", "organization_id")
+    __repr__ = sane_repr("organization_id")
 
     class Meta:
         app_label = "workflow_engine"

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -92,6 +92,23 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     def get_audit_log_data(self) -> dict[str, Any]:
         return {"name": self.name}
 
+    def get_snapshot(self) -> dict[str, Any]:
+        when_condition_group = None
+        if self.when_condition_group:
+            when_condition_group = self.when_condition_group.get_snapshot()
+
+        environment_id = None
+        if self.environment:
+            environment_id = self.environment.id
+
+        return {
+            "id": self.id,
+            "enabled": self.enabled,
+            "environment_id": environment_id,
+            "status": self.status,
+            "triggers": when_condition_group,
+        }
+
     def evaluate_trigger_conditions(
         self, event_data: WorkflowEventData, when_data_conditions: list[DataCondition] | None = None
     ) -> tuple[TriggerResult, list[DataCondition]]:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -117,7 +117,7 @@ def enqueue_workflows(
     for queue_item in items_by_workflow.values():
         if not queue_item.delayed_if_group_ids and not queue_item.passing_if_group_ids:
             # Skip because there are no IF groups we could possibly fire actions for if
-            # the WHEN/IF delayed condtions are met
+            # the WHEN/IF delayed conditions are met
             continue
         project_id = queue_item.event.project_id
         items_by_project_id[project_id].append(queue_item)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -482,7 +482,7 @@ def process_workflows(
         fire_actions,
     )
 
-    workflow_evaluation_data = WorkflowEvaluationData(group_event=event_data.event)
+    workflow_evaluation_data = WorkflowEvaluationData(event=event_data.event)
 
     try:
         if detector is None and isinstance(event_data.event, GroupEvent):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -89,7 +89,7 @@ class WorkflowEventData:
 
 @dataclass
 class WorkflowEvaluationData:
-    group_event: GroupEvent | Activity
+    event: GroupEvent | Activity
     action_groups: set[DataConditionGroup] | None = None
     workflows: set[Workflow] | None = None
     triggered_actions: set[Action] | None = None
@@ -134,7 +134,15 @@ class WorkflowEvaluation:
         else:
             log_str = f"{log_str}.actions.triggered"
 
-        logger.info(log_str, extra={**asdict(self.data), "debug_msg": self.msg})
+        logger.info(
+            log_str,
+            extra={
+                **asdict(self.data),
+                "debug_msg": self.msg,
+                "group": self.data.event.group,
+                "data": self.data.event.data,
+            },
+        )
 
 
 class ConfigTransformer(ABC):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -106,19 +106,19 @@ class WorkflowEvaluationData:
         if self.associated_detector:
             associated_detector = self.associated_detector.get_snapshot()
 
-        workflow_ids = []
+        workflow_ids = None
         if self.workflows:
             workflow_ids = [workflow.id for workflow in self.workflows]
 
-        triggered_workflows = []
+        triggered_workflows = None
         if self.triggered_workflows:
             triggered_workflows = [workflow.get_snapshot() for workflow in self.triggered_workflows]
 
-        action_filter_conditions = []
+        action_filter_conditions = None
         if self.action_groups:
             action_filter_conditions = [group.get_snapshot() for group in self.action_groups]
 
-        triggered_actions = []
+        triggered_actions = None
         if self.triggered_actions:
             triggered_actions = [action.get_snapshot() for action in self.triggered_actions]
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from logging import Logger
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
@@ -96,6 +96,43 @@ class WorkflowEvaluationData:
     triggered_workflows: set[Workflow] | None = None
     associated_detector: Detector | None = None
 
+    def get_snapshot(self) -> dict[str, Any]:
+        """
+        This method will take the complex data structures, like models / list of models,
+        and turn them into the critical attributes of a model or lists of IDs.
+        """
+
+        associated_detector = None
+        if self.associated_detector:
+            associated_detector = self.associated_detector.get_snapshot()
+
+        workflow_ids = []
+        if self.workflows:
+            workflow_ids = [workflow.id for workflow in self.workflows]
+
+        triggered_workflows = []
+        if self.triggered_workflows:
+            triggered_workflows = [workflow.get_snapshot() for workflow in self.triggered_workflows]
+
+        action_filter_conditions = []
+        if self.action_groups:
+            action_filter_conditions = [group.get_snapshot() for group in self.action_groups]
+
+        triggered_actions = []
+        if self.triggered_actions:
+            triggered_actions = [action.get_snapshot() for action in self.triggered_actions]
+
+        return {
+            "workflow_ids": workflow_ids,
+            "associated_detector": associated_detector,
+            "event": self.event,
+            "group": self.event.group,
+            "event_data": self.event.data,
+            "action_filter_conditions": action_filter_conditions,
+            "triggered_actions": triggered_actions,
+            "triggered_workflows": triggered_workflows,
+        }
+
 
 @dataclass(frozen=True)
 class WorkflowEvaluation:
@@ -134,15 +171,7 @@ class WorkflowEvaluation:
         else:
             log_str = f"{log_str}.actions.triggered"
 
-        logger.info(
-            log_str,
-            extra={
-                **asdict(self.data),
-                "debug_msg": self.msg,
-                "group": self.data.event.group,
-                "data": self.data.event.data,
-            },
-        )
+        logger.info(log_str, extra={**self.data.get_snapshot(), "debug_msg": self.msg})
 
 
 class ConfigTransformer(ABC):

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -154,13 +154,15 @@ class TestProcessWorkflowActivity(TestCase):
             mock_logger.info.assert_called_once_with(
                 "workflow_engine.process_workflows.evaluation.workflows.not_triggered",
                 extra={
-                    "debug_msg": "No workflows are associated with the detector in the event",
-                    "group_event": self.activity,
-                    "action_groups": None,
+                    "workflow_ids": None,
+                    "associated_detector": self.detector.get_snapshot(),
+                    "event": self.activity,
+                    "group": self.activity.group,
+                    "event_data": self.activity.data,
+                    "action_filter_conditions": None,
                     "triggered_actions": None,
-                    "workflows": set(),
                     "triggered_workflows": None,
-                    "associated_detector": self.detector,
+                    "debug_msg": "No workflows are associated with the detector in the event",
                 },
             )
 
@@ -199,13 +201,15 @@ class TestProcessWorkflowActivity(TestCase):
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.evaluation.workflows.triggered",
             extra={
-                "debug_msg": "No items were triggered or queued for slow evaluation",
-                "group_event": self.activity,
-                "action_groups": None,
+                "workflow_ids": [self.workflow.id],
+                "associated_detector": self.detector.get_snapshot(),
+                "event": self.activity,
+                "group": self.activity.group,
+                "event_data": self.activity.data,
+                "action_filter_conditions": None,
                 "triggered_actions": None,
-                "workflows": {self.workflow},
-                "triggered_workflows": set(),  # from the mock
-                "associated_detector": self.detector,
+                "triggered_workflows": None,
+                "debug_msg": "No items were triggered or queued for slow evaluation",
             },
         )
 
@@ -241,18 +245,6 @@ class TestProcessWorkflowActivity(TestCase):
         )
 
         mock_filter_actions.assert_called_once_with({self.action_group}, expected_event_data)
-        mock_logger.info.assert_called_once_with(
-            "workflow_engine.process_workflows.evaluation.actions.triggered",
-            extra={
-                "debug_msg": None,
-                "group_event": self.activity,
-                "action_groups": {self.action_group},
-                "triggered_actions": set(),
-                "workflows": {self.workflow},
-                "triggered_workflows": {self.workflow},
-                "associated_detector": self.detector,
-            },
-        )
 
     @mock.patch("sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers")
     @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
@@ -260,6 +252,8 @@ class TestProcessWorkflowActivity(TestCase):
         self, mock_logger, mock_evaluate_workflow_triggers
     ) -> None:
         self.workflow = self.create_workflow(organization=self.organization)
+
+        # Add additional data to ensure logs work as expected
         self.workflow.when_condition_group = self.create_data_condition_group()
         self.create_data_condition(condition_group=self.workflow.when_condition_group)
         self.workflow.save()


### PR DESCRIPTION
# Description
This PR is accomplishing two goals:
1. Makes sure we have all the data required to evaluate the tagged_event condition, this uses the workflow engine logger / context, and will log for opt'd in orgs only.
2. Update the generic logging to include as much info as possible in the log. This meant changing models to snapshots, and lists of models to id lists, and adding a few more data items (the conditions being evaluated).

Hoping that after this, we can at least root cause any issues with the specific problematic condition handler and that we'll have enough evaluation info at the top level, that it will include all the required information for us to determine why an alert did / did not trigger. (eventually, it'd be nice if this could live in something like BigTable or Cassandra so we can query the info, reduce logging costs, and let users see the alert evaluation information if they want)