### PR TITLE
Add metrics to get a spans rate in and out of the spans buffer

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -284,6 +284,8 @@ class SpansBuffer:
                 p.execute()
 
         metrics.timing("spans.buffer.process_spans.num_spans", len(spans))
+        # This incr metric is needed to get a rate overall.
+        metrics.incr("spans.buffer.process_spans.count_spans", amount=len(spans))
         metrics.timing("spans.buffer.process_spans.num_is_root_spans", is_root_span_count)
         metrics.timing("spans.buffer.process_spans.num_subsegments", len(trees))
         metrics.gauge("spans.buffer.min_redirect_depth", min_redirect_depth)
@@ -428,6 +430,8 @@ class SpansBuffer:
             output_spans = []
             has_root_span = False
             metrics.timing("spans.buffer.flush_segments.num_spans_per_segment", len(segment))
+            # This incr metric is needed to get a rate overall.
+            metrics.incr("spans.buffer.flush_segments.count_spans_per_segment", amount=len(segment))
             for payload in segment:
                 span = orjson.loads(payload)
 


### PR DESCRIPTION
We cannot get a clear spans rate into and out of the buffer from the timing metrics we have.
This is useful to ensure we are not dropping spans

