### PR TITLE
feat(mcp-insights): node manual instrumentation docs

### DIFF
--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -795,24 +795,21 @@ export const getNodeMcpOnboarding = ({
       ],
     },
   ],
-  configure: params => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: tct('Initialize the Sentry SDK with [code:Sentry.init()] call.', {
-            code: <code />,
-          }),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              code: `${getImport(packageName).join('\n')}
+  configure: params => {
+    const mcpSdkStep: ContentBlock[] = [
+      {
+        type: 'text',
+        text: tct('Initialize the Sentry SDK with [code:Sentry.init()] call.', {
+          code: <code />,
+        }),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `${getImport(packageName).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -820,38 +817,79 @@ Sentry.init({
   tracesSampleRate: 1.0,
   sendDefaultPii: true,
 });`,
-            },
-          ],
-        },
-        {
-          type: 'text',
-          text: tct(
-            'Wrap your MCP server in a [code:Sentry.wrapMcpServerWithSentry()] call. This will automatically capture spans for all MCP server interactions.',
-            {
-              code: <code />,
-            }
-          ),
-        },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              code: `
+          },
+        ],
+      },
+      {
+        type: 'text',
+        text: tct(
+          'Wrap your MCP server in a [code:Sentry.wrapMcpServerWithSentry()] call. This will automatically capture spans for all MCP server interactions.',
+          {
+            code: <code />,
+          }
+        ),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `
 const { McpServer } = require("@modelcontextprotocol/sdk");
 
 const server = Sentry.wrapMcpServerWithSentry(new McpServer({
     name: "my-mcp-server",
     version: "1.0.0",
 }));`,
-            },
-          ],
-        },
-      ],
-    },
-  ],
+          },
+        ],
+      },
+    ];
+
+    const manualStep: ContentBlock[] = [
+      {
+        type: 'text',
+        text: t('Initialize the Sentry SDK in the entry point of your application:'),
+      },
+      {
+        type: 'code',
+        tabs: [
+          {
+            label: 'JavaScript',
+            language: 'javascript',
+            code: `${getImport(packageName).join('\n')}
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  tracesSampleRate: 1.0,
+});`,
+          },
+        ],
+      },
+      {
+        type: 'text',
+        text: tct(
+          'Then follow the [link:manual instrumentation guide] to instrument your MCP server.',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/node/tracing/instrumentation/custom-instrumentation/mcp-module/#manual-instrumentation" />
+            ),
+          }
+        ),
+      },
+    ];
+
+    const selected = (params.platformOptions as any)?.integration ?? 'mcp_sdk';
+    const content = selected === 'manual' ? manualStep : mcpSdkStep;
+
+    return [
+      {
+        type: StepType.CONFIGURE,
+        content,
+      },
+    ];
+  },
   verify: () => [
     {
       type: StepType.VERIFY,

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -220,7 +220,10 @@ export function Onboarding() {
             {label: 'FastMCP / MCP SDK', value: 'mcp_sdk'},
             {label: 'Other', value: 'manual'},
           ]
-        : [{label: 'MCP SDK', value: 'mcp_sdk'}],
+        : [
+            {label: 'MCP SDK', value: 'mcp_sdk'},
+            {label: 'Other', value: 'manual'},
+          ],
     },
   };
 


### PR DESCRIPTION
- Adds 'Other' as a platform in node in-product onboarding, that points to manual docs added in https://github.com/getsentry/sentry-docs/pull/15530 making it consistent with what is already there for python platforms

<img width="677" height="532" alt="image" src="https://github.com/user-attachments/assets/a69895d3-a3de-4a43-ab1d-c1c65c69b036" />
