### PR TITLE
feat(deletions): Retry timed out tasks

### DIFF
--- a/src/sentry/deletions/tasks/scheduled.py
+++ b/src/sentry/deletions/tasks/scheduled.py
@@ -105,7 +105,7 @@ def _run_scheduled_deletions(
     ),
     silo_mode=SiloMode.CONTROL,
 )
-@retry(exclude=(DeleteAborted,))
+@retry(exclude=(DeleteAborted, timeouts=True))
 def run_deletion_control(deletion_id: int, first_pass: bool = True, **kwargs: Any) -> None:
     _run_deletion(
         deletion_id=deletion_id,

--- a/src/sentry/deletions/tasks/scheduled.py
+++ b/src/sentry/deletions/tasks/scheduled.py
@@ -126,7 +126,7 @@ def run_deletion_control(deletion_id: int, first_pass: bool = True, **kwargs: An
     ),
     silo_mode=SiloMode.REGION,
 )
-@retry(exclude=(DeleteAborted,))
+@retry(exclude=(DeleteAborted,), timeouts=True)
 def run_deletion(deletion_id: int, first_pass: bool = True, **kwargs: Any) -> None:
     _run_deletion(
         deletion_id=deletion_id,

--- a/src/sentry/deletions/tasks/scheduled.py
+++ b/src/sentry/deletions/tasks/scheduled.py
@@ -105,7 +105,7 @@ def _run_scheduled_deletions(
     ),
     silo_mode=SiloMode.CONTROL,
 )
-@retry(exclude=(DeleteAborted, timeouts=True))
+@retry(exclude=(DeleteAborted, ), timeouts=True)
 def run_deletion_control(deletion_id: int, first_pass: bool = True, **kwargs: Any) -> None:
     _run_deletion(
         deletion_id=deletion_id,

--- a/src/sentry/deletions/tasks/scheduled.py
+++ b/src/sentry/deletions/tasks/scheduled.py
@@ -105,7 +105,7 @@ def _run_scheduled_deletions(
     ),
     silo_mode=SiloMode.CONTROL,
 )
-@retry(exclude=(DeleteAborted, ), timeouts=True)
+@retry(exclude=(DeleteAborted,), timeouts=True)
 def run_deletion_control(deletion_id: int, first_pass: bool = True, **kwargs: Any) -> None:
     _run_deletion(
         deletion_id=deletion_id,


### PR DESCRIPTION
Scheduled deletions can take a long time, we should retry the task if we time out.

I know that it will be retried on the [next reattempt deletions schedule](https://github.com/getsentry/sentry/blob/eb7471ad2bd21baea397b860197c5e15474519da/src/sentry/conf/server.py#L1008) but I want to make a lot more progress during the two hours window (5 re-attempts for 20 minutes each run).

Fixes [SENTRY-41GE](https://sentry.sentry.io/issues/6683627821/).