### PR TITLE
fix(tracemetrics): Add metric button not working

### DIFF
--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -24,7 +24,12 @@ function isTraceMetric(value: unknown): value is TraceMetric {
     return false;
   }
 
-  return 'name' in value && !!value.name && 'type' in value && !!value.type;
+  return (
+    'name' in value &&
+    typeof value.name === 'string' &&
+    'type' in value &&
+    typeof value.type === 'string'
+  );
 }
 
 export interface BaseMetricQuery {


### PR DESCRIPTION
The default metric uses empty strings and relies on the component filling it later. So permit it in the validation.