### PR TITLE
fix(aci): prevent deletion of system-created monitors in UI

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/actions.tsx
+++ b/static/app/views/detectors/components/detectorListTable/actions.tsx
@@ -17,6 +17,7 @@ import {useUpdateDetectorsMutation} from 'sentry/views/detectors/hooks/useEditDe
 
 interface DetectorsTableActionsProps {
   allResultsVisible: boolean;
+  canDelete: boolean;
   canEdit: boolean;
   detectorLimitReached: boolean;
   pageSelected: boolean;
@@ -36,6 +37,7 @@ export function DetectorsTableActions({
   showEnable,
   showDisable,
   canEdit,
+  canDelete,
   detectorLimitReached,
 }: DetectorsTableActionsProps) {
   const [allInQuerySelected, setAllInQuerySelected] = useState(false);
@@ -200,13 +202,13 @@ export function DetectorsTableActions({
           )}
           <Tooltip
             title={t('You do not have permission to delete the selected monitors.')}
-            disabled={canEdit}
+            disabled={canDelete}
           >
             <Button
               size="xs"
               priority="danger"
               onClick={handleDelete}
-              disabled={isDeleting || !canEdit}
+              disabled={isDeleting || !canDelete}
             >
               {t('Delete')}
             </Button>

--- a/static/app/views/detectors/components/detectorListTable/actions.tsx
+++ b/static/app/views/detectors/components/detectorListTable/actions.tsx
@@ -17,9 +17,9 @@ import {useUpdateDetectorsMutation} from 'sentry/views/detectors/hooks/useEditDe
 
 interface DetectorsTableActionsProps {
   allResultsVisible: boolean;
-  canDelete: boolean;
   canEdit: boolean;
   detectorLimitReached: boolean;
+  hasSystemCreatedDetectors: boolean;
   pageSelected: boolean;
   queryCount: string;
   selected: Set<string>;
@@ -37,11 +37,13 @@ export function DetectorsTableActions({
   showEnable,
   showDisable,
   canEdit,
-  canDelete,
+  hasSystemCreatedDetectors,
   detectorLimitReached,
 }: DetectorsTableActionsProps) {
   const [allInQuerySelected, setAllInQuerySelected] = useState(false);
   const anySelected = selected.size > 0;
+
+  const canDelete = canEdit && !hasSystemCreatedDetectors;
 
   const {selection} = usePageFilters();
   const {query} = useLocationQuery({
@@ -201,7 +203,11 @@ export function DetectorsTableActions({
             </Tooltip>
           )}
           <Tooltip
-            title={t('You do not have permission to delete the selected monitors.')}
+            title={
+              hasSystemCreatedDetectors
+                ? t('Monitors managed by Sentry cannot be deleted.')
+                : t('You do not have permission to delete the selected monitors.')
+            }
             disabled={canDelete}
           >
             <Button

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -36,10 +36,8 @@ import {
   useMonitorViewContext,
   type MonitorListAdditionalColumn,
 } from 'sentry/views/detectors/monitorViewContext';
-import {
-  useCanDeleteDetectors,
-  useCanEditDetectors,
-} from 'sentry/views/detectors/utils/useCanEditDetector';
+import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
+import {useCanEditDetectors} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {CronServiceIncidents} from 'sentry/views/insights/crons/components/serviceIncidents';
 
 type DetectorListTableProps = {
@@ -142,7 +140,9 @@ function DetectorListTable({
 
   const selectedDetectors = detectors.filter(d => selected.has(d.id));
   const canEditDetectors = useCanEditDetectors({detectors: selectedDetectors});
-  const canDeleteDetectors = useCanDeleteDetectors({detectors: selectedDetectors});
+  const hasSystemCreatedDetectors = selectedDetectors.some(
+    d => !detectorTypeIsUserCreateable(d.type)
+  );
 
   const elementRef = useRef<HTMLDivElement>(null);
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
@@ -216,7 +216,7 @@ function DetectorListTable({
             showDisable={canDisable}
             showEnable={canEnable}
             canEdit={canEditDetectors}
-            canDelete={canDeleteDetectors}
+            hasSystemCreatedDetectors={hasSystemCreatedDetectors}
             // TODO: Check if metric detector limit is reached
             detectorLimitReached={false}
           />

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -36,7 +36,10 @@ import {
   useMonitorViewContext,
   type MonitorListAdditionalColumn,
 } from 'sentry/views/detectors/monitorViewContext';
-import {useCanEditDetectors} from 'sentry/views/detectors/utils/useCanEditDetector';
+import {
+  useCanDeleteDetectors,
+  useCanEditDetectors,
+} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {CronServiceIncidents} from 'sentry/views/insights/crons/components/serviceIncidents';
 
 type DetectorListTableProps = {
@@ -139,6 +142,7 @@ function DetectorListTable({
 
   const selectedDetectors = detectors.filter(d => selected.has(d.id));
   const canEditDetectors = useCanEditDetectors({detectors: selectedDetectors});
+  const canDeleteDetectors = useCanDeleteDetectors({detectors: selectedDetectors});
 
   const elementRef = useRef<HTMLDivElement>(null);
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
@@ -212,6 +216,7 @@ function DetectorListTable({
             showDisable={canDisable}
             showEnable={canEnable}
             canEdit={canEditDetectors}
+            canDelete={canDeleteDetectors}
             // TODO: Check if metric detector limit is reached
             detectorLimitReached={false}
           />

--- a/static/app/views/detectors/list/allMonitors.spec.tsx
+++ b/static/app/views/detectors/list/allMonitors.spec.tsx
@@ -461,6 +461,27 @@ describe('DetectorsList', () => {
       });
     });
 
+    it('can not delete system-created detectors', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        body: [
+          ErrorDetectorFixture({
+            name: 'System Created Detector',
+          }),
+        ],
+      });
+      render(<AllMonitors />, {organization});
+      renderGlobalModal();
+      await screen.findByText('System Created Detector');
+
+      const rows = screen.getAllByTestId('detector-list-row');
+      const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
+      await userEvent.click(firstRowCheckbox);
+
+      // Click Delete button
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
+    });
+
     it('shows option to select all query results when page is selected', async () => {
       const deleteRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',

--- a/static/app/views/detectors/list/allMonitors.spec.tsx
+++ b/static/app/views/detectors/list/allMonitors.spec.tsx
@@ -471,14 +471,13 @@ describe('DetectorsList', () => {
         ],
       });
       render(<AllMonitors />, {organization});
-      renderGlobalModal();
       await screen.findByText('System Created Detector');
 
       const rows = screen.getAllByTestId('detector-list-row');
       const firstRowCheckbox = within(rows[0]!).getByRole('checkbox');
       await userEvent.click(firstRowCheckbox);
 
-      // Click Delete button
+      // Verify that delete button is disabled
       expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
     });
 

--- a/static/app/views/detectors/utils/useCanEditDetector.tsx
+++ b/static/app/views/detectors/utils/useCanEditDetector.tsx
@@ -73,9 +73,3 @@ export function useCanEditDetectors({detectors}: {detectors: Detector[]}) {
 
   return true;
 }
-
-export function useCanDeleteDetectors({detectors}: {detectors: Detector[]}) {
-  const canEdit = useCanEditDetectors({detectors});
-
-  return detectors.every(d => detectorTypeIsUserCreateable(d.type)) && canEdit;
-}

--- a/static/app/views/detectors/utils/useCanEditDetector.tsx
+++ b/static/app/views/detectors/utils/useCanEditDetector.tsx
@@ -73,3 +73,9 @@ export function useCanEditDetectors({detectors}: {detectors: Detector[]}) {
 
   return true;
 }
+
+export function useCanDeleteDetectors({detectors}: {detectors: Detector[]}) {
+  const canEdit = useCanEditDetectors({detectors});
+
+  return detectors.every(d => detectorTypeIsUserCreateable(d.type)) && canEdit;
+}


### PR DESCRIPTION
system-created monitors should not be deleted by anyone, regardless of permissions

closes https://linear.app/getsentry/issue/NEW-647/disable-bulk-delete-in-ui-when-selection-includes-error-monitors