### PR TITLE
fix(performance): Fixes web vital issue trace links not working sometimes

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -3,12 +3,15 @@ import styled from '@emotion/styled';
 
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfaces/performance/utils';
+import {
+  isWebVitalsEvent,
+  TRACE_WATERFALL_PREFERENCES_KEY,
+} from 'sentry/components/events/interfaces/performance/utils';
 import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import {type Event} from 'sentry/types/event';
-import {getIssueTypeFromOccurrenceType, IssueType, type Group} from 'sentry/types/group';
+import {type Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -130,10 +133,6 @@ function OneOtherIssueEvent({event}: {event: Event}) {
 const IssuesTraceContainer = styled('div')`
   position: relative;
 `;
-
-const isWebVitalsEvent = (event: Event) => {
-  return getIssueTypeFromOccurrenceType(event.occurrence?.type) === IssueType.WEB_VITALS; // Web Vitals group type id
-};
 
 interface EventTraceViewProps {
   event: Event;

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -6,7 +6,7 @@ import type {
   TraceContextSpanProxy,
 } from 'sentry/components/events/interfaces/spans/types';
 import type {EntrySpans, EventTransaction} from 'sentry/types/event';
-import {EntryType} from 'sentry/types/event';
+import {EntryType, type Event} from 'sentry/types/event';
 import {getIssueTypeFromOccurrenceType, IssueType} from 'sentry/types/group';
 
 export const TRACE_WATERFALL_PREFERENCES_KEY =
@@ -97,3 +97,7 @@ export function getProblemSpansForSpanTree(event: EventTransaction): {
 
   return {affectedSpanIds, focusedSpanIds};
 }
+
+export const isWebVitalsEvent = (event: Event) => {
+  return getIssueTypeFromOccurrenceType(event.occurrence?.type) === IssueType.WEB_VITALS; // Web Vitals group type id
+};

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -1,6 +1,7 @@
 import type {Location, LocationDescriptor} from 'history';
 import moment from 'moment-timezone';
 
+import {isWebVitalsEvent} from 'sentry/components/events/interfaces/performance/utils';
 import {getTraceDateTimeRange} from 'sentry/components/events/interfaces/spans/utils';
 import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
@@ -42,7 +43,7 @@ export function generateTraceTarget(
       organization,
       traceSlug: traceId,
       dateSelection,
-      timestamp: getEventTimestampInSeconds(event),
+      timestamp: isWebVitalsEvent(event) ? undefined : getEventTimestampInSeconds(event),
       eventId: event.eventID,
       location,
       source,


### PR DESCRIPTION
- Fix an issue with Web Vital performance issues not linking the the trace sample properly due to timestamp. Web Vital performance issue events have a different detection timestamp from their trace sample.
- Moves `isWebVitalsEvent` utility function to a better location.