### PR TITLE
:sparkles: feat(gitlab): add inbound/outbound assignment & comment support

### DIFF
--- a/fixtures/gitlab.py
+++ b/fixtures/gitlab.py
@@ -318,6 +318,114 @@ PUSH_EVENT_IGNORED_COMMIT = b"""
 """
 
 
+ISSUE_ASSIGNED_EVENT = b"""{
+  "object_kind": "issue",
+  "event_type": "issue",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/avatar.jpg",
+    "email": "admin@example.com"
+  },
+  "project": {
+    "id": 15,
+    "name": "Sentry",
+    "description": "",
+    "web_url": "http://example.com/cool-group/sentry",
+    "avatar_url": null,
+    "git_ssh_url": "git@example.com:cool-group/sentry.git",
+    "git_http_url": "http://example.com/cool-group/sentry.git",
+    "namespace": "cool-group",
+    "visibility_level": 0,
+    "path_with_namespace": "cool-group/sentry",
+    "default_branch": "master",
+    "homepage": "http://example.com/cool-group/sentry",
+    "url": "git@example.com:cool-group/sentry.git",
+    "ssh_url": "git@example.com:cool-group/sentry.git",
+    "http_url": "http://example.com/cool-group/sentry.git"
+  },
+  "object_attributes": {
+    "id": 301,
+    "title": "Test issue",
+    "assignee_ids": [1],
+    "assignee_id": 1,
+    "author_id": 1,
+    "project_id": 15,
+    "created_at": "2023-01-01 00:00:00 UTC",
+    "updated_at": "2023-01-01 00:00:00 UTC",
+    "position": 0,
+    "branch_name": null,
+    "description": "Test issue description",
+    "milestone_id": null,
+    "state": "opened",
+    "iid": 23,
+    "url": "http://example.com/cool-group/sentry/issues/23",
+    "action": "update"
+  },
+  "assignees": [
+    {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "avatar_url": "http://www.gravatar.com/avatar/avatar.jpg",
+      "email": "admin@example.com"
+    }
+  ],
+  "labels": []
+}
+"""
+
+ISSUE_UNASSIGNED_EVENT = b"""{
+  "object_kind": "issue",
+  "event_type": "issue",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/avatar.jpg",
+    "email": "admin@example.com"
+  },
+  "project": {
+    "id": 15,
+    "name": "Sentry",
+    "description": "",
+    "web_url": "http://example.com/cool-group/sentry",
+    "avatar_url": null,
+    "git_ssh_url": "git@example.com:cool-group/sentry.git",
+    "git_http_url": "http://example.com/cool-group/sentry.git",
+    "namespace": "cool-group",
+    "visibility_level": 0,
+    "path_with_namespace": "cool-group/sentry",
+    "default_branch": "master",
+    "homepage": "http://example.com/cool-group/sentry",
+    "url": "git@example.com:cool-group/sentry.git",
+    "ssh_url": "git@example.com:cool-group/sentry.git",
+    "http_url": "http://example.com/cool-group/sentry.git"
+  },
+  "object_attributes": {
+    "id": 301,
+    "title": "Test issue",
+    "assignee_ids": [],
+    "assignee_id": null,
+    "author_id": 1,
+    "project_id": 15,
+    "created_at": "2023-01-01 00:00:00 UTC",
+    "updated_at": "2023-01-01 00:00:00 UTC",
+    "position": 0,
+    "branch_name": null,
+    "description": "Test issue description",
+    "milestone_id": null,
+    "state": "opened",
+    "iid": 23,
+    "url": "http://example.com/cool-group/sentry/issues/23",
+    "action": "update"
+  },
+  "assignees": [],
+  "labels": []
+}
+"""
+
 COMPARE_RESPONSE = r"""
 {
   "commit": {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -186,6 +186,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-external-projects-async-lookup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Project Management Integrations Feature Parity Flags
     manager.add("organizations:integrations-github-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-github_enterprise-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-gitlab-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable inviting billing members to organizations at the member limit.
     manager.add("organizations:invite-billing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     # Enable inviting members to organizations.

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -47,6 +47,7 @@ from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 
 from .client import GitLabApiClient, GitLabSetupApiClient
+from .issue_sync import GitlabIssueSyncSpec
 from .issues import GitlabIssuesSpec
 from .repository import GitlabRepositoryProvider
 
@@ -109,7 +110,9 @@ metadata = IntegrationMetadata(
 )
 
 
-class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIntegration):
+class GitlabIntegration(
+    RepositoryIntegration, GitlabIssuesSpec, GitlabIssueSyncSpec, CommitContextIntegration
+):
     codeowners_locations = ["CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"]
 
     @property

--- a/src/sentry/integrations/gitlab/issue_sync.py
+++ b/src/sentry/integrations/gitlab/issue_sync.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+from urllib.parse import quote
+
+from django.utils.translation import gettext_lazy as _
+
+from sentry import features
+from sentry.integrations.mixins.issues import IssueSyncIntegration, ResolveSyncAction
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.models.integration_external_project import IntegrationExternalProject
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import EXTERNAL_PROVIDERS_REVERSE, ExternalProviderEnum
+from sentry.organizations.services.organization import organization_service
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.users.services.user.model import RpcUser
+from sentry.users.services.user.service import user_service
+
+logger = logging.getLogger("sentry.integrations.gitlab.issue_sync")
+
+
+class GitlabIssueSyncSpec(IssueSyncIntegration):
+    comment_key = "sync_comments"
+    outbound_assignee_key = "sync_forward_assignment"
+    inbound_assignee_key = "sync_reverse_assignment"
+
+    def check_feature_flag(self) -> bool:
+        """
+        A temporary method so we can gate GitLab project management features.
+        """
+        return features.has(
+            "organizations:integrations-gitlab-project-management", self.organization
+        )
+
+    def split_external_issue_key(
+        self, external_issue_key: str
+    ) -> tuple[str, str] | tuple[None, None]:
+        """
+        Split the external issue key into project path and issue iid.
+        Format is "{domain_name}:{path_with_namespace}#{issue_iid}"
+        """
+        try:
+            _, project_and_issue_iid = external_issue_key.split(":", 1)
+            project_id, issue_iid = project_and_issue_iid.split("#")
+
+            return project_id, issue_iid
+        except ValueError:
+            logger.exception(
+                "split-external-key.invalid-format",
+                extra={
+                    "external_issue_key": external_issue_key,
+                    "provider": self.model.provider,
+                },
+            )
+            return None, None
+
+    def sync_assignee_outbound(
+        self,
+        external_issue: ExternalIssue,
+        user: RpcUser | None,
+        assign: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Propagate a sentry issue's assignee to a linked GitLab issue's assignee.
+        If assign=True, we're assigning the issue. Otherwise, deassign.
+        """
+        client = self.get_client()
+
+        project_id, issue_iid = self.split_external_issue_key(external_issue.key)
+
+        if not project_id or not issue_iid:
+            logger.error(
+                "assignee-outbound.invalid-key",
+                extra={
+                    "provider": self.model.provider,
+                    "integration_id": external_issue.integration_id,
+                    "external_issue_key": external_issue.key,
+                    "external_issue_id": external_issue.id,
+                },
+            )
+            return
+
+        gitlab_user_id = None
+
+        # If we're assigning and have a user, find their GitLab user ID
+        if user and assign:
+            # Check if user has a GitLab identity linked
+            provider = EXTERNAL_PROVIDERS_REVERSE[ExternalProviderEnum(self.model.provider)].value
+            external_actor = ExternalActor.objects.filter(
+                provider=provider,
+                user_id=user.id,
+                integration_id=external_issue.integration_id,
+                organization=external_issue.organization,
+            ).first()
+            if not external_actor:
+                logger.info(
+                    "assignee-outbound.external-actor-not-found",
+                    extra={
+                        "provider": self.model.provider,
+                        "integration_id": external_issue.integration_id,
+                        "user_id": user.id,
+                    },
+                )
+                return
+
+            # Strip the @ from the username stored in external_name
+            gitlab_username = external_actor.external_name.lstrip("@")
+
+            # Search for the GitLab user by username to get their user ID
+            try:
+                users = client.search_users(gitlab_username)
+                if not users or len(users) == 0:
+                    logger.warning(
+                        "assignee-outbound.gitlab-user-not-found",
+                        extra={
+                            "provider": self.model.provider,
+                            "integration_id": external_issue.integration_id,
+                            "gitlab_username": gitlab_username,
+                        },
+                    )
+                    return
+
+                # Take the first matching user (exact username match)
+                gitlab_user = users[0]
+                gitlab_user_id = gitlab_user["id"]
+
+                logger.info(
+                    "assignee-outbound.gitlab-user-found",
+                    extra={
+                        "provider": self.model.provider,
+                        "integration_id": external_issue.integration_id,
+                        "gitlab_username": gitlab_username,
+                        "gitlab_user_id": gitlab_user_id,
+                    },
+                )
+            except ApiError as e:
+                logger.warning(
+                    "assignee-outbound.gitlab-user-search-failed",
+                    extra={
+                        "provider": self.model.provider,
+                        "integration_id": external_issue.integration_id,
+                        "gitlab_username": gitlab_username,
+                        "error": str(e),
+                    },
+                )
+                return
+
+        # Update GitLab issue assignees
+        try:
+            data = {"assignee_ids": [gitlab_user_id] if gitlab_user_id else []}
+            # URL-encode project_id since it's a path_with_namespace (e.g., "owner/repo")
+            encoded_project_id = quote(project_id, safe="")
+            client.update_issue_assignees(encoded_project_id, issue_iid, data)
+        except Exception as e:
+            self.raise_error(e)
+
+    def sync_status_outbound(
+        self, external_issue: ExternalIssue, is_resolved: bool, project_id: int
+    ) -> None:
+        """
+        Propagate a sentry issue's status to a linked GitLab issue's status.
+        For GitLab, we only support opened/closed states.
+        """
+        raise NotImplementedError
+
+    def get_resolve_sync_action(self, data: Mapping[str, Any]) -> ResolveSyncAction:
+        """
+        Given webhook data, check whether the GitLab issue status changed.
+        GitLab issues have opened/closed state.
+        """
+        return ResolveSyncAction.NOOP
+
+    def get_config_data(self):
+        config = self.org_integration.config
+        project_mappings = IntegrationExternalProject.objects.filter(
+            organization_integration_id=self.org_integration.id
+        )
+        sync_status_forward = {}
+
+        for pm in project_mappings:
+            sync_status_forward[pm.external_id] = {
+                "on_unresolve": pm.unresolved_status,
+                "on_resolve": pm.resolved_status,
+            }
+        config["sync_status_forward"] = sync_status_forward
+        return config
+
+    def _get_organization_config_default_values(self) -> list[dict[str, Any]]:
+        """
+        Return configuration options for the GitLab integration.
+        """
+        config: list[dict[str, Any]] = []
+
+        if self.check_feature_flag():
+            config.extend(
+                [
+                    {
+                        "name": self.inbound_assignee_key,
+                        "type": "boolean",
+                        "label": _("Sync GitLab Assignment to Sentry"),
+                        "help": _(
+                            "When an issue is assigned in GitLab, assign its linked Sentry issue to the same user."
+                        ),
+                        "default": False,
+                    },
+                    {
+                        "name": self.outbound_assignee_key,
+                        "type": "boolean",
+                        "label": _("Sync Sentry Assignment to GitLab"),
+                        "help": _(
+                            "When an issue is assigned in Sentry, assign its linked GitLab issue to the same user."
+                        ),
+                        "default": False,
+                    },
+                    {
+                        "name": self.comment_key,
+                        "type": "boolean",
+                        "label": _("Sync Sentry Comments to GitLab"),
+                        "help": _("Post comments from Sentry issues to linked GitLab issues"),
+                    },
+                ]
+            )
+
+        return config
+
+    def get_organization_config(self) -> list[dict[str, Any]]:
+        """
+        Return configuration options for the GitLab integration.
+        """
+        config = self._get_organization_config_default_values()
+
+        context = organization_service.get_organization_by_id(
+            id=self.organization_id, include_projects=False, include_teams=False
+        )
+        assert context, "organizationcontext must exist to get org"
+        organization = context.organization
+
+        has_issue_sync = features.has("organizations:integrations-issue-sync", organization)
+
+        if not has_issue_sync:
+            for field in config:
+                field["disabled"] = True
+                field["disabledReason"] = _(
+                    "Your organization does not have access to this feature"
+                )
+
+        return config
+
+    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
+        """
+        Update the configuration field for an organization integration.
+        """
+        if not self.org_integration:
+            return
+
+        config = self.org_integration.config
+
+        config.update(data)
+        org_integration = integration_service.update_organization_integration(
+            org_integration_id=self.org_integration.id,
+            config=config,
+        )
+        if org_integration is not None:
+            self.org_integration = org_integration
+
+    def create_comment_attribution(self, user_id, comment_text):
+        user = user_service.get_user(user_id)
+        username = "Unknown User" if user is None else user.name
+
+        attribution = f"**{username}** wrote:\n\n"
+        quoted_text = "\n".join(f"> {line}" for line in comment_text.split("\n"))
+        return f"{attribution}{quoted_text}"
+
+    def update_comment(self, issue_id, user_id, group_note):
+        quoted_comment = self.create_comment_attribution(user_id, group_note.data["text"])
+
+        project_id, issue_iid = self.split_external_issue_key(issue_id)
+
+        if not project_id or not issue_iid:
+            logger.error(
+                "update-comment.invalid-key",
+                extra={
+                    "provider": self.model.provider,
+                    "external_issue_key": issue_id,
+                },
+            )
+            return None
+
+        encoded_project_id = quote(project_id, safe="")
+
+        return self.get_client().update_comment(
+            encoded_project_id,
+            issue_iid,
+            group_note.data["external_id"],
+            {"body": quoted_comment},
+        )
+
+    def create_comment(self, issue_id, user_id, group_note):
+        comment = group_note.data["text"]
+        quoted_comment = self.create_comment_attribution(user_id, comment)
+
+        project_id, issue_iid = self.split_external_issue_key(issue_id)
+
+        if not project_id or not issue_iid:
+            logger.error(
+                "create-comment.invalid-key",
+                extra={
+                    "provider": self.model.provider,
+                    "external_issue_key": issue_id,
+                },
+            )
+            return None
+
+        encoded_project_id = quote(project_id, safe="")
+
+        return self.get_client().create_comment(
+            encoded_project_id, issue_iid, {"body": quoted_comment}
+        )

