### PR TITLE
fix(Replay): Update Timestamp Start Query

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -39,7 +39,7 @@ def query_replay_instance_eap(
     select = [
         Column("replay_id"),
         Function("min", parameters=[Column("project_id")], alias="agg_project_id"),
-        Function("min", parameters=[Column("replay_start_timestamp")], alias="started_at"),
+        Function("min", parameters=[Column("timestamp")], alias="started_at"),
         Function("max", parameters=[Column("timestamp")], alias="finished_at"),
         Function("count", parameters=[Column("segment_id")], alias="count_segments"),
         Function("sum", parameters=[Column("count_error_events")], alias="count_errors"),


### PR DESCRIPTION
As title says, this PR fixes a timestamp query to fix this issue: https://sentry.sentry.io/issues/7061220954/?alert_rule_id=14394965&alert_type=issue&notification_uuid=21d14296-f017-420f-a929-8fded09e6bd1&project=11276&referrer=slack


Relates to: https://linear.app/getsentry/issue/REPLAY-824/create-query-function-for-replay-details