### PR TITLE
chore(triage signals): Removing 2 noisy logs

### DIFF
--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -54,12 +54,10 @@ def generate_issue_summary_only(group_id: int) -> None:
     Generate issue summary WITHOUT triggering automation.
     Used for triage signals flow when event count < 10 or when summary doesn't exist yet.
     """
-    from sentry import features
     from sentry.seer.autofix.issue_summary import get_issue_summary
 
     group = Group.objects.get(id=group_id)
-    if features.has("projects:triage-signals-v0", group.project):
-        logger.info("Task: generate_issue_summary_only, group_id=%s", group_id)
+    logger.info("Task: generate_issue_summary_only, group_id=%s", group_id)
     get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
@@ -81,12 +79,10 @@ def run_automation_only_task(group_id: int) -> None:
     """
     from django.contrib.auth.models import AnonymousUser
 
-    from sentry import features
     from sentry.seer.autofix.issue_summary import run_automation
 
     group = Group.objects.get(id=group_id)
-    if features.has("projects:triage-signals-v0", group.project):
-        logger.info("Task: run_automation_only_task, group_id=%s", group_id)
+    logger.info("Task: run_automation_only_task, group_id=%s", group_id)
 
     event = group.get_latest_event()
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1634,11 +1634,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         generate_summary_and_run_automation.delay(group.id)
     else:
         # Triage signals V0 behaviour
-
         # If event count < 10, only generate summary (no automation)
-        logger.info(
-            "Triage signals V0: %s: event count %s", group.id, group.times_seen_with_pending
-        )
         if group.times_seen_with_pending < 10:
             # Check if summary exists in cache
             cache_key = get_issue_summary_cache_key(group.id)
@@ -1662,11 +1658,6 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             generate_issue_summary_only.delay(group.id)
         else:
             # Event count >= 10: run automation
-            logger.info(
-                "Triage signals V0: %s: event count >= 10 %s",
-                group.id,
-                group.times_seen_with_pending,
-            )
             # Long-term check to avoid re-running
             if (
                 group.seer_autofix_last_triggered is not None


### PR DESCRIPTION
## PR Details
+ Removing 2 of the more noisier logs and 2 unnecessary ifs.
+ I am seeing [bunch of them](https://sentry.sentry.io/explore/logs/?logsFields=timestamp&logsFields=message&logsFields=server.address&logsFields=group_id&logsFields=project&logsQuery=message%3A%EF%80%8DContains%EF%80%8D%22Triage%20signals%20V0%3A%22&logsSortBys=-timestamp&mode=samples&project=1&statsPeriod=1h) so I know that automation is going into the new flow logic for Seer project. 