### PR TITLE
chore(issues): Remove reference to performance category in group has_replay

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -802,9 +802,9 @@ class Group(Model):
             return cached_has_replays
 
         data_source = (
-            Dataset.IssuePlatform
-            if self.issue_category == GroupCategory.PERFORMANCE
-            else Dataset.Discover
+            Dataset.Discover
+            if self.issue_category == GroupCategory.ERROR
+            else Dataset.IssuePlatform
         )
 
         counts = get_replay_counts(


### PR DESCRIPTION
The existing logic was wrong, it only used the issue platform dataset for performance issues. However, it should be using it for any non-error group types. 