### PR TITLE
chore(file-filters): add CODEOWNERS to backend_src

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -72,6 +72,10 @@ backend_src: &backend_src
   - 'migrations_lockfile.txt'
   - 'config/**/!(tsconfig)*'
   - 'fixtures/search-syntax/**/*'
+  # There is a dependency between CODEOWNERS and sentry.api.api_owners in
+  # tests/sentry/api/test_api_owners.py. As a result, any change to CODEOWNERS
+  # needs to trigger the backend tests.
+  - '.github/CODEOWNERS'
 
 backend_all: &backend_all
   - *backend_src


### PR DESCRIPTION
Removing an owner from CODEOWNERS can result in a failed test in `tests/sentry/api/test_api_owners.py` if that owner is also an API owner. Previously, changes to CODEOWNERS did not trigger the backend tests. This updates the file-filters to run the backend tests on any change to CODEOWNERS.