### PR TITLE
fix(search): Fix handle backslashes in wildcard operators

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -412,16 +412,21 @@ def handle_backslash(value: str) -> str:
     # by escaping them
 
     v = []
+    n = len(value)
 
     i = 0
-    while i < len(value):
+    while i < n:
         c = value[i]
         if c == "\\":
             j = i + 1
-            if value[j] in {"*", "\\"}:
+            if j < n and value[j] in {"*", "\\"}:
+                # found an escaped * or \
                 v.append(c)
                 i += 1
                 c = value[i]
+            else:
+                # found just a \
+                v.append("\\")
         v.append(c)
         i += 1
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -410,22 +410,35 @@ def handle_backslash(value: str) -> str:
     # when working with one of the wildcard operators,
     # we need to ensure we properly handle backslashes
     # by escaping them
-    return value.replace("\\", "\\\\")
+
+    v = []
+
+    i = 0
+    while i < len(value):
+        c = value[i]
+        if c == "\\":
+            j = i + 1
+            if value[j] in {"*", "\\"}:
+                v.append(c)
+                i += 1
+                c = value[i]
+        v.append(c)
+        i += 1
+
+    return "".join(v)
 
 
 def gen_wildcard_value(value: str, wildcard_op: str) -> str:
     if value == "" or wildcard_op == "":
         return value
+    value = handle_backslash(value)
     value = re.sub(r"(?<!\\)\*", r"\\*", value)
     if wildcard_op == WILDCARD_OPERATOR_MAP["contains"]:
-        value = handle_backslash(value)
         value = add_leading_wildcard(value)
         value = add_trailing_wildcard(value)
     elif wildcard_op == WILDCARD_OPERATOR_MAP["starts_with"]:
-        value = handle_backslash(value)
         value = add_trailing_wildcard(value)
     elif wildcard_op == WILDCARD_OPERATOR_MAP["ends_with"]:
-        value = handle_backslash(value)
         value = add_leading_wildcard(value)
     return value
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2817,6 +2817,43 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_response()
         assert response.status_code == 500
 
+    def test_wildcard_operator_with_backslash(self) -> None:
+        self.login_as(user=self.user)
+
+        event = self.store_event(
+            data={
+                "timestamp": before_now(seconds=1).isoformat(),
+                "user": {
+                    "id": "1",
+                    "email": "foo@example.com",
+                    "username": r"foo\bar",
+                    "ip_address": "192.168.0.1",
+                },
+            },
+            project_id=self.project.id,
+        )
+        assert event.group
+
+        response = self.get_success_response(query=r"user.username:foo\bar")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(event.group.id)
+
+        response = self.get_success_response(query=r"user.username:*foo\\bar*")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(event.group.id)
+
+        response = self.get_success_response(query="user.username:\uf00dContains\uf00dfoo\\bar")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(event.group.id)
+
+        response = self.get_success_response(query="user.username:\uf00dStartsWith\uf00dfoo\\bar")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(event.group.id)
+
+        response = self.get_success_response(query="user.username:\uf00dEndsWith\uf00dfoo\\bar")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(event.group.id)
+
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"


### PR DESCRIPTION
When using one of the wildcard operators (contains, starts with, ends with), we need to make sure to properly escape backslashes in order to handle the search correctly.