### PR TITLE
fix(aci): don't fire action if there is a conflict when creating WAGS

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -71,7 +71,7 @@ def process_workflow_action_group_statuses(
     workflows: BaseQuerySet[Workflow],
     group: Group,
     now: datetime,
-) -> tuple[dict[int, int], set[int], list[WorkflowActionGroupStatus]]:
+) -> tuple[dict[int, set[int]], set[int], list[WorkflowActionGroupStatus]]:
     """
     Determine which workflow actions should be fired based on their statuses.
     Prepare the statuses to update and create.

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -222,12 +222,12 @@ def filter_recently_fired_workflow_actions(
             now=now,
         )
     )
-    _, _, uncreated_statuses = update_workflow_action_group_statuses(
+    _, _, conflicted_statuses = update_workflow_action_group_statuses(
         now, statuses_to_update, missing_statuses
     )
 
     # if statuses were not created for some reason, we should not fire for them
-    for workflow_id, action_id in uncreated_statuses:
+    for workflow_id, action_id in conflicted_statuses:
         action_to_workflows_ids[action_id].remove(workflow_id)
         if not action_to_workflows_ids[action_id]:
             action_to_workflows_ids.pop(action_id)

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -107,10 +107,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         # dedupes action if both workflows will fire it
         assert set(triggered_actions) == {self.action}
         # Dedupes action so we have a single workflow_id -> environment to fire with
-        assert getattr(triggered_actions[0], "workflow_id") in {
-            self.workflow.id,
-            workflow.id,
-        }  # either is valid
+        assert getattr(triggered_actions[0], "workflow_id") == self.workflow.id
 
         assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2
 

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -239,7 +239,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
             )
         ]
         _, _, uncreated_statuses = update_workflow_action_group_statuses(
-            timezone.now(), {}, statuses_to_create
+            timezone.now(), set(), statuses_to_create
         )
 
         assert uncreated_statuses == [(self.workflow.id, self.action.id)]


### PR DESCRIPTION
If there is a conflict when we attempt to create a `WorkflowActionGroupStatus` row, that means another process has already successfully created the row and is going to fire a notification.

We should not fire an additional notification with the workflow+action that conflicted because we would not be respecting the action interval.