### PR TITLE
ref(explorer): rpc to support issue/event detail queries with event id only

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -92,6 +92,7 @@ from sentry.seer.explorer.index_data import (
 from sentry.seer.explorer.tools import (
     execute_table_query,
     execute_timeseries_query,
+    get_issue_and_event_details,
     get_issue_details,
     get_replay_metadata,
     get_repository_definition,
@@ -1209,6 +1210,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "get_issues_for_transaction": rpc_get_issues_for_transaction,
     "get_trace_waterfall": rpc_get_trace_waterfall,
     "get_issue_details": get_issue_details,
+    "get_issue_and_event_details": get_issue_and_event_details,
     "get_profile_flamegraph": rpc_get_profile_flamegraph,
     "execute_table_query": execute_table_query,
     "execute_timeseries_query": execute_timeseries_query,

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -786,6 +786,7 @@ def get_issue_and_event_details(
 
     # First fetch event by ID if issue_id is not provided. Use this to get the issue ID, if any.
     if issue_id is None:
+        uuid.UUID(selected_event)  # Raises ValueError if not valid UUID
         events_result = eventstore.backend.get_events(
             filter=eventstore.Filter(
                 event_ids=[selected_event],
@@ -857,6 +858,7 @@ def get_issue_and_event_details(
         elif selected_event == "recommended":
             event = group.get_recommended_event()
         else:
+            uuid.UUID(selected_event)  # Raises ValueError if not valid UUID
             event = eventstore.backend.get_event_by_id(
                 project_id=group.project_id,
                 event_id=selected_event,

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -732,19 +732,19 @@ def get_issue_and_event_details(
     selected_event: str,
 ) -> dict[str, Any] | None:
     """
-    Tool to get details for a Sentry issue and one of its associated events. The issue_id can be ommitted so it
-    is automatically looked up from the event's grouping info.
+    Tool to get details for a Sentry issue and one of its associated events. null issue_id can be passed so the
+    is issue is looked up from the event. We assume the event is always associated with an issue, otherwise None is returned.
 
     Args:
         organization_id: The ID of the organization to query.
-        issue_id: The issue/group ID (numeric) or short ID (string) to look up. If None, we fill this in with the event's `group` property, which we assume is always present.
+        issue_id: The issue/group ID (numeric) or short ID (string) to look up. If None, we fill this in with the event's `group` property.
         selected_event:
           If issue_id is provided, this is the event to return and must exist in the issue - the options are "oldest", "latest", "recommended", or a UUID.
           If issue_id is not provided, this must be a UUID.
 
     Returns:
         A dict containing:
-            Issue fields:
+            Issue fields: aside from `issue` these are nullable if an error occurred.
             `issue`: Serialized issue details.
             `tags_overview`: A summary of all tags in the issue.
             `event_timeseries`: Event counts over time for the issue.
@@ -754,7 +754,7 @@ def get_issue_and_event_details(
             Event fields:
             `event`: Serialized event details.
             `event_id`: The event ID of the selected event.
-            `event_trace_id`: The trace ID of the selected event.
+            `event_trace_id`: The trace ID of the selected event. Nullable.
             `project_id`: The event and issue's project ID.
             `project_slug`: The event and issue's project slug.
 

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -733,8 +733,8 @@ def get_issue_and_event_details(
 ) -> dict[str, Any] | None:
     """
     Tool to get details for a Sentry issue and one of its associated events. The issue_id can be ommitted so it
-    is automatically looked up from the event info. In this case, if the event is ungrouped we return no issue data.
-    Event details are always returned.
+    is automatically looked up from the event's grouping info. If the rare case the event is ungrouped, we return 
+    null for all issue fields. Event details are always returned.
 
     Args:
         organization_id: The ID of the organization to query.

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -733,7 +733,7 @@ def get_issue_and_event_details(
 ) -> dict[str, Any] | None:
     """
     Tool to get details for a Sentry issue and one of its associated events. The issue_id can be ommitted so it
-    is automatically looked up from the event's grouping info. If the rare case the event is ungrouped, we return 
+    is automatically looked up from the event's grouping info. If the rare case the event is ungrouped, we return
     null for all issue fields. Event details are always returned.
 
     Args:

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -757,7 +757,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
 
     @patch("sentry.models.group.get_recommended_event")
     @patch("sentry.seer.explorer.tools.get_all_tags_overview")
-    def _test_get_issue_and_event_details_success(
+    def _test_get_ie_details_basic(
         self,
         mock_get_tags,
         mock_get_recommended_event,
@@ -875,16 +875,16 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
                     selected_event=selected_event,
                 )
 
-    def test_get_issue_and_event_details_success_int_id(self):
-        self._test_get_issue_and_event_details_success(issue_id_type="int_id")
+    def test_get_ie_details_basic_int_id(self):
+        self._test_get_ie_details_basic(issue_id_type="int_id")
 
-    def test_get_issue_and_event_details_success_short_id(self):
-        self._test_get_issue_and_event_details_success(issue_id_type="short_id")
+    def test_get_ie_details_basic_short_id(self):
+        self._test_get_ie_details_basic(issue_id_type="short_id")
 
-    def test_get_issue_and_event_details_success_null_issue_id(self):
-        self._test_get_issue_and_event_details_success(issue_id_type="none")
+    def test_get_ie_details_basic_null_issue_id(self):
+        self._test_get_ie_details_basic(issue_id_type="none")
 
-    def test_get_issue_and_event_details_nonexistent_organization(self):
+    def test_get_ie_details_nonexistent_organization(self):
         """Test returns None when organization doesn't exist."""
         # Create a valid group.
         data = load_data("python", timestamp=before_now(minutes=5))
@@ -901,7 +901,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
         )
         assert result is None
 
-    def test_get_issue_and_event_details_nonexistent_issue(self):
+    def test_get_ie_details_nonexistent_issue(self):
         """Test returns None when the requested issue doesn't exist."""
         # Call with nonexistent issue ID.
         result = get_issue_and_event_details(
@@ -914,7 +914,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
     @patch("sentry.models.group.get_oldest_or_latest_event")
     @patch("sentry.models.group.get_recommended_event")
     @patch("sentry.seer.explorer.tools.get_all_tags_overview")
-    def test_get_issue_and_event_details_no_event_found(
+    def test_get_ie_details_no_event_found(
         self, mock_get_tags, mock_get_recommended_event, mock_get_oldest_or_latest_event
     ):
         """Test returns None when issue is found but selected_event is not."""
@@ -939,7 +939,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
             )
             assert result is None, et
 
-    def test_get_issue_and_event_details_no_event_found_null_issue_id(self):
+    def test_get_ie_details_no_event_found_null_issue_id(self):
         """Test returns None when issue_id is not provided and selected_event is not found."""
         _ = self.project  # Create an active project.
         result = get_issue_and_event_details(
@@ -950,7 +950,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
         assert result is None
 
     @patch("sentry.seer.explorer.tools.get_all_tags_overview")
-    def test_get_issue_and_event_details_tags_exception(self, mock_get_tags):
+    def test_get_ie_details_tags_exception(self, mock_get_tags):
         mock_get_tags.side_effect = Exception("Test exception")
         """Test other fields are returned with null tags_overview when tag util fails."""
         # Create a valid group.
@@ -975,7 +975,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
 
     @patch("sentry.models.group.get_recommended_event")
     @patch("sentry.seer.explorer.tools.get_all_tags_overview")
-    def test_get_issue_and_event_details_with_assigned_user(
+    def test_get_ie_details_with_assigned_user(
         self,
         mock_get_tags,
         mock_get_recommended_event,
@@ -1007,9 +1007,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
 
     @patch("sentry.models.group.get_recommended_event")
     @patch("sentry.seer.explorer.tools.get_all_tags_overview")
-    def test_get_issue_and_event_details_with_assigned_team(
-        self, mock_get_tags, mock_get_recommended_event
-    ):
+    def test_get_ie_details_with_assigned_team(self, mock_get_tags, mock_get_recommended_event):
         mock_get_tags.return_value = {"tags_overview": [{"key": "test_tag", "top_values": []}]}
         data = load_data("python", timestamp=before_now(minutes=5))
         event = self.store_event(data=data, project_id=self.project.id)
@@ -1038,7 +1036,7 @@ class TestGetIssueAndEventDetails(APITransactionTestCase, SnubaTestCase, Occurre
     @patch("sentry.seer.explorer.tools.client")
     @patch("sentry.models.group.get_recommended_event")
     @patch("sentry.seer.explorer.tools.get_all_tags_overview")
-    def test_get_issue_and_event_details_timeseries_resolution(
+    def test_get_ie_details_timeseries_resolution(
         self,
         mock_get_tags,
         mock_get_recommended_event,


### PR DESCRIPTION
New rpc for [AIML-1655: support issue_id=None in get_issue_details tool](https://linear.app/getsentry/issue/AIML-1655/support-issue-id=none-in-get-issue-details-tool). This is a modified + renamed version of get_issue_details.

Tests todo, looking for feedback first