### PR TITLE
fix(aci): Autosize description, remove padding

### DIFF
--- a/static/app/views/detectors/components/forms/common/describeSection.tsx
+++ b/static/app/views/detectors/components/forms/common/describeSection.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import TextareaField from 'sentry/components/forms/fields/textareaField';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import Section from 'sentry/components/workflowEngine/ui/section';
@@ -10,7 +12,7 @@ export function DescribeSection() {
         title={t('Description')}
         description={t('Additional context about this monitor for other team members.')}
       >
-        <TextareaField
+        <MinHeightTextarea
           name="description"
           stacked
           inline={false}
@@ -19,8 +21,17 @@ export function DescribeSection() {
             'Example monitor description\n\nTo debug follow these steps:\n1. \u2026\n2. \u2026\n3. \u2026'
           )}
           rows={6}
+          autosize
         />
       </Section>
     </Container>
   );
 }
+
+// Min height helps prevent resize after placeholder is replaced with user input
+const MinHeightTextarea = styled(TextareaField)`
+  padding: 0;
+  textarea {
+    min-height: 140px;
+  }
+`;


### PR DESCRIPTION
needed a min height to avoid shrinking after the first user input
fixes alignment on the right side