### PR TITLE
ref(conduit): Adjust permissions for conduit demo

### DIFF
--- a/src/sentry/conduit/endpoints/organization_conduit_demo.py
+++ b/src/sentry/conduit/endpoints/organization_conduit_demo.py
@@ -8,6 +8,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.conduit.auth import get_conduit_credentials
 from sentry.conduit.tasks import stream_demo_data
 from sentry.models.organization import Organization
@@ -23,8 +24,19 @@ class ConduitCredentialsResponseSerializer(serializers.Serializer):
     conduit = ConduitCredentialsSerializer()
 
 
+class OrganizationConduitDemoPermission(OrganizationPermission):
+    """
+    Permission for the conduit demo endpoint.
+    """
+
+    scope_map = {
+        "POST": ["org:read", "org:write", "org:admin"],
+    }
+
+
 @region_silo_endpoint
 class OrganizationConduitDemoEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationConduitDemoPermission,)
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/conduit/endpoints/organization_conduit_demo.py
+++ b/src/sentry/conduit/endpoints/organization_conduit_demo.py
@@ -27,6 +27,8 @@ class ConduitCredentialsResponseSerializer(serializers.Serializer):
 class OrganizationConduitDemoPermission(OrganizationPermission):
     """
     Permission for the conduit demo endpoint.
+    We want members to be able to generate temporary credentials for the demo.
+    This is a demo-only feature and doesn't modify organization state.
     """
 
     scope_map = {

--- a/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
+++ b/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
@@ -49,6 +49,7 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
     )
     @with_feature("organizations:conduit-demo")
     def test_post_member_can_access(self) -> None:
+        """Test that members can generate credentials."""
         member_user = self.create_user(is_superuser=False)
         self.create_member(
             user=member_user,

--- a/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
+++ b/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
@@ -41,6 +41,33 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
         assert "url" in response.data["conduit"]
         assert str(self.organization.id) in response.data["conduit"]["url"]
 
+    @override_settings(
+        CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,
+        CONDUIT_GATEWAY_JWT_ISSUER="sentry",
+        CONDUIT_GATEWAY_JWT_AUDIENCE="conduit",
+        CONDUIT_GATEWAY_URL="https://conduit.example.com",
+    )
+    @with_feature("organizations:conduit-demo")
+    def test_post_member_can_access(self) -> None:
+        member_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[],
+        )
+        self.login_as(member_user)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            method="POST",
+            status_code=201,
+        )
+
+        assert "conduit" in response.data
+        assert "token" in response.data["conduit"]
+        assert "channel_id" in response.data["conduit"]
+
     @with_feature("organizations:conduit-demo")
     def test_post_without_org_access(self) -> None:
         """Test that users without org access cannot generate credentials."""


### PR DESCRIPTION
Adjusting the permissions for the conduit demo endpoint to be accessible to members (not just managers and admins).