### PR TITLE
ref(crons): Fix N+1 query in MonitorSerializer by removing is_muted property

### DIFF
--- a/tests/sentry/monitors/endpoints/test_base_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_details.py
@@ -18,6 +18,7 @@ from sentry.monitors.models import (
     MonitorEnvironment,
     MonitorIncident,
     ScheduleType,
+    is_monitor_muted,
 )
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.monitors.utils import ensure_cron_detector, get_timeout_at
@@ -354,7 +355,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
         assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.is_muted
+        assert is_monitor_muted(monitor)
 
     def test_can_unmute(self) -> None:
         monitor = self._create_monitor()
@@ -367,7 +368,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
         assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
-        assert not monitor.is_muted
+        assert not is_monitor_muted(monitor)
 
     def test_timezone(self) -> None:
         monitor = self._create_monitor()

--- a/tests/sentry/monitors/endpoints/test_base_monitor_environment_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_environment_details.py
@@ -1,6 +1,6 @@
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
-from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
+from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus, is_monitor_muted
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -72,7 +72,7 @@ class BaseUpdateMonitorEnvironmentTest(MonitorTestCase):
 
         # Initially monitor should be unmuted
         monitor.refresh_from_db()
-        assert monitor.is_muted is False
+        assert is_monitor_muted(monitor) is False
 
         # Mute first environment
         self.get_success_response(
@@ -85,7 +85,7 @@ class BaseUpdateMonitorEnvironmentTest(MonitorTestCase):
 
         # Monitor should still be unmuted (one environment is unmuted)
         monitor.refresh_from_db()
-        assert monitor.is_muted is False
+        assert is_monitor_muted(monitor) is False
 
         # Mute second environment
         self.get_success_response(
@@ -98,7 +98,7 @@ class BaseUpdateMonitorEnvironmentTest(MonitorTestCase):
 
         # Now monitor should be muted (all environments are muted)
         monitor.refresh_from_db()
-        assert monitor.is_muted is True
+        assert is_monitor_muted(monitor) is True
 
     def test_unmuting_one_environment_unmutes_monitor(self) -> None:
         """Test that unmuting one environment when all were muted also unmutes the monitor."""
@@ -111,7 +111,7 @@ class BaseUpdateMonitorEnvironmentTest(MonitorTestCase):
 
         # Verify initial state
         monitor.refresh_from_db()
-        assert monitor.is_muted is True
+        assert is_monitor_muted(monitor) is True
 
         # Unmute one environment via the endpoint
         self.get_success_response(
@@ -124,7 +124,7 @@ class BaseUpdateMonitorEnvironmentTest(MonitorTestCase):
 
         # Monitor should now be unmuted
         monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.is_muted is False
+        assert is_monitor_muted(monitor) is False
         env1.refresh_from_db()
         assert env1.is_muted is False
         env2.refresh_from_db()

--- a/tests/sentry/monitors/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_index.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.monitors.grouptype import MonitorIncidentType
-from sentry.monitors.models import Monitor, ScheduleType
+from sentry.monitors.models import Monitor, ScheduleType, is_monitor_muted
 from sentry.monitors.serializers import MonitorSerializer
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.testutils.cases import APITestCase
@@ -205,7 +205,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         )
         assert monitor.name == "Full Config Monitor"
         assert monitor.status == ObjectStatus.DISABLED
-        assert monitor.is_muted is False
+        assert is_monitor_muted(monitor) is False
         assert monitor.config["schedule"] == "*/30 * * * *"
         assert monitor.config["checkin_margin"] == 15
         assert monitor.config["max_runtime"] == 120

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -16,6 +16,7 @@ from sentry.monitors.models import (
     MonitorIncident,
     MonitorStatus,
     ScheduleType,
+    is_monitor_muted,
 )
 from sentry.testutils.cases import TestCase
 
@@ -100,7 +101,7 @@ class MarkFailedTestCase(TestCase):
 
         monitor.refresh_from_db()
         monitor_environment.refresh_from_db()
-        assert monitor.is_muted
+        assert is_monitor_muted(monitor)
         assert monitor_environment.status == MonitorStatus.ERROR
 
         assert mock_dispatch_incident_occurrence.call_count == 0
@@ -342,7 +343,7 @@ class MarkFailedTestCase(TestCase):
 
         monitor.refresh_from_db()
         monitor_environment.refresh_from_db()
-        assert monitor.is_muted
+        assert is_monitor_muted(monitor)
         assert monitor_environment.status == MonitorStatus.ERROR
 
         assert mock_dispatch_incident_occurrence.call_count == 0

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -13,6 +13,7 @@ from sentry.monitors.models import (
     MonitorEnvironmentLimitsExceeded,
     MonitorLimitsExceeded,
     ScheduleType,
+    is_monitor_muted,
 )
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.monitors.validators import ConfigValidator
@@ -454,7 +455,7 @@ class MonitorIsMutedPropertyTestCase(TestCase):
         )
 
         # Verify monitor.is_muted is True
-        assert monitor.is_muted is True
+        assert is_monitor_muted(monitor) is True
 
     def test_is_muted_some_environments_unmuted(self):
         """Test that monitor.is_muted returns False when any environment is unmuted."""
@@ -475,7 +476,7 @@ class MonitorIsMutedPropertyTestCase(TestCase):
         )
 
         # Verify monitor.is_muted is False
-        assert monitor.is_muted is False
+        assert is_monitor_muted(monitor) is False
 
     def test_is_muted_all_environments_unmuted(self):
         """Test that monitor.is_muted returns False when all environments are unmuted."""
@@ -496,12 +497,12 @@ class MonitorIsMutedPropertyTestCase(TestCase):
         )
 
         # Verify monitor.is_muted is False
-        assert monitor.is_muted is False
+        assert is_monitor_muted(monitor) is False
 
     def test_is_muted_no_environments(self):
         """Test that monitor.is_muted returns False when there are no environments."""
         monitor = self.create_monitor()
-        assert monitor.is_muted is False
+        assert is_monitor_muted(monitor) is False
 
     def test_is_muted_single_environment(self):
         """Test is_muted works correctly with a single environment."""
@@ -514,7 +515,7 @@ class MonitorIsMutedPropertyTestCase(TestCase):
             is_muted=True,
         )
 
-        assert monitor.is_muted is True
+        assert is_monitor_muted(monitor) is True
 
         # Test with unmuted environment
         monitor2 = self.create_monitor()
@@ -525,4 +526,4 @@ class MonitorIsMutedPropertyTestCase(TestCase):
             is_muted=False,
         )
 
-        assert monitor2.is_muted is False
+        assert is_monitor_muted(monitor2) is False


### PR DESCRIPTION
Removes the computed property Monitor.is_muted and replaces it with a standalone
is_monitor_muted(monitor) function for better clarity and to fix an N+1 query
issue in MonitorSerializer.

The serializer now efficiently computes mute status for multiple monitors in a
single pass by checking if any environment is unmuted, rather than calling the
property on each monitor individually which would trigger separate queries.

Changes:
- Removed @property is_muted from Monitor model
- Added standalone is_monitor_muted() function that aggregates environment mute status
- Updated MonitorSerializer to compute is_muted efficiently using defaultdict pattern
- Updated all test files to use is_monitor_muted(monitor) instead of monitor.is_muted