### PR TITLE
ref(redis): Do not use redis-blaster for snowflake IDs generation

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -195,6 +195,7 @@ SENTRY_WEEKLY_REPORTS_REDIS_CLUSTER = "default"
 SENTRY_HYBRIDCLOUD_DELETIONS_REDIS_CLUSTER = "default"
 SENTRY_SESSION_STORE_REDIS_CLUSTER = "default"
 SENTRY_AUTH_IDPMIGRATION_REDIS_CLUSTER = "default"
+SENTRY_SNOWFLAKE_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses


### PR DESCRIPTION
<!-- Describe your PR here. -->

Migrate snowflake generation away from redis-blaster based client.

To make sure that we have a separate sequence for each model we now include its redis key in the timestamp key. https://github.com/getsentry/sentry/pull/102638#discussion_r2527979871