### PR TITLE
feat(traces): Set page title to saved query name

### DIFF
--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -121,13 +121,13 @@ function SpansTabHeader() {
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(id);
 
-  const showCustomTitle =
+  const hasSavedQueryTitle =
     defined(id) && defined(savedQuery) && savedQuery.name.length > 0;
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
-        {showCustomTitle ? (
+        {hasSavedQueryTitle ? (
           <SentryDocumentTitle title={savedQuery.name} orgSlug={organization?.slug} />
         ) : null}
         {title && defined(id) ? (

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -121,12 +121,13 @@ function SpansTabHeader() {
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(id);
 
-  const isSavedQuery = defined(id) && defined(savedQuery);
+  const showCustomTitle =
+    defined(title) && title.length > 0 && defined(id) && defined(savedQuery);
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
-        {isSavedQuery ? (
+        {showCustomTitle ? (
           <SentryDocumentTitle title={title} orgSlug={organization?.slug} />
         ) : null}
         {title && defined(id) ? (

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -39,9 +39,8 @@ export function ExploreContent() {
   Sentry.setTag('explore.visited', 'yes');
 
   const organization = useOrganization();
-  const datePageFilterProps = limitMaxPickableDays(organization);
-
   const onboardingProject = useOnboardingProject();
+  const datePageFilterProps = limitMaxPickableDays(organization);
 
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
@@ -119,11 +118,17 @@ function ExploreTagsProvider({children}: SpansTabContextProps) {
 function SpansTabHeader() {
   const id = useQueryParamsId();
   const title = useQueryParamsTitle();
+  const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(id);
+
+  const isSavedQuery = defined(id) && defined(savedQuery);
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
+        {isSavedQuery ? (
+          <SentryDocumentTitle title={title} orgSlug={organization?.slug} />
+        ) : null}
         {title && defined(id) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.SPANS} />
         ) : null}

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -122,13 +122,13 @@ function SpansTabHeader() {
   const {data: savedQuery} = useGetSavedQuery(id);
 
   const showCustomTitle =
-    defined(title) && title.length > 0 && defined(id) && defined(savedQuery);
+    defined(id) && defined(savedQuery) && savedQuery.name.length > 0;
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
         {showCustomTitle ? (
-          <SentryDocumentTitle title={title} orgSlug={organization?.slug} />
+          <SentryDocumentTitle title={savedQuery.name} orgSlug={organization?.slug} />
         ) : null}
         {title && defined(id) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.SPANS} />


### PR DESCRIPTION
This PR tweaks the spans page to set the document title name to that of the saved query if present. This should aid users with finding the correct tab in their browser.

Example:

<img width="259" height="38" alt="Screenshot 2025-11-19 at 07 28 12" src="https://github.com/user-attachments/assets/e447e8dd-2dca-4681-841d-cf5e327add6b" />
