### PR TITLE
Update frontend api logs

### DIFF
--- a/static/app/components/events/metrics/metricsSection.spec.tsx
+++ b/static/app/components/events/metrics/metricsSection.spec.tsx
@@ -121,7 +121,7 @@ describe('MetricsSection', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
-      match: [MockApiClient.matchQuery({dataset: 'ourlogs'})],
+      match: [MockApiClient.matchQuery({dataset: 'logs'})],
       body: {data: [], meta: {}},
     });
   });

--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -65,7 +65,7 @@ export function OurlogsDrawer({
 
   const tracesItemSearchQueryBuilderProps = {
     initialQuery: logsSearch.formatString(),
-    searchSource: 'ourlogs',
+    searchSource: 'logs',
     onSearch: (query: string) => setLogsQuery(query),
     numberAttributes,
     stringAttributes,

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -19,7 +19,7 @@ export enum DiscoverDatasets {
   METRICS = 'metrics',
   METRICS_ENHANCED = 'metricsEnhanced',
   ISSUE_PLATFORM = 'issuePlatform',
-  OURLOGS = 'ourlogs',
+  OURLOGS = 'logs',
   SPANS = 'spans',
   TRANSACTIONS = 'transactions',
   TRACEMETRICS = 'tracemetrics',

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -434,7 +434,7 @@ export type ResourceFrame = HydratedSpan<
 
 // OurLogs converted from log to frame for use with jump buttons etc.
 export type OurLogsPseudoFrame = {
-  category: 'ourlogs';
+  category: 'logs';
   offsetMs: number;
   timestampMs: number;
   data?: undefined;

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -17,7 +17,7 @@ export enum DataSet {
   ERRORS = 'error-events',
   TRANSACTIONS = 'transaction-like',
   SPANS = 'spans',
-  LOGS = 'ourlogs',
+  LOGS = 'logs',
 }
 
 export enum SortDirection {

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -190,7 +190,7 @@ describe('LogsPage', () => {
           query: expect.objectContaining({
             environment: [],
             statsPeriod: '24h',
-            dataset: 'ourlogs',
+            dataset: 'logs',
             field: ['severity', 'count(message)'],
             sort: '-count(message)',
           }),
@@ -205,7 +205,7 @@ describe('LogsPage', () => {
           query: expect.objectContaining({
             environment: [],
             statsPeriod: '24h',
-            dataset: 'ourlogs',
+            dataset: 'logs',
             field: ['severity', 'count(message)'],
             yAxis: 'count(message)',
             orderby: '-count_message',

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -121,7 +121,7 @@ describe('LogsTabContent', () => {
           isMetricsExtractedData: false,
           tips: {},
           datasetReason: 'unchanged',
-          dataset: 'ourlogs',
+          dataset: 'logs',
           dataScanned: 'full',
           accuracy: {
             confidence: [{}, {}],
@@ -182,7 +182,7 @@ describe('LogsTabContent', () => {
         query: expect.objectContaining({
           environment: [],
           statsPeriod: '14d',
-          dataset: 'ourlogs',
+          dataset: 'logs',
           field: [...AlwaysPresentLogFields, 'message', 'sentry.message.parameters.0'],
           sort: 'sentry.message.parameters.0',
           query: 'severity:error',
@@ -196,7 +196,7 @@ describe('LogsTabContent', () => {
         query: expect.objectContaining({
           environment: [],
           statsPeriod: '14d',
-          dataset: 'ourlogs',
+          dataset: 'logs',
           yAxis: 'count(message)',
           interval: '1h',
           query: 'severity:error timestamp_precise:<=1508208040000000000',
@@ -275,7 +275,7 @@ describe('LogsTabContent', () => {
         query: expect.objectContaining({
           environment: [],
           statsPeriod: '14d',
-          dataset: 'ourlogs',
+          dataset: 'logs',
           field: [...AlwaysPresentLogFields, 'message', 'sentry.message.parameters.0'],
           sort: 'sentry.message.parameters.0',
           query: 'severity:error',
@@ -290,7 +290,7 @@ describe('LogsTabContent', () => {
         query: expect.objectContaining({
           environment: [],
           statsPeriod: '14d',
-          dataset: 'ourlogs',
+          dataset: 'logs',
           yAxis: 'count(message)',
           interval: '1h',
           query: 'severity:error timestamp_precise:<=1508208040000000000',

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -380,7 +380,7 @@ describe('LogsInfiniteTable', () => {
           isMetricsExtractedData: false,
           tips: {},
           datasetReason: 'unchanged',
-          dataset: 'ourlogs',
+          dataset: 'logs',
           dataScanned: 'full',
           accuracy: {
             confidence: [{}, {}],

--- a/static/app/views/explore/logs/useLogsAggregatesTable.spec.tsx
+++ b/static/app/views/explore/logs/useLogsAggregatesTable.spec.tsx
@@ -72,7 +72,7 @@ describe('useLogsAggregatesTable', () => {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'ourlogs',
+          dataset: 'logs',
           sampling: SAMPLING_MODE.NORMAL,
         }),
       })
@@ -83,7 +83,7 @@ describe('useLogsAggregatesTable', () => {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'ourlogs',
+          dataset: 'logs',
           sampling: SAMPLING_MODE.HIGH_ACCURACY,
         }),
       })

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -297,7 +297,7 @@ describe('useInfiniteLogsQuery', () => {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'ourlogs',
+          dataset: 'logs',
           sampling: SAMPLING_MODE.NORMAL,
         }),
       })
@@ -308,7 +308,7 @@ describe('useInfiniteLogsQuery', () => {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'ourlogs',
+          dataset: 'logs',
           sampling: SAMPLING_MODE.HIGH_ACCURACY,
         }),
       })
@@ -318,7 +318,7 @@ describe('useInfiniteLogsQuery', () => {
   describe('high fidelity', () => {
     function makeLinkHeader(cursor: string, hasNext = true) {
       const url =
-        'https://sentry.io/api/0/organizations/org-slug/events/?caseInsensitive=&dataset=ourlogs&field=id&field=project.id&field=trace&field=severity_number&field=severity&field=timestamp&field=timestamp_precise&field=observed_timestamp&field=message.template&field=message&orderby=-timestamp&per_page=1000&query=&referrer=api.explore.logs-table&sampling=HIGHEST_ACCURACY_FLEX_TIME&sort=-timestamp&statsPeriod=1h&highFidelity=true';
+        'https://sentry.io/api/0/organizations/org-slug/events/?caseInsensitive=&dataset=logs&field=id&field=project.id&field=trace&field=severity_number&field=severity&field=timestamp&field=timestamp_precise&field=observed_timestamp&field=message.template&field=message&orderby=-timestamp&per_page=1000&query=&referrer=api.explore.logs-table&sampling=HIGHEST_ACCURACY_FLEX_TIME&sort=-timestamp&statsPeriod=1h&highFidelity=true';
       return [
         [
           `<${url}&cursor=:0:1>`,

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -53,7 +53,7 @@ export function useLogsSearchQueryBuilderProps({
 
   const tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps = {
     initialQuery: logsSearch.formatString(),
-    searchSource: 'ourlogs',
+    searchSource: 'logs',
     onSearch,
     numberAttributes,
     stringAttributes,

--- a/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
+++ b/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
@@ -113,7 +113,7 @@ describe('useLogsTimeseries', () => {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'ourlogs',
+          dataset: 'logs',
           sampling: SAMPLING_MODE.NORMAL,
         }),
       })
@@ -126,7 +126,7 @@ describe('useLogsTimeseries', () => {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: 'ourlogs',
+          dataset: 'logs',
           sampling: SAMPLING_MODE.HIGH_ACCURACY,
         }),
       })

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -62,7 +62,7 @@ function LogsSectionContent({
         filterKeys={{}}
         getTagValues={() => new Promise<string[]>(() => [])}
         initialQuery={logsSearch.formatString()}
-        searchSource="ourlogs"
+        searchSource="logs"
         onSearch={query => setLogsQuery(query)}
       />
       <TableContainer>

--- a/static/app/views/replays/detail/ourlogs/ourlogsAsFrames.tsx
+++ b/static/app/views/replays/detail/ourlogs/ourlogsAsFrames.tsx
@@ -9,7 +9,7 @@ export function ourlogsAsFrames(
   ourlogs: OurLogsResponseItem[]
 ): OurLogsPseudoFrame[] {
   return ourlogs.map(ourlog => ({
-    category: 'ourlogs',
+    category: 'logs',
     data: undefined,
     offsetMs:
       new Date(ourlog[OurLogKnownFieldKey.TIMESTAMP]).getTime() - relativeTimestampMs,


### PR DESCRIPTION
<!-- Describe your PR here. -->
Updates all frontend API references from `ourlogs` to `logs` for dataset values and search sources. This change aligns the frontend with the backend's deprecation of the `ourlogs` dataset name.

-   Updated `DiscoverDatasets` and `DataSet` enums.
-   Changed `searchSource: 'ourlogs'` to `searchSource: 'logs'` in relevant components and hooks.
-   Updated `dataset: 'ourlogs'` to `dataset: 'logs'` in API calls within test files.
-   Modified `OurLogsPseudoFrame` type and `ourlogsAsFrames` utility to use `category: 'logs'`.

Internal feature flag names (e.g., `ourlogs-enabled`) and file/variable names containing "ourlogs" were intentionally not changed.

---
[Slack Thread](https://sentry.slack.com/archives/C08SBFDKBKJ/p1763578789720649?thread_ts=1763578789.720649&cid=C08SBFDKBKJ)

<a href="https://cursor.com/background-agent?bcId=bc-6bd3fa09-5b24-4ee4-be46-a21cc2554db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6bd3fa09-5b24-4ee4-be46-a21cc2554db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

