### PR TITLE
feat(onboarding): Simplify metrics onboarding for Node SDKs

### DIFF
--- a/static/app/gettingStartedDocs/node/metrics.tsx
+++ b/static/app/gettingStartedDocs/node/metrics.tsx
@@ -7,7 +7,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getInstallCodeBlock} from 'sentry/gettingStartedDocs/node/utils';
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 
 export const getNodeMetricsOnboarding = <
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
@@ -49,7 +49,8 @@ export const getNodeMetricsOnboarding = <
       ],
     },
   ],
-  configure: () => [
+  configure: () => [],
+  verify: (params: DocsParams) => [
     {
       type: StepType.CONFIGURE,
       content: [
@@ -59,6 +60,21 @@ export const getNodeMetricsOnboarding = <
             'Metrics are automatically enabled after Sentry is initialized. You can emit metrics using the [code:Sentry.metrics] API.',
             {code: <code />}
           ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
+          code: `
+import * as Sentry from "${packageName}";
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+});
+
+Sentry.metrics.count('button_click', 1);
+Sentry.metrics.gauge('page_load_time', 150);
+Sentry.metrics.distribution('response_time', 200);
+`,
         },
         {
           type: 'text',
@@ -72,30 +88,6 @@ export const getNodeMetricsOnboarding = <
               ),
             }
           ),
-        },
-      ],
-    },
-  ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            'Send a test metric from your app to verify metrics are arriving in Sentry.'
-          ),
-        },
-        {
-          type: 'code',
-          language: 'javascript',
-          code: `const Sentry = require("${packageName}");
-
-// Emit a test metric
-Sentry.metrics.count('test_counter', 1);
-Sentry.metrics.gauge('test_gauge', 100);
-Sentry.metrics.distribution('test_distribution', 150);
-`,
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/metrics.tsx
+++ b/static/app/gettingStartedDocs/node/metrics.tsx
@@ -52,7 +52,7 @@ export const getNodeMetricsOnboarding = <
   configure: () => [],
   verify: (params: DocsParams) => [
     {
-      type: StepType.CONFIGURE,
+      type: StepType.VERIFY,
       content: [
         {
           type: 'text',

--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -98,7 +98,7 @@ function OnboardingPanel({
 const STEP_TITLES: Record<StepType, string> = {
   [StepType.INSTALL]: t('Install Sentry'),
   [StepType.CONFIGURE]: t('Configure Sentry'),
-  [StepType.VERIFY]: t('Verify Sentry'),
+  [StepType.VERIFY]: t('Send Metrics and Verify'),
 };
 
 function Onboarding({organization, project}: OnboardingProps) {


### PR DESCRIPTION
Display two instead of three steps to start using metrics with the Node SDK, consisting of

- `Install Sentry`, which is unchanged; and
- `Send Metrics and Verify`, which is the previous `Verify Sentry` step.
