### PR TITLE
fix(dashboards): set widget to loading before adding to queue

### DIFF
--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -396,6 +396,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
         tableResults: undefined,
         timeseriesResults: undefined,
         errorMessage: undefined,
+        queryFetchID: undefined,
       });
       queue.addItem({widgetQuery: this});
       return;

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -391,6 +391,12 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
   fetchDataWithQueueIfAvailable() {
     const {queue} = this.props;
     if (queue) {
+      this.setState({
+        loading: true,
+        tableResults: undefined,
+        timeseriesResults: undefined,
+        errorMessage: undefined,
+      });
       queue.addItem({widgetQuery: this});
       return;
     }


### PR DESCRIPTION
Prevents some weird issues where widgets would stay populated for until they begin to be processed.