### PR TITLE
fix(preprod): update frontend to new missing_dsym_binaries field

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -225,8 +225,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     appSizeData.treemap.category_breakdown &&
     Object.keys(appSizeData.treemap.category_breakdown).length > 0;
 
-  const missingDsymBinaries =
-    buildDetailsData?.app_info?.apple_app_info?.missing_dsym_binaries;
+  const missingDsymBinaries = appSizeData.missing_dsym_binaries;
 
   const missingProguardMapping =
     buildDetailsData?.app_info?.android_app_info?.has_proguard_mapping === false;

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -27,7 +27,7 @@ export interface BuildDetailsAppInfo {
 }
 
 interface AppleAppInfo {
-  missing_dsym_binaries?: string[];
+  has_missing_dsym_binaries?: boolean;
 }
 
 interface AndroidAppInfo {


### PR DESCRIPTION
Frontend portion of https://github.com/getsentry/sentry/pull/103733, we already had this field declared in `AppSizeApiResponse`.