### PR TITLE
perf(query-buider): Fix accidentally quadratic iteration

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -102,9 +102,10 @@ function useFilterKeyItems() {
 
     const categorizedItems = filterKeySections
       .flatMap(section => section.children)
-      .reduce<
-        Record<string, boolean>
-      >((acc, nextFilterKey) => ({...acc, [nextFilterKey]: true}), {});
+      .reduce<Record<string, boolean>>(function reduceKeys(acc, nextFilterKey) {
+        acc[nextFilterKey] = true;
+        return acc;
+      }, {});
 
     const uncategorizedFilterKeys = flatFilterKeys.filter(
       filterKey => !categorizedItems[filterKey]


### PR DESCRIPTION
The `...` spread syntax in `reduce` iterates the current keys. For situations where there are _very many keys_ (e.g., the Dashboards Widget Builder) this can take like 20-30ms. On pages where there are many queries, this really adds up!

This a free performance win, no behaviour change. Mutating the `acc` is much faster. Small side note, I'm giving the function a name so it's easier to track this while profiling.