### PR TITLE
fix(issue-timeseries): Unfilled buckets when ts aren't aligned

### DIFF
--- a/src/sentry/issues/endpoints/organization_issue_timeseries.py
+++ b/src/sentry/issues/endpoints/organization_issue_timeseries.py
@@ -290,6 +290,10 @@ def fill_timeseries(
     interval: timedelta,
     values: list[Row],
 ) -> list[Row]:
+    # remove microseconds
+    start = start.replace(microsecond=0)
+    end = end.replace(microsecond=0)
+
     def iter_interval(start: datetime, end: datetime, interval: timedelta) -> Iterator[int]:
         while start <= end:
             yield int(start.timestamp() * 1000)


### PR DESCRIPTION
- When the start and end of the query wasn't aligned the page would error since the bucket check wouldn't match since ms were being included. This removes ms from the start/end during this check to resolve the issue