### PR TITLE
feat(settings): Remove vercel log drain feature flag

### DIFF
--- a/static/app/views/settings/project/projectKeys/credentials/index.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/index.tsx
@@ -25,7 +25,6 @@ type Props = {
   showSecretKey?: boolean;
   showSecurityEndpoint?: boolean;
   showUnreal?: boolean;
-  showVercelLogDrainEndpoint?: boolean;
 };
 
 type TabValue = 'otlp' | 'security' | 'minidump' | 'unreal' | 'vercel' | 'credentials';
@@ -174,7 +173,6 @@ function ProjectKeyCredentials({
   showSecretKey = false,
   showOtlpTraces = false,
   showOtlpLogs = false,
-  showVercelLogDrainEndpoint = false,
   showSecurityEndpoint = true,
   showUnreal = true,
 }: Props) {
@@ -210,7 +208,7 @@ function ProjectKeyCredentials({
       {
         key: 'vercel',
         label: t('Vercel Drains'),
-        visible: showVercelLogDrainEndpoint || showOtlpTraces,
+        visible: true,
       },
     ];
     return tabs.filter(tab => tab.visible);
@@ -218,7 +216,6 @@ function ProjectKeyCredentials({
     showOtlpTraces,
     showOtlpLogs,
     showSecurityEndpoint,
-    showVercelLogDrainEndpoint,
     showMinidump,
     showUnreal,
     showPublicKey,
@@ -271,7 +268,6 @@ function ProjectKeyCredentials({
       case 'vercel':
         return (
           <VercelTab
-            showVercelLogDrainEndpoint={showVercelLogDrainEndpoint}
             integrationEndpoint={data.dsn.integration}
             publicKey={data.public}
             showOtlpTraces={showOtlpTraces}

--- a/static/app/views/settings/project/projectKeys/credentials/vercel.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/vercel.tsx
@@ -9,12 +9,10 @@ interface VercelTabProps {
   integrationEndpoint: string;
   publicKey: string;
   showOtlpTraces: boolean;
-  showVercelLogDrainEndpoint: boolean;
   tracesEndpoint: string;
 }
 
 export function VercelTab({
-  showVercelLogDrainEndpoint,
   integrationEndpoint,
   publicKey,
   showOtlpTraces,
@@ -22,40 +20,33 @@ export function VercelTab({
 }: VercelTabProps) {
   return (
     <Fragment>
-      {showVercelLogDrainEndpoint && (
-        <Fragment>
-          <FieldGroup
-            label={t('Vercel Log Drain Endpoint')}
-            help={tct(
-              'Use this endpoint to configure Vercel Log Drains. [link:Learn more]',
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/#log-drains" />
-                ),
-              }
-            )}
-            inline={false}
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('Vercel Log Drain Endpoint')}>
-              {`${integrationEndpoint}vercel/logs`}
-            </TextCopyInput>
-          </FieldGroup>
+      <FieldGroup
+        label={t('Vercel Log Drain Endpoint')}
+        help={tct('Use this endpoint to configure Vercel Log Drains. [link:Learn more]', {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/#log-drains" />
+          ),
+        })}
+        inline={false}
+        flexibleControlStateSize
+      >
+        <TextCopyInput aria-label={t('Vercel Log Drain Endpoint')}>
+          {`${integrationEndpoint}vercel/logs`}
+        </TextCopyInput>
+      </FieldGroup>
 
-          <FieldGroup
-            label={t('Log Drain Authentication Headers')}
-            help={t(
-              'Set these authentication headers when configuring your Vercel Log Drain.'
-            )}
-            inline={false}
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('Log Drain Authentication Header')}>
-              {`x-sentry-auth: sentry sentry_key=${publicKey}`}
-            </TextCopyInput>
-          </FieldGroup>
-        </Fragment>
-      )}
+      <FieldGroup
+        label={t('Log Drain Authentication Headers')}
+        help={t(
+          'Set these authentication headers when configuring your Vercel Log Drain.'
+        )}
+        inline={false}
+        flexibleControlStateSize
+      >
+        <TextCopyInput aria-label={t('Log Drain Authentication Header')}>
+          {`x-sentry-auth: sentry sentry_key=${publicKey}`}
+        </TextCopyInput>
+      </FieldGroup>
       {showOtlpTraces && (
         <Fragment>
           <FieldGroup

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -72,9 +72,6 @@ export function KeySettings({
   const showOtlpTraces =
     useOTelFriendlyUI() && organization.features.includes('relay-otlp-traces-endpoint');
   const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
-  const showVercelLogDrainEndpoint = organization.features.includes(
-    'relay-vercel-log-drain-endpoint'
-  );
 
   return (
     <Fragment>
@@ -156,7 +153,6 @@ export function KeySettings({
                   data={data}
                   showOtlpTraces={showOtlpTraces}
                   showOtlpLogs={showOtlpLogs}
-                  showVercelLogDrainEndpoint={showVercelLogDrainEndpoint}
                   showPublicKey
                   showSecretKey
                   showProjectId

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -50,9 +50,6 @@ function KeyRow({
   const showOtlpTraces =
     useOTelFriendlyUI() && organization.features.includes('relay-otlp-traces-endpoint');
   const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
-  const showVercelLogDrainEndpoint = organization.features.includes(
-    'relay-vercel-log-drain-endpoint'
-  );
 
   return (
     <Panel>
@@ -107,12 +104,10 @@ function KeyRow({
             data={data}
             showOtlpTraces={showOtlpTraces}
             showOtlpLogs={showOtlpLogs}
-            showVercelLogDrainEndpoint={showVercelLogDrainEndpoint}
             showMinidump={!isJsPlatform}
             showUnreal={!isJsPlatform}
             showSecurityEndpoint={!isJsPlatform}
           />
-
           {isBrowserJavaScript && (
             <LoaderScript
               projectKey={data}


### PR DESCRIPTION
The Vercel Log Drain is now GA (https://github.com/getsentry/sentry-options-automator/pull/5786, https://docs.sentry.io/product/drains/integration/vercel/#log-drains).

We need to start cleaning up the feature flags. This PR removes the flag from the frontend.

ref https://linear.app/getsentry/issue/LOGS-395/clean-up-feature-flags-for-vercel-log-drains