### PR TITLE
fix(eap): Pass `trace_item_type` in `RequestMeta` for `DeleteTraceItemsRequest` RPC

### DIFF
--- a/src/sentry/eventstream/eap.py
+++ b/src/sentry/eventstream/eap.py
@@ -8,9 +8,9 @@ from sentry_protos.snuba.v1.endpoint_delete_trace_items_pb2 import (
     DeleteTraceItemsResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import (
-    TRACE_ITEM_TYPE_OCCURRENCE,
     RequestMeta,
     TraceItemFilterWithType,
+    TraceItemType,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue, IntArray
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
@@ -43,7 +43,7 @@ def delete_groups_from_eap_rpc(
         and_filter=AndFilter(filters=[project_filter, group_id_filter])
     )
     filter_with_type = TraceItemFilterWithType(
-        item_type=TRACE_ITEM_TYPE_OCCURRENCE,
+        item_type=TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,
         filter=combined_filter,
     )
 
@@ -53,6 +53,7 @@ def delete_groups_from_eap_rpc(
             project_ids=[project_id],
             referrer=referrer,
             cogs_category="deletions",
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,
         ),
         filters=[filter_with_type],
     )

--- a/tests/sentry/eventstream/test_eap.py
+++ b/tests/sentry/eventstream/test_eap.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from sentry_protos.snuba.v1.endpoint_delete_trace_items_pb2 import DeleteTraceItemsResponse
-from sentry_protos.snuba.v1.request_common_pb2 import TRACE_ITEM_TYPE_OCCURRENCE, ResponseMeta
+from sentry_protos.snuba.v1.request_common_pb2 import ResponseMeta, TraceItemType
 
 from sentry.deletions.tasks.nodestore import delete_events_from_eap
 from sentry.eventstream.eap import delete_groups_from_eap_rpc
@@ -35,7 +35,7 @@ class TestEAPDeletion(TestCase):
         assert request.meta.cogs_category == "deletions"
 
         assert len(request.filters) == 1
-        assert request.filters[0].item_type == TRACE_ITEM_TYPE_OCCURRENCE
+        assert request.filters[0].item_type == TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
     def test_multiple_group_ids(self, mock_rpc):


### PR DESCRIPTION
Another follow-up to https://github.com/getsentry/sentry/pull/102808.

Fixes [SENTRY-5DCB](https://sentry.sentry.io/issues/7049009648?project=1).

The `trace_item_type` field must be passed in both the `TraceItemFilterWithType` and `RequestMeta` when issuing a `DeleteTraceItemsRequest` RPC. Previously, we were including this only in the `TraceItemFilterWithType`.