### PR TITLE
fix(eventstream): Fix trace item inserts to EAP via Snuba HTTP backend

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import urllib3
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
+from urllib3.fields import RequestField
+from urllib3.filepost import encode_multipart_formdata
 
 from sentry import quotas
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
@@ -497,10 +499,16 @@ class SnubaEventStream(SnubaProtocolEventStream):
 
     def _send_item(self, trace_item: TraceItem) -> None:
         try:
+            serialized = trace_item.SerializeToString()
+            field = RequestField(name="item_0", data=serialized, filename="item_0")
+            field.make_multipart(content_type="application/octet-stream")
+            body, content_type = encode_multipart_formdata([field])
+
             resp = snuba._snuba_pool.urlopen(
                 "POST",
                 EAP_ITEMS_INSERT_ENDPOINT,
-                fields={"item_0": trace_item.SerializeToString()},
+                body=body,
+                headers={"Content-Type": content_type},
             )
 
             if resp.status == 200:


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/103566.

The previous logic did not correctly serialize the trace item when making a POST request to the "/tests/entities/eap_items/insert_bytes" endpoint. With this updated logic we should see successful EAP inserts (example below).

Querying via `docker exec -it snuba-clickhouse-1 clickhouse-client --query "SELECT item_id, project_id, organization_id, trace_id, item_type, timestamp FROM eap_items_1_local ORDER BY timestamp DESC LIMIT 5 FORMAT Pretty"`.

Before ingesting new event:
<img width="1061" height="183" alt="image" src="https://github.com/user-attachments/assets/9d2eca89-8fc9-4ab5-9fb3-ae34fd862ef8" />

After ingesting new event:
<img width="1055" height="186" alt="image" src="https://github.com/user-attachments/assets/18caf67e-4d4b-4232-a2a9-b00225a52396" />