### PR TITLE
feat(triage signals): New kick_off_seer_automation flow [feature flagged]

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -291,7 +291,7 @@ def _is_issue_fixable(group: Group, fixability_score: float) -> bool:
     return False
 
 
-def _run_automation(
+def run_automation(
     group: Group,
     user: User | RpcUser | AnonymousUser,
     event: GroupEvent,
@@ -403,7 +403,7 @@ def _generate_summary(
 
     if should_run_automation:
         try:
-            _run_automation(group, user, event, source)
+            run_automation(group, user, event, source)
         except Exception:
             logger.exception(
                 "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -75,7 +75,9 @@ def run_automation_for_group(group_id: int) -> None:
     Run automation directly for a group (assumes summary and fixability already exist).
     Used for triage signals flow when event count >= 10 and summary exists.
     """
-    from sentry.seer.autofix.issue_summary import _run_automation
+    from django.contrib.auth.models import AnonymousUser
+
+    from sentry.seer.autofix.issue_summary import run_automation
 
     group = Group.objects.get(id=group_id)
     event = group.get_latest_event()
@@ -84,4 +86,6 @@ def run_automation_for_group(group_id: int) -> None:
         logger.warning("run_automation_for_group.no_event_found", extra={"group_id": group_id})
         return
 
-    _run_automation(group=group, user=None, event=event, source=SeerAutomationSource.POST_PROCESS)
+    run_automation(
+        group=group, user=AnonymousUser(), event=event, source=SeerAutomationSource.POST_PROCESS
+    )

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -31,12 +31,12 @@ def check_autofix_status(run_id: int, organization_id: int) -> None:
 
 
 @instrumented_task(
-    name="sentry.tasks.autofix.start_seer_automation",
+    name="sentry.tasks.autofix.generate_summary_and_run_automation",
     namespace=ingest_errors_tasks,
     processing_deadline_duration=35,
     retry=Retry(times=1),
 )
-def start_seer_automation(group_id: int) -> None:
+def generate_summary_and_run_automation(group_id: int) -> None:
     from sentry.seer.autofix.issue_summary import get_issue_summary
 
     group = Group.objects.get(id=group_id)
@@ -60,17 +60,18 @@ def generate_issue_summary_only(group_id: int) -> None:
     get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
-    # TODO: Generate fixability score here and check for in run_automation for triage signals V0
+    # TODO: Generate fixability score here and check for it in run_automation around line 316
+    # That will make sure that even after adding fixability here it's not re-triggered.
     # Currently fixability will only be generated after 10 when run_automation is called
 
 
 @instrumented_task(
-    name="sentry.tasks.autofix.run_automation_for_group",
+    name="sentry.tasks.autofix.run_automation_only_task",
     namespace=ingest_errors_tasks,
     processing_deadline_duration=35,
     retry=Retry(times=1),
 )
-def run_automation_for_group(group_id: int) -> None:
+def run_automation_only_task(group_id: int) -> None:
     """
     Run automation directly for a group (assumes summary and fixability already exist).
     Used for triage signals flow when event count >= 10 and summary exists.
@@ -83,7 +84,7 @@ def run_automation_for_group(group_id: int) -> None:
     event = group.get_latest_event()
 
     if not event:
-        logger.warning("run_automation_for_group.no_event_found", extra={"group_id": group_id})
+        logger.warning("run_automation_only_task.no_event_found", extra={"group_id": group_id})
         return
 
     run_automation(

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -60,6 +60,8 @@ def generate_issue_summary_only(group_id: int) -> None:
     get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
+    # TODO: Generate fixability score here and check for in run_automation for triage signals V0
+    # Currently fixability will only be generated after 10 when run_automation is called
 
 
 @instrumented_task(

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -62,7 +62,7 @@ def generate_issue_summary_only(group_id: int) -> None:
     )
     # TODO: Generate fixability score here and check for it in run_automation around line 316
     # That will make sure that even after adding fixability here it's not re-triggered.
-    # Currently fixability will only be generated after 10 when run_automation is called
+    # Currently fixability will only be generated after 10 events when run_automation is called
 
 
 @instrumented_task(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1636,7 +1636,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         # Triage signals V0 behaviour
 
         # If event count < 10, only generate summary (no automation)
-        if group.times_seen < 10:
+        if group.times_seen_with_pending < 10:
             # Check if summary exists in cache
             cache_key = get_issue_summary_cache_key(group.id)
             if cache.get(cache_key) is not None:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1681,7 +1681,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
                 # Summary exists, run automation directly
                 run_automation_only_task.delay(group.id)
             else:
-                # Rate limit check must be last, after cache.add succeeds, to avoid wasting quota
+                # Rate limit check before generating summary
                 if is_seer_scanner_rate_limited(group.project, group.organization):
                     return
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1660,14 +1660,13 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             # Early returns for eligibility checks (cheap checks first)
             if not is_issue_eligible_for_seer_automation(group):
                 return
+            if is_seer_scanner_rate_limited(group.project, group.organization):
+                return
 
             # Now acquire a longer lock to avoid race conditions when starting the automation
             lock_key, lock_name = get_issue_summary_lock_key(group.id)
-            lock = locks.get(lock_key, duration=10, name=lock_name)
+            lock = locks.get(lock_key, duration=30, name=lock_name)
             if lock.locked():
-                return
-
-            if is_seer_scanner_rate_limited(group.project, group.organization):
                 return
 
             # Check if summary exists in cache

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1661,6 +1661,8 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             # Long-term check to avoid re-running
             if (
                 group.seer_autofix_last_triggered is not None
+                or group.seer_fixability_score
+                is not None  # TODO: Remove this once fixability is generated with generate_issue_summary_only
                 or group.project.get_option("sentry:autofix_automation_tuning")
                 == AutofixAutomationTuningSettings.OFF
             ):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1663,23 +1663,22 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             if is_seer_scanner_rate_limited(group.project, group.organization):
                 return
 
-            # Acquire a task queuing lock to avoid dispatching duplicate tasks
-            # This is separate from the work execution lock in get_issue_summary()
-            lock_key = f"post-process-seer-automation-dispatch:{group.id}"
-            lock = locks.get(lock_key, duration=60, name="post_process_seer_automation_dispatch")
-            try:
-                with lock.acquire():
-                    # Check if summary exists in cache
-                    cache_key = get_issue_summary_cache_key(group.id)
-                    if cache.get(cache_key) is not None:
-                        # Summary exists, run automation directly
-                        run_automation_for_group.delay(group.id)
-                    else:
-                        # No summary yet, generate summary + run automation in one go
-                        start_seer_automation.delay(group.id)
-            except UnableToAcquireLock:
-                # Another process is already dispatching tasks for this group
-                return
+            # Check if we're already processing automation for this group
+            automation_dispatch_cache_key = f"seer-automation-dispatched:{group.id}"
+            if cache.get(automation_dispatch_cache_key) is not None:
+                return  # Another process already dispatched automation
+
+            # Set cache with 5 minute TTL to prevent duplicate dispatches
+            cache.set(automation_dispatch_cache_key, True, timeout=300)
+
+            # Check if summary exists in cache
+            cache_key = get_issue_summary_cache_key(group.id)
+            if cache.get(cache_key) is not None:
+                # Summary exists, run automation directly
+                run_automation_for_group.delay(group.id)
+            else:
+                # No summary yet, generate summary + run automation in one go
+                start_seer_automation.delay(group.id)
 
 
 GROUP_CATEGORY_POST_PROCESS_PIPELINE = {

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1595,6 +1595,7 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
+    from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
     from sentry.seer.autofix.issue_summary import (
         get_issue_summary_cache_key,
         get_issue_summary_lock_key,
@@ -1653,8 +1654,12 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             generate_issue_summary_only.delay(group.id)
         else:
             # Event count >= 10: run automation
-            # Check seer_last_triggered first (long-term check to avoid re-running)
-            if group.seer_autofix_last_triggered is not None:
+            # Long-term check to avoid re-running
+            if (
+                group.seer_autofix_last_triggered is not None
+                or group.project.get_option("sentry:autofix_automation_tuning")
+                == AutofixAutomationTuningSettings.OFF
+            ):
                 return
 
             # Early returns for eligibility checks (cheap checks first)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1635,7 +1635,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         # Triage signals V0 behaviour
 
         # If event count < 10, only generate summary (no automation)
-        if group.times_seen_with_pending < 10:
+        if group.times_seen < 10:
             # Check if summary exists in cache
             cache_key = get_issue_summary_cache_key(group.id)
             if cache.get(cache_key) is not None:
@@ -1654,7 +1654,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         else:
             # Event count >= 10: run automation
             # Check seer_last_triggered first (long-term check to avoid re-running)
-            if group.seer_last_triggered is not None:
+            if group.seer_autofix_last_triggered is not None:
                 return
 
             # Early returns for eligibility checks (cheap checks first)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1639,10 +1639,9 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             # Check if summary exists in cache
             cache_key = get_issue_summary_cache_key(group.id)
             if cache.get(cache_key) is not None:
-                # Summary already exists, nothing to do
                 return
 
-            # Check if we're already processing this issue
+            # Check if we're already generating the summary
             lock_key, lock_name = get_issue_summary_lock_key(group.id)
             lock = locks.get(lock_key, duration=5, name=lock_name)
             if lock.locked():
@@ -1662,7 +1661,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             if not is_issue_eligible_for_seer_automation(group):
                 return
 
-            # Now acquire lock (only after all cheap checks pass)
+            # Now acquire a longer lock to avoid race conditions when starting the automation
             lock_key, lock_name = get_issue_summary_lock_key(group.id)
             lock = locks.get(lock_key, duration=10, name=lock_name)
             if lock.locked():

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -18,8 +18,8 @@ from sentry.seer.autofix.issue_summary import (
     _fetch_user_preference,
     _get_event,
     _get_stopping_point_from_fixability,
-    _run_automation,
     get_issue_summary,
+    run_automation,
 )
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SummarizeIssueResponse, SummarizeIssueScores
@@ -611,7 +611,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_trigger_autofix_task.assert_called_once()
 
     @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
-    @patch("sentry.seer.autofix.issue_summary._run_automation")
+    @patch("sentry.seer.autofix.issue_summary.run_automation")
     @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.issue_summary._call_seer")
     @patch("sentry.seer.autofix.issue_summary._get_event")
@@ -623,7 +623,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_run_automation,
         mock_get_acknowledgement,
     ):
-        """Test that issue summary is still returned when _run_automation throws an exception."""
+        """Test that issue summary is still returned when run_automation throws an exception."""
         mock_get_acknowledgement.return_value = True
 
         # Set up event and seer response
@@ -641,7 +641,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         )
         mock_call_seer.return_value = mock_summary
 
-        # Make _run_automation raise an exception
+        # Make run_automation raise an exception
         mock_run_automation.side_effect = Exception("Automation failed")
 
         # Call get_issue_summary and verify it still returns successfully
@@ -652,7 +652,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         expected_response["event_id"] = event.event_id
         assert summary_data == convert_dict_key_case(expected_response, snake_to_camel_case)
 
-        # Verify _run_automation was called and failed
+        # Verify run_automation was called and failed
         mock_run_automation.assert_called_once()
         mock_call_seer.assert_called_once()
 
@@ -681,7 +681,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
                     possible_cause="cause",
                 ),
             ) as mock_call_seer,
-            patch("sentry.seer.autofix.issue_summary._run_automation"),
+            patch("sentry.seer.autofix.issue_summary.run_automation"),
             patch(
                 "sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement",
                 return_value=True,
@@ -693,7 +693,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_call_seer.assert_called_once_with(self.group, serialized_event, None)
 
     @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
-    @patch("sentry.seer.autofix.issue_summary._run_automation")
+    @patch("sentry.seer.autofix.issue_summary.run_automation")
     @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.issue_summary._call_seer")
     @patch("sentry.seer.autofix.issue_summary._get_event")
@@ -705,7 +705,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_run_automation,
         mock_get_acknowledgement,
     ):
-        """Test that should_run_automation=False prevents _run_automation from being called."""
+        """Test that should_run_automation=False prevents run_automation from being called."""
         mock_get_acknowledgement.return_value = True
         event = Mock(
             event_id="test_event_id",
@@ -743,7 +743,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_call_seer.assert_called_once_with(self.group, serialized_event, {"trace": "tree"})
         mock_get_acknowledgement.assert_called_once_with(self.group.organization)
 
-        # Verify that _run_automation was NOT called
+        # Verify that run_automation was NOT called
         mock_run_automation.assert_not_called()
 
         # Check if the cache was set correctly
@@ -798,7 +798,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
             possible_cause="c",
             scores=SummarizeIssueScores(fixability_score=0.70),
         )
-        _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
 
@@ -822,7 +822,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
             possible_cause="c",
             scores=SummarizeIssueScores(fixability_score=0.50),
         )
-        _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.SOLUTION
 
@@ -848,7 +848,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         with self.feature(
             {"organizations:gen-ai-features": True, "projects:triage-signals-v0": False}
         ):
-            _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+            run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] is None
@@ -1001,7 +1001,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         )
         mock_fetch.return_value = "solution"
 
-        _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 
         mock_trigger.assert_called_once()
         # Should be limited to SOLUTION by user preference
@@ -1031,7 +1031,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         )
         mock_fetch.return_value = "open_pr"
 
