### PR TITLE
:mag: nit: update github feature description

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -108,6 +108,20 @@ FEATURES = [
     ),
     FeatureDescription(
         """
+        Automatically synchronize assignees to and from GitHub. Don't get confused
+        who's fixing what, let us handle ensuring your issues and tickets match up
+        to your Sentry and GitHub assignees.
+        """,
+        IntegrationFeatures.ISSUE_SYNC,
+    ),
+    FeatureDescription(
+        """
+        Synchronize Comments on Sentry Issues directly to the linked GitHub issue.
+        """,
+        IntegrationFeatures.ISSUE_SYNC,
+    ),
+    FeatureDescription(
+        """
         Link your Sentry stack traces back to your GitHub source code with stack
         trace linking.
         """,
@@ -689,6 +703,7 @@ class GitHubIntegrationProvider(IntegrationProvider):
         [
             IntegrationFeatures.COMMITS,
             IntegrationFeatures.ISSUE_BASIC,
+            IntegrationFeatures.ISSUE_SYNC,
             IntegrationFeatures.STACKTRACE_LINK,
             IntegrationFeatures.CODEOWNERS,
         ]

--- a/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
@@ -238,7 +238,13 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             "repoName": "getsentry/codemap",
             "provider": {
                 "aspects": {},
-                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
+                "features": [
+                    "codeowners",
+                    "commits",
+                    "issue-basic",
+                    "issue-sync",
+                    "stacktrace-link",
+                ],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
@@ -79,7 +79,13 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
+                "features": [
+                    "codeowners",
+                    "commits",
+                    "issue-basic",
+                    "issue-sync",
+                    "stacktrace-link",
+                ],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -101,7 +107,13 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
+                "features": [
+                    "codeowners",
+                    "commits",
+                    "issue-basic",
+                    "issue-sync",
+                    "stacktrace-link",
+                ],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -137,7 +149,13 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
+                "features": [
+                    "codeowners",
+                    "commits",
+                    "issue-basic",
+                    "issue-sync",
+                    "stacktrace-link",
+                ],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -221,7 +239,13 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
+                "features": [
+                    "codeowners",
+                    "commits",
+                    "issue-basic",
+                    "issue-sync",
+                    "stacktrace-link",
+                ],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

Small nit to add the new features implemented for Github after GA

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
