### PR TITLE
fix(aci): prevent deletion of system-created monitors in API

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -31,6 +31,7 @@ from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import DetectorSerializer
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
     BulkDetectorWorkflowsValidator,
+    can_delete_detector,
     can_edit_detector,
 )
 from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
@@ -193,7 +194,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         """
         Delete a detector
         """
-        if not can_edit_detector(detector, request):
+        if not can_delete_detector(detector, request):
             raise PermissionDenied
 
         if detector.type == ErrorGroupType.slug:

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -21,7 +21,6 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import DetectorParams, GlobalParams
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
-from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.metric_issue_detector import schedule_update_project_config
 from sentry.issues import grouptype
@@ -196,9 +195,6 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         """
         if not can_delete_detector(detector, request):
             raise PermissionDenied
-
-        if detector.type == ErrorGroupType.slug:
-            return Response(status=403)
 
         validator = get_detector_validator(
             request, detector.project, detector.type, instance=detector

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -69,6 +69,31 @@ def can_edit_detector(detector: Detector, request: Request) -> bool:
     return can_edit_user_created_detectors(request, detector.project)
 
 
+def can_delete_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
+    """
+    Determine if the requesting user has access to delete the given detectors.
+    Only user-created detectors can be deleted, and require "alerts:write" permission.
+    """
+    if any(is_system_created_detector(detector) for detector in detectors):
+        return False
+
+    projects = Project.objects.filter(
+        id__in=detectors.values_list("project_id", flat=True).distinct()
+    )
+    return all(can_edit_user_created_detectors(request, project) for project in projects)
+
+
+def can_delete_detector(detector: Detector, request: Request) -> bool:
+    """
+    Determine if the requesting user has access to delete the given detector.
+    Only user-created detectors can be deleted, and require "alerts:write" permission.
+    """
+    if is_system_created_detector(detector):
+        return False
+
+    return can_edit_user_created_detectors(request, detector.project)
+
+
 def can_edit_detector_workflow_connections(detector: Detector, request: Request) -> bool:
     """
     Anyone with alert write access to the project can connect/disconnect detectors of any type,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -843,3 +843,19 @@ class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest)
         mock_seer_request.assert_called_once_with(
             source_id=int(self.data_source.source_id), organization=self.organization
         )
+
+    def test_cannot_delete_system_created_detector(self) -> None:
+        error_detector = self.create_detector(
+            project=self.project,
+            name="Error Detector",
+            type=ErrorGroupType.slug,
+        )
+
+        self.get_error_response(self.organization.slug, error_detector.id, status_code=403)
+
+        # Verify detector was not deleted
+        self.detector.refresh_from_db()
+        assert self.detector.status != ObjectStatus.PENDING_DELETION
+        assert not RegionScheduledDeletion.objects.filter(
+            model_name="Detector", object_id=self.detector.id
+        ).exists()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -854,8 +854,8 @@ class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest)
         self.get_error_response(self.organization.slug, error_detector.id, status_code=403)
 
         # Verify detector was not deleted
-        self.detector.refresh_from_db()
-        assert self.detector.status != ObjectStatus.PENDING_DELETION
+        error_detector.refresh_from_db()
+        assert error_detector.status != ObjectStatus.PENDING_DELETION
         assert not RegionScheduledDeletion.objects.filter(
-            model_name="Detector", object_id=self.detector.id
+            model_name="Detector", object_id=error_detector.id
         ).exists()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1804,73 +1804,45 @@ class OrganizationDetectorDeleteTest(OrganizationDetectorIndexBaseTest):
             type=ErrorGroupType.slug,
         )
 
-        response = self.get_error_response(
+        self.get_error_response(
             self.organization.slug,
             qs_params={"id": str(error_detector.id)},
-            status_code=400,
+            status_code=403,
         )
 
-        assert "System-created detectors cannot be deleted" in str(response.data["detail"])
-
-        # Verify the error detector was not affected
         self.assert_unaffected_detectors([error_detector])
 
-    def test_delete_mixed_detectors_filters_system_created(self) -> None:
-        # Test that system-created detectors are excluded when deleting by ID
+    def test_delete_system_and_user_created(self) -> None:
+        # Test that permission is denied when request includes system-created detectors
         error_detector = self.create_detector(
             project=self.project,
             name="Error Detector",
             type=ErrorGroupType.slug,
         )
 
-        with outbox_runner():
-            self.get_success_response(
-                self.organization.slug,
-                qs_params=[
-                    ("id", str(self.detector.id)),
-                    ("id", str(error_detector.id)),
-                ],
-                status_code=204,
-            )
+        self.get_error_response(
+            self.organization.slug,
+            qs_params=[
+                ("id", str(self.detector.id)),
+                ("id", str(error_detector.id)),
+            ],
+            status_code=403,
+        )
 
-        # User-created detector should be scheduled for deletion
-        self.detector.refresh_from_db()
-        assert self.detector.status == ObjectStatus.PENDING_DELETION
-        assert RegionScheduledDeletion.objects.filter(
-            model_name="Detector",
-            object_id=self.detector.id,
-        ).exists()
+        self.assert_unaffected_detectors([self.detector, error_detector])
 
-        # System-created detector should NOT be scheduled for deletion
-        self.assert_unaffected_detectors([error_detector])
-
-    def test_delete_by_query_filters_system_created(self) -> None:
-        # Test that system-created detectors are excluded when deleting by query
+    def test_delete_system_and_user_created_with_query_filters(self) -> None:
+        # Test that permission is denied when query filter request includes system-created detectors
         error_detector = self.create_detector(
             project=self.project,
             name="Test Error Detector",
             type=ErrorGroupType.slug,
         )
 
-        with outbox_runner():
-            self.get_success_response(
-                self.organization.slug,
-                qs_params={"query": "test", "project": self.project.id},
-                status_code=204,
-            )
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"query": "Test", "project": self.project.id},
+            status_code=403,
+        )
 
-        # User-created detector should be scheduled for deletion
-        self.detector.refresh_from_db()
-        assert self.detector.status == ObjectStatus.PENDING_DELETION
-        assert RegionScheduledDeletion.objects.filter(
-            model_name="Detector",
-            object_id=self.detector.id,
-        ).exists()
-
-        # System-created detector should NOT be deleted
-        error_detector.refresh_from_db()
-        assert error_detector.status != ObjectStatus.PENDING_DELETION
-        assert not RegionScheduledDeletion.objects.filter(
-            model_name="Detector",
-            object_id=error_detector.id,
-        ).exists()
+        self.assert_unaffected_detectors([self.detector, error_detector])


### PR DESCRIPTION
system-created monitors should not be deleted by anyone, regardless of permissions

backend fix to go with https://github.com/getsentry/sentry/pull/103838

closes https://linear.app/getsentry/issue/NEW-646/prevent-api-from-deleting-error-monitor-detectors-via-bulk-edit