### PR TITLE
feat(preprod): Add insight comparison frontend

### DIFF
--- a/static/app/views/preprod/buildComparison/main/diffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/diffTable.tsx
@@ -14,7 +14,7 @@ export type DiffTableSort = {
   kind: 'asc' | 'desc';
 };
 
-export type DiffChangeElements = {
+type DiffChangeElements = {
   icon: React.ReactNode;
   label: string;
   type: 'success' | 'error' | 'warning';

--- a/static/app/views/preprod/buildComparison/main/diffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/diffTable.tsx
@@ -3,7 +3,9 @@
 import styled from '@emotion/styled';
 
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import type {DiffType} from 'sentry/views/preprod/types/appSizeTypes';
+import {IconAdd, IconFix, IconSubtract} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {DiffItem, DiffType} from 'sentry/views/preprod/types/appSizeTypes';
 
 export const ITEMS_PER_PAGE = 40;
 
@@ -11,6 +13,58 @@ export type DiffTableSort = {
   field: string;
   kind: 'asc' | 'desc';
 };
+
+export type DiffChangeElements = {
+  icon: React.ReactNode;
+  label: string;
+  type: 'success' | 'error' | 'warning';
+};
+
+export function getDiffChangeElements(diffItem: DiffItem): DiffChangeElements {
+  let change: {
+    icon: React.ReactNode;
+    label: string;
+    type: 'success' | 'error' | 'warning';
+  };
+  switch (diffItem.type) {
+    case 'added':
+      change = {
+        type: 'error',
+        label: t('Added'),
+        icon: <IconAdd />,
+      };
+      break;
+    case 'removed':
+      change = {
+        type: 'success',
+        label: t('Removed'),
+        icon: <IconSubtract />,
+      };
+      break;
+    case 'increased':
+      change = {
+        type: 'error',
+        label: t('Increased'),
+        icon: <IconAdd />,
+      };
+      break;
+    case 'decreased':
+      change = {
+        type: 'success',
+        label: t('Decreased'),
+        icon: <IconSubtract />,
+      };
+      break;
+    default:
+      change = {
+        type: 'warning',
+        label: t('Unchanged'),
+        icon: <IconFix />,
+      };
+      break;
+  }
+  return change;
+}
 
 export const DiffTableWithColumns = styled(SimpleTable)<{
   gridTemplateColumns: string;

--- a/static/app/views/preprod/buildComparison/main/diffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/diffTable.tsx
@@ -41,8 +41,6 @@ export const DiffTableChangeAmountCell = styled(SimpleTable.RowCell)<{
       case 'removed':
       case 'decreased':
         return p.theme.successText;
-      case 'unchanged':
-        return p.theme.warningText;
       default:
         throw new Error(`Invalid change type: ${p.changeType}`);
     }

--- a/static/app/views/preprod/buildComparison/main/diffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/diffTable.tsx
@@ -1,0 +1,50 @@
+/** Various shared components for diff tables */
+
+import styled from '@emotion/styled';
+
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import type {DiffType} from 'sentry/views/preprod/types/appSizeTypes';
+
+export const ITEMS_PER_PAGE = 40;
+
+export type DiffTableSort = {
+  field: string;
+  kind: 'asc' | 'desc';
+};
+
+export const DiffTableWithColumns = styled(SimpleTable)<{
+  gridTemplateColumns: string;
+}>`
+  overflow-x: auto;
+  overflow-y: auto;
+  grid-template-columns: ${p => p.gridTemplateColumns};
+  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
+  border-left: 0px;
+  border-right: 0px;
+`;
+
+export const DiffTableHeader = styled(SimpleTable.Header)`
+  border-radius: 0;
+  border-left: 0px;
+  border-right: 0px;
+`;
+
+export const DiffTableChangeAmountCell = styled(SimpleTable.RowCell)<{
+  changeType: DiffType;
+}>`
+  align-items: end;
+  color: ${p => {
+    switch (p.changeType) {
+      case 'increased':
+      case 'added':
+        return p.theme.dangerText;
+      case 'removed':
+      case 'decreased':
+        return p.theme.successText;
+      case 'unchanged':
+        return p.theme.warningText;
+      default:
+        throw new Error(`Invalid change type: ${p.changeType}`);
+    }
+  }};
+`;

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -8,7 +8,7 @@ import {Heading} from '@sentry/scraps/text';
 import {t} from 'sentry/locale';
 import {FileInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/fileInsightDiffTable';
 import {GroupInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/groupInsightDiffTable';
-import {InsightDiffRow} from 'sentry/views/preprod/buildComparison/main/insights/InsightDiffRow';
+import {InsightDiffRow} from 'sentry/views/preprod/buildComparison/main/insights/insightDiffRow';
 import type {
   InsightDiffItem,
   InsightStatus,

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -1,0 +1,211 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge/tag';
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Separator} from '@sentry/scraps/separator';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import {SizeCompareItemDiffTable} from 'sentry/views/preprod/buildComparison/main/sizeCompareItemDiffTable';
+import type {
+  DiffItem,
+  InsightDiffItem,
+  InsightStatus,
+} from 'sentry/views/preprod/types/appSizeTypes';
+import {INSIGHT_CONFIGS} from 'sentry/views/preprod/utils/insightProcessing';
+
+interface InsightComparisonSectionProps {
+  insightDiffItems: InsightDiffItem[];
+}
+
+function getInsightConfig(insightType: string): {description: string; name: string} {
+  return (
+    INSIGHT_CONFIGS.find(config => config.key === insightType) ?? {
+      name: insightType,
+      description: t('No description available'),
+    }
+  );
+}
+
+interface InsightRowProps {
+  insight: InsightDiffItem;
+}
+
+function InsightRow({insight}: InsightRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const config = getInsightConfig(insight.insight_type);
+
+  const allDiffItems: DiffItem[] = useMemo(
+    () => [...insight.file_diffs, ...insight.group_diffs],
+    [insight.file_diffs, insight.group_diffs]
+  );
+
+  const statusCounts = useMemo(() => {
+    const newCount = insight.status === 'new' ? allDiffItems.length : 0;
+    const unresolvedCount =
+      insight.status === 'unresolved'
+        ? allDiffItems.filter(item => item.type === 'added' || item.type === 'increased')
+            .length
+        : 0;
+    const resolvedCount =
+      insight.status === 'resolved'
+        ? allDiffItems.length
+        : insight.status === 'unresolved'
+          ? allDiffItems.filter(
+              item => item.type === 'removed' || item.type === 'decreased'
+            ).length
+          : 0;
+
+    return {new: newCount, unresolved: unresolvedCount, resolved: resolvedCount};
+  }, [insight.status, allDiffItems]);
+
+  const totalSavingsChangePercentage =
+    insight.total_savings_change === 0
+      ? '0.00'
+      : ((Math.abs(insight.total_savings_change) / 1000000) * 100).toFixed(2);
+
+  return (
+    <Container background="primary" radius="lg" padding="0" border="primary">
+      <Flex direction="column" gap="0">
+        <Flex align="center" justify="between" padding="xl">
+          <Flex direction="column" gap="sm" style={{flex: 1}}>
+            <Flex align="center" gap="sm">
+              <Heading as="h3">{config.name}</Heading>
+              <Flex align="center" gap="xs">
+                {statusCounts.new > 0 && (
+                  <Tag type="promotion">{t('New (%s)', statusCounts.new)}</Tag>
+                )}
+                {statusCounts.unresolved > 0 && (
+                  <Tag type="warning">
+                    {t('Unresolved (%s)', statusCounts.unresolved)}
+                  </Tag>
+                )}
+                {statusCounts.resolved > 0 && (
+                  <Tag type="success">{t('Resolved (%s)', statusCounts.resolved)}</Tag>
+                )}
+              </Flex>
+            </Flex>
+            <Text size="sm" variant="muted">
+              {config.description}
+            </Text>
+          </Flex>
+          <Flex align="center" gap="md">
+            <Flex direction="column" align="end" gap="xs">
+              <Text bold>
+                {t(
+                  'Potential savings: %s',
+                  formatBytesBase10(insight.total_savings_change)
+                )}
+              </Text>
+              <SavingsPercentage savingsChange={insight.total_savings_change}>
+                {insight.total_savings_change > 0 ? '+' : ''}
+                {totalSavingsChangePercentage}%
+              </SavingsPercentage>
+            </Flex>
+            <Button
+              priority="transparent"
+              size="sm"
+              onClick={() => setIsExpanded(!isExpanded)}
+              aria-label={isExpanded ? t('Collapse insight') : t('Expand insight')}
+            >
+              <IconChevron
+                direction={isExpanded ? 'up' : 'down'}
+                size="sm"
+                style={{
+                  transition: 'transform 0.2s ease',
+                }}
+              />
+            </Button>
+          </Flex>
+        </Flex>
+        {isExpanded && allDiffItems.length > 0 && (
+          <SizeCompareItemDiffTable
+            diffItems={allDiffItems}
+            originalItemCount={allDiffItems.length}
+            disableHideSmallChanges={() => {}}
+          />
+        )}
+      </Flex>
+    </Container>
+  );
+}
+
+export function InsightComparisonSection({
+  insightDiffItems,
+}: InsightComparisonSectionProps) {
+  const [selectedTab, setSelectedTab] = useState<'all' | InsightStatus>('all');
+
+  const filteredInsights = useMemo(() => {
+    if (selectedTab === 'all') {
+      return insightDiffItems;
+    }
+    return insightDiffItems.filter(insight => insight.status === selectedTab);
+  }, [insightDiffItems, selectedTab]);
+
+  const statusCounts = useMemo(() => {
+    return {
+      all: insightDiffItems.length,
+      new: insightDiffItems.filter(i => i.status === 'new').length,
+      unresolved: insightDiffItems.filter(i => i.status === 'unresolved').length,
+      resolved: insightDiffItems.filter(i => i.status === 'resolved').length,
+    };
+  }, [insightDiffItems]);
+
+  if (insightDiffItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap="xl">
+      <Separator orientation="horizontal" border="primary" />
+
+      <Stack gap="md">
+        <Flex direction="column" gap="md">
+          <Heading as="h2">{t('Insights')}</Heading>
+          <Flex align="center" gap="sm" wrap="wrap">
+            <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
+              {statusCounts.all > 0 ? (
+                <SegmentedControl.Item key="all">
+                  {t('All (%s)', statusCounts.all)}
+                </SegmentedControl.Item>
+              ) : null}
+              {statusCounts.new > 0 ? (
+                <SegmentedControl.Item key="new">
+                  {t('New (%s)', statusCounts.new)}
+                </SegmentedControl.Item>
+              ) : null}
+              {statusCounts.unresolved > 0 ? (
+                <SegmentedControl.Item key="unresolved">
+                  {t('Unresolved (%s)', statusCounts.unresolved)}
+                </SegmentedControl.Item>
+              ) : null}
+              {statusCounts.resolved > 0 ? (
+                <SegmentedControl.Item key="resolved">
+                  {t('Resolved (%s)', statusCounts.resolved)}
+                </SegmentedControl.Item>
+              ) : null}
+            </SegmentedControl>
+          </Flex>
+        </Flex>
+
+        <Stack gap="md">
+          {filteredInsights.map(insight => (
+            <InsightRow key={insight.insight_type} insight={insight} />
+          ))}
+        </Stack>
+      </Stack>
+
+      <Separator orientation="horizontal" border="primary" />
+    </Stack>
+  );
+}
+
+const SavingsPercentage = styled(Text)<{savingsChange: number}>`
+  color: ${p => (p.savingsChange > 0 ? p.theme.dangerText : p.theme.successText)};
+  font-weight: ${p => p.theme.fontWeight.normal};
+`;

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -26,7 +26,7 @@ const FILE_DIFF_INSIGHT_TYPES = [
   'hermes_debug_info',
   'unnecessary_files',
   'webp_optimization',
-  'localized_strings_comments',
+  'localized_strings_minify',
   'small_files',
   'main_binary_exported_symbols',
   'audio_compression',

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.spec.tsx
@@ -1,0 +1,208 @@
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import type {DiffItem} from 'sentry/views/preprod/types/appSizeTypes';
+
+import {FileInsightItemDiffTable} from './fileInsightDiffTable';
+
+const mockFileDiffItems: DiffItem[] = [
+  {
+    path: '/assets/large-image.png',
+    type: 'added',
+    size_diff: 2500000,
+    head_size: 2500000,
+    base_size: null,
+    item_type: 'assets',
+    diff_items: null,
+  },
+  {
+    path: '/components/utils.js',
+    type: 'removed',
+    size_diff: -150000,
+    head_size: null,
+    base_size: 150000,
+    item_type: 'executables',
+    diff_items: null,
+  },
+  {
+    path: '/lib/library.so',
+    type: 'unchanged',
+    size_diff: 0,
+    head_size: 1000000,
+    base_size: 1000000,
+    item_type: 'native_libraries',
+    diff_items: null,
+  },
+];
+
+describe('FileInsightItemDiffTable', () => {
+  it('renders empty state when no diff items', () => {
+    render(<FileInsightItemDiffTable fileDiffItems={[]} />);
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('displays file items with correct information', () => {
+    render(<FileInsightItemDiffTable fileDiffItems={mockFileDiffItems} />);
+
+    // Check file paths
+    expect(screen.getByText('/assets/large-image.png')).toBeInTheDocument();
+    expect(screen.getByText('/components/utils.js')).toBeInTheDocument();
+    expect(screen.getByText('/lib/library.so')).toBeInTheDocument();
+
+    // Check status tags
+    expect(screen.getByText('Added')).toBeInTheDocument();
+    expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(screen.getByText('Unchanged')).toBeInTheDocument();
+
+    // Check sizes
+    expect(screen.getByText('+2.5 MB')).toBeInTheDocument();
+    expect(screen.getByText('-150 kB')).toBeInTheDocument();
+    expect(screen.getByText('-1 MB')).toBeInTheDocument(); // Unchanged shows as negative for consistency
+  });
+
+  it('supports sorting by different fields', async () => {
+    render(<FileInsightItemDiffTable fileDiffItems={mockFileDiffItems} />);
+
+    // Click on Status header to sort by type
+    const statusHeader = screen.getByRole('columnheader', {name: 'Status'});
+    await userEvent.click(statusHeader);
+
+    // After sorting by status ascending, "added" should come first
+    const rows = screen.getAllByRole('row');
+    expect(within(rows[1]).getByText('/assets/large-image.png')).toBeInTheDocument();
+
+    // Click again to sort descending
+    await userEvent.click(statusHeader);
+
+    // Now "unchanged" should come first
+    expect(within(rows[1]).getByText('/lib/library.so')).toBeInTheDocument();
+  });
+
+  it('supports sorting by path', async () => {
+    render(<FileInsightItemDiffTable fileDiffItems={mockFileDiffItems} />);
+
+    // Click on Affected Files header to sort by path
+    const pathHeader = screen.getByRole('columnheader', {name: 'Affected Files'});
+    await userEvent.click(pathHeader);
+
+    // Should sort alphabetically by path
+    const rows = screen.getAllByRole('row');
+    expect(within(rows[1]).getByText('/assets/large-image.png')).toBeInTheDocument();
+  });
+
+  it('handles pagination correctly', async () => {
+    // Create enough items to trigger pagination (need more than ITEMS_PER_PAGE)
+    const manyItems: DiffItem[] = [];
+    for (let i = 0; i < 50; i++) {
+      manyItems.push({
+        path: `/file${i}.txt`,
+        type: 'added',
+        size_diff: 1000 + i,
+        head_size: 1000 + i,
+        base_size: null,
+        item_type: 'files',
+        diff_items: null,
+      });
+    }
+
+    render(<FileInsightItemDiffTable fileDiffItems={manyItems} />);
+
+    // Should show pagination controls
+    expect(screen.getByText(/Page 1 of \d+/)).toBeInTheDocument();
+
+    // Navigate to next page
+    const nextButton = screen.getByLabelText('Next');
+    await userEvent.click(nextButton);
+
+    expect(screen.getByText(/Page 2 of \d+/)).toBeInTheDocument();
+
+    // Navigate back
+    const prevButton = screen.getByLabelText('Previous');
+    await userEvent.click(prevButton);
+
+    expect(screen.getByText(/Page 1 of \d+/)).toBeInTheDocument();
+  });
+
+  it('handles items with null paths gracefully', () => {
+    const itemsWithNullPaths: DiffItem[] = [
+      {
+        path: null,
+        type: 'added',
+        size_diff: 1000,
+        head_size: 1000,
+        base_size: null,
+        item_type: null,
+        diff_items: null,
+      },
+    ];
+
+    render(<FileInsightItemDiffTable fileDiffItems={itemsWithNullPaths} />);
+
+    // Should render without crashing and show empty string for path
+    expect(screen.getByText('Added')).toBeInTheDocument();
+    expect(screen.getByText('+1 kB')).toBeInTheDocument();
+  });
+
+  it('displays tooltips with copy functionality for paths', async () => {
+    render(<FileInsightItemDiffTable fileDiffItems={mockFileDiffItems} />);
+
+    // Hover over a path to show tooltip
+    const pathElement = screen.getByText('/assets/large-image.png');
+    await userEvent.hover(pathElement);
+
+    // Should show copy button in tooltip
+    expect(screen.getByLabelText('Copy path to clipboard')).toBeInTheDocument();
+  });
+
+  it('handles zero size diff correctly', () => {
+    const zeroSizeDiffItems: DiffItem[] = [
+      {
+        path: '/zero-change.txt',
+        type: 'unchanged',
+        size_diff: 0,
+        head_size: 500,
+        base_size: 500,
+        item_type: 'files',
+        diff_items: null,
+      },
+    ];
+
+    render(<FileInsightItemDiffTable fileDiffItems={zeroSizeDiffItems} />);
+
+    expect(screen.getByText('/zero-change.txt')).toBeInTheDocument();
+    expect(screen.getByText('Unchanged')).toBeInTheDocument();
+    expect(screen.getByText('-500 B')).toBeInTheDocument(); // Should show absolute value with minus
+  });
+
+  it('disables pagination buttons appropriately', async () => {
+    // Create just enough items for 2 pages
+    const twoPageItems: DiffItem[] = [];
+    for (let i = 0; i < 45; i++) {
+      twoPageItems.push({
+        path: `/file${i}.txt`,
+        type: 'added',
+        size_diff: 1000,
+        head_size: 1000,
+        base_size: null,
+        item_type: 'files',
+        diff_items: null,
+      });
+    }
+
+    render(<FileInsightItemDiffTable fileDiffItems={twoPageItems} />);
+
+    // On first page, previous should be disabled
+    const prevButton = screen.getByLabelText('Previous');
+    const nextButton = screen.getByLabelText('Next');
+
+    expect(prevButton).toBeDisabled();
+    expect(nextButton).toBeEnabled();
+
+    // Go to last page
+    await userEvent.click(nextButton);
+
+    // On last page, next should be disabled
+    expect(prevButton).toBeEnabled();
+    expect(nextButton).toBeDisabled();
+  });
+});

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.spec.tsx
@@ -25,7 +25,7 @@ const mockFileDiffItems: DiffItem[] = [
   },
   {
     path: '/lib/library.so',
-    type: 'unchanged',
+    type: 'increased',
     size_diff: 0,
     head_size: 1000000,
     base_size: 1000000,

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
@@ -63,7 +63,6 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
           increased: 1,
           decreased: 2,
           removed: 3,
-          unchanged: 4,
         };
         aValue = order[a.type];
         bValue = order[b.type];

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
@@ -143,12 +143,12 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
             </Stack>
           </SimpleTable.Empty>
         )}
-        {currentDiffItems.map(groupDiffItem => {
+        {currentDiffItems.map(fileDiffItem => {
           rowIndex++;
           let changeTypeLabel: string;
           let changeTypeIcon: React.ReactNode;
           let changeTypeTagType: 'success' | 'error' | 'warning';
-          switch (groupDiffItem.type) {
+          switch (fileDiffItem.type) {
             case 'added':
               changeTypeTagType = 'error';
               changeTypeLabel = t('Added');
@@ -157,6 +157,16 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
             case 'removed':
               changeTypeTagType = 'success';
               changeTypeLabel = t('Removed');
+              changeTypeIcon = <IconSubtract />;
+              break;
+            case 'increased':
+              changeTypeTagType = 'error';
+              changeTypeLabel = t('Increased');
+              changeTypeIcon = <IconAdd />;
+              break;
+            case 'decreased':
+              changeTypeTagType = 'success';
+              changeTypeLabel = t('Decreased');
               changeTypeIcon = <IconSubtract />;
               break;
             default:
@@ -177,20 +187,20 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
                 <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
                   <Tooltip
                     title={
-                      groupDiffItem.path ? (
+                      fileDiffItem.path ? (
                         <Flex align="start" gap="xs">
-                          <Text monospace>{groupDiffItem.path}</Text>
+                          <Text monospace>{fileDiffItem.path}</Text>
                           <CopyToClipboardButton
                             borderless
                             size="zero"
-                            text={groupDiffItem.path}
+                            text={fileDiffItem.path}
                             style={{flexShrink: 0}}
                             aria-label="Copy path to clipboard"
                           />
                         </Flex>
                       ) : null
                     }
-                    disabled={!groupDiffItem.path}
+                    disabled={!fileDiffItem.path}
                     isHoverable
                     maxWidth={420}
                   >
@@ -198,13 +208,12 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
                       ellipsisDirection="right"
                       style={{display: 'block', width: '100%'}}
                     >
-                      {groupDiffItem.path ?? ''}
+                      {fileDiffItem.path ?? ''}
                     </TextOverflow>
                   </Tooltip>
                 </SimpleTable.RowCell>
-                <DiffTableChangeAmountCell changeType={groupDiffItem.type}>
-                  {groupDiffItem.size_diff > 0 ? '+' : '-'}
-                  {formatBytesBase10(Math.abs(groupDiffItem.size_diff))}
+                <DiffTableChangeAmountCell changeType={fileDiffItem.type}>
+                  {`${fileDiffItem.size_diff > 0 ? '+' : '-'}${formatBytesBase10(Math.abs(fileDiffItem.size_diff))}`}
                 </DiffTableChangeAmountCell>
               </SimpleTable.Row>
             </Fragment>

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
@@ -9,13 +9,14 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import TextOverflow from 'sentry/components/textOverflow';
-import {IconAdd, IconChevron, IconFix, IconSubtract} from 'sentry/icons';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {
   DiffTableChangeAmountCell,
   DiffTableHeader,
   DiffTableWithColumns,
+  getDiffChangeElements,
   ITEMS_PER_PAGE,
   type DiffTableSort,
 } from 'sentry/views/preprod/buildComparison/main/diffTable';
@@ -24,15 +25,15 @@ import type {DiffItem, DiffType} from 'sentry/views/preprod/types/appSizeTypes';
 const tableHeaders = [
   {
     key: 'type',
-    label: 'Status',
+    label: t('Status'),
   },
   {
     key: 'path',
-    label: 'Affected Files',
+    label: t('Affected Files'),
   },
   {
     key: 'size_diff',
-    label: 'Potential Savings',
+    label: t('Potential Savings'),
   },
 ];
 
@@ -144,36 +145,7 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
         )}
         {currentDiffItems.map(fileDiffItem => {
           rowIndex++;
-          let changeTypeLabel: string;
-          let changeTypeIcon: React.ReactNode;
-          let changeTypeTagType: 'success' | 'error' | 'warning';
-          switch (fileDiffItem.type) {
-            case 'added':
-              changeTypeTagType = 'error';
-              changeTypeLabel = t('Added');
-              changeTypeIcon = <IconAdd />;
-              break;
-            case 'removed':
-              changeTypeTagType = 'success';
-              changeTypeLabel = t('Removed');
-              changeTypeIcon = <IconSubtract />;
-              break;
-            case 'increased':
-              changeTypeTagType = 'error';
-              changeTypeLabel = t('Increased');
-              changeTypeIcon = <IconAdd />;
-              break;
-            case 'decreased':
-              changeTypeTagType = 'success';
-              changeTypeLabel = t('Decreased');
-              changeTypeIcon = <IconSubtract />;
-              break;
-            default:
-              changeTypeTagType = 'warning';
-              changeTypeLabel = t('Unchanged');
-              changeTypeIcon = <IconFix />;
-              break;
-          }
+          const fileDiffItemChange = getDiffChangeElements(fileDiffItem);
 
           const actualDiff =
             fileDiffItem.size_diff === 0
@@ -185,8 +157,8 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
             <Fragment key={rowIndex}>
               <SimpleTable.Row key={rowIndex}>
                 <SimpleTable.RowCell>
-                  <Tag icon={changeTypeIcon} type={changeTypeTagType}>
-                    {changeTypeLabel}
+                  <Tag icon={fileDiffItemChange.icon} type={fileDiffItemChange.type}>
+                    {fileDiffItemChange.label}
                   </Tag>
                 </SimpleTable.RowCell>
                 <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
@@ -200,7 +172,7 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
                             size="zero"
                             text={fileDiffItem.path}
                             style={{flexShrink: 0}}
-                            aria-label="Copy path to clipboard"
+                            aria-label={t('Copy path to clipboard')}
                           />
                         </Flex>
                       ) : null

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
@@ -40,7 +40,7 @@ interface FileInsightItemDiffTableProps {
   fileDiffItems: DiffItem[];
 }
 
-// TODO: Test
+// This table is very similar  to FileInsightItemDiffTable, but shows only files. Should remain separate.
 export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTableProps) {
   const [sort, setSort] = useState<DiffTableSort>({
     field: 'size_diff',
@@ -89,7 +89,6 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
   const lastPageIndex = Math.max(totalPages - 1, 0);
   const safeCurrentPage = Math.min(currentPage, lastPageIndex);
   const startIndex = safeCurrentPage * ITEMS_PER_PAGE;
-  // TODO: Handle child count
   const currentDiffItems = sortedDiffItems.slice(startIndex, startIndex + ITEMS_PER_PAGE);
   const showPagination = totalPages > 1;
 

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
@@ -176,6 +176,12 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
               break;
           }
 
+          const actualDiff =
+            fileDiffItem.size_diff === 0
+              ? (fileDiffItem.head_size ?? 0) - (fileDiffItem.base_size ?? 0)
+              : fileDiffItem.size_diff;
+          const changeAmount = `${actualDiff > 0 ? '+' : '-'}${formatBytesBase10(Math.abs(actualDiff))}`;
+
           return (
             <Fragment key={rowIndex}>
               <SimpleTable.Row key={rowIndex}>
@@ -213,7 +219,7 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
                   </Tooltip>
                 </SimpleTable.RowCell>
                 <DiffTableChangeAmountCell changeType={fileDiffItem.type}>
-                  {`${fileDiffItem.size_diff > 0 ? '+' : '-'}${formatBytesBase10(Math.abs(fileDiffItem.size_diff))}`}
+                  {changeAmount}
                 </DiffTableChangeAmountCell>
               </SimpleTable.Row>
             </Fragment>

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
@@ -35,7 +35,7 @@ const mockGroupDiffItems: DiffItem[] = [
   },
   {
     path: 'LICENSE.txt',
-    type: 'added',
+    type: 'removed',
     size_diff: 0,
     head_size: 2000,
     base_size: 2000,
@@ -43,7 +43,7 @@ const mockGroupDiffItems: DiffItem[] = [
     diff_items: [
       {
         path: '/META-INF/LICENSE1.txt',
-        type: 'added',
+        type: 'removed',
         size_diff: 0,
         head_size: 1000,
         base_size: 1000,
@@ -52,7 +52,7 @@ const mockGroupDiffItems: DiffItem[] = [
       },
       {
         path: '/META-INF/LICENSE2.txt',
-        type: 'removed',
+        type: 'added',
         size_diff: 0,
         head_size: 1000,
         base_size: 1000,
@@ -91,14 +91,14 @@ describe('GroupInsightItemDiffTable', () => {
     const addedTags = screen.getAllByText('Added');
     expect(addedTags).toHaveLength(3); // 1 group + 2 children
 
-    // Check "Unchanged" tags for LICENSE.txt group
-    const unchangedTags = screen.getAllByText('Unchanged');
-    expect(unchangedTags).toHaveLength(3); // 1 group + 2 children
+    // Check "Removed" tags for LICENSE.txt group
+    const removedTags = screen.getAllByText('Removed');
+    expect(removedTags).toHaveLength(3); // 1 group + 2 children
 
     // Check sizes
-    expect(screen.getByText('+1.5 kB')).toBeInTheDocument(); // Group total
+    expect(screen.getByText('+1.5 KB')).toBeInTheDocument(); // Group total
     expect(screen.getByText('+500 B')).toBeInTheDocument(); // Child 1
-    expect(screen.getByText('+1 kB')).toBeInTheDocument(); // Child 2
+    expect(screen.getByText('+1 KB')).toBeInTheDocument(); // Child 2
   });
 
   it('supports sorting by different fields', async () => {
@@ -111,7 +111,7 @@ describe('GroupInsightItemDiffTable', () => {
     // After sorting by status, "added" items should come first (order: added < unchanged)
     const rows = screen.getAllByRole('row');
     // First data row should contain the "added" group
-    expect(within(rows[1]).getByText('icon.png')).toBeInTheDocument();
+    expect(within(rows[1]!).getByText('icon.png')).toBeInTheDocument();
   });
 
   it('handles pagination correctly with nested items', async () => {
@@ -194,6 +194,6 @@ describe('GroupInsightItemDiffTable', () => {
     await userEvent.hover(pathElement);
 
     // Should show copy button in tooltip
-    expect(screen.getByLabelText('Copy path to clipboard')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Copy path to clipboard')).toBeInTheDocument();
   });
 });

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
@@ -52,7 +52,7 @@ const mockGroupDiffItems: DiffItem[] = [
       },
       {
         path: '/META-INF/LICENSE2.txt',
-        type: 'added',
+        type: 'removed',
         size_diff: 0,
         head_size: 1000,
         base_size: 1000,

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
@@ -1,0 +1,199 @@
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import type {DiffItem} from 'sentry/views/preprod/types/appSizeTypes';
+
+import {GroupInsightItemDiffTable} from './groupInsightDiffTable';
+
+const mockGroupDiffItems: DiffItem[] = [
+  {
+    path: 'icon.png',
+    type: 'added',
+    size_diff: 1500,
+    head_size: 1500,
+    base_size: null,
+    item_type: null,
+    diff_items: [
+      {
+        path: '/assets/icon1.png',
+        type: 'added',
+        size_diff: 500,
+        head_size: 500,
+        base_size: null,
+        item_type: null,
+        diff_items: null,
+      },
+      {
+        path: '/assets/icon2.png',
+        type: 'added',
+        size_diff: 1000,
+        head_size: 1000,
+        base_size: null,
+        item_type: null,
+        diff_items: null,
+      },
+    ],
+  },
+  {
+    path: 'LICENSE.txt',
+    type: 'unchanged',
+    size_diff: 0,
+    head_size: 2000,
+    base_size: 2000,
+    item_type: null,
+    diff_items: [
+      {
+        path: '/META-INF/LICENSE1.txt',
+        type: 'unchanged',
+        size_diff: 0,
+        head_size: 1000,
+        base_size: 1000,
+        item_type: null,
+        diff_items: null,
+      },
+      {
+        path: '/META-INF/LICENSE2.txt',
+        type: 'unchanged',
+        size_diff: 0,
+        head_size: 1000,
+        base_size: 1000,
+        item_type: null,
+        diff_items: null,
+      },
+    ],
+  },
+];
+
+describe('GroupInsightItemDiffTable', () => {
+  it('renders empty state when no diff items', () => {
+    render(<GroupInsightItemDiffTable groupDiffItems={[]} />);
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('displays group items with nested child items', () => {
+    render(<GroupInsightItemDiffTable groupDiffItems={mockGroupDiffItems} />);
+
+    // Check group headers
+    expect(screen.getByText('icon.png')).toBeInTheDocument();
+    expect(screen.getByText('LICENSE.txt')).toBeInTheDocument();
+
+    // Check nested child items
+    expect(screen.getByText('/assets/icon1.png')).toBeInTheDocument();
+    expect(screen.getByText('/assets/icon2.png')).toBeInTheDocument();
+    expect(screen.getByText('/META-INF/LICENSE1.txt')).toBeInTheDocument();
+    expect(screen.getByText('/META-INF/LICENSE2.txt')).toBeInTheDocument();
+  });
+
+  it('displays correct status tags and sizes', () => {
+    render(<GroupInsightItemDiffTable groupDiffItems={mockGroupDiffItems} />);
+
+    // Check "Added" tags for icon.png group
+    const addedTags = screen.getAllByText('Added');
+    expect(addedTags).toHaveLength(3); // 1 group + 2 children
+
+    // Check "Unchanged" tags for LICENSE.txt group
+    const unchangedTags = screen.getAllByText('Unchanged');
+    expect(unchangedTags).toHaveLength(3); // 1 group + 2 children
+
+    // Check sizes
+    expect(screen.getByText('+1.5 kB')).toBeInTheDocument(); // Group total
+    expect(screen.getByText('+500 B')).toBeInTheDocument(); // Child 1
+    expect(screen.getByText('+1 kB')).toBeInTheDocument(); // Child 2
+  });
+
+  it('supports sorting by different fields', async () => {
+    render(<GroupInsightItemDiffTable groupDiffItems={mockGroupDiffItems} />);
+
+    // Click on Status header to sort by type
+    const statusHeader = screen.getByRole('columnheader', {name: 'Status'});
+    await userEvent.click(statusHeader);
+
+    // After sorting by status, "added" items should come first (order: added < unchanged)
+    const rows = screen.getAllByRole('row');
+    // First data row should contain the "added" group
+    expect(within(rows[1]).getByText('icon.png')).toBeInTheDocument();
+  });
+
+  it('handles pagination correctly with nested items', async () => {
+    // Create enough items to trigger pagination (need more than ITEMS_PER_PAGE)
+    const manyItems: DiffItem[] = [];
+    for (let i = 0; i < 15; i++) {
+      manyItems.push({
+        path: `group${i}.txt`,
+        type: 'added',
+        size_diff: 100 * i,
+        head_size: 100 * i,
+        base_size: null,
+        item_type: null,
+        diff_items: [
+          {
+            path: `/path/file${i}a.txt`,
+            type: 'added',
+            size_diff: 50 * i,
+            head_size: 50 * i,
+            base_size: null,
+            item_type: null,
+            diff_items: null,
+          },
+          {
+            path: `/path/file${i}b.txt`,
+            type: 'added',
+            size_diff: 50 * i,
+            head_size: 50 * i,
+            base_size: null,
+            item_type: null,
+            diff_items: null,
+          },
+        ],
+      });
+    }
+
+    render(<GroupInsightItemDiffTable groupDiffItems={manyItems} />);
+
+    // Should show pagination controls
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+
+    // Navigate to next page
+    const nextButton = screen.getByLabelText('Next');
+    await userEvent.click(nextButton);
+
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+
+    // Navigate back
+    const prevButton = screen.getByLabelText('Previous');
+    await userEvent.click(prevButton);
+
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+  });
+
+  it('handles group without nested items', () => {
+    const groupWithoutChildren: DiffItem[] = [
+      {
+        path: 'simple.txt',
+        type: 'removed',
+        size_diff: -500,
+        head_size: null,
+        base_size: 500,
+        item_type: null,
+        diff_items: null,
+      },
+    ];
+
+    render(<GroupInsightItemDiffTable groupDiffItems={groupWithoutChildren} />);
+
+    expect(screen.getByText('simple.txt')).toBeInTheDocument();
+    expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(screen.getByText('-500 B')).toBeInTheDocument();
+  });
+
+  it('displays tooltips with copy functionality for paths', async () => {
+    render(<GroupInsightItemDiffTable groupDiffItems={mockGroupDiffItems} />);
+
+    // Hover over a path to show tooltip
+    const pathElement = screen.getByText('icon.png');
+    await userEvent.hover(pathElement);
+
+    // Should show copy button in tooltip
+    expect(screen.getByLabelText('Copy path to clipboard')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.spec.tsx
@@ -35,7 +35,7 @@ const mockGroupDiffItems: DiffItem[] = [
   },
   {
     path: 'LICENSE.txt',
-    type: 'unchanged',
+    type: 'added',
     size_diff: 0,
     head_size: 2000,
     base_size: 2000,
@@ -43,7 +43,7 @@ const mockGroupDiffItems: DiffItem[] = [
     diff_items: [
       {
         path: '/META-INF/LICENSE1.txt',
-        type: 'unchanged',
+        type: 'added',
         size_diff: 0,
         head_size: 1000,
         base_size: 1000,
@@ -52,7 +52,7 @@ const mockGroupDiffItems: DiffItem[] = [
       },
       {
         path: '/META-INF/LICENSE2.txt',
-        type: 'unchanged',
+        type: 'removed',
         size_diff: 0,
         head_size: 1000,
         base_size: 1000,

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -40,7 +40,6 @@ interface GroupInsightItemDiffTableProps {
   groupDiffItems: DiffItem[];
 }
 
-// TODO: Test
 // This table is very similar to FileInsightItemDiffTable, but shows child items in a group. Should remain separate.
 export function GroupInsightItemDiffTable({
   groupDiffItems,

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -9,13 +9,14 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import TextOverflow from 'sentry/components/textOverflow';
-import {IconAdd, IconChevron, IconFix, IconSubtract} from 'sentry/icons';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {
   DiffTableChangeAmountCell,
   DiffTableHeader,
   DiffTableWithColumns,
+  getDiffChangeElements,
   ITEMS_PER_PAGE,
   type DiffTableSort,
 } from 'sentry/views/preprod/buildComparison/main/diffTable';
@@ -197,43 +198,14 @@ export function GroupInsightItemDiffTable({
         )}
         {currentDiffItems.map(groupDiffItem => {
           rowIndex++;
-          let changeTypeLabel: string;
-          let changeTypeIcon: React.ReactNode;
-          let changeTypeTagType: 'success' | 'error' | 'warning';
-          switch (groupDiffItem.type) {
-            case 'added':
-              changeTypeTagType = 'error';
-              changeTypeLabel = t('Added');
-              changeTypeIcon = <IconAdd />;
-              break;
-            case 'removed':
-              changeTypeTagType = 'success';
-              changeTypeLabel = t('Removed');
-              changeTypeIcon = <IconSubtract />;
-              break;
-            case 'increased':
-              changeTypeTagType = 'error';
-              changeTypeLabel = t('Increased');
-              changeTypeIcon = <IconAdd />;
-              break;
-            case 'decreased':
-              changeTypeTagType = 'success';
-              changeTypeLabel = t('Decreased');
-              changeTypeIcon = <IconSubtract />;
-              break;
-            default:
-              changeTypeTagType = 'warning';
-              changeTypeLabel = t('Unchanged');
-              changeTypeIcon = <IconFix />;
-              break;
-          }
+          const groupDiffItemChange = getDiffChangeElements(groupDiffItem);
 
           return (
             <Fragment key={rowIndex}>
               <SimpleTable.Row key={rowIndex}>
                 <SimpleTable.RowCell>
-                  <Tag icon={changeTypeIcon} type={changeTypeTagType}>
-                    {changeTypeLabel}
+                  <Tag icon={groupDiffItemChange.icon} type={groupDiffItemChange.type}>
+                    {groupDiffItemChange.label}
                   </Tag>
                 </SimpleTable.RowCell>
                 <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
@@ -269,11 +241,12 @@ export function GroupInsightItemDiffTable({
                 </DiffTableChangeAmountCell>
               </SimpleTable.Row>
               {groupDiffItem.diff_items?.map(diffItem => {
+                const diffItemChange = getDiffChangeElements(diffItem);
                 return (
                   <SimpleTable.Row key={++rowIndex}>
                     <SimpleTable.RowCell>
-                      <Tag icon={changeTypeIcon} type={changeTypeTagType}>
-                        {changeTypeLabel}
+                      <Tag icon={diffItemChange.icon} type={diffItemChange.type}>
+                        {diffItemChange.label}
                       </Tag>
                     </SimpleTable.RowCell>
                     <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -67,7 +67,6 @@ export function GroupInsightItemDiffTable({
           increased: 1,
           decreased: 2,
           removed: 3,
-          unchanged: 4,
         };
         aValue = order[a.type];
         bValue = order[b.type];

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -1,0 +1,306 @@
+import {Fragment, useEffect, useState} from 'react';
+
+import {Tag} from '@sentry/scraps/badge/tag';
+import {Button, ButtonBar} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import TextOverflow from 'sentry/components/textOverflow';
+import {IconAdd, IconChevron, IconFix, IconSubtract} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import {
+  DiffTableChangeAmountCell,
+  DiffTableHeader,
+  DiffTableWithColumns,
+  ITEMS_PER_PAGE,
+  type DiffTableSort,
+} from 'sentry/views/preprod/buildComparison/main/diffTable';
+import type {DiffItem, DiffType} from 'sentry/views/preprod/types/appSizeTypes';
+
+const tableHeaders = [
+  {
+    key: 'type',
+    label: 'Status',
+  },
+  {
+    key: 'path',
+    label: 'Affected Files',
+  },
+  {
+    key: 'size_diff',
+    label: 'Potential Savings',
+  },
+];
+
+interface GroupInsightItemDiffTableProps {
+  groupDiffItems: DiffItem[];
+}
+
+// TODO: Test
+// This table is very similar to FileInsightItemDiffTable, but shows child items in a group. Should remain separate.
+export function GroupInsightItemDiffTable({
+  groupDiffItems,
+}: GroupInsightItemDiffTableProps) {
+  const [sort, setSort] = useState<DiffTableSort>({
+    field: 'size_diff',
+    kind: 'desc',
+  });
+
+  const [currentPage, setCurrentPage] = useState(0);
+
+  // Sort just the parent items as before
+  const sortedDiffItems = [...groupDiffItems].sort((a: DiffItem, b: DiffItem) => {
+    const {field, kind} = sort;
+
+    let aValue: number | string = '';
+    let bValue: number | string = '';
+
+    switch (field) {
+      case 'type': {
+        // Sort by type: added < modified < removed
+        const order: Record<DiffType, number> = {
+          added: 0,
+          increased: 1,
+          decreased: 2,
+          removed: 3,
+          unchanged: 4,
+        };
+        aValue = order[a.type];
+        bValue = order[b.type];
+        break;
+      }
+      case 'path':
+        aValue = a.path || '';
+        bValue = b.path || '';
+        break;
+      case 'size_diff':
+        aValue = Math.abs(a.size_diff ?? 0);
+        bValue = Math.abs(b.size_diff ?? 0);
+        break;
+      default:
+        throw new Error(`Invalid field: ${field}`);
+    }
+
+    if (aValue < bValue) return kind === 'asc' ? -1 : 1;
+    if (aValue > bValue) return kind === 'asc' ? 1 : -1;
+    return 0;
+  });
+
+  /**
+   * We want each page to have ITEMS_PER_PAGE total rows,
+   * counting both parent and their child diff_items (if any).
+   * But sortedDiffItems should only be the parent items.
+   */
+  function getPagedParentItems(items: DiffItem[], itemsPerPage: number, page: number) {
+    const pagedParents: DiffItem[] = [];
+    let runningRowCount = 0;
+    let i = 0;
+    // Skip parents/children from previous pages
+    while (i < items.length && runningRowCount < page * itemsPerPage) {
+      runningRowCount += 1; // count parent
+      const childCount =
+        items[i] && Array.isArray(items[i].diff_items) ? items[i].diff_items.length : 0;
+      runningRowCount += childCount; // count children
+      i++;
+    }
+    // Reset runningRowCount for just this page
+    runningRowCount = 0;
+    // i points to first parent to be included on this page
+    while (i < items.length && runningRowCount < itemsPerPage) {
+      const parent = items[i];
+      const childCount = Array.isArray(parent.diff_items) ? parent.diff_items.length : 0;
+      const totalRowsForParent = 1 + childCount;
+      // If adding this parent would cross the page boundary (i.e., would not fit), break
+      if (runningRowCount + totalRowsForParent > itemsPerPage) {
+        break;
+      }
+      pagedParents.push(parent);
+      runningRowCount += totalRowsForParent;
+      i++;
+    }
+    return pagedParents;
+  }
+
+  // Compute total "rows" (parent + children per parent)
+  const totalRows = sortedDiffItems.reduce((count, parent) => {
+    const childCount = Array.isArray(parent.diff_items) ? parent.diff_items.length : 0;
+    return count + 1 + childCount;
+  }, 0);
+
+  const totalPages = Math.ceil(totalRows / ITEMS_PER_PAGE);
+  const lastPageIndex = Math.max(totalPages - 1, 0);
+  const safeCurrentPage = Math.min(currentPage, lastPageIndex);
+
+  // For this page, get the diff parent items whose "rows" (including children) fill this page
+  const currentDiffItems = getPagedParentItems(
+    sortedDiffItems,
+    ITEMS_PER_PAGE,
+    safeCurrentPage
+  );
+
+  const showPagination = totalPages > 1;
+
+  useEffect(() => {
+    if (safeCurrentPage !== currentPage) {
+      setCurrentPage(safeCurrentPage);
+    }
+  }, [currentPage, safeCurrentPage]);
+
+  useEffect(() => {
+    setCurrentPage(0);
+  }, [sort.field, sort.kind, groupDiffItems.length]);
+
+  const handlePageChange = (newPage: number) => {
+    const clampedPage = Math.max(0, Math.min(newPage, lastPageIndex));
+    setCurrentPage(clampedPage);
+  };
+
+  let rowIndex = 0;
+  return (
+    <Flex direction="column" gap="md">
+      <DiffTableWithColumns gridTemplateColumns="150px minmax(200px, 3fr) 180px">
+        <DiffTableHeader>
+          {tableHeaders.map(header => (
+            <SimpleTable.HeaderCell
+              key={header.key}
+              handleSortClick={
+                header.key
+                  ? () =>
+                      setSort({
+                        field: header.key,
+                        kind:
+                          sort?.field === header.key && sort.kind === 'asc'
+                            ? 'desc'
+                            : 'asc',
+                      })
+                  : undefined
+              }
+              sort={sort && sort?.field === header.key ? sort.kind : undefined}
+            >
+              {header.label}
+            </SimpleTable.HeaderCell>
+          ))}
+        </DiffTableHeader>
+        {sortedDiffItems.length === 0 && (
+          <SimpleTable.Empty>
+            <Stack gap="lg" align="center" justify="center">
+              <Text size="lg" variant="muted" bold>
+                {t('No results found')}
+              </Text>
+            </Stack>
+          </SimpleTable.Empty>
+        )}
+        {currentDiffItems.map(groupDiffItem => {
+          rowIndex++;
+          let changeTypeLabel: string;
+          let changeTypeIcon: React.ReactNode;
+          let changeTypeTagType: 'success' | 'error' | 'warning';
+          switch (groupDiffItem.type) {
+            case 'added':
+              changeTypeTagType = 'error';
+              changeTypeLabel = t('Added');
+              changeTypeIcon = <IconAdd />;
+              break;
+            case 'removed':
+              changeTypeTagType = 'success';
+              changeTypeLabel = t('Removed');
+              changeTypeIcon = <IconSubtract />;
+              break;
+            default:
+              changeTypeTagType = 'warning';
+              changeTypeLabel = t('Unchanged');
+              changeTypeIcon = <IconFix />;
+              break;
+          }
+
+          return (
+            <Fragment key={rowIndex}>
+              <SimpleTable.Row key={rowIndex}>
+                <SimpleTable.RowCell>
+                  <Tag icon={changeTypeIcon} type={changeTypeTagType}>
+                    {changeTypeLabel}
+                  </Tag>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
+                  <Tooltip
+                    title={
+                      groupDiffItem.path ? (
+                        <Flex align="start" gap="xs">
+                          <Text monospace>{groupDiffItem.path}</Text>
+                          <CopyToClipboardButton
+                            borderless
+                            size="zero"
+                            text={groupDiffItem.path}
+                            style={{flexShrink: 0}}
+                            aria-label="Copy path to clipboard"
+                          />
+                        </Flex>
+                      ) : null
+                    }
+                    disabled={!groupDiffItem.path}
+                    isHoverable
+                    maxWidth={420}
+                  >
+                    <TextOverflow
+                      ellipsisDirection="right"
+                      style={{display: 'block', width: '100%'}}
+                    >
+                      <Text bold>{groupDiffItem.path ?? ''}</Text>
+                    </TextOverflow>
+                  </Tooltip>
+                </SimpleTable.RowCell>
+                <DiffTableChangeAmountCell changeType={groupDiffItem.type}>
+                  {groupDiffItem.size_diff > 0 ? '+' : '-'}
+                  {formatBytesBase10(Math.abs(groupDiffItem.size_diff))}
+                </DiffTableChangeAmountCell>
+              </SimpleTable.Row>
+              {groupDiffItem.diff_items?.map(diffItem => (
+                <SimpleTable.Row key={++rowIndex}>
+                  <SimpleTable.RowCell>
+                    <Tag icon={changeTypeIcon} type={changeTypeTagType}>
+                      {changeTypeLabel}
+                    </Tag>
+                  </SimpleTable.RowCell>
+                  <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
+                    <Text variant="muted">{diffItem.path ?? ''}</Text>
+                  </SimpleTable.RowCell>
+                  <DiffTableChangeAmountCell changeType={diffItem.type}>
+                    {diffItem.size_diff > 0 ? '+' : '-'}
+                    {formatBytesBase10(Math.abs(diffItem.size_diff))}
+                  </DiffTableChangeAmountCell>
+                </SimpleTable.Row>
+              ))}
+            </Fragment>
+          );
+        })}
+      </DiffTableWithColumns>
+      {showPagination && (
+        <Flex align="center" justify="end" gap="md" padding="md">
+          <Text size="sm" variant="muted">
+            {t('Page %s of %s', safeCurrentPage + 1, totalPages)}
+          </Text>
+          <ButtonBar merged gap="0">
+            <Button
+              size="xs"
+              icon={<IconChevron direction="left" />}
+              aria-label={t('Previous')}
+              onClick={() => handlePageChange(safeCurrentPage - 1)}
+              disabled={safeCurrentPage === 0}
+            />
+            <Button
+              size="xs"
+              icon={<IconChevron direction="right" />}
+              aria-label={t('Next')}
+              onClick={() => handlePageChange(safeCurrentPage + 1)}
+              disabled={safeCurrentPage >= lastPageIndex}
+            />
+          </ButtonBar>
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -102,7 +102,9 @@ export function GroupInsightItemDiffTable({
     while (i < items.length && runningRowCount < page * itemsPerPage) {
       runningRowCount += 1; // count parent
       const childCount =
-        items[i] && Array.isArray(items[i].diff_items) ? items[i].diff_items.length : 0;
+        items[i] && Array.isArray(items[i]!.diff_items)
+          ? items[i]!.diff_items!.length
+          : 0;
       runningRowCount += childCount; // count children
       i++;
     }
@@ -111,13 +113,14 @@ export function GroupInsightItemDiffTable({
     // i points to first parent to be included on this page
     while (i < items.length && runningRowCount < itemsPerPage) {
       const parent = items[i];
-      const childCount = Array.isArray(parent.diff_items) ? parent.diff_items.length : 0;
+      const childCount =
+        parent && Array.isArray(parent.diff_items) ? parent.diff_items.length : 0;
       const totalRowsForParent = 1 + childCount;
       // If adding this parent would cross the page boundary (i.e., would not fit), break
       if (runningRowCount + totalRowsForParent > itemsPerPage) {
         break;
       }
-      pagedParents.push(parent);
+      pagedParents.push(parent!);
       runningRowCount += totalRowsForParent;
       i++;
     }
@@ -209,6 +212,16 @@ export function GroupInsightItemDiffTable({
               changeTypeLabel = t('Removed');
               changeTypeIcon = <IconSubtract />;
               break;
+            case 'increased':
+              changeTypeTagType = 'error';
+              changeTypeLabel = t('Increased');
+              changeTypeIcon = <IconAdd />;
+              break;
+            case 'decreased':
+              changeTypeTagType = 'success';
+              changeTypeLabel = t('Decreased');
+              changeTypeIcon = <IconSubtract />;
+              break;
             default:
               changeTypeTagType = 'warning';
               changeTypeLabel = t('Unchanged');
@@ -253,26 +266,26 @@ export function GroupInsightItemDiffTable({
                   </Tooltip>
                 </SimpleTable.RowCell>
                 <DiffTableChangeAmountCell changeType={groupDiffItem.type}>
-                  {groupDiffItem.size_diff > 0 ? '+' : '-'}
-                  {formatBytesBase10(Math.abs(groupDiffItem.size_diff))}
+                  {`${groupDiffItem.size_diff > 0 ? '+' : '-'}${formatBytesBase10(Math.abs(groupDiffItem.size_diff))}`}
                 </DiffTableChangeAmountCell>
               </SimpleTable.Row>
-              {groupDiffItem.diff_items?.map(diffItem => (
-                <SimpleTable.Row key={++rowIndex}>
-                  <SimpleTable.RowCell>
-                    <Tag icon={changeTypeIcon} type={changeTypeTagType}>
-                      {changeTypeLabel}
-                    </Tag>
-                  </SimpleTable.RowCell>
-                  <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
-                    <Text variant="muted">{diffItem.path ?? ''}</Text>
-                  </SimpleTable.RowCell>
-                  <DiffTableChangeAmountCell changeType={diffItem.type}>
-                    {diffItem.size_diff > 0 ? '+' : '-'}
-                    {formatBytesBase10(Math.abs(diffItem.size_diff))}
-                  </DiffTableChangeAmountCell>
-                </SimpleTable.Row>
-              ))}
+              {groupDiffItem.diff_items?.map(diffItem => {
+                return (
+                  <SimpleTable.Row key={++rowIndex}>
+                    <SimpleTable.RowCell>
+                      <Tag icon={changeTypeIcon} type={changeTypeTagType}>
+                        {changeTypeLabel}
+                      </Tag>
+                    </SimpleTable.RowCell>
+                    <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
+                      <Text variant="muted">{diffItem.path ?? ''}</Text>
+                    </SimpleTable.RowCell>
+                    <DiffTableChangeAmountCell changeType={diffItem.type}>
+                      {`${diffItem.size_diff > 0 ? '+' : '-'}${formatBytesBase10(Math.abs(diffItem.size_diff))}`}
+                    </DiffTableChangeAmountCell>
+                  </SimpleTable.Row>
+                );
+              })}
             </Fragment>
           );
         })}

--- a/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
@@ -1,0 +1,123 @@
+import {useMemo, useState} from 'react';
+
+import {Tag} from '@sentry/scraps/badge/tag';
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import type {DiffItem, InsightDiffItem} from 'sentry/views/preprod/types/appSizeTypes';
+import {getInsightConfig} from 'sentry/views/preprod/utils/insightProcessing';
+
+interface InsightDiffRowProps {
+  children: React.ReactNode;
+  insight: InsightDiffItem;
+  totalInstallSizeBytes: number;
+}
+
+export function InsightDiffRow({
+  insight,
+  children,
+  totalInstallSizeBytes,
+}: InsightDiffRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const config = getInsightConfig(insight.insight_type);
+
+  const allDiffItems: DiffItem[] = useMemo(
+    () => [...insight.file_diffs, ...insight.group_diffs],
+    [insight.file_diffs, insight.group_diffs]
+  );
+
+  const statusCounts = useMemo(() => {
+    const newCount = insight.status === 'new' ? allDiffItems.length : 0;
+    const unresolvedCount =
+      insight.status === 'unresolved'
+        ? allDiffItems.filter(item => item.type === 'added' || item.type === 'increased')
+            .length
+        : 0;
+    const resolvedCount =
+      insight.status === 'resolved'
+        ? allDiffItems.length
+        : insight.status === 'unresolved'
+          ? allDiffItems.filter(
+              item => item.type === 'removed' || item.type === 'decreased'
+            ).length
+          : 0;
+
+    return {new: newCount, unresolved: unresolvedCount, resolved: resolvedCount};
+  }, [insight.status, allDiffItems]);
+
+  // TODO
+  const totalSavingsChangePercentage =
+    insight.total_savings_change === 0
+      ? '0.00'
+      : ((Math.abs(insight.total_savings_change) / totalInstallSizeBytes) * 100).toFixed(
+          2
+        );
+
+  return (
+    <Container background="primary" radius="lg" padding="0" border="primary">
+      <Flex direction="column" gap="0">
+        <Flex align="center" justify="between" padding="xl">
+          <Flex direction="column" gap="xs" style={{flex: 1}}>
+            <Flex align="center" gap="sm" justify="between">
+              <Flex align="center" gap="sm">
+                <Heading as="h3">{config.name}</Heading>
+                <Flex align="center" gap="xs">
+                  {statusCounts.new > 0 && (
+                    <Tag type="promotion">{t('New (%s)', statusCounts.new)}</Tag>
+                  )}
+                  {statusCounts.unresolved > 0 && (
+                    <Tag type="warning">
+                      {t('Unresolved (%s)', statusCounts.unresolved)}
+                    </Tag>
+                  )}
+                  {statusCounts.resolved > 0 && (
+                    <Tag type="success">{t('Resolved (%s)', statusCounts.resolved)}</Tag>
+                  )}
+                </Flex>
+              </Flex>
+
+              <Flex align="center" gap="sm">
+                <Flex direction="column" align="end" gap="xs">
+                  <Text>
+                    {t(
+                      'Potential savings: %s',
+                      formatBytesBase10(insight.total_savings_change)
+                    )}{' '}
+                    <Text
+                      variant={insight.total_savings_change > 0 ? 'danger' : 'success'}
+                    >
+                      ({insight.total_savings_change > 0 ? '+' : ''}
+                      {totalSavingsChangePercentage}%)
+                    </Text>
+                  </Text>
+                </Flex>
+                <Button
+                  priority="transparent"
+                  size="sm"
+                  onClick={() => setIsExpanded(!isExpanded)}
+                  aria-label={isExpanded ? t('Collapse insight') : t('Expand insight')}
+                >
+                  <IconChevron
+                    direction={isExpanded ? 'up' : 'down'}
+                    size="sm"
+                    style={{
+                      transition: 'transform 0.2s ease',
+                    }}
+                  />
+                </Button>
+              </Flex>
+            </Flex>
+            <Text size="sm" variant="muted">
+              {config.description}
+            </Text>
+          </Flex>
+        </Flex>
+        {isExpanded ? children : null}
+      </Flex>
+    </Container>
+  );
+}

--- a/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
@@ -49,7 +49,6 @@ export function InsightDiffRow({
     return {new: newCount, unresolved: unresolvedCount, resolved: resolvedCount};
   }, [insight.status, allDiffItems]);
 
-  // TODO
   const totalSavingsChangePercentage =
     insight.total_savings_change === 0
       ? '0.00'

--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Tag} from '@sentry/scraps/badge/tag';
 import {Button} from '@sentry/scraps/button';
 import {ButtonBar} from '@sentry/scraps/button/buttonBar';
 import {Flex} from '@sentry/scraps/layout/flex';
@@ -175,16 +176,20 @@ export function SizeCompareItemDiffTable({
         {currentDiffItems.map((diffItem, index) => {
           let changeTypeLabel: string;
           let changeTypeIcon: React.ReactNode;
+          let changeTypeTagType: 'success' | 'error' | 'warning';
           switch (diffItem.type) {
             case 'added':
+              changeTypeTagType = 'error';
               changeTypeLabel = t('Added');
               changeTypeIcon = <IconAdd />;
               break;
             case 'removed':
+              changeTypeTagType = 'success';
               changeTypeLabel = t('Removed');
               changeTypeIcon = <IconSubtract />;
               break;
             default:
+              changeTypeTagType = 'warning';
               changeTypeLabel = t('Modified');
               changeTypeIcon = <IconFix />;
               break;
@@ -193,21 +198,16 @@ export function SizeCompareItemDiffTable({
           return (
             <SimpleTable.Row key={startIndex + index}>
               <SimpleTable.RowCell>
-                <ChangeTag changeType={diffItem.type}>
-                  {changeTypeIcon}
+                <Tag icon={changeTypeIcon} type={changeTypeTagType}>
                   {changeTypeLabel}
-                </ChangeTag>
+                </Tag>
               </SimpleTable.RowCell>
               <SimpleTable.RowCell justify="start" style={{minWidth: 0}}>
                 <Tooltip
                   title={
                     diffItem.path ? (
-                      <Flex
-                        align="start"
-                        gap="xs"
-                        style={{maxWidth: '100%', textAlign: 'left'}}
-                      >
-                        <FilePathTooltipText>{diffItem.path}</FilePathTooltipText>
+                      <Flex align="start" gap="xs">
+                        <Text monospace>{diffItem.path}</Text>
                         <CopyToClipboardButton
                           borderless
                           size="zero"
@@ -288,48 +288,13 @@ const SimpleTableHeader = styled(SimpleTable.Header)`
   border-right: 0px;
 `;
 
-const ChangeTag = styled('span')<{changeType: DiffType}>`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
-  border-radius: 3px;
-  font-size: ${p => p.theme.fontSize.sm};
-  background-color: ${p => {
-    switch (p.changeType) {
-      case 'increased':
-      case 'decreased':
-        return p.theme.warningFocus + '14'; // Add transparency (14 = 7% opacity)
-      case 'added':
-        return p.theme.dangerFocus + '14'; // Add transparency (14 = 7% opacity)
-      case 'removed':
-        return p.theme.successFocus + '14'; // Add transparency (14 = 7% opacity)
-      default:
-        throw new Error(`Invalid change type: ${p.changeType}`);
-    }
-  }};
-  color: ${p => {
-    switch (p.changeType) {
-      case 'increased':
-      case 'decreased':
-        return p.theme.warningText;
-      case 'added':
-        return p.theme.dangerText;
-      case 'removed':
-        return p.theme.successText;
-      default:
-        throw new Error(`Invalid change type: ${p.changeType}`);
-    }
-  }};
-`;
-
-const FilePathTooltipText = styled('span')`
-  flex: 1;
-  overflow-wrap: break-word;
-  word-break: break-all;
-  white-space: normal;
-  user-select: text;
-`;
+// const FilePathTooltipText = styled('span')`
+//   flex: 1;
+//   overflow-wrap: break-word;
+//   word-break: break-all;
+//   white-space: normal;
+//   user-select: text;
+// `;
 
 const ChangeAmountCell = styled(SimpleTable.RowCell)<{changeType: DiffType}>`
   align-items: end;

--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -271,11 +271,3 @@ export function SizeCompareItemDiffTable({
     </Flex>
   );
 }
-
-// const FilePathTooltipText = styled('span')`
-//   flex: 1;
-//   overflow-wrap: break-word;
-//   word-break: break-all;
-//   white-space: normal;
-//   user-select: text;
-// `;

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -244,6 +244,9 @@ export function SizeCompareMainContent() {
       {comparisonDataQuery.data?.insight_diff_items &&
         comparisonDataQuery.data.insight_diff_items.length > 0 && (
           <InsightComparisonSection
+            totalInstallSizeBytes={
+              comparisonDataQuery.data?.size_metric_diff_item.head_install_size
+            }
             insightDiffItems={comparisonDataQuery.data.insight_diff_items}
           />
         )}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -18,6 +18,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildComparisonMetricCards} from 'sentry/views/preprod/buildComparison/main/buildComparisonMetricCards';
+import {InsightComparisonSection} from 'sentry/views/preprod/buildComparison/main/insightComparisonSection';
 import {SizeCompareItemDiffTable} from 'sentry/views/preprod/buildComparison/main/sizeCompareItemDiffTable';
 import {SizeCompareSelectedBuilds} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectedBuilds';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
@@ -238,6 +239,14 @@ export function SizeCompareMainContent() {
         comparisonResults={comparisonDataQuery.data}
         comparisonResponse={sizeComparisonQuery.data}
       />
+
+      {/* Insights Section */}
+      {comparisonDataQuery.data?.insight_diff_items &&
+        comparisonDataQuery.data.insight_diff_items.length > 0 && (
+          <InsightComparisonSection
+            insightDiffItems={comparisonDataQuery.data.insight_diff_items}
+          />
+        )}
 
       {/* Items Changed Section */}
       <Container background="primary" radius="lg" padding="0" border="primary">

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -228,6 +228,7 @@ export interface DiffItem {
   path: string;
   size_diff: number;
   type: DiffType;
+  diff_items?: DiffItem[] | null;
 }
 
 // Keep in sync with https://github.com/getsentry/sentry/blob/a85090d7b81832982b43a35c30db9970a0258e99/src/sentry/preprod/models.py#L230

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -246,7 +246,18 @@ interface SizeMetricDiffItem {
   metrics_artifact_type: MetricsArtifactType;
 }
 
+export type InsightStatus = 'new' | 'resolved' | 'unresolved';
+
+export interface InsightDiffItem {
+  file_diffs: DiffItem[];
+  group_diffs: DiffItem[];
+  insight_type: string;
+  status: InsightStatus;
+  total_savings_change: number;
+}
+
 export interface SizeAnalysisComparisonResults {
   diff_items: DiffItem[];
+  insight_diff_items: InsightDiffItem[];
   size_metric_diff_item: SizeMetricDiffItem;
 }

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -150,7 +150,7 @@ export function getInsightConfig(insightType: string): InsightConfig {
     INSIGHT_CONFIGS.find(config => config.key === insightType) ?? {
       name: insightType,
       key: insightType,
-      description: t('No description available'),
+      description: '',
     }
   );
 }

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -145,6 +145,16 @@ export const INSIGHT_CONFIGS: InsightConfig[] = [
   },
 ];
 
+export function getInsightConfig(insightType: string): InsightConfig {
+  return (
+    INSIGHT_CONFIGS.find(config => config.key === insightType) ?? {
+      name: insightType,
+      key: insightType,
+      description: t('No description available'),
+    }
+  );
+}
+
 function markDuplicateImageVariants(processedInsights: ProcessedInsight[]): void {
   const imageInsightTypes = ['image_optimization', 'alternate_icons_optimization'];
   for (const insight of processedInsights) {

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -43,7 +43,7 @@ interface InsightConfig {
   name: string;
 }
 
-const INSIGHT_CONFIGS: InsightConfig[] = [
+export const INSIGHT_CONFIGS: InsightConfig[] = [
   {
     key: 'image_optimization',
     name: t('Image Optimization'),

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -43,7 +43,7 @@ interface InsightConfig {
   name: string;
 }
 
-export const INSIGHT_CONFIGS: InsightConfig[] = [
+const INSIGHT_CONFIGS: InsightConfig[] = [
   {
     key: 'image_optimization',
     name: t('Image Optimization'),


### PR DESCRIPTION
Adds frontend for preprod compare. 

<img width="1316" height="367" alt="Screenshot 2025-12-05 at 5 01 36 PM" src="https://github.com/user-attachments/assets/61697b5c-a1cd-4e64-8d6c-1483ddee06df" />


Designs (we chose to skip "unresolved"):
<img width="1119" height="456" alt="Screenshot 2025-12-03 at 6 55 46 PM" src="https://github.com/user-attachments/assets/1d0d96ad-39d8-4aff-bb94-885771c169d2" />
