### PR TITLE
chore(preprod): fix casing

### DIFF
--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -75,8 +75,8 @@ export function getLabels(platform: Platform | undefined): Labels {
   switch (platform) {
     case 'android':
       return {
-        installSizeLabel: t('Uncompressed size'),
-        downloadSizeLabel: t('Download size'),
+        installSizeLabel: t('Uncompressed Size'),
+        downloadSizeLabel: t('Download Size'),
         appId: t('Package name'),
         installSizeDescription: t('Uncompressed size on disk not including AOT DEX'),
         downloadSizeDescription: t('Bytes transferred over the network'),

--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -91,7 +91,7 @@ export function getLabels(platform: Platform | undefined): Labels {
         appId: t('Bundle identifier'),
         installSizeDescription: t('Unencrypted install size'),
         downloadSizeDescription: t('Bytes transferred over the network'),
-        downloadSizeLabel: t('Download size'),
+        downloadSizeLabel: t('Download Size'),
         buildConfiguration: t('Build configuration'),
         installUnavailableTooltip: t(
           'Code signature must be valid for this app to be installed.'


### PR DESCRIPTION
Make android casing consistent with iOS casing

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
