### PR TITLE
ref(explore): Increase trace explorer visualization limit from 4 to 8

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -15,7 +15,7 @@ import {
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {SpanFields} from 'sentry/views/insights/types';
 
-export const MAX_VISUALIZES = 4;
+export const MAX_VISUALIZES = 8;
 
 export const DEFAULT_VISUALIZATION_AGGREGATE = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES[0]!;
 export const DEFAULT_VISUALIZATION_FIELD = ALLOWED_EXPLORE_VISUALIZE_FIELDS[0]!;

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -12,7 +12,7 @@ import {decodeList} from 'sentry/utils/queryString';
 import {determineDefaultChartType} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
-export const MAX_VISUALIZES = 4;
+export const MAX_VISUALIZES = 8;
 
 interface VisualizeOptions {
   chartType?: ChartType;


### PR DESCRIPTION
allow for a maximum of 8 visualizations on an explore query page instead of 4. I'm finding a saved query with a bunch of plots extremely useful for monitoring LLM token usage, but i would love to put a few more charts on the page and feel constrained by 4 at the moment.