### PR TITLE
ref(billing): Convert Reservations to dynamic type

### DIFF
--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -346,6 +346,11 @@ describe('ProductSelectionAvailability', () => {
         reservedProfileDuration: 0,
         reservedProfileDurationUI: 0,
         reservedLogBytes: 0,
+        reservedSpans: undefined,
+        reservedSeerAutofix: undefined,
+        reservedSeerScanner: undefined,
+        reservedSeerUsers: undefined,
+        reservedPreventUsers: undefined,
       };
       const mockPlan = PlanFixture({});
       const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -214,6 +214,11 @@ describe('ProductUnavailableCTA', () => {
         reservedProfileDuration: 0,
         reservedProfileDurationUI: 0,
         reservedLogBytes: 0,
+        reservedSpans: undefined,
+        reservedSeerAutofix: undefined,
+        reservedSeerScanner: undefined,
+        reservedSeerUsers: undefined,
+        reservedPreventUsers: undefined,
       };
       const mockPlan = PlanFixture({});
       const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/upgradeNowModal/planTable.tsx
+++ b/static/gsApp/components/upgradeNowModal/planTable.tsx
@@ -46,7 +46,7 @@ function PlanTable({organization, previewData, reservations, subscription}: Prop
             abbr
           )}
           next={formatReservedWithUnits(
-            reservations.reservedErrors,
+            reservations.reservedErrors ?? null,
             DataCategory.ERRORS,
             abbr
           )}
@@ -61,7 +61,7 @@ function PlanTable({organization, previewData, reservations, subscription}: Prop
             abbr
           )}
           next={formatReservedWithUnits(
-            reservations.reservedTransactions,
+            reservations.reservedTransactions ?? null,
             DataCategory.TRANSACTIONS,
             abbr
           )}
@@ -83,7 +83,7 @@ function PlanTable({organization, previewData, reservations, subscription}: Prop
             abbr
           )}
           next={formatReservedWithUnits(
-            reservations.reservedAttachments,
+            reservations.reservedAttachments ?? null,
             DataCategory.ATTACHMENTS,
             abbr
           )}

--- a/static/gsApp/components/upgradeNowModal/types.tsx
+++ b/static/gsApp/components/upgradeNowModal/types.tsx
@@ -1,11 +1,50 @@
+import type {DATA_CATEGORY_INFO} from 'sentry/constants';
+
+/**
+ * Dynamically generate Reservations type from DATA_CATEGORY_INFO.
+ *
+ * Generates reservation property names by prefixing 'reserved' to the capitalized plural form
+ * of each billed category. This follows the same pattern as ReservedInvoiceItemType but produces
+ * camelCase property names for object keys.
+ *
+ * Includes all categories where isBilledCategory: true, covering reservations across
+ * all plan types (AM1, AM2, AM3+).
+ *
+ * Pattern: `reserved${Capitalize<plural>}`
+ * - DATA_CATEGORY_INFO.ERROR (plural: 'errors') -> 'reservedErrors'
+ * - DATA_CATEGORY_INFO.LOG_BYTE (plural: 'logBytes') -> 'reservedLogBytes'
+ * - DATA_CATEGORY_INFO.SPAN (plural: 'spans') -> 'reservedSpans'
+ *
+ * Values are `number | undefined` to handle:
+ * - Categories that may not be present in a customer's plan
+ * - Newer categories that haven't been fully rolled out yet
+ * - Optional reservation data
+ * - Different plan types having different category subsets
+ *
+ * @example
+ * // Generates from DATA_CATEGORY_INFO where isBilledCategory: true:
+ * {
+ *   reservedErrors: number | undefined;
+ *   reservedTransactions: number | undefined;
+ *   reservedAttachments: number | undefined;
+ *   reservedReplays: number | undefined;
+ *   reservedSpans: number | undefined;
+ *   reservedMonitorSeats: number | undefined;
+ *   reservedProfileDuration: number | undefined;
+ *   reservedProfileDurationUI: number | undefined;
+ *   reservedUptime: number | undefined;
+ *   reservedLogBytes: number | undefined;
+ *   reservedSeerAutofix: number | undefined;
+ *   reservedSeerScanner: number | undefined;
+ *   reservedPreventUsers: number | undefined;
+ * }
+ *
+ * @see DATA_CATEGORY_INFO in static/app/constants/index.tsx
+ * @see ReservedInvoiceItemType in static/gsApp/types/index.tsx for snake_case equivalent
+ * @see getsentry/billing/plans/ for plan definitions
+ */
 export type Reservations = {
-  reservedAttachments: number;
-  reservedErrors: number;
-  reservedLogBytes: number | undefined;
-  reservedMonitorSeats: number;
-  reservedProfileDuration: number | undefined;
-  reservedProfileDurationUI: number | undefined;
-  reservedReplays: number;
-  reservedTransactions: number;
-  reservedUptime: number | undefined;
-}; // TODO(data categories): BIL-956
+  [K in keyof typeof DATA_CATEGORY_INFO as (typeof DATA_CATEGORY_INFO)[K]['isBilledCategory'] extends true
+    ? `reserved${Capitalize<(typeof DATA_CATEGORY_INFO)[K]['plural']>}`
+    : never]: number | undefined;
+};

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
@@ -21,6 +21,11 @@ const mockReservations: Reservations = {
   reservedProfileDuration: 0,
   reservedProfileDurationUI: 0,
   reservedLogBytes: 5,
+  reservedSpans: undefined,
+  reservedSeerAutofix: 0,
+  reservedSeerScanner: 0,
+  reservedSeerUsers: undefined,
+  reservedPreventUsers: undefined,
 };
 
 const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
@@ -54,6 +54,11 @@ describe('useUpgradeNowParams', () => {
           reservedProfileDuration: 0,
           reservedProfileDurationUI: 0,
           reservedLogBytes: 5,
+          reservedSpans: undefined,
+          reservedSeerAutofix: 0,
+          reservedSeerScanner: 0,
+          reservedSeerUsers: undefined,
+          reservedPreventUsers: undefined,
         },
       })
     );

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
@@ -100,6 +100,11 @@ function useUpgradeNowParams({organization, subscription, enabled = true}: Opts)
         reservedProfileDuration: reserved.profileDuration,
         reservedProfileDurationUI: reserved.profileDurationUI,
         reservedLogBytes: reserved.logBytes,
+        reservedSpans: reserved.spans,
+        reservedSeerAutofix: reserved.seerAutofix,
+        reservedSeerScanner: reserved.seerScanner,
+        reservedSeerUsers: reserved.seerUsers,
+        reservedPreventUsers: reserved.preventUsers,
       },
     };
   }, [billingConfig, isPending, subscription, enabled]);

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,6 @@ declare global {
   }
 
   namespace React {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface DOMAttributes<T> {
       'data-test-id'?: string;
     }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,6 +37,7 @@ declare global {
   }
 
   namespace React {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface DOMAttributes<T> {
       'data-test-id'?: string;
     }


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-956/dynamic-reservations

Converts the hardcoded `Reservations` type to a dynamically-generated mapped type using the same pattern as `ReservedInvoiceItemType`.

Pattern: `reserved${Capitalize<plural>}` from `DATA_CATEGORY_INFO` where `isBilledCategory: true`

Automatically includes all billed categories that can have reservations across any plan type (AM1, AM2, and AM3+).