### PR TITLE
fix(alerts): filter out orphaned metric alerts when checking limit

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -605,9 +605,9 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
             "organizations:workflow-engine-metric-detector-limit", organization, actor=request.user
         ):
             alert_limit = quotas.backend.get_metric_detector_limit(organization.id)
-            alert_count = AlertRule.objects.fetch_for_organization(
-                organization=organization
-            ).count()
+            alert_count = AlertRule.objects.fetch_for_organization(organization=organization)
+            # filter out alert rules without any projects
+            alert_count = alert_count.filter(projects__isnull=False).count()
 
             if alert_limit >= 0 and alert_count >= alert_limit:
                 raise ValidationError(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -607,7 +607,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
             alert_limit = quotas.backend.get_metric_detector_limit(organization.id)
             alert_count = AlertRule.objects.fetch_for_organization(organization=organization)
             # filter out alert rules without any projects
-            alert_count = alert_count.filter(projects__isnull=False).count()
+            alert_count = alert_count.filter(projects__isnull=False).distinct().count()
 
             if alert_limit >= 0 and alert_count >= alert_limit:
                 raise ValidationError(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1612,6 +1612,13 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     @patch("sentry.quotas.backend.get_metric_detector_limit")
     def test_metric_alert_limit(self, mock_get_limit: MagicMock) -> None:
+        # create orphaned metric alert
+        project_to_delete = self.create_project(organization=self.organization)
+        alert_rule = self.create_alert_rule(
+            organization=self.organization, projects=[project_to_delete]
+        )
+        project_to_delete.delete()
+
         # Set limit to 2 alert rules
         mock_get_limit.return_value = 2
 
@@ -1646,6 +1653,13 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     @with_feature("organizations:incidents")
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     def test_metric_alert_limit_unlimited_plan(self) -> None:
+        # create orphaned metric alert
+        project_to_delete = self.create_project(organization=self.organization)
+        alert_rule = self.create_alert_rule(
+            organization=self.organization, projects=[project_to_delete]
+        )
+        project_to_delete.delete()
+
         # Create many alert rules
         for _ in range(5):
             self.create_alert_rule(organization=self.organization)


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/103881

These metric alerts don't fire nor are they visible through the API