### PR TITLE
feat(analytics): Add tracking for playlist navigation clicks in Replay Details

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -49,6 +49,9 @@ export type ReplayEventParameters = {
     resource_type: string;
     tab: string;
   };
+  'replay.details-playlist-clicked': {
+    direction: 'previous' | 'next';
+  };
   'replay.details-refresh-clicked': Record<string, unknown>;
   'replay.details-resized-panel': {
     layout: LayoutKey;
@@ -145,6 +148,7 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.ai-summary.regenerate-requested': 'Requested to Regenerate Replay AI Summary',
   'replay.canvas-detected-banner-clicked': 'Clicked Canvas Detected in Replay Banner',
   'replay.details-refresh-clicked': 'Clicked Refresh Button in Replay Details',
+  'replay.details-playlist-clicked': 'Clicked Replay Playlist Button in Replay Details',
   'replay.details-data-loaded': 'Replay Details Data Loaded',
   'replay.details-has-hydration-error': 'Replay Details Has Hydration Error',
   'replay.details-layout-changed': 'Changed Replay Details Layout',

--- a/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
@@ -12,6 +12,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconCopy, IconNext, IconPrevious} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import {getShortEventId} from 'sentry/utils/events';
 import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
@@ -121,6 +122,12 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
                       : undefined,
                     query: initialLocation.current.query,
                   }}
+                  onClick={() =>
+                    trackAnalytics('replay.details-playlist-clicked', {
+                      direction: 'previous',
+                      organization,
+                    })
+                  }
                 />
                 <LinkButton
                   size="xs"
@@ -132,6 +139,12 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
                       : undefined,
                     query: initialLocation.current.query,
                   }}
+                  onClick={() =>
+                    trackAnalytics('replay.details-playlist-clicked', {
+                      direction: 'next',
+                      organization,
+                    })
+                  }
                 />
               </ButtonBar>
             </Flex>


### PR DESCRIPTION
- Introduced new event type replay.details-playlist-clicked to capture user interactions with the playlist navigation buttons.
- Updated the ReplayDetailsPageBreadcrumbs component to track clicks for both previous and next directions.

Closes REPLAY-818