### PR TITLE
fix(cursor-agent): clearer error msg + increase api timeout

### DIFF
--- a/src/sentry/integrations/cursor/client.py
+++ b/src/sentry/integrations/cursor/client.py
@@ -63,6 +63,7 @@ class CursorAgentClient(CodingAgentClient):
             },
             data=payload.dict(exclude_none=True),
             json=True,
+            timeout=60,
         )
 
         launch_response = CursorAgentLaunchResponse.validate(api_response.json)

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -225,12 +225,14 @@ def _launch_agents_for_repos(
     repos_to_launch = validated_repos or autofix_state_repos
 
     if not repos_to_launch:
-        raise NotFound("No repos to run agents")
+        raise NotFound(
+            "There are no repos in the Seer state to launch coding agents with, make sure you have repos connected to Seer and rerun this Issue Fix."
+        )
 
     prompt = get_coding_agent_prompt(run_id, trigger_source)
 
     if not prompt:
-        raise APIException("No prompt to send to agents.")
+        raise APIException("Issue fetching prompt to send to coding agents.")
 
     successes = []
     failures = []

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -1236,4 +1236,4 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             response = self.get_error_response(
                 self.organization.slug, method="post", status_code=500, **data
             )
-            assert response.data["detail"] == "No prompt to send to agents."
+            assert response.data["detail"] == "Issue fetching prompt to send to coding agents."


### PR DESCRIPTION
Make the errors from our end clearer, and increase the cursor api launch call timeout
