### PR TITLE
feat(ui): preload current route on page load

### DIFF
--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import {wrapCreateBrowserRouterV6} from '@sentry/react';
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
@@ -10,6 +10,7 @@ import {FrontendVersionProvider} from 'sentry/components/frontendVersionContext'
 import {DocumentTitleManager} from 'sentry/components/sentryDocumentTitle/documentTitleManager';
 import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
 import {SENTRY_RELEASE_VERSION, USE_REACT_QUERY_DEVTOOL} from 'sentry/constants';
+import {preload} from 'sentry/router/preload';
 import {RouteConfigProvider} from 'sentry/router/routeConfigContext';
 import {routes} from 'sentry/router/routes';
 import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
@@ -24,6 +25,10 @@ function buildRouter() {
 
 function Main() {
   const [router] = useState(buildRouter);
+
+  useEffect(() => {
+    preload(router.routes, window.location.pathname);
+  }, [router.routes]);
 
   return (
     <AppQueryClientProvider>


### PR DESCRIPTION
Our general strategy is preloading on link hover, but for the first page load, we have no event handler. To avoid cascading loading spinners, we have already deferred our lazy-load fallbacks, but we can also trigger a one-time preloading when the page loads depending on the current path.

That gives us another couple of ms that the static asset fetches earlier.
