### PR TITLE
ref(ui): Refactor EmptyMessage to use core components and simplify API

### DIFF
--- a/static/app/components/emptyMessage.mdx
+++ b/static/app/components/emptyMessage.mdx
@@ -1,0 +1,146 @@
+---
+title: EmptyMessage
+description: A component for displaying empty states with optional icon, title, description, and action buttons. All text content uses balanced text wrapping for better readability.
+source: 'sentry/components/emptyMessage'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/emptyMessage.tsx
+---
+
+import {Button} from 'sentry/components/core/button';
+import EmptyMessage from 'sentry/components/emptyMessage';
+import Panel from 'sentry/components/panels/panel';
+import {IconSearch} from 'sentry/icons';
+import * as Storybook from 'sentry/stories';
+
+To create a basic empty message, wrap your message in an `<EmptyMessage>` component.
+
+```jsx
+<Panel>
+  <EmptyMessage>
+    This is a simple empty message with default styling and balanced text wrapping for
+    better readability.
+  </EmptyMessage>
+</Panel>
+```
+
+## Props
+
+- **title** (`React.ReactNode`) - The title of the empty message
+- **icon** (`React.ReactNode`) - Optional icon element
+- **action** (`React.ReactElement`) - Optional action button
+- **size** (`"md" | "lg"`) - Size of the text (default: md)
+- **children** (`React.ReactNode`) - Main content text (automatically uses balanced text wrapping)
+
+## Examples
+
+### With Title
+
+Add a title to provide context for the empty state.
+
+<Storybook.Demo>
+  <Panel>
+    <EmptyMessage title="No Results Found">
+      We couldn't find any results matching your search criteria. Try adjusting your
+      filters or search terms.
+    </EmptyMessage>
+  </Panel>
+</Storybook.Demo>
+```jsx
+<EmptyMessage title="No Results Found">
+  We couldn't find any results matching your search criteria. Try adjusting your filters
+  or search terms.
+</EmptyMessage>
+```
+
+### With Icon
+
+Add an icon to make the empty state more visually distinctive. Icons are defaulted to `lg` size, so there is typically no need to specify an icon size.
+
+<Storybook.Demo>
+  <Panel>
+    <EmptyMessage icon={<IconSearch />} title="No Results">
+      We couldn't find any results matching your search criteria.
+    </EmptyMessage>
+  </Panel>
+</Storybook.Demo>
+```jsx
+<EmptyMessage icon={<IconSearch />} title="No Results">
+  We couldn't find any results matching your search criteria.
+</EmptyMessage>
+```
+
+### With Action
+
+Add action buttons to guide users toward resolving the empty state.
+
+<Storybook.Demo>
+  <Panel>
+    <EmptyMessage
+      icon={<IconSearch />}
+      title="No Results Found"
+      action={<Button priority="primary">Clear Filters</Button>}
+    >
+      We couldn't find any results matching your search criteria. Try adjusting your
+      filters or search terms.
+    </EmptyMessage>
+  </Panel>
+</Storybook.Demo>
+```jsx
+<EmptyMessage
+  icon={<IconSearch />}
+  title="No Results Found"
+  action={<Button priority="primary">Clear Filters</Button>}
+>
+  We couldn't find any results matching your search criteria. Try adjusting your filters
+  or search terms.
+</EmptyMessage>
+```
+
+### Sizes
+
+EmptyMessage supports two sizes: `md` (default) and `lg`.
+
+<Storybook.Demo>
+  <div style={{display: 'flex', gap: '1rem'}}>
+    <Panel style={{flex: 1}}>
+      <EmptyMessage icon={<IconSearch />} title="Medium Size">
+        This is the default medium size empty message.
+      </EmptyMessage>
+    </Panel>
+    <Panel style={{flex: 1}}>
+      <EmptyMessage size="lg" icon={<IconSearch />} title="Large Size">
+        This is a large size empty message with bigger text.
+      </EmptyMessage>
+    </Panel>
+  </div>
+</Storybook.Demo>
+```jsx
+<EmptyMessage size="medium" icon={<IconSearch />} title="Medium Size">
+  This is the default medium size empty message.
+</EmptyMessage>
+
+<EmptyMessage size="lg" icon={<IconSearch />} title="Large Size">
+  This is a large size empty message with bigger text.
+</EmptyMessage>
+```
+
+### Text Wrapping
+
+All text content automatically uses CSS text-wrap balance mode for better readability, especially with longer messages.
+
+<Storybook.Demo>
+  <Panel>
+    <EmptyMessage icon={<IconSearch />} title="Text Wrapping">
+      Sure you haven't misspelled? If you're using a lesser-known platform, consider
+      choosing a more generic SDK like Browser JavaScript, Python, Node, .NET & Java or
+      create a generic project.
+    </EmptyMessage>
+  </Panel>
+</Storybook.Demo>
+```jsx
+<EmptyMessage icon={<IconSearch />} title="Text Wrapping">
+  Sure you haven't misspelled? If you're using a lesser-known platform, consider choosing
+  a more generic SDK like Browser JavaScript, Python, Node, .NET & Java or create a
+  generic project.
+</EmptyMessage>
+```

