### PR TITLE
User removal analytics, new logging, email notifications

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -99,6 +99,7 @@ from .sso_enabled import *  # noqa: F401,F403
 from .suspectcommit_assignment import *  # noqa: F401,F403
 from .team_created import *  # noqa: F401,F403
 from .user_created import *  # noqa: F401,F403
+from .user_removed import *  # noqa: F401,F403
 from .user_signup import *  # noqa: F401,F403
 from .webhook_repository_created import *  # noqa: F401,F403
 from .weekly_report import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/user_removed.py
+++ b/src/sentry/analytics/events/user_removed.py
@@ -1,0 +1,12 @@
+from sentry import analytics
+
+
+@analytics.eventclass("user.removed")
+class UserRemovedEvent(analytics.Event):
+    user_id: int
+    actor_id: int | None = None
+    deletion_request_datetime: str | None = None
+    deletion_datetime: str | None = None
+
+
+analytics.register(UserRemovedEvent)

--- a/src/sentry/security/emails.py
+++ b/src/sentry/security/emails.py
@@ -48,6 +48,14 @@ def generate_security_email(
     elif type == "org-auth-token-created":
         template = "sentry/emails/org-auth-token-created.txt"
         html_template = "sentry/emails/org-auth-token-created.html"
+    elif type == "user.removed":
+        subject = "Your Sentry account has been deleted"
+        template = "sentry/emails/user-deleted.txt"
+        html_template = "sentry/emails/user-deleted.html"
+    elif type == "user.deactivated":
+        subject = "Your Sentry account has been deactivated"
+        template = "sentry/emails/user-deactivated.txt"
+        html_template = "sentry/emails/user-deactivated.html"
     else:
         raise ValueError(f"unknown type: {type}")
 

--- a/src/sentry/templates/sentry/emails/user-deactivated.html
+++ b/src/sentry/templates/sentry/emails/user-deactivated.html
@@ -1,0 +1,29 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+{% load sentry_avatars %}
+{% load sentry_helpers %}
+
+{% block main %}
+  <h3>Account Deactivated</h3>
+  <p>Your Sentry account has been deactivated and is scheduled for permanent deletion.</p>
+  <table>
+    <tr>
+      <td style="width:36px;vertical-align:top;padding-right:15px;">
+        {% avatar_for_email account 36 %}
+      </td>
+      <td>
+        <strong>{{ account.email }}</strong><br />
+        {{ ip_address }}<br />
+        <strong>Deactivated:</strong> {{ deactivation_datetime }} UTC<br />
+        <strong>Scheduled Deletion:</strong> {{ scheduled_deletion_datetime }} UTC
+      </td>
+    </tr>
+  </table>
+  <p>You have until <strong>{{ scheduled_deletion_datetime }} UTC</strong> to reactivate your account. After this time, your account and all associated data will be permanently deleted.</p>
+  <p>To reactivate your account, please log in before the scheduled deletion date.</p>
+  <h4>Don't recognize this activity?</h4>
+  <p>If you didn't trigger this action, we recommend you immediately log in to reactivate your account and review your account security. If you determine that this activity is malicious please contact <a href="mailto:{% security_contact %}">{% security_contact %}</a>.</p>
+{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/src/sentry/templates/sentry/emails/user-deactivated.txt
+++ b/src/sentry/templates/sentry/emails/user-deactivated.txt
@@ -1,0 +1,25 @@
+{% spaceless %}
+{% load sentry_helpers %}
+{% autoescape off %}
+Account Deactivated
+-------------------
+Your Sentry account has been deactivated and is scheduled for permanent deletion.
+
+Details
+-------
+
+Account: {{ account.email }}
+IP: {{ ip_address }}
+Deactivated: {{ deactivation_datetime }} UTC
+Scheduled Deletion: {{ scheduled_deletion_datetime }} UTC
+
+You have until {{ scheduled_deletion_datetime }} UTC to reactivate your account. After this time, your account and all associated data will be permanently deleted.
+
+To reactivate your account, please log in before the scheduled deletion date.
+
+Don't recognize this activity?
+------------------------------
+
+If you didn't trigger this action, we recommend you immediately log in to reactivate your account and review your account security. If you determine that this activity is malicious please contact {% security_contact %}.
+{% endautoescape %}
+{% endspaceless %}

--- a/src/sentry/templates/sentry/emails/user-deleted.html
+++ b/src/sentry/templates/sentry/emails/user-deleted.html
@@ -1,0 +1,16 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+{% load sentry_helpers %}
+
+{% block main %}
+  <h3>Account Deleted</h3>
+  <p>Your Sentry account has been permanently deleted by an administrator.</p>
+  <p>
+    <strong>Account:</strong> {{ account.email }}<br />
+    <strong>When:</strong> {{ deletion_datetime }} UTC
+  </p>
+  <p>If you have questions about this action, please contact <a href="mailto:{% security_contact %}">{% security_contact %}</a>.</p>
+{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/src/sentry/templates/sentry/emails/user-deleted.txt
+++ b/src/sentry/templates/sentry/emails/user-deleted.txt
@@ -1,0 +1,16 @@
+{% spaceless %}
+{% load sentry_helpers %}
+{% autoescape off %}
+Account Deleted
+---------------
+Your Sentry account has been permanently deleted by an administrator.
+
+Details
+-------
+
+Account: {{ account.email }}
+When: {{ deletion_datetime }} UTC
+
+If you have questions about this action, please contact {% security_contact %}.
+{% endautoescape %}
+{% endspaceless %}

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -66,8 +66,8 @@ def record_user_deactivation(*, user: User, actor: Any, ip_address: str) -> None
         actor=actor,
         ip_address=ip_address,
         context={
-            "deactivation_datetime": deactivation_datetime.isoformat(),
-            "scheduled_deletion_datetime": scheduled_deletion_datetime.isoformat(),
+            "deactivation_datetime": deactivation_datetime,
+            "scheduled_deletion_datetime": scheduled_deletion_datetime,
         },
         send_email=True,
         current_datetime=deactivation_datetime,
@@ -100,7 +100,7 @@ def record_hard_user_deletion(
         type="user.removed",
         actor=actor,
         ip_address=ip_address,
-        context={"deletion_datetime": deletion_datetime.isoformat()},
+        context={"deletion_datetime": deletion_datetime},
         send_email=True,
         current_datetime=deletion_datetime,
     )

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 from django.conf import settings
 from django.contrib.auth import logout
@@ -46,16 +46,15 @@ TIMEZONE_CHOICES = get_timezone_choices()
 
 def record_user_deletion(
     *,
-    actor: User,
+    actor: Any,
     ip_address: str,
     hard_delete: bool,
     user: User | None = None,
     user_id: int | None = None,
     user_email: str | None = None,
 ) -> None:
+    account: User | Any
     if hard_delete:
-        # Since we record the deletion after a hard_delete, we have no user object left
-        # and need to construct an account object containing the user attributes
         assert user_id is not None and user_email is not None
         account = SimpleNamespace(id=user_id, email=user_email)
     else:
@@ -88,12 +87,12 @@ def record_user_deletion(
         }
 
     capture_security_activity(
-        account=account,
+        account=cast(Any, account),
         type="user.removed" if hard_delete else "user.deactivated",
         actor=actor,
         ip_address=ip_address,
         context=context,
-        send_email=False,
+        send_email=True,
         current_datetime=deletion_request_datetime,
     )
 

--- a/tests/sentry/users/api/endpoints/test_user_details_analytics.py
+++ b/tests/sentry/users/api/endpoints/test_user_details_analytics.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from django.utils import timezone as django_timezone
@@ -40,10 +40,10 @@ class UserDetailsDeleteAnalyticsTest(APITestCase):
         assert call_args.user_id == self.user.id
         assert call_args.actor_id == self.staff_user.id
 
-        deletion_request = django_timezone.datetime.fromisoformat(
-            call_args.deletion_request_datetime
-        )
-        deletion_scheduled = django_timezone.datetime.fromisoformat(call_args.deletion_datetime)
+        assert call_args.deletion_request_datetime is not None
+        assert call_args.deletion_datetime is not None
+        deletion_request = datetime.fromisoformat(call_args.deletion_request_datetime)
+        deletion_scheduled = datetime.fromisoformat(call_args.deletion_datetime)
         assert deletion_request >= before_delete
         assert deletion_scheduled >= deletion_request + timedelta(days=29)
         assert deletion_scheduled <= deletion_request + timedelta(days=31)
@@ -53,7 +53,7 @@ class UserDetailsDeleteAnalyticsTest(APITestCase):
         assert security_call[1]["type"] == "user.deactivated"
         assert security_call[1]["account"] == user
         assert security_call[1]["actor"].id == self.staff_user.id
-        assert security_call[1]["send_email"] is False
+        assert security_call[1]["send_email"] is True
         assert "deactivation_datetime" in security_call[1]["context"]
         assert "scheduled_deletion_datetime" in security_call[1]["context"]
 
@@ -78,10 +78,10 @@ class UserDetailsDeleteAnalyticsTest(APITestCase):
         assert call_args.user_id == user_id
         assert call_args.actor_id == self.staff_user.id
 
-        deletion_request = django_timezone.datetime.fromisoformat(
-            call_args.deletion_request_datetime
-        )
-        deletion_time = django_timezone.datetime.fromisoformat(call_args.deletion_datetime)
+        assert call_args.deletion_request_datetime is not None
+        assert call_args.deletion_datetime is not None
+        deletion_request = datetime.fromisoformat(call_args.deletion_request_datetime)
+        deletion_time = datetime.fromisoformat(call_args.deletion_datetime)
         assert deletion_request >= before_delete
         assert deletion_time == deletion_request
 
@@ -91,7 +91,7 @@ class UserDetailsDeleteAnalyticsTest(APITestCase):
         assert security_call[1]["account"].id == user_id
         assert security_call[1]["account"].email == user_email
         assert security_call[1]["actor"].id == self.staff_user.id
-        assert security_call[1]["send_email"] is False
+        assert security_call[1]["send_email"] is True
         assert "deletion_datetime" in security_call[1]["context"]
         assert "scheduled_deletion_datetime" not in security_call[1]["context"]
 
@@ -109,10 +109,10 @@ class UserDetailsDeleteAnalyticsTest(APITestCase):
         self.get_success_response(self.user.id, organizations=[], status_code=204)
 
         call_args = mock_analytics.call_args[0][0]
-        deletion_request = django_timezone.datetime.fromisoformat(
-            call_args.deletion_request_datetime
-        )
-        deletion_scheduled = django_timezone.datetime.fromisoformat(call_args.deletion_datetime)
+        assert call_args.deletion_request_datetime is not None
+        assert call_args.deletion_datetime is not None
+        deletion_request = datetime.fromisoformat(call_args.deletion_request_datetime)
+        deletion_scheduled = datetime.fromisoformat(call_args.deletion_datetime)
 
         delta = deletion_scheduled - deletion_request
         assert delta >= timedelta(days=29, hours=23, minutes=59)

--- a/tests/sentry/users/api/endpoints/test_user_details_analytics.py
+++ b/tests/sentry/users/api/endpoints/test_user_details_analytics.py
@@ -1,0 +1,119 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.utils import timezone as django_timezone
+
+from sentry.analytics.events.user_removed import UserRemovedEvent
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.silo import control_silo_test
+from sentry.users.models.user import User
+from sentry.users.models.userpermission import UserPermission
+
+
+@control_silo_test
+class UserDetailsDeleteAnalyticsTest(APITestCase):
+    endpoint = "sentry-api-0-user-details"
+    method = "delete"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user(email="test@example.com")
+        self.staff_user = self.create_user(email="staff@example.com", is_staff=True)
+        self.login_as(self.staff_user, staff=True)
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.users.api.endpoints.user_details.capture_security_activity")
+    def test_soft_delete_records_analytics_and_security(
+        self, mock_security_activity, mock_analytics
+    ):
+        before_delete = django_timezone.now()
+
+        self.get_success_response(self.user.id, organizations=[], status_code=204)
+
+        user = User.objects.get(id=self.user.id)
+        assert not user.is_active
+
+        assert mock_analytics.called
+        call_args = mock_analytics.call_args[0][0]
+        assert isinstance(call_args, UserRemovedEvent)
+        assert call_args.user_id == self.user.id
+        assert call_args.actor_id == self.staff_user.id
+
+        deletion_request = django_timezone.datetime.fromisoformat(
+            call_args.deletion_request_datetime
+        )
+        deletion_scheduled = django_timezone.datetime.fromisoformat(call_args.deletion_datetime)
+        assert deletion_request >= before_delete
+        assert deletion_scheduled >= deletion_request + timedelta(days=29)
+        assert deletion_scheduled <= deletion_request + timedelta(days=31)
+
+        assert mock_security_activity.called
+        security_call = mock_security_activity.call_args
+        assert security_call[1]["type"] == "user.deactivated"
+        assert security_call[1]["account"] == user
+        assert security_call[1]["actor"].id == self.staff_user.id
+        assert security_call[1]["send_email"] is False
+        assert "deactivation_datetime" in security_call[1]["context"]
+        assert "scheduled_deletion_datetime" in security_call[1]["context"]
+
+    @override_options({"staff.ga-rollout": True})
+    @patch("sentry.analytics.record")
+    @patch("sentry.users.api.endpoints.user_details.capture_security_activity")
+    def test_hard_delete_records_analytics_and_security(
+        self, mock_security_activity, mock_analytics
+    ):
+        UserPermission.objects.create(user=self.staff_user, permission="users.admin")
+        user_id = self.user.id
+        user_email = self.user.email
+        before_delete = django_timezone.now()
+
+        self.get_success_response(self.user.id, organizations=[], hardDelete=True, status_code=204)
+
+        assert not User.objects.filter(id=user_id).exists()
+
+        assert mock_analytics.called
+        call_args = mock_analytics.call_args[0][0]
+        assert isinstance(call_args, UserRemovedEvent)
+        assert call_args.user_id == user_id
+        assert call_args.actor_id == self.staff_user.id
+
+        deletion_request = django_timezone.datetime.fromisoformat(
+            call_args.deletion_request_datetime
+        )
+        deletion_time = django_timezone.datetime.fromisoformat(call_args.deletion_datetime)
+        assert deletion_request >= before_delete
+        assert deletion_time == deletion_request
+
+        assert mock_security_activity.called
+        security_call = mock_security_activity.call_args
+        assert security_call[1]["type"] == "user.removed"
+        assert security_call[1]["account"].id == user_id
+        assert security_call[1]["account"].email == user_email
+        assert security_call[1]["actor"].id == self.staff_user.id
+        assert security_call[1]["send_email"] is False
+        assert "deletion_datetime" in security_call[1]["context"]
+        assert "scheduled_deletion_datetime" not in security_call[1]["context"]
+
+    @override_options({"staff.ga-rollout": True})
+    @patch("sentry.analytics.record")
+    def test_hard_delete_timestamps_match(self, mock_analytics):
+        UserPermission.objects.create(user=self.staff_user, permission="users.admin")
+        self.get_success_response(self.user.id, organizations=[], hardDelete=True, status_code=204)
+
+        call_args = mock_analytics.call_args[0][0]
+        assert call_args.deletion_request_datetime == call_args.deletion_datetime
+
+    @patch("sentry.analytics.record")
+    def test_soft_delete_timestamps_differ_by_30_days(self, mock_analytics):
+        self.get_success_response(self.user.id, organizations=[], status_code=204)
+
+        call_args = mock_analytics.call_args[0][0]
+        deletion_request = django_timezone.datetime.fromisoformat(
+            call_args.deletion_request_datetime
+        )
+        deletion_scheduled = django_timezone.datetime.fromisoformat(call_args.deletion_datetime)
+
+        delta = deletion_scheduled - deletion_request
+        assert delta >= timedelta(days=29, hours=23, minutes=59)
+        assert delta <= timedelta(days=30, hours=0, minutes=1)


### PR DESCRIPTION
- Similar to what we added with organization removal analytics in https://github.com/getsentry/sentry/pull/97672, including the same for user removal analytics. 
- Changing the way we log user removals. Adding in `capture_security_activity()` to log these events in `sentry.security` and will remove the `sentry.deletions.api` logging in 30 days. 
- Added end user email notifications for both hardDelete and pending user deletions to improve deletion experience.