### PR TITLE
feat(dashboards): allow a single equation on a chart

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -440,7 +440,11 @@ function Visualize({error, setError}: VisualizeProps) {
                 const isOnlyFieldOrAggregate =
                   fields.length === 2 &&
                   field.kind !== FieldValueKind.EQUATION &&
-                  fields.some(fieldItem => fieldItem.kind === FieldValueKind.EQUATION);
+                  fields.some(fieldItem => fieldItem.kind === FieldValueKind.EQUATION) &&
+                  // The spans dataset can have a single equation, so isOnlyFieldOrAggregate
+                  // is not applicable. The errors dataset requires one series to be
+                  // selected for equations to work.
+                  state.dataset !== WidgetType.SPANS;
 
                 // Depending on the dataset and the display type, we use different options for
                 // displaying in the column select.


### PR DESCRIPTION
Talking with @narsaynorath, I believe we had logic in place, to restrict a single equation on a chart, that's only applicable to the errors dataset. This limitation does not exist on the spans dataset.

This addresses the problem of using equations with a significantly different scale of events than the default `count()` series.

<img width="2308" height="1074" alt="Screenshot 2025-11-20 at 5 10 43 PM" src="https://github.com/user-attachments/assets/fa7c3c17-efaa-4168-9de0-ac879bedcd46" />

