### PR TITLE
fix(eu_data_export): fixes sts transfer job schedule

### DIFF
--- a/src/sentry/profiles/data_export.py
+++ b/src/sentry/profiles/data_export.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 
 from google.cloud.storage_transfer_v1 import TransferJob
 
@@ -8,7 +7,6 @@ from sentry.replays.data_export import create_transfer_job, request_create_trans
 
 logger = logging.getLogger(__name__)
 
-EXPORT_JOB_DURATION_DEFAULT = timedelta(days=5)
 EXPORT_JOB_SOURCE_BUCKET = "sentryio-profiles"
 
 
@@ -17,7 +15,6 @@ def export_profiles_data(
     gcp_project_id: str,
     destination_bucket: str,
     destination_prefix: str,
-    blob_export_job_duration: timedelta = EXPORT_JOB_DURATION_DEFAULT,
     source_bucket: str = EXPORT_JOB_SOURCE_BUCKET,
     pubsub_topic_name: str | None = None,
 ) -> TransferJob:
@@ -27,7 +24,6 @@ def export_profiles_data(
             "organization_id": organization_id,
             "gcp_project_id": gcp_project_id,
             "destination_bucket": destination_bucket,
-            "blob_export_job_duration": str(blob_export_job_duration),
             "source_bucket": source_bucket,
             "pubsub_topic_name": pubsub_topic_name,
         },
@@ -49,7 +45,6 @@ def export_profiles_data(
         destination_prefix=destination_prefix,
         notification_topic=pubsub_topic_name,
         job_description="Profiles EU Compliance Export",
-        job_duration=blob_export_job_duration,
         do_create_transfer_job=request_create_transfer_job,
     )
     logger.info("Successfully scheduled recording export job.")

--- a/tests/sentry/replays/unit/test_data_export.py
+++ b/tests/sentry/replays/unit/test_data_export.py
@@ -1,5 +1,5 @@
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from google.cloud import storage_transfer_v1
 from google.cloud.storage_transfer_v1 import (
@@ -30,8 +30,7 @@ def test_export_blob_data() -> None:
     bucket_prefix = "PREFIX"
     start_date = datetime(year=2025, month=1, day=31)
     job_description = "something"
-    job_duration = timedelta(days=5)
-    end_date = start_date + job_duration
+    end_date = start_date
 
     result = create_transfer_job(
         gcp_project_id=gcs_project_id,
@@ -41,7 +40,6 @@ def test_export_blob_data() -> None:
         destination_prefix="destination_prefix/",
         notification_topic=notification_topic,
         job_description=job_description,
-        job_duration=job_duration,
         transfer_job_name=None,
         do_create_transfer_job=lambda event: event,
         get_current_datetime=lambda: start_date,
@@ -103,9 +101,7 @@ def test_retry_export_blob_data() -> None:
 
 def test_export_replay_blob_data() -> None:
     jobs = []
-    export_replay_blob_data(
-        1, "1", "test", "dest_prefix/", timedelta(days=1), lambda job: jobs.append(job)
-    )
+    export_replay_blob_data(1, "1", "test", "dest_prefix/", lambda job: jobs.append(job))
 
     # Assert a job is created for each retention-period.
     assert len(jobs) == 3


### PR DESCRIPTION
Fixes data export TransferJob configuration to ensure jobs are one-shot.

* Removed misleading job_duration parameter from create_transfer_job and related export functions, as the GCS Transfer Service uses schedule_end_date == schedule_start_date to define a single-run job.

