### PR TITLE
fix(aci): handle fake incident ids in IGOP lookup

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
@@ -88,10 +88,18 @@ class OrganizationIncidentGroupOpenPeriodIndexEndpoint(OrganizationEndpoint):
         fake_id = incident_identifier or incident_id
         if fake_id:
             calculated_open_period_id = get_object_id_from_fake_id(int(fake_id))
-            group_open_period = GroupOpenPeriod.objects.filter(
+            gop_queryset = GroupOpenPeriod.objects.filter(
                 id=calculated_open_period_id,
                 project__organization=organization,
-            ).first()
+            )
+
+            if group_id:
+                gop_queryset = gop_queryset.filter(group_open_period__group_id=group_id)
+
+            if open_period_id:
+                gop_queryset = gop_queryset.filter(group_open_period_id=open_period_id)
+
+            group_open_period = gop_queryset.first()
 
             if group_open_period:
                 # Serialize the GroupOpenPeriod as if it were an IncidentGroupOpenPeriod

--- a/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
@@ -15,6 +15,8 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams
+from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.workflow_engine.endpoints.serializers.incident_groupopenperiod_serializer import (
     IncidentGroupOpenPeriodSerializer,
 )
@@ -49,6 +51,9 @@ class OrganizationIncidentGroupOpenPeriodIndexEndpoint(OrganizationEndpoint):
         """
         Returns an incident and group open period relationship.
         Can optionally filter by incident_id, incident_identifier, group_id, or open_period_id.
+        If incident_identifier is provided but no match is found, falls back to calculating
+        open_period_id by subtracting 10^9 from the incident_identifier and looking up the
+        GroupOpenPeriod directly.
         """
         validator = IncidentGroupOpenPeriodValidator(data=request.query_params)
         validator.is_valid(raise_exception=True)
@@ -74,7 +79,29 @@ class OrganizationIncidentGroupOpenPeriodIndexEndpoint(OrganizationEndpoint):
             queryset = queryset.filter(group_open_period_id=open_period_id)
 
         incident_groupopenperiod = queryset.first()
-        if not incident_groupopenperiod:
-            raise ResourceDoesNotExist
 
-        return Response(serialize(incident_groupopenperiod, request.user))
+        if incident_groupopenperiod:
+            return Response(serialize(incident_groupopenperiod, request.user))
+
+        # Fallback: if incident_identifier or incident_id was provided but no IGOP found,
+        # try looking up GroupOpenPeriod directly using calculated open_period_id
+        fake_id = incident_identifier or incident_id
+        if fake_id:
+            calculated_open_period_id = get_object_id_from_fake_id(int(fake_id))
+            group_open_period = GroupOpenPeriod.objects.filter(
+                id=calculated_open_period_id,
+                project__organization=organization,
+            ).first()
+
+            if group_open_period:
+                # Serialize the GroupOpenPeriod as if it were an IncidentGroupOpenPeriod
+                return Response(
+                    {
+                        "incidentId": fake_id,
+                        "incidentIdentifier": fake_id,
+                        "groupId": str(group_open_period.group_id),
+                        "openPeriodId": str(group_open_period.id),
+                    }
+                )
+
+        raise ResourceDoesNotExist

--- a/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
@@ -97,8 +97,8 @@ class OrganizationIncidentGroupOpenPeriodIndexEndpoint(OrganizationEndpoint):
                 # Serialize the GroupOpenPeriod as if it were an IncidentGroupOpenPeriod
                 return Response(
                     {
-                        "incidentId": fake_id,
-                        "incidentIdentifier": fake_id,
+                        "incidentId": str(fake_id),
+                        "incidentIdentifier": str(fake_id),
                         "groupId": str(group_open_period.group_id),
                         "openPeriodId": str(group_open_period.id),
                     }

--- a/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_incident_groupopenperiod_index.py
@@ -94,10 +94,10 @@ class OrganizationIncidentGroupOpenPeriodIndexEndpoint(OrganizationEndpoint):
             )
 
             if group_id:
-                gop_queryset = gop_queryset.filter(group_open_period__group_id=group_id)
+                gop_queryset = gop_queryset.filter(group_id=group_id)
 
             if open_period_id:
-                gop_queryset = gop_queryset.filter(group_open_period_id=open_period_id)
+                gop_queryset = gop_queryset.filter(id=open_period_id)
 
             group_open_period = gop_queryset.first()
 

