### PR TITLE
fix(detectors): Navigate to detector type list page after deletion

### DIFF
--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -13,8 +13,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
 import {useDeleteDetectorMutation} from 'sentry/views/detectors/hooks/useDeleteDetectorMutation';
 import {
-  makeMonitorBasePathname,
   makeMonitorDetailsPathname,
+  makeMonitorTypePathname,
 } from 'sentry/views/detectors/pathnames';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
@@ -106,10 +106,10 @@ export function DeleteDetectorAction({detector}: {detector: Detector}) {
       priority: 'danger',
       onConfirm: async () => {
         await deleteDetector(detector.id);
-        navigate(makeMonitorBasePathname(organization.slug));
+        navigate(makeMonitorTypePathname(organization.slug, detector.type));
       },
     });
-  }, [deleteDetector, detector.id, navigate, organization.slug]);
+  }, [deleteDetector, detector.id, detector.type, navigate, organization.slug]);
 
   const canEdit = useCanEditDetector({
     detectorType: detector.type,

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -142,9 +142,9 @@ describe('DetectorEdit', () => {
         expect.anything()
       );
 
-      // Redirect to the monitors list
+      // Redirect to the detector type-specific list page (metrics for MetricDetectorFixture)
       expect(router.location.pathname).toBe(
-        `/organizations/${organization.slug}/monitors/`
+        `/organizations/${organization.slug}/monitors/metrics/`
       );
     });
 


### PR DESCRIPTION
When deleting a monitor, navigate to the detector type-specific list
page (e.g., /monitors/crons/, /monitors/uptime/, /monitors/metrics/)
instead of the base monitors page. This provides a predictable
navigation experience that takes users back to the relevant monitor
type they were working with.

Fixes [ID-1106: Deleting a monitor should return to previous list page](https://linear.app/getsentry/issue/ID-1106/deleting-a-monitor-should-return-to-previous-list-page)