### PR TITLE
fix(deletions): Fix Monitor deletion timeouts

### DIFF
--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -1,4 +1,9 @@
-from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.deletions.base import (
+    BaseRelation,
+    BulkModelDeletionTask,
+    ModelDeletionTask,
+    ModelRelation,
+)
 from sentry.monitors.models import Monitor
 
 
@@ -7,6 +12,8 @@ class MonitorDeletionTask(ModelDeletionTask[Monitor]):
         from sentry.monitors import models
 
         return [
-            ModelRelation(models.MonitorCheckIn, {"monitor_id": instance.id}, ModelDeletionTask),
+            ModelRelation(
+                models.MonitorCheckIn, {"monitor_id": instance.id}, BulkModelDeletionTask
+            ),
             ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
         ]

--- a/src/sentry/deletions/defaults/monitor_environment.py
+++ b/src/sentry/deletions/defaults/monitor_environment.py
@@ -1,4 +1,9 @@
-from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.deletions.base import (
+    BaseRelation,
+    BulkModelDeletionTask,
+    ModelDeletionTask,
+    ModelRelation,
+)
 from sentry.monitors.models import MonitorEnvironment
 
 
@@ -10,6 +15,6 @@ class MonitorEnvironmentDeletionTask(ModelDeletionTask[MonitorEnvironment]):
             ModelRelation(
                 models.MonitorCheckIn,
                 {"monitor_environment_id": instance.id},
-                ModelDeletionTask,
+                BulkModelDeletionTask,
             ),
         ]


### PR DESCRIPTION
changed MonitorCheckIn to be deleted using BulkModelDeletionTask.
It used to need individual deletions to clean up attachments manually but attachments were removed from this model and it can now safely use Bulk deletion to speed things up.

should fix:
[SENTRY-41GE](https://sentry.sentry.io/issues/6683627821/events/b3fcd332f8d842abb4e5110eb001d4d4/)
