### PR TITLE
fix(aci): update hits count for workflow fire history

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -295,7 +295,9 @@ class OffsetPaginator(PaginatorLike):
         if self.on_results:
             results = self.on_results(results)
 
-        if count_hits:
+        if known_hits is not None:
+            hits = known_hits
+        elif count_hits:
             hits = self.count_hits(max_hits=MAX_HITS_LIMIT)
         else:
             hits = None

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -298,7 +298,9 @@ class OffsetPaginator(PaginatorLike):
         if known_hits is not None:
             hits = known_hits
         elif count_hits:
-            hits = self.count_hits(max_hits=MAX_HITS_LIMIT)
+            if max_hits is None:
+                max_hits = MAX_HITS_LIMIT
+            hits = self.count_hits(max_hits)
         else:
             hits = None
 

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -128,11 +128,14 @@ def fetch_workflow_groups_paginated(
         .annotate(detector_id=Subquery(group_max_dates.values("detector_id")))
     )
 
+    # Count distinct groups for pagination
+    group_count = qs.count()
+
     return cast(
         CursorResult[Group],
         OffsetPaginator(
             qs,
             order_by=("-count", "-last_triggered"),
             on_results=convert_results,
-        ).get_result(per_page, cursor, count_hits=True),
+        ).get_result(per_page, cursor, known_hits=group_count),
     )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -96,7 +96,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
             self.user,
             WorkflowGroupHistorySerializer(),
         )
-        assert resp["X-Hits"] == "4"
+        assert resp["X-Hits"] == "2"  # 2 unique groups, not 4 total history records
 
         resp = self.get_success_response(
             self.organization.slug,
@@ -119,7 +119,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
             self.user,
             WorkflowGroupHistorySerializer(),
         )
-        assert resp["X-Hits"] == "4"
+        assert resp["X-Hits"] == "2"  # 2 unique groups, not 4 total history records
 
     def test_invalid_dates_error(self) -> None:
         self.get_error_response(


### PR DESCRIPTION
fixes a bug where `X-Hits` was turning the total sum of alerts (right column), rather than the total number of groups (rows in the table)

<img width="1196" height="342" alt="image (2)" src="https://github.com/user-attachments/assets/0b2807ba-39a3-40d2-b1b4-d7d5730e461e" />
