### PR TITLE
fix(aci): Fix QuerySubscription deletion

### DIFF
--- a/src/sentry/deletions/defaults/querysubscription.py
+++ b/src/sentry/deletions/defaults/querysubscription.py
@@ -14,7 +14,9 @@ class QuerySubscriptionDeletionTask(ModelDeletionTask[QuerySubscription]):
         from sentry.incidents.models.alert_rule import AlertRule
         from sentry.snuba.models import SnubaQuery
 
-        if not AlertRule.objects.filter(snuba_query_id=instance.snuba_query_id).exists():
+        if not AlertRule.objects_with_snapshots.filter(
+            snuba_query_id=instance.snuba_query_id
+        ).exists():
             if (
                 QuerySubscription.objects.filter(snuba_query_id=instance.snuba_query_id).count()
                 == 1


### PR DESCRIPTION
We have logic to ensure that SnubaQuery deletions are triggered by QuerySubscription deletion only if the SnubaQuery isn't used by AlertRules or other QuerySubscriptions.

This changes it to not exclude snapshot AlertRules, as those can still point to a SnubaQuery and fail attempts to delete it.

Fixes [SENTRY-43RZ](https://sentry.sentry.io/issues/6711913108/).
