### PR TITLE
fix(monitors): Allow editing cron monitor detectors with existing slug

### DIFF
--- a/tests/sentry/monitors/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_details.py
@@ -138,6 +138,42 @@ class OrganizationMonitorIncidentDetectorDetailsTest(APITestCase):
         assert self.monitor.name == original_monitor_name
         assert self.monitor.config == original_monitor_config
 
+    def test_update_monitor_incident_detector_with_data_sources(self):
+        """Test updating a monitor detector with dataSources field (including existing slug)."""
+        data = {
+            "name": "Updated Name",
+            "dataSources": [
+                {
+                    "name": "Updated Monitor Name",
+                    "slug": self.monitor.slug,  # Keep the existing slug
+                    "config": {
+                        "checkin_margin": 1,
+                        "failure_issue_threshold": 1,
+                        "max_runtime": 30,
+                        "recovery_threshold": 1,
+                        "timezone": "UTC",
+                        "schedule": "0 0 * * 5",
+                        "schedule_type": "crontab",
+                    },
+                }
+            ],
+        }
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.detector.id,
+            **data,
+            status_code=200,
+            method="PUT",
+        )
+
+        assert response.data["name"] == "Updated Name"
+
+        self.monitor.refresh_from_db()
+        assert self.monitor.name == "Updated Monitor Name"
+        assert self.monitor.slug == "test-monitor"  # Slug unchanged
+        assert self.monitor.config["schedule"] == "0 0 * * 5"
+
     def test_delete_monitor_incident_detector(self):
         """Test deleting a monitor incident detector."""
         with outbox_runner():


### PR DESCRIPTION
Fixed [NEW-648: Cron detectors can't be edited due to error](https://linear.app/getsentry/issue/NEW-648/cron-detectors-cant-be-edited-due-to-error)

When updating a cron monitor detector with dataSources in the request body,
the slug validation was incorrectly rejecting the existing slug as "already
in use". This occurred because the MonitorDataSourceValidator nested in a
ListField didn't have its instance property set during validation.

Created MonitorDataSourceListField to bind the Monitor instance to child
validators before validation runs, allowing the slug check to recognize
updates vs creates.