### PR TITLE
tests(deletions): Extend test to patch batch_size

### DIFF
--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -93,10 +93,14 @@ class BulkDeleteQuery:
             results = cursor.rowcount > 0
 
     def iterator(
-        self, chunk_size: int = 100, batch_size: int = ITERATOR_BATCH_SIZE
+        self, chunk_size: int = 100, batch_size: int | None = None
     ) -> Generator[tuple[int, ...]]:
         assert self.days is not None
         assert self.dtfield is not None
+
+        # Setting the default size here to help with testing.
+        if batch_size is None:
+            batch_size = ITERATOR_BATCH_SIZE
 
         cutoff = timezone.now() - timedelta(days=self.days)
         queryset = self.model.objects.filter(**{f"{self.dtfield}__lt": cutoff})

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -14,6 +14,8 @@ from sentry.utils.query import RangeQuerySetWrapper
 if TYPE_CHECKING:
     from sentry.db.models.base import BaseModel
 
+ITERATOR_BATCH_SIZE = 10000
+
 
 class BulkDeleteQuery:
     def __init__(
@@ -91,7 +93,7 @@ class BulkDeleteQuery:
             results = cursor.rowcount > 0
 
     def iterator(
-        self, chunk_size: int = 100, batch_size: int = 10000
+        self, chunk_size: int = 100, batch_size: int = ITERATOR_BATCH_SIZE
     ) -> Generator[tuple[int, ...]]:
         assert self.days is not None
         assert self.dtfield is not None

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -150,7 +150,7 @@ class RunBulkQueryDeletesByProjectTest(TestCase):
         with (
             assume_test_silo_mode(SiloMode.REGION),
             patch("sentry.runner.commands.cleanup.DELETES_BY_PROJECT_CHUNK_SIZE", 2),
-            # This batch size is larger than the number of groups to delete, so we should only get 3 chunks.
+            # This batch size is larger than the number of groups to delete (5 groups)
             patch("sentry.db.deletion.ITERATOR_BATCH_SIZE", 4),
         ):
             task_queue = SynchronousTaskQueue()


### PR DESCRIPTION
This is part of exploring as to why the cleanup script is not cleaning thoroughly.