### PR TITLE
feat(dashboards): query dashboards by prebuilt id in api

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -237,9 +237,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
         query = request.GET.get("query")
         prebuilt_ids = request.GET.getlist("prebuiltId")
-        if query:
-            dashboards = dashboards.filter(title__icontains=query)
-        if (
+        should_filter_by_prebuilt_ids = (
             prebuilt_ids
             and len(prebuilt_ids) > 0
             and features.has(
@@ -247,7 +245,10 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 organization,
                 actor=request.user,
             )
-        ):
+        )
+        if query:
+            dashboards = dashboards.filter(title__icontains=query)
+        if should_filter_by_prebuilt_ids:
             dashboards = dashboards.filter(prebuilt_id__in=prebuilt_ids)
 
         prebuilt = Dashboard.get_prebuilt_list(organization, request.user, query)
@@ -396,7 +397,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             return serialized
 
         render_pre_built_dashboard = True
-        if filter_by and filter_by in {"onlyFavorites", "owned"}:
+        if filter_by and filter_by in {"onlyFavorites", "owned"} or should_filter_by_prebuilt_ids:
             render_pre_built_dashboard = False
         elif pin_by and pin_by == "favorites":
             # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -237,15 +237,17 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
         query = request.GET.get("query")
         prebuilt_ids = request.GET.getlist("prebuiltId")
+
         should_filter_by_prebuilt_ids = (
-            prebuilt_ids
-            and len(prebuilt_ids) > 0
-            and features.has(
+            features.has(
                 "organizations:dashboards-prebuilt-insights-dashboards",
                 organization,
                 actor=request.user,
             )
+            and prebuilt_ids
+            and len(prebuilt_ids) > 0
         )
+
         if query:
             dashboards = dashboards.filter(title__icontains=query)
         if should_filter_by_prebuilt_ids:

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -236,8 +236,20 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             dashboards = Dashboard.objects.filter(organization_id=organization.id)
 
         query = request.GET.get("query")
+        prebuilt_ids = request.GET.getlist("prebuiltId")
         if query:
             dashboards = dashboards.filter(title__icontains=query)
+        if (
+            prebuilt_ids
+            and len(prebuilt_ids) > 0
+            and features.has(
+                "organizations:dashboards-prebuilt-insights-dashboards",
+                organization,
+                actor=request.user,
+            )
+        ):
+            dashboards = dashboards.filter(prebuilt_id__in=prebuilt_ids)
+
         prebuilt = Dashboard.get_prebuilt_list(organization, request.user, query)
 
         sort_by = request.query_params.get("sort")

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -6,7 +6,10 @@ from unittest.mock import patch
 
 from django.urls import reverse
 
-from sentry.dashboards.endpoints.organization_dashboards import PREBUILT_DASHBOARDS
+from sentry.dashboards.endpoints.organization_dashboards import (
+    PREBUILT_DASHBOARDS,
+    PrebuiltDashboardId,
+)
 from sentry.models.dashboard import (
     Dashboard,
     DashboardFavoriteUser,
@@ -1991,3 +1994,12 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             organization=self.organization, prebuilt_id__isnull=False
         ).count()
         assert prebuilt_count == 0
+
+    def test_get_with_prebuilt_ids(self) -> None:
+        with self.feature("organizations:dashboards-prebuilt-insights-dashboards"):
+            response = self.do_request(
+                "get", self.url, {"prebuiltId": [PrebuiltDashboardId.FRONTEND_SESSION_HEALTH]}
+            )
+            assert response.status_code == 200
+            assert len(response.data) == 1
+            assert response.data[0]["prebuiltId"] == PrebuiltDashboardId.FRONTEND_SESSION_HEALTH


### PR DESCRIPTION
Allows us to query for dashboards by `prebuilt_id`