### PR TITLE
fix(ui2): check `organization is not None`

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -99,10 +99,13 @@ class ReactMixin:
         if organization is not None and features.has("organizations:chonk-ui", organization):
             if features.has("organizations:chonk-ui-enforce", organization):
                 prefers_chonk_ui = True
-            elif react_config.get("user", None) and react_config["user"].get("options", {}).get(
-                "prefersChonkUI", False
-            ):
-                prefers_chonk_ui = react_config["user"]["options"]["prefersChonkUI"]
+
+        if (
+            prefers_chonk_ui is False
+            and react_config.get("user", None)
+            and react_config["user"].get("options", {}).get("prefersChonkUI", False)
+        ):
+            prefers_chonk_ui = react_config["user"]["options"]["prefersChonkUI"]
 
         context = {
             "CSRF_COOKIE_NAME": settings.CSRF_COOKIE_NAME,

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -96,8 +96,8 @@ class ReactMixin:
             user_theme = f"theme-{react_config['user']['options']['theme']}"
 
         prefers_chonk_ui = False
-        if features.has("organizations:chonk-ui", org_context):
-            if features.has("organizations:chonk-ui-enforce", org_context):
+        if organization is not None and features.has("organizations:chonk-ui", organization):
+            if features.has("organizations:chonk-ui-enforce", organization):
                 prefers_chonk_ui = True
             elif react_config.get("user", None) and react_config["user"].get("options", {}).get(
                 "prefersChonkUI", False

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -452,3 +452,60 @@ class ReactPageViewTest(TestCase):
                 '<link rel="preconnect" href="https://s1.sentry-cdn.com"'
                 in response_body.decode("utf-8")
             )
+
+    def test_prefers_chonk_ui_enforced(self) -> None:
+        user = self.create_user("bar@example.com")
+        org = self.create_organization(owner=user)
+        self.login_as(user)
+
+        with self.feature(
+            {
+                "organizations:chonk-ui": [org.slug],
+                "organizations:chonk-ui-enforce": [org.slug],
+            }
+        ):
+            response = self.client.get("/issues/", HTTP_HOST=f"{org.slug}.testserver")
+            assert response.status_code == 200
+            assert response.context["prefers_chonk_ui"] is True
+
+    def test_prefers_chonk_ui_user_preference(self) -> None:
+        from sentry.users.models.user_option import UserOption
+
+        user = self.create_user("bar@example.com")
+        org = self.create_organization(owner=user)
+        self.login_as(user)
+
+        UserOption.objects.set_value(user=user, key="prefers_chonk_ui", value=True)
+
+        with self.feature({"organizations:chonk-ui": [org.slug]}):
+            response = self.client.get("/issues/", HTTP_HOST=f"{org.slug}.testserver")
+            assert response.status_code == 200
+            assert response.context["prefers_chonk_ui"] is True
+
+    def test_prefers_chonk_ui_disabled(self) -> None:
+        user = self.create_user("bar@example.com")
+        org = self.create_organization(owner=user)
+        self.login_as(user)
+
+        response = self.client.get("/issues/", HTTP_HOST=f"{org.slug}.testserver")
+        assert response.status_code == 200
+        assert response.context["prefers_chonk_ui"] is False
+
+    def test_prefers_chonk_ui_enforce_overrides_user_preference(self) -> None:
+        from sentry.users.models.user_option import UserOption
+
+        user = self.create_user("bar@example.com")
+        org = self.create_organization(owner=user)
+        self.login_as(user)
+
+        UserOption.objects.set_value(user=user, key="prefers_chonk_ui", value=False)
+
+        with self.feature(
+            {
+                "organizations:chonk-ui": [org.slug],
+                "organizations:chonk-ui-enforce": [org.slug],
+            }
+        ):
+            response = self.client.get("/issues/", HTTP_HOST=f"{org.slug}.testserver")
+            assert response.status_code == 200
+            assert response.context["prefers_chonk_ui"] is True


### PR DESCRIPTION
Follow-up to #101654, switching the feature check to only happen if `organization is not None`.

🤞 should fix https://sentry.sentry.io/issues/7027783052/