### PR TITLE
test(tracemetrics): Re-enable skipped trace metrics tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
@@ -176,7 +176,6 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         assert response.data["value2"]["meta"]["dataset"] == "tracemetrics"
         assert response.data["Other"]["meta"]["dataset"] == "tracemetrics"
 
-    @pytest.mark.skip(reason="flaky: #103382")
     def test_meta_accuracy(self):
         metric_values = [1, 2, 3, 4]
 

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -180,7 +180,6 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             "sum(value, request_duration, distribution, -)": 155,
         }
 
-    @pytest.mark.skip(reason="flaky: #103384")
     def test_per_minute_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
         self.store_trace_metrics(


### PR DESCRIPTION
These tests failed because #103303 and #103071 were merged without being rebased on each other. #103071 has since been reverted.

Fixes #103382
Fixes #103384