### PR TITLE
feat: Add support for extrapolation modes in entity subscription

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -8,6 +8,9 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, TypedDict, Union
 
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    ExtrapolationMode as ProtoExtrapolationMode,
+)
 from snuba_sdk import Column, Condition, Entity, Join, Op, Request
 
 from sentry import features
@@ -27,7 +30,7 @@ from sentry.sentry_metrics.utils import resolve, resolve_tag_key, resolve_tag_va
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
+from sentry.snuba.models import ExtrapolationMode, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.rpc_dataset_common import RPCBase
@@ -65,6 +68,14 @@ ALERT_BLOCKED_FIELDS = {
     "timestamp",
     "timestamp.to_hour",
     "timestamp.to_day",
+}
+
+# Mapping from model ExtrapolationMode to proto ExtrapolationMode
+MODEL_TO_PROTO_EXTRAPOLATION_MODE = {
+    ExtrapolationMode.UNKNOWN: ProtoExtrapolationMode.EXTRAPOLATION_MODE_UNSPECIFIED,
+    ExtrapolationMode.NONE: ProtoExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+    ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED: ProtoExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+    ExtrapolationMode.SERVER_WEIGHTED: ProtoExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
 }
 
 
@@ -106,6 +117,7 @@ def apply_dataset_query_conditions(
 
 class _EntitySpecificParams(TypedDict, total=False):
     org_id: int
+    extrapolation_mode: ExtrapolationMode | None
     event_types: list[SnubaQueryEventType.EventType] | None
 
 
@@ -265,9 +277,11 @@ class PerformanceSpansEAPRpcEntitySubscription(BaseEntitySubscription):
         self.aggregate = aggregate
         self.event_types = None
         self.time_window = time_window
+        self.extrapolation_mode = None
         if extra_fields:
             self.org_id = extra_fields.get("org_id")
             self.event_types = extra_fields.get("event_types")
+            self.extrapolation_mode = extra_fields.get("extrapolation_mode")
 
     def build_rpc_request(
         self,
@@ -301,8 +315,19 @@ class PerformanceSpansEAPRpcEntitySubscription(BaseEntitySubscription):
             end=now,
             granularity_secs=self.time_window,
         )
+
+        # Convert model ExtrapolationMode to proto ExtrapolationMode
+        proto_extrapolation_mode = None
+        if self.extrapolation_mode is not None:
+            model_mode = ExtrapolationMode(self.extrapolation_mode)
+            proto_extrapolation_mode = MODEL_TO_PROTO_EXTRAPOLATION_MODE.get(model_mode)
+
         search_resolver = dataset_module.get_resolver(
-            snuba_params, SearchResolverConfig(stable_timestamp_quantization=False)
+            snuba_params,
+            SearchResolverConfig(
+                stable_timestamp_quantization=False,
+                extrapolation_mode=proto_extrapolation_mode,
+            ),
         )
 
         rpc_request, _, _ = dataset_module.get_timeseries_query(
@@ -641,6 +666,7 @@ def get_entity_subscription_from_snuba_query(
         extra_fields={
             "org_id": organization_id,
             "event_types": snuba_query.event_types,
+            "extrapolation_mode": ExtrapolationMode(snuba_query.extrapolation_mode),
         },
     )
 

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -72,7 +72,7 @@ ALERT_BLOCKED_FIELDS = {
 
 # Mapping from model ExtrapolationMode to proto ExtrapolationMode
 MODEL_TO_PROTO_EXTRAPOLATION_MODE = {
-    ExtrapolationMode.UNKNOWN: ProtoExtrapolationMode.EXTRAPOLATION_MODE_UNSPECIFIED,
+    ExtrapolationMode.UNKNOWN: ProtoExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
     ExtrapolationMode.NONE: ProtoExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED: ProtoExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
     ExtrapolationMode.SERVER_WEIGHTED: ProtoExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -284,6 +284,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
                 extra_fields={
                     "org_id": projects[0].organization_id,
                     "event_types": data.get("event_types"),
+                    "extrapolation_mode": data.get("extrapolation_mode"),
                 },
             )
         except UnsupportedQuerySubscription as e:

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -19,7 +19,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription,
     get_entity_subscription_from_snuba_query,
 )
-from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.models import ExtrapolationMode, QuerySubscription, SnubaQuery
 from sentry.snuba.utils import build_query_strings
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import alerts_tasks
@@ -133,6 +133,9 @@ def update_subscription_in_snuba(
             extra_fields={
                 "org_id": subscription.project.organization_id,
                 "event_types": subscription.snuba_query.event_types,
+                "extrapolation_mode": ExtrapolationMode(
+                    subscription.snuba_query.extrapolation_mode
+                ),
             },
         )
         old_entity_key = (


### PR DESCRIPTION
Pass down extrapolation mode to entity subscriptions so they
get applied properly in the RPC request.