### PR TITLE
fix(assisted-query): match return format for field values rpc

### DIFF
--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -84,16 +84,14 @@ def get_attribute_values_with_substring(
         item_type: Type of trace item (default: "spans")
 
     Returns:
-        Dictionary with values:
+        Dictionary with field names as keys and lists of values:
         {
-            "values": {
-                "span.status": ["ok", "error", ...],
-                "transaction": ["checkout", ...]
-            }
+            "span.status": ["ok", "error", ...],
+            "transaction": ["checkout", ...]
         }
     """
     if not fields_with_substrings:
-        return {"values": {}}
+        return {}
 
     organization = Organization.objects.get(id=org_id)
     api_key = ApiKey(organization_id=org_id, scope_list=API_KEY_SCOPES)
@@ -127,6 +125,4 @@ def get_attribute_values_with_substring(
         values.setdefault(field, set()).update(field_values_list[:limit])
 
     # Convert sets to sorted lists for JSON serialization
-    return {
-        "values": {field: sorted(field_values)[:limit] for field, field_values in values.items()}
-    }
+    return {field: sorted(field_values)[:limit] for field, field_values in values.items()}

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -90,9 +90,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             )
 
         assert result == {
-            "values": {
-                "transaction": ["bar", "baz"],
-            }
+            "transaction": ["bar", "baz"],
         }
 
     def test_get_attributes_and_values(self) -> None:
@@ -165,7 +163,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             fields_with_substrings=[],
         )
 
-        expected: dict = {"values": {}}
+        expected: dict = {}
         assert result == expected
 
     def test_get_spans_basic(self) -> None:


### PR DESCRIPTION
Remove "values" wrapping field values results to match Seer's expectations. Fixes empty results for get_field_values in query builder