### PR TITLE
ref(data-forwarding): More directly use the plugin forwarding

### DIFF
--- a/src/sentry/integrations/data_forwarding/__init__.py
+++ b/src/sentry/integrations/data_forwarding/__init__.py
@@ -1,9 +1,12 @@
+from collections.abc import Mapping
+
 from sentry.integrations.data_forwarding.amazon_sqs.forwarder import AmazonSQSForwarder
+from sentry.integrations.data_forwarding.base import BaseDataForwarder
 from sentry.integrations.data_forwarding.segment.forwarder import SegmentForwarder
 from sentry.integrations.data_forwarding.splunk.forwarder import SplunkForwarder
 from sentry.integrations.types import DataForwarderProviderSlug
 
-FORWARDER_REGISTRY = {
+FORWARDER_REGISTRY: Mapping[DataForwarderProviderSlug, type[BaseDataForwarder]] = {
     DataForwarderProviderSlug.SEGMENT.value: SegmentForwarder,
     DataForwarderProviderSlug.SQS.value: AmazonSQSForwarder,
     DataForwarderProviderSlug.SPLUNK.value: SplunkForwarder,

--- a/src/sentry/integrations/data_forwarding/__init__.py
+++ b/src/sentry/integrations/data_forwarding/__init__.py
@@ -6,7 +6,7 @@ from sentry.integrations.data_forwarding.segment.forwarder import SegmentForward
 from sentry.integrations.data_forwarding.splunk.forwarder import SplunkForwarder
 from sentry.integrations.types import DataForwarderProviderSlug
 
-FORWARDER_REGISTRY: Mapping[DataForwarderProviderSlug, type[BaseDataForwarder]] = {
+FORWARDER_REGISTRY: Mapping[str, type[BaseDataForwarder]] = {
     DataForwarderProviderSlug.SEGMENT.value: SegmentForwarder,
     DataForwarderProviderSlug.SQS.value: AmazonSQSForwarder,
     DataForwarderProviderSlug.SPLUNK.value: SplunkForwarder,

--- a/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
@@ -9,8 +9,8 @@ import orjson
 from botocore.client import Config
 from botocore.exceptions import ClientError, ParamValidationError
 
+from sentry.api.serializers import serialize
 from sentry.integrations.data_forwarding.base import BaseDataForwarder
-from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event
 
@@ -19,26 +19,15 @@ logger = logging.getLogger(__name__)
 # AWS SQS maximum message size limit
 AWS_SQS_MAX_MESSAGE_SIZE = 256 * 1024  # 256 KB
 
-DESCRIPTION = """
-Send Sentry events to Amazon SQS.
-
-This integration allows you to forward Sentry events to an Amazon SQS queue for further processing.
-
-Amazon SQS is a fully managed message queuing service that enables you to decouple and scale microservices.
-"""
-
 
 class AmazonSQSForwarder(BaseDataForwarder):
     provider = DataForwarderProviderSlug.SQS
-    rate_limit = None
-    description = DESCRIPTION
+    rate_limit = (0, 0)
 
-    @classmethod
-    def get_event_payload(cls, event: Event) -> dict[str, Any]:
-        return event.as_dict()
+    def get_event_payload(self, event: Event, config: dict[str, Any]) -> dict[str, Any]:
+        return serialize(event)
 
-    @classmethod
-    def is_unrecoverable_client_error(cls, error: ClientError) -> bool:
+    def is_unrecoverable_client_error(self, error: ClientError) -> bool:
         error_str = str(error)
 
         # Invalid or missing AWS credentials
@@ -70,9 +59,8 @@ class AmazonSQSForwarder(BaseDataForwarder):
 
         return False
 
-    @classmethod
-    def send_payload(
-        cls,
+    def forward_event(
+        self,
         payload: dict[str, Any],
         config: dict[str, Any],
         event: Event,
@@ -125,7 +113,7 @@ class AmazonSQSForwarder(BaseDataForwarder):
                 payload = {"s3Url": url, "eventID": event.event_id}
 
             except ClientError as e:
-                if cls.is_unrecoverable_client_error(e):
+                if self.is_unrecoverable_client_error(e):
                     return False
                 raise
             except ParamValidationError:
@@ -141,14 +129,8 @@ class AmazonSQSForwarder(BaseDataForwarder):
         try:
             sqs_send_message(message)
         except ClientError as e:
-            if cls.is_unrecoverable_client_error(e):
+            if self.is_unrecoverable_client_error(e):
                 return False
             raise
 
         return True
-
-    @classmethod
-    def forward_event(cls, event: Event, data_forwarder_project: DataForwarderProject) -> bool:
-        config = data_forwarder_project.get_config()
-        payload = cls.get_event_payload(event)
-        return cls.send_payload(payload, config, event)

--- a/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/amazon_sqs/forwarder.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError, ParamValidationError
 from sentry.api.serializers import serialize
 from sentry.integrations.data_forwarding.base import BaseDataForwarder
 from sentry.integrations.types import DataForwarderProviderSlug
-from sentry.services.eventstore.models import Event
+from sentry.services.eventstore.models import Event, GroupEvent
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,9 @@ class AmazonSQSForwarder(BaseDataForwarder):
     provider = DataForwarderProviderSlug.SQS
     rate_limit = (0, 0)
 
-    def get_event_payload(self, event: Event, config: dict[str, Any]) -> dict[str, Any]:
+    def get_event_payload(
+        self, event: Event | GroupEvent, config: dict[str, Any]
+    ) -> dict[str, Any]:
         return serialize(event)
 
     def is_unrecoverable_client_error(self, error: ClientError) -> bool:
@@ -61,9 +63,9 @@ class AmazonSQSForwarder(BaseDataForwarder):
 
     def forward_event(
         self,
+        event: Event | GroupEvent,
         payload: dict[str, Any],
         config: dict[str, Any],
-        event: Event,
     ) -> bool:
         queue_url = config["queue_url"]
         region = config["region"]

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -1,21 +1,62 @@
-from __future__ import annotations
-
+import logging
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import Any, ClassVar
 
+from sentry import ratelimits
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event
 
+logger = logging.getLogger(__name__)
+
 
 class BaseDataForwarder(ABC):
-    """Base class for all data forwarders."""
+    """
+    Base class for all data forwarders.
+    Copied directly from legacy plugin system, unchanged.
+    """
 
     provider: ClassVar[DataForwarderProviderSlug]
-    rate_limit: ClassVar[tuple[int, int] | None] = None
-    description: ClassVar[str] = ""
+    rate_limit: ClassVar[tuple[int, int]] = (50, 1)
+    """
+    Tuple of (Number of Requests, Window in Seconds)
+    """
 
-    @classmethod
+    def get_rl_key(self, event) -> str:
+        return f"{self.provider.value}:{event.project.organization_id}"
+
+    def is_ratelimited(self, event: Event) -> bool:
+        rl_key = self.get_rl_key(event)
+        limit, window = self.rate_limit
+        if limit and window and ratelimits.backend.is_limited(rl_key, limit=limit, window=window):
+            logger.info(
+                "data_forwarding.skip_rate_limited",
+                extra={
+                    "event_id": event.event_id,
+                    "issue_id": event.group_id,
+                    "project_id": event.project_id,
+                    "organization_id": event.project.organization_id,
+                },
+            )
+            return True
+        return False
+
+    def initialize_variables(self, event: Event, config: dict[str, Any]) -> None:
+        """This is only necessary for migrating Splunk plugin, needed for rate limiting"""
+        return
+
     @abstractmethod
-    def forward_event(cls, event: Event, data_forwarder_project: DataForwarderProject) -> bool:
-        pass
+    def forward_event(self, event: Event, payload: dict[str, Any], config: dict[str, Any]) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_event_payload(self, event: Event, config: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def post_process(self, event: Event, data_forwarder_project: DataForwarderProject) -> None:
+        config = data_forwarder_project.get_config()
+        if self.is_ratelimited(event):
+            return
+
+        payload = self.get_event_payload(event=event, config=config)
+        self.forward_event(event=event, payload=payload, config=config)

--- a/src/sentry/integrations/data_forwarding/base.py
+++ b/src/sentry/integrations/data_forwarding/base.py
@@ -61,6 +61,7 @@ class BaseDataForwarder(ABC):
         self, event: Event | GroupEvent, data_forwarder_project: DataForwarderProject
     ) -> None:
         config = data_forwarder_project.get_config()
+        self.initialize_variables(event, config)
         if self.is_ratelimited(event):
             return
 

--- a/src/sentry/integrations/data_forwarding/segment/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/segment/forwarder.py
@@ -5,47 +5,18 @@ from typing import Any, ClassVar
 
 from sentry import VERSION, http
 from sentry.integrations.data_forwarding.base import BaseDataForwarder
-from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event
 
 logger = logging.getLogger(__name__)
 
-DESCRIPTION = """
-Send Sentry events to Segment.
-
-This integration allows you to forward Sentry error events to Segment for unified analytics.
-
-Segment is a customer data platform (CDP) that helps you collect, clean, and control your customer data.
-"""
-
 
 class SegmentForwarder(BaseDataForwarder):
     provider = DataForwarderProviderSlug.SEGMENT
     rate_limit = (200, 1)
-    description = DESCRIPTION
     endpoint: ClassVar[str] = "https://api.segment.io/v1/track"
 
-    @classmethod
-    def validate_event(cls, event: Event) -> bool:
-        # we currently only support errors
-        if event.get_event_type() != "error":
-            return False
-
-        # we avoid instantiating interfaces here as they're only going to be
-        # used if there's a User present
-        user_interface = event.interfaces.get("user")
-        if not user_interface:
-            return False
-
-        # if the user id is not present, we can't forward the event
-        if not user_interface.id:
-            return False
-
-        return True
-
-    @classmethod
-    def get_event_payload(cls, event: Event) -> dict[str, Any]:
+    def get_event_payload(self, event: Event, config: dict[str, Any]) -> dict[str, Any]:
         context = {"library": {"name": "sentry", "version": VERSION}}
 
         props = {
@@ -95,43 +66,43 @@ class SegmentForwarder(BaseDataForwarder):
             "timestamp": event.datetime.isoformat() + "Z",
         }
 
-    @classmethod
-    def send_payload(
-        cls,
+    def forward_event(
+        self,
         payload: dict[str, Any],
         config: dict[str, Any],
         event: Event,
-        data_forwarder_project: DataForwarderProject,
     ) -> bool:
+        # we currently only support errors
+        if event.get_event_type() != "error":
+            return False
+
+        # we avoid instantiating interfaces here as they're only going to be
+        # used if there's a User present
+        user_interface = event.interfaces.get("user")
+        if not user_interface:
+            return False
+
+        # if the user id is not present, we can't forward the event
+        if not user_interface.id:
+            return False
+
         write_key = config["write_key"]
+        if not write_key:
+            return False
 
         try:
             with http.build_session() as session:
                 response = session.post(
-                    cls.endpoint,
+                    self.endpoint,
                     json=payload,
                     auth=(write_key, ""),
                     timeout=10,
                 )
                 response.raise_for_status()
-            return True
-
         except Exception:
             logger.exception(
                 "segment.send_payload.error",
-                extra={
-                    "event_id": event.event_id,
-                    "project_id": event.project_id,
-                    "data_forwarder_id": data_forwarder_project.data_forwarder_id,
-                },
+                extra={"event_id": event.event_id, "project_id": event.project_id},
             )
             return False
-
-    @classmethod
-    def forward_event(cls, event: Event, data_forwarder_project: DataForwarderProject) -> bool:
-        if not cls.validate_event(event):
-            return False
-
-        config = data_forwarder_project.get_config()
-        payload = cls.get_event_payload(event)
-        return cls.send_payload(payload, config, event, data_forwarder_project)
+        return True

--- a/src/sentry/integrations/data_forwarding/segment/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/segment/forwarder.py
@@ -6,7 +6,7 @@ from typing import Any, ClassVar
 from sentry import VERSION, http
 from sentry.integrations.data_forwarding.base import BaseDataForwarder
 from sentry.integrations.types import DataForwarderProviderSlug
-from sentry.services.eventstore.models import Event
+from sentry.services.eventstore.models import Event, GroupEvent
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,9 @@ class SegmentForwarder(BaseDataForwarder):
     rate_limit = (200, 1)
     endpoint: ClassVar[str] = "https://api.segment.io/v1/track"
 
-    def get_event_payload(self, event: Event, config: dict[str, Any]) -> dict[str, Any]:
+    def get_event_payload(
+        self, event: Event | GroupEvent, config: dict[str, Any]
+    ) -> dict[str, Any]:
         context = {"library": {"name": "sentry", "version": VERSION}}
 
         props = {
@@ -68,9 +70,9 @@ class SegmentForwarder(BaseDataForwarder):
 
     def forward_event(
         self,
+        event: Event | GroupEvent,
         payload: dict[str, Any],
         config: dict[str, Any],
-        event: Event,
     ) -> bool:
         # we currently only support errors
         if event.get_event_type() != "error":

--- a/src/sentry/integrations/data_forwarding/splunk/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/splunk/forwarder.py
@@ -3,33 +3,28 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from sentry import http, tagstore
+from sentry import tagstore
 from sentry.integrations.data_forwarding.base import BaseDataForwarder
-from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.services.eventstore.models import Event
 from sentry.shared_integrations.exceptions import ApiError, ApiHostError, ApiTimeoutError
 from sentry.utils.hashlib import md5_text
 from sentry_plugins.anonymizeip import anonymize_ip
+from sentry_plugins.splunk.client import SplunkApiClient
 
 logger = logging.getLogger(__name__)
-
-DESCRIPTION = """
-Send Sentry events to Splunk.
-
-This integration allows you to forward Sentry events to Splunk HTTP Event Collector (HEC) for centralized logging and analysis.
-
-Splunk is a platform for searching, monitoring, and analyzing machine-generated data.
-"""
 
 
 class SplunkForwarder(BaseDataForwarder):
     provider = DataForwarderProviderSlug.SPLUNK
     rate_limit = (1000, 1)  # 1000 requests per second
-    description = DESCRIPTION
+    project_token: str | None = None
+    project_index: str | None = None
+    project_instance: str | None = None
+    host: str | None = None
+    project_source: str | None = None
 
-    @classmethod
-    def get_host_for_splunk(cls, event: Event) -> str | None:
+    def get_host_for_splunk(self, event: Event) -> str | None:
         host = event.get_tag("server_name")
         if host:
             return host
@@ -42,8 +37,21 @@ class SplunkForwarder(BaseDataForwarder):
 
         return None
 
-    @classmethod
-    def get_event_payload_properties(cls, event: Event) -> dict[str, Any]:
+    def initialize_variables(self, event):
+        self.project_token = self.get_option("token", event.project)
+        self.project_index = self.get_option("index", event.project)
+        self.project_instance = self.get_option("instance", event.project)
+        self.host = self.get_host_for_splunk(event)
+
+        if self.project_instance and not self.project_instance.endswith("/services/collector"):
+            self.project_instance = self.project_instance.rstrip("/") + "/services/collector"
+
+        self.project_source = self.get_option("source", event.project) or "sentry"
+
+    def get_rl_key(self, event) -> str:
+        return f"{self.provider.value}:{md5_text(self.project_token).hexdigest()}"
+
+    def get_event_payload_properties(self, event: Event) -> dict[str, Any]:
         props = {
             "event_id": event.event_id,
             "issue_id": event.group_id,
@@ -53,7 +61,9 @@ class SplunkForwarder(BaseDataForwarder):
             "environment": event.get_tag("environment") or "",
             "type": event.get_event_type(),
         }
-        props["tags"] = [[tagstore.backend.get_standardized_key(k), v] for k, v in event.tags]
+        props["tags"] = [
+            [k.format(tagstore.backend.get_standardized_key(k)), v] for k, v in event.tags
+        ]
         for key, value in event.interfaces.items():
             if key == "request":
                 headers = value.headers
@@ -91,51 +101,37 @@ class SplunkForwarder(BaseDataForwarder):
                     props.update(user_payload)
         return props
 
-    @classmethod
-    def get_event_payload(cls, event: Event, config: dict[str, Any]) -> dict[str, Any]:
+    def get_event_payload(self, event: Event, config: dict[str, Any]) -> dict[str, Any]:
         return {
-            "time": int(event.datetime.timestamp()),
+            "time": int(event.datetime.strftime("%s")),
             "source": config.get("source", "sentry"),
             "index": config["index"],
-            "event": cls.get_event_payload_properties(event),
+            "event": self.get_event_payload_properties(event),
         }
 
-    @classmethod
-    def send_payload(
-        cls,
+    def forward_event(
+        self,
         payload: dict[str, Any],
         config: dict[str, Any],
         event: Event,
-        data_forwarder_project: DataForwarderProject,
     ) -> bool:
-        instance_url = config["instance_url"]
-        token = config["token"]
+        if not self.project_token or not self.project_index or not self.project_instance:
+            return False
 
-        if instance_url and not instance_url.endswith("/services/collector"):
-            instance_url = instance_url.rstrip("/") + "/services/collector"
+        if self.host:
+            payload["host"] = self.host
 
-        host = cls.get_host_for_splunk(event)
-        if host:
-            payload["host"] = host
-
-        headers = {"Authorization": f"Splunk {token}"}
+        client = SplunkApiClient(self.project_instance, self.project_token)
 
         try:
-            with http.build_session() as session:
-                response = session.post(
-                    instance_url,
-                    json=payload,
-                    headers=headers,
-                    timeout=5,
-                    verify=False,
-                )
-                if not response.ok:
-                    raise ApiError.from_response(response, url=instance_url)
+            # https://docs.splunk.com/Documentation/Splunk/7.2.3/Data/TroubleshootHTTPEventCollector
+            client.request(payload)
         except Exception as exc:
+            metric = "integrations.splunk.forward-event.error"
             logger.info(
-                "splunk.send_payload.error",
+                metric,
                 extra={
-                    "instance": instance_url,
+                    "instance": self.project_instance,
                     "project_id": event.project_id,
                     "organization_id": event.project.organization_id,
                     "error": str(exc),
@@ -146,15 +142,8 @@ class SplunkForwarder(BaseDataForwarder):
                 # These two are already handled by the API client, Just log and return.
                 isinstance(exc, (ApiHostError, ApiTimeoutError))
                 # Most 4xxs are not errors or actionable for us do not re-raise.
-                or (exc.code is not None and ((401 <= exc.code <= 405) or exc.code in (502, 504)))
+                or (exc.code is not None and (401 <= exc.code <= 405) or exc.code in (502, 504))
             ):
                 return False
             raise
-
         return True
-
-    @classmethod
-    def forward_event(cls, event: Event, data_forwarder_project: DataForwarderProject) -> bool:
-        config = data_forwarder_project.get_config()
-        payload = cls.get_event_payload(event, config)
-        return cls.send_payload(payload, config, event, data_forwarder_project)

--- a/src/sentry/integrations/data_forwarding/splunk/forwarder.py
+++ b/src/sentry/integrations/data_forwarding/splunk/forwarder.py
@@ -40,7 +40,7 @@ class SplunkForwarder(BaseDataForwarder):
     def initialize_variables(self, event: Event | GroupEvent, config: dict[str, Any]):
         self.project_token = config.get("token")
         self.project_index = config.get("index")
-        self.project_instance = config.get("instance")
+        self.project_instance = config.get("instance_url")
         self.host = self.get_host_for_splunk(event)
 
         if self.project_instance and not self.project_instance.endswith("/services/collector"):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -16,7 +16,6 @@ from google.api_core.exceptions import ServiceUnavailable
 
 from sentry import features, options, projectoptions
 from sentry.exceptions import PluginError
-from sentry.integrations.data_forwarding.base import BaseDataForwarder
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -1288,6 +1287,7 @@ def process_data_forwarding(job: PostProcessJob) -> None:
         return
 
     from sentry.integrations.data_forwarding import FORWARDER_REGISTRY
+    from sentry.integrations.data_forwarding.base import BaseDataForwarder
     from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 
     data_forwarder_projects = DataForwarderProject.objects.filter(
@@ -1300,8 +1300,8 @@ def process_data_forwarding(job: PostProcessJob) -> None:
         provider = data_forwarder_project.data_forwarder.provider
         try:
             # GroupEvent is compatible with Event for all operations forwarders need
-            forwarder: type[BaseDataForwarder] = FORWARDER_REGISTRY[provider]()
-            forwarder.post_process(event, data_forwarder_project)
+            forwarder: type[BaseDataForwarder] = FORWARDER_REGISTRY[provider]
+            forwarder().post_process(event, data_forwarder_project)
             metrics.incr(
                 "data_forwarding.post_process",
                 tags={"provider": provider},

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -16,6 +16,7 @@ from google.api_core.exceptions import ServiceUnavailable
 
 from sentry import features, options, projectoptions
 from sentry.exceptions import PluginError
+from sentry.integrations.data_forwarding.base import BaseDataForwarder
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -1283,6 +1284,9 @@ def process_data_forwarding(job: PostProcessJob) -> None:
     if not features.has("organizations:data-forwarding-revamp-access", event.project.organization):
         return
 
+    if not features.has("organizations:data-forwarding", event.project.organization):
+        return
+
     from sentry.integrations.data_forwarding import FORWARDER_REGISTRY
     from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 
@@ -1296,18 +1300,19 @@ def process_data_forwarding(job: PostProcessJob) -> None:
         provider = data_forwarder_project.data_forwarder.provider
         try:
             # GroupEvent is compatible with Event for all operations forwarders need
-            FORWARDER_REGISTRY[provider].forward_event(event, data_forwarder_project)  # type: ignore[arg-type]
+            forwarder: type[BaseDataForwarder] = FORWARDER_REGISTRY[provider]()
+            forwarder.post_process(event, data_forwarder_project)
             metrics.incr(
-                "data_forwarding.forward_event",
+                "data_forwarding.post_process",
                 tags={"provider": provider},
             )
         except Exception:
             metrics.incr(
-                "data_forwarding.forward_event.error",
+                "data_forwarding.post_process.error",
                 tags={"provider": provider},
             )
             logger.exception(
-                "data_forwarding.forward_event.error",
+                "data_forwarding.post_process.error",
                 extra={"provider": provider, "project_id": event.project_id},
             )
 

--- a/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
@@ -29,6 +29,7 @@ class AmazonSQSDataForwarderTest(TestCase):
             project=self.project,
             is_enabled=True,
         )
+        self.forwarder = AmazonSQSForwarder()
 
     @patch("boto3.client")
     def test_simple_notification(self, mock_client):
@@ -42,9 +43,8 @@ class AmazonSQSDataForwarderTest(TestCase):
             project_id=self.project.id,
         )
 
-        result = AmazonSQSForwarder.forward_event(event, self.data_forwarder_project)
+        self.forwarder.post_process(event, self.data_forwarder_project)
 
-        assert result is True
         mock_client.assert_called_once_with(
             service_name="sqs",
             region_name="us-east-1",
@@ -68,8 +68,7 @@ class AmazonSQSDataForwarderTest(TestCase):
             project_id=self.project.id,
         )
 
-        result = AmazonSQSForwarder.forward_event(event, self.data_forwarder_project)
-        assert result is False
+        self.forwarder.post_process(event, self.data_forwarder_project)
 
     @patch("boto3.client")
     def test_message_group_error(self, mock_client):
@@ -88,8 +87,7 @@ class AmazonSQSDataForwarderTest(TestCase):
             project_id=self.project.id,
         )
 
-        result = AmazonSQSForwarder.forward_event(event, self.data_forwarder_project)
-        assert result is False
+        self.forwarder.post_process(event, self.data_forwarder_project)
 
     @patch("boto3.client")
     def test_pass_message_group_id(self, mock_client):
@@ -104,9 +102,8 @@ class AmazonSQSDataForwarderTest(TestCase):
             project_id=self.project.id,
         )
 
-        result = AmazonSQSForwarder.forward_event(event, self.data_forwarder_project)
+        self.forwarder.post_process(event, self.data_forwarder_project)
 
-        assert result is True
         call_args = mock_client.return_value.send_message.call_args[1]
         assert call_args["MessageGroupId"] == "my_group"
         assert "MessageDeduplicationId" in call_args
@@ -124,9 +121,8 @@ class AmazonSQSDataForwarderTest(TestCase):
             project_id=self.project.id,
         )
 
-        result = AmazonSQSForwarder.forward_event(event, self.data_forwarder_project)
+        self.forwarder.post_process(event, self.data_forwarder_project)
 
-        assert result is True
         mock_client.return_value.put_object.assert_called_once()
         put_object_call = mock_client.return_value.put_object.call_args[1]
         assert put_object_call["Bucket"] == "my_bucket"

--- a/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import orjson
 from botocore.exceptions import ClientError
 
+from sentry.api.serializers import serialize
 from sentry.integrations.data_forwarding.amazon_sqs.forwarder import AmazonSQSForwarder
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
@@ -53,7 +54,7 @@ class AmazonSQSDataForwarderTest(TestCase):
         )
         mock_client.return_value.send_message.assert_called_once_with(
             QueueUrl="https://sqs.us-east-1.amazonaws.com/12345678/myqueue",
-            MessageBody=orjson.dumps(event.as_dict(), option=orjson.OPT_UTC_Z).decode(),
+            MessageBody=orjson.dumps(serialize(event), option=orjson.OPT_UTC_Z).decode(),
         )
 
     @patch("boto3.client")

--- a/tests/sentry/integrations/data_forwarding/segment/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/segment/test_forwarder.py
@@ -23,6 +23,7 @@ class SegmentDataForwarderTest(TestCase):
             project=self.project,
             is_enabled=True,
         )
+        self.forwarder = SegmentForwarder()
 
     @responses.activate
     def test_simple_notification(self):
@@ -39,9 +40,8 @@ class SegmentDataForwarderTest(TestCase):
             project_id=self.project.id,
         )
 
-        result = SegmentForwarder.forward_event(event, self.data_forwarder_project)
+        self.forwarder.post_process(event, self.data_forwarder_project)
 
-        assert result is True
         assert len(responses.calls) == 1
 
         request = responses.calls[0].request
@@ -75,5 +75,4 @@ class SegmentDataForwarderTest(TestCase):
             project_id=self.project.id,
         )
 
-        result = SegmentForwarder.forward_event(event, self.data_forwarder_project)
-        assert result is False
+        self.forwarder.post_process(event, self.data_forwarder_project)

--- a/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
@@ -29,6 +29,7 @@ class SplunkDataForwarderTest(TestCase):
             project=self.project,
             is_enabled=True,
         )
+        self.forwarder = SplunkForwarder()
 
     @responses.activate
     def test_simple_notification(self):
@@ -38,9 +39,7 @@ class SplunkDataForwarderTest(TestCase):
             data={"message": "Hello world", "level": "warning"}, project_id=self.project.id
         )
 
-        result = SplunkForwarder.forward_event(event, self.data_forwarder_project)
-
-        assert result is True
+        self.forwarder.post_process(event, self.data_forwarder_project)
         assert len(responses.calls) == 1
 
         request = responses.calls[0].request
@@ -62,8 +61,7 @@ class SplunkDataForwarderTest(TestCase):
             data={"message": "Hello world", "level": "warning"}, project_id=self.project.id
         )
 
