### PR TITLE
chore(aci): Remove uses of is_single_written flag

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -222,9 +222,7 @@ class RuleSerializer(Serializer):
                 )
 
                 workflow_fire_results = (
-                    WorkflowFireHistory.objects.filter(
-                        workflow_id__in=workflow_rule_lookup.keys(), is_single_written=True
-                    )
+                    WorkflowFireHistory.objects.filter(workflow_id__in=workflow_rule_lookup.keys())
                     .values("workflow_id")
                     .annotate(date_added=Max("date_added"))
                 )

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -86,7 +86,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                             UNION ALL
                             SELECT group_id, date_added, event_id
                             FROM workflow_engine_workflowfirehistory
-                            WHERE workflow_id = %s AND is_single_written = true
+                            WHERE workflow_id = %s
                             AND date_added >= %s AND date_added < %s
                         )
                         SELECT
@@ -180,7 +180,6 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                             SELECT date_added
                             FROM workflow_engine_workflowfirehistory
                             WHERE workflow_id = %s
-                                AND is_single_written = true
                                 AND date_added >= %s
                                 AND date_added < %s
                         ) combined_data

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -198,9 +198,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
                 # to be more efficient than a Max() aggregation, because it lets us look at ~1
                 # workflow fire history row per workflow.
                 latest_fire_subquery = Subquery(
-                    WorkflowFireHistory.objects.filter(
-                        workflow=OuterRef("pk"), is_single_written=True
-                    )
+                    WorkflowFireHistory.objects.filter(workflow=OuterRef("pk"))
                     .order_by("-date_added")
                     .values("date_added")[:1]
                 )

