### PR TITLE
fix(eap): Update attribute key name provided in `DeleteTraceItemsRequest` RPCs

### DIFF
--- a/src/sentry/eventstream/eap.py
+++ b/src/sentry/eventstream/eap.py
@@ -59,7 +59,7 @@ def _create_group_id_filter(group_ids: list[int]) -> TraceItemFilter:
         comparison_filter=ComparisonFilter(
             key=AttributeKey(
                 type=AttributeKey.TYPE_INT,
-                name="sentry.group_id",
+                name="group_id",
             ),
             op=ComparisonFilter.OP_IN,
             value=AttributeValue(val_int_array=IntArray(values=group_ids)),

--- a/tests/sentry/eventstream/test_eap.py
+++ b/tests/sentry/eventstream/test_eap.py
@@ -38,7 +38,7 @@ class TestEAPDeletion(TestCase):
         assert len(request.filters) == 1
         assert request.filters[0].item_type == TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE
         assert request.filters[0].filter.HasField("comparison_filter")
-        assert request.filters[0].filter.comparison_filter.key.name == "sentry.group_id"
+        assert request.filters[0].filter.comparison_filter.key.name == "group_id"
         assert (
             list(request.filters[0].filter.comparison_filter.value.val_int_array.values)
             == self.group_ids
@@ -60,7 +60,7 @@ class TestEAPDeletion(TestCase):
         request = mock_rpc.call_args[0][0]
         group_filter = request.filters[0].filter
         assert group_filter.HasField("comparison_filter")
-        assert group_filter.comparison_filter.key.name == "sentry.group_id"
+        assert group_filter.comparison_filter.key.name == "group_id"
         assert list(group_filter.comparison_filter.value.val_int_array.values) == many_group_ids
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")


### PR DESCRIPTION
Resolves [SNUBA-9Y9](https://sentry.sentry.io/issues/7052540005?project=300688). Resolves [SENTRY-5DCB](https://sentry.sentry.io/issues/7049009648?project=1).

Testing locally confirms that the request is accepted by Snuba after correcting the name on the `AttributeKey`.