### PR TITLE
chore(eco): allow deleting disabled org integrations

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_details.py
@@ -118,9 +118,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
 
         with transaction.atomic(using=router.db_for_write(OrganizationIntegration)):
             updated = False
-            for oi in OrganizationIntegration.objects.filter(
-                id=org_integration.id, status=ObjectStatus.ACTIVE
-            ):
+            for oi in OrganizationIntegration.objects.filter(id=org_integration.id):
                 oi.update(status=ObjectStatus.PENDING_DELETION)
                 updated = True
 

--- a/src/sentry/integrations/api/endpoints/organization_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_details.py
@@ -118,7 +118,9 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
 
         with transaction.atomic(using=router.db_for_write(OrganizationIntegration)):
             updated = False
-            for oi in OrganizationIntegration.objects.filter(id=org_integration.id):
+            for oi in OrganizationIntegration.objects.filter(
+                id=org_integration.id, status__in=[ObjectStatus.ACTIVE, ObjectStatus.DISABLED]
+            ):
                 oi.update(status=ObjectStatus.PENDING_DELETION)
                 updated = True
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import responses
 
 from sentry import audit_log
+from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.integration import Integration
@@ -96,6 +97,18 @@ class OrganizationIntegrationDetailsDeleteTest(OrganizationIntegrationDetailsTes
     method = "delete"
 
     def test_removal(self) -> None:
+        self.get_success_response(self.organization.slug, self.integration.id)
+        assert Integration.objects.filter(id=self.integration.id).exists()
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=self.integration, organization_id=self.organization.id
+        )
+        assert ScheduledDeletion.objects.filter(
+            model_name="OrganizationIntegration", object_id=org_integration.id
+        )
+
+    def test_delete_disabled_integration(self) -> None:
+        self.integration.update(status=ObjectStatus.DISABLED)
         self.get_success_response(self.organization.slug, self.integration.id)
         assert Integration.objects.filter(id=self.integration.id).exists()
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -108,13 +108,14 @@ class OrganizationIntegrationDetailsDeleteTest(OrganizationIntegrationDetailsTes
         )
 
     def test_delete_disabled_integration(self) -> None:
-        self.integration.update(status=ObjectStatus.DISABLED)
-        self.get_success_response(self.organization.slug, self.integration.id)
-        assert Integration.objects.filter(id=self.integration.id).exists()
-
         org_integration = OrganizationIntegration.objects.get(
             integration=self.integration, organization_id=self.organization.id
         )
+        org_integration.update(status=ObjectStatus.DISABLED)
+        self.get_success_response(self.organization.slug, self.integration.id)
+        assert Integration.objects.filter(id=self.integration.id).exists()
+
+        org_integration.refresh_from_db()
         assert ScheduledDeletion.objects.filter(
             model_name="OrganizationIntegration", object_id=org_integration.id
         )


### PR DESCRIPTION
If an org integration is disabled because of plan downgrade, we currently don't allow deleting the org integration through the API because we only filter for active integrations. We should allow deletion of the org integration if it hasn't been queued for deletion already.