### PR TITLE
fix(migrations): Fail migrations that delete models if no historical_silo_assignment is found

### DIFF
--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -68,8 +68,13 @@ class SiloRouter:
     historical_silo_assignments = {
         "authidentity_duplicate": SiloMode.CONTROL,
         "authprovider_duplicate": SiloMode.CONTROL,
+        "feedback_feedback": SiloMode.REGION,
+        "releases_commit": SiloMode.REGION,
+        "releases_commitfilechange": SiloMode.REGION,
         "sentry_actor": SiloMode.REGION,
         "sentry_alertruleactivations": SiloMode.REGION,
+        "sentry_dashboardwidgetsnapshot": SiloMode.REGION,
+        "sentry_datasecrecywaiver": SiloMode.REGION,
         "sentry_incidentseen": SiloMode.REGION,
         "sentry_incidentsubscription": SiloMode.REGION,
         "sentry_monitorlocation": SiloMode.REGION,
@@ -78,6 +83,8 @@ class SiloRouter:
         "sentry_projectavatar": SiloMode.REGION,
         "sentry_scheduledjob": SiloMode.CONTROL,
         "sentry_teamavatar": SiloMode.REGION,
+        "uptime_projectuptimesubscription": SiloMode.REGION,
+        "workflow_engine_actiongroupstatus": SiloMode.REGION,
         "workflow_engine_workflowaction": SiloMode.REGION,
     }
     """

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -269,8 +269,12 @@ def export_to_encrypted_tarball(
 
 
 def is_control_model(model):
-    meta = model._meta
-    return not hasattr(meta, "silo_limit") or SiloMode.CONTROL in meta.silo_limit.modes
+    # Check where the router actually sends this model instead of relying on metadata.
+    # Models without silo_limit (like Django's built-in models) may route to different
+    # databases depending on the router configuration.
+    using = router.db_for_write(model)
+    # In test environments, "control" database = control silo, "default" = region silo
+    return using == "control"
 
 
 def clear_model(model, *, reset_pks: bool):

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -269,12 +269,8 @@ def export_to_encrypted_tarball(
 
 
 def is_control_model(model):
-    # Check where the router actually sends this model instead of relying on metadata.
-    # Models without silo_limit (like Django's built-in models) may route to different
-    # databases depending on the router configuration.
-    using = router.db_for_write(model)
-    # In test environments, "control" database = control silo, "default" = region silo
-    return using == "control"
+    meta = model._meta
+    return not hasattr(meta, "silo_limit") or SiloMode.CONTROL in meta.silo_limit.modes
 
 
 def clear_model(model, *, reset_pks: bool):

--- a/tests/sentry/new_migrations/monkey/test_models.py
+++ b/tests/sentry/new_migrations/monkey/test_models.py
@@ -1,0 +1,81 @@
+"""
+Tests for SafeDeleteModel validation that ensures deleted models are added to
+historical_silo_assignments.
+"""
+
+import pytest
+from django.db import connection, models
+
+from sentry.new_migrations.monkey.models import SafeDeleteModel
+from sentry.new_migrations.monkey.state import DeletionAction, SentryProjectState
+from sentry.testutils.cases import TestCase
+
+
+class SafeDeleteModelTest(TestCase):
+    """
+    Tests that SafeDeleteModel fails loudly when a deleted model is not in
+    historical_silo_assignments.
+    """
+
+    def test_delete_model_without_historical_assignment_fails(self):
+        """
+        When deleting a model that is not in historical_silo_assignments and
+        cannot be found, SafeDeleteModel should raise a ValueError in test
+        environments.
+        """
+        # Create a mock model that mimics a deleted model not in the Django registry
+        # This simulates what happens when a model class has been removed but
+        # migrations still reference it
+        from unittest.mock import Mock
+
+        fake_meta = Mock()
+        fake_meta.db_table = "sentry_fake_deleted_table_not_in_router"
+        fake_meta.app_label = "sentry"
+        fake_meta.model_name = "fakedeletedmodel"
+
+        FakeDeletedModel = Mock()
+        FakeDeletedModel._meta = fake_meta
+
+        # Create project states
+        from_state = SentryProjectState()
+        to_state = SentryProjectState()
+
+        # Manually add the model to pending deletion in the from_state
+        # This simulates what happens when a model was marked for pending deletion
+        # and is now being deleted
+        from_state.pending_deletion_models[("sentry", "fakedeletedmodel")] = FakeDeletedModel
+
+        # Create the SafeDeleteModel operation
+        operation = SafeDeleteModel(name="FakeDeletedModel", deletion_action=DeletionAction.DELETE)
+
+        # Get schema editor
+        with connection.schema_editor() as schema_editor:
+            # This should raise ValueError because the table is not in historical_silo_assignments
+            with pytest.raises(ValueError) as exc_info:
+                operation.database_forwards("sentry", schema_editor, from_state, to_state)
+
+            assert "Cannot determine database for deleted model" in str(exc_info.value)
+            assert "sentry_fake_deleted_table_not_in_router" in str(exc_info.value)
+            assert "historical_silo_assignments" in str(exc_info.value)
+
+    def test_delete_model_with_move_to_pending_skips_validation(self):
+        """
+        MOVE_TO_PENDING operations should not trigger the validation check
+        since the model class still exists at that point.
+        """
+
+        class FakeModel(models.Model):
+            class Meta:
+                app_label = "sentry"
+                db_table = "sentry_fake_table"
+
+        from_state = SentryProjectState()
+        to_state = SentryProjectState()
+
+        operation = SafeDeleteModel(
+            name="FakeModel", deletion_action=DeletionAction.MOVE_TO_PENDING
+        )
+
+        with connection.schema_editor() as schema_editor:
+            # Should not raise - MOVE_TO_PENDING exits early
+            operation.database_forwards("sentry", schema_editor, from_state, to_state)


### PR DESCRIPTION
We have been silently failing the final deletion of tables for a while, because we need to add them to `historical_silo_assignments` for it to work correctly. This pr makes sure that we fail in CI if we aren't able to find an entry there.
