### PR TITLE
ref(taskbroker): Clarify docstring & class name

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -33,7 +33,7 @@ from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationFormError,
 )
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.retry import RetryTaskError
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
 from sentry.types.activity import ActivityType
 from sentry.types.rules import RuleFuture
@@ -97,7 +97,7 @@ def invoke_future_with_error_handling(
         # monitor and potentially retry this action.
         raise
     except RETRYABLE_EXCEPTIONS as e:
-        raise RetryError from e
+        raise RetryTaskError from e
     except Exception as e:
         # This is just a redefinition of the safe_execute util function, as we
         # still want to report any unhandled exceptions.

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -11,7 +11,7 @@ from django.db.models import Model
 
 from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.registry import TaskNamespace
-from sentry.taskworker.retry import Retry, RetryError, retry_task
+from sentry.taskworker.retry import Retry, RetryTaskError, retry_task
 from sentry.taskworker.state import current_task
 from sentry.taskworker.task import P, R, Task
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
@@ -123,10 +123,24 @@ def retry(
     >>> def my_task():
     >>>     ...
 
-    If timeouts is True, task timeout exceptions will trigger a retry.
-    If it is False, timeout exceptions will behave as specified by the other parameters.
-    """
+    The first set of parameters define how different exceptions are handled.
+    Raising an error will still report a Sentry event.
 
+    | Parameter          | Retry | Report | Raise | Description |
+    |--------------------|-------|--------|-------|-------------|
+    | on                 | Yes   | Yes    | No    | Exceptions that will trigger a retry & report to Sentry. |
+    | on_silent          | Yes   | No     | No    | Exceptions that will trigger a retry but not be captured to Sentry. |
+    | exclude            | No    | No     | Yes   | Exceptions that will not trigger a retry and will be raised. |
+    | ignore             | No    | No     | No    | Exceptions that will be ignored and not trigger a retry & not report to Sentry. |
+    | ignore_and_capture | No    | Yes    | No    | Exceptions that will not trigger a retry and will be captured to Sentry. |
+
+    The following modifiers modify the behavior of the retry decorator.
+
+    | Modifier               | Description |
+    |------------------------|-------------|
+    | timeouts               | ProcessingDeadlineExceeded trigger a retry. |
+    | raise_on_no_retries    | Makes a RetryTaskError not be raised if no retries are left. |
+    """
     if func:
         return retry()(func)
 
@@ -138,30 +152,20 @@ def retry(
     def inner(func):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
+            task_state = current_task()
+            no_retries_remaining = task_state and not task_state.retries_remaining
             try:
                 return func(*args, **kwargs)
             except ignore:
                 return
-            except RetryError:
-                if (
-                    not raise_on_no_retries
-                    and (task_state := current_task())
-                    and not task_state.retries_remaining
-                ):
+            except RetryTaskError:
+                if not raise_on_no_retries and no_retries_remaining:
                     return
-                # If we haven't been asked to ignore no-retries, pass along the RetryError.
+                # If we haven't been asked to ignore no-retries, pass along the RetryTaskError.
                 raise
             except timeout_exceptions:
                 if timeouts:
-                    with sentry_sdk.isolation_scope() as scope:
-                        task_state = current_task()
-                        if task_state:
-                            scope.fingerprint = [
-                                "task.processing_deadline_exceeded",
-                                task_state.namespace,
-                                task_state.taskname,
-                            ]
-                        sentry_sdk.capture_exception(level="info")
+                    sentry_sdk.capture_exception(level="info")
                     retry_task(raise_on_no_retries=raise_on_no_retries)
                 else:
                     raise

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -84,7 +84,7 @@ class Retry:
         if self.max_attempts_reached(state):
             return False
 
-        # Explicit RetryError with attempts left.
+        # Explicit RetryTaskError with attempts left.
         if isinstance(exc, RetryTaskError):
             return True
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -14,14 +14,14 @@ from sentry.taskworker.state import current_task
 from sentry.utils import metrics
 
 
-class RetryError(Exception):
+class RetryTaskError(Exception):
     """
     Exception that tasks can raise to indicate that the current task activation
     should be retried.
     """
 
 
-class NoRetriesRemainingError(RetryError):
+class NoRetriesRemainingError(RetryTaskError):
     """
     Exception that is raised by retry helper methods to signal to tasks that
     the current attempt is terminal and there won't be any further retries.
@@ -53,7 +53,7 @@ def retry_task(exc: Exception | None = None, raise_on_no_retries: bool = True) -
             raise NoRetriesRemainingError()
         else:
             return
-    raise RetryError()
+    raise RetryTaskError()
 
 
 class Retry:
@@ -85,7 +85,7 @@ class Retry:
             return False
 
         # Explicit RetryError with attempts left.
-        if isinstance(exc, RetryError):
+        if isinstance(exc, RetryTaskError):
             return True
 
         # No retries for types on the ignore list

--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.namespaces import exampletasks
-from sentry.taskworker.retry import LastAction, NoRetriesRemainingError, Retry, RetryError
+from sentry.taskworker.retry import LastAction, NoRetriesRemainingError, Retry, RetryTaskError
 from sentry.taskworker.retry import retry_task as retry_task_helper
 from sentry.utils.redis import redis_clusters
 
@@ -22,7 +22,7 @@ def say_hello(name: str, *args: list[Any], **kwargs: dict[str, Any]) -> None:
     name="examples.retry_deadletter", retry=Retry(times=2, times_exceeded=LastAction.Deadletter)
 )
 def retry_deadletter() -> None:
-    raise RetryError
+    raise RetryTaskError
 
 
 @exampletasks.register(
@@ -43,7 +43,7 @@ def retry_state() -> None:
 def will_retry(failure: str) -> None:
     if failure == "retry":
         logger.debug("going to retry with explicit retry error")
-        raise RetryError
+        raise RetryTaskError
     if failure == "raise":
         logger.debug("raising runtimeerror")
         raise RuntimeError("oh no")
@@ -71,7 +71,7 @@ def simple_task_wait_delivery() -> None:
 
 @exampletasks.register(name="examples.retry_task", retry=Retry(times=2))
 def retry_task() -> None:
-    raise RetryError
+    raise RetryTaskError
 
 
 @exampletasks.register(name="examples.fail_task")

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -11,7 +11,7 @@ from sentry.integrations.source_code_management.metrics import LinkAllReposHaltR
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.retry import RetryTaskError
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric, assert_slo_metric
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -194,7 +194,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
             status=400,
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(RetryTaskError):
             link_all_repos(
                 integration_key=self.key,
                 integration_id=self.integration.id,

--- a/tests/sentry/integrations/tasks/test_create_comment.py
+++ b/tests/sentry/integrations/tasks/test_create_comment.py
@@ -7,7 +7,7 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.tasks import create_comment
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.activity import Activity
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.retry import RetryTaskError
 from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -157,7 +157,7 @@ class TestCreateComment(TestCase):
             integration=self.example_integration,
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(RetryTaskError):
             create_comment(external_issue.id, self.user.id, self.activity.id)
 
         assert_failure_metric(mock_record_event, Exception("Something went wrong creating comment"))

--- a/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
@@ -10,7 +10,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.tasks import sync_assignee_outbound
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.retry import RetryTaskError
 from sentry.testutils.asserts import assert_halt_metric, assert_success_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -72,7 +72,7 @@ class TestSyncAssigneeOutbound(TestCase):
     ) -> None:
         mock_sync_assignee.side_effect = raise_sync_assignee_exception
 
-        with pytest.raises(RetryError):
+        with pytest.raises(RetryTaskError):
             sync_assignee_outbound(self.external_issue.id, self.user.id, True, None)
 
         mock_record_failure.assert_called_once()

--- a/tests/sentry/integrations/tasks/test_sync_status_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_status_outbound.py
@@ -7,7 +7,7 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.tasks import sync_status_outbound
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import ApiUnauthorized, IntegrationFormError
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.retry import RetryTaskError
 from sentry.testutils.asserts import assert_count_of_metric, assert_halt_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of, region_silo_test
@@ -111,7 +111,7 @@ class TestSyncStatusOutbound(TestCase):
             group=self.group, key="foo_integration", integration=self.example_integration
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(RetryTaskError):
             sync_status_outbound(self.group.id, external_issue_id=external_issue.id)
 
         assert mock_record_failure.call_count == 1

--- a/tests/sentry/integrations/tasks/test_update_comment.py
+++ b/tests/sentry/integrations/tasks/test_update_comment.py
@@ -7,7 +7,7 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.tasks import update_comment
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.activity import Activity
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.retry import RetryTaskError
 from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -150,7 +150,7 @@ class TestUpdateComment(TestCase):
             integration=self.example_integration,
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(RetryTaskError):
             update_comment(external_issue.id, self.user.id, self.activity.id)
 
         assert_failure_metric(mock_record_event, Exception("Something went wrong updating comment"))

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -895,11 +895,11 @@ class TestInvokeFutureWithErrorHandling(BaseWorkflowTest):
     def test_raises_retry_error_for_api_error(self):
         from sentry.notifications.notification_action.types import invoke_future_with_error_handling
         from sentry.shared_integrations.exceptions import ApiError
-        from sentry.taskworker.retry import RetryError
+        from sentry.taskworker.retry import RetryTaskError
 
         self.mock_callback.side_effect = ApiError("API error", 500)
 
-        with pytest.raises(RetryError) as excinfo:
+        with pytest.raises(RetryTaskError) as excinfo:
             invoke_future_with_error_handling(
                 self.event_data, self.mock_callback, self.mock_futures
             )

--- a/tests/sentry/taskworker/test_retry.py
+++ b/tests/sentry/taskworker/test_retry.py
@@ -7,7 +7,7 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DISCARD,
 )
 
-from sentry.taskworker.retry import LastAction, Retry, RetryError
+from sentry.taskworker.retry import LastAction, Retry, RetryTaskError
 
 
 class RuntimeChildError(RuntimeError):
@@ -64,7 +64,7 @@ def test_should_retry_retryerror() -> None:
     retry = Retry(times=5)
     state = retry.initial_state()
 
-    err = RetryError("something bad")
+    err = RetryTaskError("something bad")
     assert retry.should_retry(state, err)
 
     state.attempts = 4

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -10,7 +10,7 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 )
 
 from sentry.taskworker.registry import TaskNamespace
-from sentry.taskworker.retry import LastAction, Retry, RetryError
+from sentry.taskworker.retry import LastAction, Retry, RetryTaskError
 from sentry.taskworker.router import DefaultRouter
 from sentry.taskworker.task import Task
 from sentry.testutils.helpers.task_runner import TaskRunner
@@ -147,7 +147,7 @@ def test_should_retry(task_namespace: TaskNamespace) -> None:
         namespace=task_namespace,
         retry=retry,
     )
-    err = RetryError("try again plz")
+    err = RetryTaskError("try again plz")
     assert task.should_retry(state, err)
 
     state.attempts = 3


### PR DESCRIPTION
Changes included:
* A Markdown table is added to the docstring describing how to call the `retry` decorator.
* It renames `RetryError` to `RetryTaskError` to help search the codebase.