### PR TITLE
ref(events): Singularize pluralized params in the events endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -504,9 +504,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             dashboard_widget_id = request.GET.get("dashboardWidgetId", None)
             discover_saved_query_id = request.GET.get("discoverSavedQueryId", None)
             additional_queries = AdditionalQueries(
-                span=request.GET.getlist("spanQueries"),
-                log=request.GET.getlist("logQueries"),
-                metric=request.GET.getlist("metricQueries"),
+                span=request.GET.getlist("spanQuery"),
+                log=request.GET.getlist("logQuery"),
+                metric=request.GET.getlist("metricQuery"),
             )
 
             def get_rpc_config():

--- a/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
@@ -50,7 +50,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "orderby": "count()",
                 "project": self.project.id,
                 "dataset": "spans",
-                "logQueries": ["message:foo"],
+                "logQuery": ["message:foo"],
             }
         )
 
@@ -102,7 +102,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "orderby": "count()",
                 "project": self.project.id,
                 "dataset": "spans",
-                "spanQueries": ["tags[foo]:six"],
+                "spanQuery": ["tags[foo]:six"],
             }
         )
 
@@ -167,8 +167,8 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "orderby": "count()",
                 "project": self.project.id,
                 "dataset": "spans",
-                "spanQueries": ["tags[foo]:six"],
-                "logQueries": ["message:foo"],
+                "spanQuery": ["tags[foo]:six"],
+                "logQuery": ["message:foo"],
             }
         )
 
@@ -230,7 +230,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "orderby": "count()",
                 "project": self.project.id,
                 "dataset": "spans",
-                "spanQueries": ["tags[foo]:six", "tags[foo]:seven"],
+                "spanQuery": ["tags[foo]:six", "tags[foo]:seven"],
             }
         )
 
@@ -288,7 +288,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "orderby": "count()",
                 "project": self.project.id,
                 "dataset": "spans",
-                "logQueries": ["message:faa", "message:foo"],
+                "logQuery": ["message:faa", "message:foo"],
             }
         )
 


### PR DESCRIPTION
- These params were a bit odd in that they were plural when everything else is singular