### PR TITLE
fix(aci): close IGOP relationships in more cases and heal broken relationships

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -496,6 +496,11 @@ def process_group_resolution(
     activity_data: MutableMapping[str, Any],
     result: MutableMapping[str, Any],
 ) -> None:
+    from sentry.incidents.grouptype import MetricIssue
+    from sentry.workflow_engine.models.incident_groupopenperiod import (
+        update_incident_based_on_open_period_status_change,
+    )
+
     now = django_timezone.now()
     resolution = None
     created = None
@@ -655,6 +660,8 @@ def process_group_resolution(
             resolution_time=now,
             resolution_activity=activity,
         )
+        if group.issue_type == MetricIssue:
+            update_incident_based_on_open_period_status_change(group, GroupStatus.RESOLVED)
 
 
 def merge_groups(

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -563,7 +563,7 @@ class GroupManager(BaseManager["Group"]):
                         extra={"group_id": group.id},
                     )
                     continue
-                update_incident_based_on_open_period_status_change(group, status, detector_id)
+                update_incident_based_on_open_period_status_change(group, status)
 
     def from_share_id(self, share_id: str) -> Group:
         if not share_id or len(share_id) != 32:

--- a/tests/sentry/issues/test_ingest_incident_integration.py
+++ b/tests/sentry/issues/test_ingest_incident_integration.py
@@ -173,8 +173,10 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
         activity = IncidentActivity.objects.filter(incident_id=incident.id)
         assert len(activity) == 4  # detected, created, priority change, close
 
-    def test_can_update_outstanding_incident_priority(self) -> None:
-        """Test that we link and update an incident that was opened before the org started single processing"""
+    def test_can_close_outstanding_incident(self) -> None:
+        """Test that we close incidents that are left open as a result of IGOP linkage bugs"""
+        four_minutes_ago = timezone.now() - timedelta(minutes=4)
+        three_minutes_ago = timezone.now() - timedelta(minutes=3)
         _, group_info = self.save_issue_occurrence()
         group = group_info.group
         assert group is not None
@@ -183,58 +185,34 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
 
         open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
 
+        # replicate the following conditions in the DB: an open incident is tied to
+        # a closed open period, and a new open period is being passed to create_from_occurrence()
         dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
+        dummy_open_period = GroupOpenPeriod.objects.create(
+            group=group,
+            date_started=four_minutes_ago,
+            date_ended=three_minutes_ago,
+            project=self.project,
+        )
         incident = Incident.objects.get(id=dummy_relationship.incident_id)
+        dummy_relationship.delete()
+        IncidentGroupOpenPeriod.objects.create(
+            incident_id=incident.id,
+            incident_identifier=incident.identifier,
+            group_open_period=dummy_open_period,
+        )
 
-        # this is a little hacky, but to emulate dual processing -> single processing I will
-        # just delete the IGOP relationship
-        IncidentGroupOpenPeriod.objects.all().delete()
-
-        _, group_info = self.save_issue_occurrence(priority=DetectorPriorityLevel.MEDIUM)
-        group = group_info.group
-        assert group is not None
-
-        item = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
-        assert item.incident_id == incident.id
-        activity = IncidentActivity.objects.filter(incident_id=incident.id)
-
-        assert len(activity) == 4
-        last_activity_entry = activity[3]
-        assert last_activity_entry.type == 2
-        assert last_activity_entry.value == str(IncidentStatus.WARNING.value)
-        assert last_activity_entry.previous_value == str(IncidentStatus.CRITICAL.value)
-
-    def test_can_resolve_outstanding_incident(self) -> None:
-        """Test that we link and update an incident that was opened before the org started single processing on resolution"""
         _, group_info = self.save_issue_occurrence()
         group = group_info.group
         assert group is not None
 
-        assert GroupOpenPeriod.objects.filter(group=group, project=self.project).exists()
-
-        open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
-
-        dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
-        incident = Incident.objects.get(id=dummy_relationship.incident_id)
-
-        # this is a little hacky, but to emulate dual processing -> single processing I will
-        # just delete the IGOP relationship
-        IncidentGroupOpenPeriod.objects.all().delete()
-
-        with self.tasks():
-            update_status(group, self.mock_status_change_message)
-
-        open_period = GroupOpenPeriod.objects.get(group=group)
-        assert open_period.date_ended is not None
+        incident.refresh_from_db()
+        assert IncidentGroupOpenPeriod.objects.count() == 2
+        assert incident.date_closed is not None
         item = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
-        assert item.incident_id == incident.id
-        activity = IncidentActivity.objects.filter(incident_id=incident.id)
-        assert len(activity) == 4  # detected, created, priority change, close
-
-        last_activity_entry = activity[3]
-        assert last_activity_entry.type == 2
-        assert last_activity_entry.previous_value == str(IncidentStatus.CRITICAL.value)
-        assert last_activity_entry.value == str(IncidentStatus.CLOSED.value)
+        new_incident = Incident.objects.get(id=item.incident_id)
+        activity = IncidentActivity.objects.filter(incident_id=new_incident.id)
+        assert len(activity) == 3  # detected, created, status change
 
     @mock.patch("sentry.models.group.logger")
     def test_bulk_transition_new_group_to_ongoing__metric_issues__no_incident_activites(


### PR DESCRIPTION
- Close outstanding incidents when metric issues are closed through means other than detector-emitted status change messages
- To heal broken relationships, instead of returning outstanding incidents, close them. From there, we can proceed through incident creation like normal.
- To repurpose the dual close method, I've taken out the edge case logic for switching between dual and single writes—now, we don't have to pass detector_id.