### PR TITLE
feat(tracemetrics): Copy previous metric instead of using defaults

### DIFF
--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -196,7 +196,7 @@ describe('MetricsTabContent', () => {
 
     toolbars = screen.getAllByTestId('metric-toolbar');
     expect(toolbars).toHaveLength(2);
-    // selects the first metric available - sorted alphanumerically
+    // copies the last metric as a starting point
     expect(within(toolbars[1]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
     expect(screen.getAllByTestId('metric-panel')).toHaveLength(2);
 
@@ -213,8 +213,8 @@ describe('MetricsTabContent', () => {
 
     toolbars = screen.getAllByTestId('metric-toolbar');
     expect(toolbars).toHaveLength(3);
-    // selects the first metric available - sorted alphanumerically
-    expect(within(toolbars[2]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
+    // copies the last metric as a starting point
+    expect(within(toolbars[2]!).getByRole('button', {name: 'foo'})).toBeInTheDocument();
     expect(screen.getAllByTestId('metric-panel')).toHaveLength(3);
   });
 });

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -188,7 +188,10 @@ export function useAddMetricQuery() {
   return function () {
     const target = {...location, query: {...location.query}};
 
-    const newMetricQueries: string[] = [...metricQueries, defaultMetricQuery()]
+    const newMetricQueries: string[] = [
+      ...metricQueries,
+      metricQueries[metricQueries.length - 1] ?? defaultMetricQuery(),
+    ]
       .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
       .filter(defined)
       .filter(Boolean);


### PR DESCRIPTION
The default behaviour sets the new metric to the first available metric. This behaviour isn't very convenient because a common use case is to create another chart for the same metric but with a different aggregate function.