### PR TITLE
feat(automation autofix): Add parameter in get_issue_summary to not run automation

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -365,7 +365,7 @@ def _generate_summary(
     force_event_id: str | None,
     source: SeerAutomationSource,
     cache_key: str,
-    run_automation: bool = True,
+    should_run_automation: bool = True,
 ) -> tuple[dict[str, Any], int]:
     """Core logic to generate and cache the issue summary."""
     serialized_event, event = _get_event(group, user, provided_event_id=force_event_id)
@@ -390,7 +390,7 @@ def _generate_summary(
         trace_tree,
     )
 
-    if run_automation:
+    if should_run_automation:
         try:
             _run_automation(group, user, event, source)
         except Exception:
@@ -431,7 +431,7 @@ def get_issue_summary(
     user: User | RpcUser | AnonymousUser | None = None,
     force_event_id: str | None = None,
     source: SeerAutomationSource = SeerAutomationSource.ISSUE_DETAILS,
-    run_automation: bool = True,
+    should_run_automation: bool = True,
 ) -> tuple[dict[str, Any], int]:
     """
     Generate an AI summary for an issue.
@@ -441,7 +441,7 @@ def get_issue_summary(
         user: The user requesting the summary
         force_event_id: Optional event ID to force summarizing a specific event
         source: The source triggering the summary generation
-        run_automation: Whether to trigger automation after generating summary
+        should_run_automation: Whether to trigger automation after generating summary
 
     Returns:
         A tuple containing (summary_data, status_code)
@@ -465,7 +465,7 @@ def get_issue_summary(
     # if force_event_id is set, we always generate a new summary
     if force_event_id:
         summary_dict, status_code = _generate_summary(
-            group, user, force_event_id, source, cache_key, run_automation
+            group, user, force_event_id, source, cache_key, should_run_automation
         )
         _log_seer_scanner_billing_event(group, source)
         return convert_dict_key_case(summary_dict, snake_to_camel_case), status_code
@@ -487,7 +487,7 @@ def get_issue_summary(
 
             # Lock acquired and cache is still empty, proceed with generation
             summary_dict, status_code = _generate_summary(
-                group, user, force_event_id, source, cache_key, run_automation
+                group, user, force_event_id, source, cache_key, should_run_automation
             )
             _log_seer_scanner_billing_event(group, source)
             return convert_dict_key_case(summary_dict, snake_to_camel_case), status_code

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -365,6 +365,7 @@ def _generate_summary(
     force_event_id: str | None,
     source: SeerAutomationSource,
     cache_key: str,
+    run_automation: bool = True,
 ) -> tuple[dict[str, Any], int]:
     """Core logic to generate and cache the issue summary."""
     serialized_event, event = _get_event(group, user, provided_event_id=force_event_id)
@@ -389,12 +390,13 @@ def _generate_summary(
         trace_tree,
     )
 
-    try:
-        _run_automation(group, user, event, source)
-    except Exception:
-        logger.exception(
-            "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}
-        )
+    if run_automation:
+        try:
+            _run_automation(group, user, event, source)
+        except Exception:
+            logger.exception(
+                "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}
+            )
 
     summary_dict = issue_summary.dict()
     summary_dict["event_id"] = event.event_id
@@ -429,6 +431,7 @@ def get_issue_summary(
     user: User | RpcUser | AnonymousUser | None = None,
     force_event_id: str | None = None,
     source: SeerAutomationSource = SeerAutomationSource.ISSUE_DETAILS,
+    run_automation: bool = True,
 ) -> tuple[dict[str, Any], int]:
     """
     Generate an AI summary for an issue.
