### PR TITLE
feat(explorer): highlight nav links and smooth scroll

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -268,6 +268,7 @@ function BlockComponent({
   return (
     <Block
       ref={ref}
+      isFocused={isFocused}
       isLast={isLast}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
@@ -342,7 +343,6 @@ function BlockComponent({
               </BlockContentWrapper>
             </BlockRow>
           )}
-          {isFocused && <FocusIndicator />}
           <AnimatePresence>
             {showActions && (
               <motion.div
@@ -391,12 +391,13 @@ BlockComponent.displayName = 'BlockComponent';
 
 export default BlockComponent;
 
-const Block = styled('div')<{isLast?: boolean}>`
+const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
   width: 100%;
   border-bottom: ${p => (p.isLast ? 'none' : `1px solid ${p.theme.border}`)};
   position: relative;
   flex-shrink: 0; /* Prevent blocks from shrinking */
   cursor: pointer;
+  background: ${p => (p.isFocused ? p.theme.backgroundSecondary : 'transparent')};
 `;
 
 const BlockRow = styled('div')`
@@ -503,15 +504,6 @@ const UserBlockContent = styled('div')`
   white-space: pre-wrap;
   word-wrap: break-word;
   color: ${p => p.theme.subText};
-`;
-
-const FocusIndicator = styled('div')`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 3px;
-  background: ${p => p.theme.purple400};
 `;
 
 const ToolCallStack = styled(Stack)`

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -397,7 +397,7 @@ const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
   position: relative;
   flex-shrink: 0; /* Prevent blocks from shrinking */
   cursor: pointer;
-  background: ${p => (p.isFocused ? p.theme.backgroundSecondary : 'transparent')};
+  background: ${p => (p.isFocused ? p.theme.hover : 'transparent')};
 `;
 
 const BlockRow = styled('div')`

--- a/static/app/views/seerExplorer/emptyState.tsx
+++ b/static/app/views/seerExplorer/emptyState.tsx
@@ -7,11 +7,7 @@ function EmptyState() {
   return (
     <Container>
       <IconSeer size="xl" variant="waiting" />
-      <Text>
-        Welcome to Seer Explorer.
-        <br />
-        Ask me anything about your application.
-      </Text>
+      <Text>Ask Seer anything about your application.</Text>
     </Container>
   );
 }

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -364,7 +364,7 @@ const MenuPanel = styled('div')<{
 `;
 
 const MenuItem = styled('div')<{isSelected: boolean}>`
-  padding: ${space(1.5)} ${space(2)};
+  padding: ${p => p.theme.space.md};
   cursor: pointer;
   background: ${p => (p.isSelected ? p.theme.hover : 'transparent')};
   border-bottom: 1px solid ${p => p.theme.border};
@@ -379,8 +379,7 @@ const MenuItem = styled('div')<{isSelected: boolean}>`
 `;
 
 const ItemName = styled('div')`
-  font-weight: 600;
-  color: ${p => p.theme.purple400};
+  font-weight: ${p => p.theme.fontWeight.bold};
   font-size: ${p => p.theme.fontSize.sm};
   overflow: hidden;
   text-overflow: ellipsis;
@@ -390,5 +389,4 @@ const ItemName = styled('div')`
 const ItemDescription = styled('div')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSize.xs};
-  margin-top: 2px;
 `;

--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -54,7 +54,9 @@ describe('ExplorerPanel', () => {
     it('renders when feature flag is enabled', () => {
       render(<ExplorerPanel isVisible />, {organization});
 
-      expect(screen.getByText(/Welcome to Seer Explorer/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Ask Seer anything about your application./)
+      ).toBeInTheDocument();
     });
 
     it('does not render when feature flag is disabled', () => {
@@ -87,7 +89,9 @@ describe('ExplorerPanel', () => {
     it('shows empty state when no messages exist', () => {
       render(<ExplorerPanel isVisible />, {organization});
 
-      expect(screen.getByText(/Welcome to Seer Explorer/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Ask Seer anything about your application./)
+      ).toBeInTheDocument();
     });
 
     it('shows input section in empty state', () => {
@@ -149,7 +153,9 @@ describe('ExplorerPanel', () => {
       expect(
         screen.getByText('This error indicates a null pointer exception.')
       ).toBeInTheDocument();
-      expect(screen.queryByText(/Welcome to Seer Explorer/)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Ask Seer anything about your application./)
+      ).not.toBeInTheDocument();
 
       // Restore the mock
       jest.restoreAllMocks();

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -52,7 +52,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
     blocks,
     blockRefs,
     textareaRef,
-    scrollContainerRef,
     setFocusedBlockIndex,
     isMinimized,
     onDeleteFromIndex: deleteFromIndex,

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -52,6 +52,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
     blocks,
     blockRefs,
     textareaRef,
+    scrollContainerRef,
     setFocusedBlockIndex,
     isMinimized,
     onDeleteFromIndex: deleteFromIndex,

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -203,6 +203,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
   };
 
   const handleBlockClick = (index: number) => {
+    textareaRef.current?.blur();
     setFocusedBlockIndex(index);
     setIsMinimized(false);
   };
@@ -342,9 +343,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
 
                 hoveredBlockIndex.current = index;
                 setFocusedBlockIndex(index);
-                if (document.activeElement === textareaRef.current) {
-                  textareaRef.current?.blur();
-                }
+                textareaRef.current?.blur();
               }}
               onMouseLeave={() => {
                 if (hoveredBlockIndex.current === index) {

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.spec.tsx
@@ -9,7 +9,7 @@ describe('useBlockNavigation', () => {
     jest.useFakeTimers();
     // Mock requestAnimationFrame to execute callback immediately
     global.requestAnimationFrame = jest.fn(cb => {
-      cb();
+      cb(performance.now());
       return 1;
     });
     global.cancelAnimationFrame = jest.fn();
@@ -88,6 +88,7 @@ describe('useBlockNavigation', () => {
 
   const createMockTextarea = () => {
     const mockFocus = jest.fn();
+    const mockBlur = jest.fn();
     const mockScrollIntoView = jest.fn();
     const mockGetBoundingClientRect = jest.fn(() => ({
       top: 200,
@@ -99,6 +100,7 @@ describe('useBlockNavigation', () => {
     }));
     return {
       focus: mockFocus,
+      blur: mockBlur,
       scrollIntoView: mockScrollIntoView,
       offsetTop: 200,
       offsetHeight: 50,
@@ -132,6 +134,7 @@ describe('useBlockNavigation', () => {
       document.dispatchEvent(event);
 
       expect(defaultProps.setFocusedBlockIndex).toHaveBeenCalledWith(2); // Last block index
+      expect(mockTextarea.blur).toHaveBeenCalled();
       expect(mockScrollContainer.scrollTo).toHaveBeenCalled();
     });
 

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.spec.tsx
@@ -53,20 +53,36 @@ describe('useBlockNavigation', () => {
     } as unknown as HTMLTextAreaElement;
   };
 
-  const mockElement1 = createMockElement();
-  const mockElement2 = createMockElement();
-  const mockElement3 = createMockElement();
-  const mockTextarea = createMockTextarea();
-
-  const defaultProps = {
-    isOpen: true,
-    focusedBlockIndex: -1,
-    blocks: mockBlocks,
-    blockRefs: {current: [mockElement1, mockElement2, mockElement3]},
-    textareaRef: {current: mockTextarea},
-    setFocusedBlockIndex: jest.fn(),
-    onDeleteFromIndex: jest.fn(),
+  let mockElement1: ReturnType<typeof createMockElement>;
+  let mockElement2: ReturnType<typeof createMockElement>;
+  let mockElement3: ReturnType<typeof createMockElement>;
+  let mockTextarea: ReturnType<typeof createMockTextarea>;
+  let defaultProps: {
+    blockRefs: {current: Array<HTMLDivElement | null>};
+    blocks: Block[];
+    focusedBlockIndex: number;
+    isOpen: boolean;
+    onDeleteFromIndex: jest.Mock;
+    setFocusedBlockIndex: jest.Mock;
+    textareaRef: {current: HTMLTextAreaElement | null};
   };
+
+  beforeEach(() => {
+    mockElement1 = createMockElement();
+    mockElement2 = createMockElement();
+    mockElement3 = createMockElement();
+    mockTextarea = createMockTextarea();
+
+    defaultProps = {
+      isOpen: true,
+      focusedBlockIndex: -1,
+      blocks: mockBlocks,
+      blockRefs: {current: [mockElement1, mockElement2, mockElement3]},
+      textareaRef: {current: mockTextarea},
+      setFocusedBlockIndex: jest.fn(),
+      onDeleteFromIndex: jest.fn(),
+    };
+  });
 
   describe('Arrow Key Navigation', () => {
     it('moves from input to last block on ArrowUp', () => {
@@ -262,9 +278,6 @@ describe('useBlockNavigation', () => {
       const arrowUpEvent = new KeyboardEvent('keydown', {key: 'ArrowUp'});
       document.dispatchEvent(arrowUpEvent);
       expect(props.setFocusedBlockIndex).toHaveBeenCalledWith(0);
-
-      // Reset mock
-      props.setFocusedBlockIndex.mockClear();
 
       // ArrowDown from block 0 should go to input
       const propsAtBlock0 = {...props, focusedBlockIndex: 0};

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
@@ -133,6 +133,8 @@ export function useBlockNavigation({
           const newIndex = blocks.length - 1;
           const blockElement = blockRefs.current[newIndex];
           if (blockElement) {
+            // Blur textarea when navigating to a block
+            textareaRef.current?.blur();
             setFocusedBlockIndex(newIndex);
             scrollToElement(blockElement, 'down');
           }

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
@@ -13,7 +13,6 @@ interface UseBlockNavigationProps {
   onDeleteFromIndex?: (index: number) => void;
   onKeyPress?: (blockIndex: number, key: 'Enter' | 'ArrowUp' | 'ArrowDown') => boolean;
   onNavigate?: () => void;
-  scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 export function useBlockNavigation({

--- a/static/app/views/seerExplorer/inputSection.tsx
+++ b/static/app/views/seerExplorer/inputSection.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {TextArea} from '@sentry/scraps/textarea/textarea';
 
 import {IconMenu} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
 
 interface InputSectionProps {
   focusedBlockIndex: number;
@@ -67,7 +67,6 @@ function InputSection({
           data-test-id="seer-explorer-input"
         />
       </InputRow>
-      {focusedBlockIndex === -1 && <FocusIndicator />}
     </InputBlock>
   );
 }
@@ -77,7 +76,6 @@ export default InputSection;
 // Styled components
 const InputBlock = styled('div')`
   width: 100%;
-  border-top: 1px solid ${p => p.theme.border};
   background: ${p => p.theme.background};
   position: sticky;
   bottom: 0;
@@ -88,13 +86,13 @@ const InputRow = styled('div')`
   align-items: stretch;
   width: 100%;
   padding: 0;
-  gap: ${space(1)};
 `;
 
 const ButtonContainer = styled('div')`
   display: flex;
   align-items: center;
   padding: ${p => p.theme.space.sm};
+  padding-top: ${p => p.theme.space.md};
 
   button {
     width: auto;
@@ -102,34 +100,10 @@ const ButtonContainer = styled('div')`
   }
 `;
 
-const FocusIndicator = styled('div')`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 3px;
-  background: ${p => p.theme.purple400};
-`;
-
-const InputTextarea = styled('textarea')`
+const InputTextarea = styled(TextArea)`
   width: 100%;
-  border: none;
-  outline: none;
-  background: transparent;
-  padding: ${space(2)} ${space(2)} ${space(2)} 0;
+  margin: ${p => p.theme.space.sm} ${p => p.theme.space.sm} ${p => p.theme.space.sm} 0;
   color: ${p => p.theme.textColor};
   resize: none;
-  min-height: 40px;
-  max-height: 120px;
-  line-height: 1.4;
   overflow-y: auto;
-  box-sizing: border-box;
-
-  &::placeholder {
-    color: ${p => p.theme.subText};
-  }
-
-  &:focus {
-    outline: none;
-  }
 `;

--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -37,7 +37,7 @@ function PanelContainers({
               initial={{opacity: 0}}
               animate={{opacity: isMinimized ? 0 : 1}}
               exit={{opacity: 0}}
-              transition={{duration: 0.1}}
+              transition={{duration: 0.12}}
             />
           )}
           <PanelContainer
@@ -55,8 +55,8 @@ function PanelContainers({
               scaleY: 1,
               transformOrigin: 'bottom center',
             }}
-            exit={{opacity: 0, y: 50, scale: 0.1, transformOrigin: 'bottom center'}}
-            transition={{duration: 0.1, ease: 'easeInOut'}}
+            exit={{opacity: 0, y: 50, scaleY: 0.1, transformOrigin: 'bottom center'}}
+            transition={{duration: 0.12, ease: 'easeInOut'}}
           >
             <PanelContent ref={ref} data-seer-explorer-root="">
               {children}

--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -46,13 +46,13 @@ function PanelContainers({
             initial={{
               opacity: 0,
               y: 50,
-              scale: 0.1,
+              scaleY: 0.1,
               transformOrigin: 'bottom center',
             }}
             animate={{
               opacity: 1,
               y: isMinimized ? 'calc(100% - 60px)' : 0,
-              scale: 1,
+              scaleY: 1,
               transformOrigin: 'bottom center',
             }}
             exit={{opacity: 0, y: 50, scale: 0.1, transformOrigin: 'bottom center'}}
@@ -65,7 +65,7 @@ function PanelContainers({
                   initial={{opacity: 0}}
                   animate={{opacity: 1}}
                   exit={{opacity: 0}}
-                  transition={{duration: 0.2}}
+                  transition={{duration: 0.12}}
                   onClick={onUnminimize}
                 >
                   <Flex direction="column" align="center" gap="lg">
@@ -120,7 +120,7 @@ const PanelContainer = styled(motion.div)<{
       margin-left: -25vw;
     `}
 
-  transition: all 0.2s ease-in-out;
+  transition: all 0.12s ease-in-out;
 `;
 
 const PanelContent = styled('div')`


### PR DESCRIPTION
Highlights the corresponding tool call when the nav button is selected so it's more clear which button belongs to what. Also adds a link icon so you can see that nav is available even before hovering/focusing the block.

<img width="806" height="486" alt="Screenshot 2025-11-16 at 2 24 14 PM" src="https://github.com/user-attachments/assets/28b3f55f-23ac-45ca-a143-fbb6e53ea9c5" />


Also makes scrolling with arrow keys less jittery with proper smooth scroll
Also restyle to use more core components

(sorry for tacking on)