### PR TITLE
fix(spans): Shim more fields for issue detectors

### DIFF
--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -99,8 +99,15 @@ def build_shim_event_data(
     # topological sorting on the span tree.
     for span in spans:
         event_span = cast(dict[str, Any], deepcopy(span))
-        event_span["start_timestamp"] = span["start_timestamp"]
         event_span["timestamp"] = span["end_timestamp"]
+        event_span["data"] = {
+            key: value
+            for (key, attribute) in (span.get("attributes") or {}).items()
+            if (value := (attribute or {}).get("value")) is not None
+        }
+        if description := attribute_value(span, "sentry.description"):
+            event_span["description"] = description
+
         event["spans"].append(event_span)
 
     return event

--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -100,11 +100,14 @@ def build_shim_event_data(
     for span in spans:
         event_span = cast(dict[str, Any], deepcopy(span))
         event_span["timestamp"] = span["end_timestamp"]
-        event_span["data"] = {
-            key: value
-            for (key, attribute) in (span.get("attributes") or {}).items()
-            if (value := (attribute or {}).get("value")) is not None
-        }
+        event_span["data"] = {}
+        for key, value in (span.get("attributes") or {}).items():
+            if (value := attribute_value(event_span, key)) is not None:
+                if key == "sentry.description":
+                    event_span["description"] = value
+                else:
+                    event_span["data"][key] = value
+
         if description := attribute_value(span, "sentry.description"):
             event_span["description"] = description
 

--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -108,9 +108,6 @@ def build_shim_event_data(
                 else:
                     event_span["data"][key] = value
 
-        if description := attribute_value(span, "sentry.description"):
-            event_span["description"] = description
-
         event["spans"].append(event_span)
 
     return event

--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -97,6 +97,9 @@ def build_shim_event_data(
     # Add legacy span attributes required only by issue detectors. As opposed to
     # real event payloads, this also adds the segment span so detectors can run
     # topological sorting on the span tree.
+    #
+    # TODO: Remove this code once `organizations:performance-issues-spans` has graduated
+    # and performance issue detection runs 100% on spans.
     for span in spans:
         event_span = cast(dict[str, Any], deepcopy(span))
         event_span["timestamp"] = span["end_timestamp"]

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -28,12 +28,9 @@ class CompatibleSpan(SpanEvent, total=True):
 
     This type will be removed eventually."""
 
-    data: dict[str, Any]
-    description: str
     exclusive_time: float
     op: str
     sentry_tags: dict[str, str]
-    timestamp: float
 
     # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
     hash: NotRequired[str]

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -28,9 +28,12 @@ class CompatibleSpan(SpanEvent, total=True):
 
     This type will be removed eventually."""
 
+    data: dict[str, Any]
+    description: str
     exclusive_time: float
     op: str
     sentry_tags: dict[str, str]
+    timestamp: float
 
     # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
     hash: NotRequired[str]


### PR DESCRIPTION
For performance issue detection, we shim the `timestamp` field for spans, but the detector code also accesses `span.data` and `span.description`.