### PR TITLE
Remove Legacy PromptsActivityEndpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3621,11 +3621,6 @@ urlpatterns = [
         name="sentry-api-0-api-token-details",
     ),
     re_path(
-        r"^prompts-activity/$",
-        PromptsActivityEndpoint.as_view(),
-        name="sentry-api-0-prompts-activity",
-    ),
-    re_path(
         r"^seer/models/$",
         SeerModelsEndpoint.as_view(),
         name="sentry-api-0-seer-models",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3041,7 +3041,6 @@ REGION_PINNED_URL_NAMES = {
     # These paths have organization scoped aliases
     "sentry-api-0-builtin-symbol-sources",
     "sentry-api-0-grouping-configs",
-    "sentry-api-0-prompts-activity",
     # Unprefixed issue URLs
     "sentry-api-0-group-details",
     "sentry-api-0-group-activities",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -714,7 +714,6 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/pr-comments/$repoName/$prNumber/'
   | '/projects/$organizationIdOrSlug/pull-requests/size-analysis/$artifactId/'
   | '/projects/$organizationIdOrSlug/pullrequest-details/$repoName/$prNumber/'
-  | '/prompts-activity/'
   | '/publickeys/relocations/'
   | '/relays/'
   | '/relays/$relayId/'

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -89,10 +89,6 @@ class PromptsActivityTest(APITestCase):
         assert "data" in resp.data
         assert "dismissed_ts" in resp.data["data"]
 
-    def test_dismiss_legacy_path(self) -> None:
-        self.path = reverse("sentry-api-0-prompts-activity")
-        self.test_dismiss()
-
     def test_snooze(self) -> None:
         data = {
             "organization_id": self.org.id,
@@ -119,10 +115,6 @@ class PromptsActivityTest(APITestCase):
         assert "data" in resp.data
         assert "snoozed_ts" in resp.data["data"]
 
-    def test_snooze_legacy_path(self) -> None:
-        self.path = reverse("sentry-api-0-prompts-activity")
-        self.test_snooze()
-
     def test_visible(self) -> None:
         data = {
             "organization_id": self.org.id,
@@ -148,10 +140,6 @@ class PromptsActivityTest(APITestCase):
         assert "data" in resp.data
         assert resp.data["data"].get("dismissed_ts") is None
         assert resp.data["data"].get("snoozed_ts") is None
-
-    def test_visible_legacy_path(self) -> None:
-        self.path = reverse("sentry-api-0-prompts-activity")
-        self.test_visible()
 
     def test_visible_after_dismiss(self) -> None:
         data = {


### PR DESCRIPTION
This fixes the vulnerability found [here](https://linear.app/getsentry/issue/VULN-939/), by adding proper object permissions to the `PromptsActivityEndpoint`.

I also removed the legacy endpoint, `/api/0/prompts-activity/`. I checked that this endpoint hasn't been called once in the timeframe I looked at (from August to now), other than the one attempt that I made to test it. Since it's virtually unused, I think we can remove it. 


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
