### PR TITLE
fix(aci): Filter connected monitors drawer by project

### DIFF
--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -30,6 +30,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   emptyMessage?: string;
   limit?: number | null;
   openInNewTab?: boolean;
+  projectIds?: number[];
   query?: string;
   toggleConnected?: (params: {detector: Detector}) => void;
 };
@@ -75,6 +76,7 @@ export default function ConnectedMonitorsList({
   limit = DEFAULT_DETECTORS_PER_PAGE,
   query,
   openInNewTab,
+  projectIds,
   ...props
 }: Props) {
   const canEdit = Boolean(connectedDetectorIds && typeof toggleConnected === 'function');
@@ -92,6 +94,7 @@ export default function ConnectedMonitorsList({
       cursor,
       query,
       includeIssueStreamDetectors: true,
+      projects: projectIds,
     },
     {enabled: detectorIds === null || detectorIds.length > 0}
   );

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -16,6 +16,7 @@ import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {getApiQueryData, setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import ConnectedMonitorsList from 'sentry/views/automations/components/connectedMonitorsList';
 import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
 import {makeDetectorListQueryKey} from 'sentry/views/detectors/hooks';
@@ -64,6 +65,7 @@ function AllMonitors({
     setSearchQuery(query);
     setCursor(undefined);
   }, []);
+  const {selection} = usePageFilters();
 
   return (
     <PageFiltersContainer>
@@ -83,6 +85,7 @@ function AllMonitors({
           cursor={cursor}
           onCursor={setCursor}
           query={searchQuery}
+          projectIds={selection.projects}
           openInNewTab
         />
       </Section>


### PR DESCRIPTION
The connect monitors drawer on the edit automation page was not filtering by project correctly