### PR TITLE
fix(dashboards): Fix incorrect URL construction for "Open in Explore" for Logs widgets

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -1,8 +1,9 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
-import {DisplayType} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {
   getWidgetExploreUrl,
   getWidgetTableRowExploreUrlFunction,
@@ -40,6 +41,40 @@ describe('getWidgetExploreUrl', () => {
         ['mode', 'aggregate'],
         ['statsPeriod', '14d'],
         ['visualize', JSON.stringify({chartType: 1, yAxes: ['avg(span.duration)']})],
+      ],
+    });
+  });
+
+  it('returns correct URL for widgets with a project selection', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      widgetType: WidgetType.LOGS,
+      queries: [
+        WidgetQueryFixture({
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          conditions: '',
+          orderby: '-count()',
+        }),
+      ],
+    });
+
+    const widgetSelection = PageFiltersFixture({
+      projects: [17762],
+    });
+
+    const url = getWidgetExploreUrl(widget, undefined, widgetSelection, organization);
+
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/explore/logs/',
+      params: [
+        ['aggregateField', '{"chartType":1,"yAxes":["count()"]}'],
+        ['interval', '3h'],
+        ['logsGroupBy', ''],
+        ['mode', 'aggregate'],
+        ['project', '17762'],
+        ['statsPeriod', '14d'],
       ],
     });
   });

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -16,7 +16,6 @@ import {
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 import {decodeBoolean, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {
@@ -26,13 +25,6 @@ import {
 } from 'sentry/views/dashboards/utils';
 import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import type {TabularRow} from 'sentry/views/dashboards/widgets/common/types';
-import {
-  LOGS_AGGREGATE_FN_KEY,
-  LOGS_AGGREGATE_PARAM_KEY,
-  LOGS_FIELDS_KEY,
-  LOGS_GROUP_BY_KEY,
-  LOGS_QUERY_KEY,
-} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -91,76 +83,6 @@ const WIDGET_TRACE_ITEM_TO_URL_FUNCTION: Record<
     TraceItemDataset.TRACEMETRICS
   ),
 };
-
-export function getWidgetLogURL(
-  widget: Widget,
-  dashboardFilters: DashboardFilters | undefined,
-  selection: PageFilters,
-  organization: Organization,
-  referrer?: string
-) {
-  const params = new URLSearchParams();
-  if (widget.queries?.[0]) {
-    const query = widget.queries[0];
-    if (query.aggregates[0]) {
-      const aggregate = query.aggregates[0];
-      const [_, fn, arg] = aggregate.match(/^(\w+)\(([^)]+)\)$/) || [];
-      if (arg) {
-        params.set(LOGS_AGGREGATE_PARAM_KEY, arg);
-      }
-      if (fn) {
-        params.set(LOGS_AGGREGATE_FN_KEY, fn);
-      }
-    }
-    const conditions = applyDashboardFilters(query.conditions, dashboardFilters);
-    if (conditions) {
-      params.set(LOGS_QUERY_KEY, conditions);
-    }
-    for (const field of query.columns ?? []) {
-      params.append(LOGS_FIELDS_KEY, field);
-    }
-    for (const groupBy of query?.fields?.filter(
-      field => !isAggregateFieldOrEquation(field)
-    ) || []) {
-      params.append(LOGS_GROUP_BY_KEY, groupBy);
-    }
-  }
-
-  const eventView = eventViewFromWidget(widget.title, widget.queries[0]!, selection);
-  const locationQueryParams = eventView.generateQueryStringObject();
-  const effectiveSelection = {
-    ...selection,
-    end: decodeScalar(locationQueryParams.end) ?? null,
-    period: decodeScalar(locationQueryParams.statsPeriod) ?? null,
-    start: decodeScalar(locationQueryParams.start) ?? null,
-    utc: decodeBoolean(locationQueryParams.utc) ?? null,
-  };
-  if (effectiveSelection.start) {
-    params.set('start', effectiveSelection.start);
-  }
-  if (effectiveSelection.end) {
-    params.set('end', effectiveSelection.end);
-  }
-  if (effectiveSelection.period) {
-    params.set('statsPeriod', effectiveSelection.period);
-  }
-  if (effectiveSelection.utc) {
-    params.set('utc', 'true');
-  }
-  for (const project of effectiveSelection.projects) {
-    params.append('projects', String(project));
-  }
-  for (const environment of effectiveSelection.environments) {
-    params.append('environments', environment);
-  }
-  if (referrer) {
-    params.append('referrer', referrer);
-  }
-
-  return normalizeUrl(
-    `/organizations/${organization.slug}/explore/logs?${params.toString()}`
-  );
-}
 
 export function getWidgetExploreUrl(
   widget: Widget,

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -31,10 +31,7 @@ import {
   isUsingPerformanceScore,
   performanceScoreTooltip,
 } from 'sentry/views/dashboards/utils';
-import {
-  getWidgetExploreUrl,
-  getWidgetLogURL,
-} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -249,7 +246,7 @@ export function getMenuOptions(
     }
   }
 
-  if (widget.widgetType === WidgetType.SPANS) {
+  if (widget.widgetType === WidgetType.SPANS || widget.widgetType === WidgetType.LOGS) {
     menuOptions.push({
       key: 'open-in-explore',
       label: t('Open in Explore'),
@@ -259,20 +256,6 @@ export function getMenuOptions(
         selection,
         organization,
         Mode.SAMPLES,
-        getReferrer(widget.displayType)
-      ),
-    });
-  }
-
-  if (widget.widgetType === WidgetType.LOGS) {
-    menuOptions.push({
-      key: 'open-in-explore',
-      label: t('Open in Explore'),
-      to: getWidgetLogURL(
-        widget,
-        dashboardFilters,
-        selection,
-        organization,
         getReferrer(widget.displayType)
       ),
     });


### PR DESCRIPTION
When users were clicking on "Open in Explore" for Logs widgets, they'd land on weird behaviour, like incorrect project selection. Turns out, the function we use in Dashboards to construct the Logs URL is wrong! It's some weird old URL constructor that is only used there. There are canonical constructors with the same API that we should have been using instead.

This PR removes the old URL function, uses the new one, and adds a little test.
