### PR TITLE
feat(triage signals): Auto Trigger default settings change [feature flagged]

### DIFF
--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -327,8 +327,11 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     },
   ];
 
+  // When triage signals flag is on, toggle defaults to checked unless explicitly 'off'
+  // - New orgs (undefined): shows checked, persists on form interaction
+  // - Existing orgs with 'off': shows unchecked, preserves their choice
   const automationTuning = isTriageSignalsFeatureOn
-    ? (project.autofixAutomationTuning ?? 'off') !== 'off'
+    ? project.autofixAutomationTuning !== 'off'
     : (project.autofixAutomationTuning ?? 'off');
 
   return (
@@ -346,6 +349,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
         initialData={{
           seerScannerAutomation: project.seerScannerAutomation ?? false,
           // Same DB field, different UI: toggle (boolean) vs dropdown (string)
+          // When triage signals flag is on, default to true (ON)
           autofixAutomationTuning: automationTuning,
           automated_run_stopping_point: preference?.automation_handoff
             ? 'cursor_handoff'


### PR DESCRIPTION
## PR Details
+ When `triage-signals-v0` feature flag is enabled, the "Auto-Trigger Fixes" toggle defaults to checked for new projects (undefined value). Setting persists on user interaction with the form.
+ Existing projects with automation explicitly disabled (`'off'`) will see the toggle unchecked, moving them over will be handled in the onboarding billing logic. 