### PR TITLE
feat(assisted-query): add filter key/value rpcs for querying error events

### DIFF
--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -56,7 +56,7 @@ _SPECIAL_FIELD_VALUE_TYPES = {
     "timestamp.to_day": "datetime",
     "message": "text",
     "title": "text",
-    # Boolean fields - non-exhaustive
+    # Boolean values - non-exhaustive
     "error.handled": "boolean",
     "error.unhandled": "boolean",
     "error.main_thread": "boolean",

--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -42,7 +42,7 @@ _ALWAYS_RETURN_EVENT_FIELDS = frozenset(
         "trace",
         "trace.span",  # Root span ID
         "trace.parent_span",  # Parent span ID
-        "project",
+        "project",  # Project slug
         "issue",  # Issue short ID
         "has",
     }

--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -3,6 +3,7 @@ import re
 from typing import Any
 
 from sentry.api import client
+from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
@@ -200,7 +201,7 @@ def _get_predefined_field_values(key: str) -> list[dict[str, Any]] | None:
 def get_event_filter_keys(
     *,
     org_id: int,
-    project_ids: list[int],
+    project_ids: list[int] | None = None,
     stats_period: str = "7d",
 ) -> dict[str, list[str]] | None:
     """
@@ -212,6 +213,10 @@ def get_event_filter_keys(
     except Organization.DoesNotExist:
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
+
+    # Treat empty projects as a query for all projects.
+    if not project_ids:
+        project_ids = [ALL_ACCESS_PROJECT_ID]
 
     static_fields = _get_static_fields()
     tag_keys, flag_keys = _get_tag_and_feature_flag_keys(
@@ -233,10 +238,10 @@ def get_event_filter_keys(
 def get_event_filter_key_values(
     *,
     org_id,
-    project_ids: list[int],
     filter_key: str,
     is_feature_flag: bool,
     substring: str | None = None,
+    project_ids: list[int] | None = None,
     stats_period: str = "7d",
 ) -> list[dict[str, Any]] | None:
     """
@@ -269,6 +274,10 @@ def get_event_filter_key_values(
     except Organization.DoesNotExist:
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
+
+    # Treat empty projects as a query for all projects.
+    if not project_ids:
+        project_ids = [ALL_ACCESS_PROJECT_ID]
 
     predefined_values = _get_predefined_field_values(filter_key)
     if predefined_values is not None:

--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -274,8 +274,9 @@ def get_event_filter_key_values(
         params={**base_params, "dataset": Dataset.Events.value},
     )
 
+    # Try ff query. In the case of collisions we use tag values as we deem them more important.
+    # TODO: Pass in an explicit is_feature_flag param if the agent can produce it.
     if not resp.data:
-        # Try feature flags query
         resp = client.get(
             auth=api_key,
             user=None,

--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -12,59 +12,25 @@ from sentry.snuba.referrer import Referrer
 logger = logging.getLogger(__name__)
 
 
-def _get_static_fields() -> set[str]:
-    static_fields_without_txn_fields = {
+# Filter keys we think are useful to *always* return to the query agent.
+# Some of these are custom tags while others translate to a different field on the event payload.
+_ALWAYS_RETURN_EVENT_FIELDS = frozenset(
+    {
         "id",
         "timestamp",
         "timestamp.to_hour",
         "timestamp.to_day",
-        "culprit",
-        "location",
         "message",
-        "platform",
-        "platform.name",
-        "environment",
-        "release",
-        "dist",
         "title",
+        "level",
+        "environment",
+        "dist",
+        "release",
+        "release.version",
+        "release.build",
+        "release.package",
+        "release.stage",
         "event.type",
-        "transaction",
-        "unreal.crash_type",
-        "user",
-        "user.id",
-        "user.email",
-        "user.username",
-        "user.ip",
-        "sdk.name",
-        "sdk.version",
-        "http.method",
-        "http.referer",
-        "http.status_code",
-        "http.url",
-        "os.build",
-        "os.kernel_version",
-        "os.distribution_name",
-        "os.distribution_version",
-        "device.name",
-        "device.brand",
-        "device.locale",
-        "device.uuid",
-        "device.arch",
-        "device.family",
-        "device.battery_level",
-        "device.orientation",
-        "device.screen_density",
-        "device.screen_dpi",
-        "device.screen_height_pixels",
-        "device.screen_width_pixels",
-        "device.simulator",
-        "device.online",
-        "device.charging",
-        "device.class",
-        "geo.country_code",
-        "geo.region",
-        "geo.city",
-        "geo.subdivision",
         "error.type",
         "error.value",
         "error.mechanism",
@@ -72,43 +38,23 @@ def _get_static_fields() -> set[str]:
         "error.unhandled",
         "error.received",
         "error.main_thread",
-        "level",
-        "stack.abs_path",
-        "stack.filename",
-        "stack.package",
-        "stack.module",
-        "stack.function",
-        "stack.in_app",
-        "stack.colno",
-        "stack.lineno",
-        "stack.stack_level",
-        "symbolicated_in_app",
-        "app.in_foreground",
+        "transaction",
         "trace",
-        "trace.span",
-        "trace.parent_span",
-        "trace.client_sample_rate",
-        "total.count",
+        "trace.span",  # Root span ID
+        "trace.parent_span",  # Parent span ID
         "project",
-        "issue",
-        "user.display",
-        "ota_updates.channel",
-        "ota_updates.runtime_version",
-        "ota_updates.update_id",
+        "issue",  # Issue short ID
         "has",
     }
-
-    semver_tags = {
-        "release.version",
-        "release.build",
-        "release.package",
-        "release.stage",
-    }
-
-    return static_fields_without_txn_fields | semver_tags
+)
 
 
 def _is_agg_function(key: str) -> bool:
+    """
+    Check if a key is an aggregate function (e.g., count(), avg(duration), p95(transaction.duration)).
+
+    Aggregate functions follow the pattern: `function_name(optional_args)`.
+    """
     match = re.match(r"^(\w+)\((.*?)?\)$", key)
     return bool(match and len(match.groups()) == 2)
 
@@ -116,14 +62,6 @@ def _is_agg_function(key: str) -> bool:
 def _get_tag_and_feature_flag_keys(
     org_id: int, org_slug: str, project_ids: list[int], stats_period: str
 ) -> tuple[set[str], set[str]]:
-    """
-      const filteredTags = useMemo(() => {
-      return omitTags && omitTags.length > 0
-        ? omit(tags, omitTags, EXCLUDED_FILTER_KEYS)
-        : omit(tags, EXCLUDED_FILTER_KEYS);
-    }, [tags, omitTags]);
-    """
-
     api_key = ApiKey(organization_id=org_id, scope_list=["org:read", "project:read", "event:read"])
 
     base_params: dict[str, Any] = {
@@ -133,7 +71,7 @@ def _get_tag_and_feature_flag_keys(
         "useCache": "1",
     }
 
-    # Get event tags
+    # Get custom tags
     event_params = {**base_params, "dataset": Dataset.Events.value}
     event_resp = client.get(
         auth=api_key,
@@ -144,7 +82,7 @@ def _get_tag_and_feature_flag_keys(
     event_tags = event_resp.data or []
     event_tag_keys = {t["key"] for t in event_tags}
 
-    # Discard explicitly excluded tags by discover search bar.
+    # Discard tags that are explicitly excluded by the discover search bar.
     event_tag_keys.discard("total.count")
 
     # Get feature flags
@@ -165,36 +103,29 @@ def _get_tag_and_feature_flag_keys(
     return event_tag_keys, flag_keys
 
 
-def _get_predefined_field_values(key: str) -> list[dict[str, Any]] | None:
-    """Returns None if the key does not have predefined values."""
-    if key.startswith("measurements.") or key == "device.class" or _is_agg_function(key):
+def _get_static_values(key: str) -> list[dict[str, Any]] | None:
+    """
+    Get values for keys with a static set of values. Returns None if the key's
+    values are dynamic and should be queried.
+    """
+    if (
+        key == "id"
+        or key == "timestamp"
+        or key.startswith("timestamp.")
+        or key.startswith("measurements.")
+        or key == "device.class"
+        or _is_agg_function(key)
+    ):
         return []
 
-    # Boolean fields
+    # Boolean always-return fields
     if key in [
         "error.handled",
         "error.unhandled",
         "error.main_thread",
-        "stack.in_app",
-        "symbolicated_in_app",
-        "app.in_foreground",
-        "device.charging",
-        "device.online",
-        "device.simulator",
     ]:
         return [{"value": "true"}, {"value": "false"}]
 
-    # For datetime fields, only return suggestions for `-${stats_period_format}`, e.g. `-1h`, `-14d`
-    # which mean "after 1h ago" and "after 14 days ago" respectively.
-    # We defer to the query agent for more complex datetime queries with ISO timestamps.
-    if key in [
-        "timestamp",
-        "timestamp.to_hour",
-        "timestamp.to_day",
-    ]:
-        return [{"value": f"-{period}"} for period in ["1h", "24h", "7d", "14d", "30d"]]
-
-    # Look up as a tag or feature flag.
     return None
 
 
@@ -218,7 +149,7 @@ def get_event_filter_keys(
     if not project_ids:
         project_ids = [ALL_ACCESS_PROJECT_ID]
 
-    static_fields = _get_static_fields()
+    static_fields = {*_ALWAYS_RETURN_EVENT_FIELDS}
     tag_keys, flag_keys = _get_tag_and_feature_flag_keys(
         organization.id, organization.slug, project_ids, stats_period
     )
@@ -279,7 +210,7 @@ def get_event_filter_key_values(
     if not project_ids:
         project_ids = [ALL_ACCESS_PROJECT_ID]
 
-    predefined_values = _get_predefined_field_values(filter_key)
+    predefined_values = _get_static_values(filter_key)
     if predefined_values is not None:
         return predefined_values
 

--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -1,0 +1,316 @@
+import logging
+import re
+from typing import Any
+
+from sentry.api import client
+from sentry.models.apikey import ApiKey
+from sentry.models.organization import Organization
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.referrer import Referrer
+
+logger = logging.getLogger(__name__)
+
+
+def _get_static_fields() -> set[str]:
+    static_fields_without_txn_fields = {
+        "id",
+        "timestamp",
+        "timestamp.to_hour",
+        "timestamp.to_day",
+        "culprit",
+        "location",
+        "message",
+        "platform",
+        "platform.name",
+        "environment",
+        "release",
+        "dist",
+        "title",
+        "event.type",
+        "transaction",
+        "unreal.crash_type",
+        "user",
+        "user.id",
+        "user.email",
+        "user.username",
+        "user.ip",
+        "sdk.name",
+        "sdk.version",
+        "http.method",
+        "http.referer",
+        "http.status_code",
+        "http.url",
+        "os.build",
+        "os.kernel_version",
+        "os.distribution_name",
+        "os.distribution_version",
+        "device.name",
+        "device.brand",
+        "device.locale",
+        "device.uuid",
+        "device.arch",
+        "device.family",
+        "device.battery_level",
+        "device.orientation",
+        "device.screen_density",
+        "device.screen_dpi",
+        "device.screen_height_pixels",
+        "device.screen_width_pixels",
+        "device.simulator",
+        "device.online",
+        "device.charging",
+        "device.class",
+        "geo.country_code",
+        "geo.region",
+        "geo.city",
+        "geo.subdivision",
+        "error.type",
+        "error.value",
+        "error.mechanism",
+        "error.handled",
+        "error.unhandled",
+        "error.received",
+        "error.main_thread",
+        "level",
+        "stack.abs_path",
+        "stack.filename",
+        "stack.package",
+        "stack.module",
+        "stack.function",
+        "stack.in_app",
+        "stack.colno",
+        "stack.lineno",
+        "stack.stack_level",
+        "symbolicated_in_app",
+        "app.in_foreground",
+        "trace",
+        "trace.span",
+        "trace.parent_span",
+        "trace.client_sample_rate",
+        "total.count",
+        "project",
+        "issue",
+        "user.display",
+        "ota_updates.channel",
+        "ota_updates.runtime_version",
+        "ota_updates.update_id",
+        "has",
+    }
+
+    semver_tags = {
+        "release.version",
+        "release.build",
+        "release.package",
+        "release.stage",
+    }
+
+    return static_fields_without_txn_fields | semver_tags
+
+
+def _is_agg_function(key: str) -> bool:
+    match = re.match(r"^(\w+)\((.*?)?\)$", key)
+    return bool(match and len(match.groups()) == 2)
+
+
+def _get_tag_and_feature_flag_keys(
+    org_id: int, org_slug: str, project_ids: list[int], stats_period: str
+) -> tuple[set[str], set[str]]:
+    """
+      const filteredTags = useMemo(() => {
+      return omitTags && omitTags.length > 0
+        ? omit(tags, omitTags, EXCLUDED_FILTER_KEYS)
+        : omit(tags, EXCLUDED_FILTER_KEYS);
+    }, [tags, omitTags]);
+    """
+
+    api_key = ApiKey(organization_id=org_id, scope_list=["org:read", "project:read", "event:read"])
+
+    base_params: dict[str, Any] = {
+        "statsPeriod": stats_period,
+        "project": project_ids,
+        "referrer": Referrer.SEER_RPC,
+        "useCache": "1",
+    }
+
+    # Get event tags
+    event_params = {**base_params, "dataset": Dataset.Events.value}
+    event_resp = client.get(
+        auth=api_key,
+        user=None,
+        path=f"/organizations/{org_slug}/tags/",
+        params=event_params,
+    )
+    event_tags = event_resp.data or []
+    event_tag_keys = {t["key"] for t in event_tags}
+
+    # Discard explicitly excluded tags by discover search bar.
+    event_tag_keys.discard("total.count")
+
+    # Get feature flags
+    flags_params = {
+        **base_params,
+        "dataset": Dataset.Events.value,
+        "useFlagsBackend": "1",
+    }
+    flags_resp = client.get(
+        auth=api_key,
+        user=None,
+        path=f"/organizations/{org_slug}/tags/",
+        params=flags_params,
+    )
+    flags = flags_resp.data or []
+    flag_keys = {t["key"] for t in flags}
+
+    return event_tag_keys, flag_keys
+
+
+def _get_predefined_field_values(key: str) -> list[dict[str, Any]] | None:
+    """Returns None if the key does not have predefined values."""
+    if key.startswith("measurements.") or key == "device.class" or _is_agg_function(key):
+        return []
+
+    # Boolean fields
+    if key in [
+        "error.handled",
+        "error.unhandled",
+        "error.main_thread",
+        "stack.in_app",
+        "symbolicated_in_app",
+        "app.in_foreground",
+        "device.charging",
+        "device.online",
+        "device.simulator",
+    ]:
+        return [{"value": "true"}, {"value": "false"}]
+
+    # For datetime fields, only return suggestions for `-${stats_period_format}`, e.g. `-1h`, `-14d`
+    # which mean "after 1h ago" and "after 14 days ago" respectively.
+    # We defer to the query agent for more complex datetime queries with ISO timestamps.
+    if key in [
+        "timestamp",
+        "timestamp.to_hour",
+        "timestamp.to_day",
+    ]:
+        return [{"value": f"-{period}"} for period in ["1h", "24h", "7d", "14d", "30d"]]
+
+    # Look up as a tag or feature flag.
+    return None
+
+
+def get_event_filter_keys(
+    *,
+    org_id: int,
+    project_ids: list[int],
+    stats_period: str = "7d",
+) -> dict[str, list[str]] | None:
+    """
+    Get available event filter keys for the "errors" dataset (tags, feature flags, and static fields).
+    This mirrors the behavior of Discover search bar suggestions in the frontend.
+    """
+    try:
+        organization = Organization.objects.get(id=org_id)
+    except Organization.DoesNotExist:
+        logger.warning("Organization not found", extra={"org_id": org_id})
+        return None
+
+    static_fields = _get_static_fields()
+    tag_keys, flag_keys = _get_tag_and_feature_flag_keys(
+        organization.id, organization.slug, project_ids, stats_period
+    )
+
+    # Return duplicated keys as tags. They could be returned as static_fields
+    # too, since we don't treat these differently when fetching values. We just
+    # want to keep the sets disjoint.
+    static_fields -= tag_keys
+
+    return {
+        "tags": list(tag_keys),
+        "feature_flags": list(flag_keys),
+        "static_fields": list(static_fields),
+    }
+
+
+def get_event_filter_key_values(
+    *,
+    org_id,
+    project_ids: list[int],
+    filter_key: str,
+    is_feature_flag: bool,
+    substring: str | None = None,
+    stats_period: str = "7d",
+) -> list[dict[str, Any]] | None:
+    """
+    Get values for a specific filter key.
+
+    - `has` key returns all available tag keys.
+    - `device.class`, `measurements.*` and aggregate functions are not supported (return empty list)..
+    - Boolean and datetime fields return hard-coded suggestions, e.g. `error.handled`, `timestamp`.
+    - For feature flags, queries the events dataset with `useFlagsBackend=1`.
+    - All other keys are queried as regular tags in the events dataset.
+
+    Args:
+        org_id: Organization ID
+        project_ids: List of project IDs to query
+        filter_key: The filter key to get values for
+        is_feature_flag: Whether the filter key is a feature flag
+        substring: Optional substring to filter values. Only values containing this substring will be returned
+        stats_period: Time period for the query (e.g., "24h", "7d", "14d"). Defaults to "7d"
+
+    Returns:
+        List of dicts containing:
+        - value: The actual value
+        - count: Number of occurrences (excluded for `has` key)
+        - lastSeen: ISO timestamp of last occurrence (excluded for `has` key)
+        - firstSeen: ISO timestamp of first occurrence (excluded for `has` key)
+        Returns None if organization doesn't exist, empty list if key was not found in any data source.
+    """
+    try:
+        organization = Organization.objects.get(id=org_id)
+    except Organization.DoesNotExist:
+        logger.warning("Organization not found", extra={"org_id": org_id})
+        return None
+
+    predefined_values = _get_predefined_field_values(filter_key)
+    if predefined_values is not None:
+        return predefined_values
+
+    if filter_key == "has":
+        keys_response = (
+            get_event_filter_keys(org_id=org_id, project_ids=project_ids, stats_period=stats_period)
+            or {}
+        )
+        return [{"value": tag} for tag in keys_response.get("tags", [])]
+
+    api_key = ApiKey(
+        organization_id=organization.id, scope_list=["org:read", "project:read", "event:read"]
+    )
+
+    base_params: dict[str, Any] = {
+        "statsPeriod": stats_period,
+        "project": project_ids,
+        "sort": "-count",
+        "referrer": Referrer.SEER_RPC,
+    }
+    if substring:
+        base_params["query"] = substring
+
+    if is_feature_flag:
+        resp = client.get(
+            auth=api_key,
+            user=None,
+            path=f"/organizations/{organization.slug}/tags/{filter_key}/values/",
+            params={**base_params, "dataset": Dataset.Events.value, "useFlagsBackend": "1"},
+        )
+    else:
+        resp = client.get(
+            auth=api_key,
+            user=None,
+            path=f"/organizations/{organization.slug}/tags/{filter_key}/values/",
+            params={**base_params, "dataset": Dataset.Events.value},
+        )
+
+    data = resp.data or []
+    return [
+        {k: item[k] for k in item if k in ["value", "count", "lastSeen", "firstSeen"]}
+        for item in data
+    ]

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -68,6 +68,10 @@ from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.eap.utils import can_expose_attribute
 from sentry.search.events.types import SnubaParams
+from sentry.seer.assisted_query.discover_tools import (
+    get_event_filter_key_values,
+    get_event_filter_keys,
+)
 from sentry.seer.assisted_query.issues_tools import (
     execute_issues_query,
     get_filter_key_values,
@@ -1195,6 +1199,8 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "get_filter_key_values": get_filter_key_values,
     "execute_issues_query": execute_issues_query,
     "get_issues_stats": get_issues_stats,
+    "get_event_filter_keys": get_event_filter_keys,
+    "get_event_filter_key_values": get_event_filter_key_values,
     #
     # Explorer
     "get_transactions_for_project": rpc_get_transactions_for_project,

--- a/tests/sentry/seer/assisted_query/test_discover_tools.py
+++ b/tests/sentry/seer/assisted_query/test_discover_tools.py
@@ -1,0 +1,507 @@
+import pytest
+
+from sentry.seer.assisted_query.discover_tools import (
+    get_event_filter_key_values,
+    get_event_filter_keys,
+)
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+@pytest.mark.django_db(databases=["default", "control"])
+class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        super().setUp()
+        self.min_ago = before_now(minutes=1)
+
+    def test_get_event_filter_keys_success(self):
+        """Test that get_event_filter_keys returns tags, feature flags, and static fields"""
+        # Create an error event with custom tags
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"fruit": "apple", "color": "red"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        # Create an event with feature flags
+        self.store_event(
+            data={
+                "contexts": {
+                    "flags": {
+                        "values": [
+                            {"flag": "feature_a", "result": True},
+                            {"flag": "feature_b", "result": False},
+                        ]
+                    }
+                },
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        result = get_event_filter_keys(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+        )
+
+        assert result is not None
+        assert "tags" in result
+        assert "feature_flags" in result
+        assert "static_fields" in result
+
+        # Check tags
+        tags = result["tags"]
+        assert isinstance(tags, list)
+        assert len(tags) > 0
+        # Check that our custom tags are present
+        assert "fruit" in tags
+        assert "color" in tags
+
+        # Check feature flags
+        feature_flags = result["feature_flags"]
+        assert isinstance(feature_flags, list)
+        assert "feature_a" in feature_flags
+        assert "feature_b" in feature_flags
+
+        # Check static fields
+        static_fields = result["static_fields"]
+        assert isinstance(static_fields, list)
+        assert len(static_fields) > 0
+        # Should include common fields like timestamp, message, etc.
+        assert "timestamp" in static_fields
+        assert "message" in static_fields
+
+    def test_get_event_filter_keys_multiple_projects(self):
+        """Test with multiple projects"""
+        project2 = self.create_project(organization=self.organization)
+
+        # Create events in both projects
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"project1_tag": "value1"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "tags": {"project2_tag": "value2"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=project2.id,
+        )
+
+        # Empty projects should be treated as a query for all projects.
+        for pids in [[self.project.id, project2.id], [], None]:
+            result = get_event_filter_keys(
+                org_id=self.organization.id,
+                project_ids=pids,
+            )
+
+            assert result is not None
+            assert "tags" in result
+
+            tags = result["tags"]
+            # Both project tags should be present
+            assert "project1_tag" in tags
+            assert "project2_tag" in tags
+
+    def test_get_event_filter_keys_deduplicates_static_and_tags(self):
+        """Test that tags appearing in both static fields and tags are only returned as tags"""
+        # Create an event with a tag that might also be a static field
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"environment": "production"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        result = get_event_filter_keys(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+        )
+
+        assert result is not None
+        tags = result["tags"]
+        static_fields = result["static_fields"]
+
+        # If environment appears as a tag, it should not also be in static_fields
+        assert "environment" in tags
+        assert "environment" not in static_fields
+
+
+@pytest.mark.django_db(databases=["default", "control"])
+class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        super().setUp()
+        self.min_ago = before_now(minutes=1)
+
+    def test_get_event_filter_key_values_tag_key(self):
+        """Test getting values for a tag key"""
+        # Create events with the same tag key but different values
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"environment": "production"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "tags": {"environment": "staging"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "tags": {"environment": "production"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="environment",
+            is_feature_flag=False,
+        )
+
+        assert result is not None
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+        # Check structure of returned values
+        for item in result:
+            assert "value" in item
+            assert "count" in item
+            assert "lastSeen" in item
+            assert "firstSeen" in item
+
+        # Check that we have our environment values
+        values = {item["value"] for item in result}
+        assert "production" in values
+        assert "staging" in values
+
+        # Check counts
+        value_counts = {item["value"]: item["count"] for item in result}
+        assert value_counts["production"] == 2
+        assert value_counts["staging"] == 1
+
+    def test_get_event_filter_key_values_feature_flag(self):
+        """Test getting values for a feature flag"""
+        # Create events with feature flags
+        self.store_event(
+            data={
+                "contexts": {
+                    "flags": {
+                        "values": [
+                            {"flag": "organizations:test-feature", "result": True},
+                        ]
+                    }
+                },
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "contexts": {
+                    "flags": {
+                        "values": [
+                            {"flag": "organizations:test-feature", "result": False},
+                        ]
+                    }
+                },
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="organizations:test-feature",
+            is_feature_flag=True,
+        )
+
+        assert result is not None
+        assert isinstance(result, list)
+        # Should have flag values
+        if len(result) > 0:
+            for item in result:
+                assert "value" in item
+                assert "count" in item
+
+    def test_get_event_filter_key_values_boolean_field(self):
+        """Test that boolean fields return predefined values"""
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="error.handled",
+            is_feature_flag=False,
+        )
+
+        assert result is not None
+        assert isinstance(result, list)
+        # Should return true/false values
+        assert len(result) == 2
+        values = {item["value"] for item in result}
+        assert "true" in values
+        assert "false" in values
+
+    def test_get_event_filter_key_values_date_field(self):
+        """Test that date fields return predefined relative date suggestions"""
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="timestamp",
+            is_feature_flag=False,
+        )
+
+        assert result is not None
+        assert isinstance(result, list)
+        # Should return relative date suggestions like "-1h", "-24h", etc.
+        assert len(result) > 0
+        values = {item["value"] for item in result}
+        # Should include common relative dates
+        assert "-1h" in values
+        assert "-24h" in values
+        assert "-7d" in values
+
+    def test_get_event_filter_key_values_has_key(self):
+        """Test that 'has' key returns all available tag keys"""
+        # Create event with custom tag
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"custom_tag": "value", "custom2": "value2"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="has",
+            is_feature_flag=False,
+        )
+
+        assert result is not None
+        assert isinstance(result, list)
+        assert len(result) > 0
+        values = {item["value"] for item in result}
+        assert "custom_tag" in values
+        assert "custom2" in values
+
+    def test_get_event_filter_key_values_aggregate_function_returns_empty(self):
+        """Test that aggregate functions return empty list"""
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="count()",
+            is_feature_flag=False,
+        )
+
+        assert result == []
+
+    def test_get_event_filter_key_values_measurement_returns_empty(self):
+        """Test that measurements return empty list"""
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="measurements.lcp",
+            is_feature_flag=False,
+        )
+
+        assert result == []
+
+    def test_get_event_filter_key_values_device_class_returns_empty(self):
+        """Test that device.class returns empty list"""
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="device.class",
+            is_feature_flag=False,
+        )
+
+        assert result == []
+
+    def test_get_event_filter_key_values_with_substring_filter(self):
+        """Test substring filtering of filter key values"""
+        # Create events with different environment values
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"environment": "production"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "tags": {"environment": "production-eu"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "tags": {"environment": "staging"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "tags": {"environment": "development"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        # Filter for "prod" substring - should only return production values
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="environment",
+            is_feature_flag=False,
+            substring="prod",
+        )
+
+        assert result is not None
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+        # Should only contain values with "prod" in them
+        values = {item["value"] for item in result}
+        assert "production" in values
+        assert "production-eu" in values
+        assert "staging" not in values
+        assert "development" not in values
+
+    def test_get_event_filter_key_values_nonexistent_tag(self):
+        """Test that nonexistent filter key returns empty list"""
+        result = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="nonexistent_tag_key_12345",
+            is_feature_flag=False,
+        )
+        # Should return empty list, not None
+        assert result == []
+
+    def test_get_event_filter_key_values_multiple_projects(self):
+        """Test getting filter key values across multiple projects"""
+        project2 = self.create_project(organization=self.organization)
+
+        # Create events in both projects with same tag key
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"region": "us-east"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "tags": {"region": "us-west"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=project2.id,
+        )
+
+        # Empty projects should be treated as a query for all projects.
+        for pids in [[self.project.id, project2.id], [], None]:
+            result = get_event_filter_key_values(
+                org_id=self.organization.id,
+                project_ids=pids,
+                filter_key="region",
+                is_feature_flag=False,
+            )
+
+            assert result is not None
+            assert isinstance(result, list)
+            assert len(result) > 0
+
+            # Should have values from both projects
+            values = {item["value"] for item in result}
+            assert "us-east" in values
+            assert "us-west" in values
+
+    def test_get_event_filter_key_values_different_stats_periods(self):
+        """Test that different stats periods affect results"""
+        # Create an event 2 days ago
+        two_days_ago = before_now(days=2)
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "tags": {"test_tag": "old_value"},
+                "timestamp": two_days_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        # Create a recent event
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "tags": {"test_tag": "new_value"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        # Query with 1 day period - should only get recent
+        result_1d = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="test_tag",
+            is_feature_flag=False,
+            stats_period="24h",
+        )
+
+        # Query with 7 day period - should get both
+        result_7d = get_event_filter_key_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            filter_key="test_tag",
+            is_feature_flag=False,
+            stats_period="7d",
+        )
+
+        assert result_1d is not None
+        assert result_7d is not None
+
+        values_1d = {item["value"] for item in result_1d}
+        values_7d = {item["value"] for item in result_7d}
+
+        # Recent value should be in both
+        assert "new_value" in values_1d
+        assert "new_value" in values_7d
+
+        # Old value should only be in 7d results
+        assert "old_value" not in values_1d
+        assert "old_value" in values_7d

--- a/tests/sentry/seer/assisted_query/test_discover_tools.py
+++ b/tests/sentry/seer/assisted_query/test_discover_tools.py
@@ -190,7 +190,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="environment",
-            is_feature_flag=False,
         )
 
         assert result is not None
@@ -247,7 +246,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="organizations:test-feature",
-            is_feature_flag=True,
         )
 
         assert result is not None
@@ -280,7 +278,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="has",
-            is_feature_flag=False,
         )
 
         assert result is not None
@@ -296,7 +293,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="count()",
-            is_feature_flag=False,
         )
 
         assert result == []
@@ -342,7 +338,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="environment",
-            is_feature_flag=False,
             substring="prod",
         )
 
@@ -363,7 +358,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="nonexistent_tag_key_12345",
-            is_feature_flag=False,
         )
         # Should return empty list, not None
         assert result == []
@@ -396,7 +390,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
                 org_id=self.organization.id,
                 project_ids=pids,
                 filter_key="region",
-                is_feature_flag=False,
             )
 
             assert result is not None
@@ -436,7 +429,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="test_tag",
-            is_feature_flag=False,
             stats_period="24h",
         )
 
@@ -445,7 +437,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             org_id=self.organization.id,
             project_ids=[self.project.id],
             filter_key="test_tag",
-            is_feature_flag=False,
             stats_period="7d",
         )
 

