### PR TITLE
fix(workflow-engine): dont log event data

### DIFF
--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -171,7 +171,14 @@ class WorkflowEvaluation:
         else:
             log_str = f"{log_str}.actions.triggered"
 
-        logger.info(log_str, extra={**self.data.get_snapshot(), "debug_msg": self.msg})
+        data_snapshot = self.data.get_snapshot()
+        # XXX(jferg): This is a temporary fix to avoid logging the event data in the logs, as it's too large
+        try:
+            del data_snapshot["event_data"]
+        except KeyError:
+            pass
+
+        logger.info(log_str, extra={**data_snapshot, "debug_msg": self.msg})
 
 
 class ConfigTransformer(ABC):


### PR DESCRIPTION
logging event data spikes our logging COGS as the objects are too large. temporarily stops logging event data until an alternative approach can be implemented (only log event_id, e.g.). 

[dashboard showing usage/cogs implications](https://sentry.sentry.io/explore/logs?logsAggregate=sum&logsAggregateParam=payload_size&logsFields=logger.name&logsGroupBy=logger.name&project=1&referrer=api.dashboards.tablewidget&statsPeriod=7d)