### PR TITLE
fix(ui): Remove span wrapping avatar near commit author

### DIFF
--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -91,9 +91,7 @@ function CommitRow({
         <Message>{formatCommitMessage(commit.message)}</Message>
       )}
       <MetaWrapper>
-        <span>
-          {customAvatar ? customAvatar : <UserAvatar size={16} user={commit.author} />}
-        </span>
+        {customAvatar ? customAvatar : <UserAvatar size={16} user={commit.author} />}
         <Meta hasStreamlinedUI>
           <Tooltip
             title={tct(


### PR DESCRIPTION
This allows the avatar to correctly align to center

Before

![clipboard.png](https://i.imgur.com/srwV9dM.png)

After
![clipboard.png](https://i.imgur.com/cTZ7AsG.png)