### PR TITLE
feat(ui): Disable Amplitude console logging

### DIFF
--- a/static/gsApp/__mocks__/@amplitude/analytics-browser.tsx
+++ b/static/gsApp/__mocks__/@amplitude/analytics-browser.tsx
@@ -8,5 +8,6 @@ export const identify = jest.fn();
 export const init = jest.fn();
 export const track = jest.fn();
 export const setGroup = jest.fn();
+export const Types = jest.requireActual('@amplitude/analytics-browser').Types;
 
 export const _identifyInstance = identifyInstance;

--- a/static/gsApp/hooks/analyticsInitUser.spec.tsx
+++ b/static/gsApp/hooks/analyticsInitUser.spec.tsx
@@ -21,8 +21,6 @@ describe('analyticsInitUser', () => {
     ConfigStore.set('enableAnalytics', true);
     ConfigStore.set('getsentry.amplitudeApiKey', 'foo');
     setWindowLocation('http:/localhost/');
-    const {Types} = jest.requireActual('@amplitude/analytics-browser');
-    Amplitude.Types = Types;
   });
   afterEach(() => {
     sessionStorageWrapper.removeItem('marketing_event_recorded');

--- a/static/gsApp/hooks/analyticsInitUser.spec.tsx
+++ b/static/gsApp/hooks/analyticsInitUser.spec.tsx
@@ -21,6 +21,8 @@ describe('analyticsInitUser', () => {
     ConfigStore.set('enableAnalytics', true);
     ConfigStore.set('getsentry.amplitudeApiKey', 'foo');
     setWindowLocation('http:/localhost/');
+    const {Types} = jest.requireActual('@amplitude/analytics-browser');
+    Amplitude.Types = Types;
   });
   afterEach(() => {
     sessionStorageWrapper.removeItem('marketing_event_recorded');

--- a/static/gsApp/hooks/analyticsInitUser.tsx
+++ b/static/gsApp/hooks/analyticsInitUser.tsx
@@ -39,6 +39,7 @@ export default function analyticsInitUser(user: User) {
   }
 
   Amplitude.init(amplitudeKey, undefined, {
+    logLevel: Amplitude.Types.LogLevel.None,
     minIdLength: 1,
     attribution: {
       disabled: false,


### PR DESCRIPTION
Amplitude logging is not very useful for us and spams the console when its blocked from adblockers. Lets disable logging since most of it is not very actionable.

Here our the [Amplitude logs in Sentry](https://sentry.sentry.io/explore/logs/?logsFields=timestamp&logsFields=message&logsFields=replay_id&logsQuery=message%3A%EF%80%8DContains%EF%80%8D%22Amplitude%20Logger%22%20%21message%3A%EF%80%8DContains%EF%80%8D%22Load%20failed%22%20%21message%3A%EF%80%8DContains%EF%80%8D%22Failed%20to%20fetch%22%20%21message%3A%EF%80%8DContains%EF%80%8D%22NetworkError%20when%20attempting%20to%20fetch%22&logsSortBys=-timestamp&project=11276&statsPeriod=14d) with the fetch-related logs filtered out.