-        result = SplunkForwarder.forward_event(event, self.data_forwarder_project)
-        assert result is False
+        self.forwarder.post_process(event, self.data_forwarder_project)
 
     @responses.activate
     def test_reraise_error(self):
@@ -76,7 +74,7 @@ class SplunkDataForwarderTest(TestCase):
         )
 
         with pytest.raises(ApiError):
-            SplunkForwarder.forward_event(event, self.data_forwarder_project)
+            self.forwarder.post_process(event, self.data_forwarder_project)
 
     def test_http_payload(self):
         event = self.store_event(
@@ -91,7 +89,7 @@ class SplunkDataForwarderTest(TestCase):
         )
 
         config = self.data_forwarder_project.get_config()
-        result = SplunkForwarder.get_event_payload(event, config)
+        result = self.forwarder.get_event_payload(event, config)
         assert result["event"]["request_url"] == "http://example.com/"
         assert result["event"]["request_method"] == "POST"
         assert result["event"]["request_referer"] == "http://example.com/foo"
@@ -106,7 +104,7 @@ class SplunkDataForwarderTest(TestCase):
         )
 
         config = self.data_forwarder_project.get_config()
-        result = SplunkForwarder.get_event_payload(event, config)
+        result = self.forwarder.get_event_payload(event, config)
         assert result["event"]["type"] == "error"
         assert result["event"]["exception_type"] == "ValueError"
         assert result["event"]["exception_value"] == "foo bar"
