### PR TITLE
feat(logs): Without chart data when table is empty

### DIFF
--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -16,6 +16,7 @@ interface ConfidenceFooterProps {
   hasUserQuery: boolean;
   isLoading: boolean;
   rawLogCounts: RawCounts;
+  disabled?: boolean;
 }
 
 export function ConfidenceFooter({
@@ -23,6 +24,7 @@ export function ConfidenceFooter({
   hasUserQuery,
   isLoading,
   rawLogCounts,
+  disabled,
 }: ConfidenceFooterProps) {
   return (
     <Container>
@@ -35,6 +37,7 @@ export function ConfidenceFooter({
         isSampled={chartInfo.isSampled}
         sampleCount={chartInfo.sampleCount}
         topEvents={chartInfo.topEvents}
+        disabled={disabled}
       />
     </Container>
   );
@@ -46,6 +49,7 @@ interface ConfidenceMessageProps {
   rawLogCounts: RawCounts;
   confidence?: Confidence;
   dataScanned?: 'full' | 'partial';
+  disabled?: boolean;
   isSampled?: boolean | null;
   sampleCount?: number;
   topEvents?: number;
@@ -56,11 +60,16 @@ function ConfidenceMessage({
   sampleCount,
   dataScanned,
   confidence: _confidence,
+  disabled,
   topEvents,
   hasUserQuery,
   isLoading,
   isSampled,
 }: ConfidenceMessageProps) {
+  if (disabled) {
+    return <Placeholder width={0} />;
+  }
+
   if (isLoading || !defined(sampleCount)) {
     return <Placeholder width={180} />;
   }


### PR DESCRIPTION
This withholds the chart data when the table is empty. It happens when the user is searching for a log closer to the start of the query period. The chart query successfully finds the results, but because the table query is using the flex time strategy, it may not have scanned that point in time just yet. It will if the user clicks on `Continue Scanning` a few times but until the table finds the log, we have a weird state that is difficult to explain. To address this, we opted to withhold the chart data and make it look like the chart is still loading when the user clicks on `Continue Scanning`. And only when the table finds some results, will the chart finally render.