### PR TITLE
feat(seer): Add Auto-open PR and Cursor handoff toggles for triage-signals-v0 [feature flagged]

### DIFF
--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -1433,6 +1433,7 @@ describe('ProjectSeer', () => {
                 handoff_point: 'root_cause',
                 target: 'cursor_background_agent',
                 integration_id: 123,
+                auto_create_pr: false,
               },
             }),
           })

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -315,12 +315,15 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
 
   // Handler for Cursor handoff toggle (triage-signals-v0)
   // When ON: stops at root_cause and hands off to Cursor
-  // When OFF: clears handoff and defaults to code_changes
+  // When OFF: defaults to code_changes (user can then enable auto-open PR if desired)
   const handleCursorHandoffChange = useCallback(
     (value: boolean) => {
       if (value) {
         if (!cursorIntegration) {
-          throw new Error('Cursor integration not found');
+          addErrorMessage(
+            t('Cursor integration not found. Please refresh the page and try again.')
+          );
+          return;
         }
         updateProjectSeerPreferences(
           {
@@ -340,6 +343,8 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           }
         );
       } else {
+        // When turning OFF, default to code_changes
+        // User can then manually enable auto-open PR if desired
         updateProjectSeerPreferences(
           {
             repositories: preference?.repositories || [],

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -8,7 +8,10 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
 import {CursorIntegrationCta} from 'sentry/components/events/autofix/cursorIntegrationCta';
-import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {
+  makeProjectSeerPreferencesQueryKey,
+  useProjectSeerPreferences,
+} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
@@ -306,11 +309,23 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
         {
           onError: () => {
             addErrorMessage(t('Failed to update auto-open PR setting'));
+            // Refetch to reset form state to backend value
+            queryClient.invalidateQueries({
+              queryKey: [
+                makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
+              ],
+            });
           },
         }
       );
     },
-    [updateProjectSeerPreferences, preference?.repositories]
+    [
+      updateProjectSeerPreferences,
+      preference?.repositories,
+      queryClient,
+      organization.slug,
+      project.slug,
+    ]
   );
 
   // Handler for Cursor handoff toggle (triage-signals-v0)
@@ -339,6 +354,12 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           {
             onError: () => {
               addErrorMessage(t('Failed to update Cursor handoff setting'));
+              // Refetch to reset form state to backend value
+              queryClient.invalidateQueries({
+                queryKey: [
+                  makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
+                ],
+              });
             },
           }
         );
@@ -354,12 +375,25 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           {
             onError: () => {
               addErrorMessage(t('Failed to update Cursor handoff setting'));
+              // Refetch to reset form state to backend value
+              queryClient.invalidateQueries({
+                queryKey: [
+                  makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
+                ],
+              });
             },
           }
         );
       }
     },
-    [updateProjectSeerPreferences, preference?.repositories, cursorIntegration]
+    [
+      updateProjectSeerPreferences,
+      preference?.repositories,
+      cursorIntegration,
+      queryClient,
+      organization.slug,
+      project.slug,
+    ]
   );
 
   const automatedRunStoppingPointField = {


### PR DESCRIPTION
## PR Details
+ When the triage-signals-v0 feature flag is enabled, replace the "Where should Seer stop?" dropdown with two simpler toggles:
    + Auto-open PR: Controls whether Seer automatically opens PRs (off=code_changes, on=open_pr)
    + Hand off to Cursor: Enables Cursor cloud agent handoff at root cause
+ The toggles are mutually exclusive - enabling one disables the other.
+ Screenshots: 
    + <img width="2151" height="1167" alt="Screenshot 2025-11-24 at 2 08 09 PM" src="https://github.com/user-attachments/assets/02a960f1-3963-40ff-888e-a64346ac9e13" />
    + <img width="2068" height="1118" alt="Screenshot 2025-11-24 at 2 07 52 PM" src="https://github.com/user-attachments/assets/165d5bc6-cd18-4f43-a88b-f8c36185da49" />
+ Will rebase after [this one](https://github.com/getsentry/sentry/pull/103730) merged


