### PR TITLE
ref(checkout): Update route

### DIFF
--- a/src/sentry/organizations/absolute_url.py
+++ b/src/sentry/organizations/absolute_url.py
@@ -27,6 +27,7 @@ _path_patterns: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"^\/?(?!settings)[^/]+\/([^/]+)\/getting-started\/(.*)"),
         r"/getting-started/\1/\2",
     ),
+    (re.compile(r"^\/?checkout\/[^/]+\/(.*)"), r"/checkout/\1"),
 ]
 
 

--- a/src/sentry/organizations/absolute_url.py
+++ b/src/sentry/organizations/absolute_url.py
@@ -27,7 +27,6 @@ _path_patterns: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"^\/?(?!settings)[^/]+\/([^/]+)\/getting-started\/(.*)"),
         r"/getting-started/\1/\2",
     ),
-    (re.compile(r"^\/?checkout\/[^/]+\/(.*)"), r"/checkout/\1"),
 ]
 
 

--- a/static/app/utils/url/normalizeUrl.spec.tsx
+++ b/static/app/utils/url/normalizeUrl.spec.tsx
@@ -78,6 +78,8 @@ describe('normalizeUrl', () => {
       ['/join-request/acme/', '/join-request/'],
       ['/onboarding/acme/', '/onboarding/'],
       ['/onboarding/acme/project/', '/onboarding/project/'],
+      ['/checkout/acme/', '/checkout/'],
+      ['/checkout/acme/?query=value', '/checkout/?query=value'],
 
       ['/organizations/new/', '/organizations/new/'],
       ['/organizations/albertos-organizations/issues/', '/issues/'],

--- a/static/app/utils/url/normalizeUrl.tsx
+++ b/static/app/utils/url/normalizeUrl.tsx
@@ -22,6 +22,7 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   // Handles /org-slug/project-slug/getting-started/platform/ -> /getting-started/project-slug/platform/
   [/^\/?(?!settings)[^/]+\/([^/]+)\/getting-started\/(.*)/, '/getting-started/$1/$2'],
   [/^\/?accept-terms\/[^/]*\/?$/, '/accept-terms/'],
+  [/^\/?checkout\/[^/]+\/(.*)/, '/checkout/$1'],
 ];
 
 type NormalizeUrlOptions = {

--- a/static/gsApp/hooks/rootRoutes.tsx
+++ b/static/gsApp/hooks/rootRoutes.tsx
@@ -2,6 +2,7 @@ import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 import type {SentryRouteObject} from 'sentry/router/types';
 import errorHandler from 'sentry/utils/errorHandler';
 import withDomainRedirect from 'sentry/utils/withDomainRedirect';
+import withDomainRequired from 'sentry/utils/withDomainRequired';
 
 import OrganizationSubscriptionContext from 'getsentry/components/organizationSubscriptionContext';
 
@@ -10,7 +11,7 @@ const rootRoutes = (): SentryRouteObject => ({
     {
       // TODO(checkout v3): rename this to /checkout/ when the legacy checkout route is removed
       path: '/checkout/',
-      component: errorHandler(OrganizationSubscriptionContext),
+      component: withDomainRequired(errorHandler(OrganizationSubscriptionContext)),
       deprecatedRouteProps: true,
       customerDomainOnlyRoute: true,
       children: [

--- a/static/gsApp/hooks/rootRoutes.tsx
+++ b/static/gsApp/hooks/rootRoutes.tsx
@@ -1,6 +1,7 @@
 import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
 import type {SentryRouteObject} from 'sentry/router/types';
 import errorHandler from 'sentry/utils/errorHandler';
+import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 
 import OrganizationSubscriptionContext from 'getsentry/components/organizationSubscriptionContext';
 
@@ -8,10 +9,21 @@ const rootRoutes = (): SentryRouteObject => ({
   children: [
     {
       // TODO(checkout v3): rename this to /checkout/ when the legacy checkout route is removed
-      path: '/checkout-v3/',
+      path: '/checkout/',
       component: errorHandler(OrganizationSubscriptionContext),
       deprecatedRouteProps: true,
       customerDomainOnlyRoute: true,
+      children: [
+        {
+          index: true,
+          component: make(() => import('getsentry/views/decideCheckout')),
+        },
+      ],
+    },
+    {
+      path: '/checkout/:orgId/',
+      component: withDomainRedirect(errorHandler(OrganizationSubscriptionContext)),
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -138,16 +138,12 @@ class AMCheckout extends Component<Props, State> {
     const queryString =
       query && Object.keys(query).length > 0 ? `?${qs.stringify(query)}` : '';
 
-    // TODO(checkout v3): remove these checks once checkout v3 is GA'd and we've remove the legacy checkout route
-    if (props.location?.pathname.includes('checkout-v3') && !props.isNewCheckout) {
-      props.navigate(
-        `/settings/${props.organization.slug}/billing/checkout/${queryString}`,
-        {
-          replace: true,
-        }
-      );
-    } else if (!props.location?.pathname.includes('checkout-v3') && props.isNewCheckout) {
-      props.navigate(`/checkout-v3/${queryString}`, {replace: true});
+    // TODO(checkout v3): remove this check once we properly redirect from the legacy routes
+    if (
+      props.location?.pathname.includes('/settings/billing/checkout/') &&
+      props.isNewCheckout
+    ) {
+      props.navigate(`/checkout/${queryString}`, {replace: true});
     }
     let step = 1;
     if (props.location?.hash) {


### PR DESCRIPTION
Redo pt 2 of https://github.com/getsentry/sentry/pull/103069/

Depends on https://github.com/getsentry/sentry/pull/103668

This PR:
- Changes the new checkout route from `/checkout-v3/` to `/checkout/`
- Fixes all normalization patterns
- Adds a `/:orgId/` variant (needed for acceptance testing)
- Removes unnecessary redirect logic now that new checkout is GA