### PR TITLE
fix(eap): Update the filter provided when issuing `DeleteTraceItemsRequest` RPCs

### DIFF
--- a/src/sentry/eventstream/eap.py
+++ b/src/sentry/eventstream/eap.py
@@ -13,11 +13,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
     TraceItemType,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue, IntArray
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
-    AndFilter,
-    ComparisonFilter,
-    TraceItemFilter,
-)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
 from sentry.utils import snuba_rpc
 
@@ -37,14 +33,10 @@ def delete_groups_from_eap_rpc(
     if not group_ids:
         raise ValueError("group_ids must not be empty")
 
-    project_filter = _create_project_filter(project_id)
     group_id_filter = _create_group_id_filter(list(group_ids))
-    combined_filter = TraceItemFilter(
-        and_filter=AndFilter(filters=[project_filter, group_id_filter])
-    )
     filter_with_type = TraceItemFilterWithType(
         item_type=TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,
-        filter=combined_filter,
+        filter=group_id_filter,
     )
 
     request = DeleteTraceItemsRequest(
@@ -60,19 +52,6 @@ def delete_groups_from_eap_rpc(
     response = snuba_rpc.delete_trace_items_rpc(request)
 
     return response
-
-
-def _create_project_filter(project_id: int) -> TraceItemFilter:
-    return TraceItemFilter(
-        comparison_filter=ComparisonFilter(
-            key=AttributeKey(
-                type=AttributeKey.TYPE_INT,
-                name="sentry.project_id",
-            ),
-            op=ComparisonFilter.OP_EQUALS,
-            value=AttributeValue(val_int=project_id),
-        )
-    )
 
 
 def _create_group_id_filter(group_ids: list[int]) -> TraceItemFilter:

--- a/tests/sentry/eventstream/test_eap.py
+++ b/tests/sentry/eventstream/test_eap.py
@@ -33,9 +33,16 @@ class TestEAPDeletion(TestCase):
         assert request.meta.project_ids == [self.project_id]
         assert request.meta.referrer == "deletions.group.eap"
         assert request.meta.cogs_category == "deletions"
+        assert request.meta.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE
 
         assert len(request.filters) == 1
         assert request.filters[0].item_type == TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE
+        assert request.filters[0].filter.HasField("comparison_filter")
+        assert request.filters[0].filter.comparison_filter.key.name == "sentry.group_id"
+        assert (
+            list(request.filters[0].filter.comparison_filter.value.val_int_array.values)
+            == self.group_ids
+        )
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
     def test_multiple_group_ids(self, mock_rpc):
@@ -51,7 +58,9 @@ class TestEAPDeletion(TestCase):
         )
 
         request = mock_rpc.call_args[0][0]
-        group_filter = request.filters[0].filter.and_filter.filters[1]
+        group_filter = request.filters[0].filter
+        assert group_filter.HasField("comparison_filter")
+        assert group_filter.comparison_filter.key.name == "sentry.group_id"
         assert list(group_filter.comparison_filter.value.val_int_array.values) == many_group_ids
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")


### PR DESCRIPTION
Yet another follow-up to https://github.com/getsentry/sentry/pull/102808.

Resolves [SENTRY-5DCB](https://sentry.sentry.io/issues/7049009648?project=1). Resolves [SENTRY-5DCN](https://sentry.sentry.io/issues/7049508299?project=1).

The `EndpointDeleteTraceItems` implementation pulls `project_ids` out of the `RequestMeta`, so this field should not be included in the filters. The only filter condition we need to provide is a `ComparisonFilter.OP_IN` for the group IDs we are trying to delete for.