### PR TITLE
chore(explore): Add in cross event query param

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -66,9 +66,6 @@ const config: KnipConfig = {
     '!static/eslint/**/*.mjs!',
     // TEMPORARY! Abdullah Khan: WILL BE REMOVING IN STACKED PRs. Trying to merge PRs in smaller batches.
     '!static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/**/*.{js,mjs,ts,tsx}!',
-    // TODO @nsdeschenes: Remove this once we are using the new cross event feature
-    '!static/app/views/explore/queryParams/crossEvent.ts!',
-    '!static/app/views/explore/queryParams/context.tsx!',
   ],
   compilers: {
     mdx: async text => String(await compile(text)),

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -66,6 +66,9 @@ const config: KnipConfig = {
     '!static/eslint/**/*.mjs!',
     // TEMPORARY! Abdullah Khan: WILL BE REMOVING IN STACKED PRs. Trying to merge PRs in smaller batches.
     '!static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/**/*.{js,mjs,ts,tsx}!',
+    // TODO @nsdeschenes: Remove this once we are using the new cross event feature
+    '!static/app/views/explore/queryParams/crossEvent.ts!',
+    '!static/app/views/explore/queryParams/context.tsx!',
   ],
   compilers: {
     mdx: async text => String(await compile(text)),

--- a/static/app/views/explore/queryParams/context.spec.tsx
+++ b/static/app/views/explore/queryParams/context.spec.tsx
@@ -36,7 +36,7 @@ function Wrapper({children}: {children: ReactNode}) {
         mode: Mode.AGGREGATE,
         query,
         sortBys: defaultSortBys(defaultFields()),
-        crossEvents: [{query: 'foo', type: 'span'}],
+        crossEvents: [{query: 'foo', type: 'spans'}],
       }),
     [query]
   );
@@ -61,7 +61,7 @@ describe('QueryParamsContext', () => {
           additionalWrapper: Wrapper,
         });
 
-        expect(result.current).toEqual([{query: 'foo', type: 'span'}]);
+        expect(result.current).toEqual([{query: 'foo', type: 'spans'}]);
       });
     });
 

