### PR TITLE
ref(crons): Allow unmuting monitor envs when monitor "muted"

### DIFF
--- a/static/app/views/insights/crons/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/overviewRow.tsx
@@ -152,8 +152,6 @@ export function OverviewRow({
                 ? t('Unmute Environment')
                 : t('Mute Environment'),
             key: 'mute',
-            details: monitor.isMuted ? t('Monitor is muted') : undefined,
-            disabled: monitor.isMuted,
             onAction: () => onToggleMuteEnvironment(env, !isMuted),
           }),
         ]


### PR DESCRIPTION
Part of [NEW-564: There needs to be some way to mute the entire cron detector](https://linear.app/getsentry/issue/NEW-564/there-needs-to-be-some-way-to-mute-the-entire-cron-detector)

Now that `is_muted` of a monitor is computed, we need to allow unmuting
environments when they are all muted.