### PR TITLE
fix(encryption): Improve log message when we load 0 keys

### DIFF
--- a/src/sentry/utils/security/encrypted_field_key_store.py
+++ b/src/sentry/utils/security/encrypted_field_key_store.py
@@ -63,7 +63,10 @@ class FernetKeyStore:
                     sentry_sdk.capture_exception(e)
 
         cls._is_loaded = True
-        logger.info("Successfully loaded %d Fernet encryption keys.", len(cls._keys))
+        if cls._keys:
+            logger.info("Successfully loaded %d Fernet encryption keys.", len(cls._keys))
+        else:
+            logger.info("No Fernet encryption keys loaded.")
 
     @classmethod
     def get_fernet_for_key_id(cls, key_id: str) -> Fernet:


### PR DESCRIPTION
It's stupid to say "successfully loaded 0" - so i have updated a log message to say that we haven't loaded any keys
