### PR TITLE
feat(replay): Add loading state to ReplayPlaylistProvider and update usage in related components

### DIFF
--- a/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
@@ -6,20 +6,27 @@ import type {ReplayListRecord} from 'sentry/views/replays/types';
 interface Props {
   children: ReactNode;
   currentReplay: ReplayListRecord | undefined;
+  isLoading: boolean;
   replays: ReplayListRecord[];
 }
 
 const Context = createContext<{
   currentReplayIndex: number;
+  isLoading: boolean;
   replays: ReplayListRecord[];
-}>({currentReplayIndex: -1, replays: []});
+}>({currentReplayIndex: -1, replays: [], isLoading: false});
 
-export function ReplayPlaylistProvider({children, currentReplay, replays}: Props) {
+export function ReplayPlaylistProvider({
+  children,
+  currentReplay,
+  isLoading,
+  replays,
+}: Props) {
   const currentReplayIndex = useMemo(
     () => replays?.findIndex(r => r.id === currentReplay?.id) ?? -1,
     [replays, currentReplay]
   );
-  return <Context value={{replays, currentReplayIndex}}>{children}</Context>;
+  return <Context value={{replays, currentReplayIndex, isLoading}}>{children}</Context>;
 }
 
 export function useReplayPlaylist() {

--- a/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
@@ -14,7 +14,7 @@ const Context = createContext<{
   currentReplayIndex: number;
   isLoading: boolean;
   replays: ReplayListRecord[];
-}>({currentReplayIndex: -1, replays: [], isLoading: true});
+}>({currentReplayIndex: -1, replays: [], isLoading: false});
 
 export function ReplayPlaylistProvider({
   children,

--- a/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
@@ -14,7 +14,7 @@ const Context = createContext<{
   currentReplayIndex: number;
   isLoading: boolean;
   replays: ReplayListRecord[];
-}>({currentReplayIndex: -1, replays: [], isLoading: false});
+}>({currentReplayIndex: -1, replays: [], isLoading: true});
 
 export function ReplayPlaylistProvider({
   children,

--- a/static/app/views/replays/detail/body/replayDetailsProviders.tsx
+++ b/static/app/views/replays/detail/body/replayDetailsProviders.tsx
@@ -81,7 +81,7 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
       ? (query.referrer as ReplayListQueryReferrer)
       : 'replayList',
   });
-  const {data} = useApiQuery<{
+  const {data, isLoading} = useApiQuery<{
     data: ReplayListRecord[];
     enabled: boolean;
   }>(queryKey, {
@@ -106,7 +106,11 @@ export default function ReplayDetailsProviders({children, replay, projectSlug}: 
                 replay={replay}
               >
                 <ReplaySummaryContextProvider replay={replay} projectSlug={projectSlug}>
-                  <ReplayPlaylistProvider currentReplay={replayRecord} replays={replays}>
+                  <ReplayPlaylistProvider
+                    currentReplay={replayRecord}
+                    isLoading={isLoading}
+                    replays={replays}
+                  >
                     {children}
                   </ReplayPlaylistProvider>
                 </ReplaySummaryContextProvider>

--- a/static/app/views/replays/detail/playlist/index.tsx
+++ b/static/app/views/replays/detail/playlist/index.tsx
@@ -26,7 +26,7 @@ const MOBILE_COLUMNS = [
 ];
 
 export default function Playlist() {
-  const {replays, currentReplayIndex} = useReplayPlaylist();
+  const {replays, currentReplayIndex, isLoading} = useReplayPlaylist();
   const location = useLocation();
 
   const {allMobileProj} = useAllMobileProj({});
@@ -36,7 +36,10 @@ export default function Playlist() {
       columns={columns}
       error={null}
       highlightedRowIndex={currentReplayIndex}
-      isPending={false}
+      // we prefer isLoading since it is only true if there is a fetch request in flight
+      // React Query's isPending is true as long as there is no data
+      // https://github.com/TanStack/query/discussions/7329
+      isPending={isLoading}
       query={location.query}
       replays={replays}
       showDropdownFilters={false}

--- a/static/app/views/replays/detail/playlist/index.tsx
+++ b/static/app/views/replays/detail/playlist/index.tsx
@@ -36,9 +36,7 @@ export default function Playlist() {
       columns={columns}
       error={null}
       highlightedRowIndex={currentReplayIndex}
-      // we prefer isLoading since it is only true if there is a fetch request in flight
-      // React Query's isPending is true as long as there is no data
-      // https://github.com/TanStack/query/discussions/7329
+      // we prefer isLoading since isPending is true even if not enabled
       isPending={isLoading}
       query={location.query}
       replays={replays}


### PR DESCRIPTION
Forward `isLoading` from React Query to be used in playlist fetch. 

I was curious why we didn't use `isPending`. Reason is here: https://github.com/TanStack/query/discussions/7329