### PR TITLE
chore(deletions): Change schedule & date ranges

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1009,9 +1009,8 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "delete-pending-groups": {
         "task": "deletions:sentry.tasks.delete_pending_groups",
-        # Runs every 2 hours during 9am-5pm Eastern Time (EST: UTC-5)
-        # 9am, 11am, 1pm, 3pm, 5pm EST = 14:00, 16:00, 18:00, 20:00, 22:00 UTC
-        "schedule": task_crontab("0", "14,16,18,20,22", "*", "*", "*"),
+        # Runs every 6 hours (at 00:00, 06:00, 12:00, 18:00 UTC)
+        "schedule": task_crontab("0", "*/6", "*", "*", "*"),
     },
     "schedule-weekly-organization-reports-new": {
         "task": "reports:sentry.tasks.summaries.weekly_reports.schedule_organizations",

--- a/tests/sentry/tasks/test_delete_pending_groups.py
+++ b/tests/sentry/tasks/test_delete_pending_groups.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from sentry.models.group import Group, GroupStatus
 from sentry.tasks.delete_pending_groups import (
     MAX_LAST_SEEN_DAYS,
-    MIN_LAST_SEEN_DAYS,
+    MIN_LAST_SEEN_HOURS,
     delete_pending_groups,
 )
 from sentry.testutils.cases import TestCase
@@ -16,29 +16,32 @@ from sentry.types.group import GroupSubStatus
 
 
 class DeletePendingGroupsTest(TestCase):
-    def _count_groups_in_deletion_status(self) -> int:
+    def _count_groups_in_deletion_status_and_valid_date_range(self) -> int:
         """Count groups with deletion statuses in the valid date range."""
         return Group.objects.filter(
             status__in=[GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS],
             last_seen__gte=self._days_ago(MAX_LAST_SEEN_DAYS),
-            last_seen__lte=self._days_ago(MIN_LAST_SEEN_DAYS),
+            last_seen__lte=self._hours_ago(MIN_LAST_SEEN_HOURS),
         ).count()
 
     def _days_ago(self, days: int) -> datetime:
         return timezone.now() - timedelta(days=days)
 
+    def _hours_ago(self, hours: int) -> datetime:
+        return timezone.now() - timedelta(hours=hours)
+
     def test_schedules_only_groups_within_valid_date_range(self) -> None:
         """Test that only groups with last_seen between 24h-90d are scheduled for deletion."""
         project = self.create_project()
 
-        # Too recent - within 24 hours (should NOT be scheduled)
+        # Too recent - within 4 hours (should NOT be scheduled)
         too_recent = self.create_group(
-            project=project, status=GroupStatus.PENDING_DELETION, last_seen=self._days_ago(0)
+            project=project, status=GroupStatus.PENDING_DELETION, last_seen=self._hours_ago(4)
         )
 
         # Valid range - should be scheduled
         valid_group = self.create_group(
-            project=project, status=GroupStatus.PENDING_DELETION, last_seen=self._days_ago(2)
+            project=project, status=GroupStatus.PENDING_DELETION, last_seen=self._hours_ago(7)
         )
 
         # Too old - over 90 days (should NOT be scheduled)
@@ -65,11 +68,11 @@ class DeletePendingGroupsTest(TestCase):
             assert call_kwargs["object_ids"] == [valid_group.id]
             assert call_kwargs["project_id"] == project.id
 
-        assert self._count_groups_in_deletion_status() != 0
+        assert self._count_groups_in_deletion_status_and_valid_date_range() != 0
         with self.tasks():
             delete_pending_groups()
 
-        assert self._count_groups_in_deletion_status() == 0
+        assert self._count_groups_in_deletion_status_and_valid_date_range() == 0
         assert list(Group.objects.all().values_list("id", flat=True).order_by("id")) == [
             too_recent.id,
             too_old.id,


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/103820.

A failure to delete a group should be re-processed within 24 hours.

Changes included:
* Schedule re-processing task every N hours instead of odd schedule
* Re-process groups pending deletion that are older than 6 hours rather than midnight from the day before