### PR TITLE
feat(coding-agents): include solution instructions with agent trigger

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -43,6 +43,7 @@ class OrganizationCodingAgentLaunchSerializer(serializers.Serializer[dict[str, o
         default=AutofixTriggerSource.SOLUTION,
         required=False,
     )
+    instruction = serializers.CharField(required=False, allow_blank=True, max_length=4096)
 
 
 @region_silo_endpoint
@@ -92,12 +93,14 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         run_id = validated["run_id"]
         integration_id = validated["integration_id"]
         trigger_source = validated["trigger_source"]
+        instruction = validated.get("instruction")
 
         results = launch_coding_agents_for_run(
             organization_id=organization.id,
             integration_id=integration_id,
             run_id=run_id,
             trigger_source=trigger_source,
+            instruction=instruction,
         )
 
         successes = results["successes"]

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -193,6 +193,7 @@ def _launch_agents_for_repos(
     run_id: int,
     organization,
     trigger_source: AutofixTriggerSource,
+    instruction: str | None = None,
 ) -> dict[str, list]:
     """
     Launch coding agents for all repositories in the solution.
@@ -229,7 +230,7 @@ def _launch_agents_for_repos(
             "There are no repos in the Seer state to launch coding agents with, make sure you have repos connected to Seer and rerun this Issue Fix."
         )
 
-    prompt = get_coding_agent_prompt(run_id, trigger_source)
+    prompt = get_coding_agent_prompt(run_id, trigger_source, instruction)
 
     if not prompt:
         raise APIException("Issue fetching prompt to send to coding agents.")
@@ -318,6 +319,7 @@ def launch_coding_agents_for_run(
     integration_id: int,
     run_id: int,
     trigger_source: AutofixTriggerSource = AutofixTriggerSource.SOLUTION,
+    instruction: str | None = None,
 ) -> dict[str, list]:
     """
     Launch coding agents for an autofix run.
@@ -327,6 +329,7 @@ def launch_coding_agents_for_run(
         integration_id: The coding agent integration ID
         run_id: The autofix run ID
         trigger_source: The trigger source (ROOT_CAUSE or SOLUTION)
+        instruction: Optional custom instruction to append to the prompt
 
     Returns:
         Dictionary with 'successes' and 'failures' lists
@@ -361,7 +364,7 @@ def launch_coding_agents_for_run(
     )
 
     results = _launch_agents_for_repos(
-        installation, autofix_state, run_id, organization, trigger_source
+        installation, autofix_state, run_id, organization, trigger_source, instruction
     )
 
     if not results["successes"] and not results["failures"]:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -427,7 +427,9 @@ def get_autofix_prompt(run_id: int, include_root_cause: bool, include_solution: 
     return response_data.get("prompt")
 
 
-def get_coding_agent_prompt(run_id: int, trigger_source: AutofixTriggerSource) -> str:
+def get_coding_agent_prompt(
+    run_id: int, trigger_source: AutofixTriggerSource, instruction: str | None = None
+) -> str:
     """Get the coding agent prompt with prefix from Seer API."""
     include_root_cause = trigger_source in [
         AutofixTriggerSource.ROOT_CAUSE,
@@ -437,7 +439,12 @@ def get_coding_agent_prompt(run_id: int, trigger_source: AutofixTriggerSource) -
 
     autofix_prompt = get_autofix_prompt(run_id, include_root_cause, include_solution)
 
-    return f"Please fix the following issue:\n\n{autofix_prompt}"
+    base_prompt = "Please fix the following issue. Ensure that your fix is fully working."
+
+    if instruction and instruction.strip():
+        base_prompt = f"{base_prompt}\n\n{instruction.strip()}"
+
+    return f"{base_prompt}\n\n{autofix_prompt}"
 
 
 def update_coding_agent_state(

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -124,7 +124,7 @@ class TestGetCodingAgentPrompt(TestCase):
 
         result = get_coding_agent_prompt(12345, AutofixTriggerSource.SOLUTION)
 
-        expected = "Please fix the following issue:\n\nThis is the autofix prompt"
+        expected = "Please fix the following issue. Ensure that your fix is fully working.\n\nThis is the autofix prompt"
         assert result == expected
         mock_get_autofix_prompt.assert_called_once_with(12345, True, True)
 
@@ -135,9 +135,44 @@ class TestGetCodingAgentPrompt(TestCase):
 
         result = get_coding_agent_prompt(12345, AutofixTriggerSource.ROOT_CAUSE)
 
-        expected = "Please fix the following issue:\n\nRoot cause analysis prompt"
+        expected = "Please fix the following issue. Ensure that your fix is fully working.\n\nRoot cause analysis prompt"
         assert result == expected
         mock_get_autofix_prompt.assert_called_once_with(12345, True, False)
+
+    @patch("sentry.seer.autofix.utils.get_autofix_prompt")
+    def test_get_coding_agent_prompt_with_instruction(self, mock_get_autofix_prompt):
+        """Test get_coding_agent_prompt with custom instruction."""
+        mock_get_autofix_prompt.return_value = "This is the autofix prompt"
+
+        result = get_coding_agent_prompt(
+            12345, AutofixTriggerSource.SOLUTION, "Use TypeScript instead of JavaScript"
+        )
+
+        expected = "Please fix the following issue. Ensure that your fix is fully working.\n\nUse TypeScript instead of JavaScript\n\nThis is the autofix prompt"
+        assert result == expected
+        mock_get_autofix_prompt.assert_called_once_with(12345, True, True)
+
+    @patch("sentry.seer.autofix.utils.get_autofix_prompt")
+    def test_get_coding_agent_prompt_with_blank_instruction(self, mock_get_autofix_prompt):
+        """Test get_coding_agent_prompt with blank instruction is ignored."""
+        mock_get_autofix_prompt.return_value = "This is the autofix prompt"
+
+        result = get_coding_agent_prompt(12345, AutofixTriggerSource.SOLUTION, "   ")
+
+        expected = "Please fix the following issue. Ensure that your fix is fully working.\n\nThis is the autofix prompt"
+        assert result == expected
+        mock_get_autofix_prompt.assert_called_once_with(12345, True, True)
+
+    @patch("sentry.seer.autofix.utils.get_autofix_prompt")
+    def test_get_coding_agent_prompt_with_empty_instruction(self, mock_get_autofix_prompt):
+        """Test get_coding_agent_prompt with empty instruction is ignored."""
+        mock_get_autofix_prompt.return_value = "This is the autofix prompt"
+
+        result = get_coding_agent_prompt(12345, AutofixTriggerSource.SOLUTION, "")
+
+        expected = "Please fix the following issue. Ensure that your fix is fully working.\n\nThis is the autofix prompt"
+        assert result == expected
+        mock_get_autofix_prompt.assert_called_once_with(12345, True, True)
 
 
 class TestAutofixStateParsing(TestCase):


### PR DESCRIPTION
Passes an optional custom user instruction with the coding agent trigger to cursor agent.

We also improve the prompt a _lil_ bit to tell it to validate its changes.