### PR TITLE
feat: Use extrapolation mode in alerts

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -41,6 +41,7 @@ type Options = {
   end?: DateString;
   environment?: readonly string[];
   excludeOther?: boolean;
+  extrapolationMode?: string;
   field?: string[];
   generatePathname?: (org: OrganizationSummary) => string;
   includePrevious?: boolean;
@@ -108,6 +109,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean>(
     includeAllArgs,
     dataset,
     sampling,
+    extrapolationMode,
   }: EventsStatsOptions<IncludeAllArgsType>
 ): IncludeAllArgsType extends true
   ? Promise<ApiResult<EventsStats | MultiSeriesEventsStats>>
@@ -135,6 +137,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean>(
       excludeOther: excludeOther ? '1' : undefined,
       dataset,
       sampling,
+      extrapolationMode,
     }).filter(([, value]) => typeof value !== 'undefined')
   );
 

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -151,6 +151,10 @@ type EventsRequestPartialProps = {
    */
   expired?: boolean;
   /**
+   * The extrapolation mode to apply to the EAP
+   */
+  extrapolationMode?: string;
+  /**
    * List of fields to group with when doing a topEvents request.
    */
   field?: string[];

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -181,6 +181,7 @@ interface UpdateSnubaDataSourcePayload {
   query: string;
   queryType: number;
   timeWindow: number;
+  extrapolationMode?: string;
 }
 
 interface UpdateUptimeDataSourcePayload {

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -9,6 +9,7 @@ import type {
   AlertRuleThresholdType,
   Dataset,
   EventTypes,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 import type {UptimeMonitorMode} from 'sentry/views/alerts/rules/uptime/types';
 import type {Monitor, MonitorConfig} from 'sentry/views/insights/crons/types';
@@ -27,6 +28,7 @@ export interface SnubaQuery {
    */
   timeWindow: number;
   environment?: string;
+  extrapolationMode?: ExtrapolationMode;
 }
 
 /**

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -52,7 +52,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
 import {makeDefaultCta} from 'sentry/views/alerts/rules/metric/metricRulePresets';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
-import {AlertRuleTriggerType, Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {
+  AlertRuleTriggerType,
+  Dataset,
+  ExtrapolationMode,
+} from 'sentry/views/alerts/rules/metric/types';
 import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
 import {
   isEapAlertType,
@@ -475,7 +479,9 @@ export default function MetricChart({
       referrer: 'api.alerts.alert-rule-chart',
       samplingMode:
         rule.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
-          ? SAMPLING_MODE.NORMAL
+          ? rule.extrapolationMode === ExtrapolationMode.NONE
+            ? SAMPLING_MODE.HIGH_ACCURACY
+            : SAMPLING_MODE.NORMAL
           : undefined,
     },
     {enabled: !shouldUseSessionsStats}

--- a/static/app/views/alerts/rules/metric/edit.spec.tsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.tsx
@@ -7,7 +7,13 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {metric} from 'sentry/utils/analytics';
 import {MetricRulesEdit} from 'sentry/views/alerts/rules/metric/edit';
-import {AlertRuleTriggerType} from 'sentry/views/alerts/rules/metric/types';
+import {
+  AlertRuleTriggerType,
+  Dataset,
+  EventTypes,
+  ExtrapolationMode,
+} from 'sentry/views/alerts/rules/metric/types';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 jest.mock('sentry/utils/analytics', () => ({
   metric: {
@@ -57,6 +63,14 @@ describe('MetricRulesEdit', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
       body: [MemberFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
     });
   });
 
@@ -251,5 +265,155 @@ describe('MetricRulesEdit', () => {
     expect(
       await screen.findByText('This alert rule could not be found.')
     ).toBeInTheDocument();
+  });
+
+  it('preserves SERVER_WEIGHTED extrapolation mode when editing and saving', async () => {
+    const {organization, project} = initializeOrg();
+    const ruleWithExtrapolation = MetricRuleFixture({
+      id: '5',
+      name: 'Alert Rule with Extrapolation',
+      dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+      aggregate: 'count()',
+      query: '',
+      eventTypes: [EventTypes.TRACE_ITEM_SPAN],
+      extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${ruleWithExtrapolation.id}/`,
+      body: ruleWithExtrapolation,
+    });
+
+    const eventsStatsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: null,
+    });
+
+    const editRule = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${ruleWithExtrapolation.id}/`,
+      method: 'PUT',
+      body: ruleWithExtrapolation,
+    });
+
+    render(
+      <MetricRulesEdit
+        {...RouteComponentPropsFixture()}
+        params={{
+          projectId: project.slug,
+          ruleId: ruleWithExtrapolation.id,
+        }}
+        userTeamIds={[]}
+        organization={organization}
+        onChangeTitle={() => {}}
+        project={project}
+      />
+    );
+
+    // Wait for the rule to load
+    expect(await screen.findByTestId('critical-threshold')).toBeInTheDocument();
+
+    // Verify events-stats is called with 'serverOnly' extrapolation mode for the chart
+    expect(eventsStatsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          extrapolationMode: 'serverOnly',
+          sampling: SAMPLING_MODE.NORMAL,
+        }),
+      })
+    );
+
+    // Make a change to the threshold
+    await userEvent.clear(screen.getByTestId('resolve-threshold'));
+    await userEvent.type(screen.getByTestId('resolve-threshold'), '40');
+
+    // Save the rule
+    await userEvent.click(screen.getByLabelText('Save Rule'));
+
+    // Verify the save request preserves the extrapolation mode
+    expect(editRule).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+        }),
+        method: 'PUT',
+      })
+    );
+  });
+
+  it('preserves NONE extrapolation mode when editing and saving', async () => {
+    const {organization, project} = initializeOrg();
+    const ruleWithNoExtrapolation = MetricRuleFixture({
+      id: '6',
+      name: 'Alert Rule with No Extrapolation',
+      dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+      aggregate: 'count()',
+      query: '',
+      eventTypes: [EventTypes.TRACE_ITEM_SPAN],
+      extrapolationMode: ExtrapolationMode.NONE,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${ruleWithNoExtrapolation.id}/`,
+      body: ruleWithNoExtrapolation,
+    });
+
+    const eventsStatsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: null,
+    });
+
+    const editRule = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${ruleWithNoExtrapolation.id}/`,
+      method: 'PUT',
+      body: ruleWithNoExtrapolation,
+    });
+
+    render(
+      <MetricRulesEdit
+        {...RouteComponentPropsFixture()}
+        params={{
+          projectId: project.slug,
+          ruleId: ruleWithNoExtrapolation.id,
+        }}
+        userTeamIds={[]}
+        organization={organization}
+        onChangeTitle={() => {}}
+        project={project}
+      />
+    );
+
+    // Wait for the rule to load
+    expect(await screen.findByTestId('critical-threshold')).toBeInTheDocument();
+
+    // Verify events-stats is called with 'none' extrapolation mode for the chart
+    expect(eventsStatsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          extrapolationMode: 'none',
+          sampling: SAMPLING_MODE.HIGH_ACCURACY,
+        }),
+      })
+    );
+
+    // Make a change to the threshold
+    await userEvent.clear(screen.getByTestId('resolve-threshold'));
+    await userEvent.type(screen.getByTestId('resolve-threshold'), '50');
+
+    // Save the rule
+    await userEvent.click(screen.getByLabelText('Save Rule'));
+
+    // Verify the save request preserves the extrapolation mode
+    expect(editRule).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          extrapolationMode: ExtrapolationMode.NONE,
+        }),
+        method: 'PUT',
+      })
+    );
   });
 });

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1211,6 +1211,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       chartErrorMessage,
       confidence,
       seriesSamplingInfo,
+      extrapolationMode,
     } = this.state;
 
     const traceItemType = getTraceItemTypeForDatasetAndEventType(dataset, eventTypes);
@@ -1261,6 +1262,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       confidence,
       seriesSamplingInfo,
       traceItemType: traceItemType ?? undefined,
+      extrapolationMode,
     };
 
     let formattedQuery = `event.type:${eventTypes?.join(',')}`;

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -89,6 +89,7 @@ import {
 import RuleConditionsForm from './ruleConditionsForm';
 import type {
   EventTypes,
+  ExtrapolationMode,
   MetricActionTemplate,
   MetricRule,
   Trigger,
@@ -158,6 +159,7 @@ type State = {
   chartErrorMessage?: string;
   comparisonDelta?: number;
   confidence?: Confidence;
+  extrapolationMode?: ExtrapolationMode;
   isExtrapolatedChartData?: boolean;
   seasonality?: AlertRuleSeasonality;
   seriesSamplingInfo?: SeriesSamplingInfo;
@@ -259,6 +261,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       metricExtractionRules: null,
       triggers: triggersClone,
       resolveThreshold: rule.resolveThreshold,
+      extrapolationMode: rule.extrapolationMode,
       sensitivity: rule.sensitivity ?? undefined,
       seasonality: rule.seasonality ?? undefined,
       thresholdType: rule.thresholdType,
@@ -749,6 +752,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       sensitivity,
       seasonality,
       comparisonType,
+      extrapolationMode,
     } = this.state;
     // Remove empty warning trigger
     const sanitizedTriggers = triggers.filter(
@@ -813,6 +817,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             sensitivity: sensitivity ?? null,
             seasonality: seasonality ?? null,
             detectionType,
+            extrapolationMode: this.isDuplicateRule ? undefined : extrapolationMode,
           },
           {
             duplicateRule: this.isDuplicateRule ? 'true' : 'false',

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -601,6 +601,14 @@ class TriggersChart extends PureComponent<Props, State> {
       includePrevious: false,
       currentSeriesNames: [formattedAggregate || aggregate],
       partial: false,
+      sampling:
+        dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
+        this.props.traceItemType === TraceItemDataset.SPANS
+          ? extrapolationMode === ExtrapolationMode.NONE
+            ? SAMPLING_MODE.HIGH_ACCURACY
+            : SAMPLING_MODE.NORMAL
+          : undefined,
+
       extrapolationMode: extrapolationMode
         ? EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
         : undefined,
@@ -630,19 +638,7 @@ class TriggersChart extends PureComponent<Props, State> {
             {noop}
           </EventsRequest>
         ) : null}
-        <EventsRequest
-          {...baseProps}
-          period={period}
-          dataLoadedCallback={onDataLoaded}
-          sampling={
-            dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
-            this.props.traceItemType === TraceItemDataset.SPANS
-              ? extrapolationMode === ExtrapolationMode.NONE
-                ? SAMPLING_MODE.HIGH_ACCURACY
-                : SAMPLING_MODE.NORMAL
-              : undefined
-          }
-        >
+        <EventsRequest {...baseProps} period={period} dataLoadedCallback={onDataLoaded}>
           {({
             loading,
             errored,

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -46,13 +46,16 @@ import {
 import {capitalize} from 'sentry/utils/string/capitalize';
 import withApi from 'sentry/utils/withApi';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
-import type {MetricRule, Trigger} from 'sentry/views/alerts/rules/metric/types';
 import {
   AlertRuleComparisonType,
   Dataset,
+  EAP_EXTRAPOLATION_MODE_MAP,
+  ExtrapolationMode,
   SessionsAggregate,
   TimePeriod,
   TimeWindow,
+  type MetricRule,
+  type Trigger,
 } from 'sentry/views/alerts/rules/metric/types';
 import type {SeriesSamplingInfo} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {getMetricDatasetQueryExtras} from 'sentry/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras';
@@ -97,6 +100,7 @@ type Props = {
   anomalies?: Anomaly[];
   comparisonDelta?: number;
   confidence?: Confidence;
+  extrapolationMode?: ExtrapolationMode;
   formattedAggregate?: string;
   header?: React.ReactNode;
   includeHistorical?: boolean;
@@ -427,6 +431,7 @@ class TriggersChart extends PureComponent<Props, State> {
       isQueryValid,
       isOnDemandMetricAlert,
       traceItemType,
+      extrapolationMode,
     } = this.props;
 
     const period = this.getStatsPeriod()!;
@@ -463,6 +468,13 @@ class TriggersChart extends PureComponent<Props, State> {
         partial: false,
         limit: 15,
         children: noop,
+        extrapolationMode: extrapolationMode
+          ? EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
+          : undefined,
+        sampling:
+          extrapolationMode === ExtrapolationMode.NONE
+            ? SAMPLING_MODE.HIGH_ACCURACY
+            : SAMPLING_MODE.NORMAL,
       };
 
       return (
@@ -589,6 +601,9 @@ class TriggersChart extends PureComponent<Props, State> {
       includePrevious: false,
       currentSeriesNames: [formattedAggregate || aggregate],
       partial: false,
+      extrapolationMode: extrapolationMode
+        ? EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
+        : undefined,
     };
 
     return (
@@ -622,7 +637,9 @@ class TriggersChart extends PureComponent<Props, State> {
           sampling={
             dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
             this.props.traceItemType === TraceItemDataset.SPANS
-              ? SAMPLING_MODE.NORMAL
+              ? extrapolationMode === ExtrapolationMode.NONE
+                ? SAMPLING_MODE.HIGH_ACCURACY
+                : SAMPLING_MODE.NORMAL
               : undefined
           }
         >

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -147,6 +147,7 @@ export interface SavedMetricRule extends UnsavedMetricRule {
   status: number;
   createdBy?: {email: string; id: number; name: string} | null;
   errors?: Array<{detail: string}>;
+  extrapolationMode?: ExtrapolationMode;
   /**
    * Returned with the expand=latestIncident query parameter
    */

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -39,6 +39,20 @@ export enum Dataset {
   EVENTS_ANALYTICS_PLATFORM = 'events_analytics_platform',
 }
 
+export enum ExtrapolationMode {
+  CLIENT_AND_SERVER_WEIGHTED = 'client_and_server_weighted',
+  SERVER_WEIGHTED = 'server_weighted',
+  UNKNOWN = 'unknown',
+  NONE = 'none',
+}
+
+export const EAP_EXTRAPOLATION_MODE_MAP = {
+  [ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED]: 'sampleWeighted',
+  [ExtrapolationMode.SERVER_WEIGHTED]: 'serverOnly',
+  [ExtrapolationMode.NONE]: 'none',
+  [ExtrapolationMode.UNKNOWN]: 'sampleWeighted',
+};
+
 export enum EventTypes {
   DEFAULT = 'default',
   ERROR = 'error',

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -4,7 +4,11 @@ import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {Dataset, type MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {
+  Dataset,
+  ExtrapolationMode,
+  type MetricRule,
+} from 'sentry/views/alerts/rules/metric/types';
 import {shouldUseErrorsDiscoverDataset} from 'sentry/views/alerts/rules/utils';
 import {getDiscoverDataset} from 'sentry/views/alerts/wizard/options';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -21,6 +25,7 @@ export function getMetricDatasetQueryExtras({
   dataset: MetricRule['dataset'];
   newAlertOrQuery: boolean;
   organization: Organization;
+  extrapolationMode?: ExtrapolationMode;
   location?: Location;
   query?: string;
   traceItemType?: TraceItemDataset | null;

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -164,6 +164,7 @@ export function useMetricDetectorChart({
   const {series, comparisonSeries, isLoading, error} = useMetricDetectorSeries({
     detectorDataset: dataset,
     dataset: snubaQuery.dataset,
+    extrapolationMode: snubaQuery.extrapolationMode,
     aggregate: datasetConfig.fromApiAggregate(snubaQuery.aggregate),
     interval: snubaQuery.timeWindow,
     query: snubaQuery.query,

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -23,6 +23,7 @@ import {
   AlertRuleThresholdType,
   Dataset,
   EventTypes,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 import {getBackendDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
@@ -133,6 +134,7 @@ interface MetricDetectorChartProps {
    * Used in anomaly detection
    */
   thresholdType: AlertRuleThresholdType | undefined;
+  extrapolationMode?: ExtrapolationMode | undefined;
 }
 
 export function MetricDetectorChart({
@@ -149,6 +151,7 @@ export function MetricDetectorChart({
   comparisonDelta,
   sensitivity,
   thresholdType,
+  extrapolationMode,
 }: MetricDetectorChartProps) {
   const {selectedTimePeriod, setSelectedTimePeriod, timePeriodOptions} =
     useTimePeriodSelection({
@@ -167,6 +170,7 @@ export function MetricDetectorChart({
     statsPeriod: selectedTimePeriod,
     comparisonDelta,
     eventTypes,
+    extrapolationMode,
   });
 
   const {maxValue: thresholdMaxValue, additionalSeries: thresholdAdditionalSeries} =

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -19,6 +19,7 @@ import {
   AlertRuleSensitivity,
   AlertRuleThresholdType,
   Dataset,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
@@ -84,6 +85,7 @@ interface SnubaQueryFormData {
   environment: string;
   interval: number;
   query: string;
+  extrapolationMode?: ExtrapolationMode;
 }
 
 export interface MetricDetectorFormData
@@ -120,6 +122,7 @@ export const METRIC_DETECTOR_FORM_FIELDS = {
   interval: 'interval',
   query: 'query',
   name: 'name',
+  extrapolationMode: 'extrapolationMode',
 
   // Priority level fields
   initialPriorityLevel: 'initialPriorityLevel',
@@ -182,6 +185,7 @@ interface NewDataSource {
   query: string;
   queryType: number;
   timeWindow: number;
+  extrapolationMode?: string;
 }
 
 function createAnomalyDetectionCondition(
@@ -309,6 +313,7 @@ function createDataSource(data: MetricDetectorFormData): NewDataSource {
   return {
     queryType: getQueryType(data.dataset),
     dataset: getBackendDataset(data.dataset),
+    extrapolationMode: data.extrapolationMode,
     query,
     aggregate: datasetConfig.toApiAggregate(data.aggregateFunction),
     timeWindow: data.interval,
@@ -490,6 +495,7 @@ export function metricSavedDetectorToFormData(
     owner: detector.owner ? `${detector.owner?.type}:${detector.owner?.id}` : '',
     description: detector.description || null,
     query: datasetConfig.toSnubaQueryString(snubaQuery),
+    extrapolationMode: snubaQuery.extrapolationMode,
     aggregateFunction:
       datasetConfig.fromApiAggregate(snubaQuery?.aggregate || '') ||
       DEFAULT_THRESHOLD_METRIC_FORM_DATA.aggregateFunction,

--- a/static/app/views/detectors/components/forms/metric/previewChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/previewChart.tsx
@@ -19,6 +19,9 @@ export function MetricDetectorPreviewChart() {
   const rawQuery = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.query);
   const environment = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.environment);
   const projectId = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.projectId);
+  const extrapolationMode = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.extrapolationMode
+  );
 
   // Threshold-related form fields
   const highThreshold = useMetricDetectorFormField(
@@ -88,6 +91,7 @@ export function MetricDetectorPreviewChart() {
       comparisonDelta={detectionType === 'percent' ? conditionComparisonAgo : undefined}
       sensitivity={sensitivity}
       thresholdType={thresholdType}
+      extrapolationMode={extrapolationMode}
     />
   );
 }

--- a/static/app/views/detectors/datasetConfig/base.tsx
+++ b/static/app/views/detectors/datasetConfig/base.tsx
@@ -10,7 +10,11 @@ import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import type {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
+import type {
+  Dataset,
+  EventTypes,
+  ExtrapolationMode,
+} from 'sentry/views/alerts/rules/metric/types';
 import type {
   MetricDetectorInterval,
   MetricDetectorTimePeriod,
@@ -56,6 +60,7 @@ interface DetectorSeriesQueryOptions {
   extra?: {
     useOnDemandMetrics: 'true';
   };
+  extrapolationMode?: ExtrapolationMode;
   start?: string | null;
   /**
    * Relative time period for the query. Example: '7d'.

--- a/static/app/views/detectors/datasetConfig/utils/discoverSeries.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/discoverSeries.tsx
@@ -5,8 +5,9 @@ import getDuration from 'sentry/utils/duration/getDuration';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {
   EAP_EXTRAPOLATION_MODE_MAP,
-  type ExtrapolationMode,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 /**
  * Transform EventsStats API response into Series format for AreaChart
@@ -127,6 +128,10 @@ export function getDiscoverSeriesQueryOptions({
         statsPeriod,
         start,
         end,
+        sampling:
+          extrapolationMode === ExtrapolationMode.NONE
+            ? SAMPLING_MODE.HIGH_ACCURACY
+            : SAMPLING_MODE.NORMAL,
         extrapolationMode: extrapolationMode
           ? EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
           : undefined,

--- a/static/app/views/detectors/datasetConfig/utils/discoverSeries.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/discoverSeries.tsx
@@ -3,6 +3,10 @@ import type {EventsStats, Organization} from 'sentry/types/organization';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import getDuration from 'sentry/utils/duration/getDuration';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {
+  EAP_EXTRAPOLATION_MODE_MAP,
+  type ExtrapolationMode,
+} from 'sentry/views/alerts/rules/metric/types';
 
 /**
  * Transform EventsStats API response into Series format for AreaChart
@@ -87,6 +91,7 @@ interface DiscoverSeriesQueryOptions {
   extra?: {
     useOnDemandMetrics: 'true';
   };
+  extrapolationMode?: ExtrapolationMode;
   start?: string | null;
   /**
    * Relative time period for the query. Example: '7d'.
@@ -106,6 +111,7 @@ export function getDiscoverSeriesQueryOptions({
   comparisonDelta,
   start,
   end,
+  extrapolationMode,
 }: DiscoverSeriesQueryOptions): ApiQueryKey {
   return [
     `/organizations/${organization.slug}/events-stats/`,
@@ -121,6 +127,9 @@ export function getDiscoverSeriesQueryOptions({
         statsPeriod,
         start,
         end,
+        extrapolationMode: extrapolationMode
+          ? EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
+          : undefined,
         ...(environment && {environment: [environment]}),
         ...(query && {query}),
         ...(comparisonDelta && {comparisonDelta}),

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -19,6 +19,11 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
+import {
+  Dataset,
+  EventTypes,
+  ExtrapolationMode,
+} from 'sentry/views/alerts/rules/metric/types';
 import {CheckStatus} from 'sentry/views/alerts/rules/uptime/types';
 import DetectorDetails from 'sentry/views/detectors/detail';
 
@@ -373,6 +378,68 @@ describe('DetectorDetails', () => {
 
       // Connected automation
       expect(await screen.findByText('Automation 1')).toBeInTheDocument();
+    });
+
+    it('uses serverOnly extrapolation mode when detector has it configured', async () => {
+      const spanDetectorWithExtrapolation = MetricDetectorFixture({
+        id: '1',
+        projectId: project.id,
+        dataSources: [
+          SnubaQueryDataSourceFixture({
+            queryObj: {
+              id: '1',
+              status: 1,
+              subscription: '1',
+              snubaQuery: {
+                aggregate: 'count()',
+                dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                id: '',
+                query: '',
+                timeWindow: 3600,
+                eventTypes: [EventTypes.TRACE_ITEM_SPAN],
+                extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+              },
+            },
+          }),
+        ],
+        owner: ActorFixture({id: ownerTeam.id, name: ownerTeam.slug, type: 'team'}),
+        workflowIds: ['1', '2'],
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${spanDetectorWithExtrapolation.id}/`,
+        body: spanDetectorWithExtrapolation,
+      });
+
+      const eventsStatsRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-stats/`,
+        body: {
+          data: [
+            [1543449600, [20, 12]],
+            [1543449601, [10, 5]],
+          ],
+        },
+      });
+
+      render(<DetectorDetails />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      expect(
+        await screen.findByRole('heading', {name: spanDetectorWithExtrapolation.name})
+      ).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(eventsStatsRequest).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/events-stats/`,
+          expect.objectContaining({
+            query: expect.objectContaining({
+              extrapolationMode: 'serverOnly',
+            }),
+          })
+        );
+      });
     });
   });
 });

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -26,6 +26,7 @@ import {
 } from 'sentry/views/alerts/rules/metric/types';
 import {CheckStatus} from 'sentry/views/alerts/rules/uptime/types';
 import DetectorDetails from 'sentry/views/detectors/detail';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 describe('DetectorDetails', () => {
   const organization = OrganizationFixture({features: ['workflow-engine-ui']});
@@ -436,6 +437,7 @@ describe('DetectorDetails', () => {
           expect.objectContaining({
             query: expect.objectContaining({
               extrapolationMode: 'serverOnly',
+              sampling: SAMPLING_MODE.NORMAL,
             }),
           })
         );

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -29,6 +29,7 @@ import {
   AlertRuleThresholdType,
   Dataset,
   EventTypes,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 import {SnubaQueryType} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import DetectorEdit from 'sentry/views/detectors/edit';
@@ -926,6 +927,99 @@ describe('DetectorEdit', () => {
 
       // Aggregate selector should be disabled
       expect(screen.getByRole('button', {name: 'p75'})).toBeDisabled();
+    });
+
+    it('preserves SERVER_WEIGHTED extrapolation mode when editing and saving', async () => {
+      const spanDetectorWithExtrapolation = MetricDetectorFixture({
+        id: '1',
+        name: 'Span Detector with Extrapolation',
+        projectId: project.id,
+        dataSources: [
+          SnubaQueryDataSourceFixture({
+            queryObj: {
+              id: '1',
+              status: 1,
+              subscription: '1',
+              snubaQuery: {
+                aggregate: 'count()',
+                dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                id: '',
+                query: '',
+                timeWindow: 3600,
+                eventTypes: [EventTypes.TRACE_ITEM_SPAN],
+                extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+              },
+            },
+          }),
+        ],
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${spanDetectorWithExtrapolation.id}/`,
+        body: spanDetectorWithExtrapolation,
+      });
+
+      const eventsStatsRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-stats/`,
+        body: {data: []},
+      });
+
+      const updateRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${spanDetectorWithExtrapolation.id}/`,
+        method: 'PUT',
+        body: spanDetectorWithExtrapolation,
+      });
+
+      render(<DetectorEdit />, {
+        organization,
+        initialRouterConfig: {
+          route: '/organizations/:orgId/monitors/:detectorId/edit/',
+          location: {
+            pathname: `/organizations/${organization.slug}/monitors/${spanDetectorWithExtrapolation.id}/edit/`,
+          },
+        },
+      });
+
+      expect(
+        await screen.findByRole('link', {name: 'Span Detector with Extrapolation'})
+      ).toBeInTheDocument();
+
+      // Verify events-stats is called with 'serverOnly' extrapolation mode for the chart
+      await waitFor(() => {
+        expect(eventsStatsRequest).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/events-stats/`,
+          expect.objectContaining({
+            query: expect.objectContaining({
+              extrapolationMode: 'serverOnly',
+            }),
+          })
+        );
+      });
+
+      // Make a change to trigger save
+      const nameInput = screen.getByTestId('editable-text-label');
+      await userEvent.click(nameInput);
+      const nameInputField = await screen.findByRole('textbox', {name: /monitor name/i});
+      await userEvent.type(nameInputField, ' Updated');
+
+      await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+      // Verify the update request preserves the extrapolation mode
+      await waitFor(() => {
+        expect(updateRequest).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/detectors/${spanDetectorWithExtrapolation.id}/`,
+          expect.objectContaining({
+            method: 'PUT',
+            data: expect.objectContaining({
+              dataSources: expect.arrayContaining([
+                expect.objectContaining({
+                  extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+                }),
+              ]),
+            }),
+          })
+        );
+      });
     });
   });
 });

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -33,6 +33,7 @@ import {
 } from 'sentry/views/alerts/rules/metric/types';
 import {SnubaQueryType} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import DetectorEdit from 'sentry/views/detectors/edit';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 describe('DetectorEdit', () => {
   const organization = OrganizationFixture({
@@ -991,6 +992,7 @@ describe('DetectorEdit', () => {
           expect.objectContaining({
             query: expect.objectContaining({
               extrapolationMode: 'serverOnly',
+              sampling: SAMPLING_MODE.NORMAL,
             }),
           })
         );

--- a/static/app/views/detectors/hooks/useMetricDetectorSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorSeries.tsx
@@ -4,7 +4,11 @@ import type {Series} from 'sentry/types/echarts';
 import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
+import type {
+  Dataset,
+  EventTypes,
+  ExtrapolationMode,
+} from 'sentry/views/alerts/rules/metric/types';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 
@@ -19,6 +23,7 @@ interface UseMetricDetectorSeriesProps {
   query: string;
   comparisonDelta?: number;
   end?: string | null;
+  extrapolationMode?: ExtrapolationMode;
   options?: Partial<UseApiQueryOptions<any>>;
   start?: string | null;
   statsPeriod?: string | null;
@@ -48,6 +53,7 @@ export function useMetricDetectorSeries({
   end,
   comparisonDelta,
   options,
+  extrapolationMode,
 }: UseMetricDetectorSeriesProps): UseMetricDetectorSeriesResult {
   const organization = useOrganization();
   const datasetConfig = useMemo(
@@ -67,6 +73,7 @@ export function useMetricDetectorSeries({
     start,
     end,
     comparisonDelta,
+    extrapolationMode,
   });
 
   const {data, isLoading, error} = useApiQuery<

--- a/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
@@ -14,7 +14,11 @@ import {
   getPeriodInterval,
   getViableDateRange,
 } from 'sentry/views/alerts/rules/metric/details/utils';
-import {Dataset, type MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {
+  Dataset,
+  EAP_EXTRAPOLATION_MODE_MAP,
+  type MetricRule,
+} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {getMetricDatasetQueryExtras} from 'sentry/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras';
 import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
@@ -74,6 +78,7 @@ export function useMetricEventStats(
     query: ruleQuery,
     environment: ruleEnvironment,
     eventTypes: storedEventTypes,
+    extrapolationMode,
   } = rule;
   const traceItemType = getTraceItemTypeForDatasetAndEventType(dataset, storedEventTypes);
   const interval = getPeriodInterval(timePeriod, rule);
@@ -111,6 +116,9 @@ export function useMetricEventStats(
       yAxis: aggregate,
       referrer,
       sampling: samplingMode,
+      extrapolationMode: extrapolationMode
+        ? EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
+        : undefined,
       ...queryExtras,
     }).filter(([, value]) => typeof value !== 'undefined')
   );


### PR DESCRIPTION
The backend returns extrapolation mode, a field used for transaction -> span
migration. Use this value to call events-stats/ endpoint with the correct extrapolation
mode and sampling mode.
Alerts with SERVER_WEIGHTED  call events-stats/ with 'serverOnly' extrapolation mode and SAMPLING_MODE.NORMAL
Alerts with NONE  call events-stats/ with 'none' extrapolation mode and SAMPLING_MODE.HIGH_ACCURACY

Extrapolation mode will be set in the backend and not a field we'd expose to the user.
We're going to have an extrapolation mode called "serverOnly" which extrapolates based on server sampling (which will match generic_metric dataset numbers)
and disable extrapolation (ie extrapolation mode none) to match transaction  dataset numbers

This PR takes care of both legacy alerts and monitors