### PR TITLE
feat(sdk): Trial higher envelope serialization limits

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -9,6 +9,7 @@ from types import FrameType
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import sentry_sdk
+import sentry_sdk.serializer
 from django.conf import settings
 from django.db.utils import OperationalError
 from rest_framework.request import Request

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -475,6 +475,9 @@ def configure_sdk():
     from sentry_sdk.integrations.redis import RedisIntegration
     from sentry_sdk.integrations.threading import ThreadingIntegration
 
+    sentry_sdk.serializer.MAX_DATABAG_DEPTH = 100
+    sentry_sdk.serializer.MAX_DATABAG_BREADTH = 100
+
     sentry_sdk.init(
         # set back the sentry4sentry_dsn popped above since we need a default dsn on the client
         # for dynamic sampling context public_key population


### PR DESCRIPTION
Increase envelope serialization limits to dogfood https://github.com/getsentry/sentry-python/pull/5103.

The change increases the maximum serialization breadth and depth for Python objects. 

For example, nested lists up to a depth of 100 are serialized before the object is truncated with `<broken_repr>`, replacing the previous limit of 5.
