### PR TITLE
perf(eventstream): Sort redirects by ID rather than age

### DIFF
--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -23,8 +23,9 @@ def _get_all_related_redirects_query(
         ).values_list("group_id", "previous_group_id")
         # This order returns the newest redirects first. i.e. we're implicitly dropping
         # the oldest redirects if we have >THRESHOLD. We choose to drop the oldest
-        # because they're least likely to have data in retention
-        .order_by("-date_added")
+        # because they're least likely to have data in retention.
+        # Technically id != date_added, but it's a close appx (& much faster).
+        .order_by("-id")
     )
 
 

--- a/tests/sentry/services/eventstore/test_query_preprocessing.py
+++ b/tests/sentry/services/eventstore/test_query_preprocessing.py
@@ -18,22 +18,25 @@ class TestQueryPreprocessing(TestCase):
         self.g3 = self.create_group(id=3)
         self.create_group(id=4)
 
-        self.gr21 = GroupRedirect.objects.create(
-            organization_id=self.g1.project.organization_id,
-            group_id=self.g1.id,
-            previous_group_id=self.g2.id,
-            date_added=datetime.now(UTC) - timedelta(hours=1),
-        )
         self.gr31 = GroupRedirect.objects.create(
+            id=10001,
             organization_id=self.g1.project.organization_id,
             group_id=self.g1.id,
             previous_group_id=self.g3.id,
             date_added=datetime.now(UTC) - timedelta(hours=4),
         )
+        self.gr21 = GroupRedirect.objects.create(
+            id=10002,
+            organization_id=self.g1.project.organization_id,
+            group_id=self.g1.id,
+            previous_group_id=self.g2.id,
+            date_added=datetime.now(UTC) - timedelta(hours=1),
+        )
 
     def test_get_all_related_groups_query(self) -> None:
         """
         What we want is for this to return the newest redirects first.
+        What we're technically doing is taking the redirects with the highest IDs.
         """
         assert _get_all_related_redirects_query({self.g1.id})[0] == (self.g1.id, self.g2.id)
 


### PR DESCRIPTION
ID has an index, date_added doesn't. ID is monotonically increasing-ish, so it should be roughly the same. This is already an edge case, so I'm fine tweaking it like this.