--- a/src/sentry/integrations/gitlab/types.py
+++ b/src/sentry/integrations/gitlab/types.py
@@ -1,0 +1,21 @@
+from enum import StrEnum
+
+
+class GitLabIssueStatus(StrEnum):
+    OPENED = "opened"
+    CLOSED = "closed"
+
+    @classmethod
+    def get_choices(cls):
+        """Return choices formatted for dropdown selectors"""
+        return [(status.value, status.value.capitalize()) for status in cls]
+
+
+class GitLabIssueAction(StrEnum):
+    UPDATE = "update"
+    OPEN = "open"
+    REOPEN = "reopen"
+
+    @classmethod
+    def values(cls):
+        return [action.value for action in cls]

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -49,6 +49,7 @@ class GitLabApiClientPath:
     statuses = "/projects/{project}/statuses/{sha}"
     commit_statuses = "/projects/{project}/repository/commits/{sha}/statuses"
     user = "/user"
+    users = "/users"
 
     @staticmethod
     def build_api_url(base_url, path) -> str:

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -41,6 +41,12 @@ def should_sync_assignee_inbound(
 ) -> bool:
     if provider == "github":
         return features.has("organizations:integrations-github-project-management", organization)
+    elif provider == "github_enterprise":
+        return features.has(
+            "organizations:integrations-github_enterprise-project-management", organization
+        )
+    elif provider == "gitlab":
+        return features.has("organizations:integrations-gitlab-project-management", organization)
     return True
 
 
