### PR TITLE
fix(aci): Make associate_new_group_with_detector more robust

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1058,3 +1058,15 @@ class TestAssociateNewGroupWithDetector(TestCase):
         group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
         assert not associate_new_group_with_detector(group)
         assert not DetectorGroup.objects.filter(group_id=group.id).exists()
+
+    def test_deleted_detector_creates_null_association(self) -> None:
+        group = self.create_group(project=self.project, type=MetricIssue.type_id)
+        deleted_detector_id = self.metric_detector.id
+
+        self.metric_detector.delete()
+
+        assert associate_new_group_with_detector(group, deleted_detector_id)
+
+        detector_group = DetectorGroup.objects.get(group_id=group.id)
+        assert detector_group.detector_id is None
+        assert detector_group.group_id == group.id


### PR DESCRIPTION
Since we know Detectors can go away (even before we have a chance to process a new occurrence) and we have a convention for representing that with DetectorGroup, update associate_new_group_with_detector accordingly.