### PR TITLE
chore(releases): remove floating feedback widget in favor of header feedback (ENG-5961)

### DIFF
--- a/static/app/views/releases/components/header.tsx
+++ b/static/app/views/releases/components/header.tsx
@@ -1,8 +1,14 @@
+import {Button} from '@sentry/scraps/button';
+
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 
 function Header() {
+  const openFeedbackForm = useFeedbackForm();
+
   return (
     <Layout.Header noActionWrap unified>
       <Layout.HeaderContent unified>
@@ -16,6 +22,24 @@ function Header() {
           />
         </Layout.Title>
       </Layout.HeaderContent>
+      {openFeedbackForm ? (
+        <Layout.HeaderActions>
+          <Button
+            size="sm"
+            icon={<IconMegaphone />}
+            onClick={() =>
+              openFeedbackForm({
+                messagePlaceholder: t('How can we improve the Releases experience?'),
+                tags: {
+                  ['feedback.source']: 'releases-list-header',
+                },
+              })
+            }
+          >
+            {t('Give Feedback')}
+          </Button>
+        </Layout.HeaderActions>
+      ) : null}
     </Layout.Header>
   );
 }

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -3,7 +3,6 @@ import {forceCheck} from 'react-lazyload';
 import styled from '@emotion/styled';
 
 import {fetchTagValues} from 'sentry/actionCreators/tags';
-import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
@@ -399,7 +398,6 @@ export default function ReleasesList() {
                 />
               </DemoTourElement>
             )}
-            <FloatingFeedbackWidget />
           </Layout.Main>
         </Layout.Body>
       </NoProjectMessage>


### PR DESCRIPTION
Most pages use the feedback widget in the header, releases is the only top level page to have it as a floating widget

NEW (Top right)
<img width="1331" height="716" alt="image" src="https://github.com/user-attachments/assets/cc1affb6-f2ff-46a4-9d7f-c5c3f38c2267" />

OLD (bottom right)
<img width="1330" height="714" alt="image" src="https://github.com/user-attachments/assets/54d74533-22d5-4037-bc11-ee40db5bfd90" />


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
