### PR TITLE
groupstore: refactor reduce calls from On^2 to On

### DIFF
--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -150,18 +150,19 @@ const storeConfig: GroupStoreDefinition = {
   },
 
   mergeItems(items: Item[]) {
-    const itemsById = items.reduce((acc, item) => ({...acc, [item.id]: item}), {});
+    const itemsById: Record<string, Item> = items.reduce((acc, item) => {
+      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      acc[item.id] = item;
+      return acc;
+    }, {});
 
     // Merge these items into the store and return a mapping of any that aren't already in the store
     this.items.forEach((item, itemIndex) => {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       if (itemsById[item.id]) {
         this.items[itemIndex] = {
           ...item,
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           ...itemsById[item.id],
         };
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         delete itemsById[item.id];
       }
     });
@@ -188,9 +189,12 @@ const storeConfig: GroupStoreDefinition = {
    */
   addToFront(items) {
     items = toArray(items);
-    const itemMap = items.reduce((acc, item) => ({...acc, [item.id]: item}), {});
+    const itemMap: Record<string, Item> = items.reduce((acc, item) => {
+      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      acc[item.id] = item;
+      return acc;
+    }, {});
 
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     this.items = [...items, ...this.items.filter(item => !itemMap[item.id])];
 
     this.updateItems(items.map(item => item.id));
@@ -484,10 +488,10 @@ const storeConfig: GroupStoreDefinition = {
 
   onPopulateStats(itemIds, response) {
     // Organize stats by id
-    const groupStatsMap = response.reduce<Record<string, GroupStats>>(
-      (map, stats) => ({...map, [stats.id]: stats}),
-      {}
-    );
+    const groupStatsMap = response.reduce<Record<string, GroupStats>>((map, stats) => {
+      map[stats.id] = stats;
+      return map;
+    }, {});
 
     this.items.forEach((item, idx) => {
       if (itemIds?.includes(item.id)) {


### PR DESCRIPTION
Spreading when we iterate over each item will cause quadratic runtime as the accumulator object is iterated for each item.