### PR TITLE
Allow users to set `replaceGroups` on regex PII rules

### DIFF
--- a/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
+++ b/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
@@ -58,10 +58,9 @@ export function convertRelayPiiConfig(relayPiiConfig?: string | null): Rule[] {
             source,
             placeholder: redaction?.text,
             pattern: resolvedRule.pattern,
-            replaceCaptured: (
+            replaceCaptured:
               resolvedRule.replaceGroups?.length === 1 &&
-              resolvedRule.replaceGroups?.at(0) === 1
-            ).toString(),
+              resolvedRule.replaceGroups?.at(0) === 1,
           });
         } else {
           convertedRules.push({
@@ -79,10 +78,9 @@ export function convertRelayPiiConfig(relayPiiConfig?: string | null): Rule[] {
           type: RuleType.PATTERN,
           source,
           pattern: resolvedRule.pattern,
-          replaceCaptured: (
+          replaceCaptured:
             resolvedRule.replaceGroups?.length === 1 &&
-            resolvedRule.replaceGroups?.at(0) === 1
-          ).toString(),
+            resolvedRule.replaceGroups?.at(0) === 1,
         });
       } else {
         convertedRules.push({id, method, type, source});

--- a/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
+++ b/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
@@ -58,6 +58,10 @@ export function convertRelayPiiConfig(relayPiiConfig?: string | null): Rule[] {
             source,
             placeholder: redaction?.text,
             pattern: resolvedRule.pattern,
+            replaceCaptured: (
+              resolvedRule.replaceGroups?.length === 1 &&
+              resolvedRule.replaceGroups?.at(0) === 1
+            ).toString(),
           });
         } else {
           convertedRules.push({
@@ -75,6 +79,10 @@ export function convertRelayPiiConfig(relayPiiConfig?: string | null): Rule[] {
           type: RuleType.PATTERN,
           source,
           pattern: resolvedRule.pattern,
+          replaceCaptured: (
+            resolvedRule.replaceGroups?.length === 1 &&
+            resolvedRule.replaceGroups?.at(0) === 1
+          ).toString(),
         });
       } else {
         convertedRules.push({id, method, type, source});

--- a/static/app/views/settings/components/dataScrubbing/modals/edit.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/edit.spec.tsx
@@ -189,6 +189,7 @@ describe('Edit Modal', () => {
         method: 'mask',
         pattern: '',
         placeholder: '',
+        replaceCaptured: 'false',
         type: 'anything',
         source: valueSuggestions[2]!.value,
       },

--- a/static/app/views/settings/components/dataScrubbing/modals/edit.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/edit.spec.tsx
@@ -189,7 +189,7 @@ describe('Edit Modal', () => {
         method: 'mask',
         pattern: '',
         placeholder: '',
-        replaceCaptured: 'false',
+        replaceCaptured: false,
         type: 'anything',
         source: valueSuggestions[2]!.value,
       },

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -211,25 +211,30 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
               required
               showHelpInTooltip
             >
-              <RegularExpression
-                type="text"
-                name="pattern"
-                placeholder={t('[a-zA-Z0-9]+')}
-                onChange={this.handleChange('pattern')}
-                value={values.pattern}
-                onBlur={onValidate('pattern')}
-                id="regex-matches"
-              />
-              <span>
-                <Checkbox
-                  id="replace-captured"
-                  name="replaceCaptured"
-                  checked={values.replaceCaptured === 'true'}
-                  onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
+              <Flex gap="md" direction="column">
+                <RegularExpression
+                  type="text"
+                  name="pattern"
+                  placeholder={t('[a-zA-Z0-9]+')}
+                  onChange={this.handleChange('pattern')}
+                  value={values.pattern}
+                  onBlur={onValidate('pattern')}
+                  id="regex-matches"
                 />
-                &nbsp;
-                {t('Only replace first capture match')}
-              </span>
+                <Flex gap="md" align="center">
+                  <Checkbox
+                    id="replace-captured"
+                    name="replaceCaptured"
+                    checked={values.replaceCaptured === 'true'}
+                    onChange={e =>
+                      onChange('replaceCaptured', e.target.checked.toString())
+                    }
+                  />
+                  <label htmlFor="replace-captured">
+                    {t('Only replace first capture match')}
+                  </label>
+                </Flex>
+              </Flex>
             </FieldGroup>
           )}
         </FieldContainer>
@@ -408,7 +413,9 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                         onChange('replaceCaptured', e.target.checked.toString())
                       }
                     />
-                    {t('Only replace first capture match')}
+                    <label htmlFor="replace-captured">
+                      {t('Only replace first capture match')}
+                    </label>
                   </Flex>
                 </Flex>
               </FieldGroup>

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -222,21 +222,20 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                   onBlur={onValidate('pattern')}
                   id="regex-matches"
                 />
-                {hasCaptureGroups(values.pattern) && (
-                  <Flex gap="md" align="center">
-                    <Checkbox
-                      id="replace-captured"
-                      name="replaceCaptured"
-                      checked={values.replaceCaptured === 'true'}
-                      onChange={e =>
-                        onChange('replaceCaptured', e.target.checked.toString())
-                      }
-                    />
-                    <ReplaceCapturedLabel htmlFor="replace-captured">
-                      {t('Only replace first capture match')}
-                    </ReplaceCapturedLabel>
-                  </Flex>
-                )}
+                <Flex gap="md" align="center">
+                  <Checkbox
+                    id="replace-captured"
+                    name="replaceCaptured"
+                    checked={values.replaceCaptured === 'true'}
+                    disabled={!hasCaptureGroups(values.pattern)}
+                    onChange={e =>
+                      onChange('replaceCaptured', e.target.checked.toString())
+                    }
+                  />
+                  <ReplaceCapturedLabel htmlFor="replace-captured">
+                    {t('Only replace first capture match')}
+                  </ReplaceCapturedLabel>
+                </Flex>
               </Flex>
             </FieldGroup>
           )}