--- a/src/sentry/workflow_engine/endpoints/serializers/timeseries_value_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/timeseries_value_serializer.py
@@ -35,7 +35,6 @@ def fetch_workflow_hourly_stats(
             workflow=workflow,
             date_added__gte=start,
             date_added__lt=end,
-            is_single_written=True,
         )
         .annotate(bucket=TruncHour("date_added"))
         .order_by("bucket")

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -114,7 +114,6 @@ def fetch_workflow_groups_paginated(
         workflow=workflow,
         date_added__gte=start,
         date_added__lt=end,
-        is_single_written=True,
     )
 
     # subquery that retrieves row with the largest date in a group

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -37,7 +37,6 @@ class WorkflowSerializer(Serializer):
         last_triggered_map: dict[int, datetime] = dict(
             WorkflowFireHistory.objects.filter(
                 workflow__in=item_list,
-                is_single_written=True,
             )
             .values("workflow_id")
             .annotate(last_triggered=Max("date_added"))

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -35,11 +35,6 @@ def create_workflow_fire_histories(
     Record that the workflows associated with these actions were fired for this
     event.
 
-    Only records canonical entries (is_single_written=True). During migration from
-    dual-write to single-write, entries with is_single_written=False were created
-    for tracking purposes but are not the canonical record and should not be created
-    going forward.
-
     If we're reporting a fire due to delayed processing, is_delayed should be True.
     """
     # Only write canonical fire history records
@@ -75,7 +70,6 @@ def create_workflow_fire_histories(
             workflow_id=workflow_id,
             group=event_data.group,
             event_id=event_id,
-            is_single_written=is_single_processing,
         )
         for workflow_id in workflow_ids
     ]

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -70,6 +70,7 @@ def create_workflow_fire_histories(
             workflow_id=workflow_id,
             group=event_data.group,
             event_id=event_id,
+            is_single_written=True,
         )
         for workflow_id in workflow_ids
     ]

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -217,27 +217,15 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
                 )
             )
 
-        # Create some WorkflowFireHistory entries with is_single_written=True
+        # Create some WorkflowFireHistory entries
         for i in range(2):
             wfh = WorkflowFireHistory.objects.create(
                 workflow=workflow,
                 group=self.group,
                 date_added=before_now(days=i + 3),
                 event_id=f"workflow_event_{i}",
-                is_single_written=True,
             )
             wfh.update(date_added=before_now(days=i + 3))
-
-        # Create some WorkflowFireHistory entries with is_single_written=False (should be ignored)
-        for i in range(2):
-            wfh = WorkflowFireHistory.objects.create(
-                workflow=workflow,
-                group=self.group,
-                date_added=before_now(days=i + 5),
-                event_id=f"workflow_event_ignored_{i}",
-                is_single_written=False,
-            )
-            wfh.update(date_added=before_now(days=i + 5))
 
         RuleFireHistory.objects.bulk_create(rule_history)
 
@@ -254,7 +242,6 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             group=group_2,
             date_added=before_now(days=2),
             event_id="workflow_event_group2",
-            is_single_written=True,
         )
         new_workflow_history.update(date_added=before_now(days=2))
 
@@ -382,7 +369,6 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             workflow=workflow,
             group=self.group,
             date_added=before_now(hours=1),
-            is_single_written=True,
         )
         wfh.update(date_added=before_now(hours=1))
         # Hour 3: 2 workflow fire entries
@@ -391,19 +377,8 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
                 workflow=workflow,
                 group=self.group,
                 date_added=before_now(hours=3),
-                is_single_written=True,
             )
             wfh.update(date_added=before_now(hours=3))
-
-        # is_single_written=False WFH should be ignored
-        for _ in range(3):
-            wfh = WorkflowFireHistory.objects.create(
-                workflow=workflow,
-                group=self.group,
-                date_added=before_now(hours=1),
-                is_single_written=False,
-            )
-            wfh.update(date_added=before_now(hours=1))
 
         RuleFireHistory.objects.bulk_create(rule_history)
 

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_serializer.py
@@ -92,26 +92,15 @@ class TestWorkflowSerializer(TestCase):
             workflow=workflow,
             group=self.group,
             event_id=self.event.event_id,
-            is_single_written=True,
         )
         # Too old, shouldn't be used.
         WorkflowFireHistory.objects.create(
             workflow=workflow,
             group=self.group,
             event_id=self.event.event_id,
-            is_single_written=True,
         )
         history.date_added = workflow.date_added + timedelta(seconds=1)
         history.save()
-        # Dual written, shouldn't be used.
-        dual_written_history = WorkflowFireHistory.objects.create(
-            workflow=workflow,
-            group=self.group,
-            event_id=self.event.event_id,
-            is_single_written=False,
-        )
-        dual_written_history.date_added = workflow.date_added + timedelta(seconds=2)
-        dual_written_history.save()
 
         result = serialize(workflow)
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -345,52 +345,6 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
         assert len(response3.data) == 2
         assert {self.workflow.name, self.workflow_two.name} == {w["name"] for w in response3.data}
 
-    def test_sort_by_last_triggered_with_non_single_written_only(self) -> None:
-        workflow_never_fired = self.create_workflow(
-            organization_id=self.organization.id, name="Never Fired"
-        )
-
-        workflow_with_history = self.create_workflow(
-            organization_id=self.organization.id, name="With History"
-        )
-        WorkflowFireHistory.objects.create(
-            workflow=workflow_with_history,
-            group=self.group,
-            event_id=self.event.event_id,
-        )
-
-        # Test ascending order (lastTriggered)
-        response = self.get_success_response(
-            self.organization.slug, qs_params={"sortBy": "lastTriggered"}
-        )
-
-        # Workflows without history should come first, then those with it
-        expected_ascending_order = [
-            self.workflow_three.name,
-            workflow_never_fired.name,
-            self.workflow.name,
-            self.workflow_two.name,
-            workflow_with_history.name,
-        ]
-
-        assert [w["name"] for w in response.data] == expected_ascending_order
-
-        # Test descending order (-lastTriggered)
-        response_desc = self.get_success_response(
-            self.organization.slug, qs_params={"sortBy": "-lastTriggered"}
-        )
-
-        # In descending order, workflows with history should come first
-        expected_descending_order = [
-            workflow_with_history.name,
-            self.workflow_two.name,
-            self.workflow.name,
-            workflow_never_fired.name,
-            self.workflow_three.name,
-        ]
-
-        assert [w["name"] for w in response_desc.data] == expected_descending_order
-
     def test_compound_query(self) -> None:
         self.create_detector_workflow(
             workflow=self.workflow, detector=self.create_detector(project=self.project)

--- a/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow_fire_history.py
@@ -34,7 +34,6 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
                 workflow=self.workflow,
                 group=self.group,
                 event_id=self.group_event.event_id,
-                is_single_written=True,
             ).count()
             == 1
         )


### PR DESCRIPTION
It is always True now, so we don't need to filter on it.
