### PR TITLE
chore: Remove vercel logs feature flag from backend

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -327,8 +327,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:relay-otlp-traces-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables OTLP Log ingestion in Relay for an entire org.
     manager.add("organizations:relay-otel-logs-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables Vercel Log Drain ingestion in Relay for an entire org.
-    manager.add("organizations:relay-vercel-log-drain-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Prevent AI in the Sentry UI
     manager.add("organizations:prevent-ai", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Prevent AI Configuration Page in the Sentry UI

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -73,7 +73,6 @@ EXPOSABLE_FEATURES = [
     "organizations:indexed-spans-extraction",
     "organizations:relay-otlp-traces-endpoint",
     "organizations:relay-otel-logs-endpoint",
-    "organizations:relay-vercel-log-drain-endpoint",
     "organizations:ourlogs-ingestion",
     "organizations:tracemetrics-ingestion",
     "organizations:view-hierarchy-scrubbing",


### PR DESCRIPTION
The Vercel Log Drain is now GA (https://github.com/getsentry/sentry-options-automator/pull/5786, https://docs.sentry.io/product/drains/integration/vercel/#log-drains).

We need to start cleaning up the feature flags. This PR removes the flag from the backend.

resolves https://linear.app/getsentry/issue/LOGS-395/clean-up-feature-flags-for-vercel-log-drains

We've done this on the frontend (https://github.com/getsentry/sentry/pull/103940) and relay (https://github.com/getsentry/relay/pull/5406), and [relay has deployed](https://deploy.getsentry.net/go/compare/deploy-relay-pop/532/with/533), so this is a safe change.