### PR TITLE
feat(tests): Add helper to count mock calls

### DIFF
--- a/src/sentry/testutils/pytest/mocking.py
+++ b/src/sentry/testutils/pytest/mocking.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar
+from unittest.mock import MagicMock
+from unittest.mock import call as MockCall
 
 # TODO: Once we're on python 3.12, we can get rid of these and change the first line of the
 # signature of `capture_results` to
@@ -122,3 +124,14 @@ def capture_results(
         return returned_value
 
     return wrapped_fn
+
+
+def count_matching_calls(mock_fn: MagicMock, *args: Any, **kwargs: Any) -> int:
+    """
+    Given a mock function, count the calls which match the given args and kwargs.
+
+    Note: As is the case with the built-in mock methods `assert_called_with` and friends, the given
+    args and kwargs must match the full list of what was passed to the given mock.
+    """
+    matching_calls = [call for call in mock_fn.call_args_list if call == MockCall(*args, **kwargs)]
+    return len(matching_calls)


### PR DESCRIPTION
The Python built-in `MagicMock` class has `assert_called_once_with`, `assert_any_call`, `assert_has_calls`, etc, but none of those is helpful if what you really want is `assert_called_twice_with` or `assert_called_exactly_three_times_with`. This therefore adds a new testing helper, `count_matching_calls`, which works exactly the same way as the built-in ones, except that you also have to pass it the mock. So, for example, the following sets of assertions are equivalent (yes, I know some of the mock methods don't actually exist - that's the point):

```python
some_mock.assert_called_once_with("dogs", "are", "great", adopt_dont_shop=True)
assert count_matching_calls(some_mock, "dogs", "are", "great", adopt_dont_shop=True) == 1

some_mock.assert_called_twice_with("dogs", "are", "great", adopt_dont_shop=True)
assert count_matching_calls(some_mock, "dogs", "are", "great", adopt_dont_shop=True) == 2

some_mock.assert_called_exactly_three_times_with("dogs", "are", "great", adopt_dont_shop=True)
assert count_matching_calls(some_mock, "dogs", "are", "great", adopt_dont_shop=True) == 3
```

This will be helpful for testing an upcoming PR involving caching, where for example it will be nice to be able to test that `cache.get` is called twice while `cache.set` is only called once (or not at all, if certain criteria aren't met).