### PR TITLE
ref: compositeSelect gets a required trigger

### DIFF
--- a/static/app/components/core/compactSelect/composite.spec.tsx
+++ b/static/app/components/core/compactSelect/composite.spec.tsx
@@ -174,9 +174,8 @@ describe('CompactSelect', () => {
     // select Choice One
     await userEvent.click(screen.getByRole('option', {name: 'Choice One'}));
 
-    // Region 1's callback is called, and trigger label is updated
+    // Region 1's callback is called
     expect(region1Mock).toHaveBeenCalledWith({value: 'choice_one', label: 'Choice One'});
-    expect(screen.getByRole('button', {name: 'Choice One'})).toBeInTheDocument();
 
     // open the menu again
     await userEvent.click(screen.getByRole('button'));
@@ -212,7 +211,6 @@ describe('CompactSelect', () => {
     expect(region2Mock).toHaveBeenCalledWith([
       {value: 'choice_three', label: 'Choice Three'},
     ]);
-    expect(screen.getByRole('button', {name: 'Choice One +1'})).toBeInTheDocument();
   });
 
   it('can search', async () => {

--- a/static/app/components/core/compactSelect/composite.spec.tsx
+++ b/static/app/components/core/compactSelect/composite.spec.tsx
@@ -5,7 +5,10 @@ import {CompositeSelect} from './composite';
 describe('CompactSelect', () => {
   it('renders', async () => {
     render(
-      <CompositeSelect menuTitle="Menu title">
+      <CompositeSelect
+        menuTitle="Menu title"
+        trigger={props => <button {...props}>Open menu</button>}
+      >
         <CompositeSelect.Region
           label="Region 1"
           value="choice_one"
@@ -66,7 +69,7 @@ describe('CompactSelect', () => {
 
   it('renders disabled trigger button', async () => {
     render(
-      <CompositeSelect disabled>
+      <CompositeSelect disabled trigger={props => <button {...props}>Open menu</button>}>
         <CompositeSelect.Region
           label="Region 1"
           onChange={jest.fn()}
@@ -85,7 +88,7 @@ describe('CompactSelect', () => {
   // focus state. This test ensures that focus moves seamlessly between regions.
   it('manages focus between regions', async () => {
     render(
-      <CompositeSelect>
+      <CompositeSelect trigger={props => <button {...props}>Open menu</button>}>
         <CompositeSelect.Region
           label="Region 1"
           onChange={jest.fn()}
@@ -142,7 +145,7 @@ describe('CompactSelect', () => {
     const region1Mock = jest.fn();
     const region2Mock = jest.fn();
     render(
-      <CompositeSelect>
+      <CompositeSelect trigger={props => <button {...props}>Open menu</button>}>
         <CompositeSelect.Region
           label="Region 1"
           onChange={region1Mock}
@@ -214,7 +217,11 @@ describe('CompactSelect', () => {
 
   it('can search', async () => {
     render(
-      <CompositeSelect searchable searchPlaceholder="Search placeholder…">
+      <CompositeSelect
+        searchable
+        searchPlaceholder="Search placeholder…"
+        trigger={props => <button {...props}>Open menu</button>}
+      >
         <CompositeSelect.Region
           label="Region 1"
           onChange={jest.fn()}
@@ -256,7 +263,7 @@ describe('CompactSelect', () => {
 
   it('works with grid lists', async () => {
     render(
-      <CompositeSelect grid>
+      <CompositeSelect grid trigger={props => <button {...props}>Open menu</button>}>
         <CompositeSelect.Region
           label="Region 1"
           value="choice_one"
@@ -322,7 +329,7 @@ describe('CompactSelect', () => {
   it('can use numbers as values', async () => {
     const onChange = jest.fn();
     render(
-      <CompositeSelect>
+      <CompositeSelect trigger={props => <button {...props}>Open menu</button>}>
         <CompositeSelect.Region
           label="Region 1"
           value={1}

--- a/static/app/components/core/compactSelect/composite.stories.tsx
+++ b/static/app/components/core/compactSelect/composite.stories.tsx
@@ -1,5 +1,7 @@
 import {Fragment, useState} from 'react';
 
+import {Button} from '@sentry/scraps/button';
+
 import {Flex} from 'sentry/components/core/layout';
 import {IconSentry, IconStar} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
@@ -78,12 +80,11 @@ export default Storybook.story('CompositeSelect', story => {
           <code>options</code>.
         </p>
         <CompositeSelect
-          triggerProps={{
-            children: 'Select an Option',
-            showChevron: false,
-            icon: <IconSentry />,
-            size: 'sm',
-          }}
+          trigger={props => (
+            <Button icon={<IconSentry />} size="sm" {...props}>
+              Select an Option
+            </Button>
+          )}
         >
           <CompositeSelect.Region
             label="Month"
@@ -125,12 +126,11 @@ export default Storybook.story('CompositeSelect', story => {
 
         <Flex gap="md">
           <CompositeSelect
-            triggerProps={{
-              size: 'sm',
-              icon: <IconSentry />,
-              children: 'Composite Select Single Select',
-              showChevron: false,
-            }}
+            trigger={props => (
+              <Button icon={<IconSentry />} size="sm" {...props}>
+                Composite Select Single Select
+              </Button>
+            )}
           >
             <CompositeSelect.Region
               label="Mains"

--- a/static/app/components/core/compactSelect/composite.tsx
+++ b/static/app/components/core/compactSelect/composite.tsx
@@ -65,13 +65,15 @@ type CompositeSelectChild =
   | null
   | undefined;
 
-export interface CompositeSelectProps extends ControlProps {
+export interface CompositeSelectProps
+  extends Omit<ControlProps, 'triggerProps' | 'trigger'> {
   /**
    * The "regions" inside this composite selector. Each region functions as a separated,
    * self-contained selectable list (each renders as a `ul` with its own list state)
    * whose values don't interfere with one another.
    */
   children: CompositeSelectChild | CompositeSelectChild[];
+  trigger: NonNullable<ControlProps['trigger']>;
 }
 
 /**

--- a/static/app/views/insights/crons/components/overviewTimeline/sortSelector.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/sortSelector.tsx
@@ -3,6 +3,7 @@ import {
   type CompositeSelectProps,
 } from 'sentry/components/core/compactSelect/composite';
 import type {SelectOption} from 'sentry/components/core/compactSelect/types';
+import DropdownButton from 'sentry/components/dropdownButton';
 import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -77,12 +78,16 @@ export function SortSelector({onChangeOrder, onChangeSort, order, sort, size}: P
   return (
     <CompositeSelect
       size={size}
-      triggerProps={{
-        prefix: t('Sort By'),
-        'aria-label': t('Sort Cron Monitors'),
-        icon: <IconSort />,
-        children: `${label} \u2014 ${orderLabel}`,
-      }}
+      trigger={props => (
+        <DropdownButton
+          aria-label={t('Sort Cron Monitors')}
+          icon={<IconSort />}
+          prefix={t('Sort By')}
+          {...props}
+        >
+          {`${label} \u2014 ${orderLabel}`}
+        </DropdownButton>
+      )}
     >
       <CompositeSelect.Region
         aria-label={t('Sort Options')}

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -1,5 +1,6 @@
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {CompositeSelect} from 'sentry/components/core/compactSelect/composite';
+import DropdownButton from 'sentry/components/dropdownButton';
 import {IconSliders} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {OrgRole} from 'sentry/types/organization';
@@ -54,7 +55,11 @@ function MembersFilter({roles, query, onChange}: Props) {
 
   return (
     <CompositeSelect
-      triggerProps={{icon: <IconSliders />, size: 'md', children: t('Filter')}}
+      trigger={props => (
+        <DropdownButton {...props} size="md" icon={<IconSliders />}>
+          {t('Filter')}
+        </DropdownButton>
+      )}
       maxMenuHeight="22rem"
       size="sm"
     >


### PR DESCRIPTION
almost all CompositeSelect usages pass either a trigger or triggerProps already, which means they never need the default trigger label calculation that is done internally.

In an upcoming perf improvement, this calculation will be changed / removed because it relies on all options being rendered eagerly. This computation can be done in the parent for `CompactSelect` because all items are available, but `CompositeSelect` does this with regions so it would be harder. However, we don’t need it if its unused.

This PR just enforces that there won’t be a future usage that uses the default trigger label in CompositeSelect by always enforcing a trigger to be passed. It also unifies `triggerLabel` & `trigger` usages, as `triggerLabel` is no longer allowed.