### PR TITLE
fix(spike protection): Handle null threshold

### DIFF
--- a/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.tsx
@@ -18,6 +18,7 @@ import {space} from 'sentry/styles/space';
 import type {DataCategoryInfo} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
@@ -130,11 +131,13 @@ class SpikeProtectionHistoryTable extends Component<Props> {
     return [
       <SpikeProtectionTimeDetails spike={spike} key="time" />,
       <StyledCell key="threshold">
-        {formatUsageWithUnits(
-          spike.threshold,
-          dataCategoryInfo.plural,
-          getFormatUsageOptions(dataCategoryInfo.plural)
-        )}
+        {defined(spike.threshold)
+          ? formatUsageWithUnits(
+              spike.threshold,
+              dataCategoryInfo.plural,
+              getFormatUsageOptions(dataCategoryInfo.plural)
+            )
+          : '-'}
       </StyledCell>,
       <StyledCell key="duration">
         {duration ? getExactDuration(duration, true) : t('Ongoing')}

--- a/static/gsApp/views/spikeProtection/types.ts
+++ b/static/gsApp/views/spikeProtection/types.ts
@@ -3,7 +3,7 @@ import type {DataCategoryInfo} from 'sentry/types/core';
 export interface SpikeDetails {
   dataCategory: DataCategoryInfo['name'];
   start: string;
-  threshold: number;
+  threshold: number | null;
   dropped?: number;
   duration?: number | null;
   end?: string;


### PR DESCRIPTION
`initialThreshold` on a spike can be null (eventually gets filled); this PR handles that case so we don't error out the whole spike table.