### PR TITLE
fix(seer settings): Fix the automated_run_stopping_point save issue

### DIFF
--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -407,18 +407,8 @@ describe('ProjectSeer', () => {
     const option = await screen.findByText('Code Changes');
     await userEvent.click(option);
 
-    // Form has saveOnBlur=true, so wait for the PUT request
-    await waitFor(() => {
-      expect(projectPutRequest).toHaveBeenCalledTimes(1);
-    });
-    await waitFor(() => {
-      expect(projectPutRequest).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({data: {automated_run_stopping_point: 'code_changes'}})
-      );
-    });
-
-    // Also check that the seer preferences POST was called with the new stopping point
+    // The field uses getData: () => ({}) to exclude itself from the form submission
+    // Only the seer preferences POST should be called with the actual data
     await waitFor(() => {
       expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
         expect.anything(),
@@ -430,6 +420,14 @@ describe('ProjectSeer', () => {
         })
       );
     });
+
+    // The project PUT may be called but with empty data (no automated_run_stopping_point)
+    if (projectPutRequest.mock.calls.length > 0) {
+      expect(projectPutRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({data: {}})
+      );
+    }
   });
 
   it('can enable automation handoff to Cursor when Cursor integration is available', async () => {
@@ -526,12 +524,8 @@ describe('ProjectSeer', () => {
     const cursorOption = await screen.findByText('Hand off to Cursor Cloud Agent');
     await userEvent.click(cursorOption);
 
-    // Form has saveOnBlur=true, so wait for the PUT request
-    await waitFor(() => {
-      expect(projectPutRequest).toHaveBeenCalledTimes(1);
-    });
-
-    // Wait for the seer preferences POST to be called with automation_handoff
+    // The field uses getData: () => ({}) to exclude itself from the form submission
+    // Only the seer preferences POST should be called with the actual data
     await waitFor(() => {
       expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
         expect.anything(),
@@ -548,6 +542,14 @@ describe('ProjectSeer', () => {
         })
       );
     });
+
+    // The project PUT may be called but with empty data (no automated_run_stopping_point)
+    if (projectPutRequest.mock.calls.length > 0) {
+      expect(projectPutRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({data: {}})
+      );
+    }
   });
 
   it('hides Scan Issues toggle when triage-signals-v0 feature flag is enabled', async () => {

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -204,6 +204,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     saveOnBlur: true,
     saveMessage: t('Stopping point updated'),
     onChange: handleStoppingPointChange,
+    getData: () => ({}),
     visible: ({model}) => {
       const tuningValue = model?.getValue('autofixAutomationTuning');
       // Handle both boolean (toggle) and string (dropdown) values


### PR DESCRIPTION
## PR details
+ Fix to make sure change to "Where should Seer Stop" persists. Added getData: () => ({}) to the automatedRunStoppingPointField to prevent the Form from including this field in its auto-save payload to the Project API. This fixes the bug where the field's custom onChange handler correctly saved to the Seer Preferences API, but the Form also tried to save it to the Project API (which doesn't support this field), creating a false success message while the setting never persisted.
+ More context: https://sentry.slack.com/archives/C09QCAEA0DR/p1763404095142179
+ The fix is to not store it in Project API but just store it in Seer Preferences API.
+ Not super sure on this one. Apparently Claude says this bug was there even before the triage-signals changes. 
