### PR TITLE
fix(feedback): remove feature badge for AI summaries & categories

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import {AiPrivacyTooltip} from 'sentry/components/aiPrivacyTooltip';
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Button} from 'sentry/components/core/button';
 import {Disclosure} from 'sentry/components/core/disclosure';
 import {Flex} from 'sentry/components/core/layout';
@@ -75,10 +74,7 @@ export default function FeedbackSummaryCategories() {
             </Flex>
           }
         >
-          <Flex gap="xs" align="center">
-            <AiPrivacyTooltip>{t('Summary')}</AiPrivacyTooltip>
-            <FeatureBadge type="new" />
-          </Flex>
+          <AiPrivacyTooltip>{t('Summary')}</AiPrivacyTooltip>
         </Disclosure.Title>
         <Disclosure.Content>
           <SummaryContainer>


### PR DESCRIPTION
We're approaching 4 weeks of GA, let's remove the "New" feature badge from the user feedback AI summaries and categories and close this project.

Per this thread https://sentry.slack.com/archives/C08U5217A6R/p1763498608921549

Before:
<img width="620" height="186" alt="Screenshot 2025-11-18 at 3 07 37 PM" src="https://github.com/user-attachments/assets/4248d568-31f5-43d3-9233-c05429d22cf3" />

After:
<img width="624" height="171" alt="Screenshot 2025-11-18 at 3 07 00 PM" src="https://github.com/user-attachments/assets/958d129f-5703-446d-b6ec-1e0d7ea1f54e" />
