### PR TITLE
feat(explore): Display saved query names in browser tab titles

### DIFF
--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -58,11 +58,12 @@ function FeedbackButton() {
 export default function LogsContent() {
   const organization = useOrganization();
   const {defaultPeriod, maxPickableDays, relativeOptions} = logsPickableDays();
+  const queryTitle = useQueryParamsTitle();
 
   const onboardingProject = useOnboardingProject({property: 'hasLogs'});
 
   return (
-    <SentryDocumentTitle title={t('Logs')} orgSlug={organization?.slug}>
+    <SentryDocumentTitle title={queryTitle ?? t('Logs')} orgSlug={organization?.slug}>
       <PageFiltersContainer
         maxPickableDays={maxPickableDays}
         defaultSelection={{

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -12,6 +12,7 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -26,6 +27,10 @@ import {
   useQueryParamsId,
   useQueryParamsTitle,
 } from 'sentry/views/explore/queryParams/context';
+import {
+  getTitleFromLocation,
+  TITLE_KEY,
+} from 'sentry/views/explore/queryParams/savedQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 
@@ -58,7 +63,8 @@ function FeedbackButton() {
 export default function LogsContent() {
   const organization = useOrganization();
   const {defaultPeriod, maxPickableDays, relativeOptions} = logsPickableDays();
-  const queryTitle = useQueryParamsTitle();
+  const location = useLocation();
+  const queryTitle = getTitleFromLocation(location, TITLE_KEY);
 
   const onboardingProject = useOnboardingProject({property: 'hasLogs'});
 

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -53,8 +53,11 @@ export default function MetricsContent() {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject({property: 'hasTraceMetrics'});
   const {defaultPeriod, maxPickableDays, relativeOptions} = metricsPickableDays();
+  const location = useLocation();
+  const queryTitle = getTitleFromLocation(location, TITLE_KEY);
+
   return (
-    <SentryDocumentTitle title={t('Metrics')} orgSlug={organization?.slug}>
+    <SentryDocumentTitle title={queryTitle ?? t('Metrics')} orgSlug={organization?.slug}>
       <PageFiltersContainer
         defaultSelection={{
           datetime: {

--- a/static/app/views/explore/multiQueryMode/index.tsx
+++ b/static/app/views/explore/multiQueryMode/index.tsx
@@ -32,7 +32,10 @@ export default function MultiQueryMode() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <SentryDocumentTitle title={t('Compare Queries')} orgSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={title ?? t('Compare Queries')}
+        orgSlug={organization.slug}
+      >
         <Layout.Header unified>
           <Layout.HeaderContent>
             <Breadcrumbs

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -40,11 +40,12 @@ export function ExploreContent() {
 
   const organization = useOrganization();
   const datePageFilterProps = limitMaxPickableDays(organization);
+  const queryTitle = useQueryParamsTitle();
 
   const onboardingProject = useOnboardingProject();
 
   return (
-    <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
+    <SentryDocumentTitle title={queryTitle ?? t('Traces')} orgSlug={organization?.slug}>
       <PageFiltersContainer maxPickableDays={datePageFilterProps.maxPickableDays}>
         <Layout.Page>
           <SpansTabWrapper>

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -12,6 +12,7 @@ import {TourContextProvider} from 'sentry/components/tours/components';
 import {useAssistant} from 'sentry/components/tours/useAssistant';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -20,6 +21,10 @@ import {
   useQueryParamsId,
   useQueryParamsTitle,
 } from 'sentry/views/explore/queryParams/context';
+import {
+  getTitleFromLocation,
+  TITLE_KEY,
+} from 'sentry/views/explore/queryParams/savedQuery';
 import {SavedQueryEditMenu} from 'sentry/views/explore/savedQueryEditMenu';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {SpansTabContent, SpansTabOnboarding} from 'sentry/views/explore/spans/spansTab';
@@ -40,7 +45,8 @@ export function ExploreContent() {
 
   const organization = useOrganization();
   const datePageFilterProps = limitMaxPickableDays(organization);
-  const queryTitle = useQueryParamsTitle();
+  const location = useLocation();
+  const queryTitle = getTitleFromLocation(location, TITLE_KEY);
 
   const onboardingProject = useOnboardingProject();
 


### PR DESCRIPTION
https://sentry.slack.com/archives/CTZCE4WBZ/p1763470753707459

Use query title instead of generic data type for explore pages if we're on a saved query.