### PR TITLE
ref(performance): Improve web vitals issue check using occurrence type instead

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -132,7 +132,7 @@ const IssuesTraceContainer = styled('div')`
 `;
 
 const isWebVitalsEvent = (event: Event) => {
-  return event.tags.some((tag: {key: string}) => tag?.key === 'web_vital');
+  return event.occurrence?.type === 10001; // Web Vitals group type id
 };
 
 interface EventTraceViewProps {

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -8,7 +8,7 @@ import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/ut
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import {type Event} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
+import {getIssueTypeFromOccurrenceType, IssueType, type Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -132,7 +132,7 @@ const IssuesTraceContainer = styled('div')`
 `;
 
 const isWebVitalsEvent = (event: Event) => {
-  return event.occurrence?.type === 10001; // Web Vitals group type id
+  return getIssueTypeFromOccurrenceType(event.occurrence?.type) === IssueType.WEB_VITALS; // Web Vitals group type id
 };
 
 interface EventTraceViewProps {


### PR DESCRIPTION
Updates `isWebVitalsEvent` from the trace view to check for web vitals issue using the occurrence type instead