### PR TITLE
fix(ACI): Accept fallthrough type in actions

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -42,7 +42,7 @@ class EmailActionHandler(ActionHandler):
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
-            "fallthroughType": {  # TODO: migrate to snake_case
+            "fallthrough_type": {
                 "type": "string",
                 "description": "The fallthrough type for issue owners email notifications",
                 "enum": [*FallthroughChoiceType],

--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -47,6 +47,12 @@ class EmailActionHandler(ActionHandler):
                 "description": "The fallthrough type for issue owners email notifications",
                 "enum": [*FallthroughChoiceType],
             },
+            # XXX(CEO): temporarily support this incorrect camel case
+            "fallthroughType": {
+                "type": "string",
+                "description": "The fallthrough type for issue owners email notifications",
+                "enum": [*FallthroughChoiceType],
+            },
         },
         "additionalProperties": False,
     }

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
@@ -52,6 +52,6 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
 
         if target_type == ActionTarget.ISSUE_OWNERS.value:
             blob = EmailDataBlob(**action.data)
-            final_blob[EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value] = blob.fallthroughType
+            final_blob[EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value] = blob.fallthrough_type
 
         return final_blob

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
@@ -51,7 +51,13 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
         }
 
         if target_type == ActionTarget.ISSUE_OWNERS.value:
-            blob = EmailDataBlob(**action.data)
+            # XXX(CEO): temporarily handle both fallthroughType and fallthrough_type
+            action_data = action.data.copy()
+            if action.data.get("fallthroughType"):
+                del action_data["fallthroughType"]
+                action_data["fallthrough_type"] = action.data["fallthroughType"]
+
+            blob = EmailDataBlob(**action_data)
             final_blob[EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value] = blob.fallthrough_type
 
         return final_blob

--- a/src/sentry/testutils/helpers/data_blobs.py
+++ b/src/sentry/testutils/helpers/data_blobs.py
@@ -761,7 +761,7 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
         "targetType": "IssueOwners",
         "id": "sentry.mail.actions.NotifyEmailAction",
         "targetIdentifier": "None",
-        "fallthroughType": "ActiveMembers",
+        "fallthrough_type": "ActiveMembers",
         "uuid": "2e8847d7-8fe4-44d2-8a16-e25040329790",
     },
     # NoOne Fallthrough (targetIdentifier is "")
@@ -769,7 +769,7 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
         "targetType": "IssueOwners",
         "targetIdentifier": "",
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "fallthroughType": "NoOne",
+        "fallthrough_type": "NoOne",
         "uuid": "fb039430-0848-4fc4-89b4-bc7689a9f851",
     },
     # AllMembers Fallthrough (targetIdentifier is None)
@@ -777,7 +777,7 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
         "targetType": "IssueOwners",
         "id": "sentry.mail.actions.NotifyEmailAction",
         "targetIdentifier": None,
-        "fallthroughType": "AllMembers",
+        "fallthrough_type": "AllMembers",
         "uuid": "41f13756-8f90-4afe-b162-55268c6e3cdb",
     },
     # NoOne Fallthrough (targetIdentifier is "None")
@@ -785,13 +785,13 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
         "targetType": "IssueOwners",
         "id": "sentry.mail.actions.NotifyEmailAction",
         "targetIdentifier": "None",
