### PR TITLE
chore(ACI): Remove temporary fallthrough type logic

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -47,12 +47,6 @@ class EmailActionHandler(ActionHandler):
                 "description": "The fallthrough type for issue owners email notifications",
                 "enum": [*FallthroughChoiceType],
             },
-            # XXX(CEO): temporarily support this incorrect camel case
-            "fallthroughType": {
-                "type": "string",
-                "description": "The fallthrough type for issue owners email notifications",
-                "enum": [*FallthroughChoiceType],
-            },
         },
         "additionalProperties": False,
     }

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
@@ -51,13 +51,7 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
         }
 
         if target_type == ActionTarget.ISSUE_OWNERS.value:
-            # XXX(CEO): temporarily handle both fallthroughType and fallthrough_type
-            action_data = action.data.copy()
-            if action.data.get("fallthroughType"):
-                del action_data["fallthroughType"]
-                action_data["fallthrough_type"] = action.data["fallthroughType"]
-
-            blob = EmailDataBlob(**action_data)
+            blob = EmailDataBlob(**action.data)
             final_blob[EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value] = blob.fallthrough_type
 
         return final_blob

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -606,26 +606,6 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
             blob = self.handler.build_rule_action_blob(action, self.organization.id)
             assert blob == healed
 
-    def test_build_rule_action_blob_fallthrough_type_camel_case(self) -> None:
-        """
-        Test that while we are temporarily allowing both fallthroughType and fallthrough_type in Action.data
-        that both work when building the action data blob and result in the snake case version
-        """
-        action = Action.objects.create(
-            type=Action.Type.EMAIL,
-            data={"fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS},
-            config={
-                "target_type": ActionTarget.ISSUE_OWNERS,
-                "target_identifier": None,
-            },
-        )
-        blob = self.handler.build_rule_action_blob(action, self.organization.id)
-        assert blob == {
-            "fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS,
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-        }
-
 
 class TestPluginIssueAlertHandler(BaseWorkflowTest):
     def setUp(self) -> None:

--- a/tests/sentry/workflow_engine/migrations/test_0104_action_data_fallthrough_type.py
+++ b/tests/sentry/workflow_engine/migrations/test_0104_action_data_fallthrough_type.py
@@ -1,9 +1,12 @@
+import pytest
+
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import TestMigrations
 from sentry.workflow_engine.models import Action
 
 
+@pytest.mark.skip
 class TestActionDataFallthroughType(TestMigrations):
     migrate_from = "0103_add_unique_constraint"
     migrate_to = "0104_action_data_fallthrough_type"


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/103764 - once the migration is complete we can remove the temporary logic to support the incorrect case. 