### PR TITLE
chore(tracemetrics): Remove unneeded trace metric from queries

### DIFF
--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -1,5 +1,4 @@
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
-import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 
 export const SAMPLING_MODE = {
   NORMAL: 'NORMAL',
@@ -25,7 +24,6 @@ export type RPCQueryExtras = {
   caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
   samplingMode?: SamplingMode;
-  traceMetric?: TraceMetric;
 };
 
 interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -66,10 +66,7 @@ export function useMetricAggregatesTable({
       enabled,
       limit,
       traceMetric,
-      queryExtras: {
-        ...queryExtras,
-        traceMetric,
-      },
+      queryExtras,
     },
     queryOptions: {
       canTriggerHighAccuracy,

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.spec.tsx
@@ -129,7 +129,7 @@ describe('useMetricSamplesTable', () => {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: '',
+          query: 'metric.name:test.metric metric.type:counter',
           caseInsensitive: undefined,
           dataset: 'tracemetrics',
           disableAggregateExtrapolation: undefined,
@@ -150,8 +150,6 @@ describe('useMetricSamplesTable', () => {
           referrer: 'api.explore.metric-samples-table',
           sampling: SAMPLING_MODE.NORMAL,
           sort: '-timestamp',
-          metricName: 'test.metric',
-          metricType: 'counter',
         }),
       })
     );

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
@@ -67,7 +67,6 @@ function useMetricTimeseriesImpl({
       topEvents,
       orderby: sortBys.map(formatSort),
       ...queryExtras,
-      traceMetric,
     },
     'api.explore.metrics-stats',
     DiscoverDatasets.TRACEMETRICS

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -39,7 +39,6 @@ import type {
   TimeSeriesItem,
 } from 'sentry/views/dashboards/widgets/common/types';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {FALLBACK_SERIES_NAME} from 'sentry/views/explore/settings';
 import {getSeriesEventView} from 'sentry/views/insights/common/queries/getSeriesEventView';
 import {
@@ -64,7 +63,6 @@ interface Options<Fields> {
   samplingMode?: SamplingMode;
   search?: MutableSearch;
   topEvents?: number;
-  traceMetric?: TraceMetric;
   yAxis?: Fields;
 }
 
@@ -89,7 +87,6 @@ export const useSortedTimeSeries = <
     samplingMode,
     disableAggregateExtrapolation,
     caseInsensitive,
-    traceMetric,
   } = options;
 
   const pageFilters = usePageFilters();
@@ -166,8 +163,6 @@ export const useSortedTimeSeries = <
       // pagination does not cause extra requests
       cursor: undefined,
       caseInsensitive,
-      metricName: traceMetric?.name ? traceMetric.name : undefined,
-      metricType: traceMetric?.type ? traceMetric.type : undefined,
     }),
     options: {
       enabled: enabled && pageFilters.isReady,

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -19,7 +19,6 @@ import type {
   RPCQueryExtras,
   SamplingMode,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
-import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   getRetryDelay,
   shouldRetryHandler,
@@ -113,7 +112,6 @@ function useSpansQueryBase<T>({
     caseInsensitive: queryExtras?.caseInsensitive,
     samplingMode: queryExtras?.samplingMode,
     disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation,
-    traceMetric: queryExtras?.traceMetric,
   });
 
   if (trackResponseAnalytics) {
@@ -245,7 +243,6 @@ type WrappedDiscoverQueryProps<T> = {
   referrer?: string;
   refetchInterval?: number;
   samplingMode?: SamplingMode;
-  traceMetric?: TraceMetric;
 };
 
 function useWrappedDiscoverQueryBase<T>({
@@ -264,7 +261,6 @@ function useWrappedDiscoverQueryBase<T>({
   additionalQueryKey,
   refetchInterval,
   caseInsensitive,
-  traceMetric,
 }: WrappedDiscoverQueryProps<T> & {
   pageFiltersReady: boolean;
 }) {
@@ -292,11 +288,6 @@ function useWrappedDiscoverQueryBase<T>({
 
   if (allowAggregateConditions !== undefined) {
     queryExtras.allowAggregateConditions = allowAggregateConditions ? '1' : '0';
-  }
-
-  if (traceMetric?.name && traceMetric?.type) {
-    queryExtras.metricName = traceMetric.name;
-    queryExtras.metricType = traceMetric.type;
   }
 
   const result = useDiscoverQuery({


### PR DESCRIPTION
This isn't needed anymore because we parse the condition from the aggregation.