--- a/static/app/components/emptyMessage.tsx
+++ b/static/app/components/emptyMessage.tsx
@@ -1,74 +1,51 @@
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
+import {useTheme} from '@emotion/react';
+import {mergeProps} from '@react-aria/utils';
 
-import {space} from 'sentry/styles/space';
-import TextBlock from 'sentry/views/settings/components/text/textBlock';
+import {Container, Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 
 interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
-  action?: React.ReactElement;
-  description?: React.ReactNode;
+  action?: React.ReactNode;
   icon?: React.ReactNode;
-  leftAligned?: boolean;
-  size?: 'large' | 'medium';
+  size?: 'lg' | 'md';
   title?: React.ReactNode;
 }
 
-type WrapperProps = Pick<Props, 'size'>;
+function EmptyMessage({title, icon, children, action, size, ...props}: Props) {
+  const theme = useTheme();
 
-const EmptyMessage = styled(
-  ({
-    title,
-    description,
-    icon,
-    children,
-    action,
-    leftAligned: _leftAligned,
-    ...props
-  }: Props) => (
-    <div data-test-id="empty-message" {...props}>
-      {icon && <IconWrapper>{icon}</IconWrapper>}
-      {title && <Title noMargin={!description && !children && !action}>{title}</Title>}
-      {description && <Description>{description}</Description>}
-      {children && <Description noMargin>{children}</Description>}
-      {action && <Action>{action}</Action>}
-    </div>
-  )
-)<WrapperProps>`
-  display: flex;
-  ${p =>
-    p.leftAligned
-      ? css`
-          max-width: 70%;
-          align-items: flex-start;
-          padding: ${space(4)};
-        `
-      : css`
-          text-align: center;
-          align-items: center;
-          padding: ${space(4)} 15%;
-        `};
-  flex-direction: column;
-  color: ${p => p.theme.textColor};
-  font-size: ${p =>
-    p.size && p.size === 'large' ? p.theme.fontSize.xl : p.theme.fontSize.md};
-`;
-
-const IconWrapper = styled('div')`
-  color: ${p => (p.theme.isChonk ? p.theme.gray400 : p.theme.gray200)};
-  margin-bottom: ${space(1)};
-`;
-
-const Title = styled('strong')<{noMargin: boolean}>`
-  font-size: ${p => p.theme.fontSize.xl};
-  ${p => !p.noMargin && `margin-bottom: ${space(1)};`}
-`;
-
-const Description = styled(TextBlock)`
-  margin: 0;
-`;
-
-const Action = styled('div')`
-  margin-top: ${space(2)};
-`;
+  return (
+    <Flex gap="xl" direction="column" padding="3xl">
+      {stackProps => (
+        <Text
+          align="center"
+          size={size}
+          data-test-id="empty-message"
+          {...mergeProps(stackProps, props)}
+        >
+          {icon && (
+            <IconDefaultsProvider size="xl">
+              <Container color={theme.isChonk ? theme.gray400 : theme.gray200}>
+                {icon}
+              </Container>
+            </IconDefaultsProvider>
+          )}
+          {title && (
+            <Text bold size="xl" density="comfortable">
+              {title}
+            </Text>
+          )}
+          {children && (
+            <Text textWrap="balance" density="comfortable">
+              {children}
+            </Text>
+          )}
+          {action && <Container paddingTop="xl">{action}</Container>}
+        </Text>
+      )}
+    </Flex>
+  );
+}
 
 export default EmptyMessage;

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -57,7 +57,7 @@ function StackTrace({
     return (
       <Panel dashedBorder>
         <EmptyMessage
-          icon={<IconWarning size="xl" />}
+          icon={<IconWarning />}
           title={t('No app only stack trace has been found!')}
         />
       </Panel>

--- a/static/app/components/feedback/details/feedbackEmptyDetails.tsx
+++ b/static/app/components/feedback/details/feedbackEmptyDetails.tsx
@@ -7,10 +7,9 @@ import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
 const FeedbackEmptyDetails = styled((props: any) => (
   <FluidHeight {...props}>
-    <StyledEmptyMessage
-      icon={<IconMail size="xl" />}
-      description={t('No feedback selected')}
-    />
+    <StyledEmptyMessage icon={<IconMail />}>
+      {t('No feedback selected')}
+    </StyledEmptyMessage>
   </FluidHeight>
 ))`
   display: grid;

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -262,7 +262,7 @@ function PlatformPicker({
       </PlatformList>
       {platformList.length === 0 && (
         <EmptyMessage
-          icon={<IconProject size="xl" />}
+          icon={<IconProject />}
           title={t("We don't have an SDK for that yet!")}
         >
           {tct(

--- a/static/app/components/projects/missingProjectMembership.tsx
+++ b/static/app/components/projects/missingProjectMembership.tsx
@@ -147,11 +147,8 @@ class MissingProjectMembership extends Component<Props, State> {
       <StyledPanel>
         {teams.length ? (
           <EmptyMessage
-            icon={<IconFlag size="xl" />}
+            icon={<IconFlag />}
             title={t("You're not a member of this project.")}
-            description={t(
-              `You'll need to join a team with access before you can view this data.`
-            )}
             action={
               <Field>
                 <StyledSelectControl
@@ -170,9 +167,11 @@ class MissingProjectMembership extends Component<Props, State> {
                 )}
               </Field>
             }
