### PR TITLE
fix(misc): Fix getExactDuration behaviour when given a precision parameter

### DIFF
--- a/static/app/utils/duration/getExactDuration.spec.tsx
+++ b/static/app/utils/duration/getExactDuration.spec.tsx
@@ -29,6 +29,7 @@ describe('getExactDuration', () => {
 
   it('should abbreviate label', () => {
     expect(getExactDuration(234235435, true)).toBe('387wk 2d 1hr 23min 55s');
+    expect(getExactDuration(61, true, 'minutes')).toBe('1min');
   });
 
   it('should pin/truncate to the min suffix precision if provided', () => {
@@ -41,5 +42,6 @@ describe('getExactDuration', () => {
     expect(getExactDuration(234235435.2, false, 'seconds')).toBe(
       '387 weeks 2 days 1 hour 23 minutes 55 seconds'
     );
+    expect(getExactDuration(61, false, 'minutes')).toBe('1 minute');
   });
 });

--- a/static/app/utils/duration/getExactDuration.tsx
+++ b/static/app/utils/duration/getExactDuration.tsx
@@ -43,31 +43,31 @@ export function getExactDuration(
       const {quotient, remainder} = divideBy(WEEK);
       const suffix = abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`;
 
-      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${precision === 'weeks' ? '' : convertDuration(remainder / 1000, abbr)}`;
     }
     if (value >= DAY || (value && minSuffix === ' days')) {
       const {quotient, remainder} = divideBy(DAY);
       const suffix = abbr ? t('d') : ` ${tn('day', 'days', quotient)}`;
 
-      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${precision === 'days' ? '' : convertDuration(remainder / 1000, abbr)}`;
     }
     if (value >= HOUR || (value && minSuffix === ' hours')) {
       const {quotient, remainder} = divideBy(HOUR);
       const suffix = abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`;
 
-      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${precision === 'hours' ? '' : convertDuration(remainder / 1000, abbr)}`;
     }
     if (value >= MINUTE || (value && minSuffix === ' minutes')) {
       const {quotient, remainder} = divideBy(MINUTE);
       const suffix = abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`;
 
-      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${precision === 'minutes' ? '' : convertDuration(remainder / 1000, abbr)}`;
     }
     if (value >= SECOND || (value && minSuffix === ' seconds')) {
       const {quotient, remainder} = divideBy(SECOND);
       const suffix = abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`;
 
-      return `${quotient}${suffix} ${minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${precision === 'seconds' ? '' : convertDuration(remainder / 1000, abbr)}`;
     }
 
     if (value === 0) {


### PR DESCRIPTION
This PR fixes a bug visible on some [alert pages](https://sentry.sentry.io/issues/6827154726/open-periods/?project=4507946704961536&referrer=event-or-group-header).

<img width="196" height="95" alt="image" src="https://github.com/user-attachments/assets/da0907d2-14fe-4374-ad93-a411e408629f" />

The predicate in the ternary fails to return true when it's supposed to because it's matching the plural and singular version of a word. e.g. in the above case, it doesn't match `minutes` and `minute` so it recurses and appends a "0 minutes".

Instead of comparing `minSuffix` and `suffix` we now just compare `precision` (the minimum unit) and the unit of the block.