### PR TITLE
feat(aci): redirect incidents to metric issue details

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1658,7 +1658,9 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: ':alertId/',
-      component: make(() => import('sentry/views/alerts/incidentRedirect')),
+      component: make(
+        () => import('sentry/views/alerts/workflowEngineRedirectWrappers/incident')
+      ),
     },
     {
       path: ':projectId/',

--- a/static/app/views/alerts/workflowEngineRedirectWrappers/incident.tsx
+++ b/static/app/views/alerts/workflowEngineRedirectWrappers/incident.tsx
@@ -1,0 +1,9 @@
+import {lazy} from 'react';
+
+import {withOpenPeriodRedirect} from 'sentry/views/alerts/workflowEngineRedirects';
+
+const AlertWizardProjectProvider = lazy(
+  () => import('sentry/views/alerts/incidentRedirect')
+);
+
+export default withOpenPeriodRedirect(AlertWizardProjectProvider);

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -299,7 +299,7 @@ export function withOpenPeriodRedirect<P extends Record<string, any>>(
       if (incidentGroupOpenPeriod) {
         return (
           <Redirect
-            to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}`}
+            to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}/`}
           />
         );
       }

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -193,7 +193,7 @@ export const withDetectorDetailsRedirect = <P extends Record<string, any>>(
         if (incidentGroupOpenPeriod) {
           return (
             <Redirect
-              to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}`}
+              to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}/`}
             />
           );
         }

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -1,6 +1,7 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Redirect from 'sentry/components/redirect';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
@@ -24,6 +25,13 @@ interface AlertRuleDetector {
   alertRuleId: string | null;
   detectorId: string;
   ruleId: string | null;
+}
+
+interface IncidentGroupOpenPeriod {
+  groupId: string;
+  incidentId: string | null;
+  incidentIdentifier: string;
+  openPeriodId: string;
 }
 
 /**
@@ -137,10 +145,86 @@ export const withAutomationEditRedirect = <P extends Record<string, any>>(
 
 export const withDetectorDetailsRedirect = <P extends Record<string, any>>(
   Component: React.ComponentType<P>
-) =>
-  withAlertRuleRedirect(Component, (detectorId, orgSlug) =>
-    makeMonitorDetailsPathname(orgSlug, detectorId)
-  );
+) => {
+  return function WorkflowEngineRedirectWrapper(props: P) {
+    const user = useUser();
+    const organization = useOrganization();
+    const {ruleId, detectorId} = useParams();
+    const location = useLocation();
+    const alertId = location.query.alert as string | undefined;
+
+    const shouldRedirect =
+      !user.isStaff && organization.features.includes('workflow-engine-ui');
+
+    // Check for incident open period if alertId is present
+    const {data: incidentGroupOpenPeriod, isPending: isOpenPeriodPending} =
+      useApiQuery<IncidentGroupOpenPeriod>(
+        [
+          `/organizations/${organization.slug}/incident-groupopenperiod/`,
+          {query: {incident_identifier: alertId}},
+        ],
+        {
+          staleTime: 0,
+          enabled: shouldRedirect && !!alertId,
+          retry: false,
+        }
+      );
+
+    // Check for detector if no alertId
+    const {data: alertRuleDetector, isPending: isDetectorPending} =
+      useApiQuery<AlertRuleDetector>(
+        [
+          `/organizations/${organization.slug}/alert-rule-detector/`,
+          {query: {alert_rule_id: ruleId}},
+        ],
+        {
+          staleTime: 0,
+          enabled: shouldRedirect && !!ruleId && !detectorId && !alertId,
+          retry: false,
+        }
+      );
+
+    if (shouldRedirect) {
+      // If alertId is provided, redirect to metric issue
+      if (alertId) {
+        if (isOpenPeriodPending) {
+          return <LoadingIndicator />;
+        }
+        if (incidentGroupOpenPeriod) {
+          return (
+            <Redirect
+              to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}`}
+            />
+          );
+        }
+      }
+
+      // If detectorId is provided, redirect to monitor details
+      if (detectorId) {
+        return (
+          <Redirect to={makeMonitorDetailsPathname(organization.slug, detectorId)} />
+        );
+      }
+
+      // If alertRuleId is provided, fetch detector and redirect
+      if (isDetectorPending) {
+        return <LoadingIndicator />;
+      }
+      if (alertRuleDetector) {
+        return (
+          <Redirect
+            to={makeMonitorDetailsPathname(
+              organization.slug,
+              alertRuleDetector.detectorId
+            )}
+          />
+        );
+      }
+    }
+
+    return <Component {...(props as any)} />;
+  };
+};
 
 export const withDetectorEditRedirect = <P extends Record<string, any>>(
   Component: React.ComponentType<P>
@@ -178,6 +262,47 @@ export function withDetectorCreateRedirect<P extends Record<string, any>>(
         : makeMonitorCreatePathname(organization.slug);
 
       return <Redirect to={redirectPath} />;
+    }
+
+    return <Component {...(props as any)} />;
+  };
+}
+
+export function withOpenPeriodRedirect<P extends Record<string, any>>(
+  Component: React.ComponentType<P>
+) {
+  return function OpenPeriodRedirectWrapper(props: P) {
+    const user = useUser();
+    const organization = useOrganization();
+    const {alertId} = useParams();
+
+    const shouldRedirect =
+      !user.isStaff && organization.features.includes('workflow-engine-ui');
+
+    const {data: incidentGroupOpenPeriod, isPending} =
+      useApiQuery<IncidentGroupOpenPeriod>(
+        [
+          `/organizations/${organization.slug}/incident-groupopenperiod/`,
+          {query: {incident_identifier: alertId}},
+        ],
+        {
+          staleTime: 0,
+          enabled: shouldRedirect && !!alertId,
+          retry: false,
+        }
+      );
+
+    if (shouldRedirect) {
+      if (isPending) {
+        return <LoadingIndicator />;
+      }
+      if (incidentGroupOpenPeriod) {
+        return (
+          <Redirect
+            to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}`}
+          />
+        );
+      }
     }
 
     return <Component {...(props as any)} />;


### PR DESCRIPTION
redirects metric alert incidents to the appropriate metric issue.

note we don't currently support passing a specific open period id to the UI, but we can easily add this to the redirect logic later.