### PR TITLE
feat(aci): Disable error monitor create button

### DIFF
--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -16,6 +16,7 @@ import {
   makeMonitorBasePathname,
   makeMonitorDetailsPathname,
 } from 'sentry/views/detectors/pathnames';
+import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 export function DisableDetectorAction({detector}: {detector: Detector}) {
@@ -59,19 +60,23 @@ export function EditDetectorAction({detector}: {detector: Detector}) {
     projectId: detector.projectId,
   });
 
-  const permissionTooltipText = tct(
-    'You do not have permission to edit this monitor. Ask your organization owner or manager to [settingsLink:enable monitor access] for you.',
-    {
-      settingsLink: (
-        <Link
-          to={{
-            pathname: `/settings/${organization.slug}/`,
-            hash: 'alertsMemberWrite',
-          }}
-        />
-      ),
-    }
-  );
+  const permissionTooltipText = detectorTypeIsUserCreateable(detector.type)
+    ? tct(
+        'You do not have permission to edit this monitor. Ask your organization owner or manager to [settingsLink:enable monitor access] for you.',
+        {
+          settingsLink: (
+            <Link
+              to={{
+                pathname: `/settings/${organization.slug}/`,
+                hash: 'alertsMemberWrite',
+              }}
+            />
+          ),
+        }
+      )
+    : t(
+        'This monitor is managed by Sentry. Only organization owners and managers can edit it.'
+      );
 
   return (
     <LinkButton

--- a/static/app/views/detectors/list/allMonitors.tsx
+++ b/static/app/views/detectors/list/allMonitors.tsx
@@ -19,7 +19,7 @@ export default function AllMonitors() {
   return (
     <SentryDocumentTitle title={TITLE}>
       <WorkflowEngineListLayout
-        actions={<DetectorListActions />}
+        actions={<DetectorListActions detectorType={null} />}
         title={TITLE}
         description={DESCRIPTION}
         docsUrl={DOCS_URL}

--- a/static/app/views/detectors/list/common/detectorListActions.tsx
+++ b/static/app/views/detectors/list/common/detectorListActions.tsx
@@ -1,20 +1,50 @@
+import {Link} from '@sentry/scraps/link';
+
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {IconAdd} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
+import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
+import {useCanCreateDetector} from 'sentry/views/detectors/utils/useCanCreateDetector';
 
 interface DetectorListActionsProps {
+  detectorType: DetectorType | null;
   children?: React.ReactNode;
-  /**
-   * Pass a detector type to skip type selection on the create monitor page
-   */
-  detectorType?: DetectorType;
+}
+
+function getPermissionTooltipText({
+  organization,
+  detectorType,
+}: {
+  detectorType: DetectorType | null;
+  organization: Organization;
+}) {
+  const noPermissionText = tct(
+    'You do not have permission to create monitors. Ask your organization owner or manager to [settingsLink:enable monitor access] for you.',
+    {
+      settingsLink: (
+        <Link
+          to={{
+            pathname: `/settings/${organization.slug}/`,
+            hash: 'alertsMemberWrite',
+          }}
+        />
+      ),
+    }
+  );
+
+  if (!detectorType || detectorTypeIsUserCreateable(detectorType)) {
+    return noPermissionText;
+  }
+
+  return t('This monitor type is managed by Sentry.');
 }
 
 export function DetectorListActions({detectorType, children}: DetectorListActionsProps) {
@@ -24,6 +54,7 @@ export function DetectorListActions({detectorType, children}: DetectorListAction
   const createPath = makeMonitorCreatePathname(organization.slug);
   const project = selection.projects.find(pid => pid !== ALL_ACCESS_PROJECTS);
   const createQuery = detectorType ? {project, detectorType} : {project};
+  const canCreateDetector = useCanCreateDetector(detectorType);
 
   return (
     <Flex gap="sm">
@@ -37,6 +68,15 @@ export function DetectorListActions({detectorType, children}: DetectorListAction
         priority="primary"
         icon={<IconAdd />}
         size="sm"
+        disabled={!canCreateDetector}
+        title={
+          canCreateDetector
+            ? undefined
+            : getPermissionTooltipText({
+                organization,
+                detectorType,
+              })
+        }
       >
         {t('Create Monitor')}
       </LinkButton>

--- a/static/app/views/detectors/list/myMonitors.tsx
+++ b/static/app/views/detectors/list/myMonitors.tsx
@@ -18,7 +18,7 @@ export default function MyMonitorsList() {
   return (
     <SentryDocumentTitle title={TITLE}>
       <WorkflowEngineListLayout
-        actions={<DetectorListActions />}
+        actions={<DetectorListActions detectorType={null} />}
         title={TITLE}
         description={DESCRIPTION}
         docsUrl={DOCS_URL}

--- a/static/app/views/detectors/utils/useCanCreateDetector.tsx
+++ b/static/app/views/detectors/utils/useCanCreateDetector.tsx
@@ -1,0 +1,15 @@
+import {hasEveryAccess} from 'sentry/components/acl/access';
+import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import {detectorTypeIsUserCreateable} from './detectorTypeConfig';
+
+export function useCanCreateDetector(detectorType: DetectorType | null) {
+  const organization = useOrganization();
+
+  if (!detectorType) {
+    return hasEveryAccess(['alerts:write'], {organization});
+  }
+
+  return detectorTypeIsUserCreateable(detectorType);
+}


### PR DESCRIPTION
Closes ID-1104

- Disable "create monitor" button on errors page
- Better tooltip text on error monitor details page

<img width="306" height="112" alt="CleanShot 2025-11-18 at 11 23 59" src="https://github.com/user-attachments/assets/f28b4fb2-3fd2-4ba9-bc76-e4823f31eab2" />

<img width="264" height="118" alt="CleanShot 2025-11-18 at 11 24 51" src="https://github.com/user-attachments/assets/5185180c-cd67-47a2-831b-ea868f5ef487" />
