### PR TITLE
perf(dashboards): Improve slow iteration pattern

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -248,9 +248,8 @@ function getPrimaryFieldOptions(
   });
 
   const spanTags = Object.values(tags ?? {}).reduce(
-    (acc, tag) => ({
-      ...acc,
-      [`${tag.kind}:${tag.key}`]: {
+    function combineTag(acc, tag) {
+      acc[`${tag.kind}:${tag.key}`] = {
         label: tag.name,
         value: {
           kind: FieldValueKind.TAG,
@@ -260,9 +259,11 @@ function getPrimaryFieldOptions(
           // is used for grouping.
           meta: {name: tag.key, dataType: tag.kind === 'tag' ? 'string' : 'number'},
         },
-      },
-    }),
-    {}
+      };
+
+      return acc;
+    },
+    {} as Record<string, FieldValueOption>
   );
 
   return {...baseFieldOptions, ...spanTags};

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
@@ -109,8 +109,8 @@ export function SortBySelectors({
   }, [
     datasetConfig,
     organization,
-    tags,
-    widgetQuery,
+    tags, // This dependency is unstable!
+    widgetQuery, // This dependency is unstable!
     widgetType,
     displayType,
     values.sortBy,


### PR DESCRIPTION
Turns out, the `...` spread operator, if used in a loop over a big object (>1,000 keys) can take like 80ms on my M1. If this code runs a lot (e.g., if the memoization around it isn't working correctly, a problem for another day), this can introduce like 200ms of extra lag? Gross. Instead, good old object key assignment is way faster.
<img width="993" height="385" alt="Screenshot 2025-11-14 at 11 59 19 AM" src="https://github.com/user-attachments/assets/aed0d475-242b-440d-a489-37838ada1b8a" />



**Before:**
<img width="220" height="90" alt="Screenshot 2025-11-14 at 12 34 49 PM" src="https://github.com/user-attachments/assets/14913445-8207-4517-8475-eac8574333a8" />

**After:**
<img width="1025" height="90" alt="Screenshot 2025-11-14 at 12 35 23 PM" src="https://github.com/user-attachments/assets/4109efd1-5c3b-4dfa-a54e-59040e5d0519" />

