### PR TITLE
feat(grouping): Add options to control grouphash caching

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2863,6 +2863,39 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# When handling grouphashes during ingest, use the cache to reduce postgres load. With secondary
+# grouphashes we want to use ones which are already there but not create new ones, so we track the
+# boolean result of their `.exists()` check. For all existing grouphashes, secondary or not, we know
+# that if they already have a group assigned they won't be modified, so in that case we also cache
+# the full `GroupHash` object. The killswitch below controls both caches, but they have separate
+# expiry times because the secondary grouphash existence cache is used less frequently and has a
+# lighter memory footprint, so we can afford to cache things there for longer.
+#
+# TODO: Check hit/miss rates for both caches and adjust the two expiry options accordingly.
+register(
+    "grouping.use_ingest_grouphash_caching",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# How long to cache a boolean indicating whether or not a grouphash exists for a given secondary
+# hash value
+register(
+    "grouping.ingest_grouphash_existence_cache_expiry",
+    type=Int,
+    default=60,  # seconds
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# How long to cache actual `GroupHash` objects
+register(
+    "grouping.ingest_grouphash_object_cache_expiry",
+    type=Int,
+    default=60,  # seconds
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # Sample rate for double writing to experimental dsn
 register(


### PR DESCRIPTION
This adds three new options, `grouping.use_ingest_grouphash_caching`, `grouping.ingest_grouphash_existence_cache_expiry`, and `grouping.ingest_grouphash_object_cache_expiry`, to control the caching of both a check on secondary grouphash existence and of actual `GroupHash` objects during ingest. The two expiry times are controlled separately because caching a boolean takes less memory than caching a whole Django ORM object (albeit a quite simple one), so we can probably let things stay in the first cache longer than the second. (We'll know after we turn caching on and see what the respective hit rates are.)