### PR TITLE
fix(issues): Fix issue search single page count inaccuracy

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -389,6 +389,18 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
             status_labels = {QUERY_STATUS_LOOKUP[s] for s in status[0].value.raw_value}
             context = [r for r in context if "status" not in r or r["status"] in status_labels]
 
+        # Sanity check: if we're on the first and last page with no more results,
+        # the estimated hits from sampling may be too high due to Snuba/Postgres
+        # data inconsistency. Cap hits to match the actual number of results.
+        if (
+            cursor_result.hits is not None
+            and not cursor_result.next.has_results
+            and not request.GET.get("cursor")
+        ):
+            actual_count = len(context)
+            if cursor_result.hits > actual_count:
+                cursor_result.hits = actual_count
+
         response = Response(context)
 
         self.add_cursor_headers(request, response, cursor_result)

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -394,7 +394,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         # data inconsistency. Cap hits to match the actual number of results.
         if (
             cursor_result.hits is not None
-            and not cursor_result.next.has_results
+            and cursor_result.next.has_results is False
             and not request.GET.get("cursor")
         ):
             actual_count = len(context)


### PR DESCRIPTION
Our issues search pagination uses some heuristics to give the total results number, but this breaks for single page results sometimes which makes no sense. Added exception for the single page case to just use the number of results and avoid this.