### PR TITLE
fix(project-stats): Return 400 instead of 500 on bad requests

### DIFF
--- a/src/sentry/core/endpoints/project_stats.py
+++ b/src/sentry/core/endpoints/project_stats.py
@@ -1,3 +1,4 @@
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -76,7 +77,7 @@ class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
             try:
                 stat_model = FILTER_STAT_KEYS_TO_VALUES[stat]
             except KeyError:
-                raise ValueError("Invalid stat: %s" % stat)
+                raise ValidationError("Invalid stat: %s" % stat)
 
         data = tsdb.backend.get_range(
             model=stat_model,


### PR DESCRIPTION
Because of the 500 we return, our alerts are firing. In this case, 400 response is a better approach since this is user controlled parameter.
