### PR TITLE
fix(cursor-agent): fix wrong link + make loading toast stay

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -334,7 +334,7 @@ function AutofixRootCauseDisplay({
     setPreferredAction('cursor_background_agent');
 
     // Show immediate loading toast
-    addLoadingMessage(t('Launching %s...', cursorIntegration.name));
+    addLoadingMessage(t('Launching %s...', cursorIntegration.name), {duration: 60000});
 
     launchCodingAgent({
       integrationId: cursorIntegration.id,

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -536,7 +536,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                       </Button>
                     ) : (
                       <LinkButton
-                        to="/settings/integrations/cursor/"
+                        href="/settings/integrations/cursor/"
                         size="sm"
                         priority="primary"
                       >


### PR DESCRIPTION
Link button takes `href` and we make the loading toast stay for up to 60 seconds or until it's replaced by the error or success toasts when launching an agent
