### PR TITLE
feat(seer): Add separate scanner acknowledgement function with rollout rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3655,3 +3655,10 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "seer.scanner_no_consent.rollout_rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -320,9 +320,9 @@ def is_issue_eligible_for_seer_automation(group: Group) -> bool:
     ):
         return False
 
-    from sentry.seer.seer_setup import get_seer_org_acknowledgement
+    from sentry.seer.seer_setup import get_seer_org_acknowledgement_for_scanner
 
-    seer_enabled = get_seer_org_acknowledgement(group.organization)
+    seer_enabled = get_seer_org_acknowledgement_for_scanner(group.organization)
     if not seer_enabled:
         return False
 

--- a/src/sentry/seer/seer_setup.py
+++ b/src/sentry/seer/seer_setup.py
@@ -38,20 +38,14 @@ def get_seer_org_acknowledgement(organization: Organization) -> bool:
 
 
 def get_seer_org_acknowledgement_for_scanner(organization: Organization) -> bool:
-
-    if PromptsActivity.objects.filter(
+    return PromptsActivity.objects.filter(
         feature=feature_name,
         organization_id=organization.id,
         project_id=0,
-    ).exists():
-        return True
-
-    if features.has("organizations:gen-ai-consent-flow-removal", organization) and in_rollout_group(
-        "seer.scanner_no_consent.rollout_rate", organization.id
-    ):
-        return True
-
-    return False
+    ).exists() or (
+        features.has("organizations:gen-ai-consent-flow-removal", organization)
+        and in_rollout_group("seer.scanner_no_consent.rollout_rate", organization.id)
+    )
 
 
 def has_seer_access(

--- a/src/sentry/seer/seer_setup.py
+++ b/src/sentry/seer/seer_setup.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import AnonymousUser
 from sentry import features
 from sentry.models.organization import Organization
 from sentry.models.promptsactivity import PromptsActivity
+from sentry.options.rollout import in_rollout_group
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
@@ -34,6 +35,23 @@ def get_seer_org_acknowledgement(organization: Organization) -> bool:
         organization_id=organization.id,
         project_id=0,
     ).exists()