--- a/static/app/views/explore/queryParams/context.spec.tsx
+++ b/static/app/views/explore/queryParams/context.spec.tsx
@@ -1,0 +1,86 @@
+import {useMemo, type ReactNode} from 'react';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useResettableState} from 'sentry/utils/useResettableState';
+import {
+  defaultAggregateFields,
+  defaultAggregateSortBys,
+  defaultFields,
+  defaultQuery,
+  defaultSortBys,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {
+  QueryParamsContextProvider,
+  useQueryParamsCrossEvents,
+  useSetQueryParamsCrossEvents,
+} from 'sentry/views/explore/queryParams/context';
+import {defaultCursor} from 'sentry/views/explore/queryParams/cursor';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+
+const mockSetQueryParams = jest.fn();
+
+function Wrapper({children}: {children: ReactNode}) {
+  const [query] = useResettableState(defaultQuery);
+
+  const readableQueryParams = useMemo(
+    () =>
+      new ReadableQueryParams({
+        aggregateCursor: defaultCursor(),
+        aggregateFields: defaultAggregateFields(),
+        aggregateSortBys: defaultAggregateSortBys(defaultAggregateFields()),
+        cursor: defaultCursor(),
+        extrapolate: true,
+        fields: defaultFields(),
+        mode: Mode.AGGREGATE,
+        query,
+        sortBys: defaultSortBys(defaultFields()),
+        crossEvents: [{query: 'foo', type: 'span'}],
+      }),
+    [query]
+  );
+
+  return (
+    <QueryParamsContextProvider
+      isUsingDefaultFields={false}
+      queryParams={readableQueryParams}
+      setQueryParams={mockSetQueryParams}
+      shouldManageFields={false}
+    >
+      {children}
+    </QueryParamsContextProvider>
+  );
+}
+
+describe('QueryParamsContext', () => {
+  describe('crossEvents', () => {
+    describe('useQueryParamsCrossEvents', () => {
+      it('should return the crossEvents', () => {
+        const {result} = renderHookWithProviders(() => useQueryParamsCrossEvents(), {
+          additionalWrapper: Wrapper,
+        });
+
+        expect(result.current).toEqual([{query: 'foo', type: 'span'}]);
+      });
+    });
+
+    describe('useSetQueryParamsCrossEvents', () => {
+      it('should set the crossEvents', () => {
+        renderHookWithProviders(
+          () => {
+            const setCrossEvents = useSetQueryParamsCrossEvents();
+            setCrossEvents([{query: 'bar', type: 'logs'}]);
+            return useQueryParamsCrossEvents();
+          },
+          {additionalWrapper: Wrapper}
+        );
+
+        expect(mockSetQueryParams).toHaveBeenCalled();
+        expect(mockSetQueryParams).toHaveBeenCalledWith({
+          crossEvents: [{query: 'bar', type: 'logs'}],
+        });
+      });
+    });
+  });
+});

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -13,6 +13,7 @@ import type {
   AggregateField,
   WritableAggregateField,
 } from 'sentry/views/explore/queryParams/aggregateField';
+import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {updateNullableLocation} from 'sentry/views/explore/queryParams/location';
 import {deriveUpdatedManagedFields} from 'sentry/views/explore/queryParams/managedFields';
@@ -473,8 +474,8 @@ export function useSetQueryParamsCrossEvents() {
   const setQueryParams = useSetQueryParams();
 
   return useCallback(
-    () => (crossEvent: string) => {
-      setQueryParams({crossEvents: [...(queryParams.crossEvents ?? []), {crossEvent}]});
+    ({query, type}: CrossEvent) => {
+      setQueryParams({crossEvents: [...(queryParams.crossEvents ?? []), {query, type}]});
     },
     [queryParams, setQueryParams]
   );

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -462,3 +462,20 @@ export function useSetQueryParamsSavedQuery() {
     [location, navigate]
   );
 }
+
+export function useQueryParamsCrossEvents() {
+  const queryParams = useQueryParams();
+  return queryParams.crossEvents;
+}
+
+export function useSetQueryParamsCrossEvents() {
+  const queryParams = useQueryParams();
+  const setQueryParams = useSetQueryParams();
+
+  return useCallback(
+    () => (crossEvent: string) => {
+      setQueryParams({crossEvents: [...queryParams.crossEvents, {crossEvent}]});
+    },
+    [queryParams, setQueryParams]
+  );
+}

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -474,8 +474,28 @@ export function useSetQueryParamsCrossEvents() {
   const setQueryParams = useSetQueryParams();
 
   return useCallback(
-    ({query, type}: CrossEvent) => {
-      setQueryParams({crossEvents: [...(queryParams.crossEvents ?? []), {query, type}]});
+    ({
+      query,
+      type,
+      index,
+    }: CrossEvent & {
+      index?: number;
+    }) => {
+      if (!defined(queryParams.crossEvents)) {
+        setQueryParams({crossEvents: [{query, type}]});
+        return;
+      }
+
+      if (defined(index)) {
+        setQueryParams({
+          crossEvents: queryParams.crossEvents.map((crossEvent, i) =>
+            i === index ? {query, type} : crossEvent
+          ),
+        });
+        return;
+      }
+
+      setQueryParams({crossEvents: [...queryParams.crossEvents, {query, type}]});
     },
     [queryParams, setQueryParams]
   );

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -474,7 +474,7 @@ export function useSetQueryParamsCrossEvents() {
 
   return useCallback(
     () => (crossEvent: string) => {
-      setQueryParams({crossEvents: [...queryParams.crossEvents, {crossEvent}]});
+      setQueryParams({crossEvents: [...(queryParams.crossEvents ?? []), {crossEvent}]});
     },
     [queryParams, setQueryParams]
   );

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -470,33 +470,12 @@ export function useQueryParamsCrossEvents() {
 }
 
 export function useSetQueryParamsCrossEvents() {
-  const queryParams = useQueryParams();
   const setQueryParams = useSetQueryParams();
 
   return useCallback(
-    ({
-      query,
-      type,
-      index,
-    }: CrossEvent & {
-      index?: number;
-    }) => {
-      if (!defined(queryParams.crossEvents)) {
-        setQueryParams({crossEvents: [{query, type}]});
-        return;
-      }
-
-      if (defined(index)) {
-        setQueryParams({
-          crossEvents: queryParams.crossEvents.map((crossEvent, i) =>
-            i === index ? {query, type} : crossEvent
-          ),
-        });
-        return;
-      }
-
-      setQueryParams({crossEvents: [...queryParams.crossEvents, {query, type}]});
+    (crossEvents: CrossEvent[]) => {
+      setQueryParams({crossEvents});
     },
-    [queryParams, setQueryParams]
+    [setQueryParams]
   );
 }

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -2,7 +2,7 @@ import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';
 
-type CrossEventType = 'logs' | 'span' | 'metric';
+type CrossEventType = 'logs' | 'spans' | 'metrics';
 
 export interface CrossEvent {
   query: string;
@@ -30,6 +30,10 @@ export function getCrossEventsFromLocation(
   }
 
   return undefined;
+}
+
+export function isCrossEventType(value: string): value is CrossEventType {
+  return value === 'logs' || value === 'spans' || value === 'metrics';
 }
 
 function isCrossEvent(value: any): value is CrossEvent {

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -14,14 +14,14 @@ export function defaultCrossEvents() {
 export function getCrossEventsFromLocation(
   location: Location,
   key: string
-): CrossEvent[] | null {
+): CrossEvent[] | undefined {
   const rawCrossEvents = decodeList(location.query?.[key]);
 
   if (rawCrossEvents.length) {
     return rawCrossEvents.map(crossEvent => ({crossEvent}));
   }
 
-  return null;
+  return undefined;
 }
 
 export function isCrossEvent(value: any): value is CrossEvent {

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -40,7 +40,8 @@ function isCrossEvent(value: any): value is CrossEvent {
   return (
     defined(value) &&
     typeof value === 'object' &&
+    typeof value.query === 'string' &&
     typeof value.type === 'string' &&
-    typeof value.query === 'string'
+    isCrossEventType(value.type)
   );
 }

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -1,0 +1,31 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {decodeList} from 'sentry/utils/queryString';
+
+export interface CrossEvent {
+  crossEvent: string;
+}
+
+export function defaultCrossEvents() {
+  return [{crossEvent: ''}];
+}
+
+export function getCrossEventsFromLocation(
+  location: Location,
+  key: string
+): CrossEvent[] | null {
+  const rawCrossEvents = decodeList(location.query?.[key]);
+
+  if (rawCrossEvents.length) {
+    return rawCrossEvents.map(crossEvent => ({crossEvent}));
+  }
+
+  return null;
+}
+
+export function isCrossEvent(value: any): value is CrossEvent {
+  return (
+    defined(value) && typeof value === 'object' && typeof value.crossEvent === 'string'
+  );
+}

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -2,7 +2,7 @@ import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';
 
-type CrossEventType = 'trace' | 'span' | 'metric';
+type CrossEventType = 'logs' | 'span' | 'metric';
 
 export interface CrossEvent {
   query: string;
@@ -32,7 +32,7 @@ export function getCrossEventsFromLocation(
   return undefined;
 }
 
-export function isCrossEvent(value: any): value is CrossEvent {
+function isCrossEvent(value: any): value is CrossEvent {
   return (
     defined(value) &&
     typeof value === 'object' &&

--- a/static/app/views/explore/queryParams/readableQueryParams.ts
+++ b/static/app/views/explore/queryParams/readableQueryParams.ts
@@ -1,6 +1,7 @@
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import type {Mode} from 'sentry/views/explore/queryParams/mode';
 import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
@@ -10,6 +11,7 @@ export interface ReadableQueryParamsOptions {
   readonly aggregateCursor: string;
   readonly aggregateFields: readonly AggregateField[];
   readonly aggregateSortBys: readonly Sort[];
+  readonly crossEvents: readonly CrossEvent[];
   readonly cursor: string;
   readonly extrapolate: boolean;
   readonly fields: string[];
@@ -39,6 +41,8 @@ export class ReadableQueryParams {
   readonly id?: string;
   readonly title?: string;
 
+  readonly crossEvents: readonly CrossEvent[];
+
   constructor(options: ReadableQueryParamsOptions) {
     this.extrapolate = options.extrapolate;
     this.mode = options.mode;
@@ -58,6 +62,8 @@ export class ReadableQueryParams {
 
     this.id = options.id;
     this.title = options.title;
+
+    this.crossEvents = options.crossEvents;
   }
 
   replace(options: Partial<ReadableQueryParamsOptions>) {
@@ -73,6 +79,7 @@ export class ReadableQueryParams {
       sortBys: options.sortBys ?? this.sortBys,
       id: options.id ?? this.id,
       title: options.title ?? this.title,
+      crossEvents: options.crossEvents ?? this.crossEvents,
     });
   }
 }

--- a/static/app/views/explore/queryParams/readableQueryParams.ts
+++ b/static/app/views/explore/queryParams/readableQueryParams.ts
@@ -11,13 +11,13 @@ export interface ReadableQueryParamsOptions {
   readonly aggregateCursor: string;
   readonly aggregateFields: readonly AggregateField[];
   readonly aggregateSortBys: readonly Sort[];
-  readonly crossEvents: readonly CrossEvent[];
   readonly cursor: string;
   readonly extrapolate: boolean;
   readonly fields: string[];
   readonly mode: Mode;
   readonly query: string;
   readonly sortBys: Sort[];
+  readonly crossEvents?: CrossEvent[];
   readonly id?: string;
   readonly title?: string;
 }
@@ -41,7 +41,7 @@ export class ReadableQueryParams {
   readonly id?: string;
   readonly title?: string;
 
-  readonly crossEvents: readonly CrossEvent[];
+  readonly crossEvents?: CrossEvent[];
 
   constructor(options: ReadableQueryParamsOptions) {
     this.extrapolate = options.extrapolate;

--- a/static/app/views/explore/queryParams/writableQueryParams.ts
+++ b/static/app/views/explore/queryParams/writableQueryParams.ts
@@ -1,11 +1,13 @@
 import type {Sort} from 'sentry/utils/discover/fields';
 import type {WritableAggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
 import type {Mode} from 'sentry/views/explore/queryParams/mode';
 
 export interface WritableQueryParams {
   aggregateCursor?: string | null;
   aggregateFields?: readonly WritableAggregateField[] | null;
   aggregateSortBys?: readonly Sort[] | null;
+  crossEvents?: readonly CrossEvent[] | null;
   cursor?: string | null;
   extrapolate?: boolean;
   fields?: string[] | null;

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -157,9 +157,9 @@ export function getTargetWithReadableQueryParams(
   updateNullableLocation(
     target,
     SPANS_CROSS_EVENTS_KEY,
-    writableQueryParams?.crossEvents
-      ? JSON.stringify(writableQueryParams.crossEvents)
-      : null
+    writableQueryParams?.crossEvents === null
+      ? null
+      : writableQueryParams.crossEvents?.map(crossEvent => JSON.stringify(crossEvent))
   );
 
   return target;

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -154,6 +154,14 @@ export function getTargetWithReadableQueryParams(
         )
   );
 
+  updateNullableLocation(
+    target,
+    SPANS_CROSS_EVENTS_KEY,
+    writableQueryParams?.crossEvents
+      ? JSON.stringify(writableQueryParams.crossEvents)
+      : null
+  );
+
   return target;
 }
 

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -159,7 +159,7 @@ export function getTargetWithReadableQueryParams(
     SPANS_CROSS_EVENTS_KEY,
     writableQueryParams?.crossEvents === null
       ? null
-      : writableQueryParams.crossEvents?.map(crossEvent => JSON.stringify(crossEvent))
+      : JSON.stringify(writableQueryParams.crossEvents)
   );
 
   return target;

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -8,6 +8,7 @@ import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsCon
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {getAggregateFieldsFromLocation} from 'sentry/views/explore/queryParams/aggregateField';
 import {getAggregateSortBysFromLocation} from 'sentry/views/explore/queryParams/aggregateSortBy';
+import {getCrossEventsFromLocation} from 'sentry/views/explore/queryParams/crossEvent';
 import {getCursorFromLocation} from 'sentry/views/explore/queryParams/cursor';
 import {getExtrapolateFromLocation} from 'sentry/views/explore/queryParams/extrapolate';
 import {getFieldsFromLocation} from 'sentry/views/explore/queryParams/field';
@@ -49,6 +50,7 @@ const SPANS_AGGREGATE_SORT_KEY = 'aggregateSort';
 const SPANS_EXTRAPOLATE_KEY = 'extrapolate';
 const SPANS_ID_KEY = ID_KEY;
 const SPANS_TITLE_KEY = TITLE_KEY;
+const SPANS_CROSS_EVENTS_KEY = 'crossEvents';
 
 export function useSpansDataset(): DiscoverDatasets {
   return DiscoverDatasets.SPANS;
@@ -84,6 +86,8 @@ export function getReadableQueryParamsFromLocation(
   const id = getIdFromLocation(location, SPANS_ID_KEY);
   const title = getTitleFromLocation(location, SPANS_TITLE_KEY);
 
+  const crossEvents = getCrossEventsFromLocation(location, SPANS_CROSS_EVENTS_KEY);
+
   return new ReadableQueryParams({
     extrapolate,
     mode,
@@ -99,6 +103,8 @@ export function getReadableQueryParamsFromLocation(
 
     id,
     title,
+
+    crossEvents,
   });
 }
 


### PR DESCRIPTION
This PR adds in the boilerplate for adding in a new `crossEvents` query param to manage the state of displaying which and how many cross event search bars.

Ticket: EXP-600