### PR TITLE
chore(upsell-modal): Remove unused default selection from upsell modal

### DIFF
--- a/static/gsApp/actionCreators/modal.tsx
+++ b/static/gsApp/actionCreators/modal.tsx
@@ -26,7 +26,6 @@ import type {AM2UpdateSurfaces} from 'getsentry/utils/trackGetsentryAnalytics';
 type UpsellModalOptions = {
   organization: Organization;
   source: string;
-  defaultSelection?: string;
 };
 
 export async function openUpsellModal(options: UpsellModalOptions) {

--- a/static/gsApp/components/features/dateRangeQueryLimitFooter.tsx
+++ b/static/gsApp/components/features/dateRangeQueryLimitFooter.tsx
@@ -20,7 +20,6 @@ interface Props {
   organization: Organization;
   source: string;
   subscription: Subscription;
-  upsellDefaultSelection: string;
 }
 
 function DateRangeQueryLimitFooter({
@@ -28,7 +27,6 @@ function DateRangeQueryLimitFooter({
   organization,
   source,
   subscription,
-  upsellDefaultSelection,
 }: Props) {
   const checkoutUrl = normalizeUrl(
     `/settings/${organization.slug}/billing/checkout/?referrer=checkout-${source}`
@@ -62,7 +60,6 @@ function DateRangeQueryLimitFooter({
               openUpsellModal({
                 organization,
                 source,
-                defaultSelection: upsellDefaultSelection,
               })
             }
           >

--- a/static/gsApp/components/features/disabledAlertWizard.tsx
+++ b/static/gsApp/components/features/disabledAlertWizard.tsx
@@ -22,7 +22,6 @@ function DisabledAlertWizard({organization}: Props) {
             openUpsellModal({
               organization,
               source: 'alert-wizard',
-              defaultSelection: 'integration-alerts',
             })
           }
         >

--- a/static/gsApp/components/features/disabledAuthProvider.tsx
+++ b/static/gsApp/components/features/disabledAuthProvider.tsx
@@ -44,7 +44,6 @@ function DisabledAuthProvider({organization, features, children, ...props}: Prop
                     openUpsellModal({
                       organization,
                       source: `feature.auth_provider.${p.provider.key}`,
-                      defaultSelection: 'sso',
                     })
                   }
                 >

--- a/static/gsApp/components/features/disabledCustomInboundFilters.tsx
+++ b/static/gsApp/components/features/disabledCustomInboundFilters.tsx
@@ -48,7 +48,6 @@ function DisabledAlert({organization, features}: Props) {
                 openUpsellModal({
                   organization,
                   source: 'feature.custom_inbound_filters',
-                  defaultSelection: 'event-volume',
                 })
               }
             >

--- a/static/gsApp/components/features/disabledDashboardPage.tsx
+++ b/static/gsApp/components/features/disabledDashboardPage.tsx
@@ -70,7 +70,6 @@ function DisabledDashboardPage({
       requiredPlan={requiredPlan}
       features={features}
       background={DashboardBackground}
-      defaultUpsellSelection="custom-dashboards"
       customWrapper={TextWrapper}
       positioningStrategy={({mainRect, anchorRect, wrapperRect}) => {
         // Center within the anchor on the x axis, until the wrapper is larger

--- a/static/gsApp/components/features/disabledDiscover2Page.tsx
+++ b/static/gsApp/components/features/disabledDiscover2Page.tsx
@@ -82,7 +82,6 @@ function DisabledDiscover2Page({
       requiredPlan={requiredPlan}
       features={features}
       background={DiscoverBackground}
-      defaultUpsellSelection="discover-query"
       animateDelay={0.8}
       customWrapper={TextWrapper}
       positioningStrategy={({mainRect, anchorRect, wrapperRect}) => {

--- a/static/gsApp/components/features/disabledRateLimits.tsx
+++ b/static/gsApp/components/features/disabledRateLimits.tsx
@@ -45,7 +45,6 @@ function DisabledAlert({organization, features}: Props) {
                 openUpsellModal({
                   organization,
                   source: 'feature.rate_limits',
-                  defaultSelection: 'event-volume',
                 })
               }
             >

--- a/static/gsApp/components/features/exploreDateRangeQueryLimitFooter.tsx
+++ b/static/gsApp/components/features/exploreDateRangeQueryLimitFooter.tsx
@@ -8,10 +8,6 @@ const QUERY_LIMIT_REFERRER = 'explore-spans-query-limit-footer';
 
 export default function ExploreDateRangeQueryLimitFooter() {
   return (
-    <DateRangeQueryLimitFooter
-      description={DESCRIPTION}
-      source={QUERY_LIMIT_REFERRER}
-      upsellDefaultSelection="explore-spans"
-    />
+    <DateRangeQueryLimitFooter description={DESCRIPTION} source={QUERY_LIMIT_REFERRER} />
   );
 }

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
@@ -26,11 +26,7 @@ export function InsightsDateRangeQueryLimitFooter({organization, subscription}: 
   }
 
   return (
-    <DateRangeQueryLimitFooter
-      description={DESCRIPTION}
-      source={QUERY_LIMIT_REFERRER}
-      upsellDefaultSelection="insights-module"
-    />
+    <DateRangeQueryLimitFooter description={DESCRIPTION} source={QUERY_LIMIT_REFERRER} />
   );
 }
 

--- a/static/gsApp/components/features/pageUpsellOverlay.tsx
+++ b/static/gsApp/components/features/pageUpsellOverlay.tsx
@@ -24,7 +24,6 @@ type Props = Omit<React.ComponentProps<typeof PageOverlay>, 'text'> & {
   source: string;
   subscription: Subscription;
   customSecondaryCTA?: React.ReactNode;
-  defaultUpsellSelection?: string;
 };
 
 /**
@@ -42,7 +41,6 @@ function PageUpsellOverlay({
   source,
   requiredPlan,
   customSecondaryCTA,
-  defaultUpsellSelection,
   ...props
 }: Props) {
   const requiredPlanContents =
@@ -90,7 +88,6 @@ function PageUpsellOverlay({
                     openUpsellModal({
                       organization,
                       source,
-                      defaultSelection: defaultUpsellSelection,
                     })
                   }
                   size="sm"

--- a/static/gsApp/components/openInDiscoverBtn.tsx
+++ b/static/gsApp/components/openInDiscoverBtn.tsx
@@ -18,7 +18,6 @@ function OpenInDiscoverBtn(props: Props) {
       onClick={async () => {
         await openUpsellModal({
           source: 'issue-detail-open-in-discover',
-          defaultSelection: 'discover-query',
           organization: props.organization,
         });
         trackGetsentryAnalytics('growth.issue_open_in_discover_upsell_clicked', {

--- a/static/gsApp/components/upsellProvider.tsx
+++ b/static/gsApp/components/upsellProvider.tsx
@@ -50,7 +50,6 @@ type Props = {
    * if true, non-billing users clicking will trigger trial and plan upgrade requests
    */
   triggerMemberRequests?: boolean;
-  upsellDefaultSelection?: string;
 };
 
 function LoadingButton(props: {
@@ -84,7 +83,6 @@ function UpsellProvider({
   extraAnalyticsParams,
   triggerMemberRequests,
   showConfirmation,
-  upsellDefaultSelection,
   children,
 }: Props) {
   // if the org or subscription isn't loaded yet, don't render anything
@@ -224,7 +222,6 @@ function UpsellProvider({
                 openUpsellModal({
                   organization,
                   source,
-                  defaultSelection: upsellDefaultSelection,
                 });
               }
             }


### PR DESCRIPTION
Not sure what this was used for as this is currently unused and was unused when it was migrated from getsentry to sentry.