### PR TITLE
Perform ViewHierarchy deobfuscation using stored attachments

### DIFF
--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -31,7 +31,9 @@ attachment_cache: BaseAttachmentCache = import_string(settings.SENTRY_ATTACHMENT
 
 
 @sentry_sdk.trace
-def store_attachments_for_event(event: Any, attachments: list[CachedAttachment], timeout=None):
+def store_attachments_for_event(
+    project: Project, event: Any, attachments: list[CachedAttachment], timeout=None
+):
     """
     Stores the given list of `attachments` belonging to `event` for processing.
 
@@ -47,6 +49,7 @@ def store_attachments_for_event(event: Any, attachments: list[CachedAttachment],
         attachments,
         timeout=timeout,
         set_metadata=not put_metadata_into_event,
+        project=project,
     )
     event.pop("_attachments", None)
     if put_metadata_into_event:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2383,7 +2383,7 @@ def save_attachment(
         timestamp = datetime.now(timezone.utc)
 
     try:
-        attachment.stored_id or attachment.data
+        attachment.stored_id or attachment.load_data(project)
     except MissingAttachmentChunks:
         track_outcome(
             org_id=project.organization_id,

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -182,7 +182,7 @@ def process_event(
             for attachment in attachments
         ]
         if attachment_objects:
-            store_attachments_for_event(data, attachment_objects, timeout=CACHE_TIMEOUT)
+            store_attachments_for_event(project, data, attachment_objects, timeout=CACHE_TIMEOUT)
 
         with metrics.timer("ingest_consumer._store_event"):
             cache_key = processing_store.store(data)

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -191,7 +191,7 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         for sinfo in stacktrace_infos
     ]
 
-    view_hierarchies = ViewHierarchies(data)
+    view_hierarchies = ViewHierarchies(symbolicator.project, data)
     window_class_names = view_hierarchies.get_window_class_names()
 
     exceptions = Exceptions(data)

--- a/src/sentry/lang/java/view_hierarchies.py
+++ b/src/sentry/lang/java/view_hierarchies.py
@@ -8,17 +8,19 @@ from sentry.attachments import (
     store_attachments_for_event,
 )
 from sentry.ingest.consumer.processors import CACHE_TIMEOUT
+from sentry.models.project import Project
 
 
 class ViewHierarchies:
-    def __init__(self, data: Any):
+    def __init__(self, project: Project, data: Any):
+        self._project = project
         self._event = data
         self._view_hierarchies: list[tuple[CachedAttachment, Any]] = []
         self._other_attachments: list[CachedAttachment] = []
 
         for attachment in get_attachments_for_event(self._event):
             if attachment.type == "event.view_hierarchy":
-                view_hierarchy = orjson.loads(attachment.data)
+                view_hierarchy = orjson.loads(attachment.load_data(project))
                 self._view_hierarchies.append((attachment, view_hierarchy))
             else:
                 self._other_attachments.append(attachment)
@@ -60,11 +62,12 @@ class ViewHierarchies:
                     content_type=attachment.content_type,
                     data=orjson.dumps(view_hierarchy),
                     chunks=None,
+                    stored_id=attachment.stored_id,
                 )
             )
 
         attachments = self._other_attachments + new_attachments
-        store_attachments_for_event(self._event, attachments, timeout=CACHE_TIMEOUT)
+        store_attachments_for_event(self._project, self._event, attachments, timeout=CACHE_TIMEOUT)
 
 
 def _deobfuscate_view_hierarchy(view_hierarchy: Any, class_names: dict[str, str]):

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -181,7 +181,7 @@ class Symbolicator:
         )
         if force_stored_attachment:
             session = get_attachments_session(self.project.organization_id, self.project.id)
-            minidump.stored_id = session.put(minidump.data)
+            minidump.stored_id = session.put(minidump.load_data(self.project))
 
         if minidump.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
@@ -212,7 +212,7 @@ class Symbolicator:
             "options": '{"dif_candidates": true}',
             "rewrite_first_module": orjson.dumps(rewrite_first_module).decode(),
         }
-        files = {"upload_file_minidump": minidump.data}
+        files = {"upload_file_minidump": minidump.load_data(self.project)}
 
         res = self._process("process_minidump", "minidump", data=data, files=files)
         return process_response(res)
@@ -226,7 +226,7 @@ class Symbolicator:
         )
         if force_stored_attachment:
             session = get_attachments_session(self.project.organization_id, self.project.id)
-            report.stored_id = session.put(report.data)
+            report.stored_id = session.put(report.load_data(self.project))
 
         if report.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
@@ -255,7 +255,7 @@ class Symbolicator:
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": '{"dif_candidates": true}',
         }
-        files = {"apple_crash_report": report.data}
+        files = {"apple_crash_report": report.load_data(self.project)}
 
         res = self._process("process_applecrashreport", "applecrashreport", data=data, files=files)
         return process_response(res)

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -186,7 +186,7 @@ class EventAttachment(Model):
                 content_type=content_type, size=attachment.size, sha1=checksum, blob_path=blob_path
             )
 
-        data = attachment.data
+        data = attachment.load_data()
         blob = BytesIO(data)
         size, checksum = get_size_and_checksum(blob)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3517,6 +3517,8 @@ register(
 register("objectstore.double_write.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Fraction of attachments that are being stored exclusively in the new objectstore.
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Fraction of attachments that are being stored on objectstore for processing and long-term storage.
+register("objectstore.enable_for.cached_attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Fraction of events that use the processing store (the transient event payload) for attachment metadata (independant from payloads).
 register("objectstore.processing_store.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # This forces symbolication to use the "stored attachment" codepath,

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -238,7 +238,7 @@ def reprocess_event(project_id: int, event_id: str, start_time: float) -> None:
             )
 
     if attachment_objects:
-        store_attachments_for_event(data, attachment_objects, timeout=CACHE_TIMEOUT)
+        store_attachments_for_event(project, data, attachment_objects, timeout=CACHE_TIMEOUT)
 
     # Step 2: Fix up the event payload for reprocessing and put it in event
     # cache/event_processing_store

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -1,6 +1,7 @@
 import copy
 
 from sentry.attachments.base import BaseAttachmentCache, CachedAttachment
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 class InMemoryCache:
@@ -74,13 +75,14 @@ def test_basic_chunked() -> None:
     (att2,) = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 123
-    assert att2.data == att.data == b"Hello World! Bye."
+    assert att2.load_data() == att.load_data() == b"Hello World! Bye."
     assert att2.rate_limited is None
 
     cache.delete("c:foo")
     assert not list(cache.get("c:foo"))
 
 
+@django_db_all
 def test_basic_unchunked() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
@@ -91,13 +93,14 @@ def test_basic_unchunked() -> None:
     (att2,) = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 0
-    assert att2.data == att.data == b"Hello World! Bye."
+    assert att2.load_data() == att.load_data() == b"Hello World! Bye."
     assert att2.rate_limited is None
 
     cache.delete("c:foo")
     assert not list(cache.get("c:foo"))
 
 
+@django_db_all
 def test_zstd_chunks() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
@@ -107,15 +110,16 @@ def test_zstd_chunks() -> None:
     cache.set_chunk("mixed_chunks", 123, 2, b"Bye.")
 
     mixed_chunks = cache.get_from_chunks(key="mixed_chunks", id=123, chunks=3)
-    assert mixed_chunks.data == b"Hello World! Just visiting. Bye."
+    assert mixed_chunks.load_data() == b"Hello World! Just visiting. Bye."
 
     att = CachedAttachment(key="not_chunked", id=456, data=b"Hello World! Bye.")
     cache.set("not_chunked", [att])
 
     (not_chunked,) = cache.get("not_chunked")
-    assert not_chunked.data == b"Hello World! Bye."
+    assert not_chunked.load_data() == b"Hello World! Bye."
 
 
+@django_db_all
 def test_basic_rate_limited() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
@@ -128,5 +132,5 @@ def test_basic_rate_limited() -> None:
     (att2,) = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 0
-    assert att2.data == att.data == b"Hello World! Bye."
+    assert att2.load_data() == att.load_data() == b"Hello World! Bye."
     assert att2.rate_limited is True

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -52,7 +52,7 @@ def test_process_pending_one_batch(mocked_attachment_cache, mock_client) -> None
         "name": "foo.txt",
         "content_type": "text/plain",
     }
-    assert attachment.data == b"Hello World!"
+    assert attachment.load_data(None) == b"Hello World!"
 
 
 def test_chunked(mocked_attachment_cache, mock_client) -> None:
@@ -72,4 +72,4 @@ def test_chunked(mocked_attachment_cache, mock_client) -> None:
         "name": "foo.txt",
         "content_type": "text/plain",
     }
-    assert attachment.data == b"Hello World! This attachment is chunked up."
+    assert attachment.load_data(None) == b"Hello World! This attachment is chunked up."


### PR DESCRIPTION
This makes sure that view hierarchy deobfuscation can work with already stored attachments, as well as storing them in objectstore as part of processing.