### PR TITLE
fix(typing): Remove tests.sentry.issues.test_utils from type-blocklist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,7 +327,6 @@ module = [
     "sentry.snuba.metrics.query_builder",
     "sentry.testutils.cases",
     "tests.sentry.api.helpers.test_group_index",
-    "tests.sentry.issues.test_utils",
 ]
 disable_error_code = [
     "arg-type",


### PR DESCRIPTION
I'd love to get the /tests/ directory fully typed.

This PR uses `TypeGuard`s to deal with the fact that you can't pass a `TypedDict` to somewhere that expects a `dict` (since the function could mutate the `dict` in a way that, theoretically, could make it no longer match the `TypedDict` definition). This isn't ideal but is better than messing with a non-test function.