### PR TITLE
chore(aci): update product links for LA

### DIFF
--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -82,7 +82,7 @@ export default function AutomationsList() {
         description={t(
           'Alerts are triggered when issue changes state, is created, or passes a threshold. They perform external actions like sending notifications, creating tickets, or calling webhooks and integrations.'
         )}
-        docsUrl="https://docs.sentry.io/product/automations/"
+        docsUrl="https://docs.sentry.io/product/new-monitors-and-alerts/alerts/"
       >
         <TableHeader />
         <div>

--- a/static/app/views/detectors/list/allMonitors.tsx
+++ b/static/app/views/detectors/list/allMonitors.tsx
@@ -10,7 +10,7 @@ const TITLE = t('Monitors');
 const DESCRIPTION = t(
   'Monitors are used to transform errors, performance problems, and other events into issues.'
 );
-const DOCS_URL = 'https://docs.sentry.io/product/monitors/';
+const DOCS_URL = 'https://docs.sentry.io/product/new-monitors-and-alerts/monitors/';
 
 export default function AllMonitors() {
   const detectorListQuery = useDetectorListQuery();

--- a/static/app/views/detectors/list/error.tsx
+++ b/static/app/views/detectors/list/error.tsx
@@ -10,7 +10,8 @@ const TITLE = t('Error Monitors');
 const DESCRIPTION = t(
   'Error monitors are created by default for each project based on issue grouping/fingerprint rules.'
 );
-const DOCS_URL = 'https://docs.sentry.io/product/monitors/';
+const DOCS_URL =
+  'https://docs.sentry.io/product/new-monitors-and-alerts/monitors/#default-monitors';
 
 export default function ErrorDetectorsList() {
   const detectorListQuery = useDetectorListQuery({

--- a/static/app/views/detectors/list/metric.tsx
+++ b/static/app/views/detectors/list/metric.tsx
@@ -10,7 +10,8 @@ const TITLE = t('Metric Monitors');
 const DESCRIPTION = t(
   'Metric monitors track errors based on span attributes and custom metrics.'
 );
-const DOCS_URL = 'https://docs.sentry.io/product/monitors/';
+const DOCS_URL =
+  'https://docs.sentry.io/product/new-monitors-and-alerts/monitors/#metric-monitor-settings';
 
 export default function MetricDetectorsList() {
   const detectorListQuery = useDetectorListQuery({

--- a/static/app/views/detectors/list/myMonitors.tsx
+++ b/static/app/views/detectors/list/myMonitors.tsx
@@ -8,7 +8,7 @@ import {useDetectorListQuery} from 'sentry/views/detectors/list/common/useDetect
 
 const TITLE = t('My Monitors');
 const DESCRIPTION = t('View monitors assigned to you or your teams.');
-const DOCS_URL = 'https://docs.sentry.io/product/monitors/';
+const DOCS_URL = 'https://docs.sentry.io/product/new-monitors-and-alerts/monitors/';
 
 export default function MyMonitorsList() {
   const detectorListQuery = useDetectorListQuery({


### PR DESCRIPTION
updated links according to https://github.com/getsentry/sentry-docs/pull/15550

we'll be keeping monitors/alerts docs in a separate folder during LA so that they're still published/accessible but don't interfere with the structure of existing docs