### PR TITLE
fix(dashboards): queue doesn't apply to all datasets

### DIFF
--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -27,6 +27,7 @@ import {
   WidgetType,
 } from 'sentry/views/dashboards/types';
 import {dashboardFiltersToString} from 'sentry/views/dashboards/utils';
+import type {WidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import {
   DERIVED_STATUS_METRICS_PATTERN,
   DerivedStatusFields,
@@ -52,6 +53,7 @@ interface ReleaseWidgetQueriesProps {
     tableResults?: TableDataWithTitle[];
     timeseriesResults?: Series[];
   }) => void;
+  queue?: WidgetQueryQueue;
 }
 
 export function derivedMetricsToField(field: string): string {
@@ -215,6 +217,7 @@ function ReleaseWidgetQueries({
   onDataFetched,
   onDataFetchStart,
   children,
+  queue,
 }: ReleaseWidgetQueriesProps) {
   const config = ReleasesConfig;
 
@@ -371,6 +374,7 @@ function ReleaseWidgetQueries({
 
   return (
     <GenericWidgetQueries<SessionApiResponse, SessionApiResponse>
+      queue={queue}
       config={config}
       api={api}
       organization={organization}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -91,6 +91,7 @@ export function WidgetCardDataLoader({
     return (
       <ReleaseWidgetQueries
         widget={widget}
+        queue={queue}
         selection={selection}
         limit={tableItemLimit}
         onDataFetched={onDataFetched}
@@ -126,6 +127,7 @@ export function WidgetCardDataLoader({
   return (
     <WidgetQueries
       api={api}
+      queue={queue}
       organization={organization}
       widget={widget}
       selection={selection}

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -17,6 +17,7 @@ import {
   type DashboardFilters,
   type Widget,
 } from 'sentry/views/dashboards/types';
+import type {WidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 import {useDashboardsMEPContext} from './dashboardsMEPContext';
@@ -41,10 +42,12 @@ type Props = {
   onDataFetchStart?: () => void;
   onDataFetched?: (results: OnDataFetchedProps) => void;
   onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
+  queue?: WidgetQueryQueue;
 };
 
 function WidgetQueries({
   api,
+  queue,
   children,
   organization,
   selection,
@@ -162,6 +165,7 @@ function WidgetQueries({
     <OnDemandControlConsumer>
       {OnDemandControlContext => (
         <GenericWidgetQueries<SeriesResult, TableResult>
+          queue={queue}
           config={config}
           api={api}
           organization={organization}


### PR DESCRIPTION
There was an issue where widgets that don't use spans or issues dataset weren't being added to the queue