### PR TITLE
chore(releases): fix releases tooltip width

### DIFF
--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -1,4 +1,4 @@
-import {css, useTheme} from '@emotion/react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
@@ -68,7 +68,7 @@ function Version({
   const versionToDisplay = shouldFormatVersion
     ? formatVersion(version, withPackage)
     : version;
-  const theme = useTheme();
+  const isHashVersion = /\b[a-f0-9]{40}\b|\b[a-f0-9]{64}\b/.test(version);
 
   let releaseDetailProjectId: null | undefined | string | string[];
   if (projectId) {
@@ -132,27 +132,13 @@ function Version({
     </TooltipContent>
   );
 
-  const getOverlayStyle = () => {
-    // if the version name is not a hash (sha1 or sha265) and we are not on
-    // mobile, allow tooltip to be as wide as 500px
-    if (/(^[a-f0-9]{40}$)|(^[a-f0-9]{64}$)/.test(version)) {
-      return undefined;
-    }
-
-    return css`
-      @media (min-width: ${theme.breakpoints.sm}) {
-        max-width: 500px;
-      }
-    `;
-  };
-
   return (
     <Tooltip
       title={renderTooltipContent()}
       disabled={!tooltipRawVersion}
       isHoverable
       containerDisplayMode={truncate ? 'block' : 'inline-block'}
-      overlayStyle={getOverlayStyle()}
+      maxWidth={isHashVersion ? undefined : 400}
     >
       {renderVersion()}
     </Tooltip>


### PR DESCRIPTION
problem described in [feedback here](https://sentry.sentry.io/issues/feedback/?alert_rule_id=16206265&alert_type=issue&feedbackSlug=javascript%3A7051903700&notification_uuid=bf8ffb13-67dc-4466-b2ed-78cad32f187b&project=11276&referrer=slack&statsPeriod=7d). 

TL;DR - releases cards can have the same subset of title displayed, but the tooltip was getting cut off

## PR vs. current

**PR**
_tooltips show full content (can see the bundle ids are different)_
<img width="329" height="142" alt="image" src="https://github.com/user-attachments/assets/4ac02a24-c526-42b3-aaec-756e594d0299" />
https://github.com/user-attachments/assets/af731c7c-a4cd-4e79-aec2-c87cc09862d4

**current prod (releases indistinguishable)**
<img width="600" height="223" alt="image" src="https://github.com/user-attachments/assets/ecb063e2-9298-418d-aae7-60d78636cfa7" />

https://github.com/user-attachments/assets/f0e196a0-31cc-435e-9301-1e96ce1d8b04

## For a hash release
intent is to not change current behavior

**Tooltip on prod for a "hash release"**
<img width="364" height="202" alt="image" src="https://github.com/user-attachments/assets/7564cf4d-5fde-4488-8ac8-ac26100e7816" />

**Tooltip in PR for a "hash release" (same thing)**
<img width="388" height="176" alt="image" src="https://github.com/user-attachments/assets/95de6bdb-14df-4fcc-96d8-f7090a8fea4d" />

## Notes
**Issues w/ previous implementation:**
- regex for hash version was incorrect given the `version` that's passed in. The `version` passed in is actually the full release string, that often will start with something like `frontend@{hash}`. Changed regex to be if there is a 40 or 64 character hash anywhere, which worked for the Sentry Javascript project
- the overlayStyle wasn't actually doing anything, otherwise this never would have been issue. Switched to just use the maxWidth prop that's in the tooltip