### PR TITLE
feat(config): Remove log for tz mismatch

### DIFF
--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import moment from 'moment-timezone';
 import {createStore} from 'reflux';
 
@@ -11,8 +10,6 @@ interface ConfigStoreDefinition extends StrictStoreDefinition<Config> {
   loadInitialData(config: Config): void;
   set<K extends keyof Config>(key: K, value: Config[K]): void;
 }
-
-const {warn} = Sentry.logger;
 
 const storeConfig: ConfigStoreDefinition = {
   // When the app is booted we will _immediately_ hydrate the config store,
@@ -47,21 +44,7 @@ const storeConfig: ConfigStoreDefinition = {
     // TODO(dcramer): abstract this out of ConfigStore
     if (this.state.user) {
       this.state.user.permissions = new Set(this.state.user.permissions);
-
-      const systemTimeZone = moment.tz.guess();
-      const userTimeZone = this.state.user.options.timezone;
-
-      const nowInSystemTimezone = moment.tz(undefined, systemTimeZone);
-      const nowInUserTimezone = moment.tz(undefined, userTimeZone);
-
-      if (nowInSystemTimezone.utcOffset() !== nowInUserTimezone.utcOffset()) {
-        warn('System time zone does not match user preferences time zone', {
-          systemTimeZone,
-          userTimeZone,
-        });
-      }
-
-      moment.tz.setDefault(userTimeZone);
+      moment.tz.setDefault(this.state.user.options.timezone);
     }
 
     this.trigger(this.state);


### PR DESCRIPTION
No longer needed, see https://linear.app/getsentry/issue/DAIN-594/time-series-chart-x-axis-ticks-are-not-aligned-to-dates-when-system

Manual revert of https://github.com/getsentry/sentry/pull/93330
