### PR TITLE
fix(tracemetrics): Fix analytics firing

### DIFF
--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -740,7 +740,7 @@ export function useMetricsPanelAnalytics({
       return;
     }
 
-    if (metricSamplesTableResult.result.isFetching || !metricTimeseriesResult.isPending) {
+    if (metricSamplesTableResult.result.isFetching || metricTimeseriesResult.isPending) {
       return;
     }
 
@@ -810,7 +810,7 @@ export function useMetricsPanelAnalytics({
 
     if (
       metricAggregatesTableResult.result.isPending ||
-      !metricTimeseriesResult.isPending
+      metricTimeseriesResult.isPending
     ) {
       return;
     }


### PR DESCRIPTION
### Summary
Metadata panel should fire and not be based on pending.

Closes LOGS-517


