### PR TITLE
refactor(replays): replace ReplayListQueryReferrer type with a const array for improved type safety

### DIFF
--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -200,11 +200,13 @@ export type ReplayListLocationQuery = {
   utc?: 'true' | 'false';
 };
 
-export type ReplayListQueryReferrer =
-  | 'replayList'
-  | 'issueReplays'
-  | 'transactionReplays'
-  | 'replaysPlayList';
+export const REPLAY_LIST_QUERY_REFERRERS = [
+  'replayList',
+  'issueReplays',
+  'transactionReplays',
+] as const;
+
+export type ReplayListQueryReferrer = (typeof REPLAY_LIST_QUERY_REFERRERS)[number];
 
 // Sync with ReplayListRecord below
 // Skip some fields because the backend doesn't support them in the field list:


### PR DESCRIPTION
In #103007, I pass `queryReferrer` as a URL param and we lose type safety. 

I want to have ReplayListQueryReferrer in a tuple rather than just a type so I can use it to convert the string URL param back to a `ReplayListQueryReferrer` type to be passed into a hook. 

This solves a bug where some replays weren't showing for particular projects because of the incorrect queryReferrer being forwarded to `useReplayList`.  