@@ -407,21 +406,20 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                     onBlur={onValidate('pattern')}
                     id="regex-matches"
                   />
-                  {hasCaptureGroups(values.pattern) && (
-                    <Flex gap="md" align="center">
-                      <Checkbox
-                        id="replace-captured"
-                        name="replaceCaptured"
-                        checked={values.replaceCaptured === 'true'}
-                        onChange={e =>
-                          onChange('replaceCaptured', e.target.checked.toString())
-                        }
-                      />
-                      <ReplaceCapturedLabel htmlFor="replace-captured">
-                        {t('Only replace first capture match')}
-                      </ReplaceCapturedLabel>
-                    </Flex>
-                  )}
+                  <Flex gap="md" align="center">
+                    <Checkbox
+                      id="replace-captured"
+                      name="replaceCaptured"
+                      checked={values.replaceCaptured === 'true'}
+                      disabled={!hasCaptureGroups(values.pattern)}
+                      onChange={e =>
+                        onChange('replaceCaptured', e.target.checked.toString())
+                      }
+                    />
+                    <ReplaceCapturedLabel htmlFor="replace-captured">
+                      {t('Only replace first capture match')}
+                    </ReplaceCapturedLabel>
+                  </Flex>
                 </Flex>
               </FieldGroup>
             )}

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -51,7 +51,7 @@ type Props<V extends Values, K extends keyof V> = {
   errors: Partial<V>;
   eventId: EventId;
   onAttributeError: (message: string) => void;
-  onChange: (field: K, value: string) => void;
+  onChange: (field: K, value: V[K]) => void;
   onChangeDataset: (dataset: AllowedDataScrubbingDatasets) => void;
   onUpdateEventId: (eventId: string) => void;
   onValidate: (field: K) => () => void;
@@ -69,7 +69,7 @@ function ReplaceCapturedCheckbox({
   values,
   onChange,
 }: {
-  onChange: (field: 'replaceCaptured', value: string) => void;
+  onChange: (field: 'replaceCaptured', value: boolean) => void;
   values: Values;
 }) {
   const disabled = !hasCaptureGroups(values.pattern);
@@ -82,9 +82,9 @@ function ReplaceCapturedCheckbox({
         <Checkbox
           id="replace-captured"
           name="replaceCaptured"
-          checked={values.replaceCaptured === 'true'}
+          checked={values.replaceCaptured}
           disabled={disabled}
-          onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
+          onChange={e => onChange('replaceCaptured', e.target.checked)}
         />
         <ReplaceCapturedLabel htmlFor="replace-captured" disabled={disabled}>
           {t('Only replace first capture match')}
@@ -102,7 +102,7 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
   handleChange =
     <K extends keyof Values>(field: K) =>
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      this.props.onChange(field, event.target.value);
+      this.props.onChange(field, event.target.value as Values[K]);
     };
 
   handleToggleEventId = () => {

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -400,6 +400,16 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
               />
 
               {t('Only replace first capture match')}
+              {/* <Checkbox
+                checked={(values as any).replaceCaptured === 'first_capture'}
+                onChange={e =>
+                  onChange(
+                    'replaceCaptured' as any,
+                    e.target.checked ? 'first_capture' : 'entire'
+                  )
+                }
+              />
+              {t('Only replace first capture match')} */}
             </FieldGroup>
           )}
         </FieldContainer>

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -230,9 +230,9 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                       onChange('replaceCaptured', e.target.checked.toString())
                     }
                   />
-                  <label htmlFor="replace-captured">
+                  <ReplaceCapturedLabel htmlFor="replace-captured">
                     {t('Only replace first capture match')}
-                  </label>
+                  </ReplaceCapturedLabel>
                 </Flex>
               </Flex>
             </FieldGroup>
@@ -413,9 +413,9 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                         onChange('replaceCaptured', e.target.checked.toString())
                       }
                     />
