### PR TITLE
feat(dashboards): automatically populate dashboard ids in prebuilt dashboards

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1425,8 +1425,9 @@ function getDashboardUrl(
       linkedDashboard => linkedDashboard.field === field
     );
     if (dashboardLink && dashboardLink.dashboardId !== '-1') {
-      const newTemporaryFilters: GlobalFilter[] =
-        dashboardFilters[DashboardFilterKeys.GLOBAL_FILTER] ?? [];
+      const newTemporaryFilters: GlobalFilter[] = [
+        ...(dashboardFilters[DashboardFilterKeys.GLOBAL_FILTER] ?? []),
+      ].filter(filter => Boolean(filter.value));
 
       // Format the value as a proper filter condition string
       const mutableSearch = new MutableSearch('');

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -93,7 +93,10 @@ export default function FiltersBar({
       [];
 
     if (hasDrillDownFlowsFeature && dashboardFiltersFromURL) {
-      return getCombinedDashboardFilters(dashboardFiltersFromURL);
+      return getCombinedDashboardFilters(
+        globalFilters,
+        dashboardFiltersFromURL?.[DashboardFilterKeys.TEMPORARY_FILTERS]
+      );
     }
 
     return globalFilters;

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -24,7 +24,10 @@ import {globalFilterKeysAreEqual} from 'sentry/views/dashboards/globalFilter/uti
 import {useDatasetSearchBarData} from 'sentry/views/dashboards/hooks/useDatasetSearchBarData';
 import {useHasDrillDownFlows} from 'sentry/views/dashboards/hooks/useHasDrillDownFlows';
 import {useInvalidateStarredDashboards} from 'sentry/views/dashboards/hooks/useInvalidateStarredDashboards';
-import {getDashboardFiltersFromURL} from 'sentry/views/dashboards/utils';
+import {
+  getCombinedDashboardFilters,
+  getDashboardFiltersFromURL,
+} from 'sentry/views/dashboards/utils';
 
 import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import ReleasesSelectControl from './releasesSelectControl';
@@ -89,22 +92,8 @@ export default function FiltersBar({
       filters?.[DashboardFilterKeys.GLOBAL_FILTER] ??
       [];
 
-    if (hasDrillDownFlowsFeature) {
-      const finalFilters = [...globalFilters];
-      const temporaryFilters = [
-        ...(dashboardFiltersFromURL?.[DashboardFilterKeys.TEMPORARY_FILTERS] ?? []),
-      ];
-      finalFilters.forEach(filter => {
-        // if a temporary filter exists for the same dataset and key, override it and delete it from the temporary filters to avoid duplicates
-        const temporaryFilter = temporaryFilters.find(
-          tf => tf.dataset === filter.dataset && tf.tag.key === filter.tag.key
-        );
-        if (temporaryFilter) {
-          filter = {...filter, value: temporaryFilter.value};
-          temporaryFilters.splice(temporaryFilters.indexOf(temporaryFilter), 1);
-        }
-      });
-      return [...finalFilters, ...temporaryFilters];
+    if (hasDrillDownFlowsFeature && dashboardFiltersFromURL) {
+      return getCombinedDashboardFilters(dashboardFiltersFromURL);
     }
 
     return globalFilters;

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -90,10 +90,21 @@ export default function FiltersBar({
       [];
 
     if (hasDrillDownFlowsFeature) {
-      return [
-        ...globalFilters,
+      const finalFilters = [...globalFilters];
+      const temporaryFilters = [
         ...(dashboardFiltersFromURL?.[DashboardFilterKeys.TEMPORARY_FILTERS] ?? []),
       ];
+      finalFilters.forEach(filter => {
+        // if a temporary filter exists for the same dataset and key, override it and delete it from the temporary filters to avoid duplicates
+        const temporaryFilter = temporaryFilters.find(
+          tf => tf.dataset === filter.dataset && tf.tag.key === filter.tag.key
+        );
+        if (temporaryFilter) {
+          filter.value = temporaryFilter.value;
+          temporaryFilters.splice(temporaryFilters.indexOf(temporaryFilter), 1);
+        }
+      });
+      return [...finalFilters, ...temporaryFilters];
     }
 
     return globalFilters;

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -100,7 +100,7 @@ export default function FiltersBar({
           tf => tf.dataset === filter.dataset && tf.tag.key === filter.tag.key
         );
         if (temporaryFilter) {
-          filter.value = temporaryFilter.value;
+          filter = {...filter, value: temporaryFilter.value};
           temporaryFilters.splice(temporaryFilters.indexOf(temporaryFilter), 1);
         }
       });


### PR DESCRIPTION
1. Auto populate dashboard ids in prebuilt dashboards when linking to another prebuilt dashboard 
2. Update temporary global filters to account for duplicates