-        _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 
         mock_trigger.assert_called_once()
         # Should use SOLUTION from fixability, not OPEN_PR from user
@@ -1061,7 +1061,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         )
         mock_fetch.return_value = None
 
-        _run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 
         mock_trigger.assert_called_once()
         # Should use OPEN_PR from fixability

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2675,10 +2675,10 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_with_features(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -2693,15 +2693,15 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_called_once_with(event.group.id)
+        mock_generate_summary_and_run_automation.assert_called_once_with(event.group.id)
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     def test_kick_off_seer_automation_without_org_feature(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -2715,16 +2715,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=False,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_without_seer_enabled(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -2739,16 +2739,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_without_scanner_on(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -2764,16 +2764,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_skips_existing_fixability_score(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -2793,16 +2793,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_runs_with_missing_fixability_score(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -2821,16 +2821,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_called_once_with(group.id)
+        mock_generate_summary_and_run_automation.assert_called_once_with(group.id)
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_skips_with_existing_fixability_score(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         from sentry.seer.autofix.issue_summary import get_issue_summary_cache_key
 
@@ -2856,16 +2856,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch("sentry.seer.autofix.utils.is_seer_scanner_rate_limited")
     @patch("sentry.quotas.backend.has_available_reserved_budget")
     @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner")
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_rate_limit_only_checked_after_all_other_checks_pass(
         self,
-        mock_start_seer_automation,
+        mock_generate_summary_and_run_automation,
         mock_get_seer_org_acknowledgement,
         mock_has_budget,
         mock_is_rate_limited,
@@ -2889,10 +2889,10 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
         mock_is_rate_limited.assert_called_once_with(event.project, event.group.organization)
-        mock_start_seer_automation.assert_called_once_with(event.group.id)
+        mock_generate_summary_and_run_automation.assert_called_once_with(event.group.id)
 
         mock_is_rate_limited.reset_mock()
-        mock_start_seer_automation.reset_mock()
+        mock_generate_summary_and_run_automation.reset_mock()
 
         # Test 2: When seer org acknowledgement fails, rate limit should NOT be checked
         mock_get_seer_org_acknowledgement.return_value = False
@@ -2909,10 +2909,10 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event2,
         )
         mock_is_rate_limited.assert_not_called()
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
         mock_is_rate_limited.reset_mock()
-        mock_start_seer_automation.reset_mock()
+        mock_generate_summary_and_run_automation.reset_mock()
         mock_get_seer_org_acknowledgement.return_value = True  # Reset to success
 
         # Test 3: When budget check fails, rate limit should NOT be checked
@@ -2930,10 +2930,10 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event3,
         )
         mock_is_rate_limited.assert_not_called()
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
         mock_is_rate_limited.reset_mock()
-        mock_start_seer_automation.reset_mock()
+        mock_generate_summary_and_run_automation.reset_mock()
         mock_has_budget.return_value = True  # Reset to success
 
         # Test 4: When project option is disabled, rate limit should NOT be checked
@@ -2951,16 +2951,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event4,
         )
         mock_is_rate_limited.assert_not_called()
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_skips_when_lock_held(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         """Test that seer automation is skipped when another task is already processing the same issue"""
         from sentry.seer.autofix.issue_summary import get_issue_summary_lock_key
@@ -2986,7 +2986,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             )
 
         # Verify that seer automation was NOT started due to the lock
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
         # Test that it works normally when lock is not held
         event2 = self.create_event(
@@ -3002,16 +3002,16 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         )
 
         # Now it should be called since no lock is held
-        mock_start_seer_automation.assert_called_once_with(event2.group.id)
+        mock_generate_summary_and_run_automation.assert_called_once_with(event2.group.id)
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
     def test_kick_off_seer_automation_with_hide_ai_features_enabled(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         """Test that seer automation is not started when organization has hideAiFeatures set to True"""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3029,7 +3029,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_not_called()
+        mock_generate_summary_and_run_automation.assert_not_called()
 
 
 class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
@@ -3062,7 +3062,7 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        # Should call generate_issue_summary_only (not start_seer_automation)
+        # Should call generate_issue_summary_only (not generate_summary_and_run_automation)
         mock_generate_summary_only.assert_called_once_with(group.id)
 
     @patch(
@@ -3102,7 +3102,7 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.run_automation_for_group.delay")
+    @patch("sentry.tasks.autofix.run_automation_only_task.delay")
     @with_feature({"organizations:gen-ai-features": True, "projects:triage-signals-v0": True})
     def test_triage_signals_event_count_gte_10_with_cache(
         self, mock_run_automation, mock_get_seer_org_acknowledgement
@@ -3134,17 +3134,17 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        # Should call run_automation_for_group since summary exists
+        # Should call run_automation_only_task since summary exists
         mock_run_automation.assert_called_once_with(group.id)
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature({"organizations:gen-ai-features": True, "projects:triage-signals-v0": True})
     def test_triage_signals_event_count_gte_10_no_cache(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+        self, mock_generate_summary_and_run_automation, mock_get_seer_org_acknowledgement
     ):
         """Test that with event count >= 10 and no cached summary, we generate summary + run automation."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3167,14 +3167,14 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        # Should call start_seer_automation to generate summary + run automation
-        mock_start_seer_automation.assert_called_once_with(group.id)
+        # Should call generate_summary_and_run_automation to generate summary + run automation
+        mock_generate_summary_and_run_automation.assert_called_once_with(group.id)
 
     @patch(
         "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
         return_value=True,
     )
-    @patch("sentry.tasks.autofix.run_automation_for_group.delay")
+    @patch("sentry.tasks.autofix.run_automation_only_task.delay")
     @with_feature({"organizations:gen-ai-features": True, "projects:triage-signals-v0": True})
     def test_triage_signals_event_count_gte_10_skips_with_seer_last_triggered(
         self, mock_run_automation, mock_get_seer_org_acknowledgement

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3213,6 +3213,48 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
         # Should not call automation since seer_autofix_last_triggered is set
         mock_run_automation.assert_not_called()
 
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner",
+        return_value=True,
+    )
+    @patch("sentry.tasks.autofix.run_automation_only_task.delay")
+    @with_feature({"organizations:gen-ai-features": True, "projects:triage-signals-v0": True})
+    def test_triage_signals_event_count_gte_10_skips_with_existing_fixability_score(
+        self, mock_run_automation, mock_get_seer_org_acknowledgement
+    ):
+        """Test that with event count >= 10 and seer_fixability_score exists, we skip automation."""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        self.project.update_option("sentry:autofix_automation_tuning", "always")
+        event = self.create_event(
+            data={"message": "testing"},
+            project_id=self.project.id,
+        )
+
+        # Update group times_seen and set seer_fixability_score (but not seer_autofix_last_triggered)
+        group = event.group
+        group.times_seen = 10
+        group.seer_fixability_score = 0.5
+        group.save()
+        # Also update the event's cached group reference
+        event.group.times_seen = 10
+        event.group.seer_fixability_score = 0.5
+
+        # Cache a summary for this group
+        from sentry.seer.autofix.issue_summary import get_issue_summary_cache_key
+
+        cache_key = get_issue_summary_cache_key(group.id)
+        cache.set(cache_key, {"summary": "test summary"}, 3600)
+
+        self.call_post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+
+        # Should not call automation since seer_fixability_score exists
+        mock_run_automation.assert_not_called()
+
 
 class SeerAutomationHelperFunctionsTestMixin(BasePostProgressGroupMixin):
     """Unit tests for is_issue_eligible_for_seer_automation."""

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3109,6 +3109,7 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
     ):
         """Test that with event count >= 10 and cached summary exists, we run automation directly."""
         self.project.update_option("sentry:seer_scanner_automation", True)
+        self.project.update_option("sentry:autofix_automation_tuning", "always")
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
@@ -3148,6 +3149,7 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
     ):
         """Test that with event count >= 10 and no cached summary, we generate summary + run automation."""
         self.project.update_option("sentry:seer_scanner_automation", True)
+        self.project.update_option("sentry:autofix_automation_tuning", "always")
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,


### PR DESCRIPTION
## PR Details
+ I had to revert by last fixability [PR](https://github.com/getsentry/sentry/pull/103485). I am going to address it separately after this PR - made a ticket for that: https://linear.app/getsentry/issue/AIML-1650/address-fixability-issue-in-the-new-automation-flow
  + Also mentioned in the TODO comment
+ This PR just creates the new automation flow for triage signals behind a feature flag. 
+ Reference diagram: https://miro.com/app/board/uXjVJqn1-fQ=/?focusWidget=3458764648325594380
+ Also make `run_automation` a public method now since we directly use in a task. 
