### PR TITLE
chore(ACI): Pop actions off of conditions

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -43,7 +43,7 @@ class WorkflowValidator(CamelSnakeSerializer):
         self, action_filter: dict[str, Any]
     ) -> tuple[ListInputData, InputData]:
         try:
-            actions = action_filter["actions"]
+            actions = action_filter.pop("actions")
         except KeyError:
             raise serializers.ValidationError("Missing actions key in action filter")
 


### PR DESCRIPTION
Small fix for a bug I noticed - when we "split" actions from conditions we weren't actually removing the actions from the condition group data, just copying it over into it's own variable so that conditions still had actions on it. We don't need to run actions through the condition group validator as they are run through their own action validator.