--- a/src/sentry/workflow_engine/endpoints/serializers/incident_groupopenperiod_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/incident_groupopenperiod_serializer.py
@@ -19,7 +19,7 @@ class IncidentGroupOpenPeriodSerializer(Serializer):
     ) -> IncidentGroupOpenPeriodSerializerResponse:
         return {
             "incidentId": str(obj.incident_id) if obj.incident_id else None,
-            "incidentIdentifier": str(obj.incident_identifier),
+            "incidentIdentifier": str(obj.incident_identifier) if obj.incident_identifier else None,
             "groupId": str(obj.group_open_period.group_id),
             "openPeriodId": str(obj.group_open_period.id),
         }

--- a/src/sentry/workflow_engine/endpoints/serializers/incident_groupopenperiod_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/incident_groupopenperiod_serializer.py
@@ -7,7 +7,7 @@ from sentry.workflow_engine.models.incident_groupopenperiod import IncidentGroup
 
 class IncidentGroupOpenPeriodSerializerResponse(TypedDict):
     incidentId: str | None
-    incidentIdentifier: int | None
+    incidentIdentifier: str | None
     groupId: str
     openPeriodId: str
 
@@ -19,7 +19,7 @@ class IncidentGroupOpenPeriodSerializer(Serializer):
     ) -> IncidentGroupOpenPeriodSerializerResponse:
         return {
             "incidentId": str(obj.incident_id) if obj.incident_id else None,
-            "incidentIdentifier": obj.incident_identifier,
+            "incidentIdentifier": str(obj.incident_identifier),
             "groupId": str(obj.group_open_period.group_id),
             "openPeriodId": str(obj.group_open_period.id),
         }

--- a/tests/sentry/workflow_engine/endpoints/test_organization_incident_groupopenperiod.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_incident_groupopenperiod.py
@@ -1,4 +1,5 @@
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.testutils.cases import APITestCase
@@ -103,3 +104,36 @@ class OrganizationIncidentGroupOpenPeriodIndexGetTest(
 
     def test_no_filter_provided(self) -> None:
         self.get_error_response(self.organization.slug, status_code=400)
+
+    def test_fallback_with_fake_incident_identifier(self) -> None:
+        """
+        Test that when an IGOP doesn't exist, the endpoint falls back to looking up
+        the GroupOpenPeriod by subtracting 10^9 from the incident_identifier.
+        This is the reverse of the GOP -> Incident serialization logic.
+        """
+        # Create a group with open period but NO IGOP
+        group_no_igop = self.create_group(type=MetricIssue.type_id)
+        open_period_no_igop = GroupOpenPeriod.objects.get(group=group_no_igop)
+
+        # Calculate the fake incident_identifier (same as serializer does)
+        fake_incident_identifier = get_fake_id_from_object_id(open_period_no_igop.id)
+
+        # Query using the fake incident_identifier
+        response = self.get_success_response(
+            self.organization.slug, incident_identifier=str(fake_incident_identifier)
+        )
+
+        # Should return a fake IGOP response
+        assert response.data == {
+            "incidentId": fake_incident_identifier,
+            "incidentIdentifier": fake_incident_identifier,
+            "groupId": str(group_no_igop.id),
+            "openPeriodId": str(open_period_no_igop.id),
+        }
+
+    def test_fallback_with_nonexistent_open_period(self) -> None:
+        # Use a fake incident_identifier that won't map to any real open period
+        nonexistent_fake_id = get_fake_id_from_object_id(999999)
+        self.get_error_response(
+            self.organization.slug, incident_identifier=str(nonexistent_fake_id), status_code=404
+        )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_incident_groupopenperiod.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_incident_groupopenperiod.py
@@ -125,8 +125,8 @@ class OrganizationIncidentGroupOpenPeriodIndexGetTest(
 
         # Should return a fake IGOP response
         assert response.data == {
-            "incidentId": fake_incident_identifier,
-            "incidentIdentifier": fake_incident_identifier,
+            "incidentId": str(fake_incident_identifier),
+            "incidentIdentifier": str(fake_incident_identifier),
             "groupId": str(group_no_igop.id),
             "openPeriodId": str(open_period_no_igop.id),
         }


### PR DESCRIPTION
When looking up a GroupOpenPeriod via incident id, it's possible that there is no corresponding row in the IncidentGroupOpenPeriod table. We then assume that the incident id that was passed is a fake id, so we can use `get_object_id_from_fake_id()` to get the open period id and group.