### PR TITLE
ref(explorer): useSessionStorage to persist current run id

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -19,6 +19,7 @@ describe('ExplorerPanel', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    sessionStorage.clear();
 
     // This matches the real behavior when no run ID is provided.
     MockApiClient.addMockResponse({

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -7,6 +7,7 @@ import {useSeerExplorer} from './useSeerExplorer';
 describe('useSeerExplorer', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    sessionStorage.clear();
   });
 
   const organization = OrganizationFixture({

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -10,6 +10,7 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import useAsciiSnapshot from 'sentry/views/seerExplorer/hooks/useAsciiSnapshot';
 import type {Block} from 'sentry/views/seerExplorer/types';
 
@@ -94,7 +95,10 @@ export const useSeerExplorer = () => {
   const orgSlug = organization?.slug;
   const captureAsciiSnapshot = useAsciiSnapshot();
 
-  const [runId, setRunId] = useState<number | null>(null);
+  const [runId, setRunId] = useSessionStorage<number | null>(
+    'seer-explorer-run-id',
+    null
+  );
   const [waitingForResponse, setWaitingForResponse] = useState<boolean>(false);
   const [deletedFromIndex, setDeletedFromIndex] = useState<number | null>(null);
   const [interruptRequested, setInterruptRequested] = useState<boolean>(false);


### PR DESCRIPTION
Keep track of the last active explorer conversation for each web session, so it can be restored on reload or the state is lost for some other reason
https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
closes [AIML-1616: QoL: restore previous active session after hard reloading](https://linear.app/getsentry/issue/AIML-1616/qol-restore-previous-active-session-after-hard-reloading)