### PR TITLE
perf(query-builder): Lazy-render filter key details

### DIFF
--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -41,7 +41,7 @@ export type MenuListItemProps = {
    * Optional descriptive text. Like 'label', should preferably be a string or
    * have appropriate aria-labels.
    */
-  details?: React.ReactNode;
+  details?: ExtraContent;
   /**
    * Whether the item is disabled (if true, the item will be grayed out and
    * non-interactive).
@@ -172,7 +172,9 @@ function BaseMenuListItem({
                   priority={priority}
                   {...detailsProps}
                 >
-                  {details}
+                  {typeof details === 'function'
+                    ? details({disabled, isFocused, isSelected})
+                    : details}
                 </Details>
               )}
             </LabelWrap>
@@ -188,7 +190,9 @@ function BaseMenuListItem({
       </Tooltip>
       {showDetailsInOverlay && details && isFocused && (
         <DetailsOverlay size={size} id={detailId} itemRef={itemRef}>
-          {details}
+          {typeof details === 'function'
+            ? details({disabled, isFocused, isSelected})
+            : details}
         </DetailsOverlay>
       )}
     </MenuItemWrap>

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -7,7 +7,6 @@ import type {
 
 export interface KeyItem extends SelectOptionWithKey<string> {
   description: string;
-  details: React.ReactNode;
   hideCheck: boolean;
   showDetailsInOverlay: boolean;
   textValue: string;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -119,7 +119,7 @@ export function createItem(
     textValue: tag.key,
     hideCheck: true,
     showDetailsInOverlay: true,
-    details: <KeyDescription tag={tag} />,
+    details: () => <KeyDescription tag={tag} />,
     type: 'item',
   };
 }


### PR DESCRIPTION
Uses the same approach as `trailingItems` in `CompactSelect` to lazily render the "details" part of the box. The "Details" are a tooltip that shows up on hover on focused items, so this seems to work particularly well.

**Before:**

<img width="337" height="82" alt="Screenshot 2025-11-19 at 4 33 26 PM" src="https://github.com/user-attachments/assets/2ceff1d9-c87c-4bc2-abf0-cb0445eb98f9" />

Every `createSection` here takes about ~12ms. Since this is repeated a few times during re-renders, the total savings add up, because after the "laziness", each `createSection` takes about 0.5ms. This ends up being worth 30-40ms, which makes a difference while typing. Since this is a simple optimization, seems worthwhile.