@@ -438,6 +441,7 @@ def get_issue_summary(
         user: The user requesting the summary
         force_event_id: Optional event ID to force summarizing a specific event
         source: The source triggering the summary generation
+        run_automation: Whether to trigger automation after generating summary
 
     Returns:
         A tuple containing (summary_data, status_code)
@@ -461,7 +465,7 @@ def get_issue_summary(
     # if force_event_id is set, we always generate a new summary
     if force_event_id:
         summary_dict, status_code = _generate_summary(
-            group, user, force_event_id, source, cache_key
+            group, user, force_event_id, source, cache_key, run_automation
         )
         _log_seer_scanner_billing_event(group, source)
         return convert_dict_key_case(summary_dict, snake_to_camel_case), status_code
@@ -483,7 +487,7 @@ def get_issue_summary(
 
             # Lock acquired and cache is still empty, proceed with generation
             summary_dict, status_code = _generate_summary(
-                group, user, force_event_id, source, cache_key
+                group, user, force_event_id, source, cache_key, run_automation
             )
             _log_seer_scanner_billing_event(group, source)
             return convert_dict_key_case(summary_dict, snake_to_camel_case), status_code

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -57,4 +57,6 @@ def generate_issue_summary_only(group_id: int) -> None:
     from sentry.seer.autofix.issue_summary import get_issue_summary
 
     group = Group.objects.get(id=group_id)
-    get_issue_summary(group=group, source=SeerAutomationSource.POST_PROCESS, run_automation=False)
+    get_issue_summary(
+        group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
+    )

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -41,3 +41,20 @@ def start_seer_automation(group_id: int) -> None:
 
     group = Group.objects.get(id=group_id)
     get_issue_summary(group=group, source=SeerAutomationSource.POST_PROCESS)
+
+
+@instrumented_task(
+    name="sentry.tasks.autofix.generate_issue_summary_only",
+    namespace=ingest_errors_tasks,
+    processing_deadline_duration=35,
+    retry=Retry(times=1),
+)
+def generate_issue_summary_only(group_id: int) -> None:
+    """
+    Generate issue summary WITHOUT triggering automation.
+    Used for triage signals flow when event count < 10 or when summary doesn't exist yet.
+    """
+    from sentry.seer.autofix.issue_summary import get_issue_summary
+
+    group = Group.objects.get(id=group_id)
+    get_issue_summary(group=group, source=SeerAutomationSource.POST_PROCESS, run_automation=False)

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -697,7 +697,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.issue_summary._call_seer")
     @patch("sentry.seer.autofix.issue_summary._get_event")
-    def test_get_issue_summary_with_run_automation_false(
+    def test_get_issue_summary_with_should_run_automation_false(
         self,
         mock_get_event,
         mock_call_seer,
@@ -705,7 +705,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_run_automation,
         mock_get_acknowledgement,
     ):
-        """Test that run_automation=False prevents _run_automation from being called."""
+        """Test that should_run_automation=False prevents _run_automation from being called."""
         mock_get_acknowledgement.return_value = True
         event = Mock(
             event_id="test_event_id",
@@ -732,7 +732,9 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         expected_response_summary = mock_summary.dict()
         expected_response_summary["event_id"] = event.event_id
 
-        summary_data, status_code = get_issue_summary(self.group, self.user, run_automation=False)
+        summary_data, status_code = get_issue_summary(
+            self.group, self.user, should_run_automation=False
+        )
 
         assert status_code == 200
         assert summary_data == convert_dict_key_case(expected_response_summary, snake_to_camel_case)

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -692,6 +692,62 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert status_code == 200
         mock_call_seer.assert_called_once_with(self.group, serialized_event, None)
 
+    @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
+    @patch("sentry.seer.autofix.issue_summary._run_automation")
+    @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
+    @patch("sentry.seer.autofix.issue_summary._call_seer")
+    @patch("sentry.seer.autofix.issue_summary._get_event")
+    def test_get_issue_summary_with_run_automation_false(
+        self,
+        mock_get_event,
+        mock_call_seer,
+        mock_get_trace_tree,
+        mock_run_automation,
+        mock_get_acknowledgement,
+    ):
+        """Test that run_automation=False prevents _run_automation from being called."""
+        mock_get_acknowledgement.return_value = True
+        event = Mock(
+            event_id="test_event_id",
+            data="test_event_data",
+            trace_id="test_trace",
+            datetime=datetime.datetime.now(),
+        )
+        serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
+        mock_get_event.return_value = [serialized_event, event]
+        mock_summary = SummarizeIssueResponse(
+            group_id=str(self.group.id),
+            headline="Test headline",
+            whats_wrong="Test whats wrong",
+            trace="Test trace",
+            possible_cause="Test possible cause",
+            scores=SummarizeIssueScores(
+                possible_cause_confidence=0.0,
+                possible_cause_novelty=0.0,
+            ),
+        )
+        mock_call_seer.return_value = mock_summary
+        mock_get_trace_tree.return_value = {"trace": "tree"}
+
+        expected_response_summary = mock_summary.dict()
+        expected_response_summary["event_id"] = event.event_id
+
+        summary_data, status_code = get_issue_summary(self.group, self.user, run_automation=False)
+
+        assert status_code == 200
+        assert summary_data == convert_dict_key_case(expected_response_summary, snake_to_camel_case)
+        mock_get_event.assert_called_once_with(self.group, self.user, provided_event_id=None)
+        mock_get_trace_tree.assert_called_once()
+        mock_call_seer.assert_called_once_with(self.group, serialized_event, {"trace": "tree"})
+        mock_get_acknowledgement.assert_called_once_with(self.group.organization)
+
+        # Verify that _run_automation was NOT called
+        mock_run_automation.assert_not_called()
+
+        # Check if the cache was set correctly
+        cached_summary = cache.get(f"ai-group-summary-v2:{self.group.id}")
+        assert cached_summary == expected_response_summary
+
 
 class TestGetStoppingPointFromFixability:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## PR Details:
+ For triage signals project we want to run issue summary for the first event but not automation. This new paramter and new task will enable that flow. 
+ This task is not being  called yet but will be in my next PR.
+ Flow diagram:  https://miro.com/app/board/uXjVJqn1-fQ=/?focusWidget=3458764648325594380
