### PR TITLE
Wire up frontend for new multiple architectures insight

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.spec.tsx
@@ -1,4 +1,4 @@
-import {AppleInsightResultsFixture} from 'sentry-fixture/preProdAppSize';
+import {InsightResultsFixture} from 'sentry-fixture/preProdAppSize';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -9,7 +9,7 @@ import {AppSizeInsights} from './appSizeInsights';
 describe('AppSizeInsights', () => {
   const getDefaultProps = () => {
     const totalSize = 10240000;
-    const insights = AppleInsightResultsFixture();
+    const insights = InsightResultsFixture();
     return {
       processedInsights: processInsights(insights, totalSize),
       totalSize,
@@ -24,7 +24,7 @@ describe('AppSizeInsights', () => {
   });
 
   it('displays only top 5 insights in the main view', () => {
-    const manyInsights = AppleInsightResultsFixture({
+    const manyInsights = InsightResultsFixture({
       image_optimization: {
         total_savings: 600000,
         optimizable_files: [

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.spec.tsx
@@ -1,4 +1,4 @@
-import {AppleInsightResultsFixture} from 'sentry-fixture/preProdAppSize';
+import {InsightResultsFixture} from 'sentry-fixture/preProdAppSize';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -8,7 +8,7 @@ import {AppSizeInsightsSidebar} from './appSizeInsightsSidebar';
 
 describe('AppSizeInsightsSidebar', () => {
   const getDefaultProps = () => {
-    const insights = AppleInsightResultsFixture({
+    const insights = InsightResultsFixture({
       large_images: {
         total_savings: 128000,
         files: [

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -7,7 +7,7 @@ import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDeta
 export interface AppSizeApiResponse {
   generated_at: string;
   treemap: TreemapResults;
-  insights?: AppleInsightResults;
+  insights?: InsightResults;
   missing_dsym_binaries?: string[];
 }
 
@@ -189,7 +189,9 @@ interface AudioCompressionInsightResult extends FilesInsightResult {}
 
 interface VideoCompressionInsightResult extends FilesInsightResult {}
 
-export interface AppleInsightResults {
+interface MultipleNativeLibraryArchsInsightResult extends FilesInsightResult {}
+
+export interface InsightResults {
   alternate_icons_optimization?: ImageOptimizationInsightResult;
   audio_compression?: AudioCompressionInsightResult;
   duplicate_files?: DuplicateFilesInsightResult;
@@ -202,6 +204,7 @@ export interface AppleInsightResults {
   localized_strings_minify?: LocalizedStringCommentsInsightResult;
   loose_images?: LooseImagesInsightResult;
   main_binary_exported_symbols?: MainBinaryExportMetadataResult;
+  multiple_native_library_archs?: MultipleNativeLibraryArchsInsightResult;
   small_files?: SmallFilesInsightResult;
   strip_binary?: StripBinaryInsightResult;
   unnecessary_files?: UnnecessaryFilesInsightResult;

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -1,10 +1,10 @@
 import {t} from 'sentry/locale';
 import type {
-  AppleInsightResults,
   FileSavingsResult,
   FileSavingsResultGroup,
   FilesInsightResult,
   GroupsInsightResult,
+  InsightResults,
   OptimizableImageFile,
   StripBinaryFileInfo,
 } from 'sentry/views/preprod/types/appSizeTypes';
@@ -131,6 +131,13 @@ const INSIGHT_CONFIGS: InsightConfig[] = [
       "Alternate icons don't need full size quality because they are only shown downscaled in the homescreen."
     ),
   },
+  {
+    key: 'multiple_native_library_archs',
+    name: t('Multiple native library architectures'),
+    description: t(
+      'Only one native library architecture is needed. Non-arm64 architectures can be removed.'
+    ),
+  },
 ];
 
 function markDuplicateImageVariants(processedInsights: ProcessedInsight[]): void {
@@ -163,7 +170,7 @@ function markDuplicateImageVariants(processedInsights: ProcessedInsight[]): void
  * Process all insights into a standardized format for display
  */
 export function processInsights(
-  insights: AppleInsightResults,
+  insights: InsightResults,
   totalSize: number
 ): ProcessedInsight[] {
   const processedInsights: ProcessedInsight[] = [];
@@ -326,6 +333,7 @@ export function processInsights(
     'hermes_debug_info',
     'audio_compression',
     'video_compression',
+    'multiple_native_library_archs',
   ] as const;
 
   regularInsightKeys.forEach(key => {

--- a/tests/js/fixtures/preProdAppSize.ts
+++ b/tests/js/fixtures/preProdAppSize.ts
@@ -1,5 +1,4 @@
-import type {AppleInsightResults} from 'sentry/views/preprod/types/appSizeTypes';
-import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
+import type {InsightResults} from 'sentry/views/preprod/types/appSizeTypes';
 
 export function ProcessedInsightFixture(
   params: Partial<ProcessedInsight> = {}
@@ -61,9 +60,9 @@ export function ProcessedInsightFixture(
   };
 }
 
-export function AppleInsightResultsFixture(
-  params: Partial<AppleInsightResults> = {}
-): AppleInsightResults {
+export function InsightResultsFixture(
+  params: Partial<InsightResults> = {}
+): InsightResults {
   return {
     duplicate_files: {
       total_savings: 768000,

--- a/tests/js/fixtures/preProdAppSize.ts
+++ b/tests/js/fixtures/preProdAppSize.ts
@@ -1,4 +1,5 @@
 import type {InsightResults} from 'sentry/views/preprod/types/appSizeTypes';
+import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 
 export function ProcessedInsightFixture(
   params: Partial<ProcessedInsight> = {}


### PR DESCRIPTION
<img width="2236" height="161" alt="Screenshot 2025-11-14 at 3 29 14 PM" src="https://github.com/user-attachments/assets/c5155fbb-c4cd-4019-a036-e87dd56d5092" />
<img width="686" height="492" alt="Screenshot 2025-11-14 at 3 23 37 PM" src="https://github.com/user-attachments/assets/74e2a479-4c95-48a5-b564-31dfed4fff0a" />

Also renames `AppleInsightResults` to `InsightResults` since it's not apple-specific

Resolves EME-643