### PR TITLE
fix(issues): Attribute error in issue details thrown on None tag values

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -184,7 +184,7 @@ class OrganizationSpansFieldValuesEndpoint(OrganizationSpansFieldsEndpointBase):
         with handle_query_errors():
             tag_values = executor.execute()
 
-        tag_values.sort(key=lambda tag: tag.value)
+        tag_values.sort(key=lambda tag: tag.value or "")
 
         paginator = ChainPaginator([tag_values], max_limit=max_span_tag_values)
 

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -375,7 +375,7 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
 
             with handle_query_errors():
                 tag_values = executor.execute()
-            tag_values.sort(key=lambda tag: tag.value)
+            tag_values.sort(key=lambda tag: tag.value or "")
             return tag_values
 
         return self.paginate(

--- a/src/sentry/data_export/processors/issues_by_tag.py
+++ b/src/sentry/data_export/processors/issues_by_tag.py
@@ -113,7 +113,12 @@ class IssuesByTagProcessor:
             users = EventUser.for_tags(self.group.project_id, [i.value for i in items])
         else:
             users = {}
-        return [GroupTagValueAndEventUser(item, users.get(item.value)) for item in items]
+        return [
+            GroupTagValueAndEventUser(
+                item, users.get(item.value) if item.value is not None else None
+            )
+            for item in items
+        ]
 
     def get_serialized_data(self, limit: int = 1000, offset: int = 0) -> list[dict[str, str]]:
         """

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -831,7 +831,7 @@ def convert_user_tag_to_query(key: str, value: str) -> str | None:
     Converts a user tag to a query string that can be used to search for that
     user. Returns None if not a user tag.
     """
-    if key == "user" and ":" in value:
+    if key == "user" and value is not None and ":" in value:
         sub_key, value = value.split(":", 1)
         if KEYWORD_MAP.get_key(sub_key, None):
             return 'user.{}:"{}"'.format(sub_key, value.replace('"', '\\"'))

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -29,7 +29,16 @@ class TagType:
         )
 
     def __lt__(self, other: object) -> bool:
-        return getattr(self, self._sort_key) < getattr(other, self._sort_key)
+        self_val = getattr(self, self._sort_key)
+        other_val = getattr(other, self._sort_key)
+        # Handle None values in sorting - None sorts before any non-None value
+        if self_val is None and other_val is None:
+            return False
+        if self_val is None:
+            return True
+        if other_val is None:
+            return False
+        return self_val < other_val
 
     def __getstate__(self) -> dict[str, Any]:
         return {name: getattr(self, name) for name in self.__slots__}
@@ -68,7 +77,7 @@ class TagValue(TagType):
     def __init__(
         self,
         key: str,
-        value,
+        value: str | None,
         times_seen: int | None,
         first_seen: datetime | None,
         last_seen: datetime | None,
@@ -107,7 +116,7 @@ class GroupTagValue(TagType):
         self,
         group_id: int,
         key: str,
-        value,
+        value: str | None,
         times_seen: int,
         first_seen,
         last_seen,

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -314,7 +314,7 @@ class EventUser:
 
     @classmethod
     def for_tags(
-        cls: type[EventUser], project_id: int, values: Sequence[str]
+        cls: type[EventUser], project_id: int, values: Sequence[str | None]
     ) -> dict[str, EventUser]:
         """
         Finds matching EventUser objects from a list of tag values.
@@ -338,7 +338,7 @@ class EventUser:
 
     @classmethod
     def _process_tag_batch(
-        cls, projects: QuerySet[Project], values: Sequence[str]
+        cls, projects: QuerySet[Project], values: Sequence[str | None]
     ) -> dict[str, EventUser]:
         """
         Process a single batch of tag values and return the matching EventUser objects.
@@ -346,6 +346,10 @@ class EventUser:
         result = {}
         keyword_filters: dict[str, Any] = {}
         for value in values:
+            # Skip None values - these represent events without the tag set.
+            # There's no EventUser to look up for these cases.
+            if value is None:
+                continue
             key, value = value.split(":", 1)[0], value.split(":", 1)[-1]
             if keyword_filters.get(key):
                 keyword_filters[key].append(value)


### PR DESCRIPTION
Following #102048 we now need to handle GroupTagValue having None as key value. This currently causes errors when trying to `split` the tag key.

Fixes:
[SENTRY-5BYT](https://sentry.sentry.io/issues/6998373513/events/d3cd45062e7b4de69875fed27f2ae553/)