### PR TITLE
fix(preprod): update dyld label

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeTheme.ts
+++ b/static/app/views/preprod/components/visualizations/appSizeTheme.ts
@@ -76,7 +76,7 @@ export function getAppSizeCategoryInfo(
     [TreemapType.DYLD]: {
       color: groupColor1,
       headerColor: createHeaderColor(groupColor1),
-      displayName: t('Dynamic Libraries'),
+      displayName: t('DYLD'),
     },
     [TreemapType.MACHO]: {
       color: groupColor2,


### PR DESCRIPTION
This was accidentally set to "Dynamic Libraries" which is tangentially related to DYLD but the wrong label in this case.

Resolves EME-579