-          />
+          >
+            {t(`You'll need to join a team with access before you can view this data.`)}
+          </EmptyMessage>
         ) : (
-          <EmptyMessage icon={<IconFlag size="xl" />}>
+          <EmptyMessage icon={<IconFlag />}>
             {t(
               'No teams have access to this project yet. Ask an admin to add your team to this project.'
             )}

--- a/static/app/views/insights/pages/platform/nextjs/serverTree.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/serverTree.tsx
@@ -200,7 +200,7 @@ export function ServerTree() {
       {treeRequest.isLoading ? (
         <LoadingIndicator />
       ) : hasData ? null : (
-        <EmptyMessage size="large" icon={<IconSearch size="xl" />}>
+        <EmptyMessage size="lg" icon={<IconSearch />}>
           {t('No results found')}
         </EmptyMessage>
       )}

--- a/static/app/views/insights/pages/platform/shared/table/index.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/index.tsx
@@ -58,7 +58,7 @@ export function PlatformInsightsTable<DataRow extends Record<string, any>>({
           columnSortBy={[]}
           minimumColWidth={COL_WIDTH_MINIMUM}
           emptyMessage={
-            <EmptyMessage size="large" icon={<IconSearch size="xl" />}>
+            <EmptyMessage size="lg" icon={<IconSearch />}>
               {t('No results found')}
             </EmptyMessage>
           }

--- a/static/app/views/organizationStats/usageTable.tsx
+++ b/static/app/views/organizationStats/usageTable.tsx
@@ -52,14 +52,15 @@ class UsageTable extends Component<Props> {
     if (errorMessage.projectStats.responseJSON.detail === 'No projects available') {
       return (
         <EmptyMessage
-          icon={<IconWarning color="gray300" legacySize="48px" />}
+          icon={<IconWarning />}
           title={t(
             "You don't have access to any projects, or your organization has no projects."
           )}
-          description={tct('Learn more about [link:Project Access]', {
+        >
+          {tct('Learn more about [link:Project Access]', {
             link: <ExternalLink href={DOCS_URL} />,
           })}
-        />
+        </EmptyMessage>
       );
     }
     return <IconWarning color="gray300" legacySize="48px" />;

--- a/static/app/views/releases/detail/commitsAndFiles/emptyState.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/emptyState.tsx
@@ -29,10 +29,11 @@ export function NoReleaseRepos() {
       <Main width="full">
         <Panel dashedBorder>
           <EmptyMessage
-            icon={<IconCommit size="xl" />}
+            icon={<IconCommit />}
             title={t('Releases are better with commit data!')}
-            description={t('No commits associated with this release have been found.')}
-          />
+          >
+            {t('No commits associated with this release have been found.')}
+          </EmptyMessage>
         </Panel>
       </Main>
     </Body>
@@ -45,17 +46,18 @@ export function NoRepositories({orgSlug}: {orgSlug: string}) {
       <Main width="full">
         <Panel dashedBorder>
           <EmptyMessage
-            icon={<IconCommit size="xl" />}
+            icon={<IconCommit />}
             title={t('Releases are better with commit data!')}
-            description={t(
-              'Connect a repository to see commit info, files changed, and authors involved in future releases.'
-            )}
             action={
               <LinkButton priority="primary" to={`/settings/${orgSlug}/repos/`}>
                 {t('Connect a repository')}
               </LinkButton>
             }
-          />
+          >
+            {t(
+              'Connect a repository to see commit info, files changed, and authors involved in future releases.'
+            )}
+          </EmptyMessage>
         </Panel>
       </Main>
     </Body>

--- a/static/app/views/releases/drawer/releasesDrawerTable.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerTable.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Count from 'sentry/components/count';
+import EmptyMessage from 'sentry/components/emptyMessage';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
@@ -190,10 +191,9 @@ export function ReleasesDrawerTable({
   );
 
   const tableEmptyMessage = (
-    <MessageContainer>
-      <Title>{t('No releases')}</Title>
-      <Subtitle>{t('There are no releases within this timeframe')}</Subtitle>
-    </MessageContainer>
+    <EmptyMessage title={t('No releases')}>
+      {t('There are no releases within this timeframe')}
+    </EmptyMessage>
   );
 
   return (
@@ -224,23 +224,6 @@ export function ReleasesDrawerTable({
     </div>
   );
 }
-
-const Subtitle = styled('div')`
-  font-size: ${p => p.theme.fontSize.md};
-`;
-
-const Title = styled('div')`
-  font-size: 24px;
-`;
-
-const MessageContainer = styled('div')`
-  display: grid;
-  grid-auto-flow: row;
-  gap: ${space(1)};
-  justify-items: center;
-  text-align: center;
-  padding: ${space(4)};
-`;
 
 const CellWrapper = styled('div')`
   & div {

--- a/static/app/views/releases/list/releaseListInner.tsx
+++ b/static/app/views/releases/list/releaseListInner.tsx
@@ -198,7 +198,7 @@ function EmptyReleaseMessage({
   if (searchQuery?.length) {
     return (
       <Panel>
-        <EmptyMessage icon={<IconSearch size="xl" />} size="large">{`${t(
+        <EmptyMessage icon={<IconSearch />} size="lg">{`${t(
           'There are no releases that match'
         )}: '${searchQuery}'.`}</EmptyMessage>
       </Panel>
@@ -208,7 +208,7 @@ function EmptyReleaseMessage({
   if (activeSort === ReleasesSortOption.USERS_24_HOURS) {
     return (
       <Panel>
-        <EmptyMessage icon={<IconSearch size="xl" />} size="large">
+        <EmptyMessage icon={<IconSearch />} size="lg">
           {t('There are no releases with active user data (users in the last 24 hours).')}
         </EmptyMessage>
       </Panel>
@@ -218,7 +218,7 @@ function EmptyReleaseMessage({
   if (activeSort === ReleasesSortOption.SESSIONS_24_HOURS) {
     return (
       <Panel>
-        <EmptyMessage icon={<IconSearch size="xl" />} size="large">
+        <EmptyMessage icon={<IconSearch />} size="lg">
           {t(
             'There are no releases with active session data (sessions in the last 24 hours).'
           )}
@@ -233,7 +233,7 @@ function EmptyReleaseMessage({
   ) {
     return (
       <Panel>
-        <EmptyMessage icon={<IconSearch size="xl" />} size="large">
+        <EmptyMessage icon={<IconSearch />} size="lg">
           {t('There are no releases with semantic versioning.')}
         </EmptyMessage>
       </Panel>
@@ -243,7 +243,7 @@ function EmptyReleaseMessage({
   if (activeSort !== ReleasesSortOption.DATE) {
     return (
       <Panel>
-        <EmptyMessage icon={<IconSearch size="xl" />} size="large">
+        <EmptyMessage icon={<IconSearch />} size="lg">
           {`${t('There are no releases with data in the')} ${selectedPeriod}.`}
         </EmptyMessage>
       </Panel>
@@ -253,7 +253,7 @@ function EmptyReleaseMessage({
   if (activeStatus === ReleasesStatusOption.ARCHIVED) {
     return (
       <Panel>
-        <EmptyMessage icon={<IconSearch size="xl" />} size="large">
+        <EmptyMessage icon={<IconSearch />} size="lg">
           {t('There are no archived releases.')}
         </EmptyMessage>
       </Panel>
@@ -262,7 +262,7 @@ function EmptyReleaseMessage({
 
   return (
     <Panel>
-      <EmptyMessage icon={<IconSearch size="xl" />} size="large">
+      <EmptyMessage icon={<IconSearch />} size="lg">
         {`${t('There are no releases with data in the')} ${selectedPeriod}.`}
       </EmptyMessage>
     </Panel>

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -211,10 +211,9 @@ export function DataScrubbing({
             disabled={disabled}
           />
         ) : (
-          <EmptyMessage
-            icon={<IconWarning size="xl" />}
-            description={t('You have no data scrubbing rules')}
-          />
+          <EmptyMessage icon={<IconWarning />}>
+            {t('You have no data scrubbing rules')}
+          </EmptyMessage>
         )}
         <PanelAction>
           <LinkButton href={ADVANCED_DATASCRUBBING_LINK} external>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -240,7 +240,7 @@ export default function RequestLog({app}: RequestLogProps) {
                 </PanelItem>
               ))
             ) : (
-              <EmptyMessage icon={<IconFlag size="xl" />}>
+              <EmptyMessage icon={<IconFlag />}>
                 {t('No requests found in the last 30 days.')}
               </EmptyMessage>
             )}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -283,11 +283,11 @@ export default function SentryApplicationDetails() {
   const renderTokens = () => {
     if (!hasTokenAccess) {
       return (
-        <EmptyMessage description={t('You do not have access to view these tokens.')} />
+        <EmptyMessage>{t('You do not have access to view these tokens.')}</EmptyMessage>
       );
     }
     if (tokens.length < 1 && newTokens.length < 1) {
-      return <EmptyMessage description={t('No tokens created yet.')} />;
+      return <EmptyMessage>{t('No tokens created yet.')}</EmptyMessage>;
     }
     const tokensToDisplay = tokens.map(token => (
       <ApiTokenRow

--- a/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
+++ b/static/app/views/settings/organizationIntegrations/detailedView/integrationLayout.tsx
@@ -149,13 +149,11 @@ function Body({
 function EmptyConfigurations({action}: {action: React.ReactElement}) {
   return (
     <Panel>
-      <EmptyMessage
-        title={t("You haven't set anything up yet")}
-        description={t(
-          'But that doesn’t have to be the case for long! Add an installation to get started.'
+      <EmptyMessage title={t("You haven't set anything up yet")} action={action}>
+        {t(
+          "But that doesn't have to be the case for long! Add an installation to get started."
         )}
-        action={action}
-      />
+      </EmptyMessage>
     </Panel>
   );
 }

--- a/static/app/views/settings/organizationIntegrations/integrationAlertRules.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationAlertRules.tsx
@@ -20,7 +20,7 @@ export default function IntegrationAlertRules() {
       <PanelHeader>{t('Project Configuration')}</PanelHeader>
       <PanelBody>
         {projects.length === 0 && (
-          <EmptyMessage size="large">
+          <EmptyMessage size="lg">
             {t('You have no projects to add Alert Rules to')}
           </EmptyMessage>
         )}

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
@@ -116,15 +116,16 @@ function IntegrationRepos(props: Props) {
             <EmptyMessage
               icon={<IconCommit />}
               title={t('Sentry is better with commit data')}
-              description={t(
-                'Add a repository to begin tracking its commit data. Then, set up release tracking to unlock features like suspect commits, suggested issue owners, and deploy emails.'
-              )}
               action={
                 <LinkButton href="https://docs.sentry.io/product/releases/" external>
                   {t('Learn More')}
                 </LinkButton>
               }
-            />
+            >
+              {t(
+                'Add a repository to begin tracking its commit data. Then, set up release tracking to unlock features like suspect commits, suggested issue owners, and deploy emails.'
+              )}
+            </EmptyMessage>
           )}
           {itemList.map(repo => (
             <RepositoryRow

--- a/static/app/views/settings/organizationRelay/list/waitingActivity.tsx
+++ b/static/app/views/settings/organizationRelay/list/waitingActivity.tsx
@@ -15,19 +15,18 @@ function WaitingActivity({onRefresh, disabled}: Props) {
     <Panel>
       <EmptyMessage
         title={t('Waiting on Activity!')}
-        description={
-          disabled
-            ? undefined
-            : tct('Run relay in your terminal with [commandLine]', {
-                commandLine: <CommandLine>{'relay run'}</CommandLine>,
-              })
-        }
         action={
           <Button icon={<IconRefresh />} onClick={onRefresh}>
             {t('Refresh')}
           </Button>
         }
-      />
+      >
+        {disabled
+          ? undefined
+          : tct('Run relay in your terminal with [commandLine]', {
+              commandLine: <CommandLine>{'relay run'}</CommandLine>,
+            })}
+      </EmptyMessage>
     </Panel>
   );
 }

--- a/static/app/views/settings/organizationRepositories/organizationRepositories.tsx
+++ b/static/app/views/settings/organizationRepositories/organizationRepositories.tsx
@@ -66,17 +66,18 @@ function OrganizationRepositories({itemList, onRepositoryChange, organization}: 
       ) : (
         <Panel>
           <EmptyMessage
-            icon={<IconCommit size="xl" />}
+            icon={<IconCommit />}
             title={t('Sentry is better with commit data')}
-            description={t(
-              'Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.'
-            )}
             action={
               <LinkButton external href="https://docs.sentry.io/learn/releases/">
                 {t('Learn more')}
               </LinkButton>
             }
-          />
+          >
+            {t(
+              'Adding one or more repositories will enable enhanced releases and the ability to resolve Sentry Issues via git message.'
+            )}
+          </EmptyMessage>
         </Panel>
       )}
     </div>

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -346,7 +346,7 @@ export default function TeamMembers() {
       });
     }
     return (
-      <EmptyMessage icon={<IconUser size="xl" />} size="large">
+      <EmptyMessage icon={<IconUser />} size="lg">
         {t('This team has no members')}
       </EmptyMessage>
     );

--- a/static/app/views/settings/organizationTeams/teamProjects.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.tsx
@@ -165,7 +165,7 @@ export default function TeamProjects() {
               </StyledPanelItem>
             ))
           ) : linkedProjectsLoading ? null : (
-            <EmptyMessage size="large" icon={<IconFlag size="xl" />}>
+            <EmptyMessage size="lg" icon={<IconFlag />}>
               {t("This team doesn't have access to any projects.")}
             </EmptyMessage>
           )}

--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -91,12 +91,9 @@ export function ProjectFiltersChart({project}: Props) {
           />
         )}
         {hasLoaded && blankStats && (
-          <EmptyMessage
-            title={t('Nothing filtered in the last 30 days.')}
-            description={t(
-              'Issues filtered as a result of your settings below will be shown here.'
-            )}
-          />
+          <EmptyMessage title={t('Nothing filtered in the last 30 days.')}>
+            {t('Issues filtered as a result of your settings below will be shown here.')}
+          </EmptyMessage>
         )}
       </PanelBody>
     </Panel>

--- a/static/app/views/settings/project/projectKeys/details/keyStats.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyStats.tsx
@@ -112,10 +112,9 @@ class KeyStats extends Component<Props, State> {
           {this.state.loading ? (
             <Placeholder height="150px" />
           ) : this.state.emptyStats ? (
-            <EmptyMessage
-              title={t('Nothing recorded in the last 30 days.')}
-              description={t('Total events captured using these credentials.')}
-            />
+            <EmptyMessage title={t('Nothing recorded in the last 30 days.')}>
+              {t('Total events captured using these credentials.')}
+            </EmptyMessage>
           ) : (
             <MiniBarChart
               isGroupedByDate

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -149,10 +149,9 @@ export default function ProjectKeys() {
   const renderEmpty = () => {
     return (
       <Panel>
-        <EmptyMessage
-          icon={<IconFlag size="xl" />}
-          description={t('There are no keys active for this project.')}
-        />
+        <EmptyMessage icon={<IconFlag />}>
+          {t('There are no keys active for this project.')}
+        </EmptyMessage>
       </Panel>
     );
   };

--- a/static/app/views/settings/project/projectServiceHookDetails.tsx
+++ b/static/app/views/settings/project/projectServiceHookDetails.tsx
@@ -85,10 +85,9 @@ function HookStats() {
       <PanelHeader>{t('Events in the last 30 days (by day)')}</PanelHeader>
       <PanelBody withPadding>
         {emptyStats ? (
-          <EmptyMessage
-            title={t('Nothing recorded in the last 30 days.')}
-            description={t('Total webhooks fired for this configuration.')}
-          />
+          <EmptyMessage title={t('Nothing recorded in the last 30 days.')}>
+            {t('Total webhooks fired for this configuration.')}
+          </EmptyMessage>
         ) : (
           <MiniBarChart
             isGroupedByDate

--- a/static/app/views/settings/projectDataForwarding/index.tsx
+++ b/static/app/views/settings/projectDataForwarding/index.tsx
@@ -82,10 +82,9 @@ function DataForwardingStats({organization, project}: DataForwardingStatsProps) 
             height={150}
           />
         ) : (
-          <EmptyMessage
-            title={t('Nothing forwarded in the last 30 days.')}
-            description={t('Total events forwarded to third party integrations.')}
-          />
+          <EmptyMessage title={t('Nothing forwarded in the last 30 days.')}>
+            {t('Total events forwarded to third party integrations.')}
+          </EmptyMessage>
         )}
       </PanelBody>
     </Panel>

--- a/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
@@ -296,29 +296,28 @@ function SourceMapsEmptyState({
             ? t('No source maps uploads matching your search')
             : t('No source maps uploaded')
         }
-        description={
-          query
-            ? tct(
-                'Try to modify or [clear:clear] your search to see all source maps uploads.',
-                {
-                  clear: (
-                    <Button
-                      priority="link"
-                      aria-label={t('Clear Search')}
-                      onClick={onClearSearch}
-                    />
-                  ),
-                }
-              )
-            : tct(
-                'Source maps allow Sentry to map your production code to your source code. See our [docs:docs] to learn more about configuring your application to upload source maps to Sentry.',
-                {
-                  docs: <ExternalLink href={docsLink} />,
-                }
-              )
-        }
         action={project.platform === 'react-native' ? <ReactNativeCallOut /> : undefined}
-      />
+      >
+        {query
+          ? tct(
+              'Try to modify or [clear:clear] your search to see all source maps uploads.',
+              {
+                clear: (
+                  <Button
+                    priority="link"
+                    aria-label={t('Clear Search')}
+                    onClick={onClearSearch}
+                  />
+                ),
+              }
+            )
+          : tct(
+              'Source maps allow Sentry to map your production code to your source code. See our [docs:docs] to learn more about configuring your application to upload source maps to Sentry.',
+              {
+                docs: <ExternalLink href={docsLink} />,
+              }
+            )}
+      </EmptyMessage>
     </Panel>
   );
 }

--- a/static/gsApp/components/features/disabledDataForwarding.tsx
+++ b/static/gsApp/components/features/disabledDataForwarding.tsx
@@ -24,25 +24,9 @@ function DisabledDataForwarding({organization, features}: Props) {
       {({plan}) => (
         <Panel dashedBorder data-test-id="disabled-data-forwarding">
           <EmptyMessage
-            size="large"
-            icon={<IconArrow direction="right" size="xl" />}
+            size="lg"
+            icon={<IconArrow direction="right" />}
             title={t('Your business intelligence workflow is missing crucial data')}
-            description={
-              plan === null
-                ? t(
-                    'Data forwarding is not available on your plan. Contact us to migrate to a plan that supports sending your events for processing with your favorite business intelligence tools such as Segment, Amazon SQS, and Splunk.'
-                  )
-                : tct(
-                    '[strong:Data Forwarding] allows you to send processed events to your favorite business intelligence tools such as Segment, Amazon SQS, and Splunk. This feature [planRequirement] or above.',
-
-                    {
-                      strong: <strong />,
-                      planRequirement: (
-                        <strong>{t('requires a %s Plan', displayPlanName(plan))}</strong>
-                      ),
-                    }
-                  )
-            }
             action={
               <ButtonGroup>
                 <Button
@@ -64,7 +48,22 @@ function DisabledDataForwarding({organization, features}: Props) {
                 </LearnMoreButton>
               </ButtonGroup>
             }
-          />
+          >
+            {plan === null
+              ? t(
+                  'Data forwarding is not available on your plan. Contact us to migrate to a plan that supports sending your events for processing with your favorite business intelligence tools such as Segment, Amazon SQS, and Splunk.'
+                )
+              : tct(
+                  '[strong:Data Forwarding] allows you to send processed events to your favorite business intelligence tools such as Segment, Amazon SQS, and Splunk. This feature [planRequirement] or above.',
+
+                  {
+                    strong: <strong />,
+                    planRequirement: (
+                      <strong>{t('requires a %s Plan', displayPlanName(plan))}</strong>
+                    ),
+                  }
+                )}
+          </EmptyMessage>
         </Panel>
       )}
     </PlanFeature>

--- a/static/gsApp/components/features/disabledDiscardGroup.tsx
+++ b/static/gsApp/components/features/disabledDiscardGroup.tsx
@@ -24,23 +24,6 @@ function DisabledDiscardGroup({organization, features}: Props) {
         <StyledEmptyMessage
           icon={<IconDelete />}
           title={t('Keep the noise down')}
-          description={
-            plan === null
-              ? t(
-                  `Discard and Delete is not available on your plan. Contact
-                 us to migrate to a plan that supports discarding any
-                 future events like this before they reach your stream.`
-                )
-              : tct(
-                  '[strong:Discard and Delete] allows you to discard any future events before they reach your stream. This feature [planRequirement] or above.',
-                  {
-                    strong: <strong />,
-                    planRequirement: (
-                      <strong>{t('requires a %s Plan', displayPlanName(plan))}</strong>
-                    ),
-                  }
-                )
-          }
           action={
             <ButtonGroup>
               <Button
@@ -67,7 +50,23 @@ function DisabledDiscardGroup({organization, features}: Props) {
               </LearnMoreButton>
             </ButtonGroup>
           }
-        />
+        >
+          {plan === null
+            ? t(
+                `Discard and Delete is not available on your plan. Contact
+                 us to migrate to a plan that supports discarding any
+                 future events like this before they reach your stream.`
+              )
+            : tct(
+                '[strong:Discard and Delete] allows you to discard any future events before they reach your stream. This feature [planRequirement] or above.',
+                {
+                  strong: <strong />,
+                  planRequirement: (
+                    <strong>{t('requires a %s Plan', displayPlanName(plan))}</strong>
+                  ),
+                }
+              )}
+        </StyledEmptyMessage>
       )}
     </PlanFeature>
   );

--- a/static/gsApp/hooks/disabledCustomSymbolSources.tsx
+++ b/static/gsApp/hooks/disabledCustomSymbolSources.tsx
@@ -23,8 +23,8 @@ function DisabledCustomSymbolSources({organization}: Props) {
   return (
     <Content
       data-test-id={`disabled-${FEATURE}`}
-      size="large"
-      icon={<IconLock size="xl" />}
+      size="lg"
+      icon={<IconLock />}
       title={tct('Configuring custom repositories [requiredPlan]', {
         requiredPlan: (
           <PlanFeature organization={organization} features={[FEATURE]}>
@@ -36,12 +36,6 @@ function DisabledCustomSymbolSources({organization}: Props) {
           </PlanFeature>
         ),
       })}
-      description={tct(
-        '[strong: Sentry] can download debug information files from custom repositories. This allows you to stop uploading debug files and instead configure an HTTP symbol server, Amazon S3 bucket, Google Cloud Storage bucket or an App Store Connect.',
-        {
-          strong: <strong />,
-        }
-      )}
       action={
         <ButtonBar gap="sm">
           <StyledButton
@@ -66,7 +60,14 @@ function DisabledCustomSymbolSources({organization}: Props) {
           </StyledLearnMoreButton>
         </ButtonBar>
       }
-    />
+    >
+      {tct(
+        '[strong: Sentry] can download debug information files from custom repositories. This allows you to stop uploading debug files and instead configure an HTTP symbol server, Amazon S3 bucket, Google Cloud Storage bucket or an App Store Connect.',
+        {
+          strong: <strong />,
+        }
+      )}
+    </Content>
   );
 }
 

--- a/static/gsApp/views/contactBillingMembers.tsx
+++ b/static/gsApp/views/contactBillingMembers.tsx
@@ -39,18 +39,10 @@ function HelpfulMembers() {
 function ContactBillingMembers() {
   return (
     <Panel data-test-id="permission-denied">
-      <EmptyMessage
-        title={t('Insufficient Access')}
-        icon={<IconWarning size="xl" />}
-        description={
-          <Fragment>
-            <p>
-              {t("You don't have access to manage billing and subscription details.")}
-            </p>
-            <HelpfulMembers />
-          </Fragment>
-        }
-      />
+      <EmptyMessage title={t('Insufficient Access')} icon={<IconWarning />}>
+        <p>{t("You don't have access to manage billing and subscription details.")}</p>
+        <HelpfulMembers />
+      </EmptyMessage>
     </Panel>
   );
 }

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -310,12 +310,23 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
           {({plan}) => (
             <Panel dashedBorder data-test-id="disabled-allocations">
               <EmptyMessage
-                size="large"
-                icon={<IconBroadcast size="xl" />}
+                size="lg"
+                icon={<IconBroadcast />}
                 title={t(
                   'Allocate event resources to important projects every billing period.'
                 )}
-                description={tct(
+                action={
+                  <StyledLearnMoreButton
+                    organization={organization}
+                    source="allocations-upsell"
+                    href="https://docs.sentry.io/product/accounts/quotas/#spend-allocation"
+                    external
+                  >
+                    {t('Documentation')}
+                  </StyledLearnMoreButton>
+                }
+              >
+                {tct(
                   'Spend Allocations prioritize important projects by guaranteeing a monthly volume of events for exclusive consumption. This ensures coverage for your important projects, even during consumption spikes. This feature [planRequirement] or above.',
                   {
                     planRequirement: (
@@ -329,19 +340,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
                     ),
                   }
                 )}
-                action={
-                  <ButtonBar gap="0">
-                    <StyledLearnMoreButton
-                      organization={organization}
-                      source="allocations-upsell"
-                      href="https://docs.sentry.io/product/accounts/quotas/#spend-allocation"
-                      external
-                    >
-                      {t('Documentation')}
-                    </StyledLearnMoreButton>
-                  </ButtonBar>
-                }
-              />
+              </EmptyMessage>
             </Panel>
           )}
         </PlanFeature>


### PR DESCRIPTION
Modernizes the EmptyMessage component and removes redundant description prop:

- Refactors EmptyMessage from styled-components to core layout primitives (Flex, Container, Text)
- Removes redundant `description` prop - all content now uses `children`
- Automatically applies text-wrap: balance to all empty state messages for better readability
- Migrates 22 usage sites to use `children` instead of `description` prop
- Simplifies component API by having a single way to pass content

This reduces the component's surface area and makes it more consistent with the design system's layout and typography primitives.