### PR TITLE
Fixes profiles export source prefix to end in  slash

### DIFF
--- a/src/sentry/profiles/data_export.py
+++ b/src/sentry/profiles/data_export.py
@@ -44,7 +44,7 @@ def export_profiles_data(
         gcp_project_id=gcp_project_id,
         transfer_job_name=None,
         source_bucket=source_bucket,
-        source_prefix=f"{organization_id}",
+        source_prefix=f"{organization_id}/",
         destination_bucket=destination_bucket,
         destination_prefix=destination_prefix,
         notification_topic=pubsub_topic_name,

--- a/src/sentry/replays/data_export.py
+++ b/src/sentry/replays/data_export.py
@@ -593,7 +593,7 @@ def export_replay_blob_data[T](
             gcp_project_id=gcp_project_id,
             transfer_job_name=None,
             source_bucket=source_bucket,
-            source_prefix=f"{retention_days}/{project_id}",
+            source_prefix=f"{retention_days}/{project_id}/",
             destination_bucket=destination_bucket,
             destination_prefix=destination_prefix,
             notification_topic=pubsub_topic_name,

--- a/tests/sentry/replays/unit/test_data_export.py
+++ b/tests/sentry/replays/unit/test_data_export.py
@@ -109,6 +109,6 @@ def test_export_replay_blob_data() -> None:
 
     # Assert a job is created for each retention-period.
     assert len(jobs) == 3
-    assert jobs[0].transfer_job.transfer_spec.gcs_data_source.path == "30/1"
-    assert jobs[1].transfer_job.transfer_spec.gcs_data_source.path == "60/1"
-    assert jobs[2].transfer_job.transfer_spec.gcs_data_source.path == "90/1"
+    assert jobs[0].transfer_job.transfer_spec.gcs_data_source.path == "30/1/"
+    assert jobs[1].transfer_job.transfer_spec.gcs_data_source.path == "60/1/"
+    assert jobs[2].transfer_job.transfer_spec.gcs_data_source.path == "90/1/"


### PR DESCRIPTION
`google.api_core.exceptions.InvalidArgument: 400 GCS source Path argument must end with '/'`
