### PR TITLE
Changes STS export to use proper format for pubsub topic name.

### DIFF
--- a/src/sentry/replays/data_export.py
+++ b/src/sentry/replays/data_export.py
@@ -196,7 +196,7 @@ def create_transfer_job[T](
 
     if notification_topic:
         transfer_job.notification_config = NotificationConfig(
-            pubsub_topic=notification_topic,
+            pubsub_topic=f"projects/{gcp_project_id}/topics/{notification_topic}",
             event_types=[
                 NotificationConfig.EventType.TRANSFER_OPERATION_FAILED,
                 NotificationConfig.EventType.TRANSFER_OPERATION_SUCCESS,

--- a/tests/sentry/replays/unit/test_data_export.py
+++ b/tests/sentry/replays/unit/test_data_export.py
@@ -39,7 +39,7 @@ def test_export_blob_data() -> None:
         source_prefix=bucket_prefix,
         destination_bucket="b",
         destination_prefix="destination_prefix/",
-        notification_topic=pubsub_topic,
+        notification_topic=notification_topic,
         job_description=job_description,
         job_duration=job_duration,
         transfer_job_name=None,

--- a/tests/sentry/replays/unit/test_data_export.py
+++ b/tests/sentry/replays/unit/test_data_export.py
@@ -24,7 +24,8 @@ from sentry.utils import json
 def test_export_blob_data() -> None:
     # Function parameters which could be abstracted to test multiple variations of this behavior.
     gcs_project_id = "1"
-    pubsub_topic = "PUBSUB_TOPIC"
+    notification_topic = "PUBSUB_TOPIC"
+    pubsub_topic = f"projects/{gcs_project_id}/topics/{notification_topic}"
     bucket_name = "BUCKET"
     bucket_prefix = "PREFIX"
     start_date = datetime(year=2025, month=1, day=31)


### PR DESCRIPTION
We supply only the topic name, but the format of the topic needs a resource path.

`google.api_core.exceptions.InvalidArgument: 400 Invalid pubsub_topic specified. Must be of the format: projects/[^/]+/topics/[^/]+`