### PR TITLE
ref(span-buffer): Explicitly convert links and meta to JSON

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -83,14 +83,17 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
             try:
                 if attr in RENAME_ATTRIBUTES:
                     attr = RENAME_ATTRIBUTES[attr]
-                attributes[f"sentry._meta.fields.attributes.{attr}"] = _anyvalue({"meta": meta})
+                # Meta is expected to be a stringified json object.
+                value = orjson.dumps({"meta": meta}).decode()
+                attributes[f"sentry._meta.fields.attributes.{attr}"] = _anyvalue(value)
             except Exception:
                 sentry_sdk.capture_exception()
 
     if links := span.get("links"):
         try:
             sanitized_links = [_sanitize_span_link(link) for link in links if link is not None]
-            attributes["sentry.links"] = _anyvalue(sanitized_links)
+            # The links are currently expected to be a stringified json object.
+            attributes["sentry.links"] = _anyvalue(orjson.dumps(sanitized_links).decode())
         except Exception:
             sentry_sdk.capture_exception()
             attributes["sentry.dropped_links_count"] = AnyValue(int_value=len(links))


### PR DESCRIPTION
Links and meta are always expected to be strings.

We're working on enabling native support for arrays (and future objects) to EAP, once this is enabled meta and links should still remain JSON objects. Explicitly convert to not accidentally change the data type later. Also this improves the metric added in #103551 by not counting links and meta.

Note: `test_convert.py` already tests meta and links, the test results must not be affected by this change.