### PR TITLE
feat(objectstore): Improve host rewriting

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -26,7 +26,7 @@ from sentry.lang.native.sources import (
 from sentry.lang.native.utils import Backoff
 from sentry.models.project import Project
 from sentry.net.http import Session
-from sentry.objectstore import get_attachments_session, maybe_rewrite_url
+from sentry.objectstore import get_attachments_session, get_symbolicator_url
 from sentry.options.rollout import in_random_rollout
 from sentry.utils import metrics
 
@@ -197,8 +197,7 @@ class Symbolicator:
 
         if minidump.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
-            storage_url = session.object_url(minidump.stored_id)
-            storage_url = maybe_rewrite_url(storage_url)
+            storage_url = get_symbolicator_url(session, minidump.stored_id)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,
@@ -243,8 +242,7 @@ class Symbolicator:
 
         if report.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
-            storage_url = session.object_url(report.stored_id)
-            storage_url = maybe_rewrite_url(storage_url)
+            storage_url = get_symbolicator_url(session, report.stored_id)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import os
 import time
 import uuid
 from collections.abc import Callable
@@ -27,10 +26,9 @@ from sentry.lang.native.sources import (
 from sentry.lang.native.utils import Backoff
 from sentry.models.project import Project
 from sentry.net.http import Session
-from sentry.objectstore import get_attachments_session
+from sentry.objectstore import get_attachments_session, maybe_rewrite_url
 from sentry.options.rollout import in_random_rollout
 from sentry.utils import metrics
-from sentry.utils.env import in_test_environment
 
 MAX_ATTEMPTS = 3
 
@@ -200,7 +198,7 @@ class Symbolicator:
         if minidump.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
             storage_url = session.object_url(minidump.stored_id)
-            storage_url = maybe_rewrite_objectstore_url(storage_url)
+            storage_url = maybe_rewrite_url(storage_url)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,
@@ -246,7 +244,7 @@ class Symbolicator:
         if report.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
             storage_url = session.object_url(report.stored_id)
-            storage_url = maybe_rewrite_objectstore_url(storage_url)
+            storage_url = maybe_rewrite_url(storage_url)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,
@@ -541,17 +539,3 @@ class SymbolicatorSession:
 
     def reset_worker_id(self):
         self.worker_id = uuid.uuid4().hex
-
-
-def maybe_rewrite_objectstore_url(url: str) -> str:
-    """
-    This is needed during development/testing to make Symbolicator reach Objectstore.
-    This is because Sentry can reach Objectstore on 127.0.0.1 but Symbolicator cannot, as it's running in its own container.
-
-    Set USE_LOCAL_SYMBOLICATOR=1 if you are using a local (not containerized) instance of Symbolicator to disable this rewriting.
-    """
-    if os.environ.get("USE_LOCAL_SYMBOLICATOR"):
-        return url
-    if settings.IS_DEV or in_test_environment():
-        url = url.replace("127.0.0.1", "objectstore")
-    return url

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 import time
 import uuid
 from collections.abc import Callable
@@ -547,8 +548,10 @@ def maybe_rewrite_objectstore_url(url: str) -> str:
     This is needed during development/testing to make Symbolicator reach Objectstore.
     This is because Sentry can reach Objectstore on 127.0.0.1 but Symbolicator cannot, as it's running in its own container.
 
-    Note: if you are using a local (not containerized) instance of Symbolicator, you need to disable this logic.
+    Set USE_LOCAL_SYMBOLICATOR=1 if you are using a local (not containerized) instance of Symbolicator to disable this rewriting.
     """
+    if os.environ.get("USE_LOCAL_SYMBOLICATOR"):
+        return url
     if settings.IS_DEV or in_test_environment():
         url = url.replace("127.0.0.1", "objectstore")
     return url

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -70,8 +70,7 @@ def get_symbolicator_url(session: Session, key: str) -> str:
         docker_ps = subprocess.run(
             ["docker", "ps", "--format", "{{.Names}}"], capture_output=True, text=True
         )
-        if "symbolicator" in docker_ps.stdout:
-            _IS_SYMBOLICATOR_CONTAINER = True
+        _IS_SYMBOLICATOR_CONTAINER = "symbolicator" in docker_ps.stdout
 
     if not _IS_SYMBOLICATOR_CONTAINER:
         return url

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -67,12 +67,13 @@ def get_symbolicator_url(session: Session, key: str) -> str:
 
     While in development or testing, we might need to replace the hostname, depending on how Symbolicator is running.
     This function runs a `docker ps` to automatically return the correct URL in the following 2 cases:
-        - Symbolicator running in Docker (possibly via `devservices`): This is the scenario that mirrors `sentry`'s CI.
+        - Symbolicator running in Docker (possibly via `devservices`) -- this mirrors `sentry`'s CI.
           If this is detected, we replace Objectstore's hostname with the one reachable in the Docker network.
 
           Note that this approach doesn't work if Objectstore is running both locally and in Docker, as we'll always
           rewrite the URL to the Docker one, so Sentry and Symbolicator might attempt to talk to 2 different Objectstores.
-        - Symbolicator running locally: we don't need to rewrite the URL in that case.
+        - Symbolicator running locally -- this mirrors `symbolicator`'s CI.
+          In this case, we don't need to rewrite the URL.
     """
     global _IS_SYMBOLICATOR_CONTAINER  # Cached to avoid running `docker ps` multiple times
 

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from urllib.parse import urlparse, urlunparse
 
 from objectstore_client import Client, MetricsBackend, Session, TimeToLive, Usecase
 from objectstore_client.metrics import Tags
@@ -49,3 +50,16 @@ def get_attachments_session(org: int, project: int) -> Session:
         )
 
     return _ATTACHMENTS_CLIENT.session(_ATTACHMENTS_USECASE, org=org, project=project)
+
+
+def maybe_rewrite_url(url: str) -> str:
+    from sentry import options
+
+    replacement = options.get("objectstore.host_replacement")
+    if not replacement:
+        return url
+    parsed = urlparse(url)
+    if parsed.port:
+        replacement += f":{parsed.port}"
+    updated = parsed._replace(netloc=replacement)
+    return urlunparse(updated)

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -68,6 +68,7 @@ def get_symbolicator_url(session: Session, key: str) -> str:
     if "symbolicator" not in docker_ps.stdout:
         return url
 
+    # Symbolicator is running in Docker, use the Docker hostname for Objectstore
     replacement = "objectstore"
     parsed = urlparse(url)
     if parsed.port:

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -65,9 +65,6 @@ def get_symbolicator_url(session: Session, key: str) -> str:
     docker_ps = subprocess.run(
         ["docker", "ps", "--format", "{{.Names}}"], capture_output=True, text=True
     )
-    if docker_ps.returncode != 0:
-        raise RuntimeError("Failed to run docker ps")
-
     if "symbolicator" not in docker_ps.stdout:
         return url
 

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from objectstore_client import Client, MetricsBackend, Session, TimeToLive, Usecase
 from objectstore_client.metrics import Tags
 
-from sentry import options
 from sentry.utils import metrics as sentry_metrics
 from sentry.utils.env import in_test_environment
 
@@ -45,9 +44,11 @@ _ATTACHMENTS_USECASE = Usecase("attachments", expiration_policy=TimeToLive(timed
 def get_attachments_session(org: int, project: int) -> Session:
     global _ATTACHMENTS_CLIENT
     if not _ATTACHMENTS_CLIENT:
-        config = options.get("objectstore.config")
+        from sentry import options as options_store
+
+        options = options_store.get("objectstore.config")
         _ATTACHMENTS_CLIENT = Client(
-            config["base_url"],
+            options["base_url"],
             metrics_backend=SentryMetricsBackend(),
         )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -388,6 +388,15 @@ register(
     default={"base_url": "http://127.0.0.1:8888"},
     flags=FLAG_NOSTORE,
 )
+# Replacement for the host part of URLs to Objectstore
+# This replacement is carried out by the `maybe_rewrite_url` function in `src/sentry/objectstore/__init__.py`
+# This should be used for local development and testing, where services can be ran either locally or in containers
+# By default, assumes that Sentry runs as a local process while other services run in containers, as in `sentry`'s CI
+register(
+    "objectstore.host_replacement",
+    default=os.environ.get("SENTRY_OBJECTSTORE_HOST_REPLACEMENT") or "objectstore",
+    flags=FLAG_NOSTORE,
+)
 
 
 # Symbol server

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -389,6 +389,7 @@ register(
     flags=FLAG_NOSTORE,
 )
 
+
 # Symbol server
 register(
     "symbolserver.enabled",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1,7 +1,5 @@
 import os
 
-from django.conf import settings
-
 from sentry.logging import LoggingFormat
 from sentry.options import register
 from sentry.options.manager import (
@@ -18,7 +16,6 @@ from sentry.options.manager import (
     FLAG_SCALAR,
 )
 from sentry.quotas.base import build_metric_abuse_quotas
-from sentry.utils.env import in_test_environment
 from sentry.utils.types import Any, Bool, Dict, Float, Int, Sequence, String
 
 # Cache
@@ -391,18 +388,6 @@ register(
     default={"base_url": "http://127.0.0.1:8888"},
     flags=FLAG_NOSTORE,
 )
-# Replacement for the host part of URLs to Objectstore
-# This replacement is carried out by the `maybe_rewrite_url` function in `src/sentry/objectstore/__init__.py`
-# This should be used for local development and testing, where services can run either locally or in containers
-# By default, assumes that Sentry runs as a local process while other services run in containers
-# This is compatible with `sentry`'s CI and generally development workflows using `devservices`
-register(
-    "objectstore.host_replacement",
-    default=os.environ.get("SENTRY_OBJECTSTORE_HOST_REPLACEMENT")
-    or ("objectstore" if settings.IS_DEV or in_test_environment() else None),
-    flags=FLAG_NOSTORE,
-)
-
 
 # Symbol server
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -390,8 +390,9 @@ register(
 )
 # Replacement for the host part of URLs to Objectstore
 # This replacement is carried out by the `maybe_rewrite_url` function in `src/sentry/objectstore/__init__.py`
-# This should be used for local development and testing, where services can be ran either locally or in containers
-# By default, assumes that Sentry runs as a local process while other services run in containers, as in `sentry`'s CI
+# This should be used for local development and testing, where services can run either locally or in containers
+# By default, assumes that Sentry runs as a local process while other services run in containers
+# This is compatible with `sentry`'s CI and generally development workflows using `devservices`
 register(
     "objectstore.host_replacement",
     default=os.environ.get("SENTRY_OBJECTSTORE_HOST_REPLACEMENT") or "objectstore",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1,5 +1,7 @@
 import os
 
+from django.conf import settings
+
 from sentry.logging import LoggingFormat
 from sentry.options import register
 from sentry.options.manager import (
@@ -16,6 +18,7 @@ from sentry.options.manager import (
     FLAG_SCALAR,
 )
 from sentry.quotas.base import build_metric_abuse_quotas
+from sentry.utils.env import in_test_environment
 from sentry.utils.types import Any, Bool, Dict, Float, Int, Sequence, String
 
 # Cache
@@ -395,7 +398,8 @@ register(
 # This is compatible with `sentry`'s CI and generally development workflows using `devservices`
 register(
     "objectstore.host_replacement",
-    default=os.environ.get("SENTRY_OBJECTSTORE_HOST_REPLACEMENT") or "objectstore",
+    default=os.environ.get("SENTRY_OBJECTSTORE_HOST_REPLACEMENT")
+    or ("objectstore" if settings.IS_DEV or in_test_environment() else None),
     flags=FLAG_NOSTORE,
 )
 


### PR DESCRIPTION
The previous setup with `maybe_rewrite_objectstore_url` didn't work if you were using a local Symbolicator.
This happens, for example, in Symbolicator's CI, where both Sentry and Symbolicator are ran locally.

We introduce a new utility to get the URL to an object from Symbolicator's point of view, replacing `maybe_rewrite_objectstore_url`.
This checks whether a Symbolicator container is detected, therefore it doesn't require any extra env vars/settings from the user.