@@ -126,7 +124,7 @@ class SplunkDataForwarderTest(TestCase):
         )
 
         config = self.data_forwarder_project.get_config()
-        result = SplunkForwarder.get_event_payload(event, config)
+        result = self.forwarder.get_event_payload(event, config)
         assert result["event"]["type"] == "csp"
         assert result["event"]["csp_document_uri"] == "http://example.com/"
         assert result["event"]["csp_violated_directive"] == "style-src cdn.example.com"
@@ -140,7 +138,7 @@ class SplunkDataForwarderTest(TestCase):
         )
 
         config = self.data_forwarder_project.get_config()
-        result = SplunkForwarder.get_event_payload(event, config)
+        result = self.forwarder.get_event_payload(event, config)
         assert result["event"]["user_id"] == "1"
         assert result["event"]["user_email_hash"] == "b48def645758b95537d4424c84d1a9ff"
         assert result["event"]["user_ip_trunc"] == "127.0.0.0"

--- a/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
@@ -1,12 +1,10 @@
 import orjson
-import pytest
 import responses
 
 from sentry.integrations.data_forwarding.splunk.forwarder import SplunkForwarder
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
 
 
@@ -62,19 +60,6 @@ class SplunkDataForwarderTest(TestCase):
         )
 
         self.forwarder.post_process(event, self.data_forwarder_project)
-
-    @responses.activate
-    def test_reraise_error(self):
-        responses.add(
-            responses.POST, "https://splunk.example.com:8088/services/collector", status=500
-        )
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "warning"}, project_id=self.project.id
-        )
-
-        with pytest.raises(ApiError):
-            self.forwarder.post_process(event, self.data_forwarder_project)
 
     def test_http_payload(self):
         event = self.store_event(


### PR DESCRIPTION
Should resolve some issues with data forwarders
- The SQS forwarder was using `as_dict` instead of `serialize`
- The rate limiting wasn't being used at all
- It was hard to compare the plugin implementation to the data forwarding since the methods had their name changed, I reused the existing ones where possible

For Splunk, I opted to use the legacy SplunkApiClient, we can migrate off of it later and it's easier to match it for now.