### PR TITLE
ref(seer): Rename billing flag

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -325,7 +325,7 @@ describe('NotificationSettingsByType', () => {
         'continuous-profiling-billing',
         'seer-billing',
         'logs-billing',
-        'prevent-billing',
+        'seer-user-billing',
       ],
     });
     renderComponent({

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -213,7 +213,7 @@ export function NotificationSettingsByType({notificationType}: Props) {
     );
 
     const hasPreventBilling = organizations.some(organization =>
-      organization.features?.includes('prevent-billing')
+      organization.features?.includes('seer-user-billing')
     );
 
     const excludeTransactions = hasOrgWithAm3 && !hasOrgWithoutAm3;

--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -239,7 +239,7 @@ describe('ChangePlanAction', () => {
   });
 
   it('completes form with addOns', async () => {
-    mockOrg.features = ['seer-billing', 'prevent-billing'];
+    mockOrg.features = ['seer-billing', 'seer-user-billing'];
     const putMock = MockApiClient.addMockResponse({
       url: `/customers/${mockOrg.slug}/subscription/`,
       method: 'PUT',

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -209,7 +209,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.PREVENT_USER]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PREVENT_USER],
-    feature: 'prevent-billing',
+    feature: 'seer-user-billing',
     canProductTrial: true,
     maxAdminGift: 10_000, // TODO(prevent): Update this to the actual max admin gift
     tallyType: 'seat',

--- a/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
@@ -226,7 +226,7 @@ describe('UsageOverview', () => {
   });
 
   it('renders table based on add-on state', () => {
-    organization.features.push('prevent-billing');
+    organization.features.push('seer-user-billing');
     const subWithSeer = SubscriptionWithSeerFixture({organization});
     SubscriptionStore.set(organization.slug, subWithSeer);
     render(

--- a/tests/js/getsentry-test/fixtures/constants.ts
+++ b/tests/js/getsentry-test/fixtures/constants.ts
@@ -17,7 +17,7 @@ export const AM_ADD_ON_CATEGORIES = {
     apiName: AddOnCategory.PREVENT,
     dataCategories: [DataCategory.PREVENT_USER, DataCategory.PREVENT_REVIEW],
     name: 'prevent',
-    billingFlag: 'prevent-billing',
+    billingFlag: 'seer-user-billing',
     order: 2,
     productName: 'prevent',
   },


### PR DESCRIPTION
Part of BIL-1753

This PR simply replaces instances of the `prevent-billing` flag with `seer-user-billing`; future PRs will handle updating any logic or rendering