### PR TITLE
fix(vercel): Update the error message when env variable already exist

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -341,7 +341,7 @@ class VercelIntegration(IntegrationInstallation):
 
         key = data["key"]
         raise IntegrationError(
-            f"Could not update environment variable {key} in Vercel project {vercel_project_id}."
+            f"Could not update environment variable {key} in Vercel project {vercel_project_id}. Please make sure that the environment variable does not already exist."
         )
 
     def uninstall(self):


### PR DESCRIPTION
Current error message is a bit confusing to the users, as they don't know what went wrong. Telling them to make sure that the variable is not already present, helps them get unblocked