### PR TITLE
chore(issue-taxonomy): Remove issue-taxonomy flag from backend

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -44,8 +44,7 @@ advanced_search_features: Sequence[tuple[Callable[[SearchFilter], Any], str]] = 
     (lambda search_filter: search_filter.value.is_wildcard(), "wildcard search"),
 ]
 
-DEFAULT_QUERY = "is:unresolved issue.priority:[high, medium]"
-TAXONOMY_DEFAULT_QUERY = "is:unresolved"
+DEFAULT_QUERY = "is:unresolved"
 
 
 def parse_and_convert_issue_search_query(
@@ -95,11 +94,7 @@ def build_query_params_from_request(
     has_query = request.GET.get("query")
     query = request.GET.get("query", None)
     if query is None:
-        query = (
-            TAXONOMY_DEFAULT_QUERY
-            if features.has("organizations:issue-taxonomy", organization)
-            else DEFAULT_QUERY
-        )
+        query = DEFAULT_QUERY
 
     query = query.strip()
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
@@ -362,11 +362,7 @@ class GroupSerializerBase(Serializer, ABC):
         is_subscribed, subscription_details = get_subscription_from_attributes(attrs)
         share_id = attrs["share_id"]
         priority_label = PriorityLevel(obj.priority).to_str() if obj.priority else None
-        issue_category = (
-            obj.issue_category_v2.name.lower()
-            if features.has("organizations:issue-taxonomy", obj.project.organization, actor=user)
-            else obj.issue_category.name.lower()
-        )
+        issue_category = obj.issue_category_v2.name.lower()
         group_dict: BaseGroupSerializerResponse = {
             "id": str(obj.id),
             "shareId": share_id,
@@ -1185,11 +1181,7 @@ class SimpleGroupSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> SimpleGroupSerializerResponse:
-        issue_category = (
-            obj.issue_category_v2.name.lower()
-            if features.has("organizations:issue-taxonomy", obj.project.organization, actor=user)
-            else obj.issue_category.name.lower()
-        )
+        issue_category = obj.issue_category_v2.name.lower()
 
         return SimpleGroupSerializerResponse(
             id=str(obj.id),

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -338,7 +338,7 @@ class IssueParams:
     DEFAULT_QUERY = OpenApiParameter(
         name="query",
         description="An optional search query for filtering issues. A default query will apply if no view/query is set. For all results use this parameter with an empty string.",
-        default="is:unresolved issue.priority:[high,medium]",
+        default="is:unresolved",
         location=OpenApiParameter.QUERY,
         type=OpenApiTypes.STR,
         required=False,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -197,8 +197,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enabling this will remove the consent flow for free generative AI features such as issue feedback summaries
     manager.add("organizations:gen-ai-consent-flow-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable the new issue category mapping
-    manager.add("organizations:issue-taxonomy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:metric-issue-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("projects:metric-issue-creation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Large HTTP Payload Detector Improvements

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -208,7 +208,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         description=(
             "Return a list of issues for an organization. "
             "All parameters are supplied as query string parameters. "
-            "A default query of `is:unresolved issue.priority:[high,medium]` is applied. "
+            "A default query of `is:unresolved` is applied. "
             "To return all results, use an empty query value (i.e. ``?query=`). "
         ),
         parameters=[

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -460,7 +460,7 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         perf_group = event.group
         serialized = serialize(perf_group)
         assert serialized["count"] == "1"
-        assert serialized["issueCategory"] == "performance"
+        assert serialized["issueCategory"] == "db_query"
         assert serialized["issueType"] == "performance_n_plus_one_db_queries"
 
 

--- a/tests/sentry/api/serializers/test_group_stream.py
+++ b/tests/sentry/api/serializers/test_group_stream.py
@@ -59,7 +59,7 @@ class StreamGroupSerializerTestCase(
             request=self.make_request(),
         )
         assert serialized["count"] == "1"
-        assert serialized["issueCategory"] == "performance"
+        assert serialized["issueCategory"] == "db_query"
         assert serialized["issueType"] == "performance_n_plus_one_db_queries"
         assert [stat[1] for stat in serialized["stats"]["24h"][:-1]] == [0] * 23
         assert serialized["stats"]["24h"][-1][1] == 1
@@ -78,7 +78,7 @@ class StreamGroupSerializerTestCase(
             request=self.make_request(),
         )
         assert serialized["count"] == "1"
-        assert serialized["issueCategory"] == str(GroupCategory.PERFORMANCE.name).lower()
+        assert serialized["issueCategory"] == str(GroupCategory.MOBILE.name).lower()
         assert serialized["issueType"] == str(ProfileFileIOGroupType.slug)
         assert [stat[1] for stat in serialized["stats"]["24h"][:-1]] == [0] * 23
         assert serialized["stats"]["24h"][-1][1] == 1

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2051,36 +2051,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.status_code == 200
         assert [int(r["id"]) for r in response.data] == [event1.group.id]
 
-    def test_default_search_with_priority(self) -> None:
-        event1 = self.store_event(
-            data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},
-            project_id=self.project.id,
-        )
-        event1.group.priority = PriorityLevel.HIGH
-        event1.group.save()
-        event2 = self.store_event(
-            data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-3"]},
-            project_id=self.project.id,
-        )
-        event2.group.status = GroupStatus.RESOLVED
-        event2.group.substatus = None
-        event2.group.priority = PriorityLevel.HIGH
-        event2.group.save()
-
-        event3 = self.store_event(
-            data={"timestamp": before_now(seconds=400).isoformat(), "fingerprint": ["group-2"]},
-            project_id=self.project.id,
-        )
-        event3.group.priority = PriorityLevel.LOW
-        event3.group.save()
-
-        self.login_as(user=self.user)
-        sleep(1)
-
-        response = self.get_response(sort_by="date", limit=10, expand="inbox", collapse="stats")
-        assert response.status_code == 200
-        assert [int(r["id"]) for r in response.data] == [event1.group.id]
-
     def test_collapse_stats(self) -> None:
         event = self.store_event(
             data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -22,7 +22,6 @@ from sentry.notifications.types import NotificationSettingsOptionEnum
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.group import PriorityLevel
 from sentry.users.models.user_option import UserOption
@@ -471,13 +470,6 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert result["id"] == str(group.id)
 
     def test_issue_category(self) -> None:
-        group = self.create_group(type=PerformanceNPlusOneGroupType.type_id)
-        result = serialize(group, self.user, serializer=GroupSerializerSnuba())
-
-        assert result["issueCategory"] == GroupCategory.PERFORMANCE.name.lower()
-
-    @with_feature("organizations:issue-taxonomy")
-    def test_issue_category_v2(self) -> None:
         group = self.create_group(type=PerformanceNPlusOneGroupType.type_id)
         result = serialize(group, self.user, serializer=GroupSerializerSnuba())
 


### PR DESCRIPTION
`organizations:issue-taxonomy` has been GA'd for quite a while, this removes it.

There is some followup work that needs to be done in order to remove the deprecated categories, but in the meantime this allows us to get rid of the flag.

Requires https://github.com/getsentry/sentry/pull/103669 to be first merged and deployed