### PR TITLE
chore(preprod): make build details and build compare breadcrumb consistent (EME-657, EME-659)

### DIFF
--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -12,7 +12,7 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {IconCode, IconDownload, IconJson, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {
   isSizeInfoCompleted,
   type BuildDetailsApiResponse,
@@ -24,6 +24,7 @@ import {
   getPlatformIconFromPlatform,
   getReadablePlatformLabel,
 } from 'sentry/views/preprod/utils/labelUtils';
+import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 
 interface BuildCompareHeaderContentProps {
   buildDetails: BuildDetailsApiResponse;
@@ -32,22 +33,29 @@ interface BuildCompareHeaderContentProps {
 
 export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps) {
   const {buildDetails, projectId} = props;
-  const organization = useOrganization();
   const theme = useTheme();
+  const project = ProjectsStore.getBySlug(projectId);
   const labels = getLabels(buildDetails.app_info?.platform ?? undefined);
   const breadcrumbs: Crumb[] = [
     {
-      to: '#',
+      to: makeReleasesUrl(project?.id, {}),
       label: t('Releases'),
     },
-    {
-      to: `/organizations/${organization.slug}/preprod/${projectId}/${buildDetails.id}/`,
-      label: buildDetails.app_info.version ?? t('Build Version'),
-    },
-    {
-      label: t('Compare'),
-    },
   ];
+
+  if (buildDetails.app_info.version) {
+    breadcrumbs.push({
+      to: makeReleasesUrl(project?.id, {
+        version: buildDetails.app_info.version,
+        appId: buildDetails.app_info.app_id ?? undefined,
+      }),
+      label: buildDetails.app_info.version,
+    });
+  }
+
+  breadcrumbs.push({
+    label: t('Compare'),
+  });
 
   return (
     <Flex justify="between" align="center" gap="lg">

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -38,7 +38,9 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
   const labels = getLabels(buildDetails.app_info?.platform ?? undefined);
   const breadcrumbs: Crumb[] = [
     {
-      to: makeReleasesUrl(project?.id, {}),
+      to: makeReleasesUrl(project?.id, {
+        appId: buildDetails.app_info.app_id ?? undefined,
+      }),
       label: t('Releases'),
     },
   ];

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -29,34 +29,9 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 
 import {useBuildDetailsActions} from './useBuildDetailsActions';
-
-function makeReleasesUrl(
-  projectId: string | undefined,
-  query: {appId?: string; version?: string}
-): string {
-  const {appId, version} = query;
-
-  // Not knowing the projectId should be transient.
-  if (projectId === undefined) {
-    return '#';
-  }
-
-  const params = new URLSearchParams();
-  params.set('project', projectId);
-  const parts = [];
-  if (appId) {
-    parts.push(`release.package:${appId}`);
-  }
-  if (version) {
-    parts.push(`release.version:${version}`);
-  }
-  if (parts.length) {
-    params.set('query', parts.join(' '));
-  }
-  return `/explore/releases/?${params}`;
-}
 
 interface BuildDetailsHeaderContentProps {
   artifactId: string;
@@ -107,9 +82,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   const breadcrumbs: Crumb[] = [
     {
-      to: makeReleasesUrl(project?.id, {
-        version: buildDetailsData.app_info.version ?? undefined,
-      }),
+      to: makeReleasesUrl(project?.id, {}),
       label: 'Releases',
     },
   ];

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -82,7 +82,9 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   const breadcrumbs: Crumb[] = [
     {
-      to: makeReleasesUrl(project?.id, {}),
+      to: makeReleasesUrl(project?.id, {
+        appId: buildDetailsData.app_info.app_id ?? undefined,
+      }),
       label: 'Releases',
     },
   ];

--- a/static/app/views/preprod/utils/releasesUrl.ts
+++ b/static/app/views/preprod/utils/releasesUrl.ts
@@ -1,0 +1,25 @@
+export function makeReleasesUrl(
+  projectId: string | undefined,
+  query: {appId?: string; version?: string}
+): string {
+  const {appId, version} = query;
+
+  // Not knowing the projectId should be transient.
+  if (projectId === undefined) {
+    return '#';
+  }
+
+  const params = new URLSearchParams();
+  params.set('project', projectId);
+  const parts = [];
+  if (appId) {
+    parts.push(`release.package:${appId}`);
+  }
+  if (version) {
+    parts.push(`release.version:${version}`);
+  }
+  if (parts.length) {
+    params.set('query', parts.join(' '));
+  }
+  return `/explore/releases/?${params}`;
+}


### PR DESCRIPTION
make behavior consistent for breadcrumb nav across compare and build details

https://github.com/user-attachments/assets/2f89d873-3e80-49bd-8cec-d79078b63b16

