### PR TITLE
fix(aci): Snake casing for data sources in evidence data

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -10,6 +10,7 @@ from django.db.models import Q
 from sentry_redis_tools.retrying_cluster import RetryingRedisCluster
 
 from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework.base import camel_to_snake_case, convert_dict_key_case
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
@@ -370,7 +371,8 @@ class StatefulDetectorHandler(
                     },
                 )
                 return []
-            return serialize(data_sources)
+            # Serializers return camelcased keys, but evidence data should use snakecase
+            return convert_dict_key_case(serialize(data_sources), camel_to_snake_case)
         except Exception:
             logger.exception(
                 "Failed to serialize data source definition when building workflow engine evidence data"

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -54,22 +54,22 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
             "data_sources": [
                 {
                     "id": str(self.data_source.id),
-                    "organizationId": str(self.organization.id),
+                    "organization_id": str(self.organization.id),
                     "type": self.data_source.type,
-                    "sourceId": str(self.query_subscription.id),
-                    "queryObj": {
+                    "source_id": str(self.query_subscription.id),
+                    "query_obj": {
                         "id": str(self.query_subscription.id),
                         "status": self.query_subscription.status,
                         "subscription": self.query_subscription.subscription_id,
-                        "snubaQuery": {
+                        "snuba_query": {
                             "id": str(self.snuba_query.id),
                             "dataset": self.snuba_query.dataset,
                             "query": self.snuba_query.query,
                             "aggregate": self.snuba_query.aggregate,
-                            "timeWindow": self.snuba_query.time_window,
+                            "time_window": self.snuba_query.time_window,
                             "environment": self.environment.name,
-                            "eventTypes": ["error"],
-                            "extrapolationMode": "unknown",
+                            "event_types": ["error"],
+                            "extrapolation_mode": "unknown",
                         },
                     },
                 }


### PR DESCRIPTION
I missed this in https://github.com/getsentry/sentry/pull/103549

I was using the default serializer, which outputs camelcased keys. However, the occurrence evidence data uses snake case by convention. Using camelcased keys also has a problem where our event detail endpoint will run a camel-case converter again, which does things like `snubaQuery -> snubaquery` and then the frontend can't reuse those types.

So this runs the serialized data source through a casing converter to ensure it's snake case.