### PR TITLE
fix(aci): Correct issues link on automation history

### DIFF
--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -122,7 +122,12 @@ export default function AutomationHistoryList({
               )}
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>
-              <StyledLink to={`/issues/${row.group.id}`}>
+              <StyledLink
+                to={{
+                  pathname: `/organizations/${org.slug}/issues/${row.group.id}/events/${row.eventId}/`,
+                  query: {project: row.group.project.id},
+                }}
+              >
                 <Flex gap="xs" align="center">
                   <PlatformIcon platform={row.group.platform} size={16} />
                   <TruncatedText>


### PR DESCRIPTION
Was missing the full path. Adds project id since to save a rerender and because we have it available.
