### PR TITLE
fix(explorer): stricter short ID regex

### DIFF
--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -69,10 +69,8 @@ function PanelContainers({
                   onClick={onUnminimize}
                 >
                   <Flex direction="column" align="center" gap="lg">
-                    <IconSeer variant="waiting" size="lg" color="purple400" />
-                    <Text variant="muted">
-                      Press Tab ⇥ or click to continue with Seer
-                    </Text>
+                    <IconSeer variant="waiting" size="lg" />
+                    <Text>Press Tab ⇥ or click to continue with Seer</Text>
                   </Flex>
                 </MinimizedOverlay>
               )}

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -223,7 +223,8 @@ export function getToolsStringFromBlock(block: Block): string[] {
 function linkifyIssueShortIds(text: string): string {
   // Pattern matches: PROJECT_SLUG-SHORT_ID (uppercase only, case-sensitive)
   // Requires at least 2 chars before hyphen and 1+ chars after
-  const shortIdPattern = /\b([A-Z0-9_]{2,}-[A-Z0-9]+)\b/g;
+  // First segment must contain at least one uppercase letter (all letters must be uppercase)
+  const shortIdPattern = /\b((?:[A-Z][A-Z0-9_]{1,}|[0-9_]+[A-Z][A-Z0-9_]*)-[A-Z0-9]+)\b/g;
 
   // Track positions that should be excluded (inside code blocks, links, or URLs)
   const excludedRanges: Array<{end: number; start: number}> = [];


### PR DESCRIPTION
Makes the short ID regex so we don't match timestamp strings by accident anymore.

<img width="577" height="316" alt="Screenshot 2025-11-20 at 10 19 50 AM" src="https://github.com/user-attachments/assets/adbfa07f-b82e-4e42-bcd2-fd8fa3507d59" />

Closes AIML-1647 and AIML-1658