-        "fallthroughType": "NoOne",
+        "fallthrough_type": "NoOne",
         "uuid": "99c9b517-0a0f-47f0-b3ff-2a9cd2fd9c49",
     },
     # ActiveMembers Fallthrough
     {
         "targetType": "Member",
-        "fallthroughType": "ActiveMembers",
+        "fallthrough_type": "ActiveMembers",
         "id": "sentry.mail.actions.NotifyEmailAction",
         "targetIdentifier": 3234013,
         "uuid": "6e83337b-9561-4167-a208-27d6bdf5e613",
@@ -807,7 +807,7 @@ EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
     {
         "targetType": "Team",
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "fallthroughType": "AllMembers",
+        "fallthrough_type": "AllMembers",
         "uuid": "71b445cf-573b-4e0c-86bc-8dfbad93c480",
         "targetIdentifier": 188022,
     },

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -98,8 +98,8 @@ class EmailFieldMappingKeys(StrEnum):
     EmailFieldMappingKeys is an enum that represents the keys of an email field mapping.
     """
 
-    FALLTHROUGH_TYPE_KEY = "fallthroughType"
-    TARGET_TYPE_KEY = "targetType"
+    FALLTHROUGH_TYPE_KEY = "fallthrough_type"
+    TARGET_TYPE_KEY = "target_type"
 
 
 class ActionFieldMapping(TypedDict):
@@ -740,7 +740,7 @@ class EmailDataBlob(DataBlob):
     EmailDataBlob represents the data blob for an email notification action.
     """
 
-    fallthroughType: str = ""
+    fallthrough_type: str = ""
 
 
 issue_alert_action_translator_mapping: dict[str, type[BaseActionTranslator]] = {

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -577,7 +577,7 @@ class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
         ):
             return dataclasses.asdict(
                 EmailDataBlob(
-                    fallthroughType=self.action.get(
+                    fallthrough_type=self.action.get(
                         EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value,
                         FallthroughChoiceType.ACTIVE_MEMBERS.value,
                     ),

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -99,7 +99,7 @@ class EmailFieldMappingKeys(StrEnum):
     """
 
     FALLTHROUGH_TYPE_KEY = "fallthrough_type"
-    TARGET_TYPE_KEY = "target_type"
+    TARGET_TYPE_KEY = "targetType"
 
 
 class ActionFieldMapping(TypedDict):

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -538,31 +538,31 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
         self.detector = self.create_detector(project=self.project)
         # These are the actions that are healed from the old email action data blobs
         # It removes targetIdentifier for IssueOwner targets (since that shouldn't be set for those)
-        # It also removes the fallthroughType for Team and Member targets (since that shouldn't be set for those)
+        # It also removes the fallthrough_type for Team and Member targets (since that shouldn't be set for those)
         self.HEALED_EMAIL_ACTION_DATA_BLOBS = [
             # IssueOwners (targetIdentifier is "None")
             {
                 "targetType": "IssueOwners",
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "fallthroughType": "ActiveMembers",
+                "fallthrough_type": "ActiveMembers",
             },
             # NoOne Fallthrough (targetIdentifier is "")
             {
                 "targetType": "IssueOwners",
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "fallthroughType": "NoOne",
+                "fallthrough_type": "NoOne",
             },
             # AllMembers Fallthrough (targetIdentifier is None)
             {
                 "targetType": "IssueOwners",
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "fallthroughType": "AllMembers",
+                "fallthrough_type": "AllMembers",
             },
             # NoOne Fallthrough (targetIdentifier is "None")
             {
                 "targetType": "IssueOwners",
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "fallthroughType": "NoOne",
+                "fallthrough_type": "NoOne",
             },
             # ActiveMembers Fallthrough
             {
@@ -587,10 +587,8 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
     def test_build_rule_action_blob(self) -> None:
         for expected, healed in zip(EMAIL_ACTION_DATA_BLOBS, self.HEALED_EMAIL_ACTION_DATA_BLOBS):
             action_data = pop_keys_from_data_blob(expected, Action.Type.EMAIL)
-
             # pop the targetType from the action_data
             target_type = EmailActionHelper.get_target_type_object(action_data.pop("targetType"))
-
             # Handle all possible targetIdentifier formats
             target_identifier: str | None = str(expected["targetIdentifier"])
             if target_identifier in ("None", "", None):
@@ -605,7 +603,6 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
                 },
             )
             blob = self.handler.build_rule_action_blob(action, self.organization.id)
-
             assert blob == healed
 
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -10,17 +10,20 @@ from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import region_silo_test
 from sentry.workflow_engine.models import (
     Action,
+    DataConditionGroupAction,
     DetectorWorkflow,
     Workflow,
     WorkflowDataConditionGroup,
     WorkflowFireHistory,
 )
+from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.workflow_engine.test_base import MockActionValidatorTranslator
 
 
@@ -394,6 +397,15 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
             role="member",
             organization=self.organization,
         )
+        self.basic_condition = (
+            [
+                {
+                    "type": Condition.EQUAL.value,
+                    "comparison": 1,
+                    "conditionResult": True,
+                }
+            ],
+        )
 
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.workflow.create_audit_entry")
     def test_create_workflow__basic(self, mock_audit: mock.MagicMock) -> None:
@@ -428,13 +440,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
     def test_create_workflow__with_triggers(self) -> None:
         self.valid_workflow["triggers"] = {
             "logicType": "any",
-            "conditions": [
-                {
-                    "type": "eq",
-                    "comparison": 1,
-                    "conditionResult": True,
-                }
-            ],
+            "conditions": self.basic_condition,
         }
 
         response = self.get_success_response(
@@ -457,13 +463,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
         self.valid_workflow["actionFilters"] = [
             {
                 "logicType": "any",
-                "conditions": [
-                    {
-                        "type": "eq",
-                        "comparison": 1,
-                        "conditionResult": True,
-                    }
-                ],
+                "conditions": self.basic_condition,
                 "actions": [
                     {
                         "type": Action.Type.SLACK,
@@ -491,6 +491,54 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
         assert str(new_action_filters[0].condition_group.id) == response.data.get(
             "actionFilters", []
         )[0].get("id")
+
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_create_workflow__with_fallthrough_type_action(
+        self, mock_action_validator: mock.MagicMock
+    ):
+        self.valid_workflow["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": self.basic_condition,
+                "actions": [
+                    {
+                        "type": Action.Type.EMAIL,
+                        "config": {
+                            "targetType": "issue_owners",
+                        },
+                        "data": {"fallthroughType": "ActiveMembers"},
+                    },
+                ],
+            }
+        ]
+
+        response = self.get_success_response(
+            self.organization.slug,
+            raw_data=self.valid_workflow,
+        )
+
+        assert response.status_code == 201
+        new_workflow = Workflow.objects.get(id=response.data["id"])
+        new_action_filters = WorkflowDataConditionGroup.objects.filter(workflow=new_workflow)
+        assert len(new_action_filters) == len(response.data.get("actionFilters", []))
+        dcga = DataConditionGroupAction.objects.filter(
+            condition_group=new_action_filters[0].condition_group
+        ).first()
+        assert str(new_action_filters[0].condition_group.id) == response.data.get(
+            "actionFilters", []
+        )[0].get("id")
+        assert (
+            response.data.get("actionFilters")[0]
+            .get("actions")[0]
+            .get("data")
+            .get("fallthrough_type")
+            == FallthroughChoiceType.ACTIVE_MEMBERS.value
+        )
+        assert dcga.action.type == Action.Type.EMAIL
+        assert dcga.action.data == {"fallthrough_type": "ActiveMembers"}
 
     def test_create_invalid_workflow(self) -> None:
         self.valid_workflow["name"] = ""

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -397,15 +397,13 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
             role="member",
             organization=self.organization,
         )
-        self.basic_condition = (
-            [
-                {
-                    "type": Condition.EQUAL.value,
-                    "comparison": 1,
-                    "conditionResult": True,
-                }
-            ],
-        )
+        self.basic_condition = [
+            {
+                "type": Condition.EQUAL.value,
+                "comparison": 1,
+                "conditionResult": True,
+            }
+        ]
 
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.workflow.create_audit_entry")
     def test_create_workflow__basic(self, mock_audit: mock.MagicMock) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -498,7 +498,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
     )
     def test_create_workflow__with_fallthrough_type_action(
         self, mock_action_validator: mock.MagicMock
-    ):
+    ) -> None:
         self.valid_workflow["actionFilters"] = [
             {
                 "logicType": "any",
@@ -527,6 +527,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
         dcga = DataConditionGroupAction.objects.filter(
             condition_group=new_action_filters[0].condition_group
         ).first()
+        assert dcga
         assert str(new_action_filters[0].condition_group.id) == response.data.get(
             "actionFilters", []
         )[0].get("id")

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -114,8 +114,8 @@ class TestNotificationActionMigrationUtils(TestCase):
                         assert action.data.get(field) == source_value
                     else:
                         # For unmapped fields, check directly with empty string default
-                        if action.type == Action.Type.EMAIL and field == "fallthroughType":
-                            # for email actions, the default value for fallthroughType should be "ActiveMembers"
+                        if action.type == Action.Type.EMAIL and field == "fallthrough_type":
+                            # for email actions, the default value for fallthrough_type should be "ActiveMembers"
                             assert action.data.get(field) == compare_dict.get(
                                 field, "ActiveMembers"
                             )
@@ -131,10 +131,10 @@ class TestNotificationActionMigrationUtils(TestCase):
                 if key not in exclude_keys:
                     if (
                         action.type == Action.Type.EMAIL
-                        and key == "fallthroughType"
+                        and key == "fallthrough_type"
                         and action.config.get("target_type") != ActionTarget.ISSUE_OWNERS
                     ):
-                        # for email actions, fallthroughType should only be set for when targetType is ISSUE_OWNERS
+                        # for email actions, fallthrough_type should only be set for when targetType is ISSUE_OWNERS
                         continue
                     else:
                         assert compare_dict[key] == action.data[key]
@@ -626,9 +626,9 @@ class TestNotificationActionMigrationUtils(TestCase):
             {
                 "uuid": "12345678-90ab-cdef-0123-456789abcdef",
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "fallthroughType": "NoOne",
+                "fallthrough_type": "NoOne",
             },
-            # This should be ok since we have a default value for fallthroughType
+            # This should be ok since we have a default value for fallthrough_type
             {
                 "uuid": "12345678-90ab-cdef-0123-456789abcdef",
                 "id": "sentry.mail.actions.NotifyEmailAction",

--- a/tests/sentry/workflow_engine/processors/test_action_deduplication.py
+++ b/tests/sentry/workflow_engine/processors/test_action_deduplication.py
@@ -330,7 +330,7 @@ class TestActionDeduplication(TestCase):
             type=Action.Type.EMAIL,
             config={"target_type": ActionTarget.USER, "target_identifier": str(self.user.id)},
             data={
-                "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
+                "fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS.value,
             },
         )
 
@@ -360,7 +360,7 @@ class TestActionDeduplication(TestCase):
                 "target_identifier": str(self.user.id),
             },
             data={
-                "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
+                "fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS.value,
             },
         )
 
@@ -371,7 +371,7 @@ class TestActionDeduplication(TestCase):
                 "target_identifier": str(self.user.id),
             },
             data={
-                "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
+                "fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS.value,
             },
         )
 


### PR DESCRIPTION
If "suggested assignees" are selected when creating an action that uses the fallthrough type the schema was incorrectly expecting it to be camel case instead of snake case which prevented the action from being created. This updates that and adds a test case around that particular action.

For now we must support both types until we can run a migration, after which I can go back and remove support for the incorrect camel case type.

Fixes https://getsentry.atlassian.net/browse/ACI-504

Related migration https://github.com/getsentry/sentry/pull/103764