### PR TITLE
ref(detectors): Hide environment selector for cron monitors

### DIFF
--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -47,6 +47,7 @@ export function NewCronDetectorForm() {
       initialFormData={{
         scheduleType: CRON_DEFAULT_SCHEDULE_TYPE,
       }}
+      noEnvironment
     >
       <CronDetectorForm />
     </NewDetectorLayout>
@@ -59,6 +60,7 @@ export function EditExistingCronDetectorForm({detector}: {detector: CronDetector
       detector={detector}
       formDataToEndpointPayload={cronFormDataToEndpointPayload}
       savedDetectorToFormData={cronSavedDetectorToFormData}
+      noEnvironment
     >
       <CronDetectorForm detector={detector} />
     </EditDetectorLayout>

--- a/static/app/views/detectors/components/forms/detectorBaseFields.tsx
+++ b/static/app/views/detectors/components/forms/detectorBaseFields.tsx
@@ -12,7 +12,11 @@ import useProjects from 'sentry/utils/useProjects';
 import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/context';
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
-export function DetectorBaseFields() {
+interface DetectorBaseFieldsProps {
+  noEnvironment?: boolean;
+}
+
+export function DetectorBaseFields({noEnvironment}: DetectorBaseFieldsProps) {
   const {setHasSetDetectorName} = useDetectorFormContext();
 
   return (
@@ -39,7 +43,7 @@ export function DetectorBaseFields() {
       </Layout.Title>
       <Flex gap="md">
         <ProjectField />
-        <EnvironmentField />
+        {!noEnvironment && <EnvironmentField />}
       </Flex>
     </Flex>
   );

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -24,6 +24,7 @@ type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   savedDetectorToFormData: (detector: TDetector) => TFormData;
   mapFormErrors?: (error: any) => any;
+  noEnvironment?: boolean;
   previewChart?: React.ReactNode;
 };
 
@@ -38,6 +39,7 @@ export function EditDetectorLayout<
   formDataToEndpointPayload,
   savedDetectorToFormData,
   mapFormErrors,
+  noEnvironment,
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
@@ -71,7 +73,7 @@ export function EditDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields />
+          <DetectorBaseFields noEnvironment={noEnvironment} />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -22,6 +22,7 @@ type NewDetectorLayoutProps<TFormData, TUpdatePayload> = {
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   initialFormData: Partial<TFormData>;
   mapFormErrors?: (error: any) => any;
+  noEnvironment?: boolean;
   previewChart?: React.ReactNode;
 };
 
@@ -33,6 +34,7 @@ export function NewDetectorLayout<
   formDataToEndpointPayload,
   initialFormData,
   mapFormErrors,
+  noEnvironment,
   previewChart,
   detectorType,
 }: NewDetectorLayoutProps<TFormData, TUpdatePayload>) {
@@ -83,7 +85,7 @@ export function NewDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields />
+          <DetectorBaseFields noEnvironment={noEnvironment} />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>


### PR DESCRIPTION
Fixes [NEW-645](https://linear.app/getsentry/issue/NEW-645/there-should-not-be-a-environment-selector-for-crons)