### PR TITLE
feat(explore): Add saved queries to title for logs and metrics

### DIFF
--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -18,6 +18,7 @@ import useProjects from 'sentry/utils/useProjects';
 import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {LogsTabOnboarding} from 'sentry/views/explore/logs/logsOnboarding';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
@@ -109,9 +110,19 @@ export default function LogsContent() {
 function LogsHeader() {
   const pageId = useQueryParamsId();
   const title = useQueryParamsTitle();
+  const organization = useOrganization();
+  const {data: savedQuery} = useGetSavedQuery(pageId);
+
+  const hasSavedQueryTitle =
+    defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
+  const documentTitle = hasSavedQueryTitle ? `${savedQuery.name} — ${t('Logs')}` : title;
+
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
+        {hasSavedQueryTitle ? (
+          <SentryDocumentTitle title={documentTitle} orgSlug={organization?.slug} />
+        ) : null}
         {title && defined(pageId) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.LOGS} />
         ) : null}

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -115,13 +115,15 @@ function LogsHeader() {
 
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
-  const documentTitle = hasSavedQueryTitle ? `${savedQuery.name} — ${t('Logs')}` : title;
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
         {hasSavedQueryTitle ? (
-          <SentryDocumentTitle title={documentTitle} orgSlug={organization?.slug} />
+          <SentryDocumentTitle
+            title={`${savedQuery.name} — ${t('Logs')}`}
+            orgSlug={organization?.slug}
+          />
         ) : null}
         {title && defined(pageId) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.LOGS} />

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -11,6 +11,7 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
+import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {MetricsTabOnboarding} from 'sentry/views/explore/metrics/metricsOnboarding';
 import {MetricsTabContent} from 'sentry/views/explore/metrics/metricsTab';
 import {metricsPickableDays} from 'sentry/views/explore/metrics/utils';
@@ -92,13 +93,24 @@ function MetricsHeader() {
   const location = useLocation();
   const pageId = getIdFromLocation(location, ID_KEY);
   const title = getTitleFromLocation(location, TITLE_KEY);
+  const organization = useOrganization();
+  const {data: savedQuery} = useGetSavedQuery(pageId);
+
+  const hasSavedQueryTitle =
+    defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
+  const documentTitle = hasSavedQueryTitle
+    ? `${savedQuery.name} — ${t('Metrics')}`
+    : title;
+
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
+        {hasSavedQueryTitle ? (
+          <SentryDocumentTitle title={documentTitle} orgSlug={organization?.slug} />
+        ) : null}
         {title && defined(pageId) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.TRACEMETRICS} />
         ) : null}
-
         <Layout.Title>
           {title ? title : t('Metrics')}
           <FeatureBadge type="beta" />

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -98,15 +98,15 @@ function MetricsHeader() {
 
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
-  const documentTitle = hasSavedQueryTitle
-    ? `${savedQuery.name} — ${t('Metrics')}`
-    : title;
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
         {hasSavedQueryTitle ? (
-          <SentryDocumentTitle title={documentTitle} orgSlug={organization?.slug} />
+          <SentryDocumentTitle
+            title={`${savedQuery.name} — ${t('Metrics')}`}
+            orgSlug={organization?.slug}
+          />
         ) : null}
         {title && defined(pageId) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.TRACEMETRICS} />

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -123,12 +123,15 @@ function SpansTabHeader() {
 
   const hasSavedQueryTitle =
     defined(id) && defined(savedQuery) && savedQuery.name.length > 0;
+  const documentTitle = hasSavedQueryTitle
+    ? `${savedQuery.name} — ${t('Traces')}`
+    : title;
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
         {hasSavedQueryTitle ? (
-          <SentryDocumentTitle title={savedQuery.name} orgSlug={organization?.slug} />
+          <SentryDocumentTitle title={documentTitle} orgSlug={organization?.slug} />
         ) : null}
         {title && defined(id) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.SPANS} />

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -123,15 +123,15 @@ function SpansTabHeader() {
 
   const hasSavedQueryTitle =
     defined(id) && defined(savedQuery) && savedQuery.name.length > 0;
-  const documentTitle = hasSavedQueryTitle
-    ? `${savedQuery.name} — ${t('Traces')}`
-    : title;
 
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
         {hasSavedQueryTitle ? (
-          <SentryDocumentTitle title={documentTitle} orgSlug={organization?.slug} />
+          <SentryDocumentTitle
+            title={`${savedQuery.name} — ${t('Traces')}`}
+            orgSlug={organization?.slug}
+          />
         ) : null}
         {title && defined(id) ? (
           <ExploreBreadcrumb traceItemDataset={TraceItemDataset.SPANS} />


### PR DESCRIPTION
This PR extends #103633 adding in custom titles for logs and metrics.

Also this updates the traces tab to include `Traces` in the title as that is how Discover currently does this, e.g. `<saved query> - <Traces | Metrics | Logs> - <org> - Sentry`