+
+
+def get_seer_org_acknowledgement_for_scanner(organization: Organization) -> bool:
+
+    if PromptsActivity.objects.filter(
+        feature=feature_name,
+        organization_id=organization.id,
+        project_id=0,
+    ).exists():
+        return True
+
+    if features.has("organizations:gen-ai-consent-flow-removal", organization) and in_rollout_group(
+        "seer.scanner_no_consent.rollout_rate", organization.id
+    ):
+        return True
+
+    return False
 
 
 def has_seer_access(

--- a/tests/sentry/seer/test_seer_setup.py
+++ b/tests/sentry/seer/test_seer_setup.py
@@ -1,0 +1,210 @@
+from unittest.mock import patch
+
+import orjson
+
+from sentry.models.promptsactivity import PromptsActivity
+from sentry.seer.seer_setup import (
+    get_seer_org_acknowledgement,
+    get_seer_org_acknowledgement_for_scanner,
+    get_seer_user_acknowledgement,
+)
+from sentry.testutils.cases import TestCase
+
+
+class TestGetSeerOrgAcknowledgementForScanner(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(name="test-org")
+        self.user = self.create_user()
+        self.feature_name = "seer_autofix_setup_acknowledged"
+
+    def test_returns_true_when_org_has_acknowledged(self):
+        """Test returns True when organization has acknowledged via PromptsActivity."""
+        PromptsActivity.objects.create(
+            user_id=self.user.id,
+            feature=self.feature_name,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps({"dismissed_ts": 123456789}).decode("utf-8"),
+        )
+
+        result = get_seer_org_acknowledgement_for_scanner(self.organization)
+        assert result is True
+
+    def test_returns_false_when_no_acknowledgement_and_feature_not_enabled(self):
+        """Test returns False when no acknowledgement exists and feature flag is disabled."""
+        result = get_seer_org_acknowledgement_for_scanner(self.organization)
+        assert result is False
+
+    @patch("sentry.seer.seer_setup.in_rollout_group")
+    def test_returns_true_when_feature_enabled_and_passes_rollout(self, mock_in_rollout_group):
+        """Test returns True when gen-ai-consent-flow-removal is enabled and passes rollout rate."""
+        with self.feature("organizations:gen-ai-consent-flow-removal"):
+            mock_in_rollout_group.return_value = True
+
+            result = get_seer_org_acknowledgement_for_scanner(self.organization)
+
+            assert result is True
+            mock_in_rollout_group.assert_called_once_with(
+                "seer.scanner_no_consent.rollout_rate", self.organization.id
+            )
+
+    @patch("sentry.seer.seer_setup.in_rollout_group")
+    def test_returns_false_when_feature_enabled_but_fails_rollout(self, mock_in_rollout_group):
+        """Test returns False when gen-ai-consent-flow-removal is enabled but fails rollout rate."""
+        with self.feature("organizations:gen-ai-consent-flow-removal"):
+            mock_in_rollout_group.return_value = False
+
+            result = get_seer_org_acknowledgement_for_scanner(self.organization)
+
+            assert result is False
+            mock_in_rollout_group.assert_called_once_with(
+                "seer.scanner_no_consent.rollout_rate", self.organization.id
+            )
+
+    @patch("sentry.seer.seer_setup.in_rollout_group")
+    def test_returns_true_when_feature_enabled_and_100_percent_rollout(self, mock_in_rollout_group):
+        """Test returns True when gen-ai-consent-flow-removal is enabled with 100% rollout."""
+        with self.feature("organizations:gen-ai-consent-flow-removal"):
+            mock_in_rollout_group.return_value = True
+
+            result = get_seer_org_acknowledgement_for_scanner(self.organization)
+
+            assert result is True
+            mock_in_rollout_group.assert_called_once_with(
+                "seer.scanner_no_consent.rollout_rate", self.organization.id
+            )
+
+    @patch("sentry.seer.seer_setup.in_rollout_group")
+    def test_returns_false_when_feature_enabled_and_0_percent_rollout(self, mock_in_rollout_group):
+        """Test returns False when gen-ai-consent-flow-removal is enabled with 0% rollout."""
+        with self.feature("organizations:gen-ai-consent-flow-removal"):
+            mock_in_rollout_group.return_value = False
+
+            result = get_seer_org_acknowledgement_for_scanner(self.organization)
+
+            assert result is False
+            mock_in_rollout_group.assert_called_once_with(
+                "seer.scanner_no_consent.rollout_rate", self.organization.id
+            )
+
+    @patch("sentry.seer.seer_setup.in_rollout_group")
+    def test_prioritizes_acknowledgement_over_feature_flag(self, mock_in_rollout_group):
+        """Test that explicit acknowledgement takes priority over feature flag rollout."""
+        PromptsActivity.objects.create(
+            user_id=self.user.id,
+            feature=self.feature_name,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps({"dismissed_ts": 123456789}).decode("utf-8"),
+        )
+
+        with self.feature("organizations:gen-ai-consent-flow-removal"):
+            mock_in_rollout_group.return_value = False
+
+            result = get_seer_org_acknowledgement_for_scanner(self.organization)
+
+            assert result is True
+            # Should return True before checking rollout
+            mock_in_rollout_group.assert_not_called()
+
+    def test_different_organizations_isolated(self):
+        """Test that acknowledgements are isolated per organization."""
+        org2 = self.create_organization(name="test-org-2")
+
+        PromptsActivity.objects.create(
+            user_id=self.user.id,
+            feature=self.feature_name,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps({"dismissed_ts": 123456789}).decode("utf-8"),
+        )
+
+        result1 = get_seer_org_acknowledgement_for_scanner(self.organization)
+        result2 = get_seer_org_acknowledgement_for_scanner(org2)
+
+        assert result1 is True
+        assert result2 is False
+
+
+class TestGetSeerOrgAcknowledgement(TestCase):
+    """Test the standard get_seer_org_acknowledgement function for comparison."""
+
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(name="test-org")
+        self.user = self.create_user()
+        self.feature_name = "seer_autofix_setup_acknowledged"
+
+    def test_returns_true_when_gen_ai_consent_removal_enabled(self):
+        """Test returns True when gen-ai-consent-flow-removal feature is enabled."""
+        with self.feature("organizations:gen-ai-consent-flow-removal"):
+            result = get_seer_org_acknowledgement(self.organization)
+            assert result is True
+
+    def test_returns_true_when_org_has_acknowledged(self):
+        """Test returns True when organization has acknowledged via PromptsActivity."""
+        PromptsActivity.objects.create(
+            user_id=self.user.id,
+            feature=self.feature_name,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps({"dismissed_ts": 123456789}).decode("utf-8"),
+        )
+
+        result = get_seer_org_acknowledgement(self.organization)
+        assert result is True
+
+    def test_returns_false_when_no_acknowledgement_and_feature_not_enabled(self):
+        """Test returns False when no acknowledgement exists and feature flag is disabled."""
+        result = get_seer_org_acknowledgement(self.organization)
+        assert result is False
+
+
+class TestGetSeerUserAcknowledgement(TestCase):
+    """Test the get_seer_user_acknowledgement function."""
+
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(name="test-org")
+        self.user = self.create_user()
+        self.feature_name = "seer_autofix_setup_acknowledged"
+
+    def test_returns_true_when_gen_ai_consent_removal_enabled(self):
+        """Test returns True when gen-ai-consent-flow-removal feature is enabled."""
+        with self.feature("organizations:gen-ai-consent-flow-removal"):
+            result = get_seer_user_acknowledgement(self.user.id, self.organization)
+            assert result is True
+
+    def test_returns_true_when_user_has_acknowledged(self):
+        """Test returns True when user has acknowledged via PromptsActivity."""
+        PromptsActivity.objects.create(
+            user_id=self.user.id,
+            feature=self.feature_name,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps({"dismissed_ts": 123456789}).decode("utf-8"),
+        )
+
+        result = get_seer_user_acknowledgement(self.user.id, self.organization)
+        assert result is True
+
+    def test_returns_false_when_no_acknowledgement_and_feature_not_enabled(self):
+        """Test returns False when user has not acknowledged and feature flag is disabled."""
+        result = get_seer_user_acknowledgement(self.user.id, self.organization)
+        assert result is False
+
+    def test_returns_false_when_different_user_acknowledged(self):
+        """Test returns False when a different user has acknowledged."""
+        other_user = self.create_user()
+
+        PromptsActivity.objects.create(
+            user_id=other_user.id,
+            feature=self.feature_name,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps({"dismissed_ts": 123456789}).decode("utf-8"),
+        )
+
+        result = get_seer_user_acknowledgement(self.user.id, self.organization)
+        assert result is False

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2672,7 +2672,7 @@ class ProcessSimilarityTestMixin(BasePostProgressGroupMixin):
 
 class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -2696,7 +2696,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_called_once_with(event.group.id)
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -2718,7 +2718,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_not_called()
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=False,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -2742,7 +2742,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_not_called()
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -2767,7 +2767,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_not_called()
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -2796,7 +2796,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_not_called()
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -2824,7 +2824,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_called_once_with(group.id)
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -2860,7 +2860,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
 
     @patch("sentry.seer.autofix.utils.is_seer_scanner_rate_limited")
     @patch("sentry.quotas.backend.has_available_reserved_budget")
-    @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement")
+    @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner")
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_rate_limit_only_checked_after_all_other_checks_pass(
@@ -2954,7 +2954,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_not_called()
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -3005,7 +3005,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_start_seer_automation.assert_called_once_with(event2.group.id)
 
     @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
@@ -3036,7 +3036,7 @@ class SeerAutomationHelperFunctionsTestMixin(BasePostProgressGroupMixin):
     """Unit tests for is_issue_eligible_for_seer_automation."""
 
     @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
-    @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement", return_value=True)
+    @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner", return_value=True)
     @patch("sentry.features.has", return_value=True)
     def test_is_issue_eligible_for_seer_automation(
         self, mock_features_has, mock_get_seer_org_acknowledgement, mock_has_budget


### PR DESCRIPTION
This PR adds a new `get_seer_org_acknowledgement_for_scanner` function that provides independent control over scanner behavior with respect to AI consent. We were seeing increased volume from scanner after enabling the `no_ai_consent` flag, and we'd like to roll this increased volume out separately to the in-UI AI changes.

We do this by adding a new option which will allow us to control the rollout rate of scanner separately to the rest of our AI features.