### PR TITLE
feat(aci): redirect alert rules to detectors

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -13,11 +13,11 @@ import {translateSentryRoute} from 'sentry/utils/reactRouter6Compat/router';
 import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 import {
-  WorkflowEngineRedirectToAutomationDetails,
-  WorkflowEngineRedirectToAutomationEdit,
-  WorkflowEngineRedirectToDetectorCreate,
-  WorkflowEngineRedirectToDetectorDetails,
-  WorkflowEngineRedirectToDetectorEdit,
+  withAutomationDetailsRedirect,
+  withAutomationEditRedirect,
+  withDetectorCreateRedirect,
+  withDetectorDetailsRedirect,
+  withDetectorEditRedirect,
 } from 'sentry/views/alerts/workflowEngineRedirects';
 import App from 'sentry/views/app';
 import {AppBodyContent} from 'sentry/views/app/appBodyContent';
@@ -1478,15 +1478,10 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: 'details/:ruleId/',
-          component: WorkflowEngineRedirectToDetectorDetails,
+          component: withDetectorDetailsRedirect(
+            make(() => import('sentry/views/alerts/rules/metric/details'))
+          ),
           deprecatedRouteProps: true,
-          children: [
-            {
-              index: true,
-              component: make(() => import('sentry/views/alerts/rules/metric/details')),
-              deprecatedRouteProps: true,
-            },
-          ],
         },
         {
           path: ':projectId/',
@@ -1501,31 +1496,19 @@ function buildRoutes(): RouteObject[] {
             },
             {
               path: ':ruleId/',
-              component: WorkflowEngineRedirectToAutomationEdit,
+              component: withAutomationEditRedirect(
+                make(() => import('sentry/views/alerts/edit'))
+              ),
               deprecatedRouteProps: true,
-              children: [
-                {
-                  index: true,
-                  component: make(() => import('sentry/views/alerts/edit')),
-                  deprecatedRouteProps: true,
-                },
-              ],
             },
           ],
         },
         {
           path: ':projectId/:ruleId/details/',
-          component: WorkflowEngineRedirectToAutomationDetails,
+          component: withAutomationDetailsRedirect(
+            make(() => import('sentry/views/alerts/rules/issue/details/ruleDetails'))
+          ),
           deprecatedRouteProps: true,
-          children: [
-            {
-              index: true,
-              component: make(
-                () => import('sentry/views/alerts/rules/issue/details/ruleDetails')
-              ),
-              deprecatedRouteProps: true,
-            },
-          ],
         },
         {
           path: 'uptime/',
@@ -1534,22 +1517,15 @@ function buildRoutes(): RouteObject[] {
           children: [
             {
               path: ':projectId/:detectorId/details/',
-              component: WorkflowEngineRedirectToDetectorDetails,
+              component: withDetectorDetailsRedirect(
+                make(() => import('sentry/views/alerts/rules/uptime/details'))
+              ),
               deprecatedRouteProps: true,
-              children: [
-                {
-                  index: true,
-                  component: make(
-                    () => import('sentry/views/alerts/rules/uptime/details')
-                  ),
-                  deprecatedRouteProps: true,
-                },
-              ],
             },
             {
               path: 'existing-or-create/',
-              component: make(
-                () => import('sentry/views/alerts/rules/uptime/existingOrCreate')
+              component: withDetectorCreateRedirect(
+                make(() => import('sentry/views/alerts/rules/uptime/existingOrCreate'))
               ),
             },
           ],
@@ -1590,15 +1566,10 @@ function buildRoutes(): RouteObject[] {
             },
             {
               path: ':ruleId/',
-              component: WorkflowEngineRedirectToDetectorDetails,
+              component: withDetectorEditRedirect(
+                make(() => import('sentry/views/alerts/edit'))
+              ),
               deprecatedRouteProps: true,
-              children: [
-                {
-                  index: true,
-                  component: make(() => import('sentry/views/alerts/edit')),
-                  deprecatedRouteProps: true,
-                },
-              ],
             },
           ],
         },
@@ -1614,15 +1585,10 @@ function buildRoutes(): RouteObject[] {
           children: [
             {
               path: ':ruleId/',
-              component: WorkflowEngineRedirectToDetectorEdit,
+              component: withDetectorEditRedirect(
+                make(() => import('sentry/views/alerts/edit'))
+              ),
               deprecatedRouteProps: true,
-              children: [
-                {
-                  index: true,
-                  component: make(() => import('sentry/views/alerts/edit')),
-                  deprecatedRouteProps: true,
-                },
-              ],
             },
           ],
         },
@@ -1647,22 +1613,17 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'wizard/',
-      component: WorkflowEngineRedirectToDetectorCreate,
-      deprecatedRouteProps: true,
+      component: withDetectorCreateRedirect(
+        make(() => import('sentry/views/alerts/builder/projectProvider'))
+      ),
       children: [
         {
           index: true,
-          component: make(() => import('sentry/views/alerts/builder/projectProvider')),
-          children: [
-            {
-              index: true,
-              component: make(() => import('sentry/views/alerts/wizard')),
-              deprecatedRouteProps: true,
-            },
-          ],
+          component: make(() => import('sentry/views/alerts/wizard')),
           deprecatedRouteProps: true,
         },
       ],
+      deprecatedRouteProps: true,
     },
     {
       path: 'new/',
@@ -1677,15 +1638,10 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: ':alertType/',
-          component: WorkflowEngineRedirectToDetectorCreate,
+          component: withDetectorCreateRedirect(
+            make(() => import('sentry/views/alerts/create'))
+          ),
           deprecatedRouteProps: true,
-          children: [
-            {
-              index: true,
-              component: make(() => import('sentry/views/alerts/create')),
-              deprecatedRouteProps: true,
-            },
-          ],
         },
       ],
     },
