### PR TITLE
chore(spans-migration): add isolation scope to misfire and action tags in alerts comparison

### DIFF
--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -327,10 +327,11 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
                 "confidence": values.get("confidence"),
             }
 
-    sentry_sdk.set_tag("false_positive_misfires", false_positive_misfire)
-    sentry_sdk.set_tag("false_negative_misfires", false_negative_misfire)
-    for trigger_action_type, count in trigger_action_types.items():
-        sentry_sdk.set_tag(f"trigger_action_type.{trigger_action_type}", count)
+    with sentry_sdk.isolation_scope() as scope:
+        scope.set_tag("false_positive_misfires", false_positive_misfire)
+        scope.set_tag("false_negative_misfires", false_negative_misfire)
+        for trigger_action_type, count in trigger_action_types.items():
+            scope.set_tag(f"trigger_action_type.{trigger_action_type}", count)
 
     if mismatches:
         with sentry_sdk.isolation_scope() as scope:

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -332,6 +332,7 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
         scope.set_tag("false_negative_misfires", false_negative_misfire)
         for trigger_action_type, count in trigger_action_types.items():
             scope.set_tag(f"trigger_action_type.{trigger_action_type}", count)
+        sentry_sdk.capture_message("False Misfires", level="info", scope=scope)
 
     if mismatches:
         with sentry_sdk.isolation_scope() as scope:

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -332,7 +332,7 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
         scope.set_tag("false_negative_misfires", false_negative_misfire)
         for trigger_action_type, count in trigger_action_types.items():
             scope.set_tag(f"trigger_action_type.{trigger_action_type}", count)
-        sentry_sdk.capture_message("False Misfires", level="info", scope=scope)
+        sentry_sdk.capture_message("False Misfires", level="info")
 
     if mismatches:
         with sentry_sdk.isolation_scope() as scope:


### PR DESCRIPTION
was getting scope bleed for the trigger action counts so adding in the isolation scope