### PR TITLE
chore(preprod): Use nonblocked project_id tag for e2e metric

### DIFF
--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -215,12 +215,13 @@ def compare_preprod_artifact_size_analysis(
 
     time_now = timezone.now()
     e2e_size_analysis_compare_duration = time_now - artifact.date_added
+    # TODO: Remove project_id_value once this metric's volume get too big to avoid high cardinality cost issues
     metrics.distribution(
         "preprod.size_analysis.compare.results_e2e",
         e2e_size_analysis_compare_duration.total_seconds(),
         sample_rate=1.0,
         tags={
-            "project_id": project_id,
+            "project_id_value": project_id,
             "organization_id": org_id,
             "artifact_type": artifact_type_name,
         },


### PR DESCRIPTION
to temporarily get around this logic: https://github.com/getsentry/sentry/blob/master/src/sentry/metrics/middleware.py#L37-L40C23