### PR TITLE
fix(ui): Do not add extranious height to AI insights onboarding

### DIFF
--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -455,8 +455,8 @@ const Body = styled('div')`
 const Arcade = styled('iframe')`
   width: 750px;
   max-width: 100%;
+  min-height: 370px;
   margin-top: ${p => p.theme.space['2xl']};
-  height: 522px;
   border: 0;
 `;
 


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="1840" src="https://i.imgur.com/qr1b4uJ.png" />

After

<img alt="clipboard.png" width="1840" src="https://i.imgur.com/QptHpuN.png" />