### PR TITLE
feat(aci): Move threshold info into detect section of metric monitor details

### DIFF
--- a/static/app/views/detectors/components/details/metric/detect.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.spec.tsx
@@ -36,8 +36,11 @@ describe('MetricDetectorDetailsDetect', () => {
 
     render(<MetricDetectorDetailsDetect detector={detector} />);
 
-    expect(screen.getByText(/Above 8/)).toBeInTheDocument();
     expect(screen.getByText('High')).toBeInTheDocument();
+    expect(screen.getByText(/Above 8/)).toBeInTheDocument();
+
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(screen.getByText(/Below or equal to 8/)).toBeInTheDocument();
   });
 
   it('renders percent change description with delta window', () => {
@@ -49,6 +52,11 @@ describe('MetricDetectorDetailsDetect', () => {
 
     expect(screen.getByText('Percent change')).toBeInTheDocument();
     expect(screen.getByText(/8% higher than the previous 1 minute/)).toBeInTheDocument();
+
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Less than 8% lower than the previous 1 minute/)
+    ).toBeInTheDocument();
   });
 
   it('renders dynamic detection notice', () => {

--- a/static/app/views/detectors/components/details/metric/detect.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.spec.tsx
@@ -1,0 +1,66 @@
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MetricDetectorDetailsDetect} from './detect';
+
+describe('MetricDetectorDetailsDetect', () => {
+  it('renders dataset, visualize, where, interval, and threshold', () => {
+    const detector = MetricDetectorFixture();
+
+    render(<MetricDetectorDetailsDetect detector={detector} />);
+
+    // Dataset
+    expect(screen.getByText('Dataset:')).toBeInTheDocument();
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+
+    // Visualize (aggregate)
+    expect(screen.getByText('Visualize')).toBeInTheDocument();
+    // Aggregate function
+    expect(screen.getByText('count()')).toBeInTheDocument();
+    // Query
+    expect(screen.getByText('Where')).toBeInTheDocument();
+    expect(screen.getByLabelText('is:unresolved')).toBeInTheDocument();
+
+    // Interval is 60s by default in fixture
+    expect(screen.getByText('Interval:')).toBeInTheDocument();
+    expect(screen.getByText('1 minute')).toBeInTheDocument();
+
+    // Threshold label for static detection
+    expect(screen.getByText('Threshold:')).toBeInTheDocument();
+    expect(screen.getByText('Static threshold')).toBeInTheDocument();
+  });
+
+  it('renders human readable priority conditions for static detection', () => {
+    const detector = MetricDetectorFixture();
+
+    render(<MetricDetectorDetailsDetect detector={detector} />);
+
+    expect(screen.getByText(/Above 8/)).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+  });
+
+  it('renders percent change description with delta window', () => {
+    const detector = MetricDetectorFixture({
+      config: {detectionType: 'percent', comparisonDelta: 60},
+    });
+
+    render(<MetricDetectorDetailsDetect detector={detector} />);
+
+    expect(screen.getByText('Percent change')).toBeInTheDocument();
+    expect(screen.getByText(/8% higher than the previous 1 minute/)).toBeInTheDocument();
+  });
+
+  it('renders dynamic detection notice', () => {
+    const detector = MetricDetectorFixture({
+      config: {detectionType: 'dynamic'},
+    });
+
+    render(<MetricDetectorDetailsDetect detector={detector} />);
+
+    expect(screen.getByText('Dynamic threshold')).toBeInTheDocument();
+    expect(
+      screen.getByText('Sentry will automatically update priority.')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -93,7 +93,7 @@ function DetectorPriorities({detector}: {detector: MetricDetector}) {
 }
 
 export function MetricDetectorDetailsDetect({detector}: {detector: MetricDetector}) {
-  const dataSource = detector.dataSources?.[0];
+  const dataSource = detector.dataSources[0];
 
   if (!dataSource.queryObj) {
     return <Container>{t('Query not found.')}</Container>;

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -1,18 +1,10 @@
 import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
-import styled from '@emotion/styled';
 
-import {GroupPriorityBadge} from 'sentry/components/badge/groupPriority';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Section from 'sentry/components/workflowEngine/ui/section';
-import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import {
-  DataConditionType,
-  DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL,
-  DetectorPriorityLevel,
-} from 'sentry/types/workflowEngine/dataConditions';
+import {DetectorPriorityLevel} from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -26,60 +18,6 @@ import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetect
 
 interface DetectorDetailsSidebarProps {
   detector: MetricDetector;
-}
-
-function DetectorPriorities({detector}: {detector: MetricDetector}) {
-  const detectionType = detector.config?.detectionType || 'static';
-
-  // For dynamic detectors, show the automatic priority message
-  if (detectionType === 'dynamic') {
-    return <div>{t('Sentry will automatically update priority.')}</div>;
-  }
-
-  const conditions = detector.conditionGroup?.conditions || [];
-
-  // Filter out OK conditions and sort by priority level
-  const priorityConditions = conditions
-    .filter(condition => condition.conditionResult !== DetectorPriorityLevel.OK)
-    .sort((a, b) => (a.conditionResult || 0) - (b.conditionResult || 0));
-
-  if (priorityConditions.length === 0) {
-    return null;
-  }
-
-  const getConditionLabel = (condition: (typeof priorityConditions)[0]) => {
-    const typeLabel =
-      condition.type === DataConditionType.GREATER ? t('Above') : t('Below');
-
-    // For static/percent detectors, comparison should be a simple number
-    const comparisonValue =
-      typeof condition.comparison === 'number' ? String(condition.comparison) : '';
-    const thresholdSuffix = getMetricDetectorSuffix(
-      detector.config?.detectionType || 'static',
-      detector.dataSources[0].queryObj?.snubaQuery?.aggregate || 'count()'
-    );
-
-    return `${typeLabel} ${comparisonValue}${thresholdSuffix}`;
-  };
-
-  return (
-    <PrioritiesList>
-      {priorityConditions.map((condition, index) => (
-        <Fragment key={index}>
-          <PriorityCondition>{getConditionLabel(condition)}</PriorityCondition>
-          <IconArrow direction="right" />
-          <GroupPriorityBadge
-            showLabel
-            priority={
-              DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL[
-                condition.conditionResult as keyof typeof DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL
-              ]
-            }
-          />
-        </Fragment>
-      ))}
-    </PrioritiesList>
-  );
 }
 
 function DetectorResolve({detector}: {detector: MetricDetector}) {
@@ -146,9 +84,6 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
         <MetricDetectorDetailsDetect detector={detector} />
       </Section>
       <DetectorDetailsAssignee owner={detector.owner} />
-      <Section title={t('Prioritize')}>
-        <DetectorPriorities detector={detector} />
-      </Section>
       <Section title={t('Resolve')}>
         <DetectorResolve detector={detector} />
       </Section>
@@ -163,22 +98,3 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
     </Fragment>
   );
 }
-
-const PrioritiesList = styled('div')`
-  display: grid;
-  grid-template-columns: auto auto auto;
-  align-items: center;
-  width: fit-content;
-  gap: ${space(0.5)} ${space(1)};
-
-  p {
-    margin: 0;
-    width: fit-content;
-  }
-`;
-
-const PriorityCondition = styled('div')`
-  justify-self: flex-end;
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.textColor};
-`;

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -5,7 +5,6 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
-import {DetectorPriorityLevel} from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -14,46 +13,9 @@ import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details
 import {DetectorDetailsDescription} from 'sentry/views/detectors/components/details/common/description';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {MetricDetectorDetailsDetect} from 'sentry/views/detectors/components/details/metric/detect';
-import {getResolutionDescription} from 'sentry/views/detectors/utils/getDetectorResolutionDescription';
-import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 
 interface DetectorDetailsSidebarProps {
   detector: MetricDetector;
-}
-
-function DetectorResolve({detector}: {detector: MetricDetector}) {
-  const detectionType = detector.config?.detectionType || 'static';
-  const conditions = detector.conditionGroup?.conditions || [];
-
-  // Get the main condition (first non-OK condition)
-  const mainCondition = conditions.find(
-    condition => condition.conditionResult !== DetectorPriorityLevel.OK
-  );
-
-  // Get the OK condition (resolution condition)
-  const okCondition = conditions.find(
-    condition => condition.conditionResult === DetectorPriorityLevel.OK
-  );
-
-  const thresholdSuffix = getMetricDetectorSuffix(
-    detector.config?.detectionType || 'static',
-    detector.dataSources[0].queryObj?.snubaQuery?.aggregate || 'count()'
-  );
-
-  const description = getResolutionDescription({
-    detectionType,
-    conditionType: mainCondition?.type,
-    highThreshold:
-      typeof mainCondition?.comparison === 'number'
-        ? mainCondition.comparison
-        : undefined,
-    resolutionThreshold:
-      typeof okCondition?.comparison === 'number' ? okCondition.comparison : undefined,
-    comparisonDelta: (detector.config as any)?.comparison_delta,
-    thresholdSuffix,
-  });
-
-  return <div>{description}</div>;
 }
 
 function GoToMetricAlert({detector}: {detector: MetricDetector}) {
@@ -87,9 +49,6 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
         </ErrorBoundary>
       </Section>
       <DetectorDetailsAssignee owner={detector.owner} />
-      <Section title={t('Resolve')}>
-        <DetectorResolve detector={detector} />
-      </Section>
       <DetectorDetailsDescription description={detector.description} />
       <DetectorExtraDetails>
         <DetectorExtraDetails.DateCreated detector={detector} />

--- a/static/app/views/detectors/components/details/metric/sidebar.tsx
+++ b/static/app/views/detectors/components/details/metric/sidebar.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import {DetectorPriorityLevel} from 'sentry/types/workflowEngine/dataConditions';
@@ -81,7 +82,9 @@ export function MetricDetectorDetailsSidebar({detector}: DetectorDetailsSidebarP
   return (
     <Fragment>
       <Section title={t('Detect')}>
-        <MetricDetectorDetailsDetect detector={detector} />
+        <ErrorBoundary mini>
+          <MetricDetectorDetailsDetect detector={detector} />
+        </ErrorBoundary>
       </Section>
       <DetectorDetailsAssignee owner={detector.owner} />
       <Section title={t('Resolve')}>

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -16,6 +16,7 @@ import FormContext from 'sentry/components/forms/formContext';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {PriorityLevel} from 'sentry/types/group';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import type {Detector, MetricDetectorConfig} from 'sentry/types/workflowEngine/detectors';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
@@ -197,7 +198,7 @@ function validateMediumThreshold({
 interface PriorityRowProps {
   aggregate: string;
   detectionType: 'static' | 'percent';
-  priority: 'high' | 'medium';
+  priority: PriorityLevel;
   showComparisonAgo?: boolean;
 }
 
@@ -480,12 +481,12 @@ function DetectSection() {
                 </DefineThresholdParagraph>
                 <PriorityRowsContainer>
                   <PriorityRow
-                    priority="high"
+                    priority={PriorityLevel.HIGH}
                     detectionType="static"
                     aggregate={aggregate}
                   />
                   <PriorityRow
-                    priority="medium"
+                    priority={PriorityLevel.MEDIUM}
                     detectionType="static"
                     aggregate={aggregate}
                   />
@@ -502,13 +503,13 @@ function DetectSection() {
                 </DefineThresholdParagraph>
                 <PriorityRowsContainer>
                   <PriorityRow
-                    priority="high"
+                    priority={PriorityLevel.HIGH}
                     detectionType="percent"
                     aggregate={aggregate}
                     showComparisonAgo
                   />
                   <PriorityRow
-                    priority="medium"
+                    priority={PriorityLevel.MEDIUM}
                     detectionType="percent"
                     aggregate={aggregate}
                   />

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -49,6 +49,7 @@ import {useIntervalChoices} from 'sentry/views/detectors/components/forms/metric
 import {Visualize} from 'sentry/views/detectors/components/forms/metric/visualize';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
+import {PriorityDot} from 'sentry/views/detectors/components/priorityDot';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
@@ -680,14 +681,6 @@ const PriorityRowContainer = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-`;
-
-const PriorityDot = styled('div')<{priority: 'high' | 'medium'}>`
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: ${p => (p.priority === 'high' ? p.theme.red300 : p.theme.yellow400)};
-  flex-shrink: 0;
 `;
 
 const PriorityLabel = styled('span')`

--- a/static/app/views/detectors/components/priorityDot.tsx
+++ b/static/app/views/detectors/components/priorityDot.tsx
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+import {PriorityLevel} from 'sentry/types/group';
+
+export const PriorityDot = styled('div')<{priority: PriorityLevel | 'resolved'}>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: ${p => {
+    switch (p.priority) {
+      case PriorityLevel.HIGH:
+        return p.theme.red300;
+      case PriorityLevel.MEDIUM:
+        return p.theme.yellow400;
+      case 'resolved':
+        return p.theme.green300;
+      default:
+        return p.theme.gray300;
+    }
+  }};
+  flex-shrink: 0;
+`;

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -155,7 +155,7 @@ export function SnubaQueryDataSourceFixture(
         aggregate: 'count()',
         dataset: Dataset.ERRORS,
         id: '',
-        query: '',
+        query: 'is:unresolved',
         timeWindow: 60,
         eventTypes: [EventTypes.ERROR],
       },


### PR DESCRIPTION
This is more similar to the new form which shows thresholds in the "detect" section. This will also now display the "threshold type".

Before:

<img width="357" height="347" alt="CleanShot 2025-11-24 at 13 34 24" src="https://github.com/user-attachments/assets/76486cb9-3957-4ba0-89e3-1e2fabe7f339" />

After:

<img width="360" alt="CleanShot 2025-11-25 at 10 17 53@2x" src="https://github.com/user-attachments/assets/cc2e0078-28c5-456f-a178-fb22134275af" />

