### PR TITLE
feat(seer_grouping): Filter Seer grouping requests by token count instead of frame count

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -12,7 +12,7 @@ from sentry import options
 from sentry.constants import DATA_ROOT
 from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
-from sentry.grouping.variants import BaseVariant, ComponentVariant
+from sentry.grouping.variants import BaseVariant
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -350,12 +350,10 @@ def stacktrace_exceeds_limits(
     # is using it for grouping (in which case none of the below conditions should apply), but still
     # worth checking that we have enough information to answer the question just in case
     if (
-        # Fingerprint, checksum, fallback variants
-        not isinstance(contributing_variant, ComponentVariant)
-        # Security violations, log-message-based grouping
-        or contributing_variant.variant_name == "default"
         # Any ComponentVariant will have this, but this reassures mypy
-        or not contributing_component
+        not contributing_component
+        # Filter out events that don't use stacktrace-based grouping
+        or "stacktrace" not in contributing_variant.key
     ):
         # We don't bother to collect a metric on this outcome, because we shouldn't have called the
         # function in the first place

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -350,7 +350,7 @@ def stacktrace_exceeds_limits(
     # is using it for grouping (in which case none of the below conditions should apply), but still
     # worth checking that we have enough information to answer the question just in case
     if (
-        # Any ComponentVariant will have this, but this reassures mypy
+        # Should always have it, but this reassures mypy
         not contributing_component
         # Filter out events that don't use stacktrace-based grouping
         or "stacktrace" not in contributing_variant.key

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -337,7 +337,7 @@ def stacktrace_exceeds_limits(
     Check if a stacktrace exceeds length limits for Seer similarity analysis.
 
     For platforms that bypass length checks (to maintain consistency with backfilled data),
-    all stacktraces pass through. For other platforms, uses a two-step approach:
+    all stacktraces pass through. For other platforms, we use a two-step approach:
     1. First check raw string length - if shorter than token limit, pass immediately
     2. Only if string is long enough to potentially exceed limit, run expensive token count
     """
@@ -373,6 +373,9 @@ def stacktrace_exceeds_limits(
         return False
 
     max_token_count = options.get("seer.similarity.max_token_count")
+
+    stacktrace_type = "in_app" if contributing_variant.variant_name == "app" else "system"
+    shared_tags["stacktrace_type"] = stacktrace_type
 
     # raw string length check
     stacktrace_text = event.data.get("stacktrace_string")

--- a/tests/sentry/grouping/seer_similarity/test_seer.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer.py
@@ -5,7 +5,6 @@ from sentry import options
 from sentry.grouping.ingest.seer import maybe_check_seer_for_matching_grouphash
 from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.types import GroupingVersion
-from sentry.seer.similarity.utils import MAX_FRAME_COUNT
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
 
@@ -75,72 +74,6 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
     @patch("sentry.grouping.ingest.seer.record_did_call_seer_metric")
     @patch("sentry.grouping.ingest.seer.get_seer_similar_issues")
     @patch("sentry.seer.similarity.utils.metrics")
-    def test_too_many_frames(
-        self,
-        mock_metrics: MagicMock,
-        mock_get_similar_issues: MagicMock,
-        mock_record_did_call_seer: MagicMock,
-    ) -> None:
-        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
-
-        error_type = "FailedToFetchError"
-        error_value = "Charlie didn't bring the ball back"
-        context_line = f"raise {error_type}('{error_value}')"
-        new_event = Event(
-            project_id=self.project.id,
-            event_id="22312012112120120908201304152013",
-            data={
-                "title": f"{error_type}('{error_value}')",
-                "exception": {
-                    "values": [
-                        {
-                            "type": error_type,
-                            "value": error_value,
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": f"play_fetch_{i}",
-                                        "filename": f"dogpark{i}.py",
-                                        "context_line": context_line,
-                                    }
-                                    for i in range(MAX_FRAME_COUNT + 1)
-                                ]
-                            },
-                        }
-                    ]
-                },
-                "platform": "java",
-            },
-        )
-
-        new_grouphash = GroupHash.objects.create(
-            project=self.project, group=new_event.group, hash=new_event.get_primary_hash()
-        )
-        group_hashes = list(GroupHash.objects.filter(project_id=self.project.id))
-        maybe_check_seer_for_matching_grouphash(
-            new_event, new_grouphash, new_event.get_grouping_variants(), group_hashes
-        )
-
-        sample_rate = options.get("seer.similarity.metrics_sample_rate")
-        mock_metrics.incr.assert_any_call(
-            "grouping.similarity.stacktrace_length_filter",
-            sample_rate=sample_rate,
-            tags={
-                "platform": "java",
-                "referrer": "ingest",
-                "stacktrace_type": "system",
-                "outcome": "block_frames",
-            },
-        )
-        mock_record_did_call_seer.assert_any_call(
-            new_event, call_made=False, blocker="stacktrace-too-long"
-        )
-
-        mock_get_similar_issues.assert_not_called()
-
-    @patch("sentry.grouping.ingest.seer.record_did_call_seer_metric")
-    @patch("sentry.grouping.ingest.seer.get_seer_similar_issues")
-    @patch("sentry.seer.similarity.utils.metrics")
     def test_too_many_tokens(
         self,
         mock_metrics: MagicMock,
@@ -172,9 +105,7 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                                             "filename": f"dogpark{i}.py",
                                             "context_line": context_line,
                                         }
-                                        for i in range(
-                                            3
-                                        )  # Just 3 frames, well under MAX_FRAME_COUNT
+                                        for i in range(3)  # Just 3 frames
                                     ]
                                 },
                             }
@@ -199,7 +130,6 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                 tags={
                     "platform": "java",
                     "referrer": "ingest",
-                    "stacktrace_type": "system",
                     "outcome": "block_tokens",
                 },
             )
@@ -210,38 +140,43 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
             mock_get_similar_issues.assert_not_called()
 
     @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
-    def test_too_many_frames_bypassed_platform(self, mock_get_similarity_data: MagicMock) -> None:
+    def test_bypassed_platform_calls_seer_regardless_of_length(
+        self, mock_get_similarity_data: MagicMock
+    ) -> None:
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
-        error_type = "FailedToFetchError"
-        error_value = "Charlie didn't bring the ball back"
-        context_line = f"raise {error_type}('{error_value}')"
-        new_event = Event(
-            project_id=self.project.id,
-            event_id="22312012112120120908201304152013",
-            data={
-                "title": f"{error_type}('{error_value}')",
-                "exception": {
-                    "values": [
-                        {
-                            "type": error_type,
-                            "value": error_value,
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": f"play_fetch_{i}",
-                                        "filename": f"dogpark{i}.py",
-                                        "context_line": context_line,
-                                    }
-                                    for i in range(MAX_FRAME_COUNT + 1)
-                                ]
-                            },
-                        }
-                    ]
+        # Set a low token limit to ensure the stacktrace would be blocked if not bypassed
+        with self.options({"seer.similarity.max_token_count": 100}):
+            error_type = "FailedToFetchError"
+            error_value = "Charlie didn't bring the ball back"
+            context_line = f"raise {error_type}('{error_value}')"
+            # Create a stacktrace that would exceed the token limit if not bypassed
+            new_event = Event(
+                project_id=self.project.id,
+                event_id="22312012112120120908201304152013",
+                data={
+                    "title": f"{error_type}('{error_value}')",
+                    "exception": {
+                        "values": [
+                            {
+                                "type": error_type,
+                                "value": error_value,
+                                "stacktrace": {
+                                    "frames": [
+                                        {
+                                            "function": f"play_fetch_{i}",
+                                            "filename": f"dogpark{i}.py",
+                                            "context_line": context_line,
+                                        }
+                                        for i in range(20)
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                    "platform": "python",
                 },
-                "platform": "python",
-            },
-        )
+            )
 
         new_grouphash = GroupHash.objects.create(
             project=self.project, group=new_event.group, hash=new_event.get_primary_hash()

--- a/tests/sentry/grouping/seer_similarity/test_seer.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer.py
@@ -131,6 +131,7 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                     "platform": "java",
                     "referrer": "ingest",
                     "outcome": "block_tokens",
+                    "stacktrace_type": "system",
                 },
             )
             mock_record_did_call_seer.assert_any_call(
@@ -178,31 +179,31 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                 },
             )
 
-        new_grouphash = GroupHash.objects.create(
-            project=self.project, group=new_event.group, hash=new_event.get_primary_hash()
-        )
-        group_hashes = list(GroupHash.objects.filter(project_id=self.project.id))
-        maybe_check_seer_for_matching_grouphash(
-            new_event, new_grouphash, new_event.get_grouping_variants(), group_hashes
-        )
+            new_grouphash = GroupHash.objects.create(
+                project=self.project, group=new_event.group, hash=new_event.get_primary_hash()
+            )
+            group_hashes = list(GroupHash.objects.filter(project_id=self.project.id))
+            maybe_check_seer_for_matching_grouphash(
+                new_event, new_grouphash, new_event.get_grouping_variants(), group_hashes
+            )
 
-        mock_get_similarity_data.assert_called_with(
-            {
-                "event_id": new_event.event_id,
-                "hash": new_event.get_primary_hash(),
-                "project_id": self.project.id,
-                "stacktrace": ANY,
-                "exception_type": "FailedToFetchError",
-                "k": 1,
-                "referrer": "ingest",
-                "use_reranking": True,
-                "model": GroupingVersion.V1,
-                "training_mode": False,
-            },
-            {
-                "platform": "python",
-                "model_version": "v1",
-                "training_mode": False,
-                "hybrid_fingerprint": False,
-            },
-        )
+            mock_get_similarity_data.assert_called_with(
+                {
+                    "event_id": new_event.event_id,
+                    "hash": new_event.get_primary_hash(),
+                    "project_id": self.project.id,
+                    "stacktrace": ANY,
+                    "exception_type": "FailedToFetchError",
+                    "k": 1,
+                    "referrer": "ingest",
+                    "use_reranking": True,
+                    "model": GroupingVersion.V1,
+                    "training_mode": False,
+                },
+                {
+                    "platform": "python",
+                    "model_version": "v1",
+                    "training_mode": False,
+                    "hybrid_fingerprint": False,
+                },
+            )

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -844,29 +844,12 @@ class SeerUtilsTest(TestCase):
         assert filter_null_from_string(string_with_null) == 'String with null , "" is null'
 
 
-class HasTooManyFramesTest(TestCase):
+class StacktraceExceedsLimitsTest(TestCase):
     def setUp(self) -> None:
-        # The `in_app` and `contributes` values of these frames will be determined by the project
-        # stacktrace rules we'll add below
-        self.contributing_system_frame = {
-            "function": "handleRequest",
-            "filename": "/node_modules/express/router.js",
-            "context_line": "return handler(request);",
-        }
-        self.non_contributing_system_frame = {
-            "function": "runApp",
-            "filename": "/node_modules/express/app.js",
-            "context_line": "return server.serve(port);",
-        }
         self.contributing_in_app_frame = {
             "function": "playFetch",
             "filename": "/dogApp/dogpark.js",
             "context_line": "raise FailedToFetchError('Charlie didn't bring the ball back');",
-        }
-        self.non_contributing_in_app_frame = {
-            "function": "recordMetrics",
-            "filename": "/dogApp/metrics.js",
-            "context_line": "return withMetrics(handler, metricName, tags);",
         }
         self.exception_value = {
             "type": "FailedToFetchError",
@@ -877,178 +860,136 @@ class HasTooManyFramesTest(TestCase):
             project_id=self.project.id,
             data={
                 "title": "FailedToFetchError('Charlie didn't bring the ball back')",
+                "platform": "python",
                 "exception": {"values": [self.exception_value]},
             },
         )
         self.project.update_option(
             "sentry:grouping_enhancements",
-            "\n".join(
-                [
-                    "stack.function:runApp -app -group",
-                    "stack.function:handleRequest -app +group",
-                    "stack.function:recordMetrics +app -group",
-                    "stack.function:playFetch +app +group",
-                ]
-            ),
+            "stack.function:playFetch +app +group",
         )
 
-    def test_single_exception_simple(self) -> None:
-        for stacktrace_length, expected_result in [
-            (MAX_FRAME_COUNT - 1, False),
-            (MAX_FRAME_COUNT + 1, True),
-        ]:
-            self.event.data["platform"] = "java"
-            self.event.data["exception"]["values"][0]["stacktrace"] = {
-                "frames": [self.contributing_in_app_frame] * stacktrace_length
-            }
-
-            # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
-            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
-
-            assert (
-                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
-                is expected_result
-            )
-
-    def test_single_exception_bypassed_platform(self) -> None:
-        # Regardless of the number of frames, we never flag it as being too long
-        for stacktrace_length, expected_result in [
-            (MAX_FRAME_COUNT - 1, False),
-            (MAX_FRAME_COUNT + 1, False),
-        ]:
-            self.event.data["platform"] = "python"
-            self.event.data["exception"]["values"][0]["stacktrace"] = {
-                "frames": [self.contributing_in_app_frame] * stacktrace_length
-            }
-
-            # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
-            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
-
-            assert (
-                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
-                is expected_result
-            )
-
-    def test_chained_exception_simple(self) -> None:
-        for total_frames, expected_result in [
-            (MAX_FRAME_COUNT - 2, False),
-            (MAX_FRAME_COUNT + 2, True),
-        ]:
-            self.event.data["platform"] = "java"
-            self.event.data["exception"]["values"] = [
-                {**self.exception_value},
-                {**self.exception_value},
-            ]
-            self.event.data["exception"]["values"][0]["stacktrace"] = {
-                "frames": [self.contributing_in_app_frame] * (total_frames // 2)
-            }
-            self.event.data["exception"]["values"][1]["stacktrace"] = {
-                "frames": [self.contributing_in_app_frame] * (total_frames // 2)
-            }
-
-            # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
-            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
-
-            assert (
-                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
-                is expected_result
-            )
-
-    def test_chained_exception_bypassed_platform(self) -> None:
-        # Regardless of the number of frames, we never flag it as being too long
-        for total_frames, expected_result in [
-            (MAX_FRAME_COUNT - 2, False),
-            (MAX_FRAME_COUNT + 2, False),
-        ]:
-            self.event.data["platform"] = "python"
-            self.event.data["exception"]["values"] = [
-                {**self.exception_value},
-                {**self.exception_value},
-            ]
-            self.event.data["exception"]["values"][0]["stacktrace"] = {
-                "frames": [self.contributing_in_app_frame] * (total_frames // 2)
-            }
-            self.event.data["exception"]["values"][1]["stacktrace"] = {
-                "frames": [self.contributing_in_app_frame] * (total_frames // 2)
-            }
-
-            # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
-            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
-
-            assert (
-                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
-                is expected_result
-            )
-
-    def test_ignores_non_contributing_frames(self) -> None:
+    def test_passes_when_string_length_below_token_limit(self) -> None:
+        """
+        Test that short stacktraces pass without running token count.
+        If string length < max_token_count, we skip tokenization.
+        """
+        # Use a non-bypassed platform
         self.event.data["platform"] = "java"
-        self.event.data["exception"]["values"][0]["stacktrace"] = {
-            "frames": (
-                # Taken together, there are too many frames
-                [self.contributing_in_app_frame] * (MAX_FRAME_COUNT - 1)
-                + [self.non_contributing_in_app_frame] * 2
-            )
-        }
+        # Create a short stacktrace
+        short_stacktrace = 'Error: short\n  File "a.py", function a\n    x = 1'
+        self.event.data["stacktrace_string"] = short_stacktrace
 
-        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
-        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
-
-        assert (
-            stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
-            is False  # Not flagged as too many because only contributing frames are counted
-        )
-
-    def test_prefers_app_frames(self) -> None:
-        self.event.data["platform"] = "java"
-        self.event.data["exception"]["values"][0]["stacktrace"] = {
-            "frames": (
-                [self.contributing_in_app_frame] * (MAX_FRAME_COUNT - 1)  # Under the limit
-                + [self.contributing_system_frame] * (MAX_FRAME_COUNT + 1)  # Over the limit
-            )
-        }
-
-        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
-        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
-
-        assert (
-            stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
-            is False  # Not flagged as too many because only in-app frames are counted
-        )
-
-    def test_uses_app_or_system_variants(self) -> None:
-        for frame, expected_variant_name in [
-            (self.contributing_in_app_frame, "app"),
-            (self.contributing_system_frame, "system"),
-        ]:
-            self.event.data["platform"] = "java"
-            self.event.data["exception"]["values"][0]["stacktrace"] = {
-                "frames": [frame] * (MAX_FRAME_COUNT + 1)
-            }
-
-            # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
+        with self.options({"seer.similarity.max_token_count": 10000}):
             variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-            contributing_variant, _ = get_contributing_variant_and_component(variants)
-            assert contributing_variant.variant_name == expected_variant_name
+            # Should pass because string length (50 chars) < max_token_count (10000)
+            assert stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST) is False
 
+    def test_blocks_when_token_count_exceeds_limit(self) -> None:
+        """
+        Test that long stacktraces are blocked when token count exceeds limit.
+        """
+        # Use a non-bypassed platform
+        self.event.data["platform"] = "java"
+        # Create a very long stacktrace that will definitely exceed token count
+        long_stacktrace = "VeryLongError: " + ("a" * 10000) + "\n" + ("  File 'x.py'\n" * 100)
+        self.event.data["stacktrace_string"] = long_stacktrace
+
+        with self.options({"seer.similarity.max_token_count": 100}):
+            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+            # Should be blocked because token count will exceed 100
             assert stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST) is True
 
-    def test_ignores_events_not_grouped_on_stacktrace(self) -> None:
+    def test_passes_when_string_long_but_tokens_under_limit(self) -> None:
+        """
+        Test that stacktraces with long string length but acceptable token count pass.
+        This tests the case where string length > max_token_count (triggering tokenization)
+        but actual token count < max_token_count (so it passes).
+        """
+        # Use a non-bypassed platform
+        self.event.data["platform"] = "java"
+        # Create a stacktrace that's long in characters (>7000) but not in tokens (<7000)
+        # Repetitive text compresses well in tokens
+        long_stacktrace = "Error: test\n" + ("  File 'file.py', function func\n    line\n" * 200)
+        self.event.data["stacktrace_string"] = long_stacktrace
+
+        # String is ~8000 chars (triggers token count), but token count should be under 7000
+        with self.options({"seer.similarity.max_token_count": 7000}):
+            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+            # Should pass because token count is under the limit despite long string
+            assert stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST) is False
+
+    def test_uses_cached_stacktrace_string(self) -> None:
+        """
+        Test that the function uses cached stacktrace_string from event.data.
+        """
+        # Use a non-bypassed platform
+        self.event.data["platform"] = "java"
+        cached_stacktrace = "Cached: error\n  File 'cached.py'\n    cached_line"
+        self.event.data["stacktrace_string"] = cached_stacktrace
+
+        with self.options({"seer.similarity.max_token_count": 10000}):
+            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+            with patch("sentry.seer.similarity.utils.get_stacktrace_string") as mock_get_stacktrace:
+                stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
+                # Should not call get_stacktrace_string since we have cached value
+                mock_get_stacktrace.assert_not_called()
+
+    def test_generates_stacktrace_when_not_cached(self) -> None:
+        """
+        Test that the function generates stacktrace string when not cached.
+        """
+        # Use a non-bypassed platform
         self.event.data["platform"] = "java"
         self.event.data["exception"]["values"][0]["stacktrace"] = {
-            "frames": ([self.contributing_system_frame] * (MAX_FRAME_COUNT + 1))  # Over the limit
+            "frames": [self.contributing_in_app_frame]
         }
-        self.event.data["fingerprint"] = ["dogs_are_great"]
 
-        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
-        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
-        contributing_variant, _ = get_contributing_variant_and_component(variants)
-        assert isinstance(contributing_variant, CustomFingerprintVariant)
+        with self.options({"seer.similarity.max_token_count": 10000}):
+            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        assert (
-            stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST)
-            is False  # Not flagged as too many because it's grouped by fingerprint
-        )
+            # No cached stacktrace_string, so it should generate one
+            assert stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST) is False
+
+    def test_ignores_events_not_grouped_on_stacktrace(self) -> None:
+        """
+        Test that events grouped by fingerprint are not checked for stacktrace length.
+        """
+        # Use a non-bypassed platform
+        self.event.data["platform"] = "java"
+        long_stacktrace = "VeryLongError: " + ("a" * 10000)
+        self.event.data["stacktrace_string"] = long_stacktrace
+        self.event.data["fingerprint"] = ["custom_fingerprint"]
+
+        with self.options({"seer.similarity.max_token_count": 100}):
+            variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+            contributing_variant, _ = get_contributing_variant_and_component(variants)
+            assert isinstance(contributing_variant, CustomFingerprintVariant)
+
+            # Should return False because it's not grouped on stacktrace
+            assert stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST) is False
+
+    def test_bypassed_platforms_always_pass(self) -> None:
+        """
+        Test that bypassed platforms (python, javascript, etc.) always pass regardless of length.
+        """
+        for platform in ["python", "javascript", "node", "go", "php", "ruby"]:
+            self.event.data["platform"] = platform
+            # Create a very long stacktrace that would normally be blocked
+            long_stacktrace = "VeryLongError: " + ("a" * 10000)
+            self.event.data["stacktrace_string"] = long_stacktrace
+
+            with self.options({"seer.similarity.max_token_count": 100}):
+                variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+                # Bypassed platforms should always pass, even with long stacktraces
+                assert (
+                    stacktrace_exceeds_limits(self.event, variants, ReferrerOptions.INGEST) is False
+                )
 
 
 class GetTokenCountTest(TestCase):

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -854,6 +854,7 @@ class StacktraceExceedsLimitsTest(TestCase):
         self.exception_value = {
             "type": "FailedToFetchError",
             "value": "Charlie didn't bring the ball back",
+            "stacktrace": {"frames": [self.contributing_in_app_frame]},
         }
         self.event = Event(
             event_id="12312012041520130908201311212012",


### PR DESCRIPTION
Change the stacktrace length check to go by token count and not be stacktrace frame count. We also do a sanity check on raw string length first, if it is below the token max then no point counting tokens, just pass. We are keeping the old bypass for certain platforms to not change current behaviour, once we move to v2 grouping model we will enable this for them as well.