### PR TITLE
feat: migrations should noop faster

### DIFF
--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -65,8 +65,6 @@ def _upgrade(
     _check_big_ints()
     _check_history()
 
-    no_migrations_to_run = True
-
     for db_conn in settings.DATABASES.keys():
         # Run migrations on all non-read replica connections.
         # This is used for sentry.io as our production database runs on multiple hosts.
@@ -80,8 +78,6 @@ def _upgrade(
             if not plan:
                 click.echo(f"No migrations to run for {db_conn}")
                 continue
-
-            no_migrations_to_run = False
 
             click.echo(f"Running migrations for {db_conn}")
             dj_call_command(
@@ -112,7 +108,7 @@ def _upgrade(
 
         call_command("sentry.runner.commands.repair.repair")
 
-    if not no_migrations_to_run and run_post_upgrade:
+    if run_post_upgrade:
         post_upgrade.send(sender=SiloMode.get_current_mode(), interactive=interactive)
 
 

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.db import connections
 from django.db.utils import ProgrammingError
 
+from sentry.new_migrations.monkey.executor import SentryMigrationExecutor
 from sentry.runner.decorators import configuration
 from sentry.signals import post_upgrade
 from sentry.silo.base import SiloMode
@@ -64,10 +65,24 @@ def _upgrade(
     _check_big_ints()
     _check_history()
 
+    no_migrations_to_run = True
+
     for db_conn in settings.DATABASES.keys():
         # Run migrations on all non-read replica connections.
         # This is used for sentry.io as our production database runs on multiple hosts.
         if not settings.DATABASES[db_conn].get("REPLICA_OF", False):
+            # We want the noop case to be quickly skipped.
+            click.echo(f"Checking for migrations to run for {db_conn}")
+            conn = connections[db_conn]
+            executor = SentryMigrationExecutor(conn)
+            targets = executor.loader.graph.leaf_nodes()
+            plan = executor.migration_plan(targets)
+            if not plan:
+                click.echo(f"No migrations to run for {db_conn}")
+                continue
+
+            no_migrations_to_run = False
+
             click.echo(f"Running migrations for {db_conn}")
             dj_call_command(
                 "migrate",
@@ -97,7 +112,7 @@ def _upgrade(
 
         call_command("sentry.runner.commands.repair.repair")
 
-    if run_post_upgrade:
+    if not no_migrations_to_run and run_post_upgrade:
         post_upgrade.send(sender=SiloMode.get_current_mode(), interactive=interactive)
 
 


### PR DESCRIPTION
currently migrations noop takes ~10 minutes in us and a few minutes each in other regions and customers

i'd like to optimize the noop case by only checking the migrations table before dj_call_command migrate does all the heavy stuff like loading apps and models

`getsentry upgrade --verbosity=2 --no-repair --noinput` local noop before and after (3 databases - default, secondary, billing):

```
Executed in   62.95 secs    fish           external
   usr time   61.39 secs    0.18 millis   61.39 secs
   sys time    0.97 secs    3.43 millis    0.96 secs

Executed in    3.46 secs    fish           external
   usr time    2.50 secs    0.24 millis    2.50 secs
   sys time    0.54 secs    4.33 millis    0.54 secs
```


