### PR TITLE
chore(triage signals): Adding more logs for debugging

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -346,6 +346,7 @@ def run_automation(
 
     stopping_point = None
     if features.has("projects:triage-signals-v0", group.project):
+        logger.info("Triage signals V0: %s: generating stopping point", group.id)
         fixability_stopping_point = _get_stopping_point_from_fixability(
             issue_summary.scores.fixability_score
         )
@@ -358,7 +359,11 @@ def run_automation(
         stopping_point = _apply_user_preference_upper_bound(
             fixability_stopping_point, user_preference
         )
-        logger.info("Final stopping point after upper bound: %s", stopping_point)
+        logger.info(
+            "Triage signals V0: %s: Final stopping point after upper bound: %s",
+            group.id,
+            stopping_point,
+        )
 
     _trigger_autofix_task.delay(
         group_id=group.id,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -301,11 +301,15 @@ def run_automation(
 
     # Only log for projects with triage-signals-v0
     if features.has("projects:triage-signals-v0", group.project):
+        try:
+            times_seen = group.times_seen_with_pending
+        except (AssertionError, AttributeError):
+            times_seen = group.times_seen
         logger.info(
-            "run_automation called: group_id=%s, source=%s, times_seen_with_pending=%s",
+            "run_automation called: group_id=%s, source=%s, times_seen=%s",
             group.id,
             source.value,
-            group.times_seen_with_pending,
+            times_seen,
         )
 
     user_id = user.id if user else None

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -306,7 +306,7 @@ def run_automation(
         except (AssertionError, AttributeError):
             times_seen = group.times_seen
         logger.info(
-            "run_automation called: group_id=%s, source=%s, times_seen=%s",
+            "Triage signals V0: %s: run_automation called: source=%s, times_seen=%s",
             group.id,
             source.value,
             times_seen,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -299,6 +299,15 @@ def run_automation(
     if source == SeerAutomationSource.ISSUE_DETAILS:
         return
 
+    # Only log for projects with triage-signals-v0
+    if features.has("projects:triage-signals-v0", group.project):
+        logger.info(
+            "run_automation called: group_id=%s, source=%s, times_seen_with_pending=%s",
+            group.id,
+            source.value,
+            group.times_seen_with_pending,
+        )
+
     user_id = user.id if user else None
     auto_run_source = auto_run_source_map.get(source, "unknown_source")
 

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -54,9 +54,12 @@ def generate_issue_summary_only(group_id: int) -> None:
     Generate issue summary WITHOUT triggering automation.
     Used for triage signals flow when event count < 10 or when summary doesn't exist yet.
     """
+    from sentry import features
     from sentry.seer.autofix.issue_summary import get_issue_summary
 
     group = Group.objects.get(id=group_id)
+    if features.has("projects:triage-signals-v0", group.project):
+        logger.info("Task: generate_issue_summary_only, group_id=%s", group_id)
     get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
@@ -78,9 +81,13 @@ def run_automation_only_task(group_id: int) -> None:
     """
     from django.contrib.auth.models import AnonymousUser
 
+    from sentry import features
     from sentry.seer.autofix.issue_summary import run_automation
 
     group = Group.objects.get(id=group_id)
+    if features.has("projects:triage-signals-v0", group.project):
+        logger.info("Task: run_automation_only_task, group_id=%s", group_id)
+
     event = group.get_latest_event()
 
     if not event:


### PR DESCRIPTION
## PR Details
+ Observing Seer automation running on issues with <10 events despite triage-signals-v0 flag, which should only generate summaries without triggering automation for low event counts.
+ Moreover I am not seeing `run_automation_only_task` and `generate_issue_summary_only` being called at all. [Traces](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22span.description%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28%29%22%5D%2C%22chartType%22%3A0%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=span.category&field=region&field=user.geo.region&interval=1m&mode=aggregate&project=1&query=span.description%3A%5Bsentry.tasks.autofix.generate_issue_summary_only%2Csentry.tasks.autofix.run_automation_only_task%5D&sort=-count%28%29&statsPeriod=8h&visualize=%7B%22chartType%22%3A0%2C%22yAxes%22%3A%5B%22count%28%29%22%5D%7D)
+ To add to the confusion logs behind the feature flag in `run_automation` are being called - [Logs](https://sentry.sentry.io/explore/logs/?logsFields=timestamp&logsFields=message&logsFields=server.address&logsFields=group_id&logsFields=project&logsQuery=message%3A%EF%80%8DContains%EF%80%8D%22stopping%20point%22&logsSortBys=-timestamp&mode=samples&project=1&statsPeriod=8h)
+ I will remove these logs as soon as the root cause is figured out. Also only Seer project has the feature flag on so log volume should be minimal.
