### PR TITLE
feat(events): Add rpc request even on error

### DIFF
--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -12,7 +12,6 @@ from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolv
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill
-from sentry.utils import snuba_rpc
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.ourlogs")
@@ -108,7 +107,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
         )
 
         """Run the query"""
-        rpc_response = snuba_rpc.timeseries_rpc([rpc_request])[0]
+        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
 
         """Process the results"""
         result = rpc_dataset_common.ProcessedTimeseries()

--- a/src/sentry/snuba/profile_functions.py
+++ b/src/sentry/snuba/profile_functions.py
@@ -11,7 +11,6 @@ from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolv
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill
-from sentry.utils import snuba_rpc
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.profile_functions")
@@ -87,7 +86,7 @@ class ProfileFunctions(rpc_dataset_common.RPCBase):
         )
 
         """Run the query"""
-        rpc_response = snuba_rpc.timeseries_rpc([rpc_request])[0]
+        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
 
         """Process the results"""
         result = rpc_dataset_common.ProcessedTimeseries()

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -12,6 +12,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     Expression,
     TimeSeries,
     TimeSeriesRequest,
+    TimeSeriesResponse,
 )
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     Column,
@@ -318,7 +319,13 @@ class RPCBase:
         """Run the query"""
         table_request = cls.get_table_rpc_request(query)
         rpc_request = table_request.rpc_request
-        rpc_response = snuba_rpc.table_rpc([rpc_request])[0]
+        try:
+            rpc_response = snuba_rpc.table_rpc([rpc_request])[0]
+        except Exception as e:
+            # add the rpc to the error so we can include it in the response
+            if debug:
+                setattr(e, "debug", MessageToJson(rpc_request))
+            raise
         sentry_sdk.set_tag(
             "query.storage_meta.tier", rpc_response.meta.downsampled_storage_meta.tier
         )
@@ -516,6 +523,18 @@ class RPCBase:
             return ts_filter, params
         else:
             raise InvalidSearchQuery("start, end and interval are required")
+
+    @classmethod
+    def _run_timeseries_rpc(
+        self, debug: bool, rpc_request: TimeSeriesRequest
+    ) -> TimeSeriesResponse:
+        try:
+            return snuba_rpc.timeseries_rpc([rpc_request])[0]
+        except Exception as e:
+            # add the rpc to the error so we can include it in the response
+            if debug:
+                setattr(e, "debug", MessageToJson(rpc_request))
+            raise
 
     @classmethod
     def process_timeseries_list(cls, timeseries_list: list[TimeSeries]) -> ProcessedTimeseries:

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -100,7 +100,8 @@ class Spans(rpc_dataset_common.RPCBase):
         )
 
         """Run the query"""
-        rpc_response = snuba_rpc.timeseries_rpc([rpc_request])[0]
+        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
+
         """Process the results"""
         result = rpc_dataset_common.ProcessedTimeseries()
         final_meta: EventsMeta = events_meta_from_rpc_request_meta(rpc_response.meta)

--- a/src/sentry/snuba/trace_metrics.py
+++ b/src/sentry/snuba/trace_metrics.py
@@ -12,7 +12,6 @@ from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolv
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill
-from sentry.utils import snuba_rpc
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.trace_metrics")
@@ -99,7 +98,7 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
         )
 
         """Run the query"""
-        rpc_response = snuba_rpc.timeseries_rpc([rpc_request])[0]
+        rpc_response = cls._run_timeseries_rpc(params.debug, rpc_request)
 
         """Process the results"""
         result = rpc_dataset_common.ProcessedTimeseries()


### PR DESCRIPTION
- Currently we only return the rpc request when there's no error, but it would be (more) helpful to get it when there is an error