### PR TITLE
ref(billing): Add nested categories to checkout.upgrade event

### DIFF
--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -102,9 +102,19 @@ type GetsentryEventParameters = {
   'checkout.updated_billing_details': BillingInfoUpdateEvent;
   'checkout.updated_cc': BillingInfoUpdateEvent;
   // no sub here
-  'checkout.upgrade': Partial<
-    Record<DataCategory | `previous_${DataCategory}`, number | undefined>
-  > & {previous_plan: string} & Checkout;
+  'checkout.upgrade': {
+    previous_plan: string;
+    categories?: Partial<
+      Record<
+        DataCategory,
+        {
+          previous_reserved: number | undefined;
+          reserved: number | undefined;
+        }
+      >
+    >;
+  } & Partial<Record<DataCategory | `previous_${DataCategory}`, number | undefined>> &
+    Checkout;
   'data_consent_modal.learn_more': Record<PropertyKey, unknown>;
   'data_consent_priority.viewed': Record<PropertyKey, unknown>;
   'data_consent_settings.updated': {setting: string; value: FieldValue};

--- a/static/gsApp/views/amCheckout/steps/reviewAndConfirm.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reviewAndConfirm.spec.tsx
@@ -281,6 +281,32 @@ describe('AmCheckout > ReviewAndConfirm', () => {
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
       uptime: 1,
+      categories: {
+        errors: {
+          reserved: updatedData.reserved.errors,
+          previous_reserved: 5000,
+        },
+        transactions: {
+          reserved: updatedData.reserved.transactions,
+          previous_reserved: 10_000,
+        },
+        attachments: {
+          reserved: updatedData.reserved.attachments,
+          previous_reserved: 1,
+        },
+        replays: {
+          reserved: updatedData.reserved.replays,
+          previous_reserved: 50,
+        },
+        monitorSeats: {
+          reserved: updatedData.reserved.monitorSeats,
+          previous_reserved: 1,
+        },
+        uptime: {
+          reserved: 1,
+          previous_reserved: 1,
+        },
+      },
     });
 
     expect(trackGetsentryAnalytics).toHaveBeenCalledWith('checkout.product_select', {
@@ -395,13 +421,46 @@ describe('AmCheckout > ReviewAndConfirm', () => {
       previous_uptime: 1,
       plan: updatedData.plan,
       errors: updatedData.reserved.errors,
-      transactions: undefined,
       attachments: updatedData.reserved.attachments,
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
       spans: updatedData.reserved.spans,
       profileDuration: updatedData.reserved.profileDuration,
       uptime: updatedData.reserved.uptime,
+      categories: {
+        errors: {
+          reserved: updatedData.reserved.errors,
+          previous_reserved: 5000,
+        },
+        transactions: {
+          reserved: undefined,
+          previous_reserved: 10_000,
+        },
+        attachments: {
+          reserved: updatedData.reserved.attachments,
+          previous_reserved: 1,
+        },
+        replays: {
+          reserved: updatedData.reserved.replays,
+          previous_reserved: 50,
+        },
+        monitorSeats: {
+          reserved: updatedData.reserved.monitorSeats,
+          previous_reserved: 1,
+        },
+        spans: {
+          reserved: updatedData.reserved.spans,
+          previous_reserved: undefined,
+        },
+        profileDuration: {
+          reserved: updatedData.reserved.profileDuration,
+          previous_reserved: undefined,
+        },
+        uptime: {
+          reserved: updatedData.reserved.uptime,
+          previous_reserved: 1,
+        },
+      },
     });
 
     expect(trackGetsentryAnalytics).toHaveBeenCalledWith(
@@ -494,12 +553,41 @@ describe('AmCheckout > ReviewAndConfirm', () => {
       previous_spans: undefined,
       plan: updatedData.plan,
       errors: updatedData.reserved.errors,
-      transactions: undefined,
       attachments: updatedData.reserved.attachments,
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
       spans: updatedData.reserved.spans,
       previous_uptime: 1,
+      categories: {
+        errors: {
+          reserved: updatedData.reserved.errors,
+          previous_reserved: 5000,
+        },
+        transactions: {
+          reserved: undefined,
+          previous_reserved: 10_000,
+        },
+        attachments: {
+          reserved: updatedData.reserved.attachments,
+          previous_reserved: 1,
+        },
+        replays: {
+          reserved: updatedData.reserved.replays,
+          previous_reserved: 50,
+        },
+        monitorSeats: {
+          reserved: updatedData.reserved.monitorSeats,
+          previous_reserved: 1,
+        },
+        spans: {
+          reserved: updatedData.reserved.spans,
+          previous_reserved: undefined,
+        },
+        uptime: {
+          reserved: undefined,
+          previous_reserved: 1,
+        },
+      },
     });
 
     expect(trackGetsentryAnalytics).toHaveBeenCalledWith(
@@ -711,7 +799,32 @@ describe('AmCheckout > ReviewAndConfirm', () => {
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
       uptime: updatedData.reserved.uptime,
-      spans: undefined,
+      categories: {
+        errors: {
+          reserved: updatedData.reserved.errors,
+          previous_reserved: 100000,
+        },
+        transactions: {
+          reserved: updatedData.reserved.transactions,
+          previous_reserved: 250000,
+        },
+        attachments: {
+          reserved: updatedData.reserved.attachments,
+          previous_reserved: 1,
+        },
+        replays: {
+          reserved: updatedData.reserved.replays,
+          previous_reserved: 500,
+        },
+        monitorSeats: {
+          reserved: updatedData.reserved.monitorSeats,
+          previous_reserved: 1,
+        },
+        uptime: {
+          reserved: updatedData.reserved.uptime,
+          previous_reserved: undefined,
+        },
+      },
     });
     expect(trackGetsentryAnalytics).not.toHaveBeenCalledWith(
       'checkout.transactions_upgrade'
@@ -778,7 +891,32 @@ describe('AmCheckout > ReviewAndConfirm', () => {
       replays: updatedData.reserved.replays,
       monitorSeats: updatedData.reserved.monitorSeats,
       uptime: updatedData.reserved.uptime,
-      spans: undefined,
+      categories: {
+        errors: {
+          reserved: updatedData.reserved.errors,
+          previous_reserved: 100000,
+        },
+        transactions: {
+          reserved: updatedData.reserved.transactions,
+          previous_reserved: 500000,
+        },
+        attachments: {
+          reserved: updatedData.reserved.attachments,
+          previous_reserved: 1,
+        },
+        replays: {
+          reserved: updatedData.reserved.replays,
+          previous_reserved: 500,
+        },
+        monitorSeats: {
+          reserved: updatedData.reserved.monitorSeats,
+          previous_reserved: 1,
+        },
+        uptime: {
+          reserved: updatedData.reserved.uptime,
+          previous_reserved: undefined,
+        },
+      },
     });
 
     expect(trackGetsentryAnalytics).not.toHaveBeenCalledWith(

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -400,7 +400,7 @@ function recordAnalytics(
       if (!categories[cat]) {
         categories[cat] = {reserved: undefined, previous_reserved: undefined};
       }
-      categories[cat]!.previous_reserved = metricHistory.reserved;
+      categories[cat].previous_reserved = metricHistory.reserved;
     }
   });
 
@@ -418,7 +418,7 @@ function recordAnalytics(
         if (!categories[targetKey]) {
           categories[targetKey] = {reserved: undefined, previous_reserved: undefined};
         }
-        categories[targetKey]!.reserved = value;
+        categories[targetKey].reserved = value;
       }
     }
     if (key.startsWith('addOn')) {

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -347,6 +347,21 @@ type PreviousData = {
   previous_plan: string;
 } & Partial<Record<`previous_${DataCategory}`, number>>;
 
+/**
+ * Nested structure for category reservations in checkout.upgrade event.
+ * This provides a cleaner structure for Amplitude analytics while maintaining
+ * backwards compatibility with flat fields.
+ */
+type CategoryReservations = Partial<
+  Record<
+    DataCategory,
+    {
+      previous_reserved: number | undefined;
+      reserved: number | undefined;
+    }
+  >
+>;
+
 function recordAnalytics(
   organization: Organization,
   subscription: Subscription,
@@ -366,20 +381,45 @@ function recordAnalytics(
     previous_plan: subscription.plan,
   };
 
+  // Build nested categories structure for better Amplitude analytics
+  const categories: CategoryReservations = {};
+
+  // Parse previous data and populate both flat and nested structures
   Object.entries(subscription.categories).forEach(([category, metricHistory]) => {
     if (
       subscription.planDetails.checkoutCategories.includes(category as DataCategory) &&
       metricHistory.reserved !== null &&
       metricHistory.reserved !== undefined
     ) {
+      const cat = category as DataCategory;
+
+      // Legacy flat structure (backwards compatibility)
       (previousData as any)[`previous_${category}`] = metricHistory.reserved;
+
+      // New nested structure
+      if (!categories[cat]) {
+        categories[cat] = {reserved: undefined, previous_reserved: undefined};
+      }
+      categories[cat]!.previous_reserved = metricHistory.reserved;
     }
   });
 
+  // Parse current data and populate both flat and nested structures
   Object.keys(data).forEach(key => {
     if (key.startsWith('reserved')) {
-      const targetKey = key.charAt(8).toLowerCase() + key.slice(9);
-      (currentData as any)[targetKey] = data[key as keyof CheckoutAPIData];
+      const targetKey = (key.charAt(8).toLowerCase() + key.slice(9)) as DataCategory;
+      const value = data[key as keyof CheckoutAPIData] as number | undefined;
+
+      // Legacy flat structure (backwards compatibility)
+      (currentData as any)[targetKey] = value;
+
+      // New nested structure - only add if value is defined
+      if (value !== undefined) {
+        if (!categories[targetKey]) {
+          categories[targetKey] = {reserved: undefined, previous_reserved: undefined};
+        }
+        categories[targetKey]!.reserved = value;
+      }
     }
     if (key.startsWith('addOn')) {
       const targetKey = (key.charAt(5).toLowerCase() + key.slice(6)) as AddOnCategory;
@@ -392,11 +432,20 @@ function recordAnalytics(
     }
   });
 
+  // Filter out categories where both values are undefined
+  const filteredCategories: CategoryReservations = {};
+  Object.entries(categories).forEach(([category, values]) => {
+    if (values.reserved !== undefined || values.previous_reserved !== undefined) {
+      filteredCategories[category as DataCategory] = values;
+    }
+  });
+
   trackGetsentryAnalytics('checkout.upgrade', {
     organization,
     subscription,
     ...previousData,
     ...currentData,
+    categories: filteredCategories, // Add new nested structure
   });
 
   trackGetsentryAnalytics('checkout.product_select', {


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-968


Implements double-write pattern for `checkout.upgrade` Amplitude event to include
both legacy flat fields and new nested categories structure. This makes `checkout.upgrade` consistent with the pre-existing`checkout.product_select` event pattern.

Example event payload now includes:
```
{
  // Legacy flat fields (backwards compatibility)
  errors: 100000, previous_errors: 50000,

  // New nested structure (preferred for new queries)
  categories: {
    errors: {reserved: 100000, previous_reserved: 50000}
  }
}
```