### PR TITLE
fix(aci): Immediate deletion of workflow-detector connections in DELETE endpoints

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_workflow_index.py
@@ -18,7 +18,6 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams
-from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.serializers.detector_workflow_serializer import (
     DetectorWorkflowSerializer,
@@ -135,13 +134,16 @@ class OrganizationDetectorWorkflowIndexEndpoint(OrganizationEndpoint):
         if not queryset:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
+        detector_workflows = list(queryset)
+
         # check that the user has permission to edit all detectors connections before deleting
-        for detector_workflow in queryset:
+        for detector_workflow in detector_workflows:
             if not can_edit_detector_workflow_connections(detector_workflow.detector, request):
                 raise PermissionDenied
 
-        for detector_workflow in queryset:
-            RegionScheduledDeletion.schedule(detector_workflow, days=0, actor=request.user)
+        queryset.delete()
+
+        for detector_workflow in detector_workflows:
             create_audit_entry(
                 request=request,
                 organization=organization,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_workflow_details.py
@@ -3,7 +3,6 @@ from unittest import mock
 from sentry import audit_log
 from sentry.api.serializers import serialize
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
-from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import region_silo_test
@@ -70,16 +69,6 @@ class OrganizationDetectorWorkflowDetailsDeleteTest(OrganizationDetectorWorkflow
                 self.organization.slug,
                 self.detector_workflow.id,
             )
-
-        # verify the DetectorWorkflow was scheduled for deletion
-        assert RegionScheduledDeletion.objects.filter(
-            model_name="DetectorWorkflow",
-            object_id=self.detector_workflow.id,
-        ).exists()
-
-        # delete the DetectorWorkflow
-        with self.tasks():
-            run_scheduled_deletions()
 
         # verify it was deleted
         assert not DetectorWorkflow.objects.filter(id=self.detector_workflow.id).exists()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_workflow_index.py
@@ -2,7 +2,6 @@ from unittest import mock
 from unittest.mock import MagicMock, call
 
 from sentry import audit_log
-from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
@@ -311,8 +310,6 @@ class OrganizationDetectorWorkflowIndexDeleteTest(OrganizationDetectorWorkflowAP
             self.organization.slug,
             qs_params={"detector_id": self.detector_1.id, "workflow_id": self.workflow_1.id},
         )
-        with self.tasks():
-            run_scheduled_deletions()
 
         assert not DetectorWorkflow.objects.filter(
             detector_id=self.detector_1.id, workflow_id=self.workflow_1.id
@@ -335,9 +332,6 @@ class OrganizationDetectorWorkflowIndexDeleteTest(OrganizationDetectorWorkflowAP
             self.organization.slug,
             qs_params={"detector_id": self.detector_1.id},
         )
-        with self.tasks():
-            run_scheduled_deletions()
-
         assert not DetectorWorkflow.objects.filter(detector_id=self.detector_1.id).exists()
         assert DetectorWorkflow.objects.filter(detector_id=self.detector_2.id).exists()
 


### PR DESCRIPTION
The DetectorWorkflow index and details endpoints were scheduling deletions, which was not working properly since we don't have logic to filter them out of queries while they are soft deleted.

This is a simple model without any complex deletion behavior, so I think it's best to just delete them immediately.