### PR TITLE
perf(encryption): Load encryption keys on boot up

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -13,6 +13,7 @@ from sentry.silo.patches.silo_aware_transaction_patch import patch_silo_aware_at
 from sentry.utils import warnings
 from sentry.utils.arroyo import initialize_arroyo_main
 from sentry.utils.sdk import configure_sdk
+from sentry.utils.security.encrypted_field_key_store import initialize_encrypted_field_key_store
 from sentry.utils.warnings import DeprecatedSettingWarning
 
 
@@ -367,6 +368,10 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
     import_grouptype()
 
     initialize_arroyo_main()
+
+    # Encryption keys should be initialized before any
+    # database queries that use encrypted fields are made
+    initialize_encrypted_field_key_store()
 
     # Hacky workaround to dynamically set the CSRF_TRUSTED_ORIGINS for self hosted
     if settings.SENTRY_SELF_HOSTED and not settings.CSRF_TRUSTED_ORIGINS:

--- a/src/sentry/utils/security/encrypted_field_key_store.py
+++ b/src/sentry/utils/security/encrypted_field_key_store.py
@@ -102,6 +102,6 @@ class FernetKeyStore:
         return primary_key_id, cls.get_fernet_for_key_id(primary_key_id)
 
 
-def initialize_encrypted_field_key_store():
+def initialize_encrypted_field_key_store() -> None:
     # FernetKeyStore load keys from the mounted file system
     FernetKeyStore.load_keys()

--- a/src/sentry/utils/security/encrypted_field_key_store.py
+++ b/src/sentry/utils/security/encrypted_field_key_store.py
@@ -100,3 +100,8 @@ class FernetKeyStore:
             raise ValueError("Fernet primary key ID is not configured.")
 
         return primary_key_id, cls.get_fernet_for_key_id(primary_key_id)
+
+
+def initialize_encrypted_field_key_store():
+    # FernetKeyStore load keys from the mounted file system
+    FernetKeyStore.load_keys()


### PR DESCRIPTION
Performance improvement for EncryptedFields to load the encryption keys on runner initialization, and not during the first request that needs the keys.

This is still not used anywhere but in S4S - but soon it will be tested in DE on a low traffic table, and we shouldn't see any problems, but it is best to solve this immediately 
