### PR TITLE
fix(data-forwarding): Icon adjustments

### DIFF
--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -40,6 +40,7 @@ const PLUGIN_ICONS = {
   os: sentry,
   urls: sentry,
   webhooks: sentry,
+  sqs: aws,
   'amazon-sqs': aws,
   aws_lambda: aws,
   cursor,

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -30,7 +30,6 @@ import {
   useMutateDataForwarder,
 } from 'sentry/views/settings/organizationDataForwarding/util/hooks';
 import {
-  DataForwarderProviderSlug,
   ProviderLabels,
   type DataForwarder,
 } from 'sentry/views/settings/organizationDataForwarding/util/types';
@@ -154,9 +153,7 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
                 }
               >
                 <Flex align="center" gap="sm">
-                  <PluginIcon
-                    pluginId={key === DataForwarderProviderSlug.SQS ? 'amazon-sqs' : key}
-                  />
+                  <PluginIcon pluginId={key} />
                   <b>{label}</b>
                 </Flex>
               </TabList.Item>

--- a/static/app/views/settings/organizationDataForwarding/setup.tsx
+++ b/static/app/views/settings/organizationDataForwarding/setup.tsx
@@ -127,9 +127,7 @@ export default function OrganizationDataForwardingSetup() {
                 }
               >
                 <Flex align="center" gap="sm">
-                  <PluginIcon
-                    pluginId={key === DataForwarderProviderSlug.SQS ? 'amazon-sqs' : key}
-                  />
+                  <PluginIcon pluginId={key} />
                   <b>{label}</b>
                 </Flex>
               </TabList.Item>


### PR DESCRIPTION
Allows `sqs` to render the AWS logo for ease of use, and makes all the plugin icons uniform