### PR TITLE
feat: Remove adjacent tracing feature flag

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
@@ -3,7 +3,6 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {tct} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
 import {TraceLinkNavigationButton} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton';
@@ -15,9 +14,7 @@ export function TraceLinksNavigation({
   rootEventResults: TraceRootEventQueryResults;
   source: string;
 }) {
-  const organization = useOrganization();
   const showLinkedTraces =
-    organization?.features.includes('trace-view-linked-traces') &&
     // Don't show the linked traces buttons when the waterfall is embedded in the replay
     // detail page, as it already contains all traces of the replay session.
     source !== 'replay';


### PR DESCRIPTION
We will now show the adjacent traces for all. 

For now we will keep the feature flag in place in case something should break that we can easily enable it again (it is very unlikely that this will happen though).
 
Follow up to: #102472