### PR TITLE
fix(aci): always combine rule and workflow fire history in API

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -9,7 +9,6 @@ from typing import Any, TypedDict
 from django.db.models import Max, Prefetch, Q, prefetch_related_objects
 from rest_framework import serializers
 
-from sentry import features
 from sentry.api.serializers import Serializer, register
 from sentry.constants import ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
@@ -210,10 +209,7 @@ class RuleSerializer(Serializer):
             }
 
             # Update lastTriggered with WorkflowFireHistory if available
-            if item_list and features.has(
-                "organizations:workflow-engine-single-process-workflows",
-                item_list[0].project.organization,
-            ):
+            if item_list:
                 rule_ids = [rule.id for rule in item_list]
                 workflow_rule_lookup = dict(
                     AlertRuleWorkflow.objects.filter(rule_id__in=rule_ids).values_list(

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -14,7 +14,6 @@ from sentry.rules.filters.event_attribute import EventAttributeFilter
 from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.users.services.user.serial import serialize_rpc_user
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import WorkflowDataConditionGroup, WorkflowFireHistory
@@ -36,7 +35,6 @@ class RuleSerializerTest(TestCase):
         result = serialize(rule, self.user, RuleSerializer(expand=["lastTriggered"]))
         assert result["lastTriggered"] == timezone.now()
 
-    @with_feature("organizations:workflow-engine-single-process-workflows")
     def test_last_triggered_with_workflow_only(self) -> None:
         rule = self.create_project_rule()
 
@@ -50,7 +48,6 @@ class RuleSerializerTest(TestCase):
         result = serialize(rule, self.user, RuleSerializer(expand=["lastTriggered"]))
         assert result["lastTriggered"] == timezone.now()
 
-    @with_feature("organizations:workflow-engine-single-process-workflows")
     def test_last_triggered_with_workflow(self) -> None:
         rule = self.create_project_rule()
 

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -6,7 +6,6 @@ from sentry.rules.history.backends.postgres import PostgresRuleHistoryBackend
 from sentry.rules.history.base import RuleGroupHistory
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.models import AlertRuleWorkflow, WorkflowFireHistory
 
@@ -334,7 +333,6 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         assert len(results) == 24
         assert [r.count for r in results[-5:]] == [0, 0, 1, 1, 0]
 
-    @with_feature("organizations:workflow-engine-single-process-workflows")
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory for hourly stats when feature flag is enabled"""
         rule = self.create_project_rule(project=self.event.project)

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -196,7 +196,6 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             ],
         )
 
-    @with_feature("organizations:workflow-engine-single-process-workflows")
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory when feature flag is enabled"""
         rule = self.create_project_rule(project=self.event.project)


### PR DESCRIPTION
Since we will be using the single process workflows flag to roll out other types of issues, we shouldn't be using it to gate other features like combining rule and workflow history. We should always be combining the history