### PR TITLE
fix(aci): correctly query open periods within date range

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.utils import timezone
 
 from sentry.incidents.grouptype import MetricIssue
@@ -280,3 +282,130 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["start"] == unresolved_time
         assert resp["end"] == second_resolved_time
         assert resp["isOpen"] is False
+        assert resp["lastChecked"].replace(second=0, microsecond=0) == second_resolved_time.replace(
+            second=0, microsecond=0
+        )
+
+    def test_get_open_periods_time_range_starts_after_query_start(self) -> None:
+        """Test that open periods starting after query_start and ending after query_end are included."""
+        base_time = timezone.now() - timedelta(days=10)
+        GroupOpenPeriod.objects.filter(group=self.group).delete()
+
+        # Open period: Day 2 to Day 7
+        open_period = GroupOpenPeriod.objects.create(
+            group=self.group,
+            project=self.group.project,
+            date_started=base_time + timedelta(days=2),
+            date_ended=base_time + timedelta(days=7),
+        )
+
+        # Query range: Day 0 to Day 5
+        query_start = base_time.isoformat()
+        query_end = (base_time + timedelta(days=5)).isoformat()
+
+        response = self.get_success_response(
+            *self.get_url_args(),
+            qs_params={
+                "groupId": self.group.id,
+                "start": query_start,
+                "end": query_end,
+            },
+        )
+
+        assert len(response.data) == 1
+        resp = response.data[0]
+        assert resp["id"] == str(open_period.id)
+
+    def test_get_open_periods_time_range_starts_before_ends_within(self) -> None:
+        """Test that open periods starting before query_start and ending before query_end are included."""
+
+        base_time = timezone.now() - timedelta(days=10)
+
+        GroupOpenPeriod.objects.filter(group=self.group).delete()
+
+        # Open period: Day 0 to Day 3 (ends within range)
+        open_period = GroupOpenPeriod.objects.create(
+            group=self.group,
+            project=self.group.project,
+            date_started=base_time,
+            date_ended=base_time + timedelta(days=3),
+        )
+
+        # Query range: Day 2 to Day 7
+        query_start = (base_time + timedelta(days=2)).isoformat()
+        query_end = (base_time + timedelta(days=7)).isoformat()
+
+        response = self.get_success_response(
+            *self.get_url_args(),
+            qs_params={
+                "groupId": self.group.id,
+                "start": query_start,
+                "end": query_end,
+            },
+        )
+
+        assert len(response.data) == 1
+        resp = response.data[0]
+        assert resp["id"] == str(open_period.id)
+
+    def test_get_open_periods_time_range_starts_before_still_ongoing(self) -> None:
+        """Test that open periods starting before query_start and still ongoing (date_ended=None) are included."""
+
+        base_time = timezone.now() - timedelta(days=10)
+
+        GroupOpenPeriod.objects.filter(group=self.group).delete()
+
+        # Open period: Day 1 to ongoing
+        open_period = GroupOpenPeriod.objects.create(
+            group=self.group,
+            project=self.group.project,
+            date_started=base_time + timedelta(days=1),
+            date_ended=None,
+        )
+
+        # Query range: Day 0 to Day 7
+        query_start = base_time.isoformat()
+        query_end = (base_time + timedelta(days=7)).isoformat()
+
+        response = self.get_success_response(
+            *self.get_url_args(),
+            qs_params={
+                "groupId": self.group.id,
+                "start": query_start,
+                "end": query_end,
+            },
+        )
+
+        assert len(response.data) == 1
+        resp = response.data[0]
+        assert resp["id"] == str(open_period.id)
+
+    def test_get_open_periods_none_in_range(self) -> None:
+        """Test that open periods outside the query range are not included."""
+
+        base_time = timezone.now() - timedelta(days=10)
+
+        GroupOpenPeriod.objects.filter(group=self.group).delete()
+
+        # Open period: Day 0 to Day 1 (starts + ends before query range)
+        GroupOpenPeriod.objects.create(
+            group=self.group,
+            project=self.group.project,
+            date_started=base_time,
+            date_ended=base_time + timedelta(days=1),
+        )
+
+        # Query range: Day 2 to Day 7
+        query_start = (base_time + timedelta(days=2)).isoformat()
+        query_end = (base_time + timedelta(days=7)).isoformat()
+
+        response = self.get_success_response(
+            *self.get_url_args(),
+            qs_params={
+                "groupId": self.group.id,
+                "start": query_start,
+                "end": query_end,
+            },
+        )
+
+        assert len(response.data) == 0

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -282,9 +282,6 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["start"] == unresolved_time
         assert resp["end"] == second_resolved_time
         assert resp["isOpen"] is False
-        assert resp["lastChecked"].replace(second=0, microsecond=0) == second_resolved_time.replace(
-            second=0, microsecond=0
-        )
 
     def test_get_open_periods_time_range_starts_after_query_start(self) -> None:
         """Test that open periods starting after query_start and ending after query_end are included."""


### PR DESCRIPTION
we were only returning open periods that started during/after `query_start`, which does not include open periods that started before `query_start` but were still ongoing during the query range