### PR TITLE
ref(billing): Use Reservations type in CheckoutAPIData

### DIFF
--- a/static/gsApp/views/amCheckout/types.tsx
+++ b/static/gsApp/views/amCheckout/types.tsx
@@ -2,6 +2,7 @@ import type {Client} from 'sentry/api';
 import type {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 
+import type {Reservations} from 'getsentry/components/upgradeNowModal/types';
 import type {
   AddOnCategory,
   BillingConfig,
@@ -29,7 +30,7 @@ export type CheckoutAPIData = Omit<BaseCheckoutData, 'addOns'> & {
   paymentIntent?: string;
   previewToken?: string;
   referrer?: string;
-} & Partial<Record<`reserved${Capitalize<DataCategory>}`, number>> &
+} & Partial<Reservations> &
   Partial<Record<`addOn${Capitalize<AddOnCategory>}`, boolean>>;
 
 type BaseStepProps = {

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -20,6 +20,7 @@ import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
 
+import type {Reservations} from 'getsentry/components/upgradeNowModal/types';
 import {
   DEFAULT_TIER,
   MONTHLY,
@@ -541,7 +542,7 @@ export function getCheckoutAPIData({
       })}`,
       formatReservedData(value),
     ])
-  ) satisfies Partial<Record<`reserved${Capitalize<DataCategory>}`, number>>;
+  ) satisfies Partial<Reservations>;
 
   const onDemandMaxSpend = shouldUpdateOnDemand
     ? (formData.onDemandMaxSpend ?? 0)


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-956/dynamic-reservations

Continues from https://github.com/getsentry/sentry/pull/103855.

Replaces template literal type `Partial<Record<`reserved${Capitalize<DataCategory>}`, number>>` with the new `Reservations` mapped type introduced in BIL-956.
