### PR TITLE
feat(workflow_engine): Add list of tags to help users define alerts

### DIFF
--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -56,7 +56,7 @@ function KeyField() {
     {}
   );
 
-  const sortedTags = useMemo(() => {
+  const sortedOptions = useMemo(() => {
     const sorted = tagOptions.toSorted((a, b) => {
       return (a.totalValues || 0) > (b.totalValues || 0) ? -1 : 1;
     });
@@ -68,7 +68,10 @@ function KeyField() {
       sorted.unshift(condition.comparison);
     }
 
-    return sorted;
+    return Object.values(sorted).map((tag: Tag) => ({
+      value: tag.key,
+      label: tag.key,
+    }));
   }, [tagOptions, condition.comparison]);
 
   return (
@@ -77,12 +80,9 @@ function KeyField() {
       creatable
       name={`${condition_id}.comparison.key`}
       aria-label={t('Tag')}
-      placeholder={isLoading ? t('Loading tags...') : t('tag')}
+      placeholder={isLoading ? t('Loading tags\u2026') : t('tag')}
       value={condition.comparison.key}
-      options={Object.values(sortedTags).map((tag: Tag) => ({
-        value: tag.key,
-        label: tag.key,
-      }))}
+      options={sortedOptions}
       onChange={(e: SelectValue<MatchType>) => {
         onUpdate({comparison: {...condition.comparison, key: e.value}});
         removeError(condition.id);

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -91,6 +91,10 @@ describe('DataConditionNodeList', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/data-conditions/`,
       body: dataConditionHandlers,
     });
@@ -156,7 +160,9 @@ describe('DataConditionNodeList', () => {
       {organization}
     );
 
-    await userEvent.type(screen.getByRole('textbox', {name: 'Tag'}), 's');
+    // Wait until the request for tags is completed
+    const tagInput = await screen.findByRole('textbox', {name: 'Tag'});
+    await userEvent.type(tagInput, 'names{enter}');
     expect(mockUpdateCondition).toHaveBeenCalledWith('1', {
       comparison: {key: 'names', match: MatchType.CONTAINS, value: 'moo deng'},
     });

--- a/static/app/views/automations/edit.spec.tsx
+++ b/static/app/views/automations/edit.spec.tsx
@@ -66,6 +66,13 @@ describe('EditAutomation', () => {
       body: {id: automation.createdBy, name: 'Test User'},
     });
 
+    // Mock the organization tags
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/tags/`,
+      method: 'GET',
+      body: [],
+    });
+
     jest.mocked(useParams).mockReturnValue({
       automationId: automation.id,
     });

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -49,6 +49,13 @@ describe('AutomationNewSettings', () => {
       ],
     });
 
+    // Mock the tags for an organization
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/tags/`,
+      method: 'GET',
+      body: [],
+    });
+
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/data-conditions/`,
       method: 'GET',
@@ -119,7 +126,8 @@ describe('AutomationNewSettings', () => {
       screen.getByRole('textbox', {name: 'Add filter'}),
       /tagged event/i
     );
-    await userEvent.type(screen.getByRole('textbox', {name: 'Tag'}), 'env');
+    const tagInput = await screen.findByRole('textbox', {name: 'Tag'});
+    await userEvent.type(tagInput, 'env{enter}');
     await userEvent.type(screen.getByRole('textbox', {name: 'Value'}), 'prod');
 
     // Add an action to the block (Slack), also updates the automatic naming


### PR DESCRIPTION
# Description
Currently we use a free form text field for the `tagged event` condition. We've had a few user issues that that the tagged event was configured on an event that hasn't been seen.

This is only using the tags seen on error events; this is a bit closer to the intent of the condition and hope this clarifies the condition for the user.


https://github.com/user-attachments/assets/d9acdf19-7584-4f0f-93c2-db5a54339145