### PR TITLE
feat(insights): Adds an endpoint to manually start issue detection task on a project

### DIFF
--- a/src/sentry/api/endpoints/project_web_vitals_detection.py
+++ b/src/sentry/api/endpoints/project_web_vitals_detection.py
@@ -1,0 +1,28 @@
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.models.project import Project
+from sentry.tasks.web_vitals_issue_detection import dispatch_detection_for_project_ids
+
+
+@region_silo_endpoint
+class ProjectWebVitalsDetectionEndpoint(ProjectEndpoint):
+    owner = ApiOwner.DATA_BROWSING
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get(self, request: Request, project: Project) -> Response:
+        results = dispatch_detection_for_project_ids([project.id])
+        if results[project.id].get("success", False):
+            return Response({"status": "dispatched"}, status=status.HTTP_202_ACCEPTED)
+        else:
+            return Response(
+                {"status": results[project.id].get("reason", "unknown")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )

--- a/src/sentry/api/endpoints/project_web_vitals_detection.py
+++ b/src/sentry/api/endpoints/project_web_vitals_detection.py
@@ -19,10 +19,11 @@ class ProjectWebVitalsDetectionEndpoint(ProjectEndpoint):
 
     def get(self, request: Request, project: Project) -> Response:
         results = dispatch_detection_for_project_ids([project.id])
+        if project.id not in results:
+            return Response({"status": "invalid_project"}, status=status.HTTP_400_BAD_REQUEST)
         if results[project.id].get("success", False):
             return Response({"status": "dispatched"}, status=status.HTTP_202_ACCEPTED)
-        else:
-            return Response(
-                {"status": results[project.id].get("reason", "unknown")},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        return Response(
+            {"status": results[project.id].get("reason", "rejected")},
+            status=status.HTTP_400_BAD_REQUEST,
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -50,6 +50,7 @@ from sentry.api.endpoints.project_stacktrace_coverage import ProjectStacktraceCo
 from sentry.api.endpoints.project_statistical_detectors import ProjectStatisticalDetectors
 from sentry.api.endpoints.project_template_detail import OrganizationProjectTemplateDetailEndpoint
 from sentry.api.endpoints.project_templates_index import OrganizationProjectTemplatesIndexEndpoint
+from sentry.api.endpoints.project_web_vitals_detection import ProjectWebVitalsDetectionEndpoint
 from sentry.api.endpoints.release_thresholds.release_threshold import ReleaseThresholdEndpoint
 from sentry.api.endpoints.release_thresholds.release_threshold_details import (
     ReleaseThresholdDetailsEndpoint,
@@ -3091,6 +3092,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/performance/configure/$",
         ProjectPerformanceGeneralSettingsEndpoint.as_view(),
         name="sentry-api-0-project-performance-general-settings",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/web-vitals-detector/$",
+        ProjectWebVitalsDetectionEndpoint.as_view(),
+        name="sentry-api-0-project-web-vitals-detection",
     ),
     # Load plugin project urls
     re_path(

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -711,6 +711,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/user-reports/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/user-stats/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/users/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/web-vitals-detector/'
   | '/projects/$organizationIdOrSlug/pr-comments/$repoName/$prNumber/'
   | '/projects/$organizationIdOrSlug/pull-requests/size-analysis/$artifactId/'
   | '/projects/$organizationIdOrSlug/pullrequest-details/$repoName/$prNumber/'

--- a/tests/sentry/api/endpoints/test_project_web_vitals_detection.py
+++ b/tests/sentry/api/endpoints/test_project_web_vitals_detection.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch
+
+from sentry.testutils.cases import APITestCase
+
+
+class ProjectWebVitalsDetectionTest(APITestCase):
+    endpoint = "sentry-api-0-project-web-vitals-detection"
+    method = "get"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    @patch("sentry.api.endpoints.project_web_vitals_detection.dispatch_detection_for_project_ids")
+    def test_get_success(self, mock_dispatch):
+        mock_dispatch.return_value = {self.project.id: {"success": True}}
+
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, status_code=202
+        )
+
+        assert response.status_code == 202
+        assert response.data == {"status": "dispatched"}
+        mock_dispatch.assert_called_once_with([self.project.id])
+
+    def test_get_requires_project_access(self):
+        other_user = self.create_user()
+        self.login_as(user=other_user)
+
+        response = self.get_error_response(self.organization.slug, self.project.slug)
+
+        assert response.status_code == 403


### PR DESCRIPTION
Adds a `web-vitals-detector` endpoint that allows manually triggering the web vitals issue detection task for a selected project id. This endpoint is private for internal testing and validation only.