### PR TITLE
chore(explore): Hard code sdk name and version as span string attrs

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -55,6 +55,8 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanFields.NORMALIZED_DESCRIPTION,
   SpanFields.RELEASE, // temporary as orgs with >1k keys still want releases
   SpanFields.PROJECT_ID,
+  SpanFields.SDK_NAME,
+  SpanFields.SDK_VERSION,
   SpanFields.SPAN_SYSTEM,
   SpanFields.SPAN_CATEGORY,
 ];


### PR DESCRIPTION
Hard code sdk.name and sdk.version into span string attrs. More orgs are running into the limit and for now, we'll hard code in more sentry attributes while we figure out a path forwards.