### PR TITLE
chore(dashboards): Address global filter UI feedback

### DIFF
--- a/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
@@ -62,7 +62,7 @@ describe('AddFilter', () => {
     await userEvent.click(screen.getByText('Errors'));
 
     // Should see filter key options for the dataset
-    expect(screen.getByText('Select Filter Tag')).toBeInTheDocument();
+    expect(screen.getByText('Select Errors Tag')).toBeInTheDocument();
     expect(screen.getByText(mockFilterKeys['browser.name']!.key)).toBeInTheDocument();
     expect(screen.getByText(mockFilterKeys.environment!.key)).toBeInTheDocument();
 

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -178,12 +178,14 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
       size="md"
       menuWidth="300px"
       menuTitle={
-        isSelectingFilterKey
-          ? t(
-              'Select %s Tag',
-              selectedDataset ? getDatasetLabel(selectedDataset) : 'Filter'
-            )
-          : t('Select Filter Dataset')
+        <MenuTitleWrapper>
+          {isSelectingFilterKey
+            ? t(
+                'Select %s Tag',
+                selectedDataset ? getDatasetLabel(selectedDataset) : 'Filter'
+              )
+            : t('Select Filter Dataset')}
+        </MenuTitleWrapper>
       }
       menuFooter={isSelectingFilterKey && filterOptionsMenuFooter}
       trigger={triggerProps => (
@@ -208,4 +210,10 @@ const FooterWrap = styled('div')`
   &:not(:first-child) {
     margin-top: ${space(1)};
   }
+`;
+
+const MenuTitleWrapper = styled('span')`
+  display: inline-block;
+  padding-top: ${space(0.5)};
+  padding-bottom: ${space(0.5)};
 `;

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -178,7 +178,12 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
       size="md"
       menuWidth="300px"
       menuTitle={
-        isSelectingFilterKey ? t('Select Filter Tag') : t('Select Filter Dataset')
+        isSelectingFilterKey
+          ? t(
+              'Select %s Tag',
+              selectedDataset ? getDatasetLabel(selectedDataset) : 'Filter'
+            )
+          : t('Select Filter Dataset')
       }
       menuFooter={isSelectingFilterKey && filterOptionsMenuFooter}
       trigger={triggerProps => (

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -10,7 +10,6 @@ import {ValueType} from 'sentry/components/searchQueryBuilder/tokens/filterKeyLi
 import {getInitialFilterText} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import {IconAdd, IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Tag} from 'sentry/types/group';
 import {
   FieldKind,
@@ -19,6 +18,7 @@ import {
   type FieldDefinition,
 } from 'sentry/utils/fields';
 import type {SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
+import {MenuTitleWrapper} from 'sentry/views/dashboards/globalFilter/filterSelector';
 import {getFieldDefinitionForDataset} from 'sentry/views/dashboards/globalFilter/utils';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
 import {shouldExcludeTracingKeys} from 'sentry/views/performance/utils';
@@ -204,16 +204,10 @@ export default AddFilter;
 const FooterWrap = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  gap: ${space(2)};
+ gap:${p => p.theme.space.xl}
 
   /* If there's FooterMessage above */
   &:not(:first-child) {
-    margin-top: ${space(1)};
+    margin-top: ${p => p.theme.space.md};
   }
-`;
-
-const MenuTitleWrapper = styled('span')`
-  display: inline-block;
-  padding-top: ${space(0.5)};
-  padding-bottom: ${space(0.5)};
 `;

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -35,7 +35,7 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ':'});
+    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
     await userEvent.click(button);
 
     expect(screen.getByText('chrome')).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ':'});
+    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
     await userEvent.click(button);
 
     await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
@@ -84,7 +84,7 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ':'});
+    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
     await userEvent.click(button);
 
     expect(screen.getByRole('checkbox', {name: 'Select firefox'})).toBeChecked();
@@ -101,7 +101,7 @@ describe('FilterSelector', () => {
       />
     );
 
-    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ':'});
+    const button = screen.getByRole('button', {name: mockGlobalFilter.tag.key + ' :'});
     await userEvent.click(button);
     await userEvent.click(screen.getByRole('button', {name: 'Remove Filter'}));
 

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -15,6 +15,7 @@ import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {keepPreviousData, useQuery} from 'sentry/utils/queryClient';
+import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {type SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
@@ -124,7 +125,7 @@ function FilterSelector({
     const optionMap = new Map<string, SelectOption<string>>();
     const fixedOptionMap = new Map<string, SelectOption<string>>();
     const addOption = (value: string, map: Map<string, SelectOption<string>>) =>
-      map.set(value, {label: value, value});
+      map.set(value, {label: middleEllipsis(value, 70, /[\s-_:]/), value});
 
     // Filter values in the global filter
     activeFilterValues.forEach(value => addOption(value, optionMap));
@@ -254,7 +255,6 @@ function FilterSelector({
         setStagedFilterValues(value);
       }}
       sizeLimit={30}
-      maxMenuWidth={500}
       onClose={() => {
         setSearchQuery('');
         setStagedFilterValues([]);

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -286,12 +286,12 @@ const StyledButton = styled(Button)`
   padding: 0 ${space(0.5)};
   margin: ${p =>
     p.theme.isChonk
-      ? `-${space(0.5)} -${space(0.5)}`
-      : `-${space(0.25)} -${space(0.25)}`};
+      ? `-${p.theme.space.xs} -${p.theme.space.xs}`
+      : `-${p.theme.space['2xs']} -${p.theme.space['2xs']}`};
 `;
 
-const MenuTitleWrapper = styled('span')`
+export const MenuTitleWrapper = styled('span')`
   display: inline-block;
-  padding-top: ${space(0.5)};
-  padding-bottom: ${space(0.5)};
+  padding-top: ${p => p.theme.space.xs};
+  padding-bottom: ${p => p.theme.space.xs};
 `;

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -180,7 +180,7 @@ function FilterSelector({
   };
 
   const renderMenuHeaderTrailingItems = ({closeOverlay}: any) => (
-    <Flex gap="md">
+    <Flex gap="lg">
       {activeFilterValues.length > 0 && (
         <StyledButton
           aria-label={t('Clear Selections')}
@@ -228,7 +228,9 @@ function FilterSelector({
         onClose={() => {
           setStagedFilterValues([]);
         }}
-        menuTitle={t('%s Filter', getDatasetLabel(dataset))}
+        menuTitle={
+          <MenuTitleWrapper>{t('%s Filter', getDatasetLabel(dataset))}</MenuTitleWrapper>
+        }
         menuHeaderTrailingItems={renderMenuHeaderTrailingItems}
         triggerProps={{
           children: renderFilterSelectorTrigger(),
@@ -261,7 +263,9 @@ function FilterSelector({
       emptyMessage={
         isFetching ? t('Loading filter values...') : t('No filter values found')
       }
-      menuTitle={t('%s Filter', getDatasetLabel(dataset))}
+      menuTitle={
+        <MenuTitleWrapper>{t('%s Filter', getDatasetLabel(dataset))}</MenuTitleWrapper>
+      }
       menuHeaderTrailingItems={renderMenuHeaderTrailingItems}
       triggerProps={{
         children: renderFilterSelectorTrigger(),
@@ -281,4 +285,10 @@ const StyledButton = styled(Button)`
     p.theme.isChonk
       ? `-${space(0.5)} -${space(0.5)}`
       : `-${space(0.25)} -${space(0.25)}`};
+`;
+
+const MenuTitleWrapper = styled('span')`
+  display: inline-block;
+  padding-top: ${space(0.5)};
+  padding-bottom: ${space(0.5)};
 `;

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -125,7 +125,10 @@ function FilterSelector({
     const optionMap = new Map<string, SelectOption<string>>();
     const fixedOptionMap = new Map<string, SelectOption<string>>();
     const addOption = (value: string, map: Map<string, SelectOption<string>>) =>
-      map.set(value, {label: middleEllipsis(value, 70, /[\s-_:]/), value});
+      map.set(value, {
+        label: middleEllipsis(value, 70, /[\s-_:]/),
+        value,
+      });
 
     // Filter values in the global filter
     activeFilterValues.forEach(value => addOption(value, optionMap));

--- a/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {prettifyTagKey} from 'sentry/utils/fields';
 import type {UseQueryResult} from 'sentry/utils/queryClient';
+import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 import type {GlobalFilter} from 'sentry/views/dashboards/types';
 
 type FilterSelectorTriggerProps = {
@@ -33,13 +34,19 @@ function FilterSelectorTrigger({
   const isAllSelected =
     activeFilterValues.length === 0 || activeFilterValues.length === options.length;
 
+  const tagKey = prettifyTagKey(tag.key);
+  const truncatedTagKey = middleEllipsis(tagKey, 50, /[\s-_:]/);
+  const truncatedValue = activeFilterValues[0]
+    ? middleEllipsis(activeFilterValues[0], 60, /[\s-_:]/)
+    : '';
+
   return (
     <ButtonLabelWrapper>
       <TextOverflow>
-        {prettifyTagKey(tag.key)}:{' '}
+        {truncatedTagKey}:{' '}
         {!isFetching && (
           <span style={{fontWeight: 'normal'}}>
-            {isAllSelected ? t('All') : activeFilterValues[0]}
+            {isAllSelected ? t('All') : truncatedValue}
           </span>
         )}
       </TextOverflow>

--- a/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {Badge} from 'sentry/components/core/badge';
 import type {SelectOption} from 'sentry/components/core/compactSelect/types';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import TextOverflow from 'sentry/components/textOverflow';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {prettifyTagKey} from 'sentry/utils/fields';
 import type {UseQueryResult} from 'sentry/utils/queryClient';
-import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 import type {GlobalFilter} from 'sentry/views/dashboards/types';
 
 type FilterSelectorTriggerProps = {
@@ -35,21 +35,22 @@ function FilterSelectorTrigger({
     activeFilterValues.length === 0 || activeFilterValues.length === options.length;
 
   const tagKey = prettifyTagKey(tag.key);
-  const truncatedTagKey = middleEllipsis(tagKey, 50, /[\s-_:]/);
-  const truncatedValue = activeFilterValues[0]
-    ? middleEllipsis(activeFilterValues[0], 60, /[\s-_:]/)
-    : '';
+  const filterValue = activeFilterValues[0] ?? '';
+  const separator = <FilterValueSeparator>{':'}</FilterValueSeparator>;
 
   return (
     <ButtonLabelWrapper>
-      <TextOverflow>
-        {truncatedTagKey}:{' '}
-        {!isFetching && (
-          <span style={{fontWeight: 'normal'}}>
-            {isAllSelected ? t('All') : truncatedValue}
-          </span>
-        )}
-      </TextOverflow>
+      <FilterValueTruncated>{tagKey}</FilterValueTruncated>
+      {separator}
+      {!isFetching && (
+        <span style={{fontWeight: 'normal'}}>
+          {isAllSelected ? (
+            t('All')
+          ) : (
+            <FilterValueTruncated>{filterValue}</FilterValueTruncated>
+          )}
+        </span>
+      )}
       {isFetching && <StyledLoadingIndicator size={14} />}
       {shouldShowBadge && (
         <StyledBadge type="default">{`+${activeFilterValues.length - 1}`}</StyledBadge>
@@ -77,11 +78,16 @@ const StyledBadge = styled(Badge)`
   padding: 0 ${space(0.5)};
 `;
 
-const ButtonLabelWrapper = styled('span')`
-  width: 100%;
-  text-align: left;
+const ButtonLabelWrapper = styled(Flex)`
   align-items: center;
-  display: inline-grid;
-  grid-template-columns: 1fr auto;
-  line-height: 1;
+`;
+
+const FilterValueSeparator = styled('span')`
+  margin-right: ${space(0.5)};
+`;
+
+const FilterValueTruncated = styled('div')`
+  ${p => p.theme.overflowEllipsis};
+  max-width: 300px;
+  width: min-content;
 `;

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -354,7 +354,7 @@ function NumericFilterSelector({
 export default NumericFilterSelector;
 
 const MenuBodyWrap = styled('div')`
-  padding: 10px;
+  padding: ${p => p.theme.space.md};
 `;
 
 const FooterWrap = styled('div')`

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -94,7 +94,7 @@ function useNativeOperatorFilter(
 
   const renderInputField = () => {
     return (
-      <Input
+      <StyledInput
         aria-label="Filter value"
         value={stagedFilterValue}
         onChange={e => {
@@ -287,7 +287,11 @@ function NumericFilterSelector({
         filter.resetValues();
         setStagedIsNativeOperator(isNativeOperator);
       }}
-      menuTitle={t('%s Filter', getDatasetLabel(globalFilter.dataset))}
+      menuTitle={
+        <MenuTitleWrapper>
+          {t('%s Filter', getDatasetLabel(globalFilter.dataset))}
+        </MenuTitleWrapper>
+      }
       menuHeaderTrailingItems={() => (
         <StyledButton
           aria-label={t('Remove Filter')}
@@ -350,7 +354,7 @@ function NumericFilterSelector({
 export default NumericFilterSelector;
 
 const MenuBodyWrap = styled('div')`
-  margin: 4px;
+  padding: 10px;
 `;
 
 const FooterWrap = styled('div')`
@@ -390,4 +394,14 @@ const StyledButton = styled(Button)`
     p.theme.isChonk
       ? `-${space(0.5)} -${space(0.5)}`
       : `-${space(0.25)} -${space(0.25)}`};
+`;
+
+const StyledInput = styled(Input)`
+  text-align: center;
+`;
+
+const MenuTitleWrapper = styled('span')`
+  display: inline-block;
+  padding-top: ${space(0.5)};
+  padding-bottom: ${space(0.5)};
 `;

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -16,8 +16,8 @@ import {
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
+import {MenuTitleWrapper} from 'sentry/views/dashboards/globalFilter/filterSelector';
 import type {GenericFilterSelectorProps} from 'sentry/views/dashboards/globalFilter/genericFilterSelector';
 import {
   BetweenFilterSelectorTrigger,
@@ -360,18 +360,18 @@ const MenuBodyWrap = styled('div')`
 const FooterWrap = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  gap: ${space(2)};
+  gap: ${p => p.theme.space.xl};
 
   /* If there's FooterMessage above */
   &:not(:first-child) {
-    margin-top: ${space(1)};
+    margin-top: ${p => p.theme.space.md};
   }
 `;
 const FooterInnerWrap = styled('div')`
   grid-row: -1;
   display: grid;
   grid-auto-flow: column;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   justify-self: end;
   justify-items: end;
 
@@ -389,19 +389,13 @@ const StyledButton = styled(Button)`
   font-size: inherit;
   font-weight: ${p => p.theme.fontWeight.normal};
   color: ${p => p.theme.subText};
-  padding: 0 ${space(0.5)};
+  padding: 0 ${p => p.theme.space.xs};
   margin: ${p =>
     p.theme.isChonk
-      ? `-${space(0.5)} -${space(0.5)}`
-      : `-${space(0.25)} -${space(0.25)}`};
+      ? `-${p.theme.space.xs} -${p.theme.space.xs}`
+      : `-${p.theme.space['2xs']} -${p.theme.space['2xs']}`};
 `;
 
 const StyledInput = styled(Input)`
   text-align: center;
-`;
-
-const MenuTitleWrapper = styled('span')`
-  display: inline-block;
-  padding-top: ${space(0.5)};
-  padding-bottom: ${space(0.5)};
 `;


### PR DESCRIPTION
- Adds the dataset name to the menu title when selecting filter tags.
- Fixes spacing issues in filterSelector and addFilter menu titles.
- Truncates filter key and value in the global filter selector (using middle ellipsis truncation).

Note: An easy way to test truncation is to add a spans global filter for `span.description` or `sentry.normalized_description`