### PR TITLE
feat(devservices): Add symbolicator-tests mode

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -254,6 +254,9 @@ x-sentry-service-config:
         post-process-forwarder-issue-platform,
       ]
     minimal: [postgres, snuba]
+    # The minimal set of services Symbolicator needs to run
+    # Sentry integration tests.
+    symbolicator-tests: [postgres, snuba, objectstore]
     uptime:
       [
         snuba,


### PR DESCRIPTION
Symbolicator runs Sentry tests as part of its CI to guard against regressions. Previously it set up Sentry devservices with the `minimal` mode, but since some tests now require `objectstore`, we make a new mode for this purpose that is just `minimal` + `objectstore`.

See https://github.com/getsentry/symbolicator/actions/runs/19644280253/job/56255551649?pr=1829 and https://github.com/getsentry/symbolicator/actions/runs/19644283114/job/56255561109?pr=1830 for examples of CI runs that this unblocks.

ref: https://github.com/getsentry/symbolicator/issues/1831 ref: SYMBOLI-40