### PR TITLE
feat(preprod): Add codesigning type to check for updates filter

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -66,6 +66,7 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
         provided_build_version = request.GET.get("build_version")
         provided_build_number = request.GET.get("build_number")
         provided_build_configuration = request.GET.get("build_configuration")
+        provided_codesigning_type = request.GET.get("codesigning_type")
 
         if not provided_app_id or not provided_platform or not provided_build_version:
             return Response({"error": "Missing required parameters"}, status=400)
@@ -104,6 +105,9 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
                 ]
             elif provided_platform == "ios":
                 filter_kwargs["artifact_type"] = PreprodArtifact.ArtifactType.XCARCHIVE
+
+            if provided_codesigning_type:
+                filter_kwargs["extras__codesigning_type"] = provided_codesigning_type
 
             return filter_kwargs
 
@@ -157,6 +161,10 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
         new_build_filter_kwargs = get_base_filters()
         if preprod_artifact:
             new_build_filter_kwargs["build_configuration"] = preprod_artifact.build_configuration
+            if preprod_artifact.extras:
+                codesigning_type = preprod_artifact.extras.get("codesigning_type")
+                if codesigning_type:
+                    new_build_filter_kwargs["extras__codesigning_type"] = codesigning_type
         elif build_configuration:
             new_build_filter_kwargs["build_configuration"] = build_configuration
         all_versions = (


### PR DESCRIPTION
Uses code signing type to return the most relevant update

Closes https://linear.app/getsentry/issue/EME-653/use-provisioning-type-for-distribution-updates