### PR TITLE
fix(replay): Fix infinite re-render in breadcrumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -68,14 +68,21 @@ export default function BreadcrumbItem({
   });
 
   const prevExtractState = useRef(isPending);
+  const prevShowSnippet = useRef(showSnippet);
 
   useEffect(() => {
     if (!updateDimensions) {
       return;
     }
 
-    if (isPending !== prevExtractState.current || showSnippet) {
+    if (
+      isPending !== prevExtractState.current ||
+      (showSnippet && prevShowSnippet.current !== showSnippet)
+    ) {
       prevExtractState.current = isPending;
+      // We want/need to only re-render once when showSnippet is initially toggled,
+      // otherwise can potentially trigger an infinite re-render.
+      prevShowSnippet.current = showSnippet;
       updateDimensions();
     }
   }, [isPending, updateDimensions, showSnippet]);


### PR DESCRIPTION
Fixes an infinite re-render in replay breadcrumbs when an HTML snippet is displayed and we scroll around quickly.

Due to virtualized rows, we need to tell the virtualizer to update the row dimensions when we show the HTML snippet.
When we scroll away and back, it is possible to hit a race condition where we call updateDimensions infinitely.

Fixes JAVASCRIPT-31G4
