### PR TITLE
chore(aci): support pasting metric issue links and unfurling

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -139,6 +139,7 @@ def fetch_metric_issue_open_periods(
     time_window: int = 0,
 ) -> list[Any]:
     detector_id = open_period_identifier
+    identifier_is_detector = True
     try:
         # temporarily fetch the alert rule ID from the detector ID
         alert_rule_detector = AlertRuleDetector.objects.filter(
@@ -147,10 +148,15 @@ def fetch_metric_issue_open_periods(
         if alert_rule_detector is not None:
             # open_period_identifier is a metric detector ID -> get the alert rule ID
             open_period_identifier = alert_rule_detector.alert_rule_id
+        else:
+            identifier_is_detector = False
 
-        if features.has(
-            "organizations:new-metric-issue-charts",
-            organization,
+        if (
+            features.has(
+                "organizations:new-metric-issue-charts",
+                organization,
+            )
+            and identifier_is_detector
         ):
             resp = client.get(
                 auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -138,6 +138,7 @@ def fetch_metric_issue_open_periods(
     user: User | RpcUser | None = None,
     time_window: int = 0,
 ) -> list[Any]:
+    detector_id = open_period_identifier
     identifier_is_detector = True
     try:
         # temporarily fetch the alert rule ID from the detector ID
@@ -160,8 +161,8 @@ def fetch_metric_issue_open_periods(
                 ).first()
                 if alert_rule_detector is not None:
                     detector_id = alert_rule_detector.detector_id
-            else:
-                detector_id = open_period_identifier
+                else:
+                    raise Exception("passed ID was not an alert rule ID or a detector ID")
 
             resp = client.get(
                 auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),


### PR DESCRIPTION
I think the unfurl will still fail, due to other happenings with the slack integration, but this gets the correct detector ID if an alert rule ID is passed in as the open period identifier (as with pasted links).