### PR TITLE
fix(deletions): Fix MonitorCheckIn direct deletion

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -106,7 +106,7 @@ def load_defaults(manager: DeletionTaskManager) -> None:
     manager.register(integrations.RepositoryProjectPathConfig, defaults.RepositoryProjectPathConfigDeletionTask)
     manager.register(monitors.Monitor, defaults.MonitorDeletionTask)
     manager.register(monitors.MonitorEnvironment, defaults.MonitorEnvironmentDeletionTask)
-    manager.register(monitors.MonitorCheckIn, BulkModelDeletionTask)
+    manager.register(monitors.MonitorCheckIn, defaults.MonitorCheckInDeletionTask)
     manager.register(monitors.MonitorIncident, defaults.MonitorIncidentDeletionTask)
     manager.register(monitors.MonitorEnvBrokenDetection, BulkModelDeletionTask)
     manager.register(sentry_apps.PlatformExternalIssue, defaults.PlatformExternalIssueDeletionTask)

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -13,6 +13,7 @@ from .group import *  # noqa: F401,F403
 from .grouphash import *  # noqa: F401,F403
 from .incident import *  # noqa: F401,F403
 from .monitor import *  # noqa: F401,F403
+from .monitor_checkin import *  # noqa: F401,F403
 from .monitor_environment import *  # noqa: F401,F403
 from .monitor_incident import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -1,4 +1,9 @@
-from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.deletions.base import (
+    BaseRelation,
+    BulkModelDeletionTask,
+    ModelDeletionTask,
+    ModelRelation,
+)
 from sentry.monitors.models import Monitor
 
 
@@ -8,6 +13,9 @@ class MonitorDeletionTask(ModelDeletionTask[Monitor]):
 
         return [
             ModelRelation(models.MonitorIncident, {"monitor_id": instance.id}),
-            ModelRelation(models.MonitorCheckIn, {"monitor_id": instance.id}),
+            # Use BulkModelDeletionTask here since MonitorIncidents are already handled above
+            ModelRelation(
+                models.MonitorCheckIn, {"monitor_id": instance.id}, BulkModelDeletionTask
+            ),
             ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
         ]

--- a/src/sentry/deletions/defaults/monitor_checkin.py
+++ b/src/sentry/deletions/defaults/monitor_checkin.py
@@ -1,0 +1,20 @@
+from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.monitors.models import MonitorCheckIn
+
+
+class MonitorCheckInDeletionTask(ModelDeletionTask[MonitorCheckIn]):
+    def get_child_relations(self, instance: MonitorCheckIn) -> list[BaseRelation]:
+        from sentry.monitors import models
+
+        # When MonitorCheckIn is deleted directly, we need to delete MonitorIncidents
+        # that reference it. MonitorIncident has two FKs pointing to MonitorCheckIn.
+        return [
+            ModelRelation(
+                models.MonitorIncident,
+                {"starting_checkin_id": instance.id},
+            ),
+            ModelRelation(
+                models.MonitorIncident,
+                {"resolving_checkin_id": instance.id},
+            ),
+        ]

--- a/src/sentry/deletions/defaults/monitor_environment.py
+++ b/src/sentry/deletions/defaults/monitor_environment.py
@@ -1,4 +1,9 @@
-from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.deletions.base import (
+    BaseRelation,
+    BulkModelDeletionTask,
+    ModelDeletionTask,
+    ModelRelation,
+)
 from sentry.monitors.models import MonitorEnvironment
 
 
@@ -11,8 +16,10 @@ class MonitorEnvironmentDeletionTask(ModelDeletionTask[MonitorEnvironment]):
                 models.MonitorIncident,
                 {"monitor_environment_id": instance.id},
             ),
+            # Use BulkModelDeletionTask here since MonitorIncidents are already handled above
             ModelRelation(
                 models.MonitorCheckIn,
                 {"monitor_environment_id": instance.id},
+                BulkModelDeletionTask,
             ),
         ]


### PR DESCRIPTION
In #103786, we refactored the way MonitorCheckIn gets deleted through Monitor and MonitorEnvironment deletion, but in the process hurt direct MonitorCheckIn cleanup which also happens daily. Added a task to handle it and set the relations to use Bulk Deletion instead of defaulting to Bulk.