### PR TITLE
ref: switch to type-fest for utility types

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "swc-plugin-component-annotate": "1.11.0",
     "ts-checker-rspack-plugin": "1.1.5",
     "tslib": "^2.8.1",
+    "type-fest": "^5.2.0",
     "typescript": "5.9.2",
     "zrender": "6.0.0",
     "zxcvbn": "^4.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+      type-fest:
+        specifier: ^5.2.0
+        version: 5.2.0
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -8183,6 +8186,10 @@ packages:
     resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}
     engines: {node: '>=10.0.0'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -8365,6 +8372,10 @@ packages:
   type-fest@4.37.0:
     resolution: {integrity: sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==}
     engines: {node: '>=16'}
+
+  type-fest@5.2.0:
+    resolution: {integrity: sha512-xxCJm+Bckc6kQBknN7i9fnP/xobQRsRQxR01CztFkp/h++yfVxUUcmMgfR2HttJx/dpWjS9ubVuyspJv24Q9DA==}
+    engines: {node: '>=20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -18395,6 +18406,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tagged-tag@1.0.0: {}
+
   tapable@2.2.1: {}
 
   tapable@2.2.2: {}
@@ -18549,6 +18562,10 @@ snapshots:
   type-fest@3.13.1: {}
 
   type-fest@4.37.0: {}
+
+  type-fest@5.2.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@1.6.18:
     dependencies:

--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
-
-import type {DistributiveOmit} from '@sentry/scraps/types';
+import type {DistributedOmit} from 'type-fest';
 
 import {FeatureBadge} from 'sentry/components/core/badge';
 import type {
@@ -19,7 +18,7 @@ type BaseProps = {
   featureType?: 'alpha' | 'beta' | 'new';
 };
 
-type SingleUnClearableProps = DistributiveOmit<
+type SingleUnClearableProps = DistributedOmit<
   SingleSelectProps<string>,
   'onChange' | 'multiple' | 'title' | 'value'
 > &
@@ -30,7 +29,7 @@ type SingleUnClearableProps = DistributiveOmit<
     multiple?: false;
   };
 
-type SingleClearableProps = DistributiveOmit<
+type SingleClearableProps = DistributedOmit<
   SingleSelectProps<string>,
   'onChange' | 'multiple' | 'title' | 'value'
 > &
@@ -43,7 +42,7 @@ type SingleClearableProps = DistributiveOmit<
 
 type SingleProps = SingleClearableProps | SingleUnClearableProps;
 
-type MultipleProps = DistributiveOmit<
+type MultipleProps = DistributedOmit<
   MultipleSelectProps<string>,
   'onChange' | 'multiple' | 'title' | 'value'
 > &
@@ -67,9 +66,9 @@ function OptionSelector({
   const mappedOptions = useMemo(() => {
     return options.map(opt => ({
       ...opt,
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+
       textValue: String(opt.label),
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+
       label: <Truncate value={String(opt.label)} maxLength={60} expandDirection="left" />,
     }));
   }, [options]);

--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -66,9 +66,9 @@ function OptionSelector({
   const mappedOptions = useMemo(() => {
     return options.map(opt => ({
       ...opt,
-
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
       textValue: String(opt.label),
-
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
       label: <Truncate value={String(opt.label)} maxLength={60} expandDirection="left" />,
     }));
   }, [options]);

--- a/static/app/components/core/alert/alert.tsx
+++ b/static/app/components/core/alert/alert.tsx
@@ -3,8 +3,7 @@ import {css, useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useHover} from '@react-aria/interactions';
 import classNames from 'classnames';
-
-import type {DistributiveOmit} from '@sentry/scraps/types';
+import type {DistributedOmit} from 'type-fest';
 
 import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {IconCheckmark, IconChevron, IconInfo, IconNot, IconWarning} from 'sentry/icons';
@@ -334,7 +333,7 @@ const Container = styled('div')`
 
 Alert.Container = Container;
 
-function AlertButton(props: DistributiveOmit<ButtonProps, 'size'>) {
+function AlertButton(props: DistributedOmit<ButtonProps, 'size'>) {
   const theme = useTheme();
   return <Button {...props} size={theme.isChonk ? 'zero' : 'sm'} />;
 }

--- a/static/app/components/core/compactSelect/compactSelect.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.tsx
@@ -1,7 +1,6 @@
 import {useId, useMemo} from 'react';
 import {Item, Section} from '@react-stately/collections';
-
-import type {DistributiveOmit} from '@sentry/scraps/types';
+import type {DistributedOmit} from 'type-fest';
 
 import {t} from 'sentry/locale';
 
@@ -26,10 +25,10 @@ interface BaseSelectProps<Value extends SelectKey>
 }
 
 export type SingleSelectProps<Value extends SelectKey> = BaseSelectProps<Value> &
-  DistributiveOmit<SingleListProps<Value>, 'children' | 'items' | 'grid' | 'label'>;
+  DistributedOmit<SingleListProps<Value>, 'children' | 'items' | 'grid' | 'label'>;
 
 export type MultipleSelectProps<Value extends SelectKey> = BaseSelectProps<Value> &
-  DistributiveOmit<MultipleListProps<Value>, 'children' | 'items' | 'grid' | 'label'>;
+  DistributedOmit<MultipleListProps<Value>, 'children' | 'items' | 'grid' | 'label'>;
 
 export type SelectProps<Value extends SelectKey> =
   | SingleSelectProps<Value>

--- a/static/app/components/core/compactSelect/composite.tsx
+++ b/static/app/components/core/compactSelect/composite.tsx
@@ -2,8 +2,7 @@ import {Children, useMemo} from 'react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {Item} from '@react-stately/collections';
-
-import type {DistributiveOmit} from '@sentry/scraps/types';
+import type {DistributedOmit} from 'type-fest';
 
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -30,7 +29,7 @@ interface BaseCompositeSelectRegion<Value extends SelectKey> {
  */
 type SingleCompositeSelectRegion<Value extends SelectKey> =
   BaseCompositeSelectRegion<Value> &
-    DistributiveOmit<SingleListProps<Value>, 'children' | 'items' | 'grid' | 'size'>;
+    DistributedOmit<SingleListProps<Value>, 'children' | 'items' | 'grid' | 'size'>;
 
 /**
  * A multiple-selection (multiple options can be selected at the same time) "region"
@@ -40,7 +39,7 @@ type SingleCompositeSelectRegion<Value extends SelectKey> =
  */
 type MultipleCompositeSelectRegion<Value extends SelectKey> =
   BaseCompositeSelectRegion<Value> &
-    DistributiveOmit<MultipleListProps<Value>, 'children' | 'items' | 'grid' | 'size'>;
+    DistributedOmit<MultipleListProps<Value>, 'children' | 'items' | 'grid' | 'size'>;
 
 /**
  * A "region" inside a composite select. Each "region" is a separated, self-contained

--- a/static/app/components/core/layout/flex.tsx
+++ b/static/app/components/core/layout/flex.tsx
@@ -1,7 +1,6 @@
 import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
-
-import type {DistributiveOmit} from '@sentry/scraps/types';
+import type {DistributedOmit} from 'type-fest';
 
 import {Container, type ContainerElement, type ContainerProps} from './container';
 import {getSpacing, rc, type Responsive, type SpacingSize} from './styles';
@@ -52,7 +51,7 @@ interface FlexLayoutProps {
   wrap?: Responsive<'nowrap' | 'wrap' | 'wrap-reverse'>;
 }
 
-export type FlexProps<T extends ContainerElement = 'div'> = DistributiveOmit<
+export type FlexProps<T extends ContainerElement = 'div'> = DistributedOmit<
   ContainerProps<T>,
   'display'
 > &

--- a/static/app/components/core/types.ts
+++ b/static/app/components/core/types.ts
@@ -1,4 +1,0 @@
-export type DistributiveOmit<
-  TObject,
-  TKey extends keyof TObject,
-> = TObject extends unknown ? Omit<TObject, TKey> : never;

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -1,7 +1,6 @@
 import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
-
-import type {DistributiveOmit} from '@sentry/scraps/types';
+import type {DistributedOmit} from 'type-fest';
 
 import {Button} from 'sentry/components/core/button';
 import {
@@ -50,7 +49,7 @@ export interface ChoiceMapperProps extends DefaultProps {
   /**
    * Props forwarded to the add mapping dropdown.
    */
-  addDropdown: DistributiveOmit<SingleSelectProps<string>, 'options' | 'clearable'> & {
+  addDropdown: DistributedOmit<SingleSelectProps<string>, 'options' | 'clearable'> & {
     items: Array<SelectOption<string>>;
     noResultsMessage?: string;
   };


### PR DESCRIPTION
[type-fest](https://github.com/sindresorhus/type-fest) is a well-maintained library that offers utility types (no runtime) like `DistributedOmit` that we can use instead of rolling our own.