-                    <label htmlFor="replace-captured">
+                    <ReplaceCapturedLabel htmlFor="replace-captured">
                       {t('Only replace first capture match')}
-                    </label>
+                    </ReplaceCapturedLabel>
                   </Flex>
                 </Flex>
               </FieldGroup>
@@ -481,6 +481,11 @@ const SourceGroup = styled('div')<{isExpanded?: boolean}>`
 
 const RegularExpression = styled(Input)`
   font-family: ${p => p.theme.text.familyMono};
+`;
+
+const ReplaceCapturedLabel = styled('label')`
+  font-weight: normal;
+  margin-bottom: 0;
 `;
 
 const DatasetRadioField = styled(RadioField)`

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -78,7 +78,7 @@ function ReplaceCapturedCheckbox({
       title={disabled ? t('This rule does not contain capture groups') : undefined}
       disabled={!disabled}
     >
-      <ReplaceCapturedCheckboxContainer gap="xs" align="center" disabled={disabled}>
+      <Flex gap="xs" align="center">
         <Checkbox
           id="replace-captured"
           name="replaceCaptured"
@@ -86,8 +86,10 @@ function ReplaceCapturedCheckbox({
           disabled={disabled}
           onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
         />
-        <label htmlFor="replace-captured">{t('Only replace first capture match')}</label>
-      </ReplaceCapturedCheckboxContainer>
+        <ReplaceCapturedLabel htmlFor="replace-captured" disabled={disabled}>
+          {t('Only replace first capture match')}
+        </ReplaceCapturedLabel>
+      </Flex>
     </Tooltip>
   );
 }
@@ -510,15 +512,13 @@ const Toggle = styled(Button)`
   }
 `;
 
-const ReplaceCapturedCheckboxContainer = styled(Flex)<{disabled: boolean}>`
-  label {
-    font-weight: normal;
-    margin-bottom: 0;
-    line-height: 1rem;
-    ${p =>
-      p.disabled &&
-      css`
-        color: ${p.theme.disabled};
-      `}
-  }
+const ReplaceCapturedLabel = styled('label')<{disabled: boolean}>`
+  font-weight: normal;
+  margin-bottom: 0;
+  line-height: 1rem;
+  ${p =>
+    p.disabled &&
+    css`
+      color: ${p.theme.disabled};
+    `}
 `;

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -5,6 +5,7 @@ import sortBy from 'lodash/sortBy';
 
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Checkbox} from 'sentry/components/core/checkbox';
 import {Input} from 'sentry/components/core/input';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import RadioField from 'sentry/components/forms/fields/radioField';
@@ -217,6 +218,20 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                 onBlur={onValidate('pattern')}
                 id="regex-matches"
               />
+              <PatternOptions>
+                <Checkbox
+                  checked={(values as any).patternReplacement === 'first_capture'}
+                  onChange={e =>
+                    onChange(
+                      'patternReplacement' as any,
+                      e.target.checked ? 'first_capture' : 'entire'
+                    )
+                  }
+                />
+                <PatternOptionLabel>
+                  {t('Only replace first capture match')}
+                </PatternOptionLabel>
+              </PatternOptions>
             </FieldGroup>
           )}
         </FieldContainer>
@@ -384,6 +399,20 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                 onBlur={onValidate('pattern')}
                 id="regex-matches"
               />
+              <PatternOptions>
+                <Checkbox
+                  checked={(values as any).patternReplacement === 'first_capture'}
+                  onChange={e =>
+                    onChange(
+                      'patternReplacement' as any,
+                      e.target.checked ? 'first_capture' : 'entire'
+                    )
+                  }
+                />
+                <PatternOptionLabel>
+                  {t('Only replace first capture match')}
+                </PatternOptionLabel>
+              </PatternOptions>
             </FieldGroup>
           )}
         </FieldContainer>
@@ -473,4 +502,14 @@ const Toggle = styled(Button)`
     grid-template-columns: repeat(2, max-content);
     align-items: center;
   }
+`;
+
+const PatternOptions = styled('div')`
+  display: flex;
+  align-items: center;
+  margin-top: ${space(1)};
+`;
+
+const PatternOptionLabel = styled('span')`
+  margin-left: ${space(1)};
 `;

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -218,20 +218,13 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                 onBlur={onValidate('pattern')}
                 id="regex-matches"
               />
-              <PatternOptions>
-                <Checkbox
-                  checked={(values as any).patternReplacement === 'first_capture'}
-                  onChange={e =>
-                    onChange(
-                      'patternReplacement' as any,
-                      e.target.checked ? 'first_capture' : 'entire'
-                    )
-                  }
-                />
-                <PatternOptionLabel>
-                  {t('Only replace first capture match')}
-                </PatternOptionLabel>
-              </PatternOptions>
+
+              <Checkbox
+                checked={values.replaceCaptured === 'true'}
+                onChange={this.handleChange('replaceCaptured')}
+              />
+
+              {t('Only replace first capture match')}
             </FieldGroup>
           )}
         </FieldContainer>
@@ -399,20 +392,14 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                 onBlur={onValidate('pattern')}
                 id="regex-matches"
               />
-              <PatternOptions>
-                <Checkbox
-                  checked={(values as any).patternReplacement === 'first_capture'}
-                  onChange={e =>
-                    onChange(
-                      'patternReplacement' as any,
-                      e.target.checked ? 'first_capture' : 'entire'
-                    )
-                  }
-                />
-                <PatternOptionLabel>
-                  {t('Only replace first capture match')}
-                </PatternOptionLabel>
-              </PatternOptions>
+              <Checkbox
+                id="replace-captured"
+                name="replaceCaptured"
+                checked={values.replaceCaptured === 'true'}
+                onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
+              />
+
+              {t('Only replace first capture match')}
             </FieldGroup>
           )}
         </FieldContainer>
@@ -502,14 +489,4 @@ const Toggle = styled(Button)`
     grid-template-columns: repeat(2, max-content);
     align-items: center;
   }
