### PR TITLE
feat(size-analysis): Wireup frontend for WebP optimization insight

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -41,6 +41,7 @@ export function formatUpside(percentage: number): string {
 
 const INSIGHTS_WITH_MORE_INFO_MODAL = [
   'image_optimization',
+  'webp_optimization',
   'alternate_icons_optimization',
   'localized_strings_minify',
   'strip_binary',
@@ -74,7 +75,10 @@ export function AppSizeInsightsSidebarRow({
   const handleOpenModal = () => {
     if (insight.key === 'alternate_icons_optimization') {
       openAlternativeIconsInsightModal();
-    } else if (insight.key === 'image_optimization') {
+    } else if (
+      insight.key === 'image_optimization' ||
+      insight.key === 'webp_optimization'
+    ) {
       openOptimizeImagesModal(platform);
     } else if (insight.key === 'localized_strings_minify') {
       openMinifyLocalizedStringsModal();

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -191,6 +191,8 @@ interface VideoCompressionInsightResult extends FilesInsightResult {}
 
 interface MultipleNativeLibraryArchsInsightResult extends FilesInsightResult {}
 
+interface WebPOptimizationInsightResult extends FilesInsightResult {}
+
 export interface InsightResults {
   alternate_icons_optimization?: ImageOptimizationInsightResult;
   audio_compression?: AudioCompressionInsightResult;
@@ -209,6 +211,7 @@ export interface InsightResults {
   strip_binary?: StripBinaryInsightResult;
   unnecessary_files?: UnnecessaryFilesInsightResult;
   video_compression?: VideoCompressionInsightResult;
+  webp_optimization?: WebPOptimizationInsightResult;
 }
 
 /**

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -52,6 +52,11 @@ const INSIGHT_CONFIGS: InsightConfig[] = [
     ),
   },
   {
+    key: 'webp_optimization',
+    name: t('WebP Optimization'),
+    description: t('Images can be converted to WebP to reduce size.'),
+  },
+  {
     key: 'duplicate_files',
     name: t('Duplicate Files'),
     description: t(
@@ -334,6 +339,7 @@ export function processInsights(
     'audio_compression',
     'video_compression',
     'multiple_native_library_archs',
+    'webp_optimization',
   ] as const;
 
   regularInsightKeys.forEach(key => {
@@ -348,15 +354,17 @@ export function processInsights(
           description: config.description,
           totalSavings: insight.total_savings,
           percentage: (insight.total_savings / totalSize) * 100,
-          files: files.map((file: FileSavingsResult) => ({
-            path: file.file_path,
-            savings: file.total_savings,
-            percentage: (file.total_savings / totalSize) * 100,
-            data: {
-              fileType: 'regular' as const,
-              originalFile: file,
-            },
-          })),
+          files: files
+            .sort((a, b) => b.total_savings - a.total_savings)
+            .map((file: FileSavingsResult) => ({
+              path: file.file_path,
+              savings: file.total_savings,
+              percentage: (file.total_savings / totalSize) * 100,
+              data: {
+                fileType: 'regular' as const,
+                originalFile: file,
+              },
+            })),
         });
       }
     }


### PR DESCRIPTION
Realized we weren't showing the Android WebP optimization insight as we simply had never wired up the frontend for it.
<img width="277" height="175" alt="Screenshot 2025-11-19 at 1 14 56 PM" src="https://github.com/user-attachments/assets/a4602511-f245-4059-b715-684c0ede61b8" />
<img width="687" height="452" alt="Screenshot 2025-11-19 at 1 14 50 PM" src="https://github.com/user-attachments/assets/39975b10-1b07-4ba9-80d6-d202b288b003" />
<img width="691" height="297" alt="Screenshot 2025-11-19 at 1 12 33 PM" src="https://github.com/user-attachments/assets/5973d11f-fe95-47ea-a03c-9e0a4e97259d" />