@@ -1695,25 +1651,20 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: ':projectId/',
-      component: WorkflowEngineRedirectToDetectorCreate,
+      component: withDetectorCreateRedirect(
+        make(() => import('sentry/views/alerts/builder/projectProvider'))
+      ),
       deprecatedRouteProps: true,
       children: [
         {
-          index: true,
-          component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+          path: 'new/',
+          component: make(() => import('sentry/views/alerts/create')),
           deprecatedRouteProps: true,
-          children: [
-            {
-              path: 'new/',
-              component: make(() => import('sentry/views/alerts/create')),
-              deprecatedRouteProps: true,
-            },
-            {
-              path: 'wizard/',
-              component: make(() => import('sentry/views/alerts/wizard')),
-              deprecatedRouteProps: true,
-            },
-          ],
+        },
+        {
+          path: 'wizard/',
+          component: make(() => import('sentry/views/alerts/wizard')),
+          deprecatedRouteProps: true,
         },
       ],
     },

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1520,7 +1520,6 @@ function buildRoutes(): RouteObject[] {
               component: withDetectorDetailsRedirect(
                 make(() => import('sentry/views/alerts/rules/uptime/details'))
               ),
-              deprecatedRouteProps: true,
             },
             {
               path: 'existing-or-create/',

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -12,13 +12,6 @@ import {ProvideAriaRouter} from 'sentry/utils/provideAriaRouter';
 import {translateSentryRoute} from 'sentry/utils/reactRouter6Compat/router';
 import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
-import {
-  withAutomationDetailsRedirect,
-  withAutomationEditRedirect,
-  withDetectorCreateRedirect,
-  withDetectorDetailsRedirect,
-  withDetectorEditRedirect,
-} from 'sentry/views/alerts/workflowEngineRedirects';
 import App from 'sentry/views/app';
 import {AppBodyContent} from 'sentry/views/app/appBodyContent';
 import AuthLayout from 'sentry/views/auth/layout';
@@ -1478,8 +1471,11 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: 'details/:ruleId/',
-          component: withDetectorDetailsRedirect(
-            make(() => import('sentry/views/alerts/rules/metric/details'))
+          component: make(
+            () =>
+              import(
+                'sentry/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleDetails'
+              )
           ),
           deprecatedRouteProps: true,
         },
@@ -1496,8 +1492,9 @@ function buildRoutes(): RouteObject[] {
             },
             {
               path: ':ruleId/',
-              component: withAutomationEditRedirect(
-                make(() => import('sentry/views/alerts/edit'))
+              component: make(
+                () =>
+                  import('sentry/views/alerts/workflowEngineRedirectWrappers/alertEdit')
               ),
               deprecatedRouteProps: true,
             },
@@ -1505,8 +1502,11 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: ':projectId/:ruleId/details/',
-          component: withAutomationDetailsRedirect(
-            make(() => import('sentry/views/alerts/rules/issue/details/ruleDetails'))
+          component: make(
+            () =>
+              import(
+                'sentry/views/alerts/workflowEngineRedirectWrappers/issueAlertRuleDetails'
+              )
           ),
           deprecatedRouteProps: true,
         },
@@ -1517,14 +1517,20 @@ function buildRoutes(): RouteObject[] {
           children: [
             {
               path: ':projectId/:detectorId/details/',
-              component: withDetectorDetailsRedirect(
-                make(() => import('sentry/views/alerts/rules/uptime/details'))
+              component: make(
+                () =>
+                  import(
+                    'sentry/views/alerts/workflowEngineRedirectWrappers/uptimeAlertRuleDetails'
+                  )
               ),
             },
             {
               path: 'existing-or-create/',
-              component: withDetectorCreateRedirect(
-                make(() => import('sentry/views/alerts/rules/uptime/existingOrCreate'))
+              component: make(
+                () =>
+                  import(
+                    'sentry/views/alerts/workflowEngineRedirectWrappers/uptimeExistingOrCreate'
+                  )
               ),
             },
           ],
@@ -1565,8 +1571,11 @@ function buildRoutes(): RouteObject[] {
             },
             {
               path: ':ruleId/',
-              component: withDetectorEditRedirect(
-                make(() => import('sentry/views/alerts/edit'))
+              component: make(
+                () =>
+                  import(
+                    'sentry/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleEdit'
+                  )
               ),
               deprecatedRouteProps: true,
             },
@@ -1584,8 +1593,11 @@ function buildRoutes(): RouteObject[] {
           children: [
             {
               path: ':ruleId/',
-              component: withDetectorEditRedirect(
-                make(() => import('sentry/views/alerts/edit'))
+              component: make(
+                () =>
+                  import(
+                    'sentry/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleEdit'
+                  )
               ),
               deprecatedRouteProps: true,
             },
@@ -1612,8 +1624,11 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'wizard/',
-      component: withDetectorCreateRedirect(
-        make(() => import('sentry/views/alerts/builder/projectProvider'))
+      component: make(
+        () =>
+          import(
+            'sentry/views/alerts/workflowEngineRedirectWrappers/alertBuilderProjectProvider'
+          )
       ),
       children: [
         {
@@ -1637,8 +1652,8 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: ':alertType/',
-          component: withDetectorCreateRedirect(
-            make(() => import('sentry/views/alerts/create'))
+          component: make(
+            () => import('sentry/views/alerts/workflowEngineRedirectWrappers/alertCreate')
           ),
           deprecatedRouteProps: true,
         },
@@ -1650,8 +1665,11 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: ':projectId/',
-      component: withDetectorCreateRedirect(
-        make(() => import('sentry/views/alerts/builder/projectProvider'))
+      component: make(
+        () =>
+          import(
+            'sentry/views/alerts/workflowEngineRedirectWrappers/alertBuilderProjectProvider'
+          )
       ),
       deprecatedRouteProps: true,
       children: [

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -15,6 +15,9 @@ import withDomainRequired from 'sentry/utils/withDomainRequired';
 import {
   WorkflowEngineRedirectToAutomationDetails,
   WorkflowEngineRedirectToAutomationEdit,
+  WorkflowEngineRedirectToDetectorCreate,
+  WorkflowEngineRedirectToDetectorDetails,
+  WorkflowEngineRedirectToDetectorEdit,
 } from 'sentry/views/alerts/workflowEngineRedirects';
 import App from 'sentry/views/app';
 import {AppBodyContent} from 'sentry/views/app/appBodyContent';
@@ -1475,8 +1478,15 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: 'details/:ruleId/',
-          component: make(() => import('sentry/views/alerts/rules/metric/details')),
+          component: WorkflowEngineRedirectToDetectorDetails,
           deprecatedRouteProps: true,
+          children: [
+            {
+              index: true,
+              component: make(() => import('sentry/views/alerts/rules/metric/details')),
+              deprecatedRouteProps: true,
+            },
+          ],
         },
         {
           path: ':projectId/',
@@ -1524,7 +1534,17 @@ function buildRoutes(): RouteObject[] {
           children: [
             {
               path: ':projectId/:detectorId/details/',
-              component: make(() => import('sentry/views/alerts/rules/uptime/details')),
+              component: WorkflowEngineRedirectToDetectorDetails,
+              deprecatedRouteProps: true,
+              children: [
+                {
+                  index: true,
+                  component: make(
+                    () => import('sentry/views/alerts/rules/uptime/details')
+                  ),
+                  deprecatedRouteProps: true,
+                },
+              ],
             },
             {
               path: 'existing-or-create/',
@@ -1570,8 +1590,15 @@ function buildRoutes(): RouteObject[] {
             },
             {
               path: ':ruleId/',
-              component: make(() => import('sentry/views/alerts/edit')),
+              component: WorkflowEngineRedirectToDetectorDetails,
               deprecatedRouteProps: true,
+              children: [
+                {
+                  index: true,
+                  component: make(() => import('sentry/views/alerts/edit')),
+                  deprecatedRouteProps: true,
+                },
+              ],
             },
           ],
         },
@@ -1587,8 +1614,15 @@ function buildRoutes(): RouteObject[] {
           children: [
             {
               path: ':ruleId/',
-              component: make(() => import('sentry/views/alerts/edit')),
+              component: WorkflowEngineRedirectToDetectorEdit,
               deprecatedRouteProps: true,
+              children: [
+                {
+                  index: true,
+                  component: make(() => import('sentry/views/alerts/edit')),
+                  deprecatedRouteProps: true,
+                },
+              ],
             },
           ],
         },
@@ -1613,15 +1647,22 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'wizard/',
-      component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+      component: WorkflowEngineRedirectToDetectorCreate,
+      deprecatedRouteProps: true,
       children: [
         {
           index: true,
-          component: make(() => import('sentry/views/alerts/wizard')),
+          component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+          children: [
+            {
+              index: true,
+              component: make(() => import('sentry/views/alerts/wizard')),
+              deprecatedRouteProps: true,
+            },
+          ],
           deprecatedRouteProps: true,
         },
       ],
-      deprecatedRouteProps: true,
     },
     {
       path: 'new/',
@@ -1636,8 +1677,15 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: ':alertType/',
-          component: make(() => import('sentry/views/alerts/create')),
+          component: WorkflowEngineRedirectToDetectorCreate,
           deprecatedRouteProps: true,
+          children: [
+            {
+              index: true,
+              component: make(() => import('sentry/views/alerts/create')),
+              deprecatedRouteProps: true,
+            },
+          ],
         },
       ],
     },
@@ -1647,18 +1695,25 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: ':projectId/',
-      component: make(() => import('sentry/views/alerts/builder/projectProvider')),
+      component: WorkflowEngineRedirectToDetectorCreate,
       deprecatedRouteProps: true,
       children: [
         {
-          path: 'new/',
-          component: make(() => import('sentry/views/alerts/create')),
+          index: true,
+          component: make(() => import('sentry/views/alerts/builder/projectProvider')),
           deprecatedRouteProps: true,
-        },
-        {
-          path: 'wizard/',
-          component: make(() => import('sentry/views/alerts/wizard')),
-          deprecatedRouteProps: true,
+          children: [
+            {
+              path: 'new/',
+              component: make(() => import('sentry/views/alerts/create')),
+              deprecatedRouteProps: true,
+            },
+            {
+              path: 'wizard/',
+              component: make(() => import('sentry/views/alerts/wizard')),
+              deprecatedRouteProps: true,
+            },
+          ],
         },
       ],
     },

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -12,6 +12,7 @@ import {useTestRouteContext} from './useRouteContext';
  */
 type ParamKeys =
   | 'alertId'
+  | 'alertType'
   | 'apiKey'
   | 'appId'
   | 'appSlug'
@@ -42,6 +43,7 @@ type ParamKeys =
   | 'release'
   | 'relocationUuid'
   | 'replaySlug'
+  | 'ruleId'
   | 'scrubbingId'
   | 'searchId'
   | 'sentryAppSlug'

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -23,7 +23,6 @@ type ParamKeys =
   | 'dataForwarderId'
   | 'dataExportId'
   | 'detectorId'
-  | 'detectorId'
   | 'docIntegrationSlug'
   | 'eventId'
   | 'eventSlug'

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/alertBuilderProjectProvider.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/alertBuilderProjectProvider.tsx
@@ -1,0 +1,9 @@
+import {lazy} from 'react';
+
+import {withDetectorCreateRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const AlertWizardProjectProvider = lazy(
+  () => import('sentry/views/alerts/builder/projectProvider')
+);
+
+export default withDetectorCreateRedirect(AlertWizardProjectProvider);

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/alertCreate.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/alertCreate.tsx
@@ -1,0 +1,7 @@
+import {lazy} from 'react';
+
+import {withDetectorCreateRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const AlertCreate = lazy(() => import('sentry/views/alerts/create'));
+
+export default withDetectorCreateRedirect(AlertCreate);

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/alertEdit.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/alertEdit.tsx
@@ -1,0 +1,7 @@
+import {lazy} from 'react';
+
+import {withAutomationEditRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const AlertEdit = lazy(() => import('sentry/views/alerts/edit'));
+
+export default withAutomationEditRedirect(AlertEdit);

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/issueAlertRuleDetails.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/issueAlertRuleDetails.tsx
@@ -1,0 +1,9 @@
+import {lazy} from 'react';
+
+import {withAutomationDetailsRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const IssueAlertRuleDetails = lazy(
+  () => import('sentry/views/alerts/rules/issue/details/ruleDetails')
+);
+
+export default withAutomationDetailsRedirect(IssueAlertRuleDetails);

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleDetails.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleDetails.tsx
@@ -1,0 +1,7 @@
+import {lazy} from 'react';
+
+import {withDetectorDetailsRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const MetricAlertDetails = lazy(() => import('sentry/views/alerts/rules/metric/details'));
+
+export default withDetectorDetailsRedirect(MetricAlertDetails);

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleEdit.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/metricAlertRuleEdit.tsx
@@ -1,0 +1,7 @@
+import {lazy} from 'react';
+
+import {withDetectorEditRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const MetricAlertEdit = lazy(() => import('sentry/views/alerts/edit'));
+
+export default withDetectorEditRedirect(MetricAlertEdit);

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/uptimeAlertRuleDetails.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/uptimeAlertRuleDetails.tsx
@@ -1,0 +1,7 @@
+import {lazy} from 'react';
+
+import {withDetectorDetailsRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const UptimeAlertDetails = lazy(() => import('sentry/views/alerts/rules/uptime/details'));
+
+export default withDetectorDetailsRedirect(UptimeAlertDetails);

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/uptimeExistingOrCreate.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/uptimeExistingOrCreate.tsx
@@ -1,0 +1,9 @@
+import {lazy} from 'react';
+
+import {withDetectorCreateRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const UptimeExistingOrCreate = lazy(
+  () => import('sentry/views/alerts/rules/uptime/existingOrCreate')
+);
+
+export default withDetectorCreateRedirect(UptimeExistingOrCreate);

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -7,7 +7,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
 import {
-  makeAutomationBasePathname,
   makeAutomationDetailsPathname,
   makeAutomationEditPathname,
 } from 'sentry/views/automations/pathnames';
@@ -166,25 +165,6 @@ function WorkflowEngineRedirectWithAlertRuleData({
   return children;
 }
 
-// Simple static redirects
-
-export function WorkflowEngineRedirectToAutomationList({
-  children,
-  ...props
-}: {
-  children: React.ReactNode;
-}) {
-  const organization = useOrganization();
-  return (
-    <WorkflowEngineRedirect
-      redirectTo={makeAutomationBasePathname(organization.slug)}
-      {...props}
-    >
-      {children}
-    </WorkflowEngineRedirect>
-  );
-}
-
 export function WorkflowEngineRedirectToDetectorCreate({
   children,
   ...props
@@ -211,8 +191,6 @@ export function WorkflowEngineRedirectToDetectorCreate({
     </WorkflowEngineRedirect>
   );
 }
-
-// Data-dependent redirects for issue rules (with projectId)
 
 export function WorkflowEngineRedirectToAutomationDetails({
   children,
@@ -249,8 +227,6 @@ export function WorkflowEngineRedirectToAutomationEdit({
     </WorkflowEngineRedirectWithRuleData>
   );
 }
-
-// Data-dependent redirects for alert rules
 
 export function WorkflowEngineRedirectToDetectorDetails({
   children,

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -165,6 +165,17 @@ function WorkflowEngineRedirectWithAlertRuleData({
   return children;
 }
 
+const getDetectionType = (type: string | undefined): string | null => {
+  switch (type) {
+    case 'crons':
+      return 'monitor_check_in_failure';
+    case 'uptime':
+      return 'uptime_domain_failure';
+    default:
+      return null;
+  }
+};
+
 export function WorkflowEngineRedirectToDetectorCreate({
   children,
   ...props
@@ -174,12 +185,7 @@ export function WorkflowEngineRedirectToDetectorCreate({
   const organization = useOrganization();
 
   const {alertType} = useParams();
-  const detectorType =
-    alertType === 'crons'
-      ? 'monitor_check_in_failure'
-      : alertType === 'uptime'
-        ? 'uptime_domain_failure'
-        : null;
+  const detectorType = getDetectionType(alertType);
 
   const redirectPath = detectorType
     ? makeMonitorCreatePathname(organization.slug) + `?detectorType=${detectorType}`

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -7,9 +7,15 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
 import {
+  makeAutomationBasePathname,
   makeAutomationDetailsPathname,
   makeAutomationEditPathname,
 } from 'sentry/views/automations/pathnames';
+import {
+  makeMonitorCreatePathname,
+  makeMonitorDetailsPathname,
+  makeMonitorEditPathname,
+} from 'sentry/views/detectors/pathnames';
 
 interface AlertRuleWorkflow {
   alertRuleId: string | null;
@@ -17,11 +23,47 @@ interface AlertRuleWorkflow {
   workflowId: string;
 }
 
+interface AlertRuleDetector {
+  alertRuleId: string | null;
+  detectorId: string;
+  ruleId: string | null;
+}
+
+/**
+ * Base component for workflow engine redirects that conditionally redirects
+ * users based on feature flags.
+ */
+function WorkflowEngineRedirect({
+  children,
+  redirectTo,
+  ...props
+}: {
+  children: React.ReactNode;
+  redirectTo: string;
+}) {
+  const user = useUser();
+  const organization = useOrganization();
+
+  const shouldRedirect =
+    !user.isStaff && organization.features.includes('workflow-engine-ui');
+
+  if (shouldRedirect) {
+    return <Redirect to={redirectTo} />;
+  }
+
+  // Pass through all props to children
+  if (isValidElement(children)) {
+    return cloneElement(children, props);
+  }
+
+  return children;
+}
+
 /**
  * Base component for workflow engine redirects that require fetching
- * workflow data from a rule before redirecting.
+ * workflow data from an issue alert rule before redirecting.
  */
-function WorkflowEngineRedirectWithData({
+function WorkflowEngineRedirectWithRuleData({
   children,
   makeRedirectPath,
   ...props
@@ -31,8 +73,7 @@ function WorkflowEngineRedirectWithData({
 }) {
   const user = useUser();
   const organization = useOrganization();
-  const params = useParams<{projectId: string; ruleId: string}>();
-  const {ruleId} = params;
+  const {ruleId} = useParams();
 
   const shouldRedirect =
     !user.isStaff && organization.features.includes('workflow-engine-ui');
@@ -44,7 +85,7 @@ function WorkflowEngineRedirectWithData({
     ],
     {
       staleTime: 0,
-      enabled: shouldRedirect,
+      enabled: shouldRedirect && !!ruleId,
       retry: false,
     }
   );
@@ -70,7 +111,108 @@ function WorkflowEngineRedirectWithData({
   return children;
 }
 
-// Data-dependent redirects
+/**
+ * Base component for workflow engine redirects that require fetching
+ * workflow data from a metric alert rule before redirecting.
+ */
+function WorkflowEngineRedirectWithAlertRuleData({
+  children,
+  makeRedirectPath,
+  ...props
+}: {
+  children: React.ReactNode;
+  makeRedirectPath: (detectorId: string, orgSlug: string) => string;
+}) {
+  const user = useUser();
+  const organization = useOrganization();
+  const {ruleId, detectorId} = useParams();
+
+  const shouldRedirect =
+    !user.isStaff && organization.features.includes('workflow-engine-ui');
+
+  const {data: alertRuleDetector, isPending} = useApiQuery<AlertRuleDetector>(
+    [
+      `/organizations/${organization.slug}/alert-rule-detector/`,
+      {query: {alert_rule_id: ruleId}},
+    ],
+    {
+      staleTime: 0,
+      enabled: shouldRedirect && !!ruleId && !detectorId,
+      retry: false,
+    }
+  );
+
+  if (shouldRedirect) {
+    if (detectorId) {
+      return <Redirect to={makeRedirectPath(detectorId, organization.slug)} />;
+    }
+    if (isPending) {
+      return <LoadingIndicator />;
+    }
+    if (alertRuleDetector) {
+      return (
+        <Redirect
+          to={makeRedirectPath(alertRuleDetector.detectorId, organization.slug)}
+        />
+      );
+    }
+  }
+
+  // Pass through all props to children
+  if (isValidElement(children)) {
+    return cloneElement(children, props);
+  }
+
+  return children;
+}
+
+// Simple static redirects
+
+export function WorkflowEngineRedirectToAutomationList({
+  children,
+  ...props
+}: {
+  children: React.ReactNode;
+}) {
+  const organization = useOrganization();
+  return (
+    <WorkflowEngineRedirect
+      redirectTo={makeAutomationBasePathname(organization.slug)}
+      {...props}
+    >
+      {children}
+    </WorkflowEngineRedirect>
+  );
+}
+
+export function WorkflowEngineRedirectToDetectorCreate({
+  children,
+  ...props
+}: {
+  children: React.ReactNode;
+}) {
+  const organization = useOrganization();
+
+  const {alertType} = useParams();
+  const detectorType =
+    alertType === 'crons'
+      ? 'monitor_check_in_failure'
+      : alertType === 'uptime'
+        ? 'uptime_domain_failure'
+        : null;
+
+  const redirectPath = detectorType
+    ? makeMonitorCreatePathname(organization.slug) + `?detectorType=${detectorType}`
+    : makeMonitorCreatePathname(organization.slug);
+
+  return (
+    <WorkflowEngineRedirect redirectTo={redirectPath} {...props}>
+      {children}
+    </WorkflowEngineRedirect>
+  );
+}
+
+// Data-dependent redirects for issue rules (with projectId)
 
 export function WorkflowEngineRedirectToAutomationDetails({
   children,
@@ -79,14 +221,14 @@ export function WorkflowEngineRedirectToAutomationDetails({
   children: React.ReactNode;
 }) {
   return (
-    <WorkflowEngineRedirectWithData
+    <WorkflowEngineRedirectWithRuleData
       makeRedirectPath={(workflowId, orgSlug) =>
         makeAutomationDetailsPathname(orgSlug, workflowId)
       }
       {...props}
     >
       {children}
-    </WorkflowEngineRedirectWithData>
+    </WorkflowEngineRedirectWithRuleData>
   );
 }
 
@@ -97,13 +239,51 @@ export function WorkflowEngineRedirectToAutomationEdit({
   children: React.ReactNode;
 }) {
   return (
-    <WorkflowEngineRedirectWithData
+    <WorkflowEngineRedirectWithRuleData
       makeRedirectPath={(workflowId, orgSlug) =>
         makeAutomationEditPathname(orgSlug, workflowId)
       }
       {...props}
     >
       {children}
-    </WorkflowEngineRedirectWithData>
+    </WorkflowEngineRedirectWithRuleData>
+  );
+}
+
+// Data-dependent redirects for alert rules
+
+export function WorkflowEngineRedirectToDetectorDetails({
+  children,
+  ...props
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <WorkflowEngineRedirectWithAlertRuleData
+      makeRedirectPath={(detectorId, orgSlug) =>
+        makeMonitorDetailsPathname(orgSlug, detectorId)
+      }
+      {...props}
+    >
+      {children}
+    </WorkflowEngineRedirectWithAlertRuleData>
+  );
+}
+
+export function WorkflowEngineRedirectToDetectorEdit({
+  children,
+  ...props
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <WorkflowEngineRedirectWithAlertRuleData
+      makeRedirectPath={(detectorId, orgSlug) =>
+        makeMonitorEditPathname(orgSlug, detectorId)
+      }
+      {...props}
+    >
+      {children}
+    </WorkflowEngineRedirectWithAlertRuleData>
   );
 }

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -31,11 +31,11 @@ interface AlertRuleDetector {
  * redirects for issue alert rules. Fetches workflow data if needed and
  * shows loading state while requests are in flight.
  */
-function withRuleRedirect(
-  Component: React.ComponentType<any>,
+function withRuleRedirect<P extends Record<string, any>>(
+  Component: React.ComponentType<P>,
   makeRedirectPath: (workflowId: string, orgSlug: string) => string
 ) {
-  return function WorkflowEngineRedirectWrapper(props: any) {
+  return function WorkflowEngineRedirectWrapper(props: P) {
     const user = useUser();
     const organization = useOrganization();
     const {ruleId} = useParams();
@@ -68,7 +68,7 @@ function withRuleRedirect(
       }
     }
 
-    return <Component {...props} />;
+    return <Component {...(props as any)} />;
   };
 }
 
@@ -77,11 +77,11 @@ function withRuleRedirect(
  * redirects for metric alert rules. Fetches detector data if needed and
  * shows loading state while requests are in flight.
  */
-function withAlertRuleRedirect(
-  Component: React.ComponentType<any>,
+function withAlertRuleRedirect<P extends Record<string, any>>(
+  Component: React.ComponentType<P>,
   makeRedirectPath: (detectorId: string, orgSlug: string) => string
 ) {
-  return function WorkflowEngineRedirectWrapper(props: any) {
+  return function WorkflowEngineRedirectWrapper(props: P) {
     const user = useUser();
     const organization = useOrganization();
     const {ruleId, detectorId} = useParams();
@@ -117,26 +117,34 @@ function withAlertRuleRedirect(
       }
     }
 
-    return <Component {...props} />;
+    return <Component {...(props as any)} />;
   };
 }
 
-export const withAutomationDetailsRedirect = (Component: React.ComponentType<any>) =>
+export const withAutomationDetailsRedirect = <P extends Record<string, any>>(
+  Component: React.ComponentType<P>
+) =>
   withRuleRedirect(Component, (workflowId, orgSlug) =>
     makeAutomationDetailsPathname(orgSlug, workflowId)
   );
 
-export const withAutomationEditRedirect = (Component: React.ComponentType<any>) =>
+export const withAutomationEditRedirect = <P extends Record<string, any>>(
+  Component: React.ComponentType<P>
+) =>
   withRuleRedirect(Component, (workflowId, orgSlug) =>
     makeAutomationEditPathname(orgSlug, workflowId)
   );
 
-export const withDetectorDetailsRedirect = (Component: React.ComponentType<any>) =>
+export const withDetectorDetailsRedirect = <P extends Record<string, any>>(
+  Component: React.ComponentType<P>
+) =>
   withAlertRuleRedirect(Component, (detectorId, orgSlug) =>
     makeMonitorDetailsPathname(orgSlug, detectorId)
   );
 
-export const withDetectorEditRedirect = (Component: React.ComponentType<any>) =>
+export const withDetectorEditRedirect = <P extends Record<string, any>>(
+  Component: React.ComponentType<P>
+) =>
   withAlertRuleRedirect(Component, (detectorId, orgSlug) =>
     makeMonitorEditPathname(orgSlug, detectorId)
   );
@@ -152,8 +160,10 @@ const getDetectionType = (type: string | undefined): string | null => {
   }
 };
 
-export function withDetectorCreateRedirect(Component: React.ComponentType<any>) {
-  return function WorkflowEngineRedirectWrapper(props: any) {
+export function withDetectorCreateRedirect<P extends Record<string, any>>(
+  Component: React.ComponentType<P>
+) {
+  return function WorkflowEngineRedirectWrapper(props: P) {
     const user = useUser();
     const organization = useOrganization();
     const {alertType} = useParams();
@@ -170,6 +180,6 @@ export function withDetectorCreateRedirect(Component: React.ComponentType<any>) 
       return <Redirect to={redirectPath} />;
     }
 
-    return <Component {...props} />;
+    return <Component {...(props as any)} />;
   };
 }

--- a/static/app/views/detectors/pathnames.tsx
+++ b/static/app/views/detectors/pathnames.tsx
@@ -22,3 +22,7 @@ export const makeMonitorDetailsPathname = (orgSlug: string, monitorId: string) =
 export const makeMonitorCreatePathname = (orgSlug: string) => {
   return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}new/`);
 };
+
+export const makeMonitorEditPathname = (orgSlug: string, monitorId: string) => {
+  return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}${monitorId}/edit/`);
+};


### PR DESCRIPTION
redirects metric alert rules and uptime monitors to the new monitors views.

note that links to cron monitors do not get redirected at the moment since that would require a lookup from the monitorSlug to the detectorId