--- a/tests/sentry/seer/assisted_query/test_discover_tools.py
+++ b/tests/sentry/seer/assisted_query/test_discover_tools.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.seer.assisted_query.discover_tools import (
     _ALWAYS_RETURN_EVENT_FIELDS,
     _SPECIAL_FIELD_VALUE_TYPES,
@@ -10,9 +8,7 @@ from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 
 
-@pytest.mark.django_db(databases=["default", "control"])
 class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
-    databases = "__all__"
 
     def setUp(self):
         super().setUp()
@@ -104,9 +100,7 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
             assert "project2_tag" in result
 
 
-@pytest.mark.django_db(databases=["default", "control"])
 class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
-    databases = "__all__"
 
     def setUp(self):
         super().setUp()
@@ -148,7 +142,6 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
         assert len(result) > 0
 
         # Check structure of returned values
@@ -206,12 +199,18 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
-        # Should have flag values
-        if len(result) > 0:
-            for item in result:
-                assert "value" in item
-                assert "count" in item
+        assert len(result) == 2
+
+        for item in result:
+            assert "value" in item
+            assert "count" in item
+            assert "lastSeen" in item
+            assert "firstSeen" in item
+            assert item["count"] == 1
+
+        values = {item["value"] for item in result}
+        assert "true" in values
+        assert "false" in values
 
     def test_get_event_filter_key_values_has_key(self):
         """Test that 'has' key returns all available tag keys"""


### PR DESCRIPTION
closes [AIML-1634: RPCs to expose error event (discover) filter keys and values](https://linear.app/getsentry/issue/AIML-1634/rpcs-to-expose-error-event-discover-filter-keys-and-values)

To query error events, call [execute_table_query](https://github.com/getsentry/sentry/blob/2a209328b7e0b9ab82170e4a72f019cca942f475/src/sentry/seer/explorer/tools.py#L37) and [execute_timeseries_query](https://github.com/getsentry/sentry/blob/2a209328b7e0b9ab82170e4a72f019cca942f475/src/sentry/seer/explorer/tools.py#L100) with **dataset=errors**

We can address issuePlatform filter keys/values in a separate follow up. This is for occurrences of performance issues, feedback, rage clicks, etc. Since they'll have to be a separate query to `dataset=issuePlatform`, the filter kv rpcs should probably be separate, or we can pass in a param like `use_issue_platform`