### PR TITLE
fix(cursor-integration): unique uuid external_id

### DIFF
--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -26,7 +26,7 @@ from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.apitoken import generate_token
-from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
 DESCRIPTION = "Connect your Sentry organization with Cursor Cloud Agents."
 
@@ -100,7 +100,7 @@ class CursorAgentIntegrationProvider(CodingAgentIntegrationProvider):
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
         config = state.get("config", {})
         if not config:
-            raise IntegrationError("Missing configuration data")
+            raise IntegrationConfigurationError("Missing configuration data")
 
         webhook_secret = generate_token()
 
@@ -146,7 +146,7 @@ class CursorAgentIntegration(CodingAgentIntegration):
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
         api_key = data.get("api_key")
         if not api_key:
-            raise IntegrationError("API key is required")
+            raise IntegrationConfigurationError("API key is required")
 
         metadata = dict(self.model.metadata or {})
         metadata["api_key"] = CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value(api_key)
@@ -168,7 +168,7 @@ class CursorAgentIntegration(CodingAgentIntegration):
         if encrypted_value:
             decrypted = CURSOR_INTEGRATION_SECRET_FIELD.to_python(encrypted_value)
             return decrypted.decode("utf-8") if isinstance(decrypted, bytes) else decrypted
-        raise IntegrationError("Webhook secret is not configured")
+        raise IntegrationConfigurationError("Webhook secret is not configured")
 
     @property
     def api_key(self) -> str:
@@ -176,4 +176,4 @@ class CursorAgentIntegration(CodingAgentIntegration):
         if encrypted_value:
             decrypted = CURSOR_INTEGRATION_SECRET_FIELD.to_python(encrypted_value)
             return decrypted.decode("utf-8") if isinstance(decrypted, bytes) else decrypted
-        raise IntegrationError("API key is not configured")
+        raise IntegrationConfigurationError("API key is not configured")

--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -154,7 +154,7 @@ class CursorAgentIntegration(CodingAgentIntegration):
         if not api_key:
             raise IntegrationConfigurationError("API key is required")
 
