### PR TITLE
fix(checkout): Use correct unit for attachments

### DIFF
--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -320,7 +320,11 @@ function VolumeSliders({
                       onChange={value => value && handleReservedChange(value, category)}
                     />
                     <MinMax isNewCheckout={!!isNewCheckout}>
-                      <div>{formatReservedWithUnits(min, category)}</div>
+                      <div>
+                        {formatReservedWithUnits(min, category, {
+                          isAbbreviated: !isByteCategory(category),
+                        })}
+                      </div>
                       <div>
                         {formatReservedWithUnits(max, category, {
                           isAbbreviated: !isByteCategory(category),

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -246,9 +246,7 @@ function VolumeSliders({
                     <MinMax isNewCheckout={!!isNewCheckout}>
                       <div>
                         {tct('[min] included', {
-                          min: formatReservedWithUnits(min, category, {
-                            isAbbreviated: !isByteCategory(category),
-                          }),
+                          min: formatReservedWithUnits(min, category),
                         })}
                       </div>
                       <div>
@@ -322,11 +320,7 @@ function VolumeSliders({
                       onChange={value => value && handleReservedChange(value, category)}
                     />
                     <MinMax isNewCheckout={!!isNewCheckout}>
-                      <div>
-                        {formatReservedWithUnits(min, category, {
-                          isAbbreviated: !isByteCategory(category),
-                        })}
-                      </div>
+                      <div>{formatReservedWithUnits(min, category)}</div>
                       <div>
                         {formatReservedWithUnits(max, category, {
                           isAbbreviated: !isByteCategory(category),

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -201,18 +201,13 @@ function VolumeSliders({
                   <div>
                     <SpaceBetweenGrid>
                       <VolumeAmount>
-                        {isByteCategory(category)
-                          ? utils.getEventsWithUnit(
-                              formData.reserved[category] ?? 0,
-                              category
-                            )
-                          : formatReservedWithUnits(
-                              formData.reserved[category] ?? null,
-                              category,
-                              {
-                                isAbbreviated: true,
-                              }
-                            )}
+                        {formatReservedWithUnits(
+                          formData.reserved[category] ?? null,
+                          category,
+                          {
+                            isAbbreviated: !isByteCategory(category),
+                          }
+                        )}
                       </VolumeAmount>
                       <div>
                         <Price isIncluded={isIncluded}>
@@ -251,12 +246,16 @@ function VolumeSliders({
                     <MinMax isNewCheckout={!!isNewCheckout}>
                       <div>
                         {tct('[min] included', {
-                          min: isByteCategory(category)
-                            ? utils.getEventsWithUnit(min, category)
-                            : formatReservedWithUnits(min, category),
+                          min: formatReservedWithUnits(min, category, {
+                            isAbbreviated: !isByteCategory(category),
+                          }),
                         })}
                       </div>
-                      <div>{utils.getEventsWithUnit(max, category)}</div>
+                      <div>
+                        {formatReservedWithUnits(max, category, {
+                          isAbbreviated: !isByteCategory(category),
+                        })}
+                      </div>
                     </MinMax>
                   </div>
                   {showTransactionsDisclaimer && (
@@ -323,8 +322,16 @@ function VolumeSliders({
                       onChange={value => value && handleReservedChange(value, category)}
                     />
                     <MinMax isNewCheckout={!!isNewCheckout}>
-                      <div>{utils.getEventsWithUnit(min, category)}</div>
-                      <div>{utils.getEventsWithUnit(max, category)}</div>
+                      <div>
+                        {formatReservedWithUnits(min, category, {
+                          isAbbreviated: !isByteCategory(category),
+                        })}
+                      </div>
+                      <div>
+                        {formatReservedWithUnits(max, category, {
+                          isAbbreviated: !isByteCategory(category),
+                        })}
+                      </div>
                     </MinMax>
                   </div>
                   {showTransactionsDisclaimer && (

--- a/static/gsApp/views/amCheckout/steps/addDataVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/addDataVolume.spec.tsx
@@ -158,8 +158,8 @@ describe('AddDataVolume for legacy plans', () => {
       {
         billingInterval: MONTHLY,
         category: 'attachments',
-        max: '1TB',
-        min: '1GB',
+        max: '1,000 GB',
+        min: '1 GB',
         selectedTier: '1 GB',
       },
       {
@@ -210,8 +210,8 @@ describe('AddDataVolume for legacy plans', () => {
       {
         billingInterval: MONTHLY,
         category: 'attachments',
-        max: '1GB',
-        min: '1TB',
+        max: '1 GB',
+        min: '1,000 GB',
         selectedTier: '50 GB',
         tierPrice: 12,
         pricePerEvent: '$0.25',
@@ -265,8 +265,8 @@ describe('AddDataVolume for legacy plans', () => {
       {
         billingInterval: ANNUAL,
         category: 'attachments',
-        max: '1GB',
-        min: '1TB',
+        max: '1 GB',
+        min: '1,000 GB',
         selectedTier: '25 GB',
         tierPrice: 63,
       },
@@ -454,8 +454,8 @@ describe('AddDataVolume for modern plans', () => {
       {
         billingInterval: MONTHLY,
         category: 'attachments',
-        max: '1GB',
-        min: '1TB',
+        max: '1 GB',
+        min: '1,000 GB',
         selectedTier: '1 GB',
       },
       {
@@ -503,8 +503,8 @@ describe('AddDataVolume for modern plans', () => {
       {
         billingInterval: MONTHLY,
         category: 'attachments',
-        max: '1GB',
-        min: '1TB',
+        max: '1 GB',
+        min: '1,000 GB',
         selectedTier: '50 GB',
         tierPrice: 12,
         pricePerEvent: '$0.25',
@@ -559,8 +559,8 @@ describe('AddDataVolume for modern plans', () => {
       {
         billingInterval: ANNUAL,
         category: 'attachments',
-        max: '1GB',
-        min: '1TB',
+        max: '1 GB',
+        min: '1,000 GB',
         selectedTier: '25 GB',
         tierPrice: 65,
       },

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -142,9 +142,9 @@ describe('ReserveAdditionalVolume', () => {
         {
           billingInterval: MONTHLY,
           category: 'attachments',
-          max: '1TB',
-          min: '1GB',
-          selectedTier: '1GB',
+          max: '1,000 GB',
+          min: '1 GB',
+          selectedTier: '1 GB',
         },
         {
           billingInterval: MONTHLY,
@@ -270,9 +270,9 @@ describe('ReserveAdditionalVolume', () => {
         {
           billingInterval: MONTHLY,
           category: 'attachments',
-          max: '1TB',
-          min: '1GB',
-          selectedTier: '1GB',
+          max: '1,000 GB',
+          min: '1 GB',
+          selectedTier: '1 GB',
         },
         {
           billingInterval: MONTHLY,

--- a/static/gsApp/views/amCheckout/utils.spec.tsx
+++ b/static/gsApp/views/amCheckout/utils.spec.tsx
@@ -1,7 +1,5 @@
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 
-import {DataCategory} from 'sentry/types/core';
-
 import {AddOnCategory, InvoiceItemType, PlanTier} from 'getsentry/types';
 import * as utils from 'getsentry/views/amCheckout/utils';
 import {getCheckoutAPIData} from 'getsentry/views/amCheckout/utils';
@@ -208,23 +206,6 @@ describe('utils', () => {
       );
       expect(utils.displayUnitPrice({cents: 0.0167})).toBe('$0.000167');
       expect(utils.displayUnitPrice({cents: 0.528})).toBe('$0.00528');
-    });
-  });
-
-  describe('getEventsWithUnit', () => {
-    it('returns correct event amount', () => {
-      expect(utils.getEventsWithUnit(1_000, DataCategory.ERRORS)).toBe('1K');
-      expect(utils.getEventsWithUnit(50_000, DataCategory.ERRORS)).toBe('50K');
-      expect(utils.getEventsWithUnit(1_000_000, DataCategory.TRANSACTIONS)).toBe('1M');
-      expect(utils.getEventsWithUnit(4_000_000, DataCategory.TRANSACTIONS)).toBe('4M');
-      expect(utils.getEventsWithUnit(1, DataCategory.ATTACHMENTS)).toBe('1GB');
-      expect(utils.getEventsWithUnit(999, DataCategory.ATTACHMENTS)).toBe('999GB');
-      expect(utils.getEventsWithUnit(1_000, DataCategory.ATTACHMENTS)).toBe('1TB');
-      expect(utils.getEventsWithUnit(4_000, DataCategory.ATTACHMENTS)).toBe('4TB');
-      expect(utils.getEventsWithUnit(1_000_000_000, DataCategory.ERRORS)).toBe('1B');
-      expect(utils.getEventsWithUnit(10_000_000_000, DataCategory.ERRORS)).toBe('10B');
-      expect(utils.getEventsWithUnit(1, DataCategory.LOG_BYTE)).toBe('1GB');
-      expect(utils.getEventsWithUnit(25, DataCategory.LOG_BYTE)).toBe('25GB');
     });
   });
 

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -50,7 +50,6 @@ import {
   isTeamPlanFamily,
   isTrialPlan,
 } from 'getsentry/utils/billing';
-import {isByteCategory} from 'getsentry/utils/dataCategory';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import trackMarketingEvent from 'getsentry/utils/trackMarketingEvent';
 import type {State as CheckoutState} from 'getsentry/views/amCheckout/';
@@ -343,41 +342,6 @@ export function getDiscountedPrice({
  */
 export function getShortInterval(billingInterval: string): string {
   return billingInterval === MONTHLY ? 'mo' : 'yr';
-}
-
-function getWithBytes(gigabytes: number): string {
-  if (gigabytes >= 1000) {
-    return `${(gigabytes / 1000).toLocaleString()} TB`;
-  }
-  return `${gigabytes.toLocaleString()} GB`;
-}
-
-/**
- * Used by RangeSlider. As such, a value of zero is not equivalent to unlimited.
- */
-export function getEventsWithUnit(
-  events: number,
-  dataType: string
-): string | number | null {
-  if (!events) {
-    return null;
-  }
-
-  if (isByteCategory(dataType)) {
-    return getWithBytes(events).replace(' ', '');
-  }
-
-  if (events >= 1_000_000_000) {
-    return `${events / 1_000_000_000}B`;
-  }
-  if (events >= 1_000_000) {
-    return `${events / 1_000_000}M`;
-  }
-  if (events >= 1_000) {
-    return `${events / 1_000}K`;
-  }
-
-  return events;
 }
 
 type CheckoutData = {


### PR DESCRIPTION
Also gets rid of a two redundant functions.

The only difference between `formatReservedWithUnits` and `getEventsWithUnit` (the function I got rid of) is that the latter doesn't include a space between "<number>" and "GB" (ie. "1GB" instead of "1 GB"). The difference is so minute that I don't think it's worth keeping the function around. 