### PR TITLE
feat(cursor-agent): add frontend toggle for whether to create pr

### DIFF
--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -315,6 +315,7 @@ interface SeerAutomationHandoffConfiguration {
   handoff_point: 'root_cause';
   integration_id: number;
   target: 'cursor_background_agent';
+  auto_create_pr?: boolean;
 }
 
 export interface ProjectSeerPreferences {

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -304,19 +304,10 @@ describe('ProjectSeer', () => {
     // Open the menu and select a new value
     await userEvent.click(select);
 
-    const options = await screen.findAllByText('Minimally Actionable and Above');
+    const options = await screen.findAllByText('Highly Actionable and Above');
     expect(options[0]).toBeDefined();
     if (options[0]) {
       await userEvent.click(options[0]);
-    }
-
-    // Reopen the menu to select another value
-    await userEvent.click(select);
-
-    const options2 = await screen.findAllByText('Highly Actionable and Above');
-    expect(options2[0]).toBeDefined();
-    if (options2[0]) {
-      await userEvent.click(options2[0]);
     }
 
     // Form has saveOnBlur=true, so wait for the PUT request

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -867,6 +867,19 @@ describe('ProjectSeer', () => {
         },
       });
 
+      MockApiClient.addMockResponse({
+        url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/`,
+        method: 'PUT',
+        body: {},
+      });
+
+      // Mock for the Form's empty apiEndpoint POST
+      MockApiClient.addMockResponse({
+        url: '',
+        method: 'POST',
+        body: {},
+      });
+
       const seerPreferencesPostRequest = MockApiClient.addMockResponse({
         url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/seer/preferences/`,
         method: 'POST',

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -120,7 +120,7 @@ function CodingAgentSettings({
 
   return (
     <Form
-      key="coding-agent-settings"
+      key={`coding-agent-settings-${initialValue}`}
       apiMethod="POST"
       saveOnBlur
       initialData={{
@@ -136,7 +136,7 @@ function CodingAgentSettings({
                 name: 'auto_create_pr',
                 label: t('Auto-Create Pull Requests'),
                 help: t(
-                  'When enabled, Cursor Cloud Agents will automatically create pull requests after making code changes.'
+                  'When enabled, Cursor Cloud Agents will automatically create pull requests after hand off.'
                 ),
                 saveOnBlur: true,
                 type: 'boolean',

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -105,14 +105,14 @@ function CodingAgentSettings({
   preference,
   handleAutoCreatePrChange,
   canWriteProject,
-  autofixAutomationTuning,
+  isAutomationOn,
 }: {
-  autofixAutomationTuning: boolean;
   canWriteProject: boolean;
   handleAutoCreatePrChange: (value: boolean) => void;
   preference: ProjectSeerPreferences | null | undefined;
+  isAutomationOn?: boolean;
 }) {
-  if (!preference?.automation_handoff || !autofixAutomationTuning) {
+  if (!preference?.automation_handoff || !isAutomationOn) {
     return null;
   }
 
@@ -327,11 +327,9 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     },
   ];
 
-  const automationTuning = Boolean(
-    isTriageSignalsFeatureOn
-      ? (project.autofixAutomationTuning ?? 'off') !== 'off'
-      : (project.autofixAutomationTuning ?? 'off')
-  );
+  const automationTuning = isTriageSignalsFeatureOn
+    ? (project.autofixAutomationTuning ?? 'off') !== 'off'
+    : (project.autofixAutomationTuning ?? 'off');
 
   return (
     <Fragment>
@@ -369,7 +367,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
       <CodingAgentSettings
         preference={preference}
         handleAutoCreatePrChange={handleAutoCreatePrChange}
-        autofixAutomationTuning={automationTuning}
+        isAutomationOn={automationTuning && automationTuning !== 'off'}
         canWriteProject={canWriteProject}
       />
     </Fragment>


### PR DESCRIPTION
Adds a toggle for whether the cursor agent should auto create prs or not. this will be updated in the future to be a setting for all coding-agents.

This toggle ONLY shows if you select the cursor agent as the handoff. Making it a separate card because following up with custom instructions for the cursor agent.
<img width="2848" height="1124" alt="CleanShot 2025-11-20 at 23 54 00@2x" src="https://github.com/user-attachments/assets/da390d24-cdf2-4d84-bfa1-5a5d960dc07a" />

