### PR TITLE
fix(ourlogs): Add drawer QP and fix scroll

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -43,6 +43,10 @@ interface LogIssueDrawerProps {
   event: Event;
   group: Group;
   project: Project;
+  additionalData?: {
+    event?: Event;
+    scrollToDisabled?: boolean;
+  };
   embeddedOptions?: {
     openWithExpandedIds?: string[];
   };
@@ -53,6 +57,7 @@ export function OurlogsDrawer({
   project,
   group,
   embeddedOptions,
+  additionalData: propAdditionalData,
 }: LogIssueDrawerProps) {
   const organization = useOrganization();
   const setLogsQuery = useSetQueryParamsQuery();
@@ -81,8 +86,9 @@ export function OurlogsDrawer({
   const additionalData = useMemo(
     () => ({
       event,
+      scrollToDisabled: propAdditionalData?.scrollToDisabled,
     }),
-    [event]
+    [event, propAdditionalData?.scrollToDisabled]
   );
 
   const exploreUrl = useMemo(() => {

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -79,6 +79,12 @@ export const LOGS_INSTRUCTIONS_URL =
 
 export const LOGS_FILTER_KEY_SECTIONS: FilterKeySection[] = [LOGS_FILTERS];
 
+/**
+ * Query parameter key for controlling the logs drawer state.
+ * When this parameter is set to 'true', the logs drawer should open automatically.
+ */
+export const LOGS_DRAWER_QUERY_PARAM = 'logsDrawer';
+
 export const VIRTUAL_STREAMED_INTERVAL_MS = 250;
 export const MINIMUM_INFINITE_SCROLL_FETCH_COOLDOWN_MS = 1000;
 

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -179,3 +179,9 @@ export const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
   distribution: 'p75',
   gauge: 'avg',
 };
+
+/**
+ * Query parameter key for controlling the metrics drawer state.
+ * When this parameter is set to 'true', the metrics drawer should open automatically.
+ */
+export const METRICS_DRAWER_QUERY_PARAM = 'metricsDrawer';


### PR DESCRIPTION
### Summary
This fixes draw scrollTo for log exceptions to not infinitely scroll, and fixes both metrics and logs to have a query param to have it open for linking.
