### PR TITLE
feat(explore): Update confidence footer again

### DIFF
--- a/static/app/views/alerts/rules/metric/utils/determineSeriesSampleCount.tsx
+++ b/static/app/views/alerts/rules/metric/utils/determineSeriesSampleCount.tsx
@@ -44,7 +44,7 @@ export function determineSeriesSampleCountAndIsSampled(
       }
 
       const sampleRate = data[i]!.values[j]!.sampleRate;
-      if (sampleRate === 1) {
+      if (defined(sampleRate) && sampleRate >= 1) {
         hasUnsampledInterval = true;
       } else if (defined(sampleRate) && sampleRate < 1) {
         hasSampledInterval = true;

--- a/static/app/views/explore/logs/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.spec.tsx
@@ -1,0 +1,582 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+import {ConfidenceFooter} from './confidenceFooter';
+
+function Wrapper({children}: {children: React.ReactNode}) {
+  return <div data-test-id="wrapper">{children}</div>;
+}
+
+describe('ConfidenceFooter', () => {
+  const rawLogCounts = {
+    normal: {
+      count: 100,
+      isLoading: false,
+    },
+    highAccuracy: {
+      count: 1000,
+      isLoading: false,
+    },
+  };
+
+  function chartInfo(info: Partial<ChartInfo>) {
+    return {
+      chartType: ChartType.LINE,
+      series: [],
+      timeseriesResult: {} as any,
+      yAxis: '',
+      ...info,
+    };
+  }
+
+  it('loading', () => {
+    render(
+      <ConfidenceFooter
+        rawLogCounts={rawLogCounts}
+        chartInfo={chartInfo({})}
+        hasUserQuery={false}
+        isLoading
+      />,
+      {wrapper: Wrapper}
+    );
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+  });
+
+  describe('with raw counts', () => {
+    describe('unsampled', () => {
+      describe('without user query', () => {
+        it('loaded without top events', () => {
+          render(
+            <ConfidenceFooter
+              rawLogCounts={rawLogCounts}
+              chartInfo={chartInfo({sampleCount: 100, isSampled: false})}
+              hasUserQuery={false}
+              isLoading={false}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent('Log count: 100');
+        });
+
+        it('loaded with top events', () => {
+          render(
+            <ConfidenceFooter
+              rawLogCounts={rawLogCounts}
+              chartInfo={chartInfo({sampleCount: 100, isSampled: false, topEvents: 5})}
+              hasUserQuery={false}
+              isLoading={false}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Log count for top 5 groups: 100'
+          );
+        });
+      });
+
+      describe('with user query', () => {
+        it('loaded without top events', () => {
+          render(
+            <ConfidenceFooter
+              rawLogCounts={rawLogCounts}
+              chartInfo={chartInfo({sampleCount: 100, isSampled: false})}
+              hasUserQuery
+              isLoading={false}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Log count: 100 matches of 1k logs'
+          );
+        });
+
+        it('loaded with top events', () => {
+          render(
+            <ConfidenceFooter
+              rawLogCounts={rawLogCounts}
+              chartInfo={chartInfo({sampleCount: 100, isSampled: false, topEvents: 5})}
+              hasUserQuery
+              isLoading={false}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Log count for top 5 groups: 100 matches of 1k logs'
+          );
+        });
+      });
+    });
+
+    describe('sampled', () => {
+      describe('without user query', () => {
+        describe('partial scan', () => {
+          it('loaded 1', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 sample of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 sample')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 1 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                  topEvents: 5,
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 sample of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 sample')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 samples of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 samples')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                  topEvents: 5,
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 samples of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 samples')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe('full scan', () => {
+          it('loaded 1', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'full',
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 log'
+            );
+          });
+
+          it('loaded 1 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'full',
+                  topEvents: 5,
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 log'
+            );
+          });
+
+          it('loaded 10', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'full',
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 logs'
+            );
+          });
+
+          it('loaded 10 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'full',
+                  topEvents: 5,
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 logs'
+            );
+          });
+        });
+      });
+
+      describe('with user query', () => {
+        describe('partial scan', () => {
+          it('loaded 1', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                })}
+                hasUserQuery
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 match after scanning 100 samples of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 match')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 1 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                  topEvents: 5,
+                })}
+                hasUserQuery
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 match after scanning 100 samples of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 match')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                })}
+                hasUserQuery
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 matches after scanning 100 samples of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 matches')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'partial',
+                  topEvents: 5,
+                })}
+                hasUserQuery
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 matches after scanning 100 samples of 1k logs'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 matches')
+            );
+            expect(
+              await screen.findByText(
+                /The volume of logs in this time range is too large for us to do a full scan./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /Try reducing the date range or number of projects to attempt scanning all logs./
+              )
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe('full scan', () => {
+          it('loaded 1', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'full',
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 log'
+            );
+          });
+
+          it('loaded 1 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 1,
+                  isSampled: true,
+                  dataScanned: 'full',
+                  topEvents: 5,
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 log'
+            );
+          });
+
+          it('loaded 10', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'full',
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 logs'
+            );
+          });
+
+          it('loaded 10 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawLogCounts={rawLogCounts}
+                chartInfo={chartInfo({
+                  sampleCount: 10,
+                  isSampled: true,
+                  dataScanned: 'full',
+                  topEvents: 5,
+                })}
+                hasUserQuery={false}
+                isLoading={false}
+              />,
+              {
+                wrapper: Wrapper,
+              }
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 logs'
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/static/app/views/explore/logs/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.spec.tsx
@@ -59,7 +59,7 @@ describe('ConfidenceFooter', () => {
               wrapper: Wrapper,
             }
           );
-          expect(screen.getByTestId('wrapper')).toHaveTextContent('Log count: 100');
+          expect(screen.getByTestId('wrapper')).toHaveTextContent('100 logs');
         });
 
         it('loaded with top events', () => {
@@ -75,7 +75,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Log count for top 5 groups: 100'
+            '100 logs for top 5 groups'
           );
         });
       });
@@ -94,7 +94,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Log count: 100 matches of 1k logs'
+            '100 matches of 1k logs'
           );
         });
 
@@ -111,7 +111,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Log count for top 5 groups: 100 matches of 1k logs'
+            '100 matches of 1k logs for top 5 groups'
           );
         });
       });

