### PR TITLE
feat(deletions): Retry task on timeout

### DIFF
--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -20,7 +20,7 @@ from sentry.taskworker.retry import Retry
     retry=Retry(times=MAX_RETRIES, delay=60 * 5),
     silo_mode=SiloMode.REGION,
 )
-@retry(exclude=(DeleteAborted,))
+@retry(exclude=(DeleteAborted,), timeouts=True)
 @track_group_async_operation
 def delete_groups_for_project(
     project_id: int,


### PR DESCRIPTION
If `timeout` is not set to True, the task will only be reported and not retried.
https://github.com/getsentry/sentry/blob/86f3b6a4c6f9b9b70d1e21687ea06c9527d9e83d/src/sentry/tasks/base.py#L133-L136
https://github.com/getsentry/sentry/blob/86f3b6a4c6f9b9b70d1e21687ea06c9527d9e83d/src/sentry/tasks/base.py#L154-L167

[This issue](https://sentry.sentry.io/issues/6770482833/) is an example of the task not being retried.