@@ -165,6 +171,7 @@ def sync_group_assignee_inbound_by_external_actor(
         user_ids = [
             external_actor for external_actor in external_actors if external_actor is not None
         ]
+
         log_context["user_ids"] = user_ids
         logger.info("sync_group_assignee_inbound_by_external_actor.user_ids", extra=log_context)
 

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -19,13 +19,16 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
+from sentry.integrations.types import ExternalProviders
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
+from sentry.users.services.user.serial import serialize_rpc_user
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
 
 
@@ -771,3 +774,355 @@ class GitlabApiClientTest(GitLabTestCase):
             assert control_proxy_response.call_count == 1
             assert client.base_url not in request.url
             assert_proxy_request(request, is_proxy=True)
+
+
+@control_silo_test
+class GitlabIssueSyncTest(GitLabTestCase):
+    def _setup_assignee_sync_test(
+        self,
+        user_email: str = "foo@example.com",
+        external_name: str = "@gitlab_user",
+        external_id: str = "123",
+        issue_key: str = "example.gitlab.com/group-x:cool-group/sentry#45",
+        create_external_user: bool = True,
+    ) -> tuple:
+        """
+        Common setup for assignee sync tests.
+
+        Returns:
+            tuple: (user, installation, external_issue, integration, group)
+        """
+
+        user = serialize_rpc_user(self.create_user(email=user_email))
+        integration = Integration.objects.get(provider=self.provider)
+
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        group = self.create_group()
+
+        if create_external_user:
+            self.create_external_user(
+                user=user,
+                organization=self.organization,
+                integration=integration,
+                provider=ExternalProviders.GITLAB.value,
+                external_name=external_name,
+                external_id=external_id,
+            )
+
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key=issue_key,
+        )
+
+        return user, installation, external_issue, integration, group
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_get_organization_config(self) -> None:
+        """Test that organization config fields are returned correctly"""
+
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        fields = installation.get_organization_config()
+
+        assert [field["name"] for field in fields] == [
+            "sync_reverse_assignment",
+            "sync_forward_assignment",
+            "sync_comments",
+        ]
+
+    @responses.activate
+    def test_update_organization_config(self) -> None:
+        """Test updating organization config saves to org_integration"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        # Initial config should be empty
+        assert org_integration.config == {}
+
+        # Update configuration
+        data = {"sync_reverse_assignment": True, "other_option": "test_value"}
+        installation.update_organization_config(data)
+
+        # Refresh from database
+        org_integration.refresh_from_db()
+
+        # Check that config was updated
+        assert org_integration.config["sync_reverse_assignment"] is True
+        assert org_integration.config["other_option"] == "test_value"
+
+    @responses.activate
+    def test_update_organization_config_preserves_existing(self) -> None:
+        """Test that updating org config preserves existing keys"""
+        integration = Integration.objects.get(provider=self.provider)
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+
+        org_integration.config = {
+            "existing_key": "existing_value",
+            "sync_reverse_assignment": False,
+        }
+        org_integration.save()
+
+        # Update configuration with new data
+        data = {"sync_reverse_assignment": True, "new_key": "new_value"}
+        installation.update_organization_config(data)
+
+        org_integration.refresh_from_db()
+
+        # Check that config was updated and existing keys preserved
+        assert org_integration.config["existing_key"] == "existing_value"
+        assert org_integration.config["sync_reverse_assignment"] is True
+        assert org_integration.config["new_key"] == "new_value"
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_assignee_outbound(self) -> None:
+        """Test assigning a GitLab issue to a user with linked GitLab account"""
+        user, installation, external_issue, _, _ = self._setup_assignee_sync_test()
+
+        # Mock user search endpoint
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/users?username=gitlab_user",
+            json=[{"id": 123, "username": "gitlab_user", "name": "GitLab User"}],
+            status=200,
+        )
+
+        # Mock issue update endpoint
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"assignees": [{"id": 123}]},
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            installation.sync_assignee_outbound(external_issue, user, assign=True)
+
+        assert len(responses.calls) == 2
+        # First call searches for user
+        assert "users?username=gitlab_user" in responses.calls[0].request.url
+        # Second call updates issue
+        request = responses.calls[1].request
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == request.url
+        )
+        assert orjson.loads(request.body) == {"assignee_ids": [123]}
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_assignee_outbound_strips_at_symbol(self) -> None:
+        """Test that @ symbol is stripped from external_name when syncing"""
+        user, installation, external_issue, _, _ = self._setup_assignee_sync_test()
+
+        # Mock user search endpoint - note the username without @
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/users?username=gitlab_user",
+            json=[{"id": 123, "username": "gitlab_user", "name": "GitLab User"}],
+            status=200,
+        )
+
+        # Mock issue update endpoint
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"assignees": [{"id": 123}]},
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            installation.sync_assignee_outbound(external_issue, user, assign=True)
+
+        assert len(responses.calls) == 2
+        # Verify @ was stripped in user search
+        assert "users?username=gitlab_user" in responses.calls[0].request.url
+        assert "@" not in responses.calls[0].request.url
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_assignee_outbound_unassign(self) -> None:
+        """Test unassigning a GitLab issue"""
+        user, installation, external_issue, _, _ = self._setup_assignee_sync_test()
+
+        # Mock issue update endpoint
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"assignees": []},
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            installation.sync_assignee_outbound(external_issue, user, assign=False)
+
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == request.url
+        )
+        assert orjson.loads(request.body) == {"assignee_ids": []}
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_assignee_outbound_no_external_actor(self) -> None:
+        """Test that sync fails gracefully when user has no GitLab account linked"""
+        user, installation, external_issue, _, _ = self._setup_assignee_sync_test(
+            create_external_user=False
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            installation.sync_assignee_outbound(external_issue, user, assign=True)
+
+        # Should not make any API calls
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_assignee_outbound_invalid_key_format(self) -> None:
+        """Test that sync handles invalid external issue key format gracefully"""
+        user, installation, external_issue, _, _ = self._setup_assignee_sync_test(
+            issue_key="invalid-key-format"
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            installation.sync_assignee_outbound(external_issue, user, assign=True)
+
+        # Should not make any API calls
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_sync_assignee_outbound_with_none_user(self) -> None:
+        """Test that assigning with no user unassigns the issue"""
+        integration = Integration.objects.get(provider=self.provider)
+
+        installation = get_installation_of_type(
+            GitlabIntegration, integration, self.organization.id
+        )
+
+        group = self.create_group()
+
+        external_issue = self.create_integration_external_issue(
+            group=group,
+            integration=integration,
+            key="example.gitlab.com/group-x:cool-group/sentry#45",
+        )
+
+        # Mock issue update endpoint - when user is None, it unassigns
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45",
+            json={"assignees": []},
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            installation.sync_assignee_outbound(external_issue, None, assign=True)
+
+        # Should make API call to unassign when user is None
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+        assert (
+            "https://example.gitlab.com/api/v4/projects/cool-group%2Fsentry/issues/45"
+            == request.url
+        )
+        assert orjson.loads(request.body) == {"assignee_ids": []}
+
+    @responses.activate
+    @with_feature("organizations:integrations-gitlab-project-management")
+    def test_sync_assignee_outbound_user_not_found(self) -> None:
+        """Test that sync handles case when GitLab user is not found"""
+        user, installation, external_issue, _, _ = self._setup_assignee_sync_test()
+
+        # Mock user search endpoint returning empty list
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/users?username=gitlab_user",
+            json=[],
+            status=200,
+        )
+
+        responses.calls.reset()
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            installation.sync_assignee_outbound(external_issue, user, assign=True)
+
+        # Should only call user search, not issue update
+        assert len(responses.calls) == 1
+        assert "users?username=gitlab_user" in responses.calls[0].request.url
+
+    def test_create_comment(self) -> None:
+        """Test creating a comment on a GitLab issue"""
+        self.user.name = "Sentry Admin"
+        self.user.save()
+        installation = self.installation
+
+        group_note = Mock()
+        comment = "hello world\nThis is a comment.\n\n\n    Glad it's quoted"
+        group_note.data = {"text": comment}
+
+        with patch.object(
+            installation.get_client().__class__, "create_comment"
+        ) as mock_create_comment:
+            installation.create_comment(
+                "example.gitlab.com/group-x:cool-group/sentry#123", self.user.id, group_note
+            )
+            # The project_id will be URL-encoded by create_comment
+            assert mock_create_comment.call_args[0][0] == "cool-group%2Fsentry"
+            assert mock_create_comment.call_args[0][1] == "123"
+            assert mock_create_comment.call_args[0][2] == {
+                "body": "**Sentry Admin** wrote:\n\n> hello world\n> This is a comment.\n> \n> \n>     Glad it's quoted"
+            }
+
+    def test_split_external_issue_key_invalid(self) -> None:
+        """Test splitting an invalid external issue key"""
+        installation = self.installation
+
+        project_id, issue_iid = installation.split_external_issue_key("invalid-key-format")
+
+        assert project_id is None
+        assert issue_iid is None
+
+    def test_create_comment_attribution(self) -> None:
+        """Test comment attribution formatting"""
+        self.user.name = "Test User"
+        self.user.save()
+        installation = self.installation
+
+        comment_text = "This is a comment\nWith multiple lines"
+        result = installation.create_comment_attribution(self.user.id, comment_text)
+
+        assert result == "**Test User** wrote:\n\n> This is a comment\n> With multiple lines"


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR adds inbound/outbound assignment and comment synchronization support between Sentry and GitLab issues.

It is gated behind `organizations:integrations-gitlab-project-management` flag.


### Comment Syncing

https://github.com/user-attachments/assets/6c925765-592e-47bf-a3f4-c27af1290b71

### Outbound Assignment Sync

https://github.com/user-attachments/assets/706cbc25-d1e3-4d3f-97c7-a93728e836e0

### Inbound Assignment Sync

https://github.com/user-attachments/assets/fe3ae8fb-8738-4d7a-aecb-00eebbaeac32


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
