### PR TITLE
feat(settings): Disable AI settings when gen-ai-features flag is off

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -5,8 +5,7 @@ import type {Organization} from 'sentry/types/organization';
 
 export const defaultEnableSeerFeaturesValue = (organization: Organization) => {
   const isBaa = false; // TODO: add check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
-  const hasFeatureFlag = organization.features.includes('organizations:gen-ai-features');
-  return !organization.hideAiFeatures && !isBaa && hasFeatureFlag;
+  return !organization.hideAiFeatures && !isBaa;
 };
 
 export const makeHideAiFeaturesField = (organization: Organization): FieldObject => {

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -5,11 +5,13 @@ import type {Organization} from 'sentry/types/organization';
 
 export const defaultEnableSeerFeaturesValue = (organization: Organization) => {
   const isBaa = false; // TODO: add check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
-  return !organization.hideAiFeatures && !isBaa;
+  const hasFeatureFlag = organization.features.includes('organizations:gen-ai-features');
+  return !organization.hideAiFeatures && !isBaa && hasFeatureFlag;
 };
 
 export const makeHideAiFeaturesField = (organization: Organization): FieldObject => {
   const isBaa = false; // TODO: add a check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
+  const hasFeatureFlag = organization.features.includes('organizations:gen-ai-features');
 
   return {
     name: 'hideAiFeatures',
@@ -24,7 +26,7 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
       }
     ),
     defaultValue: defaultEnableSeerFeaturesValue(organization),
-    disabled: ({access}) => !access.has('org:write'),
+    disabled: ({access}) => !hasFeatureFlag || !access.has('org:write'),
     getValue: value => {
       // Reversing value because the field was previously called hideAiFeatures and we've inverted the behavior.
       return !value;
@@ -33,6 +35,8 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
       ? t(
           'To remain HIPAA compliant, Generative AI features are disabled for BAA customers'
         )
-      : null,
+      : hasFeatureFlag
+        ? null
+        : t('This feature is not available'),
   };
 };

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -17,7 +17,7 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     type: 'boolean',
     label: t('Show Generative AI Features'),
     help: tct('Allows organization members to access [link:generative AI features]', {
-      docs: (
+      link: (
         <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/#ai-powered-features" />
       ),
     }),

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -27,6 +27,11 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => !hasFeatureFlag || !access.has('org:write'),
     getValue: value => {
+      // If feature flag is off, always return false (show as disabled)
+      // regardless of the org's actual setting
+      if (!hasFeatureFlag) {
+        return false;
+      }
       // Reversing value because the field was previously called hideAiFeatures and we've inverted the behavior.
       return !value;
     },
@@ -34,8 +39,6 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
       ? t(
           'To remain HIPAA compliant, Generative AI features are disabled for BAA customers'
         )
-      : hasFeatureFlag
-        ? null
-        : t('This feature is not available'),
+      : null,
   };
 };

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -10,7 +10,7 @@ export const defaultEnableSeerFeaturesValue = (organization: Organization) => {
 
 export const makeHideAiFeaturesField = (organization: Organization): FieldObject => {
   const isBaa = false; // TODO: add a check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
-  const hasFeatureFlag = organization.features.includes('organizations:gen-ai-features');
+  const hasFeatureFlag = organization.features.includes('gen-ai-features');
 
   return {
     name: 'hideAiFeatures',

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -26,7 +26,10 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     ),
     defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => !hasFeatureFlag || !access.has('org:write'),
-    getValue: value => !value,
+    getValue: value => {
+      // Reversing value because the field was previously called hideAiFeatures and we've inverted the behavior.
+      return !value;
+    },
     setValue: value => {
       if (!hasFeatureFlag) {
         return false;

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -27,13 +27,16 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => !hasFeatureFlag || !access.has('org:write'),
     getValue: value => {
-      // If feature flag is off, always return false (show as disabled)
-      // regardless of the org's actual setting
+      // getValue is used when submitting to API
+      // Invert because the checkbox shows "Show AI" but field is "hideAiFeatures"
+      return !value;
+    },
+    setValue: value => {
+      // If feature flag is off, force checkbox to be unchecked (value=false means unchecked)
       if (!hasFeatureFlag) {
         return false;
       }
-      // Reversing value because the field was previously called hideAiFeatures and we've inverted the behavior.
-      return !value;
+      return value;
     },
     disabledReason: isBaa
       ? t(

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -26,13 +26,8 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     ),
     defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => !hasFeatureFlag || !access.has('org:write'),
-    getValue: value => {
-      // getValue is used when submitting to API
-      // Invert because the checkbox shows "Show AI" but field is "hideAiFeatures"
-      return !value;
-    },
+    getValue: value => !value,
     setValue: value => {
-      // If feature flag is off, force checkbox to be unchecked (value=false means unchecked)
       if (!hasFeatureFlag) {
         return false;
       }

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -16,14 +16,11 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     name: 'hideAiFeatures',
     type: 'boolean',
     label: t('Show Generative AI Features'),
-    help: tct(
-      'Allows organization members to access [docs:features] powered by generative AI',
-      {
-        docs: (
-          <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/#ai-powered-features" />
-        ),
-      }
-    ),
+    help: tct('Allows organization members to access [link:generative AI features]', {
+      docs: (
+        <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/#ai-powered-features" />
+      ),
+    }),
     defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => !hasFeatureFlag || !access.has('org:write'),
     getValue: value => {

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -433,7 +433,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: [], // No gen-ai-features flag
+            features: ['gen-ai-features'],
           },
         }
       );
@@ -442,9 +442,8 @@ describe('OrganizationSettingsForm', () => {
         name: /Enable AI Code Review/i,
       });
       expect(preventAiField).toBeInTheDocument();
-      expect(preventAiField).toBeDisabled();
+      expect(preventAiField).toBeEnabled();
 
-      // No disabled tag shown when feature flag is off
       expect(screen.queryByTestId('prevent-ai-disabled-tag')).not.toBeInTheDocument();
     });
 

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -399,7 +399,7 @@ describe('OrganizationSettingsForm', () => {
       expect(screen.queryByTestId('prevent-ai-disabled-tag')).not.toBeInTheDocument();
     });
 
-    it('is disabled when feature flag is off', async () => {
+    it('is disabled when feature flag is off', () => {
       jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
         name: 'us',
         displayName: 'United States of America (US)',

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -180,7 +180,7 @@ describe('OrganizationSettingsForm', () => {
     // Default org fixture has hideAiFeatures: false, so Seer is enabled by default
     const hiddenAiOrg = OrganizationFixture({
       hideAiFeatures: true,
-      features: ['organizations:gen-ai-features'],
+      features: ['gen-ai-features'],
     });
     render(
       <OrganizationSettingsForm
@@ -244,7 +244,7 @@ describe('OrganizationSettingsForm', () => {
       {
         organization: {
           ...organization,
-          features: ['autofix', 'organizations:gen-ai-features'],
+          features: ['autofix', 'gen-ai-features'],
         },
       }
     );
@@ -344,7 +344,7 @@ describe('OrganizationSettingsForm', () => {
       {
         organization: {
           ...organization,
-          features: ['organizations:gen-ai-features'],
+          features: ['gen-ai-features'],
         },
       }
     );
@@ -386,7 +386,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['organizations:gen-ai-features'],
+            features: ['gen-ai-features'],
           },
         }
       );
@@ -450,7 +450,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['organizations:gen-ai-features'],
+            features: ['gen-ai-features'],
           },
         }
       );
@@ -489,7 +489,7 @@ describe('OrganizationSettingsForm', () => {
           organization: {
             ...organization,
             access: ['org:write'],
-            features: ['organizations:gen-ai-features'],
+            features: ['gen-ai-features'],
           },
         }
       );
@@ -521,7 +521,7 @@ describe('OrganizationSettingsForm', () => {
           organization: {
             ...organization,
             access: ['org:read'],
-            features: ['organizations:gen-ai-features'],
+            features: ['gen-ai-features'],
           },
         }
       );
@@ -549,7 +549,7 @@ describe('OrganizationSettingsForm', () => {
           organization: {
             ...organization,
             access: ['org:write'],
-            features: ['organizations:gen-ai-features'],
+            features: ['gen-ai-features'],
           },
         }
       );

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -430,39 +430,6 @@ describe('OrganizationSettingsForm', () => {
       expect(screen.queryByTestId('prevent-ai-disabled-tag')).not.toBeInTheDocument();
     });
 
-    it('shows as unchecked when feature flag is off even if org setting is true', () => {
-      jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
-        name: 'us',
-        displayName: 'United States of America (US)',
-        url: 'https://sentry.example.com',
-      });
-
-      render(
-        <OrganizationSettingsForm
-          {...routerProps}
-          initialData={OrganizationFixture({
-            hideAiFeatures: true,
-            enablePrReviewTestGeneration: true, // Org setting is true
-          })}
-          onSave={onSave}
-        />,
-        {
-          organization: {
-            ...organization,
-            features: [], // No gen-ai-features flag
-          },
-        }
-      );
-
-      const preventAiField = screen.getByRole('checkbox', {
-        name: /Enable AI Code Review/i,
-      });
-      expect(preventAiField).toBeInTheDocument();
-      expect(preventAiField).toBeDisabled();
-      // The checkbox should be unchecked even though the org value is true
-      expect(preventAiField).not.toBeChecked();
-    });
-
     it('is disabled when non US region', async () => {
       jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
         name: 'de',

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -426,12 +426,8 @@ describe('OrganizationSettingsForm', () => {
       expect(preventAiField).toBeInTheDocument();
       expect(preventAiField).toBeDisabled();
 
-      const disabledTag = screen.getByTestId('prevent-ai-disabled-tag');
-      expect(disabledTag).toBeInTheDocument();
-      await userEvent.hover(disabledTag);
-      expect(
-        await screen.findByText('This feature is not available')
-      ).toBeInTheDocument();
+      // No disabled tag shown when feature flag is off
+      expect(screen.queryByTestId('prevent-ai-disabled-tag')).not.toBeInTheDocument();
     });
 
     it('is disabled when non US region', async () => {

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -430,6 +430,39 @@ describe('OrganizationSettingsForm', () => {
       expect(screen.queryByTestId('prevent-ai-disabled-tag')).not.toBeInTheDocument();
     });
 
+    it('shows as unchecked when feature flag is off even if org setting is true', () => {
+      jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
+        name: 'us',
+        displayName: 'United States of America (US)',
+        url: 'https://sentry.example.com',
+      });
+
+      render(
+        <OrganizationSettingsForm
+          {...routerProps}
+          initialData={OrganizationFixture({
+            hideAiFeatures: true,
+            enablePrReviewTestGeneration: true, // Org setting is true
+          })}
+          onSave={onSave}
+        />,
+        {
+          organization: {
+            ...organization,
+            features: [], // No gen-ai-features flag
+          },
+        }
+      );
+
+      const preventAiField = screen.getByRole('checkbox', {
+        name: /Enable AI Code Review/i,
+      });
+      expect(preventAiField).toBeInTheDocument();
+      expect(preventAiField).toBeDisabled();
+      // The checkbox should be unchecked even though the org value is true
+      expect(preventAiField).not.toBeChecked();
+    });
+
     it('is disabled when non US region', async () => {
       jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
         name: 'de',

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -282,7 +282,13 @@ describe('OrganizationSettingsForm', () => {
         {...routerProps}
         initialData={OrganizationFixture({hideAiFeatures: true})}
         onSave={onSave}
-      />
+      />,
+      {
+        organization: {
+          ...organization,
+          features: ['gen-ai-features'],
+        },
+      }
     );
 
     expect(screen.getByText('Enable AI Code Review')).toBeInTheDocument();
@@ -308,7 +314,13 @@ describe('OrganizationSettingsForm', () => {
         // This logic is inverted from the variable name
         initialData={OrganizationFixture({hideAiFeatures: false})}
         onSave={onSave}
-      />
+      />,
+      {
+        organization: {
+          ...organization,
+          features: ['gen-ai-features'],
+        },
+      }
     );
 
     expect(screen.queryByText('Enable AI Code Review')).not.toBeInTheDocument();
@@ -325,7 +337,13 @@ describe('OrganizationSettingsForm', () => {
         {...routerProps}
         initialData={OrganizationFixture({hideAiFeatures: true})}
         onSave={onSave}
-      />
+      />,
+      {
+        organization: {
+          ...organization,
+          features: ['gen-ai-features'],
+        },
+      }
     );
 
     expect(screen.getByText('Enable AI Code Review')).toBeInTheDocument();

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -19,9 +19,9 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
   const isDisabled = isSelfHosted || !isUSOrg || !hasFeatureFlag;
   const disabledReason = isSelfHosted
     ? t('This feature is not available for self-hosted instances')
-    : hasFeatureFlag
-      ? t('This feature is only available in the US region')
-      : t('This feature is not available');
+    : isUSOrg
+      ? null
+      : t('This feature is only available in the US region');
 
   return {
     name: 'enablePrReviewTestGeneration',
@@ -33,7 +33,7 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
           type="beta"
           {...(isDisabled ? {tooltipProps: {position: 'top'}} : {})}
         />
-        {isDisabled && (
+        {isDisabled && disabledReason && (
           <Tooltip title={disabledReason} position="top">
             <Tag
               role="status"

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -14,14 +14,11 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
   const regionData = getRegionDataFromOrganization(organization);
   const isUSOrg = regionData?.name?.toLowerCase() === 'us';
   const isSelfHosted = ConfigStore.get('isSelfHosted');
-  const hasFeatureFlag = organization.features.includes('gen-ai-features');
 
-  const isDisabled = isSelfHosted || !isUSOrg || !hasFeatureFlag;
+  const isDisabled = isSelfHosted || !isUSOrg;
   const disabledReason = isSelfHosted
     ? t('This feature is not available for self-hosted instances')
-    : isUSOrg
-      ? null
-      : t('This feature is only available in the US region');
+    : t('This feature is only available in the US region');
 
   return {
     name: 'enablePrReviewTestGeneration',
@@ -33,7 +30,7 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
           type="beta"
           {...(isDisabled ? {tooltipProps: {position: 'top'}} : {})}
         />
-        {isDisabled && disabledReason && (
+        {isDisabled && (
           <Tooltip title={disabledReason} position="top">
             <Tag
               role="status"
@@ -52,10 +49,9 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       ),
     }),
     visible: ({model}) => {
-      if (hasFeatureFlag) {
-        return !!model.getValue('hideAiFeatures');
-      }
-      return model.initialData.hideAiFeatures === true;
+      // Show field when AI features are enabled (hideAiFeatures is false)
+      const hideAiFeatures = model.getValue('hideAiFeatures');
+      return hideAiFeatures;
     },
     disabled: ({access}) => isDisabled || !access.has('org:write'),
   };

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -14,7 +14,7 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
   const regionData = getRegionDataFromOrganization(organization);
   const isUSOrg = regionData?.name?.toLowerCase() === 'us';
   const isSelfHosted = ConfigStore.get('isSelfHosted');
-  const hasFeatureFlag = organization.features.includes('organizations:gen-ai-features');
+  const hasFeatureFlag = organization.features.includes('gen-ai-features');
 
   const isDisabled = isSelfHosted || !isUSOrg || !hasFeatureFlag;
   const disabledReason = isSelfHosted

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -52,17 +52,13 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       ),
     }),
     visible: ({model}) => {
-      // Check if feature flag is on - if so, use current model value for dynamic toggling
       if (hasFeatureFlag) {
         return !!model.getValue('hideAiFeatures');
       }
-      // If flag is off, use initialData because setValue forces model value to false
       return model.initialData.hideAiFeatures === true;
     },
     disabled: ({access}) => isDisabled || !access.has('org:write'),
     setValue: value => {
-      // If feature flag is off, always show as disabled (false)
-      // regardless of the org's actual setting
       if (!hasFeatureFlag) {
         return false;
       }

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -57,5 +57,13 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       return hideAiFeatures;
     },
     disabled: ({access}) => isDisabled || !access.has('org:write'),
+    setValue: value => {
+      // If feature flag is off, always show as disabled (false)
+      // regardless of the org's actual setting
+      if (!hasFeatureFlag) {
+        return false;
+      }
+      return value;
+    },
   };
 };

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -52,9 +52,12 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       ),
     }),
     visible: ({model}) => {
-      // Show field when AI features are enabled (hideAiFeatures is false)
-      const hideAiFeatures = model.getValue('hideAiFeatures');
-      return hideAiFeatures;
+      // Check if feature flag is on - if so, use current model value for dynamic toggling
+      if (hasFeatureFlag) {
+        return !!model.getValue('hideAiFeatures');
+      }
+      // If flag is off, use initialData because setValue forces model value to false
+      return model.initialData.hideAiFeatures === true;
     },
     disabled: ({access}) => isDisabled || !access.has('org:write'),
     setValue: value => {

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -58,11 +58,5 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       return model.initialData.hideAiFeatures === true;
     },
     disabled: ({access}) => isDisabled || !access.has('org:write'),
-    setValue: value => {
-      if (!hasFeatureFlag) {
-        return false;
-      }
-      return value;
-    },
   };
 };

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -14,11 +14,14 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
   const regionData = getRegionDataFromOrganization(organization);
   const isUSOrg = regionData?.name?.toLowerCase() === 'us';
   const isSelfHosted = ConfigStore.get('isSelfHosted');
+  const hasFeatureFlag = organization.features.includes('organizations:gen-ai-features');
 
-  const isDisabled = isSelfHosted || !isUSOrg;
+  const isDisabled = isSelfHosted || !isUSOrg || !hasFeatureFlag;
   const disabledReason = isSelfHosted
     ? t('This feature is not available for self-hosted instances')
-    : t('This feature is only available in the US region');
+    : hasFeatureFlag
+      ? t('This feature is only available in the US region')
+      : t('This feature is not available');
 
   return {
     name: 'enablePrReviewTestGeneration',


### PR DESCRIPTION
When the `organizations:gen-ai-features` feature flag is disabled, the "gen ai" setting is now disabled and set to "off" regardless of the org's setting value.
<img width="607" height="85" alt="Screenshot 2025-11-19 at 3 51 34 PM" src="https://github.com/user-attachments/assets/8ef6c49d-02e3-4ee7-8a81-b799c5d57711" />
