### PR TITLE
feat(Replay): Update Query Archived Alias

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -67,7 +67,7 @@ def query_replay_instance_eap(
             ],
             alias="count_rage_clicks",
         ),
-        Function("max", parameters=[Column("is_archived")], alias="is_archived"),
+        Function("max", parameters=[Column("is_archived")], alias="isArchived"),
     ]
 
     snuba_query = Query(

--- a/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
+++ b/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
@@ -112,7 +112,7 @@ class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
         assert "count_warnings" in replay1_data
         assert "count_dead_clicks" in replay1_data
         assert "count_rage_clicks" in replay1_data
-        assert "is_archived" in replay1_data
+        assert "isArchived" in replay1_data
         assert "started_at" in replay1_data
         assert "finished_at" in replay1_data
 


### PR DESCRIPTION
The previous query implementation labelled the archived field as "is_archived", which was causing this following issue: https://sentry.sentry.io/issues/7052385268/?project=1&query=id%3A61ea7f29fdcb482d8fe214cf91277254&referrer=issue-stream

The fix is trivial, as we rename the field to match the implementation to avoid the keyError.


Relates to: https://linear.app/getsentry/issue/REPLAY-824/create-query-function-for-replay-details 
