### PR TITLE
Unconditionally store attachment metadata along event payload

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -126,7 +126,6 @@ class BaseAttachmentCache:
         key: str,
         attachments: list[CachedAttachment],
         timeout=None,
-        set_metadata=True,
         project: Project | None = None,
     ) -> list[dict]:
         for id, attachment in enumerate(attachments):
@@ -167,9 +166,6 @@ class BaseAttachmentCache:
         for attachment in attachments:
             attachment._cache = self
             meta.append(attachment.meta())
-
-        if set_metadata:
-            self.inner.set(ATTACHMENT_META_KEY.format(key=key), meta, timeout, raw=False)
 
         return meta
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -368,7 +368,7 @@ def do_process_event(
         has_changed = True
         data = new_data
 
-    attachments = data.pop("_attachments", None)
+    attachments = data.get("_attachments", None)
 
     # Second round of datascrubbing after stacktrace and language-specific
     # processing. First round happened as part of ingest.

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -70,16 +70,13 @@ def test_basic_chunked() -> None:
     cache.set_chunk("c:foo", 123, 2, b"Bye.")
 
     att = CachedAttachment(key="c:foo", id=123, name="lol.txt", content_type="text/plain", chunks=3)
-    cache.set("c:foo", [att])
+    (meta,) = cache.set("c:foo", [att])
+    att2 = CachedAttachment(cache=cache, **meta)
 
-    (att2,) = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 123
     assert att2.load_data() == att.load_data() == b"Hello World! Bye."
     assert att2.rate_limited is None
-
-    cache.delete("c:foo")
-    assert not list(cache.get("c:foo"))
 
 
 @django_db_all
@@ -88,16 +85,13 @@ def test_basic_unchunked() -> None:
     cache = BaseAttachmentCache(data)
 
     att = CachedAttachment(name="lol.txt", content_type="text/plain", data=b"Hello World! Bye.")
-    cache.set("c:foo", [att])
+    (meta,) = cache.set("c:foo", [att])
+    att2 = CachedAttachment(cache=cache, **meta)
 
-    (att2,) = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 0
     assert att2.load_data() == att.load_data() == b"Hello World! Bye."
     assert att2.rate_limited is None
-
-    cache.delete("c:foo")
-    assert not list(cache.get("c:foo"))
 
 
 @django_db_all
@@ -113,9 +107,9 @@ def test_zstd_chunks() -> None:
     assert mixed_chunks.load_data() == b"Hello World! Just visiting. Bye."
 
     att = CachedAttachment(key="not_chunked", id=456, data=b"Hello World! Bye.")
-    cache.set("not_chunked", [att])
+    (meta,) = cache.set("not_chunked", [att])
+    not_chunked = CachedAttachment(cache=cache, **meta)
 
-    (not_chunked,) = cache.get("not_chunked")
     assert not_chunked.load_data() == b"Hello World! Bye."
 
 
@@ -127,9 +121,9 @@ def test_basic_rate_limited() -> None:
     att = CachedAttachment(
         name="lol.txt", content_type="text/plain", data=b"Hello World! Bye.", rate_limited=True
     )
-    cache.set("c:foo", [att])
+    (meta,) = cache.set("c:foo", [att])
+    att2 = CachedAttachment(cache=cache, **meta)
 
-    (att2,) = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 0
     assert att2.load_data() == att.load_data() == b"Hello World! Bye."

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -343,19 +343,6 @@ def test_deobfuscate_view_hierarchy(default_project, task_runner, live_server) -
 
 
 @django_db_all
-@requires_symbolicator
-@pytest.mark.symbolicator
-@thread_leak_allowlist(reason="django dev server", issue=97036)
-def test_deobfuscate_view_hierarchy_processingstore(
-    default_project, task_runner, live_server
-) -> None:
-    with override_options(
-        {"system.url-prefix": live_server.url, "objectstore.processing_store.attachments": 1}
-    ):
-        do_process_view_hierarchy(default_project, task_runner)
-
-
-@django_db_all
 @requires_objectstore
 @requires_symbolicator
 @pytest.mark.symbolicator


### PR DESCRIPTION
Instead of storing attachment metadata in the attachment cache, this stores it alongside the event payload in the processing store.

This is independent of the attachment payloads themselves, which will eventually transition over to objectstore.

Kind of depends on full rollout in https://github.com/getsentry/sentry-options-automator/pull/5792

ref FS-224, FS-225