### PR TITLE
chore(issues): Remove old reference to performance category when building alert message

### DIFF
--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -6,7 +6,6 @@ from typing import Any, Literal, TypedDict
 from sentry import features
 from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -333,9 +332,5 @@ def get_color(
             color = event_for_tags.occurrence.level
         if color and color in LEVEL_TO_COLOR.keys():
             return color
-    if group.issue_category == GroupCategory.PERFORMANCE:
-        # XXX(CEO): this shouldn't be needed long term, but due to a race condition
-        # the group's latest event is not found and we end up with no event_for_tags here for perf issues
-        return "info"
 
     return "error"


### PR DESCRIPTION
I'm trying to remove existing references to the performance category on the backend so that the old categories can be removed. The categories aren't meant to be used for anything besides issue search.

This shouldn't be necessary anymore (according to the old comment), so I think it makes sense to remove. The worst that could happen is that some alerts would have the wrong color. (and if that is the case, it's already wrong because there are other issue types besides performance). If the logic is still needed, we could change this to `group.issue_category != error`