### PR TITLE
ref(eap): Create a constant for the EAP insert items endpoint path

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -18,6 +18,7 @@ from sentry.models.project import Project
 from sentry.options.rollout import in_rollout_group
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import json, metrics, snuba
+from sentry.utils.eap import EAP_ITEMS_INSERT_ENDPOINT
 from sentry.utils.safe import get_path
 from sentry.utils.sdk import set_current_event_project
 
@@ -498,7 +499,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
         try:
             resp = snuba._snuba_pool.urlopen(
                 "POST",
-                "/tests/entities/eap_items/insert_bytes",
+                EAP_ITEMS_INSERT_ENDPOINT,
                 fields={"item_0": trace_item.SerializeToString()},
             )
 

--- a/src/sentry/replays/lib/eap/write.py
+++ b/src/sentry/replays/lib/eap/write.py
@@ -13,6 +13,7 @@ from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem as EAPTraceItem
 from sentry.conf.types.kafka_definition import Topic
 from sentry.replays.lib.eap.snuba_transpiler import TRACE_ITEM_TYPE_MAP, TRACE_ITEM_TYPES
 from sentry.replays.lib.kafka import EAP_ITEMS_CODEC, eap_producer
+from sentry.utils.eap import EAP_ITEMS_INSERT_ENDPOINT
 from sentry.utils.kafka_config import get_topic_definition
 
 Value = bool | bytes | str | int | float | Sequence["Value"] | MutableMapping[str, "Value"]
@@ -86,7 +87,7 @@ def write_trace_items_test_suite(trace_items: list[EAPTraceItem]) -> None:
         `docker logs -f snuba-snuba-1`
     """
     response = requests.post(
-        settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+        settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
         files={
             f"item_{i}": trace_item.SerializeToString() for i, trace_item in enumerate(trace_items)
         },

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -151,6 +151,7 @@ from sentry.users.models.user_option import UserOption
 from sentry.users.models.useremail import UserEmail
 from sentry.utils import json
 from sentry.utils.auth import SsoSession
+from sentry.utils.eap import EAP_ITEMS_INSERT_ENDPOINT
 from sentry.utils.json import dumps_htmlsafe
 from sentry.utils.not_set import NOT_SET, NotSet, default_if_not_set
 from sentry.utils.samples import load_data
@@ -1147,7 +1148,7 @@ class SnubaTestCase(BaseTestCase):
                 files[f"item_{i}"] = trace_item.SerializeToString()
             assert (
                 requests.post(
-                    settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+                    settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
                     files=files,
                 ).status_code
                 == 200
@@ -1164,7 +1165,7 @@ class SnubaTestCase(BaseTestCase):
     def store_ourlogs(self, ourlogs):
         files = {f"log_{i}": log.SerializeToString() for i, log in enumerate(ourlogs)}
         response = requests.post(
-            settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
             files=files,
         )
         assert response.status_code == 200
@@ -1175,7 +1176,7 @@ class SnubaTestCase(BaseTestCase):
             for i, trace_metric in enumerate(trace_metrics)
         }
         response = requests.post(
-            settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
             files=files,
         )
         assert response.status_code == 200
@@ -1186,7 +1187,7 @@ class SnubaTestCase(BaseTestCase):
             for i, profile_function in enumerate(profile_functions)
         }
         response = requests.post(
-            settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
             files=files,
         )
         assert response.status_code == 200
@@ -2266,7 +2267,7 @@ class ProfilesSnubaTestCase(
                 files[f"item_{i}"] = trace_item.SerializeToString()
             assert (
                 requests.post(
-                    settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+                    settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
                     files=files,
                 ).status_code
                 == 200
@@ -3897,7 +3898,7 @@ class ReplayEAPTestCase(BaseTestCase):
 
         files = {f"replay_{i}": replay.SerializeToString() for i, replay in enumerate(replays)}
         response = requests.post(
-            settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
             files=files,
         )
         assert response.status_code == 200
@@ -4044,7 +4045,7 @@ class UptimeResultEAPTestCase(BaseTestCase):
             f"uptime_{i}": result.SerializeToString() for i, result in enumerate(uptime_results)
         }
         response = requests.post(
-            settings.SENTRY_SNUBA + "/tests/entities/eap_items/insert_bytes",
+            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
             files=files,
         )
         assert response.status_code == 200

--- a/src/sentry/utils/eap.py
+++ b/src/sentry/utils/eap.py
@@ -1,0 +1,1 @@
+EAP_ITEMS_INSERT_ENDPOINT = "/tests/entities/eap_items/insert_bytes"


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/103566.

Fixes [ID-1112](https://linear.app/getsentry/issue/ID-1112/extract-testsentitieseap-itemsinsert-bytes-endpoint-name-out-into-a).

No change in logic; creates a constant for the EAP insert items endpoint path ("/tests/entities/eap_items/insert_bytes") in a new utils file `src/sentry/utils/eap.py`.