-        metadata = CursorIntegrationMetadata.validate(self.model.metadata or {})
+        metadata = CursorIntegrationMetadata.parse_obj(self.model.metadata or {})
         metadata.api_key = api_key
         integration_service.update_integration(
             integration_id=self.model.id, metadata=metadata.dict()
@@ -172,8 +172,8 @@ class CursorAgentIntegration(CodingAgentIntegration):
 
     @property
     def webhook_secret(self) -> str:
-        return CursorIntegrationMetadata.validate(self.model.metadata).webhook_secret
+        return CursorIntegrationMetadata.parse_obj(self.model.metadata).webhook_secret
 
     @property
     def api_key(self) -> str:
-        return CursorIntegrationMetadata.validate(self.model.metadata).api_key
+        return CursorIntegrationMetadata.parse_obj(self.model.metadata).api_key

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -12,12 +12,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from rest_framework.exceptions import (
-    MethodNotAllowed,
-    NotFound,
-    ParseError,
-    PermissionDenied,
-)
+from rest_framework.exceptions import MethodNotAllowed, NotFound, ParseError, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -1,13 +1,78 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
 
-from sentry.integrations.cursor.integration import CursorAgentIntegrationProvider
-from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.integrations.base import IntegrationError
+from sentry.integrations.cursor.integration import (
+    CURSOR_INTEGRATION_SECRET_FIELD,
+    CursorAgentIntegration,
+    CursorAgentIntegrationProvider,
+)
 from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
+
+
+@pytest.fixture
+def provider():
+    return CursorAgentIntegrationProvider()
+
+
+def test_build_integration_encrypts_metadata(provider):
+    fake_uuid = UUID("11111111-2222-3333-4444-555555555555")
+    with (
+        patch("sentry.integrations.cursor.integration.uuid.uuid4", return_value=fake_uuid),
+        patch("sentry.integrations.cursor.integration.generate_token", return_value="hook-secret"),
+        override_options({"database.encryption.method": "plaintext"}),
+    ):
+        integration_data = provider.build_integration(state={"config": {"api_key": "cursor-api"}})
+
+    assert integration_data["external_id"] == fake_uuid.hex
+    metadata = integration_data["metadata"]
+    assert "api_key" in metadata
+    assert "webhook_secret" in metadata
+    assert metadata["domain_name"] == "cursor.sh"
+    assert metadata["api_key"] != "cursor-api"
+    assert metadata["webhook_secret"] != "hook-secret"
+    assert integration_data["external_id"] == fake_uuid.hex
+    assert (
+        CURSOR_INTEGRATION_SECRET_FIELD.to_python(metadata["api_key"]).decode("utf-8")
+        == "cursor-api"
+    )
+    assert (
+        CURSOR_INTEGRATION_SECRET_FIELD.to_python(metadata["webhook_secret"]).decode("utf-8")
+        == "hook-secret"
+    )
+
+
+def test_build_integration_encrypts_api_key_and_webhook_secret(provider):
+    """Test that build_integration encrypts both API key and webhook secret"""
+    with override_options({"database.encryption.method": "plaintext"}):
+        integration_data = provider.build_integration(state={"config": {"api_key": "new-api"}})
+
+    metadata_arg = integration_data["metadata"]
+
+    # Verify values are encrypted (not stored as plaintext)
+    assert metadata_arg["api_key"] != "new-api"
+    assert isinstance(metadata_arg["webhook_secret"], (str, bytes))
+
+    # Verify encrypted values can be decrypted correctly
+    assert (
+        CURSOR_INTEGRATION_SECRET_FIELD.to_python(metadata_arg["api_key"]).decode("utf-8")
+        == "new-api"
+    )
+
+    # Verify webhook secret was generated and encrypted
+    decrypted_webhook = CURSOR_INTEGRATION_SECRET_FIELD.to_python(
+        metadata_arg["webhook_secret"]
+    ).decode("utf-8")
+    assert decrypted_webhook  # Should be a non-empty string
+    assert len(decrypted_webhook) > 0  # Webhook secret should be generated
 
 
 class CursorIntegrationTest(IntegrationTestCase):
@@ -15,20 +80,32 @@ class CursorIntegrationTest(IntegrationTestCase):
 
     def test_build_integration(self):
         state: Mapping[str, Any] = {"config": {"api_key": "test_api_key_123"}}
+        fake_uuid = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
-        integration_dict = self.provider().build_integration(state)
+        with (
+            patch("sentry.integrations.cursor.integration.uuid.uuid4", return_value=fake_uuid),
+            patch(
+                "sentry.integrations.cursor.integration.generate_token", return_value="secret123"
+            ),
+            override_options({"database.encryption.method": "plaintext"}),
+        ):
+            integration_dict = self.provider().build_integration(state)
 
-        assert integration_dict["external_id"] == "cursor"
-        assert integration_dict["name"] == "Cursor Agent"
-        assert integration_dict["metadata"]["api_key"] == "test_api_key_123"
-        assert integration_dict["metadata"]["domain_name"] == "cursor.sh"
-
-        # Verify webhook secret is generated
-        assert "webhook_secret" in integration_dict["metadata"]
-        webhook_secret = integration_dict["metadata"]["webhook_secret"]
-        assert isinstance(webhook_secret, str)
-        assert len(webhook_secret) == 64  # generate_token() creates 64-char hex string
-        assert 32 <= len(webhook_secret) <= 256  # Meets Cursor requirements
+        assert integration_dict["external_id"] == fake_uuid.hex
+        metadata = integration_dict["metadata"]
+        assert metadata["domain_name"] == "cursor.sh"
+        assert "api_key" in metadata
+        assert "webhook_secret" in metadata
+        assert metadata["api_key"] != "test_api_key_123"
+        assert metadata["webhook_secret"] != "secret123"
+        assert (
+            CURSOR_INTEGRATION_SECRET_FIELD.to_python(metadata["api_key"]).decode("utf-8")
+            == "test_api_key_123"
+        )
+        assert (
+            CURSOR_INTEGRATION_SECRET_FIELD.to_python(metadata["webhook_secret"]).decode("utf-8")
+            == "secret123"
+        )
 
     def test_build_integration_missing_config(self):
         """Test that build_integration raises error when config is missing"""
@@ -45,15 +122,18 @@ class CursorIntegrationTest(IntegrationTestCase):
             self.provider().build_integration(state)
 
     def test_get_client(self):
+        with override_options({"database.encryption.method": "plaintext"}):
+            metadata = {
+                "api_key": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("test_api_key_123"),
+                "webhook_secret": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("test_secret_123"),
+                "domain_name": "cursor.sh",
+            }
+
         integration = self.create_provider_integration(
             provider="cursor",
             name="Cursor Agent",
             external_id="cursor",
-            metadata={
-                "api_key": "test_api_key_123",
-                "domain_name": "cursor.sh",
-                "webhook_secret": "test_secret_123",
-            },
+            metadata=metadata,
         )
 
         installation = integration.get_installation(organization_id=self.organization.id)
@@ -70,7 +150,6 @@ class CursorIntegrationTest(IntegrationTestCase):
         from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentStatus
         from sentry.seer.models import SeerRepoDefinition
 
-        # Mock the response
         mock_response = MagicMock()
         mock_response.json = {
             "id": "test_session_123",
@@ -89,20 +168,22 @@ class CursorIntegrationTest(IntegrationTestCase):
         }
         mock_post.return_value = mock_response
 
+        with override_options({"database.encryption.method": "plaintext"}):
+            metadata = {
+                "api_key": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("test_api_key_123"),
+                "webhook_secret": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("test_secret_123"),
+                "domain_name": "cursor.sh",
+            }
+
         integration = self.create_provider_integration(
             provider="cursor",
             name="Cursor Agent",
             external_id="cursor",
-            metadata={
-                "api_key": "test_api_key_123",
-                "domain_name": "cursor.sh",
-                "webhook_secret": "test_secret_123",
-            },
+            metadata=metadata,
         )
 
         installation = integration.get_installation(organization_id=self.organization.id)
 
-        # Create a launch request
         request = CodingAgentLaunchRequest(
             prompt="Fix the bug",
             repository=SeerRepoDefinition(
@@ -116,9 +197,6 @@ class CursorIntegrationTest(IntegrationTestCase):
             branch_name="fix-bug",
         )
 
-        # Cast to concrete integration type to access launch()
-        from sentry.integrations.cursor.integration import CursorAgentIntegration
-
         result = cast(CursorAgentIntegration, installation).launch(request=request)
 
         assert result.id == "test_session_123"
@@ -126,35 +204,45 @@ class CursorIntegrationTest(IntegrationTestCase):
         assert result.provider == CodingAgentProviderType.CURSOR_BACKGROUND_AGENT
         assert result.name == "Test Session"
 
-        # Verify the API call
         mock_post.assert_called_once()
         call_args = mock_post.call_args
         assert call_args[0][0] == "/v0/agents"
 
     def test_update_organization_config_persists_api_key_and_clears_org_config(self):
-        # Create a Cursor integration linked to this organization
-        integration = self.create_integration(
-            organization=self.organization,
-            provider="cursor",
-            name="Cursor Agent",
-            external_id="cursor",
-            metadata={
-                "api_key": "old_key",
-                "domain_name": "cursor.sh",
-                "webhook_secret": "secret123",
-            },
-        )
+        with override_options({"database.encryption.method": "plaintext"}):
+            integration = self.create_integration(
+                organization=self.organization,
+                provider="cursor",
+                name="Cursor Agent",
+                external_id="cursor",
+                metadata={
+                    "api_key": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("old_key"),
+                    "webhook_secret": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("secret123"),
+                    "domain_name": "cursor.sh",
+                },
+            )
 
         installation = integration.get_installation(organization_id=self.organization.id)
 
-        # Call update with a new API key
-        installation.update_organization_config({"api_key": "new_secret_key"})
+        with override_options({"database.encryption.method": "plaintext"}):
+            installation.update_organization_config({"api_key": "new_secret_key"})
 
-        # Metadata should be updated on the Integration
         integration.refresh_from_db()
-        assert integration.metadata["api_key"] == "new_secret_key"
+        assert "api_key" in integration.metadata
+        assert (
+            CURSOR_INTEGRATION_SECRET_FIELD.to_python(integration.metadata["api_key"]).decode(
+                "utf-8"
+            )
+            == "new_secret_key"
+        )
+        assert "webhook_secret" in integration.metadata
+        assert (
+            CURSOR_INTEGRATION_SECRET_FIELD.to_python(
+                integration.metadata["webhook_secret"]
+            ).decode("utf-8")
+            == "secret123"
+        )
 
-        # OrganizationIntegration config should remain empty (no secret stored there)
         from sentry.integrations.models.organization_integration import OrganizationIntegration
 
         with assume_test_silo_mode_of(OrganizationIntegration):
@@ -164,21 +252,62 @@ class CursorIntegrationTest(IntegrationTestCase):
             assert org_integration.config == {}
 
     def test_update_organization_config_missing_api_key_raises(self):
-        # Create a Cursor integration linked to this organization
-        integration = self.create_integration(
-            organization=self.organization,
-            provider="cursor",
-            name="Cursor Agent",
-            external_id="cursor",
-            metadata={
-                "api_key": "present_key",
-                "domain_name": "cursor.sh",
-                "webhook_secret": "secret123",
-            },
-        )
+        with override_options({"database.encryption.method": "plaintext"}):
+            integration = self.create_integration(
+                organization=self.organization,
+                provider="cursor",
+                name="Cursor Agent",
+                external_id="cursor",
+                metadata={
+                    "api_key": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("present_key"),
+                    "webhook_secret": CURSOR_INTEGRATION_SECRET_FIELD.get_prep_value("secret123"),
+                    "domain_name": "cursor.sh",
+                },
+            )
 
         installation = integration.get_installation(organization_id=self.organization.id)
 
-        # Missing api_key should raise
         with pytest.raises(IntegrationError, match="API key is required"):
             installation.update_organization_config({})
+
+    def test_build_integration_creates_unique_installations(self):
+        """Test that each call to build_integration creates a unique integration"""
+        state: Mapping[str, Any] = {"config": {"api_key": "test_api_key_123"}}
+
+        with override_options({"database.encryption.method": "plaintext"}):
+            integration_dict_1 = self.provider().build_integration(state)
+            integration_dict_2 = self.provider().build_integration(state)
+            integration_dict_3 = self.provider().build_integration(state)
+
+        # Each integration should have a unique external_id
+        external_ids = {
+            integration_dict_1["external_id"],
+            integration_dict_2["external_id"],
+            integration_dict_3["external_id"],
+        }
+        assert (
+            len(external_ids) == 3
+        ), "Each build_integration call should create a unique external_id"
+
+        # All should have the same basic structure
+        for integration_dict in [integration_dict_1, integration_dict_2, integration_dict_3]:
+            assert integration_dict["name"] == "Cursor Agent"
+            assert "external_id" in integration_dict
+            assert "metadata" in integration_dict
+            assert integration_dict["metadata"]["domain_name"] == "cursor.sh"
+            assert "api_key" in integration_dict["metadata"]
+            assert "webhook_secret" in integration_dict["metadata"]
+
+        # Each should have unique webhook secrets too
+        webhook_secret_1 = CURSOR_INTEGRATION_SECRET_FIELD.to_python(
+            integration_dict_1["metadata"]["webhook_secret"]
+        ).decode("utf-8")
+        webhook_secret_2 = CURSOR_INTEGRATION_SECRET_FIELD.to_python(
+            integration_dict_2["metadata"]["webhook_secret"]
+        ).decode("utf-8")
+        webhook_secret_3 = CURSOR_INTEGRATION_SECRET_FIELD.to_python(
+            integration_dict_3["metadata"]["webhook_secret"]
+        ).decode("utf-8")
+
+        webhook_secrets = {webhook_secret_1, webhook_secret_2, webhook_secret_3}
+        assert len(webhook_secrets) == 3, "Each integration should have a unique webhook secret"

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -224,6 +224,28 @@ class CursorIntegrationTest(IntegrationTestCase):
         with pytest.raises(IntegrationConfigurationError, match="API key is required"):
             installation.update_organization_config({})
 
+    def test_property_getters(self):
+        """Test that api_key and webhook_secret property getters return correct values"""
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="Cursor Agent",
+            external_id="cursor",
+            metadata={
+                "api_key": "test_api_key_value",
+                "webhook_secret": "test_webhook_secret_value",
+                "domain_name": "cursor.sh",
+            },
+        )
+
+        installation = cast(
+            CursorAgentIntegration,
+            integration.get_installation(organization_id=self.organization.id),
+        )
+
+        assert installation.api_key == "test_api_key_value"
+        assert installation.webhook_secret == "test_webhook_secret_value"
+
     def test_build_integration_creates_unique_installations(self):
         """Test that each call to build_integration creates a unique integration"""
         state: Mapping[str, Any] = {"config": {"api_key": "test_api_key_123"}}

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -7,12 +7,12 @@ from uuid import UUID
 
 import pytest
 
-from sentry.integrations.base import IntegrationError
 from sentry.integrations.cursor.integration import (
     CURSOR_INTEGRATION_SECRET_FIELD,
     CursorAgentIntegration,
     CursorAgentIntegrationProvider,
 )
+from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -111,14 +111,14 @@ class CursorIntegrationTest(IntegrationTestCase):
         """Test that build_integration raises error when config is missing"""
         state: Mapping[str, Any] = {}
 
-        with pytest.raises(IntegrationError, match="Missing configuration data"):
+        with pytest.raises(IntegrationConfigurationError, match="Missing configuration data"):
             self.provider().build_integration(state)
 
     def test_build_integration_empty_config(self):
         """Test that build_integration raises error when config is empty"""
         state: Mapping[str, Any] = {"config": {}}
 
-        with pytest.raises(IntegrationError, match="Missing configuration data"):
+        with pytest.raises(IntegrationConfigurationError, match="Missing configuration data"):
             self.provider().build_integration(state)
 
     def test_get_client(self):
@@ -267,7 +267,7 @@ class CursorIntegrationTest(IntegrationTestCase):
 
         installation = integration.get_installation(organization_id=self.organization.id)
 
-        with pytest.raises(IntegrationError, match="API key is required"):
+        with pytest.raises(IntegrationConfigurationError, match="API key is required"):
             installation.update_organization_config({})
 
     def test_build_integration_creates_unique_installations(self):


### PR DESCRIPTION
Make sure cursor integration installations are unique via a UUID external_id.

We use UUIDs here for each integration installation because we don't know how many times this **user-level** API key will be used, or if the same org can have multiple cursor agents (in the near future) or if the same user can have multiple installations across multiple orgs. So just a UUID per installation is the best approach. 

We're also waiting for cursor to soon launch service account api keys which will be on a cursor organization-level which should cleanly replace this.