### PR TITLE
chore(releases): add give feedback to release details page

### DIFF
--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {Container} from '@sentry/scraps/layout/container';
 
 import {archiveRelease, restoreRelease} from 'sentry/actionCreators/release';
 import {Client} from 'sentry/api';
@@ -188,20 +189,22 @@ function ReleaseActions({projectSlug, release, releaseMeta, refetchData}: Props)
   return (
     <ButtonBar>
       {openFeedbackForm ? (
-        <Button
-          size="sm"
-          icon={<IconMegaphone />}
-          onClick={() =>
-            openFeedbackForm({
-              messagePlaceholder: t('How can we improve the Releases experience?'),
-              tags: {
-                ['feedback.source']: 'release-detail',
-              },
-            })
-          }
-        >
-          {t('Give Feedback')}
-        </Button>
+        <Container display={{'2xs': 'none', xs: 'block'}}>
+          <Button
+            size="sm"
+            icon={<IconMegaphone />}
+            onClick={() =>
+              openFeedbackForm({
+                messagePlaceholder: t('How can we improve the Releases experience?'),
+                tags: {
+                  ['feedback.source']: 'release-detail',
+                },
+              })
+            }
+          >
+            {t('Give Feedback')}
+          </Button>
+        </Container>
       ) : null}
       <ButtonBar merged gap="0">
         <LinkButton

--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -1,6 +1,8 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
+
 import {archiveRelease, restoreRelease} from 'sentry/actionCreators/release';
 import {Client} from 'sentry/api';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -10,11 +12,12 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import TextOverflow from 'sentry/components/textOverflow';
-import {IconEllipsis, IconNext, IconPrevious} from 'sentry/icons';
+import {IconEllipsis, IconMegaphone, IconNext, IconPrevious} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Release, ReleaseMeta} from 'sentry/types/release';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -33,6 +36,7 @@ function ReleaseActions({projectSlug, release, releaseMeta, refetchData}: Props)
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
+  const openFeedbackForm = useFeedbackForm();
 
   async function handleArchive() {
     try {
@@ -183,6 +187,22 @@ function ReleaseActions({projectSlug, release, releaseMeta, refetchData}: Props)
 
   return (
     <ButtonBar>
+      {openFeedbackForm ? (
+        <Button
+          size="sm"
+          icon={<IconMegaphone />}
+          onClick={() =>
+            openFeedbackForm({
+              messagePlaceholder: t('How can we improve the Releases experience?'),
+              tags: {
+                ['feedback.source']: 'release-detail',
+              },
+            })
+          }
+        >
+          {t('Give Feedback')}
+        </Button>
+      ) : null}
       <ButtonBar merged gap="0">
         <LinkButton
           size="sm"


### PR DESCRIPTION
*need to test mobile before merging*
Release details page doesn't have a "Give Feedback" button, adding here.

<img width="1427" height="135" alt="image" src="https://github.com/user-attachments/assets/c420057b-f702-41c8-b77f-a814bc4d2077" />

convention in other parts of the product has been to put "Give Feedback" as the leftmost button 
Dashboard example
<img width="1379" height="54" alt="image" src="https://github.com/user-attachments/assets/39c20468-a848-4966-b86f-1d97b4868d6e" />

cron example
<img width="1395" height="63" alt="image" src="https://github.com/user-attachments/assets/0597afdf-3191-46bb-8de8-b9a8bb1e2d57" />


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
