### PR TITLE
ref(crons): Simplify is_muted logic using all() instead of double negative

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -219,7 +219,7 @@ class MonitorSerializer(Serializer):
         # A monitor is muted only if it has environments AND all of them are muted
         is_muted_data = {
             item.id: bool(monitor_envs_by_id.get(item.id, []))
-            and not any(not env.is_muted for env in monitor_envs_by_id.get(item.id, []))
+            and all(env.is_muted for env in monitor_envs_by_id.get(item.id, []))
             for item in item_list
         }
 


### PR DESCRIPTION
Address code review feedback from Dan to replace the double negative
`not any(not env.is_muted ...)` with the clearer `all(env.is_muted ...)`.
Both are logically equivalent but all() is much more readable.