### PR TITLE
feat(explorer): send interactivity flag in client

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -112,7 +112,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         on_page_context = validated_data.get("on_page_context")
 
         try:
-            client = SeerExplorerClient(organization, request.user)
+            client = SeerExplorerClient(organization, request.user, is_interactive=True)
             if run_id:
                 # Continue existing conversation
                 result_run_id = client.continue_run(

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -101,7 +101,7 @@ class SeerExplorerClient:
             artifact_schema: Optional Pydantic model to generate a structured artifact at the end of the run
             custom_tools: Optional list of `ExplorerTool` objects to make available as tools to the agent. Each tool must inherit from ExplorerTool and implement get_params() and execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).
             intelligence_level: Optionally set the intelligence level of the agent. Higher intelligence gives better result quality at the cost of significantly higher latency and cost.
-            is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer. An example use of this is the explorer chat in Sentry UI. 
+            is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer. An example use of this is the explorer chat in Sentry UI.
     """
 
     def __init__(

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -225,6 +225,7 @@ class SeerExplorerClient:
             "run_id": run_id,
             "insert_index": insert_index,
             "on_page_context": on_page_context,
+            "is_interactive": self.is_interactive,
         }
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -101,7 +101,7 @@ class SeerExplorerClient:
             artifact_schema: Optional Pydantic model to generate a structured artifact at the end of the run
             custom_tools: Optional list of `ExplorerTool` objects to make available as tools to the agent. Each tool must inherit from ExplorerTool and implement get_params() and execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).
             intelligence_level: Optionally set the intelligence level of the agent. Higher intelligence gives better result quality at the cost of significantly higher latency and cost.
-            is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer.
+            is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer. An example use of this is the explorer chat in Sentry UI. 
     """
 
     def __init__(

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -101,6 +101,7 @@ class SeerExplorerClient:
             artifact_schema: Optional Pydantic model to generate a structured artifact at the end of the run
             custom_tools: Optional list of `ExplorerTool` objects to make available as tools to the agent. Each tool must inherit from ExplorerTool and implement get_params() and execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).
             intelligence_level: Optionally set the intelligence level of the agent. Higher intelligence gives better result quality at the cost of significantly higher latency and cost.
+            is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer.
     """
 
     def __init__(
@@ -112,6 +113,7 @@ class SeerExplorerClient:
         artifact_schema: type[BaseModel] | None = None,
         custom_tools: list[type[ExplorerTool]] | None = None,
         intelligence_level: Literal["low", "medium", "high"] = "medium",
+        is_interactive: bool = False,
     ):
         self.organization = organization
         self.user = user
@@ -120,6 +122,7 @@ class SeerExplorerClient:
         self.intelligence_level = intelligence_level
         self.category_key = category_key
         self.category_value = category_value
+        self.is_interactive = is_interactive
 
         # Validate that category_key and category_value are provided together
         if category_key == "" or category_value == "":
@@ -160,6 +163,7 @@ class SeerExplorerClient:
             "on_page_context": on_page_context,
             "user_org_context": collect_user_org_context(self.user, self.organization),
             "intelligence_level": self.intelligence_level,
+            "is_interactive": self.is_interactive,
         }
 
         # Add artifact schema if provided

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -69,7 +69,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.data == {"run_id": 456}
 
         # Verify client was called correctly
-        mock_client_class.assert_called_once_with(self.organization, ANY)
+        mock_client_class.assert_called_once_with(self.organization, ANY, is_interactive=True)
         mock_client.start_run.assert_called_once_with(
             prompt="What is this error about?", on_page_context=None
         )
@@ -90,7 +90,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.data == {"run_id": 789}
 
         # Verify client was called correctly
-        mock_client_class.assert_called_once_with(self.organization, ANY)
+        mock_client_class.assert_called_once_with(self.organization, ANY, is_interactive=True)
         mock_client.continue_run.assert_called_once_with(
             run_id=789, prompt="Follow up question", insert_index=2, on_page_context=None
         )


### PR DESCRIPTION
Sends an `is_interactive` flag in the client. Defaults to False, but sets to True for the UI chat endpoint.

Part of [AIML-1689: indicator on state whether on Sentry UI or not](https://linear.app/getsentry/issue/AIML-1689/indicator-on-state-whether-on-sentry-ui-or-not)