### PR TITLE
fix(timeseries): Remove unwanted `groupBy` parameter

### DIFF
--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -124,7 +124,9 @@ export const useSortedTimeSeries = <
     useIsSampled(0.1, key) &&
     organization.features.includes('explore-events-time-series-spot-check');
 
-  const groupBy = fields?.filter(field => !(yAxis as unknown as string).includes(field));
+  const groupBy = fields?.filter(
+    field => !(yAxis as unknown as string[]).includes(field)
+  );
 
   const timeSeriesResult = useFetchEventsTimeSeries(
     dataset ?? DiscoverDatasets.SPANS,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -124,13 +124,15 @@ export const useSortedTimeSeries = <
     useIsSampled(0.1, key) &&
     organization.features.includes('explore-events-time-series-spot-check');
 
+  const groupBy = fields?.filter(field => !(yAxis as unknown as string).includes(field));
+
   const timeSeriesResult = useFetchEventsTimeSeries(
     dataset ?? DiscoverDatasets.SPANS,
     {
       yAxis: yAxis as unknown as any,
       query: search,
       topEvents,
-      groupBy: fields as unknown as any,
+      groupBy,
       pageFilters: pageFilters.selection,
       sort: decodeSorts(orderby)[0],
       interval,


### PR DESCRIPTION
There's an API difference between `/events-stats/` and `/events-timeseries/`. In `/events-stats/`, the fields parameter includes both the group by, and the Y axis. e.g., fields can be `["count(span.duration)", "environment"]` and the Y axis would be `["count(span.duration)"]` which works correctly, and the `"environment"` field is only used for the grouping.

In `/events-timeseries/`, there is not "fields", there is only an explicit group by, and an explicit Y axis. In this PR, I'm filtering the Y axis values out of the `groupBy`, to prevent us sending an unnecessary `groupBy` parameter. This doesn't change the response at all, it's just less confusing when looking at the request.
