### PR TITLE
chore(search-bar): Remove auto replacement on paste

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -962,48 +962,40 @@ export function useQueryBuilderState({
         }
         case 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE':
         case 'REPLACE_TOKENS_WITH_TEXT_ON_KEY_DOWN': {
-          return {
-            ...replaceTokensWithText(state, {
-              tokens: action.tokens,
-              text: action.text,
-              focusOverride: action.focusOverride,
-              getFieldDefinition,
-              shouldCommitQuery: hasReplaceRawSearchKeys ? false : true,
-            }),
-          };
+          return replaceTokensWithText(state, {
+            tokens: action.tokens,
+            text: action.text,
+            focusOverride: action.focusOverride,
+            getFieldDefinition,
+            shouldCommitQuery: hasReplaceRawSearchKeys ? false : true,
+          });
         }
         case 'REPLACE_TOKENS_WITH_TEXT_ON_CUT':
         case 'REPLACE_TOKENS_WITH_TEXT_ON_DELETE':
         case 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT': {
-          return {
-            ...replaceTokensWithText(state, {
-              tokens: action.tokens,
-              text: action.text,
-              focusOverride: action.focusOverride,
-              getFieldDefinition,
-              shouldCommitQuery: true,
-            }),
-          };
+          return replaceTokensWithText(state, {
+            tokens: action.tokens,
+            text: action.text,
+            focusOverride: action.focusOverride,
+            getFieldDefinition,
+            shouldCommitQuery: true,
+          });
         }
         case 'UPDATE_FILTER_KEY':
-          return {...updateFilterKey(state, action)};
+          return updateFilterKey(state, action);
         case 'UPDATE_FILTER_OP':
-          return {
-            ...modifyFilterOperator(state, action, hasWildcardOperators),
-          };
+          return modifyFilterOperator(state, action, hasWildcardOperators);
         case 'UPDATE_TOKEN_VALUE':
           return {
             ...state,
             query: modifyFilterValue(state.query, action.token, action.value),
           };
         case 'UPDATE_LOGIC_OPERATOR':
-          return {...updateLogicOperator(state, action)};
+          return updateLogicOperator(state, action);
         case 'UPDATE_AGGREGATE_ARGS':
-          return {
-            ...updateAggregateArgs(state, action, {getFieldDefinition}),
-          };
+          return updateAggregateArgs(state, action, {getFieldDefinition});
         case 'TOGGLE_FILTER_VALUE':
