### PR TITLE
fix(ui): point hardcoded dark background colors to UI2 theme token values

### DIFF
--- a/static/less/base.less
+++ b/static/less/base.less
@@ -35,14 +35,14 @@ body {
 // Applied to body
 body.theme-dark {
   // theme.tokens.background.primary
-  background: #241D2A;
+  background: #272433;
   // theme.tokens.content.primary
   color: #F6F5FA;
 }
 body.theme-system {
   @media (prefers-color-scheme: dark) {
     // theme.tokens.background.primary
-    background: #241D2A;
+    background: #272433;
     // theme.content.primary
     color: #F6F5FA;
   }

--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -440,7 +440,7 @@ table.table.key-value {
 
 .theme-dark .loading .loading-indicator {
   // theme.tokens.background.primary
-  background: #241D2A;
+  background: #272433;
 }
 
 @-webkit-keyframes loading {


### PR DESCRIPTION
before:

<img width="1712" height="1303" alt="Screenshot 2025-11-24 at 11 14 11" src="https://github.com/user-attachments/assets/e209c442-c9ad-4094-82a7-b3a36b7c4405" />

after:

<img width="1712" height="1303" alt="Screenshot 2025-11-24 at 11 13 45" src="https://github.com/user-attachments/assets/96c1382c-bdee-4ffd-b06a-bf9c5988a549" />
