### PR TITLE
feat(search-bar): Tweak logic category

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -718,24 +718,8 @@ describe('SearchQueryBuilder', () => {
     });
 
     describe('logic category', () => {
-      it('renders only parenthetical filters when on first input', async () => {
+      it('renders conditional and parenthetical filters', async () => {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="" />, {
-          organization: {features: ['search-query-builder-conditionals-combobox-menus']},
-        });
-        await userEvent.click(getLastInput());
-
-        // Should show conditionals button
-        expect(await screen.findByRole('button', {name: 'Logic'})).toBeInTheDocument();
-
-        await userEvent.click(screen.getByRole('button', {name: 'Logic'}));
-        expect(await screen.findByRole('option', {name: '('})).toBeInTheDocument();
-        expect(screen.queryByRole('option', {name: ')'})).not.toBeInTheDocument();
-        expect(screen.queryByRole('option', {name: 'AND'})).not.toBeInTheDocument();
-        expect(screen.queryByRole('option', {name: 'OR'})).not.toBeInTheDocument();
-      });
-
-      it('renders conditional and parenthetical filters when not on first input', async () => {
-        render(<SearchQueryBuilder {...defaultProps} initialQuery="span.op:test" />, {
           organization: {features: ['search-query-builder-conditionals-combobox-menus']},
         });
         await userEvent.click(getLastInput());

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -434,6 +434,7 @@ describe('SearchQueryBuilder', () => {
       expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Category 1'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Category 2'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Logic'})).toBeInTheDocument();
 
       const menu = screen.getByRole('listbox');
       const groups = within(menu).getAllByRole('group');
@@ -717,25 +718,35 @@ describe('SearchQueryBuilder', () => {
     });
 
     describe('logic category', () => {
-      it('does not render logic category when on first input', async () => {
+      it('renders only parenthetical filters when on first input', async () => {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="" />, {
           organization: {features: ['search-query-builder-conditionals-combobox-menus']},
         });
-
         await userEvent.click(getLastInput());
-        expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
 
-        expect(screen.queryByRole('button', {name: 'Logic'})).not.toBeInTheDocument();
+        // Should show conditionals button
+        expect(await screen.findByRole('button', {name: 'Logic'})).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Logic'}));
+        expect(await screen.findByRole('option', {name: '('})).toBeInTheDocument();
+        expect(screen.queryByRole('option', {name: ')'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('option', {name: 'AND'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('option', {name: 'OR'})).not.toBeInTheDocument();
       });
 
-      it('renders logic category when not on first input', async () => {
+      it('renders conditional and parenthetical filters when not on first input', async () => {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="span.op:test" />, {
           organization: {features: ['search-query-builder-conditionals-combobox-menus']},
         });
-
         await userEvent.click(getLastInput());
+
         // Should show conditionals button
         expect(await screen.findByRole('button', {name: 'Logic'})).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', {name: 'Logic'}));
+        expect(await screen.findByRole('option', {name: '('})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: ')'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'AND'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'OR'})).toBeInTheDocument();
       });
     });
   });

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -31,11 +31,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
 import {itemIsSection} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
-import type {
-  ParseResultToken,
-  Token,
-  TokenResult,
-} from 'sentry/components/searchSyntax/parser';
+import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import type {RecentSearch, TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -204,11 +200,10 @@ const logicFilterItems = [
 ];
 
 interface UseFilterKeyListBoxArgs {
-  filterItem: Node<ParseResultToken>;
   filterValue: string;
 }
 
-export function useFilterKeyListBox({filterValue, filterItem}: UseFilterKeyListBoxArgs) {
+export function useFilterKeyListBox({filterValue}: UseFilterKeyListBoxArgs) {
   const {
     filterKeys,
     getFieldDefinition,
@@ -260,18 +255,12 @@ export function useFilterKeyListBox({filterValue, filterItem}: UseFilterKeyListB
       ];
     }
 
-    const isFirstItem = filterItem.key.toString().endsWith(':0');
-
     if (
       !disallowLogicalOperators &&
       selectedSection === LOGIC_CATEGORY_VALUE &&
       hasConditionalsInCombobox
     ) {
-      return [
-        ...askSeerItem,
-        // only show opening parenthesis on first item
-        ...(isFirstItem ? [createLogicFilterItem({value: '('})] : logicFilterItems),
-      ];
+      return [...askSeerItem, ...logicFilterItems];
     }
 
     const filteredByCategory = sectionedItems.filter(item => {
@@ -289,7 +278,6 @@ export function useFilterKeyListBox({filterValue, filterItem}: UseFilterKeyListB
   }, [
     disallowLogicalOperators,
     enableAISearch,
-    filterItem.key,
     filterKeys,
     gaveSeerConsent,
     getFieldDefinition,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -134,9 +134,7 @@ function useFilterKeyItems() {
 
 function useFilterKeySections({
   recentSearches,
-  filterItem,
 }: {
-  filterItem: Node<ParseResultToken>;
   recentSearches: RecentSearch[] | undefined;
 }) {
   const {filterKeySections, query, disallowLogicalOperators} = useSearchQueryBuilder();
@@ -155,7 +153,6 @@ function useFilterKeySections({
       return [];
     }
 
-    const isFirstItem = filterItem.key.toString().endsWith(':0');
     if (recentSearches?.length && !query) {
       const recentSearchesSections: Section[] = [
         RECENT_SEARCH_CATEGORY,
@@ -163,14 +160,14 @@ function useFilterKeySections({
         ...definedSections,
       ];
 
-      if (!disallowLogicalOperators && !isFirstItem && hasConditionalsInCombobox) {
+      if (!disallowLogicalOperators && hasConditionalsInCombobox) {
         recentSearchesSections.push(LOGIC_CATEGORY);
       }
       return recentSearchesSections;
     }
 
     const customSections: Section[] = [ALL_CATEGORY, ...definedSections];
-    if (!disallowLogicalOperators && !isFirstItem && hasConditionalsInCombobox) {
+    if (!disallowLogicalOperators && hasConditionalsInCombobox) {
       customSections.push(LOGIC_CATEGORY);
     }
 
@@ -179,7 +176,6 @@ function useFilterKeySections({
     disallowLogicalOperators,
     filterKeySections,
     hasConditionalsInCombobox,
-    filterItem.key,
     query,
     recentSearches?.length,
   ]);
@@ -200,7 +196,7 @@ function useFilterKeySections({
   return {sections, selectedSection, setSelectedSection};
 }
 
-const conditionalFilterItems = [
+const logicFilterItems = [
   createLogicFilterItem({value: 'AND'}),
   createLogicFilterItem({value: 'OR'}),
   createLogicFilterItem({value: '('}),
@@ -228,7 +224,6 @@ export function useFilterKeyListBox({filterValue, filterItem}: UseFilterKeyListB
   const {data: recentSearches} = useRecentSearches();
   const {sections, selectedSection, setSelectedSection} = useFilterKeySections({
     recentSearches,
-    filterItem,
   });
 
   const organization = useOrganization();
@@ -265,12 +260,18 @@ export function useFilterKeyListBox({filterValue, filterItem}: UseFilterKeyListB
       ];
     }
 
+    const isFirstItem = filterItem.key.toString().endsWith(':0');
+
     if (
       !disallowLogicalOperators &&
       selectedSection === LOGIC_CATEGORY_VALUE &&
       hasConditionalsInCombobox
     ) {
-      return [...askSeerItem, ...conditionalFilterItems];
+      return [
+        ...askSeerItem,
+        // only show opening parenthesis on first item
+        ...(isFirstItem ? [createLogicFilterItem({value: '('})] : logicFilterItems),
+      ];
     }
 
     const filteredByCategory = sectionedItems.filter(item => {
@@ -288,6 +289,7 @@ export function useFilterKeyListBox({filterValue, filterItem}: UseFilterKeyListB
   }, [
     disallowLogicalOperators,
     enableAISearch,
+    filterItem.key,
     filterKeys,
     gaveSeerConsent,
     getFieldDefinition,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -301,7 +301,6 @@ function SearchQueryBuilderInputInternal({
 
   const {customMenu, sectionItems, maxOptions, onKeyDownCapture, handleOptionSelected} =
     useFilterKeyListBox({
-      filterItem: item,
       filterValue,
     });
   const sortedFilteredItems = useSortedFilterKeyItems({


### PR DESCRIPTION
<s>Currently the logic category only renders when the filter item is not the first item in the search bar. This PR tweaks this to render the category, but with only the opening paren item, as it is the only valid one in that location.</s>

This PR removes the first item checks, and will display all logic operators at all times.