--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -71,16 +71,19 @@ function ConfidenceMessage({
   // No sampling happened, so don't mention estimations.
   if (noSampling) {
     if (!hasUserQuery) {
+      const matchingLogsCount =
+        sampleCount > 1
+          ? t('%s logs', <Count value={sampleCount} />)
+          : t('%s log', <Count value={sampleCount} />);
+
       if (isTopN) {
-        return tct('Log count for top [topEvents] groups: [matchingLogsCount]', {
+        return tct('[matchingLogsCount] for top [topEvents] groups', {
+          matchingLogsCount,
           topEvents,
-          matchingLogsCount: <Count value={sampleCount} />,
         });
       }
 
-      return tct('Log count: [matchingLogsCount]', {
-        matchingLogsCount: <Count value={sampleCount} />,
-      });
+      return matchingLogsCount;
     }
 
     const matchingLogsCount =
@@ -99,17 +102,14 @@ function ConfidenceMessage({
     );
 
     if (isTopN) {
-      return tct(
-        'Log count for top [topEvents] groups: [matchingLogsCount] of [totalLogsCount]',
-        {
-          topEvents,
-          matchingLogsCount,
-          totalLogsCount,
-        }
-      );
+      return tct('[matchingLogsCount] of [totalLogsCount] for top [topEvents] groups', {
+        matchingLogsCount,
+        totalLogsCount,
+        topEvents,
+      });
     }
 
-    return tct('Log count: [matchingLogsCount] of [totalLogsCount]', {
+    return tct('[matchingLogsCount] of [totalLogsCount]', {
       matchingLogsCount,
       totalLogsCount,
     });

--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -3,10 +3,7 @@ import Count from 'sentry/components/count';
 import {t, tct} from 'sentry/locale';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import {
-  Container,
-  usePreviouslyLoaded,
-} from 'sentry/views/explore/components/chart/chartFooter';
+import {Container} from 'sentry/views/explore/components/chart/chartFooter';
 import {
   Placeholder,
   WarningIcon,
@@ -22,12 +19,11 @@ interface ConfidenceFooterProps {
 }
 
 export function ConfidenceFooter({
-  chartInfo: currentChartInfo,
+  chartInfo,
   hasUserQuery,
   isLoading,
   rawLogCounts,
 }: ConfidenceFooterProps) {
-  const chartInfo = usePreviouslyLoaded(currentChartInfo, isLoading);
   return (
     <Container>
       <ConfidenceMessage
@@ -65,37 +61,15 @@ function ConfidenceMessage({
   isLoading,
   isSampled,
 }: ConfidenceMessageProps) {
-  const isTopN = defined(topEvents) && topEvents > 1;
-
-  if (!defined(sampleCount) || isLoading) {
+  if (isLoading || !defined(sampleCount)) {
     return <Placeholder width={180} />;
   }
 
+  const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
-  const matchingLogsCount =
-    sampleCount > 1
-      ? t('%s matches', <Count value={sampleCount} />)
-      : t('%s match', <Count value={sampleCount} />);
-  const downsampledLogsCount = rawLogCounts.normal.count ? (
-    rawLogCounts.normal.count > 1 ? (
-      t('%s samples', <Count value={rawLogCounts.normal.count} />)
-    ) : (
-      t('%s sample', <Count value={rawLogCounts.normal.count} />)
-    )
-  ) : (
-    <Placeholder width={40} />
-  );
-  const allLogsCount = rawLogCounts.highAccuracy.count ? (
-    rawLogCounts.highAccuracy.count > 1 ? (
-      t('%s logs', <Count value={rawLogCounts.highAccuracy.count} />)
-    ) : (
-      t('%s log', <Count value={rawLogCounts.highAccuracy.count} />)
-    )
-  ) : (
-    <Placeholder width={40} />
-  );
 
-  if (dataScanned === 'full') {
+  // No sampling happened, so don't mention estimations.
+  if (noSampling) {
     if (!hasUserQuery) {
       if (isTopN) {
         return tct('Log count for top [topEvents] groups: [matchingLogsCount]', {
@@ -109,46 +83,211 @@ function ConfidenceMessage({
       });
     }
 
-    // For logs, if the full data was scanned, we can assume that no
-    // extrapolation happened and we should remove mentions of extrapolation.
+    const matchingLogsCount =
+      sampleCount > 1
+        ? t('%s matches', <Count value={sampleCount} />)
+        : t('%s match', <Count value={sampleCount} />);
+
+    const totalLogsCount = rawLogCounts.highAccuracy.count ? (
+      rawLogCounts.highAccuracy.count > 1 ? (
+        t('%s logs', <Count value={rawLogCounts.highAccuracy.count} />)
+      ) : (
+        t('%s log', <Count value={rawLogCounts.highAccuracy.count} />)
+      )
+    ) : (
+      <Placeholder width={40} />
+    );
+
     if (isTopN) {
-      return tct('[matchingLogsCount] for top [topEvents] groups in [allLogsCount]', {
-        topEvents,
-        matchingLogsCount,
-        allLogsCount,
-      });
+      return tct(
+        'Log count for top [topEvents] groups: [matchingLogsCount] of [totalLogsCount]',
+        {
+          topEvents,
+          matchingLogsCount,
+          totalLogsCount,
+        }
+      );
     }
 
-    return tct('[matchingLogsCount] in [allLogsCount]', {
+    return tct('Log count: [matchingLogsCount] of [totalLogsCount]', {
       matchingLogsCount,
-      allLogsCount,
+      totalLogsCount,
     });
   }
 
-  const downsampledTooltip = <DownsampledTooltip noSampling={noSampling} />;
+  const maybeWarning =
+    dataScanned === 'partial' ? tct('[warning] ', {warning: <WarningIcon />}) : null;
+  const maybeTooltip =
+    dataScanned === 'partial' ? <DownsampledTooltip noSampling={noSampling} /> : null;
+
+  // no user query means it's showing the total number of logs scanned
+  // so no need to mention how many matched
+  if (!hasUserQuery) {
+    // partial scans means that we didnt scan all the data so it's useful
+    // to mention the total number of logs available
+    if (dataScanned === 'partial') {
+      const matchingLogsCount =
+        sampleCount > 1
+          ? t('%s samples', <Count value={sampleCount} />)
+          : t('%s sample', <Count value={sampleCount} />);
+
+      const totalLogsCount = rawLogCounts.highAccuracy.count ? (
+        rawLogCounts.highAccuracy.count > 1 ? (
+          t('%s logs', <Count value={rawLogCounts.highAccuracy.count} />)
+        ) : (
+          t('%s log', <Count value={rawLogCounts.highAccuracy.count} />)
+        )
+      ) : (
+        <Placeholder width={40} />
+      );
+
+      if (isTopN) {
+        return tct(
+          '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingLogsCount]] of [totalLogsCount]',
+          {
+            maybeWarning,
+            topEvents,
+            maybeTooltip,
+            matchingLogsCount,
+            totalLogsCount,
+          }
+        );
+      }
+
+      return tct(
+        '[maybeWarning]Estimated from [maybeTooltip:[matchingLogsCount]] of [totalLogsCount]',
+        {
+          maybeWarning,
+          maybeTooltip,
+          matchingLogsCount,
+          totalLogsCount,
+        }
+      );
+    }
+
+    // otherwise, a full scan was done
+    // full scan means we scanned all the data available so no need to repeat that information twice
+
+    const matchingLogsCount =
+      sampleCount > 1
+        ? t('%s logs', <Count value={sampleCount} />)
+        : t('%s log', <Count value={sampleCount} />);
+
+    if (isTopN) {
+      return tct(
+        '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingLogsCount]]',
+        {
+          maybeWarning,
+          topEvents,
+          maybeTooltip,
+          matchingLogsCount,
+        }
+      );
+    }
+
+    return tct('[maybeWarning]Estimated from [maybeTooltip:[matchingLogsCount]]', {
+      maybeWarning,
+      maybeTooltip,
+      matchingLogsCount,
+    });
+  }
+
+  // otherwise, a user query was specified
+  // with a user query, it means we should tell the user how many of the scanned logs
+  // matched the user query
+
+  // partial scans means that we didnt scan all the data so it's useful
+  // to mention the total number of logs available
+  if (dataScanned === 'partial') {
+    const matchingLogsCount =
+      sampleCount > 1
+        ? t('%s matches', <Count value={sampleCount} />)
+        : t('%s match', <Count value={sampleCount} />);
+
+    const scannedLogsCount = rawLogCounts.normal.count ? (
+      rawLogCounts.normal.count > 1 ? (
+        t('%s samples', <Count value={rawLogCounts.normal.count} />)
+      ) : (
+        t('%s sample', <Count value={rawLogCounts.normal.count} />)
+      )
+    ) : (
+      <Placeholder width={40} />
+    );
+
+    const totalLogsCount = rawLogCounts.highAccuracy.count ? (
+      rawLogCounts.highAccuracy.count > 1 ? (
+        t('%s logs', <Count value={rawLogCounts.highAccuracy.count} />)
+      ) : (
+        t('%s log', <Count value={rawLogCounts.highAccuracy.count} />)
+      )
+    ) : (
+      <Placeholder width={40} />
+    );
+
+    if (isTopN) {
+      return tct(
+        '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingLogsCount]] after scanning [scannedLogsCount] of [totalLogsCount]',
+        {
+          maybeWarning,
+          topEvents,
+          maybeTooltip,
+          matchingLogsCount,
+          scannedLogsCount,
+          totalLogsCount,
+        }
+      );
+    }
+
+    return tct(
+      '[maybeWarning]Estimated from [maybeTooltip:[matchingLogsCount]] after scanning [scannedLogsCount] of [totalLogsCount]',
+      {
+        maybeWarning,
+        maybeTooltip,
+        matchingLogsCount,
+        scannedLogsCount,
+        totalLogsCount,
+      }
+    );
+  }
+
+  // otherwise, a full scan was done
+  // full scan means we scanned all the data available so no need to repeat that information twice
+
+  const matchingLogsCount =
+    sampleCount > 1
+      ? t('%s matches', <Count value={sampleCount} />)
+      : t('%s match', <Count value={sampleCount} />);
+
+  const totalLogsCount = rawLogCounts.highAccuracy.count ? (
+    rawLogCounts.highAccuracy.count > 1 ? (
+      t('%s logs', <Count value={rawLogCounts.highAccuracy.count} />)
+    ) : (
+      t('%s log', <Count value={rawLogCounts.highAccuracy.count} />)
+    )
+  ) : (
+    <Placeholder width={40} />
+  );
 
   if (isTopN) {
     return tct(
-      '[warning] Extrapolated from [matchingLogsCount] for top [topEvents] groups after scanning [tooltip:[downsampledLogsCount] of [allLogsCount]]',
+      '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingLogsCount]] of [totalLogsCount]',
       {
-        warning: <WarningIcon />,
+        maybeWarning,
         topEvents,
+        maybeTooltip,
         matchingLogsCount,
-        downsampledLogsCount,
-        allLogsCount,
-        tooltip: downsampledTooltip,
+        totalLogsCount,
       }
     );
   }
 
   return tct(
-    '[warning] Extrapolated from [matchingLogsCount] after scanning [tooltip:[downsampledLogsCount] of [allLogsCount]]',
+    '[maybeWarning]Estimated from [maybeTooltip:[matchingLogsCount]] of [totalLogsCount]',
     {
-      warning: <WarningIcon />,
+      maybeWarning,
+      maybeTooltip,
       matchingLogsCount,
-      downsampledLogsCount,
-      allLogsCount,
-      tooltip: downsampledTooltip,
+      totalLogsCount,
     }
   );
 }
@@ -167,6 +306,7 @@ function DownsampledTooltip({
           {t(
             'The volume of logs in this time range is too large for us to do a full scan.'
           )}
+          <br />
           <br />
           {t(
             'Try reducing the date range or number of projects to attempt scanning all logs.'

--- a/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
@@ -7,105 +7,831 @@ function Wrapper({children}: {children: React.ReactNode}) {
 }
 
 describe('ConfidenceFooter', () => {
-  describe('low confidence', () => {
-    it('renders for full scan without grouping', async () => {
-      render(
-        <ConfidenceFooter
-          confidence="low"
-          sampleCount={100}
-          topEvents={undefined}
-          dataScanned="full"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Extrapolated from 100 spans'
-      );
-      await userEvent.hover(screen.getByText('100'));
-      expect(
-        await screen.findByText(
-          /You may not have enough span samples for a high accuracy extrapolation of your query./
-        )
-      ).toBeInTheDocument();
-    });
-    it('renders for full scan with grouping', async () => {
-      render(
-        <ConfidenceFooter
-          confidence="low"
-          sampleCount={100}
-          topEvents={5}
-          dataScanned="full"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Extrapolated from 100 spans for top 5 groups'
-      );
-      await userEvent.hover(screen.getByText('100'));
-      expect(
-        await screen.findByText(
-          /You may not have enough span samples for a high accuracy extrapolation of your query./
-        )
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe('high confidence', () => {
-    it('renders for full scan without grouping', () => {
-      render(
-        <ConfidenceFooter
-          confidence="high"
-          sampleCount={100}
-          topEvents={undefined}
-          dataScanned="full"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
-    });
-    it('renders for full scan with grouping', () => {
-      render(
-        <ConfidenceFooter
-          confidence="high"
-          sampleCount={100}
-          topEvents={5}
-          dataScanned="full"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Span count for top 5 groups: 100'
-      );
-    });
+  it('loading', () => {
+    render(<ConfidenceFooter extrapolate={false} />, {wrapper: Wrapper});
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
   });
 
   describe('unextrapolated', () => {
-    it('unextrapolated loading', () => {
-      render(<ConfidenceFooter extrapolate={false} />, {wrapper: Wrapper});
-
-      expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
-    });
-
-    it('unextrapolated loaded', () => {
+    it('loaded without top events', () => {
       render(<ConfidenceFooter extrapolate={false} sampleCount={100} />, {
         wrapper: Wrapper,
       });
-
       expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
     });
 
-    it('unextrapolated loaded with grouping', () => {
+    it('loaded with top events', () => {
       render(<ConfidenceFooter extrapolate={false} sampleCount={100} topEvents={5} />, {
         wrapper: Wrapper,
       });
-
       expect(screen.getByTestId('wrapper')).toHaveTextContent(
         'Span count for top 5 groups: 100'
       );
+    });
+  });
+
+  describe('unsampled', () => {
+    it('loaded without top events', () => {
+      render(<ConfidenceFooter isSampled={false} sampleCount={100} />, {
+        wrapper: Wrapper,
+      });
+      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
+    });
+
+    it('loaded with top events', () => {
+      render(<ConfidenceFooter isSampled={false} sampleCount={100} topEvents={5} />, {
+        wrapper: Wrapper,
+      });
+      expect(screen.getByTestId('wrapper')).toHaveTextContent(
+        'Span count for top 5 groups: 100'
+      );
+    });
+  });
+
+  describe('without raw counts', () => {
+    describe('low confidence', () => {
+      it('loaded 1', async () => {
+        render(<ConfidenceFooter sampleCount={1} confidence="low" />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent('Estimated from 1 span');
+        await userEvent.hover(
+          screen.getByText((_, element) => element?.textContent === '1 span')
+        );
+        expect(
+          await screen.findByText(
+            /You may not have enough span samples for a high accuracy estimation of your query./
+          )
+        ).toBeInTheDocument();
+      });
+
+      it('loaded 1 with grouping', async () => {
+        render(<ConfidenceFooter sampleCount={1} confidence="low" topEvents={5} />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent(
+          'Estimated for top 5 groups from 1 span'
+        );
+        await userEvent.hover(
+          screen.getByText((_, element) => element?.textContent === '1 span')
+        );
+        expect(
+          await screen.findByText(
+            /You may not have enough span samples for a high accuracy estimation of your query./
+          )
+        ).toBeInTheDocument();
+      });
+
+      it('loaded 10', async () => {
+        render(<ConfidenceFooter sampleCount={10} confidence="low" />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent(
+          'Estimated from 10 spans'
+        );
+        await userEvent.hover(
+          screen.getByText((_, element) => element?.textContent === '10 spans')
+        );
+        expect(
+          await screen.findByText(
+            /You may not have enough span samples for a high accuracy estimation of your query./
+          )
+        ).toBeInTheDocument();
+      });
+
+      it('loaded 10 with grouping', async () => {
+        render(<ConfidenceFooter sampleCount={10} confidence="low" topEvents={5} />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent(
+          'Estimated for top 5 groups from 10 spans'
+        );
+        await userEvent.hover(
+          screen.getByText((_, element) => element?.textContent === '10 spans')
+        );
+        expect(
+          await screen.findByText(
+            /You may not have enough span samples for a high accuracy estimation of your query./
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe('high confidence', () => {
+      it('loaded 1', () => {
+        render(<ConfidenceFooter sampleCount={1} confidence="high" />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent('Estimated from 1 span');
+      });
+
+      it('loaded 1 with grouping', () => {
+        render(<ConfidenceFooter sampleCount={1} confidence="high" topEvents={5} />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent(
+          'Estimated for top 5 groups from 1 span'
+        );
+      });
+
+      it('loaded 10', () => {
+        render(<ConfidenceFooter sampleCount={10} confidence="high" />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent(
+          'Estimated from 10 spans'
+        );
+      });
+
+      it('loaded 10 with grouping', () => {
+        render(<ConfidenceFooter sampleCount={10} confidence="high" topEvents={5} />, {
+          wrapper: Wrapper,
+        });
+        expect(screen.getByTestId('wrapper')).toHaveTextContent(
+          'Estimated for top 5 groups from 10 spans'
+        );
+      });
+    });
+  });
+
+  describe('with raw counts', () => {
+    const rawSpanCounts = {
+      normal: {
+        count: 100,
+        isLoading: false,
+      },
+      highAccuracy: {
+        count: 1000,
+        isLoading: false,
+      },
+    };
+
+    describe('without user query', () => {
+      describe('partial scan', () => {
+        describe('low confidence', () => {
+          it('loaded 1', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="low"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 sample of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 sample')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 1 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="low"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 sample of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 sample')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="low"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 samples of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 samples')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="low"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 samples of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 samples')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe('high confidence', () => {
+          it('loaded 1', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="high"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 sample of 1k spans'
+            );
+          });
+
+          it('loaded 1 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="high"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 sample of 1k spans'
+            );
+          });
+
+          it('loaded 10', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="high"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 samples of 1k spans'
+            );
+          });
+
+          it('loaded 10 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="high"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 samples of 1k spans'
+            );
+          });
+        });
+      });
+
+      describe('full scan', () => {
+        describe('low confidence', () => {
+          it('loaded 1', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="low"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 span'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 span')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 1 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="low"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 span'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 span')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="low"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 spans')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="low"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 spans')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe('high confidence', () => {
+          it('loaded 1', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="high"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 span'
+            );
+          });
+
+          it('loaded 1 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={1}
+                confidence="high"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 span'
+            );
+          });
+
+          it('loaded 10', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="high"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 spans'
+            );
+          });
+
+          it('loaded 10 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                sampleCount={10}
+                confidence="high"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 spans'
+            );
+          });
+        });
+      });
+    });
+
+    describe('with user query', () => {
+      describe('partial scan', () => {
+        describe('low confidence', () => {
+          it('loaded 1', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="low"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 match after scanning 100 samples of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 match')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 1 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="low"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 match after scanning 100 samples of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 match')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="low"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 matches after scanning 100 samples of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 matches')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="low"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 matches after scanning 100 samples of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 matches')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe('high confidence', () => {
+          it('loaded 1', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="high"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 match after scanning 100 samples of 1k spans'
+            );
+          });
+
+          it('loaded 1 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="high"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 match after scanning 100 samples of 1k spans'
+            );
+          });
+
+          it('loaded 10', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="high"
+                dataScanned="partial"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 matches after scanning 100 samples of 1k spans'
+            );
+          });
+
+          it('loaded 10 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="high"
+                dataScanned="partial"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 matches after scanning 100 samples of 1k spans'
+            );
+          });
+        });
+      });
+
+      describe('full scan', () => {
+        describe('low confidence', () => {
+          it('loaded 1', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="low"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 match of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 match')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 1 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="low"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 match of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '1 match')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="low"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 matches of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 matches')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+
+          it('loaded 10 with grouping', async () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="low"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 matches of 1k spans'
+            );
+            await userEvent.hover(
+              screen.getByText((_, element) => element?.textContent === '10 matches')
+            );
+            expect(
+              await screen.findByText(
+                /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe('high confidence', () => {
+          it('loaded 1', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="high"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 1 match of 1k spans'
+            );
+          });
+
+          it('loaded 1 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={1}
+                confidence="high"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 1 match of 1k spans'
+            );
+          });
+
+          it('loaded 10', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="high"
+                dataScanned="full"
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated from 10 matches of 1k spans'
+            );
+          });
+
+          it('loaded 10 with grouping', () => {
+            render(
+              <ConfidenceFooter
+                rawSpanCounts={rawSpanCounts}
+                userQuery="query"
+                sampleCount={10}
+                confidence="high"
+                dataScanned="full"
+                topEvents={5}
+              />,
+              {wrapper: Wrapper}
+            );
+            expect(screen.getByTestId('wrapper')).toHaveTextContent(
+              'Estimated for top 5 groups from 10 matches of 1k spans'
+            );
+          });
+        });
+      });
     });
   });
 });

--- a/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
@@ -163,7 +163,7 @@ describe('ConfidenceFooter', () => {
               wrapper: Wrapper,
             }
           );
-          expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
+          expect(screen.getByTestId('wrapper')).toHaveTextContent('100 spans');
         });
 
         it('loaded with top events', () => {
@@ -179,7 +179,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Span count for top 5 groups: 100'
+            '100 spans for top 5 groups'
           );
         });
       });
@@ -198,7 +198,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Span count: 100 matches of 1k spans'
+            '100 matches of 1k spans'
           );
         });
 
@@ -216,7 +216,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Span count for top 5 groups: 100 matches of 1k spans'
+            '100 matches of 1k spans for top 5 groups'
           );
         });
       });
@@ -235,7 +235,7 @@ describe('ConfidenceFooter', () => {
               wrapper: Wrapper,
             }
           );
-          expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
+          expect(screen.getByTestId('wrapper')).toHaveTextContent('100 spans');
         });
 
         it('loaded with top events', () => {
@@ -251,7 +251,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Span count for top 5 groups: 100'
+            '100 spans for top 5 groups'
           );
         });
       });
@@ -270,7 +270,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Span count: 100 matches of 1k spans'
+            '100 matches of 1k spans'
           );
         });
 
@@ -288,7 +288,7 @@ describe('ConfidenceFooter', () => {
             }
           );
           expect(screen.getByTestId('wrapper')).toHaveTextContent(
-            'Span count for top 5 groups: 100 matches of 1k spans'
+            '100 matches of 1k spans for top 5 groups'
           );
         });
       });

