### PR TITLE
ref(crons): Invalidate monitor query after environment muting

### DIFF
--- a/static/app/views/insights/crons/components/detailsTimeline.tsx
+++ b/static/app/views/insights/crons/components/detailsTimeline.tsx
@@ -66,7 +66,9 @@ export function DetailsTimeline({monitor, onStatsLoaded, onEnvironmentUpdated}: 
     organization,
     monitor.project.slug,
     monitor.slug,
-    {...location.query}
+    {
+      environment: location.query.environment,
+    }
   );
 
   const {data: monitorStats} = useMonitorStats({
@@ -110,21 +112,8 @@ export function DetailsTimeline({monitor, onStatsLoaded, onEnvironmentUpdated}: 
       return;
     }
 
-    setApiQueryData<Monitor>(queryClient, monitorDetailsQueryKey, oldMonitorDetails => {
-      return oldMonitorDetails
-        ? {
-            ...oldMonitorDetails,
-            environments: oldMonitorDetails.environments.map(monitorEnv =>
-              monitorEnv.name === env
-                ? {
-                    ...monitorEnv,
-                    isMuted,
-                  }
-                : monitorEnv
-            ),
-          }
-        : undefined;
-    });
+    // Invalidate the query to refetch the monitor with updated environment data
+    queryClient.invalidateQueries({queryKey: monitorDetailsQueryKey});
 
     onEnvironmentUpdated?.();
   };

--- a/static/app/views/insights/crons/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/overviewRow.tsx
@@ -147,10 +147,7 @@ export function OverviewRow({
     ...(onToggleMuteEnvironment
       ? [
           (env: string, isMuted: boolean) => ({
-            label:
-              isMuted && !monitor.isMuted
-                ? t('Unmute Environment')
-                : t('Mute Environment'),
+            label: isMuted ? t('Unmute Environment') : t('Mute Environment'),
             key: 'mute',
             details: monitor.isMuted ? t('Monitor is muted') : undefined,
             disabled: monitor.isMuted,


### PR DESCRIPTION
Part of [NEW-564: There needs to be some way to mute the entire cron detector](https://linear.app/getsentry/issue/NEW-564/there-needs-to-be-some-way-to-mute-the-entire-cron-detector)

Changes the monitor update flow to invalidate the query cache instead of manually updating cached data when muting/unmuting monitor environments. This ensures the UI always reflects the latest environment data from the server, including mute status and other environment properties.