### PR TITLE
feat(data-forwarding): Allow project overrides in UI

### DIFF
--- a/static/app/utils/analytics/ecosystemAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/ecosystemAnalyticsEvents.tsx
@@ -22,6 +22,10 @@ export type EcosystemEventParameters = {
     old_project_count: number;
     provider?: DataForwarderProviderSlug;
   };
+  'data_forwarding.edit_override_complete': {
+    platform?: PlatformKey;
+    provider?: DataForwarderProviderSlug;
+  };
   'data_forwarding.onboarding_cta_clicked': Record<string, unknown>;
   'data_forwarding.setup_complete': {
     are_new_projects_enrolled: boolean;
@@ -84,6 +88,7 @@ export const ecosystemEventMap: Record<EcosystemEventKeys, string | null> = {
   'data_forwarding.docs_link_clicked': 'Data Forwarding: Docs Link Clicked',
   'data_forwarding.edit_clicked': 'Data Forwarding: Edit Clicked',
   'data_forwarding.edit_complete': 'Data Forwarding: Edit Complete',
+  'data_forwarding.edit_override_complete': 'Data Forwarding: Edit Override Complete',
   'data_forwarding.onboarding_cta_clicked': 'Data Forwarding: Onboarding CTA Clicked',
   'data_forwarding.setup_complete': 'Data Forwarding: Setup Complete',
   'integrations.stacktrace_complete_setup': 'Integrations: Stacktrace Complete Setup',

--- a/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
@@ -46,7 +46,6 @@ export function ProjectOverrideForm({
   useEffect(() => {
     formModel.setInitialData({
       is_enabled: projectConfig?.isEnabled ?? false,
-      project_id: project.id,
       ...projectConfig?.overrides,
     });
   }, [projectConfig, formModel, project.id]);
@@ -56,13 +55,11 @@ export function ProjectOverrideForm({
       model={formModel}
       onSubmit={data => {
         const {is_enabled, ...overrides} = data;
-        const overridePayload = {
+        updateDataForwarder({
           project_id: `${project.id}`,
           overrides,
           is_enabled,
-        };
-        // console.log(overridePayload);
-        updateDataForwarder(overridePayload);
+        });
       }}
       hideFooter
     >

--- a/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
@@ -1,0 +1,89 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import FormModel from 'sentry/components/forms/model';
+import Panel from 'sentry/components/panels/panel';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import {IconInfo} from 'sentry/icons/iconInfo';
+import {t} from 'sentry/locale';
+import type {AvatarProject} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import {getProjectOverrideForm} from 'sentry/views/settings/organizationDataForwarding/util/forms';
+import {useMutateDataForwarderProject} from 'sentry/views/settings/organizationDataForwarding/util/hooks';
+import type {DataForwarder} from 'sentry/views/settings/organizationDataForwarding/util/types';
+
+export function ProjectOverrideForm({
+  project,
+  dataForwarder,
+}: {
+  dataForwarder: DataForwarder;
+  project: AvatarProject;
+}) {
+  const organization = useOrganization();
+  const formModel = useMemo(() => new FormModel(), []);
+  const {mutate: updateDataForwarder} = useMutateDataForwarderProject({
+    params: {orgSlug: organization.slug, dataForwarderId: dataForwarder.id, project},
+    onSuccess: () => {
+      trackAnalytics('data_forwarding.edit_override_complete', {
+        organization,
+        platform: project.platform,
+        provider: dataForwarder.provider,
+      });
+    },
+  });
+  return (
+    <Form
+      model={formModel}
+      onSubmit={data => {
+        const {is_enabled, ...overrides} = data;
+        const overridePayload = {
+          project_id: `${project.id}`,
+          overrides,
+          is_enabled,
+        };
+        // console.log(overridePayload);
+        updateDataForwarder(overridePayload);
+      }}
+      hideFooter
+    >
+      <OverrideForm
+        forms={[getProjectOverrideForm({dataForwarder, project})]}
+        collapsible
+        renderHeader={() => (
+          <Flex padding="sm lg" borderBottom="primary" gap="md" align="center">
+            <IconInfo size="sm" />
+            <Text variant="muted" size="sm" bold>
+              {t('Overrides set here will only affect this project')}
+            </Text>
+          </Flex>
+        )}
+        renderFooter={() => (
+          <Flex justify="end" padding="lg xl">
+            <Button priority="primary" size="sm" type="submit">
+              {t('Save Override')}
+            </Button>
+          </Flex>
+        )}
+      />
+    </Form>
+  );
+}
+
+const OverrideForm = styled(JsonForm)`
+  ${Panel} {
+    margin: 0;
+  }
+  ${PanelHeader} {
+    text-transform: none;
+    background: ${p => p.theme.backgroundSecondary};
+    padding: ${p => `${p.theme.space.md} ${p.theme.space.lg}`};
+  }
+  margin: 0;
+`;

--- a/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -38,6 +38,19 @@ export function ProjectOverrideForm({
       });
     },
   });
+
+  const projectConfig = dataForwarder.projectConfigs.find(
+    config => config.project.id === project.id
+  );
+
+  useEffect(() => {
+    formModel.setInitialData({
+      is_enabled: projectConfig?.isEnabled ?? false,
+      project_id: project.id,
+      ...projectConfig?.overrides,
+    });
+  }, [projectConfig, formModel, project.id]);
+
   return (
     <Form
       model={formModel}

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 
 import {Button} from '@sentry/scraps/button';
 import {LinkButton} from '@sentry/scraps/button/linkButton';
@@ -55,6 +56,7 @@ export default function OrganizationDataForwardingEditWrapper() {
 
 function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataForwarder}) {
   const {provider} = dataForwarder;
+  const theme = useTheme();
   const navigate = useNavigate();
   const organization = useOrganization();
   const {projects} = useProjects({orgId: organization.slug});
@@ -185,6 +187,12 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
             </DataForwarderDeleteConfirm>
           }
           submitLabel={t('Update Forwarder')}
+          footerStyle={{
+            borderTop: 0,
+            borderBottom: `1px solid ${theme.border}`,
+            marginTop: `-${theme.space.lg}`,
+            paddingBottom: theme.space['3xl'],
+          }}
         >
           <JsonForm
             forms={getDataForwarderFormGroups({
@@ -194,6 +202,21 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
             })}
           />
         </Form>
+        <Flex align="center" justify="between" gap="2xl">
+          <Flex direction="column" gap="sm">
+            <Flex align="center" gap="lg">
+              <Heading as="h2" size="2xl">
+                {t('Manage your overrides')}
+              </Heading>
+            </Flex>
+            <Text variant="muted">
+              {t(
+                'These configurations apply to individual projects under your %s forwarder.',
+                ProviderLabels[provider]
+              )}
+            </Text>
+          </Flex>
+        </Flex>
         <Stack gap="xl">
           {dataForwarder.enrolledProjects.map(project => (
             <ProjectOverrideForm

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -2,7 +2,7 @@ import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {LinkButton} from '@sentry/scraps/button/linkButton';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -22,6 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {DataForwarderDeleteConfirm} from 'sentry/views/settings/organizationDataForwarding/components/dataForwarderDeleteConfirm';
+import {ProjectOverrideForm} from 'sentry/views/settings/organizationDataForwarding/components/projectOverrideForm';
 import {getDataForwarderFormGroups} from 'sentry/views/settings/organizationDataForwarding/util/forms';
 import {
   useDataForwarders,
@@ -163,7 +164,7 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
         <Form
           model={formModel}
           onSubmit={data => {
-            const {enroll_new_projects, project_ids, is_enabled, ...config} = data;
+            const {enroll_new_projects, project_ids = [], is_enabled, ...config} = data;
             const dataForwardingPayload: Record<string, any> = {
               provider,
               config,
@@ -193,6 +194,15 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
             })}
           />
         </Form>
+        <Stack gap="xl">
+          {dataForwarder.enrolledProjects.map(project => (
+            <ProjectOverrideForm
+              key={project.id}
+              project={project}
+              dataForwarder={dataForwarder}
+            />
+          ))}
+        </Stack>
       </Flex>
     </Fragment>
   );

--- a/static/app/views/settings/organizationDataForwarding/util/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/forms.tsx
@@ -109,7 +109,6 @@ export function getProjectOverrideForm({
 }): JsonFormObject {
   const [providerForm] = getProviderForm({provider: dataForwarder.provider});
   const providerFields = providerForm?.fields;
-
   const projectConfig = dataForwarder.projectConfigs.find(
     config => config.project.id === project.id
   );

--- a/static/app/views/settings/organizationDataForwarding/util/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/forms.tsx
@@ -1,7 +1,14 @@
+import styled from '@emotion/styled';
+
+import {ProjectAvatar} from '@sentry/scraps/avatar';
+import {Tag} from '@sentry/scraps/badge/tag';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
 import type {JsonFormObject} from 'sentry/components/forms/types';
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
-import type {Project} from 'sentry/types/project';
+import type {AvatarProject, Project} from 'sentry/types/project';
 import {
   DataForwarderProviderSlug,
   type DataForwarder,
@@ -16,32 +23,35 @@ export function getDataForwarderFormGroups({
   dataForwarder?: DataForwarder;
   provider?: DataForwarderProviderSlug;
 }): JsonFormObject[] {
-  let providerFormGroups: JsonFormObject[] = [];
-  switch (provider) {
-    case DataForwarderProviderSlug.SQS:
-      providerFormGroups = [SQS_GLOBAL_CONFIGURATION_FORM];
-      break;
-    case DataForwarderProviderSlug.SEGMENT:
-      providerFormGroups = [SEGMENT_GLOBAL_CONFIGURATION_FORM];
-      break;
-    case DataForwarderProviderSlug.SPLUNK:
-      providerFormGroups = [SPLUNK_GLOBAL_CONFIGURATION_FORM];
-      break;
-    default:
-      providerFormGroups = [];
-  }
   return [
     getEnablementForm({dataForwarder}),
-    ...providerFormGroups,
-    getProjectConfigurationForm(projects),
+    ...getProviderForm({provider}),
+    getProjectConfigurationForm({projects}),
   ];
 }
 
-const getEnablementForm = ({
+function getProviderForm({
+  provider,
+}: {
+  provider?: DataForwarderProviderSlug;
+}): JsonFormObject[] {
+  switch (provider) {
+    case DataForwarderProviderSlug.SQS:
+      return [SQS_GLOBAL_CONFIGURATION_FORM];
+    case DataForwarderProviderSlug.SEGMENT:
+      return [SEGMENT_GLOBAL_CONFIGURATION_FORM];
+    case DataForwarderProviderSlug.SPLUNK:
+      return [SPLUNK_GLOBAL_CONFIGURATION_FORM];
+    default:
+      return [];
+  }
+}
+
+function getEnablementForm({
   dataForwarder,
 }: {
   dataForwarder?: DataForwarder;
-}): JsonFormObject => {
+}): JsonFormObject {
   const hasCompleteSetup = dataForwarder;
 
   return {
@@ -53,15 +63,15 @@ const getEnablementForm = ({
         type: 'boolean',
         defaultValue: dataForwarder?.isEnabled ?? true,
         help: hasCompleteSetup
-          ? t('Will override everything to shut-off data forwarding.')
+          ? t('Will override all projects to shut-off data forwarding altogether.')
           : t('Will be enabled after the initial setup is complete.'),
         disabled: !hasCompleteSetup,
       },
     ],
   };
-};
+}
 
-function getProjectConfigurationForm(projects: Project[]): JsonFormObject {
+function getProjectConfigurationForm({projects}: {projects: Project[]}): JsonFormObject {
   const projectOptions = projects.map(project => ({
     value: project.id,
     label: project.slug,
@@ -89,6 +99,56 @@ function getProjectConfigurationForm(projects: Project[]): JsonFormObject {
     ],
   };
 }
+
+export function getProjectOverrideForm({
+  project,
+  dataForwarder,
+}: {
+  dataForwarder: DataForwarder;
+  project: AvatarProject;
+}): JsonFormObject {
+  const [providerForm] = getProviderForm({provider: dataForwarder.provider});
+  const providerFields = providerForm?.fields;
+
+  const projectConfig = dataForwarder.projectConfigs.find(
+    config => config.project.id === project.id
+  );
+  const hasOverrides =
+    projectConfig?.overrides && Object.keys(projectConfig?.overrides).length > 0;
+  return {
+    title: (
+      <Flex justify="between" width="100%" paddingRight="lg">
+        <Flex align="center" gap="md">
+          <ProjectAvatar project={project} size={16} />
+          <Text>{project.slug}</Text>
+        </Flex>
+        {projectConfig?.isEnabled ? (
+          <CalmTag type={hasOverrides ? 'warning' : 'success'}>
+            {hasOverrides ? t('Forwarding with Overrides') : t('Forwarding')}
+          </CalmTag>
+        ) : (
+          <CalmTag type="error">{t('Disabled')}</CalmTag>
+        )}
+      </Flex>
+    ),
+    initiallyCollapsed: true,
+    fields: [
+      {
+        name: 'is_enabled',
+        label: t('Enable forwarding'),
+        help: t('Control forwarding for this project.'),
+        type: 'boolean',
+        defaultValue: true,
+      },
+      ...(providerFields ?? []),
+    ],
+  };
+}
+
+const CalmTag = styled(Tag)`
+  /* Need to override the panel header's styles here */
+  text-transform: none;
+`;
 
 const SQS_GLOBAL_CONFIGURATION_FORM: JsonFormObject = {
   title: t('Global Configuration'),

--- a/static/app/views/settings/organizationDataForwarding/util/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/forms.tsx
@@ -5,7 +5,7 @@ import {Tag} from '@sentry/scraps/badge/tag';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import type {JsonFormObject} from 'sentry/components/forms/types';
+import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
 import type {AvatarProject, Project} from 'sentry/types/project';
@@ -108,7 +108,14 @@ export function getProjectOverrideForm({
   project: AvatarProject;
 }): JsonFormObject {
   const [providerForm] = getProviderForm({provider: dataForwarder.provider});
-  const providerFields = providerForm?.fields;
+  const providerFields = providerForm?.fields.map(
+    field =>
+      ({
+        ...field,
+        defaultValue: undefined,
+        required: false,
+      }) as FieldObject
+  );
   const projectConfig = dataForwarder.projectConfigs.find(
     config => config.project.id === project.id
   );

--- a/static/app/views/settings/organizationDataForwarding/util/types.ts
+++ b/static/app/views/settings/organizationDataForwarding/util/types.ts
@@ -16,6 +16,7 @@ interface DataForwarderProject {
   dataForwarderId: string;
   effectiveConfig: Record<string, any>;
   id: string;
+  isEnabled: boolean;
   overrides: Record<string, any>;
   project: Required<AvatarProject>;
 }


### PR DESCRIPTION
This will enable project overrides within the UI. They appear at the bottom and are separate forms. This was done in order to be complicit with the API and the overrides only appear in the edit UI for now.

<img width="688" height="505" alt="image" src="https://github.com/user-attachments/assets/e941aebc-39b2-44fd-b6f7-f5b2a4068f80" />