--- a/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
@@ -12,42 +12,6 @@ describe('ConfidenceFooter', () => {
     expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
   });
 
-  describe('unextrapolated', () => {
-    it('loaded without top events', () => {
-      render(<ConfidenceFooter extrapolate={false} sampleCount={100} />, {
-        wrapper: Wrapper,
-      });
-      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
-    });
-
-    it('loaded with top events', () => {
-      render(<ConfidenceFooter extrapolate={false} sampleCount={100} topEvents={5} />, {
-        wrapper: Wrapper,
-      });
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Span count for top 5 groups: 100'
-      );
-    });
-  });
-
-  describe('unsampled', () => {
-    it('loaded without top events', () => {
-      render(<ConfidenceFooter isSampled={false} sampleCount={100} />, {
-        wrapper: Wrapper,
-      });
-      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
-    });
-
-    it('loaded with top events', () => {
-      render(<ConfidenceFooter isSampled={false} sampleCount={100} topEvents={5} />, {
-        wrapper: Wrapper,
-      });
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Span count for top 5 groups: 100'
-      );
-    });
-  });
-
   describe('without raw counts', () => {
     describe('low confidence', () => {
       it('loaded 1', async () => {
@@ -165,6 +129,150 @@ describe('ConfidenceFooter', () => {
         isLoading: false,
       },
     };
+
+    describe('unextrapolated', () => {
+      describe('without user query', () => {
+        it('loaded without top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              extrapolate={false}
+              sampleCount={100}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
+        });
+
+        it('loaded with top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              extrapolate={false}
+              sampleCount={100}
+              topEvents={5}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Span count for top 5 groups: 100'
+          );
+        });
+      });
+
+      describe('with user query', () => {
+        it('loaded without top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              userQuery="query"
+              extrapolate={false}
+              sampleCount={100}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Span count: 100 matches of 1k spans'
+          );
+        });
+
+        it('loaded with top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              userQuery="query"
+              extrapolate={false}
+              sampleCount={100}
+              topEvents={5}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Span count for top 5 groups: 100 matches of 1k spans'
+          );
+        });
+      });
+    });
+
+    describe('unsampled', () => {
+      describe('without user query', () => {
+        it('loaded without top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              isSampled={false}
+              sampleCount={100}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent('Span count: 100');
+        });
+
+        it('loaded with top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              isSampled={false}
+              sampleCount={100}
+              topEvents={5}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Span count for top 5 groups: 100'
+          );
+        });
+      });
+
+      describe('with user query', () => {
+        it('loaded without top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              userQuery="query"
+              isSampled={false}
+              sampleCount={100}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Span count: 100 matches of 1k spans'
+          );
+        });
+
+        it('loaded with top events', () => {
+          render(
+            <ConfidenceFooter
+              rawSpanCounts={rawSpanCounts}
+              userQuery="query"
+              isSampled={false}
+              sampleCount={100}
+              topEvents={5}
+            />,
+            {
+              wrapper: Wrapper,
+            }
+          );
+          expect(screen.getByTestId('wrapper')).toHaveTextContent(
+            'Span count for top 5 groups: 100 matches of 1k spans'
+          );
+        });
+      });
+    });
 
     describe('without user query', () => {
       describe('partial scan', () => {

--- a/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
@@ -27,6 +27,11 @@ describe('ConfidenceFooter', () => {
             /You may not have enough span samples for a high accuracy estimation of your query./
           )
         ).toBeInTheDocument();
+        expect(
+          await screen.findByText(
+            /You can try adjusting your query by increasing the chart's time interval./
+          )
+        ).toBeInTheDocument();
       });
 
       it('loaded 1 with grouping', async () => {
@@ -42,6 +47,11 @@ describe('ConfidenceFooter', () => {
         expect(
           await screen.findByText(
             /You may not have enough span samples for a high accuracy estimation of your query./
+          )
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText(
+            /You can try adjusting your query by increasing the chart's time interval./
           )
         ).toBeInTheDocument();
       });
@@ -61,6 +71,11 @@ describe('ConfidenceFooter', () => {
             /You may not have enough span samples for a high accuracy estimation of your query./
           )
         ).toBeInTheDocument();
+        expect(
+          await screen.findByText(
+            /You can try adjusting your query by increasing the chart's time interval./
+          )
+        ).toBeInTheDocument();
       });
 
       it('loaded 10 with grouping', async () => {
@@ -76,6 +91,11 @@ describe('ConfidenceFooter', () => {
         expect(
           await screen.findByText(
             /You may not have enough span samples for a high accuracy estimation of your query./
+          )
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText(
+            /You can try adjusting your query by increasing the chart's time interval./
           )
         ).toBeInTheDocument();
       });
@@ -298,6 +318,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range or increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 1 with grouping', async () => {
@@ -320,6 +345,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range or increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });
@@ -345,6 +375,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range or increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 10 with grouping', async () => {
@@ -367,6 +402,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range or increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });
@@ -460,6 +500,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 1 with grouping', async () => {
@@ -482,6 +527,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });
@@ -507,6 +557,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 10 with grouping', async () => {
@@ -529,6 +584,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });
@@ -625,6 +685,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range, removing filters or increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 1 with grouping', async () => {
@@ -648,6 +713,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range, removing filters or increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });
@@ -674,6 +744,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range, removing filters or increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 10 with grouping', async () => {
@@ -697,6 +772,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by narrowing the date range, removing filters or increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });
@@ -795,6 +875,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by removing filters or increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 1 with grouping', async () => {
@@ -818,6 +903,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by removing filters or increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });
@@ -844,6 +934,11 @@ describe('ConfidenceFooter', () => {
                 /You may not have enough span samples for a high accuracy estimation of your query./
               )
             ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by removing filters or increasing the chart's time interval./
+              )
+            ).toBeInTheDocument();
           });
 
           it('loaded 10 with grouping', async () => {
@@ -867,6 +962,11 @@ describe('ConfidenceFooter', () => {
             expect(
               await screen.findByText(
                 /You may not have enough span samples for a high accuracy estimation of your query./
+              )
+            ).toBeInTheDocument();
+            expect(
+              await screen.findByText(
+                /You can try adjusting your query by removing filters or increasing the chart's time interval./
               )
             ).toBeInTheDocument();
           });

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -6,7 +6,6 @@ import Count from 'sentry/components/count';
 import {t, tct} from 'sentry/locale';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import usePrevious from 'sentry/utils/usePrevious';
 import {
   Placeholder,
   WarningIcon,
@@ -26,13 +25,11 @@ type Props = {
 };
 
 export function ConfidenceFooter(props: Props) {
-  const previousProps = usePrevious(props, props.isLoading);
-  return (
-    <Container>{confidenceMessage(props.isLoading ? previousProps : props)}</Container>
-  );
+  return <Container>{confidenceMessage(props)}</Container>;
 }
 
 function confidenceMessage({
+  dataScanned,
   extrapolate,
   rawSpanCounts,
   sampleCount,
@@ -42,19 +39,18 @@ function confidenceMessage({
   isLoading,
   userQuery,
 }: Props) {
-  const isTopN = defined(topEvents) && topEvents > 1;
-
-  if (!defined(sampleCount) || isLoading) {
+  if (isLoading || !defined(sampleCount)) {
     return <Placeholder width={180} />;
   }
 
+  const isTopN = defined(topEvents) && topEvents > 1;
+  const noSampling = defined(isSampled) && !isSampled;
+
   if (
-    // Extrapolation disabled, so don't mention extrapolation.
+    // Extrapolation disabled, so don't mention estimations.
     (defined(extrapolate) && !extrapolate) ||
-    // High confidence without user query means we're in a default query.
-    // We check for high confidence here because we still want to show the
-    // tooltip here if it's low confidence
-    (confidence === 'high' && !userQuery)
+    // No sampling happened, so don't mention estimations.
+    noSampling
   ) {
     return isTopN
       ? tct('Span count for top [topEvents] groups: [matchingSpansCount]', {
@@ -66,62 +62,177 @@ function confidenceMessage({
         });
   }
 
-  const noSampling = defined(isSampled) && !isSampled;
-  const lowAccuracyFullSampleCount = <_LowAccuracyFullTooltip noSampling={noSampling} />;
+  const maybeWarning =
+    confidence === 'low' ? tct('[warning] ', {warning: <WarningIcon />}) : null;
+  const maybeTooltip =
+    confidence === 'low' ? <_LowAccuracyFullTooltip noSampling={noSampling} /> : null;
 
   // The multi query mode does not fetch the raw span counts
   // so make sure to have a backup when this happens.
   if (!defined(rawSpanCounts)) {
     const matchingSpansCount =
-      sampleCount > 1
-        ? t('%s spans', <Count value={sampleCount} />)
-        : t('%s span', <Count value={sampleCount} />);
-
-    if (confidence === 'high') {
-      if (isTopN) {
-        return tct('Extrapolated from [matchingSpansCount] for top [topEvents] groups', {
-          topEvents,
-          matchingSpansCount,
-        });
-      }
-
-      return tct('Extrapolated from [matchingSpansCount]', {
-        matchingSpansCount,
-      });
-    }
+      sampleCount === 1
+        ? t('%s span', <Count value={sampleCount} />)
+        : t('%s spans', <Count value={sampleCount} />);
 
     if (isTopN) {
       return tct(
-        'Extrapolated from [tooltip:[matchingSpansCount]] for top [topEvents] groups',
+        '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingSpansCount]]',
         {
+          maybeWarning,
           topEvents,
+          maybeTooltip,
           matchingSpansCount,
-          tooltip: lowAccuracyFullSampleCount,
         }
       );
     }
 
-    return tct('Extrapolated from [tooltip:[matchingSpansCount]]', {
+    return tct('[maybeWarning]Estimated from [maybeTooltip:[matchingSpansCount]]', {
+      maybeWarning,
+      maybeTooltip,
       matchingSpansCount,
-      tooltip: lowAccuracyFullSampleCount,
     });
   }
+
+  // no user query means it's showing the total number of spans scanned
+  // so no need to mention how many matched
+  if (!userQuery) {
+    // partial scans means that we didnt scan all the data so it's useful
+    // to mention the total number of spans available
+    if (dataScanned === 'partial') {
+      const matchingSpansCount =
+        sampleCount > 1
+          ? t('%s samples', <Count value={sampleCount} />)
+          : t('%s sample', <Count value={sampleCount} />);
+
+      const totalSpansCount = rawSpanCounts.highAccuracy.count ? (
+        rawSpanCounts.highAccuracy.count > 1 ? (
+          t('%s spans', <Count value={rawSpanCounts.highAccuracy.count} />)
+        ) : (
+          t('%s span', <Count value={rawSpanCounts.highAccuracy.count} />)
+        )
+      ) : (
+        <Placeholder width={40} />
+      );
+
+      if (isTopN) {
+        return tct(
+          '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingSpansCount]] of [totalSpansCount]',
+          {
+            maybeWarning,
+            topEvents,
+            maybeTooltip,
+            matchingSpansCount,
+            totalSpansCount,
+          }
+        );
+      }
+
+      return tct(
+        '[maybeWarning]Estimated from [maybeTooltip:[matchingSpansCount]] of [totalSpansCount]',
+        {
+          maybeWarning,
+          maybeTooltip,
+          matchingSpansCount,
+          totalSpansCount,
+        }
+      );
+    }
+
+    // otherwise, a full scan was done
+    // full scan means we scanned all the data available so no need to repeat that information twice
+
+    const matchingSpansCount =
+      sampleCount > 1
+        ? t('%s spans', <Count value={sampleCount} />)
+        : t('%s span', <Count value={sampleCount} />);
+
+    if (isTopN) {
+      return tct(
+        '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingSpansCount]]',
+        {
+          maybeWarning,
+          maybeTooltip,
+          topEvents,
+          matchingSpansCount,
+        }
+      );
+    }
+
+    return tct('[maybeWarning]Estimated from [maybeTooltip:[matchingSpansCount]]', {
+      maybeWarning,
+      maybeTooltip,
+      matchingSpansCount,
+    });
+  }
+
+  // otherwise, a user query was specified
+  // with a user query, it means we should tell the user how many of the scanned spans
+  // matched the user query
+
+  // partial scans means that we didnt scan all the data so it's useful
+  // to mention the total number of spans available
+  if (dataScanned === 'partial') {
+    const matchingSpansCount =
+      sampleCount > 1
+        ? t('%s matches', <Count value={sampleCount} />)
+        : t('%s match', <Count value={sampleCount} />);
+
+    const scannedSpansCount = rawSpanCounts.normal.count ? (
+      rawSpanCounts.normal.count > 1 ? (
+        t('%s samples', <Count value={rawSpanCounts.normal.count} />)
+      ) : (
+        t('%s sample', <Count value={rawSpanCounts.normal.count} />)
+      )
+    ) : (
+      <Placeholder width={40} />
+    );
+
+    const totalSpansCount = rawSpanCounts.highAccuracy.count ? (
+      rawSpanCounts.highAccuracy.count > 1 ? (
+        t('%s spans', <Count value={rawSpanCounts.highAccuracy.count} />)
+      ) : (
+        t('%s span', <Count value={rawSpanCounts.highAccuracy.count} />)
+      )
+    ) : (
+      <Placeholder width={40} />
+    );
+
+    if (isTopN) {
+      return tct(
+        '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingSpansCount]] after scanning [scannedSpansCount] of [totalSpansCount]',
+        {
+          maybeWarning,
+          maybeTooltip,
+          matchingSpansCount,
+          scannedSpansCount,
+          totalSpansCount,
+          topEvents,
+        }
+      );
+    }
+
+    return tct(
+      '[maybeWarning]Estimated from [maybeTooltip:[matchingSpansCount]] after scanning [scannedSpansCount] of [totalSpansCount]',
+      {
+        maybeWarning,
+        maybeTooltip,
+        matchingSpansCount,
+        scannedSpansCount,
+        totalSpansCount,
+      }
+    );
+  }
+
+  // otherwise, a full scan was done
+  // full scan means we scanned all the data available so no need to repeat that information twice
 
   const matchingSpansCount =
     sampleCount > 1
       ? t('%s matches', <Count value={sampleCount} />)
       : t('%s match', <Count value={sampleCount} />);
 
-  const downSampledSpansCount = rawSpanCounts.normal.count ? (
-    rawSpanCounts.normal.count > 1 ? (
-      t('%s samples', <Count value={rawSpanCounts.normal.count} />)
-    ) : (
-      t('%s sample', <Count value={rawSpanCounts.normal.count} />)
-    )
-  ) : (
-    <Placeholder width={40} />
-  );
-  const allSpansCount = rawSpanCounts.highAccuracy.count ? (
+  const totalSpansCount = rawSpanCounts.highAccuracy.count ? (
     rawSpanCounts.highAccuracy.count > 1 ? (
       t('%s spans', <Count value={rawSpanCounts.highAccuracy.count} />)
     ) : (
@@ -131,46 +242,26 @@ function confidenceMessage({
     <Placeholder width={40} />
   );
 
-  if (confidence === 'high') {
-    if (isTopN) {
-      return tct(
-        'Extrapolated from [matchingSpansCount] for top [topEvents] groups in [allSpansCount]',
-        {
-          topEvents,
-          matchingSpansCount,
-          allSpansCount,
-        }
-      );
-    }
-
-    return tct('Extrapolated from [matchingSpansCount] in [allSpansCount]', {
-      matchingSpansCount,
-      allSpansCount,
-    });
-  }
-
   if (isTopN) {
     return tct(
-      '[warning] Extrapolated from [matchingSpansCount] for top [topEvents] groups after scanning [tooltip:[downSampledSpansCount] of [allSpansCount]]',
+      '[maybeWarning]Estimated for top [topEvents] groups from [maybeTooltip:[matchingSpansCount]] of [totalSpansCount]',
       {
-        warning: <WarningIcon />,
+        maybeWarning,
         topEvents,
+        maybeTooltip,
         matchingSpansCount,
-        downSampledSpansCount,
-        allSpansCount,
-        tooltip: lowAccuracyFullSampleCount,
+        totalSpansCount,
       }
     );
   }
 
   return tct(
-    '[warning] Extrapolated from [matchingSpansCount] after scanning [tooltip:[downSampledSpansCount] of [allSpansCount]]',
+    '[maybeWarning]Estimated from [maybeTooltip:[matchingSpansCount]] of [totalSpansCount]',
     {
-      warning: <WarningIcon />,
+      maybeWarning,
+      maybeTooltip,
       matchingSpansCount,
-      downSampledSpansCount,
-      allSpansCount,
-      tooltip: lowAccuracyFullSampleCount,
+      totalSpansCount,
     }
   );
 }
@@ -187,8 +278,9 @@ function _LowAccuracyFullTooltip({
       title={
         <div>
           {t(
-            'You may not have enough span samples for a high accuracy extrapolation of your query.'
+            'You may not have enough span samples for a high accuracy estimation of your query.'
           )}
+          <br />
           <br />
           {t(
             "You can try adjusting your query by narrowing the date range, removing filters or increasing the chart's time interval."
@@ -197,6 +289,7 @@ function _LowAccuracyFullTooltip({
           {!noSampling && (
             <Fragment>
               <br />
+              <br />
               {t(
                 'You can also increase your sampling rates to get more samples and accurate trends.'
               )}
@@ -204,7 +297,7 @@ function _LowAccuracyFullTooltip({
           )}
         </div>
       }
-      maxWidth={270}
+      maxWidth={300}
       showUnderline
     >
       {children}

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -46,22 +46,6 @@ function confidenceMessage({
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
 
-  if (
-    // Extrapolation disabled, so don't mention estimations.
-    (defined(extrapolate) && !extrapolate) ||
-    // No sampling happened, so don't mention estimations.
-    noSampling
-  ) {
-    return isTopN
-      ? tct('Span count for top [topEvents] groups: [matchingSpansCount]', {
-          topEvents,
-          matchingSpansCount: <Count value={sampleCount} />,
-        })
-      : tct('Span count: [matchingSpansCount]', {
-          matchingSpansCount: <Count value={sampleCount} />,
-        });
-  }
-
   const maybeWarning =
     confidence === 'low' ? tct('[warning] ', {warning: <WarningIcon />}) : null;
   const maybeTooltip =
@@ -91,6 +75,57 @@ function confidenceMessage({
       maybeWarning,
       maybeTooltip,
       matchingSpansCount,
+    });
+  }
+
+  if (
+    // Extrapolation disabled, so don't mention estimations.
+    (defined(extrapolate) && !extrapolate) ||
+    // No sampling happened, so don't mention estimations.
+    noSampling
+  ) {
+    if (!userQuery) {
+      if (isTopN) {
+        return tct('Span count for top [topEvents] groups: [matchingSpansCount]', {
+          topEvents,
+          matchingSpansCount: <Count value={sampleCount} />,
+        });
+      }
+
+      return tct('Span count: [matchingSpansCount]', {
+        matchingSpansCount: <Count value={sampleCount} />,
+      });
+    }
+
+    const matchingSpansCount =
+      sampleCount > 1
+        ? t('%s matches', <Count value={sampleCount} />)
+        : t('%s match', <Count value={sampleCount} />);
+
+    const totalSpansCount = rawSpanCounts.highAccuracy.count ? (
+      rawSpanCounts.highAccuracy.count > 1 ? (
+        t('%s spans', <Count value={rawSpanCounts.highAccuracy.count} />)
+      ) : (
+        t('%s span', <Count value={rawSpanCounts.highAccuracy.count} />)
+      )
+    ) : (
+      <Placeholder width={40} />
+    );
+
+    if (isTopN) {
+      return tct(
+        'Span count for top [topEvents] groups: [matchingSpansCount] of [totalSpansCount]',
+        {
+          topEvents,
+          matchingSpansCount,
+          totalSpansCount,
+        }
+      );
+    }
+
+    return tct('Span count: [matchingSpansCount] of [totalSpansCount]', {
+      matchingSpansCount,
+      totalSpansCount,
     });
   }
 

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -49,7 +49,13 @@ function confidenceMessage({
   const maybeWarning =
     confidence === 'low' ? tct('[warning] ', {warning: <WarningIcon />}) : null;
   const maybeTooltip =
-    confidence === 'low' ? <_LowAccuracyFullTooltip noSampling={noSampling} /> : null;
+    confidence === 'low' ? (
+      <_LowAccuracyFullTooltip
+        noSampling={noSampling}
+        dataScanned={dataScanned}
+        userQuery={userQuery}
+      />
+    ) : null;
 
   // The multi query mode does not fetch the raw span counts
   // so make sure to have a backup when this happens.
@@ -304,9 +310,13 @@ function confidenceMessage({
 function _LowAccuracyFullTooltip({
   noSampling,
   children,
+  dataScanned,
+  userQuery,
 }: {
   noSampling: boolean;
   children?: React.ReactNode;
+  dataScanned?: 'full' | 'partial';
+  userQuery?: string;
 }) {
   return (
     <Tooltip
@@ -317,9 +327,21 @@ function _LowAccuracyFullTooltip({
           )}
           <br />
           <br />
-          {t(
-            "You can try adjusting your query by narrowing the date range, removing filters or increasing the chart's time interval."
-          )}
+          {dataScanned === 'partial' && userQuery
+            ? t(
+                "You can try adjusting your query by narrowing the date range, removing filters or increasing the chart's time interval."
+              )
+            : dataScanned === 'partial'
+              ? t(
+                  "You can try adjusting your query by narrowing the date range or increasing the chart's time interval."
+                )
+              : userQuery
+                ? t(
+                    "You can try adjusting your query by removing filters or increasing the chart's time interval."
+                  )
+                : t(
+                    "You can try adjusting your query by increasing the chart's time interval."
+                  )}
           {/* Do not show if no sampling happened to the data points in the series as they are already at 100% sampling  */}
           {!noSampling && (
             <Fragment>

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -91,16 +91,19 @@ function confidenceMessage({
     noSampling
   ) {
     if (!userQuery) {
+      const matchingSpansCount =
+        sampleCount > 1
+          ? t('%s spans', <Count value={sampleCount} />)
+          : t('%s span', <Count value={sampleCount} />);
+
       if (isTopN) {
-        return tct('Span count for top [topEvents] groups: [matchingSpansCount]', {
+        return tct('[matchingSpansCount] for top [topEvents] groups', {
           topEvents,
-          matchingSpansCount: <Count value={sampleCount} />,
+          matchingSpansCount,
         });
       }
 
-      return tct('Span count: [matchingSpansCount]', {
-        matchingSpansCount: <Count value={sampleCount} />,
-      });
+      return matchingSpansCount;
     }
 
     const matchingSpansCount =
@@ -119,17 +122,14 @@ function confidenceMessage({
     );
 
     if (isTopN) {
-      return tct(
-        'Span count for top [topEvents] groups: [matchingSpansCount] of [totalSpansCount]',
-        {
-          topEvents,
-          matchingSpansCount,
-          totalSpansCount,
-        }
-      );
+      return tct('[matchingSpansCount] of [totalSpansCount] for top [topEvents] groups', {
+        matchingSpansCount,
+        totalSpansCount,
+        topEvents,
+      });
     }
 
-    return tct('Span count: [matchingSpansCount] of [totalSpansCount]', {
+    return tct('[matchingSpansCount] of [totalSpansCount]', {
       matchingSpansCount,
       totalSpansCount,
     });


### PR DESCRIPTION
This update follows a few philosophies:
1. use the number matched, number scanned, number total to inform the user
2. give as much information to the user as possible about what was done to compute the results
3. never display the same number more than once as it is repetitive/redundant

<table>
<tr>
 <td>Spans
 <td><img width="2730" height="2619" alt="image" src="https://github.com/user-attachments/assets/858e47f7-b890-408a-8fe6-c044e075144a" />
<tr>
 <td>Logs
 <td><img width="2423" height="1625" alt="image" src="https://github.com/user-attachments/assets/a2ee6e1a-3ae8-42f9-bcf6-4a99986060d1" />
</table>