### PR TITLE
feat(dashboards): ensure global filters carryforward when clicking view span samples on table

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -687,9 +687,13 @@ export const performanceScoreTooltip = t('peformance_score is not supported in D
 
 export function applyDashboardFilters(
   baseQuery: string | undefined,
-  dashboardFilters: DashboardFilters | undefined
+  dashboardFilters: DashboardFilters | undefined,
+  widgetType?: WidgetType
 ): string | undefined {
-  const dashboardFilterConditions = dashboardFiltersToString(dashboardFilters);
+  const dashboardFilterConditions = dashboardFiltersToString(
+    dashboardFilters,
+    widgetType
+  );
   if (dashboardFilterConditions) {
     if (baseQuery) {
       return `(${baseQuery}) ${dashboardFilterConditions}`;

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -303,7 +303,8 @@ function _getWidgetExploreUrl(
     field: fields,
     query: applyDashboardFilters(
       overrideQuery?.formatString() ?? decodeScalar(locationQueryParams.query),
-      dashboardFilters
+      dashboardFilters,
+      widget.widgetType
     ),
     sort: sort || undefined,
     interval:


### PR DESCRIPTION
When clicking `view span samples` on a table, we should also append the `globalFilters` when we end up in explore
<img width="1110" height="187" alt="image" src="https://github.com/user-attachments/assets/38ca2d2b-6ae4-4d99-bd12-99b9ec8bffe7" />

There is existing logic to do so already here
https://github.com/getsentry/sentry/blob/c45e912173187a9e9177c4ffc181c0c5f1b25eb5/static/app/views/dashboards/utils.tsx#L615-L622
 We just had to pass in the `widgetType` so the widget correctly filters out any non-applicable filters based on the dataset.