### PR TITLE
ref(replay): rm beta badge and add new badge to replay summaries

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -42,7 +42,7 @@ export default function Ai() {
   const skipConsentFlow = organization.features.includes('gen-ai-consent-flow-removal');
 
   const replayTooLongMessage = t(
-    'While in beta phase, we only summarize a small portion of the replay.'
+    'If a replay is too long, we may only summarize a small portion of it.'
   );
 
   const {

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -51,7 +51,7 @@ function getReplayTabs({
           >
             {t('AI Summary')}
           </Tooltip>
-          <FeatureBadge type="beta" />
+          <FeatureBadge type="new" />
         </Flex>
       ) : null,
     [TabKey.BREADCRUMBS]: t('Breadcrumbs'),


### PR DESCRIPTION
to be merged whenever we want to GA replay summaries (only for web). to be merged with https://github.com/getsentry/sentry-docs/pull/15523

<img width="479" height="148" alt="SCR-20251114-kdnc" src="https://github.com/user-attachments/assets/7a7c030c-9980-43f8-b214-bad6729dc686" />