-          return {...multiSelectTokenValue(state, action)};
+          return multiSelectTokenValue(state, action);
         case 'RESET_CLEAR_ASK_SEER_FEEDBACK':
           return {...state, clearAskSeerFeedback: false};
         default:

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -48,7 +48,7 @@ type QueryBuilderState = {
   focusOverride: FocusOverride | null;
 
   /**
-   * Stores the previous action that was preformed. This enables us to determine if we should take certain actions based on what was previously done.
+   * Stores the previous action that was performed. This enables us to determine if we should take certain actions based on what was previously done.
    */
   previousAction: QueryBuilderActions['type'] | null;
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -499,13 +499,13 @@ function replaceTokensWithText(
     text,
     tokens,
     focusOverride: incomingFocusOverride,
-    shouldCommitQuery = true,
+    shouldCommitQuery,
   }: {
     getFieldDefinition: FieldDefinitionGetter;
+    shouldCommitQuery: boolean;
     text: string;
     tokens: Array<TokenResult<Token>>;
     focusOverride?: FocusOverride;
-    shouldCommitQuery?: boolean;
   }
 ): QueryBuilderState {
   const newQuery = replaceTokensWithPadding(state.query, tokens, text);
@@ -516,7 +516,9 @@ function replaceTokensWithText(
 
   // Only update the committed query if we aren't in the middle of creating a filter
   const committedQuery =
-    incomingFocusOverride?.part === 'value' ? state.committedQuery : newQuery;
+    incomingFocusOverride?.part === 'value' && shouldCommitQuery
+      ? state.committedQuery
+      : newQuery;
 
   if (incomingFocusOverride) {
     return {
@@ -924,6 +926,7 @@ export function useQueryBuilderState({
               tokens: [action.token],
               text: '',
               getFieldDefinition,
+              shouldCommitQuery: true,
             }),
             clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
             previousAction: action.type,
@@ -997,6 +1000,7 @@ export function useQueryBuilderState({
               text: action.text,
               focusOverride: action.focusOverride,
               getFieldDefinition,
+              shouldCommitQuery: true,
             }),
             previousAction: action.type,
           };

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -48,11 +48,6 @@ type QueryBuilderState = {
   focusOverride: FocusOverride | null;
 
   /**
-   * Stores the previous action that was performed. This enables us to determine if we should take certain actions based on what was previously done.
-   */
-  previousAction: QueryBuilderActions['type'] | null;
-
-  /**
    * The current query value.
    * This is the basic source of truth for what is currently being displayed.
    */
@@ -849,7 +844,6 @@ export function useQueryBuilderState({
     committedQuery: initialQuery,
     focusOverride: null,
     clearAskSeerFeedback: false,
-    previousAction: null,
   };
 
   const reducer: Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
@@ -865,7 +859,7 @@ export function useQueryBuilderState({
         case 'CLEAR':
           return {
             ...state,
-            previousAction: action.type,
+
             query: '',
             committedQuery: '',
             focusOverride: {
@@ -874,23 +868,18 @@ export function useQueryBuilderState({
           };
         case 'COMMIT_QUERY':
           if (state.query === state.committedQuery) {
-            return {...state, previousAction: action.type};
+            return {...state};
           }
-          return {...state, committedQuery: state.query, previousAction: action.type};
+          return {...state, committedQuery: state.query};
         case 'UPDATE_QUERY': {
           const shouldCommitQuery = action.shouldCommitQuery ?? true;
 
-          if (
-            !hasWildcardOperators ||
-            !hasReplaceRawSearchKeys ||
-            state.previousAction === 'UPDATE_FREE_TEXT_ON_BLUR'
-          ) {
+          if (!hasWildcardOperators || !hasReplaceRawSearchKeys) {
             return {
               ...state,
               query: action.query,
               committedQuery: shouldCommitQuery ? action.query : state.committedQuery,
               focusOverride: action.focusOverride ?? null,
-              previousAction: action.type,
             };
           }
 
@@ -911,14 +900,12 @@ export function useQueryBuilderState({
             query,
             committedQuery,
             focusOverride,
-            previousAction: action.type,
           };
         }
         case 'RESET_FOCUS_OVERRIDE':
           return {
             ...state,
             focusOverride: null,
-            previousAction: action.type,
           };
         case 'DELETE_TOKEN': {
           return {
@@ -929,14 +916,12 @@ export function useQueryBuilderState({
               shouldCommitQuery: true,
             }),
             clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
-            previousAction: action.type,
           };
         }
         case 'DELETE_TOKENS': {
           return {
             ...deleteQueryTokens(state, action),
             clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
-            previousAction: action.type,
           };
         }
         case 'UPDATE_FREE_TEXT_ON_BLUR': {
@@ -946,7 +931,6 @@ export function useQueryBuilderState({
             committedQuery: state.committedQuery,
             clearAskSeerFeedback:
               newState.query !== state.query && displayAskSeerFeedback ? true : false,
-            previousAction: action.type,
           };
         }
         case 'UPDATE_FREE_TEXT_ON_SELECT':
@@ -958,7 +942,6 @@ export function useQueryBuilderState({
             ...newState,
             clearAskSeerFeedback:
               newState.query !== state.query && displayAskSeerFeedback ? true : false,
-            previousAction: action.type,
           };
         }
         case 'UPDATE_FREE_TEXT_ON_EXIT':
@@ -975,7 +958,6 @@ export function useQueryBuilderState({
             ...newState,
             clearAskSeerFeedback:
               newState.query !== state.query && displayAskSeerFeedback ? true : false,
-            previousAction: action.type,
           };
         }
         case 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE':
@@ -988,7 +970,6 @@ export function useQueryBuilderState({
               getFieldDefinition,
               shouldCommitQuery: hasReplaceRawSearchKeys ? false : true,
             }),
-            previousAction: action.type,
           };
         }
         case 'REPLACE_TOKENS_WITH_TEXT_ON_CUT':
@@ -1002,33 +983,29 @@ export function useQueryBuilderState({
               getFieldDefinition,
               shouldCommitQuery: true,
             }),
-            previousAction: action.type,
           };
         }
         case 'UPDATE_FILTER_KEY':
-          return {...updateFilterKey(state, action), previousAction: action.type};
+          return {...updateFilterKey(state, action)};
         case 'UPDATE_FILTER_OP':
           return {
             ...modifyFilterOperator(state, action, hasWildcardOperators),
-            previousAction: action.type,
           };
         case 'UPDATE_TOKEN_VALUE':
           return {
             ...state,
             query: modifyFilterValue(state.query, action.token, action.value),
-            previousAction: action.type,
           };
         case 'UPDATE_LOGIC_OPERATOR':
-          return {...updateLogicOperator(state, action), previousAction: action.type};
+          return {...updateLogicOperator(state, action)};
         case 'UPDATE_AGGREGATE_ARGS':
           return {
             ...updateAggregateArgs(state, action, {getFieldDefinition}),
-            previousAction: action.type,
           };
         case 'TOGGLE_FILTER_VALUE':
-          return {...multiSelectTokenValue(state, action), previousAction: action.type};
+          return {...multiSelectTokenValue(state, action)};
         case 'RESET_CLEAR_ASK_SEER_FEEDBACK':
-          return {...state, clearAskSeerFeedback: false, previousAction: action.type};
+          return {...state, clearAskSeerFeedback: false};
         default:
           return state;
       }

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4385,98 +4385,6 @@ describe('SearchQueryBuilder', () => {
         });
       });
 
-      describe('pasting text', () => {
-        it('should replace raw search keys on paste', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          await userEvent.click(getLastInput());
-          await userEvent.paste('randomValue');
-
-          // Should have tokenized the pasted text
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
-            })
-          ).toBeInTheDocument();
-          // Focus should be at the end of the pasted text
-          expect(
-            screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
-          ).toHaveFocus();
-        });
-
-        it('should replace raw search keys on paste, leaving other tokens intact', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery="browser.name:firefox span.description:test"
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          await userEvent.click(getLastInput());
-          await userEvent.paste('randomValue');
-
-          // leaves unrelated filter key tokens intact
-          expect(
-            screen.getByRole('row', {name: 'browser.name:firefox'})
-          ).toBeInTheDocument();
-
-          // leaves the same filter key minus the wildcard contains operator intact
-          expect(
-            screen.getByRole('row', {name: 'span.description:test'})
-          ).toBeInTheDocument();
-
-          // Should have tokenized the pasted text
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
-            })
-          ).toBeInTheDocument();
-          // Focus should be at the end of the pasted text
-          expect(
-            screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
-          ).toHaveFocus();
-        });
-
-        it('should replace raw search keys on paste, merging with existing tokens', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery={`span.description:${WildcardOperators.CONTAINS}test`}
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          await userEvent.click(getLastInput());
-          await userEvent.paste('randomValue');
-          // the new filter key combobox is opened, when we get moved to the new token
-          await userEvent.keyboard('{Escape}');
-
-          // Should have tokenized the pasted text
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}test`,
-            })
-          ).toBeInTheDocument();
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
-            })
-          ).toBeInTheDocument();
-          // Focus should be at the end of the pasted text
-          expect(getLastInput()).toHaveFocus();
-        });
-      });
-
       describe('on commit', () => {
         it('should replace the raw search key with the defined key:value', async () => {
           render(
@@ -4497,31 +4405,6 @@ describe('SearchQueryBuilder', () => {
             })
           ).toBeInTheDocument();
           expect(getLastInput()).toHaveFocus();
-        });
-      });
-
-      describe('on blur', () => {
-        it('should replace the raw search key with the defined key:value', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          const input = getLastInput();
-          await userEvent.click(input);
-          await userEvent.keyboard('randomValue');
-          await userEvent.click(document.body);
-
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
-            })
-          ).toBeInTheDocument();
-          expect(getLastInput()).not.toHaveFocus();
         });
       });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4385,6 +4385,57 @@ describe('SearchQueryBuilder', () => {
         });
       });
 
+      describe('pasting text', () => {
+        it('should not replace raw search keys on paste', async () => {
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery=""
+              replaceRawSearchKeys={['span.description']}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          await userEvent.click(getLastInput());
+          await userEvent.paste('randomValue');
+
+          // Should have the pasted text
+          expect(screen.getByRole('row', {name: 'randomValue'})).toBeInTheDocument();
+        });
+
+        it('not should replace raw search keys on paste, leaving other tokens intact', async () => {
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:firefox span.description:test"
+              replaceRawSearchKeys={['span.description']}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          await userEvent.click(getLastInput());
+          await userEvent.paste('randomValue');
+          await userEvent.keyboard('{Escape}');
+
+          // leaves unrelated filter key tokens intact
+          expect(
+            screen.getByRole('row', {name: 'browser.name:firefox'})
+          ).toBeInTheDocument();
+
+          // leaves the same filter key minus the wildcard contains operator intact
+          expect(
+            screen.getByRole('row', {name: 'span.description:test'})
+          ).toBeInTheDocument();
+
+          // Should have the pasted text
+          expect(screen.getByRole('row', {name: 'randomValue'})).toBeInTheDocument();
+          // Focus should be at the end of the pasted text
+          expect(
+            screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+          ).toHaveFocus();
+        });
+      });
+
       describe('on commit', () => {
         it('should replace the raw search key with the defined key:value', async () => {
           render(
@@ -4404,6 +4455,27 @@ describe('SearchQueryBuilder', () => {
               name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
             })
           ).toBeInTheDocument();
+          expect(getLastInput()).toHaveFocus();
+        });
+      });
+
+      describe('on blur', () => {
+        it('should not replace the raw search key with the defined key:value', async () => {
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery=""
+              replaceRawSearchKeys={['span.description']}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          const input = getLastInput();
+          await userEvent.click(input);
+          await userEvent.keyboard('randomValue');
+          await userEvent.click(document.body);
+
+          expect(screen.getByRole('row', {name: `randomValue`})).toBeInTheDocument();
           expect(getLastInput()).toHaveFocus();
         });
       });


### PR DESCRIPTION
This PR tweaks how search bar state operates, focused on handling edge cases when replace search keys are present. 

For search bars that operate without any replace search keys they should remain operating as before. Search bars with replace keys should now no longer auto replace on paste, and when interacting with free text should not submit any values when for example selecting all and clearing.

Ticket: EXP-0604