### PR TITLE
ref(seer): Introduce legacy add-on

### DIFF
--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -24,7 +24,7 @@ import useApi from 'sentry/utils/useApi';
 import PlanList from 'admin/components/planList';
 import {ANNUAL, MONTHLY} from 'getsentry/constants';
 import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
-import {CheckoutType, PlanTier, ReservedBudgetCategoryType} from 'getsentry/types';
+import {CheckoutType, PlanTier} from 'getsentry/types';
 
 const ALLOWED_TIERS = [PlanTier.MM2, PlanTier.AM1, PlanTier.AM2, PlanTier.AM3];
 
@@ -48,23 +48,6 @@ function ChangePlanAction({
   const [activePlan, setActivePlan] = useState<Plan | null>(null);
   const [formModel] = useState(() => new FormModel());
   const orgId = organization.slug;
-
-  /**
-   * Check if the current subscription has Seer budget enabled
-   */
-  const hasCurrentSeerBudget = useMemo(() => {
-    return (
-      subscription.reservedBudgets?.some(
-        budget =>
-          budget.apiName === ReservedBudgetCategoryType.SEER && budget.reservedBudget > 0
-      ) ?? false
-    );
-  }, [subscription.reservedBudgets]);
-
-  // Initialize Seer budget value in form model
-  React.useEffect(() => {
-    formModel.setValue('addOnSeer', hasCurrentSeerBudget);
-  }, [formModel, hasCurrentSeerBudget]);
 
   const api = useApi({persistInFlight: true});
   const {
@@ -214,17 +197,11 @@ function ChangePlanAction({
       return;
     }
 
-    // Add Seer budget parameter for AM plans and TEST tier
-    const submitData = {
-      ...data,
-      addOnSeer: formModel.getValue('addOnSeer'),
-    };
-
     if (activeTier === PlanTier.MM2) {
       try {
         await api.requestPromise(`/customers/${orgId}/`, {
           method: 'PUT',
-          data: submitData,
+          data,
         });
         onSubmitSuccess(data);
       } catch (error) {
@@ -237,7 +214,7 @@ function ChangePlanAction({
     try {
       await api.requestPromise(`/customers/${orgId}/subscription/`, {
         method: 'PUT',
-        data: submitData,
+        data,
       });
       onSubmitSuccess(data);
       onSuccess?.();
@@ -281,7 +258,6 @@ function ChangePlanAction({
             setActiveTier(tab);
             setBillingInterval(MONTHLY);
             setContractInterval(MONTHLY);
-            formModel.setValue('addOnSeer', hasCurrentSeerBudget);
           }}
         >
           <TabList>

--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -87,6 +87,12 @@ function PlanList({
       return productInfo;
     });
 
+  availableProducts.forEach(productInfo => {
+    const addOnKey = `addOn${toTitleCase(productInfo.apiName, {allowInnerUpperCase: true})}`;
+    const enabled = subscription.addOns?.[productInfo.apiName]?.enabled;
+    formModel.setValue(addOnKey, enabled);
+  });
+
   return (
     <Form
       onSubmit={onSubmit}
@@ -177,10 +183,10 @@ function PlanList({
         <StyledFormSection>
           <h4>Available Products</h4>
           {availableProducts.map(productInfo => {
-            const addOnKey = `addOn${toTitleCase(productInfo.apiName)}`;
+            const addOnKey = `addOn${toTitleCase(productInfo.apiName, {allowInnerUpperCase: true})}`;
             return (
               <CheckboxField
-                key={productInfo.productName}
+                key={productInfo.apiName}
                 data-test-id={`checkbox-${productInfo.productName}`}
                 label={toTitleCase(productInfo.productName)}
                 name={addOnKey}

--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -1,3 +1,4 @@
+import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import CheckboxField from 'sentry/components/forms/fields/checkboxField';
@@ -78,20 +79,27 @@ function PlanList({
     100000: '100K',
   };
 
-  const availableProducts = Object.values(activePlan?.addOnCategories || {})
-    .filter(
-      productInfo =>
-        productInfo.billingFlag && organization.features.includes(productInfo.billingFlag)
-    )
-    .map(productInfo => {
-      return productInfo;
-    });
+  const availableProducts = useMemo(
+    () =>
+      Object.values(activePlan?.addOnCategories || {})
+        .filter(
+          productInfo =>
+            productInfo.billingFlag &&
+            organization.features.includes(productInfo.billingFlag)
+        )
+        .map(productInfo => {
+          return productInfo;
+        }),
+    [activePlan?.addOnCategories, organization.features]
+  );
 
-  availableProducts.forEach(productInfo => {
-    const addOnKey = `addOn${toTitleCase(productInfo.apiName, {allowInnerUpperCase: true})}`;
-    const enabled = subscription.addOns?.[productInfo.apiName]?.enabled;
-    formModel.setValue(addOnKey, enabled);
-  });
+  useEffect(() => {
+    availableProducts.forEach(productInfo => {
+      const addOnKey = `addOn${toTitleCase(productInfo.apiName, {allowInnerUpperCase: true})}`;
+      const enabled = subscription.addOns?.[productInfo.apiName]?.enabled;
+      formModel.setValue(addOnKey, enabled);
+    });
+  }, [availableProducts, subscription.addOns, formModel]);
 
   return (
     <Form

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -137,6 +137,7 @@ export type ReservedBudgetCategory = {
 export enum AddOnCategory {
   SEER = 'seer',
   PREVENT = 'prevent',
+  LEGACY_SEER = 'legacySeer',
 }
 
 export type AddOnCategoryInfo = {

--- a/static/gsApp/views/amCheckout/steps/productSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.tsx
@@ -96,33 +96,35 @@ function ProductSelect({
   );
 
   const theme = useTheme();
-  const PRODUCT_CHECKOUT_INFO = {
-    [AddOnCategory.SEER]: {
-      color: theme.pink400 as Color,
-      gradientEndColor: theme.pink100 as Color,
-      buttonBorderColor: theme.pink200 as Color,
-      getProductDescription: (includedBudget: string) =>
-        getProductCheckoutDescription({
-          product: AddOnCategory.SEER,
-          isNewCheckout: !!isNewCheckout,
-          withPunctuation: false,
-          includedBudget,
-        }),
-      categoryInfo: {
-        [DataCategory.SEER_AUTOFIX]: {
-          description: t(
-            'Uses the latest AI models with Sentry data to find root causes & proposes PRs'
-          ),
-          maxEventPriceDigits: 0,
-        },
-        [DataCategory.SEER_SCANNER]: {
-          description: t(
-            'Triages issues as they happen, automatically flagging highly-fixable ones for followup'
-          ),
-          maxEventPriceDigits: 3,
-        },
+  const SEER_CHECKOUT_INFO = {
+    color: theme.pink400 as Color,
+    gradientEndColor: theme.pink100 as Color,
+    buttonBorderColor: theme.pink200 as Color,
+    getProductDescription: (includedBudget: string) =>
+      getProductCheckoutDescription({
+        product: AddOnCategory.SEER,
+        isNewCheckout: !!isNewCheckout,
+        withPunctuation: false,
+        includedBudget,
+      }),
+    categoryInfo: {
+      [DataCategory.SEER_AUTOFIX]: {
+        description: t(
+          'Uses the latest AI models with Sentry data to find root causes & proposes PRs'
+        ),
+        maxEventPriceDigits: 0,
+      },
+      [DataCategory.SEER_SCANNER]: {
+        description: t(
+          'Triages issues as they happen, automatically flagging highly-fixable ones for followup'
+        ),
+        maxEventPriceDigits: 3,
       },
     },
+  };
+  const PRODUCT_CHECKOUT_INFO = {
+    [AddOnCategory.SEER]: SEER_CHECKOUT_INFO,
+    [AddOnCategory.LEGACY_SEER]: SEER_CHECKOUT_INFO,
     [AddOnCategory.PREVENT]: {
       getProductDescription: (includedBudget: string) =>
         getProductCheckoutDescription({

--- a/tests/js/getsentry-test/fixtures/constants.ts
+++ b/tests/js/getsentry-test/fixtures/constants.ts
@@ -21,4 +21,4 @@ export const AM_ADD_ON_CATEGORIES = {
     order: 2,
     productName: 'prevent',
   },
-} satisfies Record<AddOnCategory, AddOnCategoryInfo>;
+} satisfies Record<Exclude<AddOnCategory, AddOnCategory.LEGACY_SEER>, AddOnCategoryInfo>; // TODO(seer): Add LEGACY_SEER once the backend is updated to use the new value and the rest of the frontend can be updated


### PR DESCRIPTION
Pt 1 of BIL-1796

This introduces the new value for the `AddOnCategory` enum, as well as compatibility with the new enum in the _admin Change Plan action and checkout (the two places where you can enable or disable Seer). 

Follow up PRs will update the backend and the rest of the frontend. This PR is necessary for maintaining compatibility in the limbo state when the backend is updated but the rest of the frontend still needs to be updated.

See https://github.com/getsentry/getsentry/pull/18869 for order of operations.