-`;
-
-const PatternOptions = styled('div')`
-  display: flex;
-  align-items: center;
-  margin-top: ${space(1)};
-`;
-
-const PatternOptionLabel = styled('span')`
-  margin-left: ${space(1)};
 `;

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -218,13 +218,16 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                 onBlur={onValidate('pattern')}
                 id="regex-matches"
               />
-
-              <Checkbox
-                checked={values.replaceCaptured === 'true'}
-                onChange={this.handleChange('replaceCaptured')}
-              />
-
-              {t('Only replace first capture match')}
+              <span>
+                <Checkbox
+                  id="replace-captured"
+                  name="replaceCaptured"
+                  checked={values.replaceCaptured === 'true'}
+                  onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
+                />
+                &nbsp;
+                {t('Only replace first capture match')}
+              </span>
             </FieldGroup>
           )}
         </FieldContainer>
@@ -392,24 +395,16 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                 onBlur={onValidate('pattern')}
                 id="regex-matches"
               />
-              <Checkbox
-                id="replace-captured"
-                name="replaceCaptured"
-                checked={values.replaceCaptured === 'true'}
-                onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
-              />
-
-              {t('Only replace first capture match')}
-              {/* <Checkbox
-                checked={(values as any).replaceCaptured === 'first_capture'}
-                onChange={e =>
-                  onChange(
-                    'replaceCaptured' as any,
-                    e.target.checked ? 'first_capture' : 'entire'
-                  )
-                }
-              />
-              {t('Only replace first capture match')} */}
+              <span>
+                <Checkbox
+                  id="replace-captured"
+                  name="replaceCaptured"
+                  checked={values.replaceCaptured === 'true'}
+                  onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
+                />
+                &nbsp;
+                {t('Only replace first capture match')}
+              </span>
             </FieldGroup>
           )}
         </FieldContainer>

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -17,6 +17,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import withOrganization from 'sentry/utils/withOrganization';
+import {hasCaptureGroups} from 'sentry/views/settings/components/dataScrubbing/modals/utils';
 import {
   AllowedDataScrubbingDatasets,
   MethodType,
@@ -221,19 +222,21 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                   onBlur={onValidate('pattern')}
                   id="regex-matches"
                 />
-                <Flex gap="md" align="center">
-                  <Checkbox
-                    id="replace-captured"
-                    name="replaceCaptured"
-                    checked={values.replaceCaptured === 'true'}
-                    onChange={e =>
-                      onChange('replaceCaptured', e.target.checked.toString())
-                    }
-                  />
-                  <ReplaceCapturedLabel htmlFor="replace-captured">
-                    {t('Only replace first capture match')}
-                  </ReplaceCapturedLabel>
-                </Flex>
+                {hasCaptureGroups(values.pattern) && (
+                  <Flex gap="md" align="center">
+                    <Checkbox
+                      id="replace-captured"
+                      name="replaceCaptured"
+                      checked={values.replaceCaptured === 'true'}
+                      onChange={e =>
+                        onChange('replaceCaptured', e.target.checked.toString())
+                      }
+                    />
+                    <ReplaceCapturedLabel htmlFor="replace-captured">
+                      {t('Only replace first capture match')}
+                    </ReplaceCapturedLabel>
+                  </Flex>
+                )}
               </Flex>
             </FieldGroup>
           )}
@@ -404,19 +407,21 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
                     onBlur={onValidate('pattern')}
                     id="regex-matches"
                   />
-                  <Flex gap="md" align="center">
-                    <Checkbox
-                      id="replace-captured"
-                      name="replaceCaptured"
-                      checked={values.replaceCaptured === 'true'}
-                      onChange={e =>
-                        onChange('replaceCaptured', e.target.checked.toString())
-                      }
-                    />
-                    <ReplaceCapturedLabel htmlFor="replace-captured">
-                      {t('Only replace first capture match')}
-                    </ReplaceCapturedLabel>
-                  </Flex>
+                  {hasCaptureGroups(values.pattern) && (
+                    <Flex gap="md" align="center">
+                      <Checkbox
+                        id="replace-captured"
+                        name="replaceCaptured"
+                        checked={values.replaceCaptured === 'true'}
+                        onChange={e =>
+                          onChange('replaceCaptured', e.target.checked.toString())
+                        }
+                      />
+                      <ReplaceCapturedLabel htmlFor="replace-captured">
+                        {t('Only replace first capture match')}
+                      </ReplaceCapturedLabel>
+                    </Flex>
+                  )}
                 </Flex>
               </FieldGroup>
             )}

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -3,6 +3,8 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {Checkbox} from 'sentry/components/core/checkbox';
@@ -351,76 +353,81 @@ class Form extends Component<Props<Values, KeysOfUnion<Values>>, State> {
             </FieldGroup>
           )}
         </FieldContainer>
-        <FieldContainer hasTwoColumns={values.type === RuleType.PATTERN}>
-          <FieldGroup
-            data-test-id="type-field"
-            label={t('Data Type')}
-            help={t(
-              'What to look for. Use an existing pattern or define your own using regular expressions.'
-            )}
-            inline={false}
-            flexibleControlStateSize
-            stacked
-            showHelpInTooltip
-          >
-            <SelectField
-              placeholder={t('Select type')}
-              name="type"
-              options={sortBy(Object.values(RuleType)).map(value => ({
-                label: getRuleLabel(value),
-                value,
-              }))}
-              value={type}
-              onChange={value => onChange('type', value?.value)}
-            />
-          </FieldGroup>
-          {values.type === RuleType.PATTERN && (
+        <Flex direction="column" gap="md">
+          <FieldContainer hasTwoColumns={values.type === RuleType.PATTERN}>
             <FieldGroup
-              label={t('Regex matches')}
-              help={t('Custom regular expression (see documentation)')}
+              data-test-id="type-field"
+              label={t('Data Type')}
+              help={t(
+                'What to look for. Use an existing pattern or define your own using regular expressions.'
+              )}
               inline={false}
-              id="regex-matches"
-              error={errors?.pattern}
               flexibleControlStateSize
               stacked
-              required
               showHelpInTooltip
             >
-              <RegularExpression
-                type="text"
-                name="pattern"
-                placeholder={t('[a-zA-Z0-9]+')}
-                onChange={this.handleChange('pattern')}
-                value={values.pattern}
-                onBlur={onValidate('pattern')}
-                id="regex-matches"
+              <SelectField
+                placeholder={t('Select type')}
+                name="type"
+                options={sortBy(Object.values(RuleType)).map(value => ({
+                  label: getRuleLabel(value),
+                  value,
+                }))}
+                value={type}
+                onChange={value => onChange('type', value?.value)}
               />
-              <span>
-                <Checkbox
-                  id="replace-captured"
-                  name="replaceCaptured"
-                  checked={values.replaceCaptured === 'true'}
-                  onChange={e => onChange('replaceCaptured', e.target.checked.toString())}
-                />
-                &nbsp;
-                {t('Only replace first capture match')}
-              </span>
             </FieldGroup>
-          )}
-        </FieldContainer>
-        <ToggleWrapper>
-          {displayEventId ? (
-            <Toggle priority="link" onClick={this.handleToggleEventId}>
-              {t('Hide event ID field')}
-              <IconChevron direction="up" size="xs" />
-            </Toggle>
-          ) : (
-            <Toggle priority="link" onClick={this.handleToggleEventId}>
-              {t('Use event ID for auto-completion')}
-              <IconChevron direction="down" size="xs" />
-            </Toggle>
-          )}
-        </ToggleWrapper>
+            {values.type === RuleType.PATTERN && (
+              <FieldGroup
+                label={t('Regex matches')}
+                help={t('Custom regular expression (see documentation)')}
+                inline={false}
+                id="regex-matches"
+                error={errors?.pattern}
+                flexibleControlStateSize
+                stacked
+                required
+                showHelpInTooltip
+              >
+                <Flex gap="md" direction="column">
+                  <RegularExpression
+                    type="text"
+                    name="pattern"
+                    placeholder={t('[a-zA-Z0-9]+')}
+                    onChange={this.handleChange('pattern')}
+                    value={values.pattern}
+                    onBlur={onValidate('pattern')}
+                    id="regex-matches"
+                  />
+                  <Flex gap="md" align="center">
+                    <Checkbox
+                      id="replace-captured"
+                      name="replaceCaptured"
+                      checked={values.replaceCaptured === 'true'}
+                      onChange={e =>
+                        onChange('replaceCaptured', e.target.checked.toString())
+                      }
+                    />
+                    {t('Only replace first capture match')}
+                  </Flex>
+                </Flex>
+              </FieldGroup>
+            )}
+          </FieldContainer>
+          <ToggleWrapper>
+            {displayEventId ? (
+              <Toggle priority="link" onClick={this.handleToggleEventId}>
+                {t('Hide event ID field')}
+                <IconChevron direction="up" size="xs" />
+              </Toggle>
+            ) : (
+              <Toggle priority="link" onClick={this.handleToggleEventId}>
+                {t('Use event ID for auto-completion')}
+                <IconChevron direction="down" size="xs" />
+              </Toggle>
+            )}
+          </ToggleWrapper>
+        </Flex>
         <SourceGroup isExpanded={displayEventId}>
           {displayEventId && (
             <EventIdField onUpdateEventId={onUpdateEventId} eventId={eventId} />

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -118,7 +118,7 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
       source: initialState?.source ?? '',
       placeholder: initialState?.placeholder ?? '',
       pattern: initialState?.pattern ?? '',
-      patternReplacement: (initialState as any)?.patternReplacement ?? 'entire',
+      replaceCaptured: initialState?.replaceCaptured ?? 'false',
     };
   }
 

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -118,6 +118,7 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
       source: initialState?.source ?? '',
       placeholder: initialState?.placeholder ?? '',
       pattern: initialState?.pattern ?? '',
+      patternReplacement: (initialState as any)?.patternReplacement ?? 'entire',
     };
   }
 

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -245,8 +245,9 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
       [field]: value,
     };
 
-    if (values.type !== RuleType.PATTERN && values.pattern) {
+    if (values.type !== RuleType.PATTERN) {
       values.pattern = '';
+      values.replaceCaptured = 'false';
     }
 
     if (values.type === RuleType.PATTERN && !hasCaptureGroups(values.pattern)) {

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -118,7 +118,7 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
       source: initialState?.source ?? '',
       placeholder: initialState?.placeholder ?? '',
       pattern: initialState?.pattern ?? '',
-      replaceCaptured: initialState?.replaceCaptured?.toString() ?? 'false',
+      replaceCaptured: initialState?.replaceCaptured ?? false,
     };
   }
 
@@ -247,11 +247,11 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
 
     if (values.type !== RuleType.PATTERN) {
       values.pattern = '';
-      values.replaceCaptured = 'false';
+      values.replaceCaptured = false;
     }
 
     if (values.type === RuleType.PATTERN && !hasCaptureGroups(values.pattern)) {
-      values.replaceCaptured = 'false';
+      values.replaceCaptured = false;
     }
 
     if (values.method !== MethodType.REPLACE && values.placeholder) {
@@ -297,7 +297,12 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
   handleValidate =
     <K extends keyof Values>(field: K) =>
     () => {
-      const isFieldValueEmpty = !this.state.values[field].trim();
+      const value = this.state.values[field];
+      if (typeof value !== 'string') {
+        return;
+      }
+
+      const isFieldValueEmpty = !value.trim();
 
       const fieldErrorAlreadyExist = this.state.errors[field];
 

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -29,7 +29,7 @@ import {
 import Form from './form';
 import handleError, {ErrorType} from './handleError';
 import Modal from './modal';
-import {useSourceGroupData} from './utils';
+import {hasCaptureGroups, useSourceGroupData} from './utils';
 
 type FormProps = React.ComponentProps<typeof Form>;
 type Values = FormProps['values'];
@@ -247,6 +247,10 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
 
     if (values.type !== RuleType.PATTERN && values.pattern) {
       values.pattern = '';
+    }
+
+    if (values.type === RuleType.PATTERN && !hasCaptureGroups(values.pattern)) {
+      values.replaceCaptured = 'false';
     }
 
     if (values.method !== MethodType.REPLACE && values.placeholder) {

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -118,7 +118,7 @@ class ModalManager extends Component<ModalManagerWithLocalStorageProps, State> {
       source: initialState?.source ?? '',
       placeholder: initialState?.placeholder ?? '',
       pattern: initialState?.pattern ?? '',
-      replaceCaptured: initialState?.replaceCaptured ?? 'false',
+      replaceCaptured: initialState?.replaceCaptured?.toString() ?? 'false',
     };
   }
 

--- a/static/app/views/settings/components/dataScrubbing/modals/utils.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/utils.tsx
@@ -42,3 +42,8 @@ export function useSourceGroupData() {
     saveToSourceGroupData,
   };
 }
+
+export function hasCaptureGroups(pattern: string) {
+  const m = pattern.match(/\(.*\)/);
+  return m !== null && m.length > 0;
+}

--- a/static/app/views/settings/components/dataScrubbing/submitRules.tsx
+++ b/static/app/views/settings/components/dataScrubbing/submitRules.tsx
@@ -12,6 +12,7 @@ function getSubmitFormatRule(rule: Rule): PiiConfig {
         method: rule.method,
         text: rule?.placeholder,
       },
+      replaceGroups: rule.replaceCaptured === 'true' ? [1] : undefined,
     };
   }
 
@@ -22,6 +23,7 @@ function getSubmitFormatRule(rule: Rule): PiiConfig {
       redaction: {
         method: rule.method,
       },
+      replaceGroups: rule.replaceCaptured === 'true' ? [1] : undefined,
     };
   }
 

--- a/static/app/views/settings/components/dataScrubbing/submitRules.tsx
+++ b/static/app/views/settings/components/dataScrubbing/submitRules.tsx
@@ -12,7 +12,7 @@ function getSubmitFormatRule(rule: Rule): PiiConfig {
         method: rule.method,
         text: rule?.placeholder,
       },
-      replaceGroups: rule.replaceCaptured === 'true' ? [1] : undefined,
+      replaceGroups: rule.replaceCaptured ? [1] : undefined,
     };
   }
 
@@ -23,7 +23,7 @@ function getSubmitFormatRule(rule: Rule): PiiConfig {
       redaction: {
         method: rule.method,
       },
-      replaceGroups: rule.replaceCaptured === 'true' ? [1] : undefined,
+      replaceGroups: rule.replaceCaptured ? [1] : undefined,
     };
   }
 

--- a/static/app/views/settings/components/dataScrubbing/types.tsx
+++ b/static/app/views/settings/components/dataScrubbing/types.tsx
@@ -75,6 +75,7 @@ export type RuleDefault = RuleBase & {
 
 type RulePattern = RuleBase & {
   pattern: string;
+  replaceCaptured: string;
   type: RuleType.PATTERN;
 } & Pick<RuleDefault, 'method'>;
 

--- a/static/app/views/settings/components/dataScrubbing/types.tsx
+++ b/static/app/views/settings/components/dataScrubbing/types.tsx
@@ -75,7 +75,7 @@ export type RuleDefault = RuleBase & {
 
 type RulePattern = RuleBase & {
   pattern: string;
-  replaceCaptured: string;
+  replaceCaptured: boolean;
   type: RuleType.PATTERN;
 } & Pick<RuleDefault, 'method'>;
 
@@ -95,7 +95,12 @@ export type EventId = {
   value: string;
 };
 
-export type EditableRule = Omit<Record<KeysOfUnion<Rule>, string>, 'id'>;
+export type EditableRule = Omit<
+  {
+    [K in KeysOfUnion<Rule>]: K extends 'replaceCaptured' ? boolean : string;
+  },
+  'id'
+>;
 
 export type AttributeResults = Record<
   AllowedDataScrubbingDatasets,

--- a/static/app/views/settings/components/dataScrubbing/types.tsx
+++ b/static/app/views/settings/components/dataScrubbing/types.tsx
@@ -123,6 +123,7 @@ type PiiConfigPattern = {
     method: RulePattern['method'];
   };
   type: RulePattern['type'];
+  replaceGroups?: number[];
 };
 
 type PiiConfigReplaceAndPattern = Omit<PiiConfigPattern, 'redaction'> &


### PR DESCRIPTION
Relay already has the ability to configure what part of a pattern match to scrub, but so far it has not been exposed to users. Add a checkbox to the UI to allow scrubbing the first match group instead of the entire expression.

<img width="569" height="245" alt="image" src="https://github.com/user-attachments/assets/9064cacc-d0dc-4cdb-96de-d19edab10db1" />


Fixes INGEST-625