### PR TITLE
feat(Replay): Strip Dash Before EAP Replay Query

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -33,6 +33,9 @@ def query_replay_instance_eap(
     request_user_id: int | None,
     referrer: str = "replays.query.details_query",
 ):
+    # EAP stores replay_id in hex without dashes
+    replay_ids_no_dashes = [replay_id.replace("-", "") for replay_id in replay_ids]
+
     select = [
         Column("replay_id"),
         Function("min", parameters=[Column("project_id")], alias="agg_project_id"),
@@ -71,7 +74,7 @@ def query_replay_instance_eap(
         match=Entity("replays"),
         select=select,
         where=[
-            Condition(Column("replay_id"), Op.IN, replay_ids),
+            Condition(Column("replay_id"), Op.IN, replay_ids_no_dashes),
         ],
         groupby=[Column("replay_id")],
         granularity=Granularity(3600),


### PR DESCRIPTION
As title says, this PR fixes a suspected "404 Not Found" bug that occurs when an EAP query is executed for a replay ID. The reason this is caused is likely because replay IDs are stored in hex without dashes in EAP, but the current query includes the dashes in the replay ID query, resulting in no data found.

Relates to: https://linear.app/getsentry/issue/REPLAY-824/create-query-function-for-replay-details