### PR TITLE
chore(deletions: Increase group deletion deadline

### DIFF
--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -38,7 +38,7 @@ crons_tasks = app.taskregistry.create_namespace(
 
 deletion_tasks = app.taskregistry.create_namespace(
     "deletions",
-    processing_deadline_duration=60 * 10,
+    processing_deadline_duration=60 * 20,
     app_feature="shared",
 )
 


### PR DESCRIPTION
Doubles the `processing_deadline_duration` for the `deletion_tasks` namespace from 600 seconds (10 minutes) to 1200 seconds (20 minutes). This provides more time for deletion tasks, such as `delete_groups_for_project`, to complete successfully.

[SENTRY-48X9](https://sentry.sentry.io/issues/6770482833/)