### PR TITLE
fix(issues): use correct tz for absolute date picker

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/specificDatePicker.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/specificDatePicker.tsx
@@ -112,7 +112,7 @@ function SpecificDatePicker({
                 if (newDate instanceof Date) {
                   handleSelectDateTime(
                     createDateStringFromSelection({
-                      date: getInternalDate(newDate, utc),
+                      date: newDate,
                       time,
                       utc,
                     })


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/103188

https://linear.app/getsentry/issue/RTC-1170/the-absolute-date-picker-including-timestamp-without-utc-check-behaves