### PR TITLE
feat(triage signals): Auto Trigger Fixes "On" maps to Medium fixability threshold

### DIFF
--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -661,7 +661,7 @@ describe('ProjectSeer', () => {
       ).toBeChecked();
     });
 
-    it('saves "always" when toggled ON, "off" when toggled OFF', async () => {
+    it('saves "medium" when toggled ON, "off" when toggled OFF', async () => {
       const projectPutRequest = MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${project.slug}/`,
         method: 'PUT',
@@ -685,7 +685,7 @@ describe('ProjectSeer', () => {
       await waitFor(() => {
         expect(projectPutRequest).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({data: {autofixAutomationTuning: 'always'}})
+          expect.objectContaining({data: {autofixAutomationTuning: 'medium'}})
         );
       });
 

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -94,8 +94,9 @@ const autofixAutomationToggleField = {
   type: 'boolean',
   saveOnBlur: true,
   saveMessage: t('Automatic Seer settings updated'),
+  // For triage signals V0: toggle ON maps to 'medium' threshold (fixability >= 0.40)
   getData: (data: Record<PropertyKey, unknown>) => ({
-    autofixAutomationTuning: data.autofixAutomationTuning ? 'always' : 'off',
+    autofixAutomationTuning: data.autofixAutomationTuning ? 'medium' : 'off',
   }),
 } satisfies FieldObject;
 


### PR DESCRIPTION
## PR details
+ For the V0, rather than running on all issues with >= event count we are only running for issues with >= med. fixability and >= 10 event count. 
+ This will help us reuse the `_is_issue_fixable` function as is in run_automation.
