### PR TITLE
chore(preprod): amplitude events for emerge pages (EME-638)

### DIFF
--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -28,6 +28,7 @@ interface PreprodBuildsTableProps {
   projectSlug: string;
   error?: boolean;
   hasSearchQuery?: boolean;
+  onRowClick?: (build: BuildDetailsApiResponse, rowIndex: number) => void;
   pageLinks?: string | null;
 }
 
@@ -36,6 +37,7 @@ export function PreprodBuildsTable({
   isLoading,
   error,
   pageLinks,
+  onRowClick,
   organizationSlug,
   projectSlug,
   hasSearchQuery,
@@ -54,12 +56,12 @@ export function PreprodBuildsTable({
     </SimpleTable.Header>
   );
 
-  const renderBuildRow = (build: BuildDetailsApiResponse) => {
+  const renderBuildRow = (build: BuildDetailsApiResponse, rowIndex: number) => {
     const linkUrl = `/organizations/${organizationSlug}/preprod/${projectSlug}/${build.id}`;
 
     return (
       <SimpleTable.Row key={build.id}>
-        <FullRowLink to={linkUrl}>
+        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build, rowIndex)}>
           <InteractionStateLayer />
           <SimpleTable.RowCell justify="start">
             {build.app_info?.name || build.app_info?.app_id ? (
@@ -176,7 +178,9 @@ export function PreprodBuildsTable({
       </SimpleTable.Empty>
     );
   } else {
-    tableContent = <Fragment>{builds.map(renderBuildRow)}</Fragment>;
+    tableContent = (
+      <Fragment>{builds.map((build, index) => renderBuildRow(build, index))}</Fragment>
+    );
   }
 
   return (

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -28,7 +28,7 @@ interface PreprodBuildsTableProps {
   projectSlug: string;
   error?: boolean;
   hasSearchQuery?: boolean;
-  onRowClick?: (build: BuildDetailsApiResponse, rowIndex: number) => void;
+  onRowClick?: (build: BuildDetailsApiResponse) => void;
   pageLinks?: string | null;
 }
 
@@ -56,12 +56,12 @@ export function PreprodBuildsTable({
     </SimpleTable.Header>
   );
 
-  const renderBuildRow = (build: BuildDetailsApiResponse, rowIndex: number) => {
+  const renderBuildRow = (build: BuildDetailsApiResponse) => {
     const linkUrl = `/organizations/${organizationSlug}/preprod/${projectSlug}/${build.id}`;
 
     return (
       <SimpleTable.Row key={build.id}>
-        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build, rowIndex)}>
+        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
           <InteractionStateLayer />
           <SimpleTable.RowCell justify="start">
             {build.app_info?.name || build.app_info?.app_id ? (
@@ -178,9 +178,7 @@ export function PreprodBuildsTable({
       </SimpleTable.Empty>
     );
   } else {
-    tableContent = (
-      <Fragment>{builds.map((build, index) => renderBuildRow(build, index))}</Fragment>
-    );
+    tableContent = <Fragment>{builds.map(build => renderBuildRow(build))}</Fragment>;
   }
 
   return (

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -73,6 +73,8 @@ import type {OnboardingEventParameters} from './analytics/onboardingAnalyticsEve
 import {onboardingEventMap} from './analytics/onboardingAnalyticsEvents';
 import type {PerformanceEventParameters} from './analytics/performanceAnalyticsEvents';
 import {performanceEventMap} from './analytics/performanceAnalyticsEvents';
+import type {PreprodBuildEventParameters} from './analytics/preprodBuildAnalyticsEvents';
+import {preprodBuildEventMap} from './analytics/preprodBuildAnalyticsEvents';
 import type {ProfilingEventParameters} from './analytics/profilingAnalyticsEvents';
 import {profilingEventMap} from './analytics/profilingAnalyticsEvents';
 import type {ProjectCreationEventParameters} from './analytics/projectCreationAnalyticsEvents';
@@ -113,6 +115,7 @@ interface EventParameters
     MonitorsEventParameters,
     PerformanceEventParameters,
     ProfilingEventParameters,
+    PreprodBuildEventParameters,
     ReleasesEventParameters,
     ReplayEventParameters,
     SearchEventParameters,
@@ -151,6 +154,7 @@ const allEventMap: Record<string, string | null> = {
   ...monitorsEventMap,
   ...nextJsInsightsEventMap,
   ...performanceEventMap,
+  ...preprodBuildEventMap,
   ...tracingEventMap,
   ...profilingEventMap,
   ...exploreAnalyticsEventMap,

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -15,6 +15,7 @@ export type PreprodBuildEventParameters = {
   'preprod.builds.compare.select_base_build': BasePreprodBuildEvent;
   'preprod.builds.compare.trigger_comparison': BasePreprodBuildEvent;
   'preprod.builds.details.compare_build_clicked': BasePreprodBuildEvent;
+  'preprod.builds.details.delete_build': BasePreprodBuildEvent;
   'preprod.builds.details.expand_insight': BasePreprodBuildEvent & {
     insight_key: string;
   };
@@ -36,6 +37,7 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
   'preprod.builds.details.expand_insight': 'Preprod Build Details: Insight Expanded',
   'preprod.builds.details.open_insight_details_modal':
     'Preprod Build Details: Open Insight Details Modal',
+  'preprod.builds.details.delete_build': 'Preprod Build Details: Delete Build',
   'preprod.builds.details.compare_build_clicked':
     'Preprod Build Details: Compare Clicked',
   'preprod.builds.compare.go_to_build_details':

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -15,10 +15,7 @@ export type PreprodBuildEventParameters = {
     slot?: 'head' | 'base';
   };
   'preprod.builds.compare.select_base_build': BasePreprodBuildEvent;
-  'preprod.builds.compare.trigger_comparison': BasePreprodBuildEvent & {
-    base_build_id: string;
-    head_build_id: string;
-  };
+  'preprod.builds.compare.trigger_comparison': BasePreprodBuildEvent;
   'preprod.builds.details.compare_build_clicked': BasePreprodBuildEvent;
   'preprod.builds.details.expand_insight': BasePreprodBuildEvent & {
     insight_key: string;
@@ -28,7 +25,6 @@ export type PreprodBuildEventParameters = {
   };
   'preprod.builds.details.open_insights_sidebar': BasePreprodBuildEvent & {
     source: 'metric_card' | 'insight_table';
-    insight_count?: number;
   };
   'preprod.builds.release.build_row_clicked': BasePreprodBuildEvent;
 };

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -4,59 +4,51 @@ import makeAnalyticsFunction from './makeAnalyticsFunction';
 
 type BasePreprodBuildEvent = {
   organization: Organization;
-  base_id?: string;
   build_id?: string;
-  head_id?: string;
   platform?: string | null;
   project_slug?: string;
   project_type?: string | null;
 };
 
 export type PreprodBuildEventParameters = {
-  'preprod.builds.compare_build_clicked': BasePreprodBuildEvent & {
+  'preprod.builds.compare.go_to_build_details': BasePreprodBuildEvent & {
     slot?: 'head' | 'base';
   };
-  'preprod.builds.compare_build_selected': BasePreprodBuildEvent;
-  'preprod.builds.compare_selection_viewed': BasePreprodBuildEvent;
-  'preprod.builds.compare_state_viewed': BasePreprodBuildEvent;
-  'preprod.builds.compare_trigger_clicked': BasePreprodBuildEvent;
-  'preprod.builds.details_compare_clicked': BasePreprodBuildEvent;
-  'preprod.builds.details_delete_clicked': BasePreprodBuildEvent;
-  'preprod.builds.details_insight_action_clicked': BasePreprodBuildEvent & {
+  'preprod.builds.compare.select_base_build': BasePreprodBuildEvent;
+  'preprod.builds.compare.trigger_comparison': BasePreprodBuildEvent & {
+    base_build_id: string;
+    head_build_id: string;
+  };
+  'preprod.builds.details.compare_build_clicked': BasePreprodBuildEvent;
+  'preprod.builds.details.expand_insight': BasePreprodBuildEvent & {
     insight_key: string;
   };
-  'preprod.builds.details_insight_expanded': BasePreprodBuildEvent & {
+  'preprod.builds.details.open_insight_details_modal': BasePreprodBuildEvent & {
     insight_key: string;
-    insight_name?: string;
   };
-  'preprod.builds.details_insights_opened': BasePreprodBuildEvent & {
+  'preprod.builds.details.open_insights_sidebar': BasePreprodBuildEvent & {
+    source: 'metric_card' | 'insight_table';
     insight_count?: number;
-    source?: string;
   };
-  'preprod.builds.details_viewed': BasePreprodBuildEvent;
-  'preprod.builds.release_row_clicked': BasePreprodBuildEvent;
-  'preprod.builds.release_tab_viewed': BasePreprodBuildEvent & {
-    has_results?: boolean;
-  };
+  'preprod.builds.release.build_row_clicked': BasePreprodBuildEvent;
 };
 
 type PreprodBuildAnalyticsKey = keyof PreprodBuildEventParameters;
 
 export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | null> = {
-  'preprod.builds.release_tab_viewed': 'Preprod Builds: Release Tab Viewed',
-  'preprod.builds.release_row_clicked': 'Preprod Builds: Release Row Clicked',
-  'preprod.builds.details_viewed': 'Preprod Build Details: Viewed',
-  'preprod.builds.details_insights_opened': 'Preprod Build Details: Insights Opened',
-  'preprod.builds.details_insight_expanded': 'Preprod Build Details: Insight Expanded',
-  'preprod.builds.details_insight_action_clicked':
-    'Preprod Build Details: Insight Action Clicked',
-  'preprod.builds.details_compare_clicked': 'Preprod Build Details: Compare Clicked',
-  'preprod.builds.details_delete_clicked': 'Preprod Build Details: Delete Clicked',
-  'preprod.builds.compare_selection_viewed': 'Preprod Build Comparison: Selection Viewed',
-  'preprod.builds.compare_state_viewed': 'Preprod Build Comparison: Compare View Viewed',
-  'preprod.builds.compare_build_clicked': 'Preprod Build Comparison: Build Clicked',
-  'preprod.builds.compare_build_selected': 'Preprod Build Comparison: Base Selected',
-  'preprod.builds.compare_trigger_clicked': 'Preprod Build Comparison: Compare Triggered',
+  'preprod.builds.release.build_row_clicked': 'Preprod Builds: Release Build Row Clicked',
+  'preprod.builds.details.open_insights_sidebar':
+    'Preprod Build Details: Insights Sidebar Opened',
+  'preprod.builds.details.expand_insight': 'Preprod Build Details: Insight Expanded',
+  'preprod.builds.details.open_insight_details_modal':
+    'Preprod Build Details: Open Insight Details Modal',
+  'preprod.builds.details.compare_build_clicked':
+    'Preprod Build Details: Compare Clicked',
+  'preprod.builds.compare.go_to_build_details':
+    'Preprod Build Comparison: Go to Build Details',
+  'preprod.builds.compare.select_base_build': 'Preprod Build Comparison: Base Selected',
+  'preprod.builds.compare.trigger_comparison':
+    'Preprod Build Comparison: Compare Triggered',
 };
 
 export const trackPreprodBuildAnalytics =

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -1,7 +1,5 @@
 import type {Organization} from 'sentry/types/organization';
 
-import makeAnalyticsFunction from './makeAnalyticsFunction';
-
 type BasePreprodBuildEvent = {
   organization: Organization;
   build_id?: string;
@@ -46,6 +44,3 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
   'preprod.builds.compare.trigger_comparison':
     'Preprod Build Comparison: Compare Triggered',
 };
-
-export const trackPreprodBuildAnalytics =
-  makeAnalyticsFunction<PreprodBuildEventParameters>(preprodBuildEventMap);

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -1,0 +1,63 @@
+import type {Organization} from 'sentry/types/organization';
+
+import makeAnalyticsFunction from './makeAnalyticsFunction';
+
+type BasePreprodBuildEvent = {
+  organization: Organization;
+  base_id?: string;
+  build_id?: string;
+  head_id?: string;
+  platform?: string | null;
+  project_slug?: string;
+  project_type?: string | null;
+};
+
+export type PreprodBuildEventParameters = {
+  'preprod.builds.compare_build_clicked': BasePreprodBuildEvent & {
+    slot?: 'head' | 'base';
+  };
+  'preprod.builds.compare_build_selected': BasePreprodBuildEvent;
+  'preprod.builds.compare_selection_viewed': BasePreprodBuildEvent;
+  'preprod.builds.compare_state_viewed': BasePreprodBuildEvent;
+  'preprod.builds.compare_trigger_clicked': BasePreprodBuildEvent;
+  'preprod.builds.details_compare_clicked': BasePreprodBuildEvent;
+  'preprod.builds.details_delete_clicked': BasePreprodBuildEvent;
+  'preprod.builds.details_insight_action_clicked': BasePreprodBuildEvent & {
+    insight_key: string;
+  };
+  'preprod.builds.details_insight_expanded': BasePreprodBuildEvent & {
+    insight_key: string;
+    insight_name?: string;
+  };
+  'preprod.builds.details_insights_opened': BasePreprodBuildEvent & {
+    insight_count?: number;
+    source?: string;
+  };
+  'preprod.builds.details_viewed': BasePreprodBuildEvent;
+  'preprod.builds.release_row_clicked': BasePreprodBuildEvent;
+  'preprod.builds.release_tab_viewed': BasePreprodBuildEvent & {
+    has_results?: boolean;
+  };
+};
+
+type PreprodBuildAnalyticsKey = keyof PreprodBuildEventParameters;
+
+export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | null> = {
+  'preprod.builds.release_tab_viewed': 'Preprod Builds: Release Tab Viewed',
+  'preprod.builds.release_row_clicked': 'Preprod Builds: Release Row Clicked',
+  'preprod.builds.details_viewed': 'Preprod Build Details: Viewed',
+  'preprod.builds.details_insights_opened': 'Preprod Build Details: Insights Opened',
+  'preprod.builds.details_insight_expanded': 'Preprod Build Details: Insight Expanded',
+  'preprod.builds.details_insight_action_clicked':
+    'Preprod Build Details: Insight Action Clicked',
+  'preprod.builds.details_compare_clicked': 'Preprod Build Details: Compare Clicked',
+  'preprod.builds.details_delete_clicked': 'Preprod Build Details: Delete Clicked',
+  'preprod.builds.compare_selection_viewed': 'Preprod Build Comparison: Selection Viewed',
+  'preprod.builds.compare_state_viewed': 'Preprod Build Comparison: Compare View Viewed',
+  'preprod.builds.compare_build_clicked': 'Preprod Build Comparison: Build Clicked',
+  'preprod.builds.compare_build_selected': 'Preprod Build Comparison: Base Selected',
+  'preprod.builds.compare_trigger_clicked': 'Preprod Build Comparison: Compare Triggered',
+};
+
+export const trackPreprodBuildAnalytics =
+  makeAnalyticsFunction<PreprodBuildEventParameters>(preprodBuildEventMap);

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -7,7 +7,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconClose, IconCommit, IconFocus, IconLock, IconTelescope} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
@@ -34,7 +34,7 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
     <LinkButton
       to={buildUrl}
       onClick={() =>
-        trackPreprodBuildAnalytics('preprod.builds.compare.go_to_build_details', {
+        trackAnalytics('preprod.builds.compare.go_to_build_details', {
           organization,
           build_id: buildId,
           project_slug: projectId,
@@ -155,7 +155,7 @@ export function SizeCompareSelectedBuilds({
         <Button
           onClick={() => {
             if (baseBuildDetails) {
-              trackPreprodBuildAnalytics('preprod.builds.compare.trigger_comparison', {
+              trackAnalytics('preprod.builds.compare.trigger_comparison', {
                 organization,
                 project_slug: projectId,
                 project_type: projectType,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -35,7 +35,7 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
     <LinkButton
       to={buildUrl}
       onClick={() =>
-        trackPreprodBuildAnalytics('preprod.builds.compare_build_clicked', {
+        trackPreprodBuildAnalytics('preprod.builds.compare.go_to_build_details', {
           organization,
           build_id: buildId,
           project_slug: projectId,
@@ -125,7 +125,6 @@ export function SizeCompareSelectedBuilds({
 }: SizeCompareSelectedBuildsProps) {
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
-  const headId = headBuildDetails.id;
   const headPlatform = headBuildDetails.app_info?.platform ?? null;
   const projectType = headBuildDetails.app_info?.platform ?? null;
 
@@ -158,13 +157,13 @@ export function SizeCompareSelectedBuilds({
         <Button
           onClick={() => {
             if (baseBuildDetails) {
-              trackPreprodBuildAnalytics('preprod.builds.compare_trigger_clicked', {
+              trackPreprodBuildAnalytics('preprod.builds.compare.trigger_comparison', {
                 organization,
-                head_id: headId,
-                base_id: baseBuildDetails.id,
                 project_slug: projectId,
                 project_type: projectType,
                 platform: headPlatform,
+                base_build_id: baseBuildDetails.id,
+                head_build_id: headBuildDetails.id,
               });
               onTriggerComparison();
             }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -124,7 +124,6 @@ export function SizeCompareSelectedBuilds({
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
   const platform = headBuildDetails.app_info?.platform ?? null;
-  const projectType = headBuildDetails.app_info?.platform ?? null;
 
   return (
     <ComparisonContainer>
@@ -158,8 +157,8 @@ export function SizeCompareSelectedBuilds({
               trackAnalytics('preprod.builds.compare.trigger_comparison', {
                 organization,
                 project_slug: projectId,
-                project_type: projectType,
                 platform,
+                build_id: headBuildDetails.id,
               });
               onTriggerComparison();
             }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -29,7 +29,6 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
 
   const buildUrl = `/organizations/${organization.slug}/preprod/${projectId}/${buildId}/`;
   const platform = buildDetails.app_info?.platform ?? null;
-  const projectType = buildDetails.app_info?.platform ?? null;
 
   return (
     <LinkButton
@@ -39,7 +38,6 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
           organization,
           build_id: buildId,
           project_slug: projectId,
-          project_type: projectType,
           platform,
           slot,
         })

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -48,7 +48,7 @@ function BuildButton({
           build_id: buildId,
           project_slug: projectId,
           platform,
-          project_type: projectType ?? null,
+          project_type: projectType,
           slot,
         })
       }
@@ -173,7 +173,7 @@ export function SizeCompareSelectedBuilds({
                 project_slug: projectId,
                 platform,
                 build_id: headBuildDetails.id,
-                project_type: projectType ?? null,
+                project_type: projectType,
               });
               onTriggerComparison();
             }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -162,8 +162,6 @@ export function SizeCompareSelectedBuilds({
                 project_slug: projectId,
                 project_type: projectType,
                 platform: headPlatform,
-                base_build_id: baseBuildDetails.id,
-                head_build_id: headBuildDetails.id,
               });
               onTriggerComparison();
             }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -7,6 +7,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconClose, IconCommit, IconFocus, IconLock, IconTelescope} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -16,11 +17,19 @@ interface BuildButtonProps {
   buildDetails: BuildDetailsApiResponse;
   icon: React.ReactNode;
   label: string;
+  projectType: string | null;
   slot: 'head' | 'base';
   onRemove?: () => void;
 }
 
-function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonProps) {
+function BuildButton({
+  buildDetails,
+  icon,
+  label,
+  onRemove,
+  slot,
+  projectType,
+}: BuildButtonProps) {
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
   const sha = buildDetails.vcs_info?.head_sha?.substring(0, 7);
@@ -39,6 +48,7 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
           build_id: buildId,
           project_slug: projectId,
           platform,
+          project_type: projectType ?? null,
           slot,
         })
       }
@@ -124,6 +134,8 @@ export function SizeCompareSelectedBuilds({
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
   const platform = headBuildDetails.app_info?.platform ?? null;
+  const project = ProjectsStore.getBySlug(projectId);
+  const projectType = project?.platform ?? null;
 
   return (
     <ComparisonContainer>
@@ -132,6 +144,7 @@ export function SizeCompareSelectedBuilds({
         icon={<IconLock size="xs" locked />}
         label={t('Head')}
         slot="head"
+        projectType={projectType}
       />
 
       <Text>{t('vs')}</Text>
@@ -143,6 +156,7 @@ export function SizeCompareSelectedBuilds({
           label={t('Base')}
           onRemove={onClearBaseBuild}
           slot="base"
+          projectType={projectType}
         />
       ) : (
         <SelectBuild>
@@ -159,6 +173,7 @@ export function SizeCompareSelectedBuilds({
                 project_slug: projectId,
                 platform,
                 build_id: headBuildDetails.id,
+                project_type: projectType ?? null,
               });
               onTriggerComparison();
             }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -125,7 +125,7 @@ export function SizeCompareSelectedBuilds({
 }: SizeCompareSelectedBuildsProps) {
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
-  const headPlatform = headBuildDetails.app_info?.platform ?? null;
+  const platform = headBuildDetails.app_info?.platform ?? null;
   const projectType = headBuildDetails.app_info?.platform ?? null;
 
   return (
@@ -161,7 +161,7 @@ export function SizeCompareSelectedBuilds({
                 organization,
                 project_slug: projectId,
                 project_type: projectType,
-                platform: headPlatform,
+                platform,
               });
               onTriggerComparison();
             }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -182,10 +182,9 @@ export function SizeCompareSelectionContent({
                 isSelected={selectedBaseBuild === build}
                 onSelect={() => {
                   setSelectedBaseBuild(build);
-                  trackPreprodBuildAnalytics('preprod.builds.compare_build_selected', {
+                  trackPreprodBuildAnalytics('preprod.builds.compare.select_base_build', {
                     organization,
-                    head_id: headBuildDetails.id,
-                    base_id: build.id,
+                    build_id: build.id,
                     project_slug: projectId,
                     project_type: headBuildDetails.app_info?.platform ?? null,
                     platform:
@@ -212,12 +211,6 @@ interface BuildItemProps {
 }
 
 function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
-  const organization = useOrganization();
-  const {projectId} = useParams<{projectId: string}>();
-  const headId = useParams<{headId?: string}>().headId;
-  const platform = build.app_info?.platform ?? null;
-  const projectType = build.app_info?.platform ?? null;
-
   const prNumber = build.vcs_info?.pr_number;
   const commitHash = build.vcs_info?.head_sha?.substring(0, 7);
   const branchName = build.vcs_info?.head_ref;
@@ -228,18 +221,7 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
 
   return (
     <BuildItemContainer
-      onClick={() => {
-        trackPreprodBuildAnalytics('preprod.builds.compare_build_clicked', {
-          organization,
-          build_id: build.id,
-          project_slug: projectId,
-          project_type: projectType,
-          platform,
-          slot: 'base',
-          head_id: headId ? Number(headId) : undefined,
-        });
-        onSelect();
-      }}
+      onClick={onSelect}
       isSelected={isSelected}
       align="center"
       gap="md"

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -23,6 +23,7 @@ import {
 } from 'sentry/icons';
 import {IconBranch} from 'sentry/icons/iconBranch';
 import {t} from 'sentry/locale';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {useApiQuery, useMutation, type UseApiQueryResult} from 'sentry/utils/queryClient';
@@ -63,6 +64,8 @@ export function SizeCompareSelectionContent({
   const {projectId} = useParams<{
     projectId: string;
   }>();
+  const project = ProjectsStore.getBySlug(projectId);
+  const projectType = project?.platform ?? null;
   const [selectedBaseBuild, setSelectedBaseBuild] = useState<
     BuildDetailsApiResponse | undefined
   >(baseBuildDetails);
@@ -187,6 +190,11 @@ export function SizeCompareSelectionContent({
                     build_id: build.id,
                     project_slug: projectId,
                     platform:
+                      build.app_info?.platform ??
+                      headBuildDetails.app_info?.platform ??
+                      null,
+                    project_type:
+                      projectType ??
                       build.app_info?.platform ??
                       headBuildDetails.app_info?.platform ??
                       null,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -186,7 +186,6 @@ export function SizeCompareSelectionContent({
                     organization,
                     build_id: build.id,
                     project_slug: projectId,
-                    project_type: headBuildDetails.app_info?.platform ?? null,
                     platform:
                       build.app_info?.platform ??
                       headBuildDetails.app_info?.platform ??

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/icons';
 import {IconBranch} from 'sentry/icons/iconBranch';
 import {t} from 'sentry/locale';
-import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {useApiQuery, useMutation, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -182,7 +182,7 @@ export function SizeCompareSelectionContent({
                 isSelected={selectedBaseBuild === build}
                 onSelect={() => {
                   setSelectedBaseBuild(build);
-                  trackPreprodBuildAnalytics('preprod.builds.compare.select_base_build', {
+                  trackAnalytics('preprod.builds.compare.select_base_build', {
                     organization,
                     build_id: build.id,
                     project_slug: projectId,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -193,11 +193,7 @@ export function SizeCompareSelectionContent({
                       build.app_info?.platform ??
                       headBuildDetails.app_info?.platform ??
                       null,
-                    project_type:
-                      projectType ??
-                      build.app_info?.platform ??
-                      headBuildDetails.app_info?.platform ??
-                      null,
+                    project_type: projectType,
                   });
                 }}
               />

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -5,6 +5,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {
   fetchMutation,
   useApiQuery,
@@ -95,6 +96,8 @@ export default function BuildDetails() {
   const buildDetails = buildDetailsQuery.data;
   const version = buildDetails?.app_info?.version;
   const buildNumber = buildDetails?.app_info?.build_number;
+  const project = ProjectsStore.getBySlug(projectId);
+  const projectType = project?.platform ?? null;
 
   let title = t('Build details');
   if (
@@ -136,6 +139,7 @@ export default function BuildDetails() {
             buildDetailsQuery={buildDetailsQuery}
             projectId={projectId}
             artifactId={artifactId}
+            projectType={projectType}
           />
         </Layout.Header>
 
@@ -156,6 +160,7 @@ export default function BuildDetails() {
                 isRerunning={isRerunning}
                 buildDetailsData={buildDetailsQuery.data}
                 isBuildDetailsPending={buildDetailsQuery.isLoading}
+                projectType={projectType}
               />
             </BuildDetailsMain>
           </UrlParamBatchProvider>

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -23,6 +23,7 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
@@ -128,6 +129,26 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   const version = `v${buildDetailsData.app_info.version ?? 'Unknown'} (${buildDetailsData.app_info.build_number ?? 'Unknown'})`;
 
+  const platform = buildDetailsData.app_info?.platform ?? null;
+  const buildId = buildDetailsData.id;
+
+  const handleCompareClick = () => {
+    trackPreprodBuildAnalytics('preprod.builds.details_compare_clicked', {
+      organization,
+      platform,
+      build_id: buildId,
+    });
+  };
+
+  const handleConfirmDelete = () => {
+    trackPreprodBuildAnalytics('preprod.builds.details_delete_clicked', {
+      organization,
+      platform,
+      build_id: buildId,
+    });
+    handleDeleteArtifact();
+  };
+
   return (
     <React.Fragment>
       <Layout.HeaderContent>
@@ -152,6 +173,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
           />
           <Link
             to={`/organizations/${organization.slug}/preprod/${projectId}/compare/${buildDetailsData.id}/`}
+            onClick={handleCompareClick}
           >
             <Button size="sm" priority="default" icon={<IconTelescope />}>
               {t('Compare Build')}
@@ -162,7 +184,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
               'Are you sure you want to delete this build? This action cannot be undone and will permanently remove all associated files and data.'
             )}
             confirmInput={artifactId}
-            onConfirm={handleDeleteArtifact}
+            onConfirm={handleConfirmDelete}
           >
             {({open: openDeleteModal}) => {
               const menuItems: MenuItemProps[] = [

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -62,12 +62,13 @@ interface BuildDetailsHeaderContentProps {
   artifactId: string;
   buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
   projectId: string;
+  projectType: string | null;
 }
 
 export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps) {
   const organization = useOrganization();
   const isSentryEmployee = useIsSentryEmployee();
-  const {buildDetailsQuery, projectId, artifactId} = props;
+  const {buildDetailsQuery, projectId, artifactId, projectType} = props;
   const {
     isDeletingArtifact,
     handleDeleteArtifact,
@@ -134,6 +135,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
       organization,
       platform: buildDetailsData.app_info?.platform ?? null,
       build_id: buildDetailsData.id,
+      project_type: projectType,
     });
   };
 
@@ -144,7 +146,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
       platform: buildDetailsData.app_info?.platform ?? null,
       build_id: buildDetailsData.id,
       project_slug: projectId,
-      project_type: buildDetailsData.app_info?.platform ?? null,
+      project_type: projectType,
     });
   };
 

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
@@ -130,7 +130,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
   const version = `v${buildDetailsData.app_info.version ?? 'Unknown'} (${buildDetailsData.app_info.build_number ?? 'Unknown'})`;
 
   const handleCompareClick = () => {
-    trackPreprodBuildAnalytics('preprod.builds.details.compare_build_clicked', {
+    trackAnalytics('preprod.builds.details.compare_build_clicked', {
       organization,
       platform: buildDetailsData.app_info?.platform ?? null,
       build_id: buildDetailsData.id,

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -133,7 +133,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
   const buildId = buildDetailsData.id;
 
   const handleCompareClick = () => {
-    trackPreprodBuildAnalytics('preprod.builds.details_compare_clicked', {
+    trackPreprodBuildAnalytics('preprod.builds.details.compare_build_clicked', {
       organization,
       platform,
       build_id: buildId,
@@ -141,11 +141,6 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
   };
 
   const handleConfirmDelete = () => {
-    trackPreprodBuildAnalytics('preprod.builds.details_delete_clicked', {
-      organization,
-      platform,
-      build_id: buildId,
-    });
     handleDeleteArtifact();
   };
 

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -129,14 +129,11 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   const version = `v${buildDetailsData.app_info.version ?? 'Unknown'} (${buildDetailsData.app_info.build_number ?? 'Unknown'})`;
 
-  const platform = buildDetailsData.app_info?.platform ?? null;
-  const buildId = buildDetailsData.id;
-
   const handleCompareClick = () => {
     trackPreprodBuildAnalytics('preprod.builds.details.compare_build_clicked', {
       organization,
-      platform,
-      build_id: buildId,
+      platform: buildDetailsData.app_info?.platform ?? null,
+      build_id: buildDetailsData.id,
     });
   };
 

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -136,6 +136,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
       platform: buildDetailsData.app_info?.platform ?? null,
       build_id: buildDetailsData.id,
       project_type: projectType,
+      project_slug: projectId,
     });
   };
 

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -139,6 +139,13 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   const handleConfirmDelete = () => {
     handleDeleteArtifact();
+    trackAnalytics('preprod.builds.details.delete_build', {
+      organization,
+      platform: buildDetailsData.app_info?.platform ?? null,
+      build_id: buildDetailsData.id,
+      project_slug: projectId,
+      project_type: buildDetailsData.app_info?.platform ?? null,
+    });
   };
 
   return (

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -39,6 +39,7 @@ interface BuildDetailsMainContentProps {
   onRerunAnalysis: () => void;
   buildDetailsData?: BuildDetailsApiResponse | null;
   isBuildDetailsPending?: boolean;
+  projectType?: string | null;
 }
 
 export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
@@ -48,6 +49,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     appSizeQuery,
     buildDetailsData,
     isBuildDetailsPending = false,
+    projectType,
   } = props;
   const {
     data: appSizeData,
@@ -305,6 +307,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
         processedInsights={processedInsights}
         totalSize={totalSize}
         platform={buildDetailsData?.app_info?.platform ?? null}
+        projectType={projectType}
         onOpenInsightsSidebar={openInsightsSidebar}
       />
 
@@ -353,7 +356,8 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
 
       <AppSizeInsights
         processedInsights={processedInsights}
-        platform={validatedPlatform(buildDetailsData?.app_info?.platform)}
+        platform={validatedPlatform(buildDetailsData?.app_info?.platform ?? undefined)}
+        projectType={projectType}
       />
     </Stack>
   );

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -7,8 +7,10 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconCode, IconDownload, IconLightning, IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
+import useOrganization from 'sentry/utils/useOrganization';
 import {MetricCard} from 'sentry/views/preprod/components/metricCard';
 import {MetricsArtifactType} from 'sentry/views/preprod/types/appSizeTypes';
 import {
@@ -59,6 +61,8 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
     platform: platformProp,
     onOpenInsightsSidebar,
   } = props;
+
+  const organization = useOrganization();
 
   if (!isSizeInfoCompleted(sizeInfo)) {
     return null;
@@ -144,7 +148,18 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                     icon: <IconSettings size="sm" color="white" />,
                     tooltip: t('View insight details'),
                     ariaLabel: t('View insight details'),
-                    onClick: onOpenInsightsSidebar,
+                    onClick: () => {
+                      trackPreprodBuildAnalytics(
+                        'preprod.builds.details_insights_opened',
+                        {
+                          organization,
+                          insight_count: processedInsights.length,
+                          platform: platformProp ?? null,
+                          source: 'metric_card',
+                        }
+                      );
+                      onOpenInsightsSidebar();
+                    },
                   }
                 : undefined
             }

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -150,7 +150,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                     ariaLabel: t('View insight details'),
                     onClick: () => {
                       trackPreprodBuildAnalytics(
-                        'preprod.builds.details_insights_opened',
+                        'preprod.builds.details.open_insights_sidebar',
                         {
                           organization,
                           insight_count: processedInsights.length,

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -35,6 +35,7 @@ interface BuildDetailsMetricCardsProps {
   sizeInfo: BuildDetailsSizeInfo | undefined;
   totalSize: number;
   platform?: Platform | null;
+  projectType?: string | null;
 }
 
 interface MetricCardConfig {
@@ -59,6 +60,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
     processedInsights,
     totalSize,
     platform: platformProp,
+    projectType,
     onOpenInsightsSidebar,
   } = props;
 
@@ -152,6 +154,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                       trackAnalytics('preprod.builds.details.open_insights_sidebar', {
                         organization,
                         platform: platformProp ?? null,
+                        project_type: projectType ?? null,
                         source: 'metric_card',
                       });
                       onOpenInsightsSidebar();

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -7,7 +7,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconCode, IconDownload, IconLightning, IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -149,14 +149,11 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                     tooltip: t('View insight details'),
                     ariaLabel: t('View insight details'),
                     onClick: () => {
-                      trackPreprodBuildAnalytics(
-                        'preprod.builds.details.open_insights_sidebar',
-                        {
-                          organization,
-                          platform: platformProp ?? null,
-                          source: 'metric_card',
-                        }
-                      );
+                      trackAnalytics('preprod.builds.details.open_insights_sidebar', {
+                        organization,
+                        platform: platformProp ?? null,
+                        source: 'metric_card',
+                      });
                       onOpenInsightsSidebar();
                     },
                   }

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -153,7 +153,6 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                         'preprod.builds.details.open_insights_sidebar',
                         {
                           organization,
-                          insight_count: processedInsights.length,
                           platform: platformProp ?? null,
                           source: 'metric_card',
                         }

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -154,7 +154,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                       trackAnalytics('preprod.builds.details.open_insights_sidebar', {
                         organization,
                         platform: platformProp ?? null,
-                        project_type: projectType ?? null,
+                        project_type: projectType,
                         source: 'metric_card',
                       });
                       onOpenInsightsSidebar();

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -28,7 +28,7 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
   const organization = useOrganization();
 
   const openSidebar = useCallback(() => {
-    trackPreprodBuildAnalytics('preprod.builds.details_insights_opened', {
+    trackPreprodBuildAnalytics('preprod.builds.details.open_insights_sidebar', {
       organization,
       insight_count: processedInsights.length,
       platform: platform ?? null,

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -37,7 +37,7 @@ export function AppSizeInsights({
       organization,
       platform: platform ?? null,
       source: 'insight_table',
-      project_type: projectType ?? null,
+      project_type: projectType,
     });
     const newParams = new URLSearchParams(searchParams);
     newParams.set('insights', 'open');

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -30,14 +30,13 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
   const openSidebar = useCallback(() => {
     trackPreprodBuildAnalytics('preprod.builds.details.open_insights_sidebar', {
       organization,
-      insight_count: processedInsights.length,
       platform: platform ?? null,
       source: 'insight_table',
     });
     const newParams = new URLSearchParams(searchParams);
     newParams.set('insights', 'open');
     setSearchParams(newParams);
-  }, [organization, platform, processedInsights.length, searchParams, setSearchParams]);
+  }, [organization, platform, searchParams, setSearchParams]);
 
   const closeSidebar = useCallback(() => {
     const newParams = new URLSearchParams(searchParams);

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -9,7 +9,9 @@ import {Text} from '@sentry/scraps/text/text';
 
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import useOrganization from 'sentry/utils/useOrganization';
 import {AppSizeInsightsSidebar} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar';
 import {formatUpside} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
@@ -23,12 +25,19 @@ interface AppSizeInsightsProps {
 export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const isSidebarOpen = searchParams.get('insights') === 'open';
+  const organization = useOrganization();
 
   const openSidebar = useCallback(() => {
+    trackPreprodBuildAnalytics('preprod.builds.details_insights_opened', {
+      organization,
+      insight_count: processedInsights.length,
+      platform: platform ?? null,
+      source: 'insight_table',
+    });
     const newParams = new URLSearchParams(searchParams);
     newParams.set('insights', 'open');
     setSearchParams(newParams);
-  }, [searchParams, setSearchParams]);
+  }, [organization, platform, processedInsights.length, searchParams, setSearchParams]);
 
   const closeSidebar = useCallback(() => {
     const newParams = new URLSearchParams(searchParams);

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -9,7 +9,7 @@ import {Text} from '@sentry/scraps/text/text';
 
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AppSizeInsightsSidebar} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar';
@@ -28,7 +28,7 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
   const organization = useOrganization();
 
   const openSidebar = useCallback(() => {
-    trackPreprodBuildAnalytics('preprod.builds.details.open_insights_sidebar', {
+    trackAnalytics('preprod.builds.details.open_insights_sidebar', {
       organization,
       platform: platform ?? null,
       source: 'insight_table',

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -20,9 +20,14 @@ import {type ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessin
 interface AppSizeInsightsProps {
   processedInsights: ProcessedInsight[];
   platform?: Platform;
+  projectType?: string | null;
 }
 
-export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsProps) {
+export function AppSizeInsights({
+  processedInsights,
+  platform,
+  projectType,
+}: AppSizeInsightsProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const isSidebarOpen = searchParams.get('insights') === 'open';
   const organization = useOrganization();
@@ -32,11 +37,12 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
       organization,
       platform: platform ?? null,
       source: 'insight_table',
+      project_type: projectType ?? null,
     });
     const newParams = new URLSearchParams(searchParams);
     newParams.set('insights', 'open');
     setSearchParams(newParams);
-  }, [organization, platform, searchParams, setSearchParams]);
+  }, [organization, platform, projectType, searchParams, setSearchParams]);
 
   const closeSidebar = useCallback(() => {
     const newParams = new URLSearchParams(searchParams);
@@ -123,6 +129,7 @@ export function AppSizeInsights({processedInsights, platform}: AppSizeInsightsPr
         isOpen={isSidebarOpen}
         onClose={closeSidebar}
         platform={platform}
+        projectType={projectType}
       />
     </Container>
   );

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -20,6 +20,7 @@ interface AppSizeInsightsSidebarProps {
   onClose: () => void;
   processedInsights: ProcessedInsight[];
   platform?: Platform;
+  projectType?: string | null;
 }
 
 function getInsightsDocsUrl(platform?: Platform): string {
@@ -37,6 +38,7 @@ export function AppSizeInsightsSidebar({
   isOpen,
   onClose,
   platform,
+  projectType,
 }: AppSizeInsightsSidebarProps) {
   const [expandedInsights, setExpandedInsights] = useState<Set<string>>(new Set());
 
@@ -141,6 +143,7 @@ export function AppSizeInsightsSidebar({
                       isExpanded={expandedInsights.has(insight.key)}
                       onToggleExpanded={() => toggleExpanded(insight.key)}
                       platform={platform}
+                      projectType={projectType}
                       itemsPerPage={isGroupedInsight ? 10 : undefined}
                     />
                   );

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -56,12 +56,14 @@ export function AppSizeInsightsSidebarRow({
   onToggleExpanded,
   platform,
   itemsPerPage = DEFAULT_ITEMS_PER_PAGE,
+  projectType,
 }: {
   insight: ProcessedInsight;
   isExpanded: boolean;
   onToggleExpanded: () => void;
   itemsPerPage?: number;
   platform?: Platform;
+  projectType?: string | null;
 }) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -79,6 +81,7 @@ export function AppSizeInsightsSidebarRow({
       organization,
       insight_key: insight.key,
       platform: platform ?? null,
+      project_type: projectType ?? null,
     });
     if (insight.key === 'alternate_icons_optimization') {
       openAlternativeIconsInsightModal();
@@ -107,6 +110,7 @@ export function AppSizeInsightsSidebarRow({
         organization,
         insight_key: insight.key,
         platform: platform ?? null,
+        project_type: projectType ?? null,
       });
     }
     onToggleExpanded();

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -12,7 +12,7 @@ import {IconInfo} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconFlag} from 'sentry/icons/iconFlag';
 import {t, tn} from 'sentry/locale';
-import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -75,7 +75,7 @@ export function AppSizeInsightsSidebarRow({
   const showPagination = insight.files.length > itemsPerPage;
 
   const handleOpenModal = () => {
-    trackPreprodBuildAnalytics('preprod.builds.details.open_insight_details_modal', {
+    trackAnalytics('preprod.builds.details.open_insight_details_modal', {
       organization,
       insight_key: insight.key,
       platform: platform ?? null,
@@ -103,7 +103,7 @@ export function AppSizeInsightsSidebarRow({
 
   const handleToggleExpanded = () => {
     if (!isExpanded) {
-      trackPreprodBuildAnalytics('preprod.builds.details.expand_insight', {
+      trackAnalytics('preprod.builds.details.expand_insight', {
         organization,
         insight_key: insight.key,
         platform: platform ?? null,

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -81,7 +81,7 @@ export function AppSizeInsightsSidebarRow({
       organization,
       insight_key: insight.key,
       platform: platform ?? null,
-      project_type: projectType ?? null,
+      project_type: projectType,
     });
     if (insight.key === 'alternate_icons_optimization') {
       openAlternativeIconsInsightModal();
@@ -110,7 +110,7 @@ export function AppSizeInsightsSidebarRow({
         organization,
         insight_key: insight.key,
         platform: platform ?? null,
-        project_type: projectType ?? null,
+        project_type: projectType,
       });
     }
     onToggleExpanded();

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -75,7 +75,7 @@ export function AppSizeInsightsSidebarRow({
   const showPagination = insight.files.length > itemsPerPage;
 
   const handleOpenModal = () => {
-    trackPreprodBuildAnalytics('preprod.builds.details_insight_action_clicked', {
+    trackPreprodBuildAnalytics('preprod.builds.details.open_insight_details_modal', {
       organization,
       insight_key: insight.key,
       platform: platform ?? null,
@@ -102,7 +102,7 @@ export function AppSizeInsightsSidebarRow({
       setCurrentPage(0);
     }
     if (!wasExpandedRef.current && isExpanded) {
-      trackPreprodBuildAnalytics('preprod.builds.details_insight_expanded', {
+      trackPreprodBuildAnalytics('preprod.builds.details.expand_insight', {
         organization,
         insight_key: insight.key,
         platform: platform ?? null,

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Tag} from '@sentry/scraps/badge/tag';
@@ -95,21 +95,24 @@ export function AppSizeInsightsSidebarRow({
     setCurrentPage(newPage);
   };
 
-  const wasExpandedRef = useRef(isExpanded);
-
   useEffect(() => {
     if (!isExpanded) {
       setCurrentPage(0);
     }
-    if (!wasExpandedRef.current && isExpanded) {
+  }, [isExpanded]);
+
+  const handleToggleExpanded = () => {
+    if (isExpanded) {
+      setCurrentPage(0);
+    } else {
       trackPreprodBuildAnalytics('preprod.builds.details.expand_insight', {
         organization,
         insight_key: insight.key,
         platform: platform ?? null,
       });
     }
-    wasExpandedRef.current = isExpanded;
-  }, [insight.key, isExpanded, organization, platform]);
+    onToggleExpanded();
+  };
 
   return (
     <Flex border="muted" radius="md" padding="xl" direction="column" gap="md">
@@ -144,7 +147,7 @@ export function AppSizeInsightsSidebarRow({
         <Container paddingTop="md">
           <Button
             size="sm"
-            onClick={onToggleExpanded}
+            onClick={handleToggleExpanded}
             style={{marginBottom: isExpanded ? '16px' : '0'}}
             icon={
               <IconChevron

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -102,9 +102,7 @@ export function AppSizeInsightsSidebarRow({
   }, [isExpanded]);
 
   const handleToggleExpanded = () => {
-    if (isExpanded) {
-      setCurrentPage(0);
-    } else {
+    if (!isExpanded) {
       trackPreprodBuildAnalytics('preprod.builds.details.expand_insight', {
         organization,
         insight_key: insight.key,

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -106,7 +106,7 @@ export default function PreprodBuilds() {
 
   const handleBuildRowClick = useCallback(
     (build: BuildDetailsApiResponse, _rowIndex: number) => {
-      trackPreprodBuildAnalytics('preprod.builds.release_row_clicked', {
+      trackPreprodBuildAnalytics('preprod.builds.release.build_row_clicked', {
         organization,
         project_type: projectPlatform ?? null,
         platform: build.app_info?.platform ?? projectPlatform ?? null,

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from 'react';
+import {useCallback, useContext, useEffect, useState} from 'react';
 
 import {Container} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -7,6 +7,7 @@ import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -17,6 +18,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
 import {ReleaseContext} from 'sentry/views/releases/detail';
 
@@ -97,9 +99,23 @@ export default function PreprodBuilds() {
   const builds = buildsData?.builds || [];
   const pageLinks = getResponseHeader?.('Link') || null;
 
-  const hasSearchQuery = !!urlSearchQuery?.trim();
+  const trimmedSearchQuery = urlSearchQuery?.trim() ?? '';
+  const hasSearchQuery = trimmedSearchQuery.length > 0;
   const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
+
+  const handleBuildRowClick = useCallback(
+    (build: BuildDetailsApiResponse, _rowIndex: number) => {
+      trackPreprodBuildAnalytics('preprod.builds.release_row_clicked', {
+        organization,
+        project_type: projectPlatform ?? null,
+        platform: build.app_info?.platform ?? projectPlatform ?? null,
+        build_id: build.id,
+        project_slug: projectSlug,
+      });
+    },
+    [organization, projectPlatform, projectSlug]
+  );
 
   return (
     <Layout.Body>
@@ -133,7 +149,8 @@ export default function PreprodBuilds() {
             pageLinks={pageLinks}
             organizationSlug={organization.slug}
             projectSlug={projectSlug}
-            hasSearchQuery
+            hasSearchQuery={hasSearchQuery}
+            onRowClick={handleBuildRowClick}
           />
         )}
       </Layout.Main>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -108,7 +108,7 @@ export default function PreprodBuilds() {
       trackAnalytics('preprod.builds.release.build_row_clicked', {
         organization,
         project_type: projectPlatform ?? null,
-        platform: build.app_info?.platform ?? projectPlatform ?? null,
+        platform: build.app_info?.platform ?? null,
         build_id: build.id,
         project_slug: projectSlug,
       });

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -7,7 +7,7 @@ import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {trackPreprodBuildAnalytics} from 'sentry/utils/analytics/preprodBuildAnalyticsEvents';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -105,7 +105,7 @@ export default function PreprodBuilds() {
 
   const handleBuildRowClick = useCallback(
     (build: BuildDetailsApiResponse, _rowIndex: number) => {
-      trackPreprodBuildAnalytics('preprod.builds.release.build_row_clicked', {
+      trackAnalytics('preprod.builds.release.build_row_clicked', {
         organization,
         project_type: projectPlatform ?? null,
         platform: build.app_info?.platform ?? projectPlatform ?? null,

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -99,8 +99,7 @@ export default function PreprodBuilds() {
   const builds = buildsData?.builds || [];
   const pageLinks = getResponseHeader?.('Link') || null;
 
-  const trimmedSearchQuery = urlSearchQuery?.trim() ?? '';
-  const hasSearchQuery = trimmedSearchQuery.length > 0;
+  const hasSearchQuery = !!urlSearchQuery?.trim();
   const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
 
@@ -149,8 +148,8 @@ export default function PreprodBuilds() {
             pageLinks={pageLinks}
             organizationSlug={organization.slug}
             projectSlug={projectSlug}
-            hasSearchQuery={hasSearchQuery}
             onRowClick={handleBuildRowClick}
+            hasSearchQuery
           />
         )}
       </Layout.Main>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -104,7 +104,7 @@ export default function PreprodBuilds() {
   const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
 
   const handleBuildRowClick = useCallback(
-    (build: BuildDetailsApiResponse, _rowIndex: number) => {
+    (build: BuildDetailsApiResponse) => {
       trackAnalytics('preprod.builds.release.build_row_clicked', {
         organization,
         project_type: projectPlatform ?? null,


### PR DESCRIPTION
add amplitude events for size analysis pages

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
