### PR TITLE
feat(explore): Enabling searching attributes on group by

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -40,6 +40,10 @@ interface ToolbarGroupByDropdownProps {
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;
+  disableSearchFilter?: boolean;
+  loading?: boolean;
+  onClose?: () => void;
+  onSearch?: (search: string) => void;
 }
 
 export function ToolbarGroupByDropdown({
@@ -48,6 +52,10 @@ export function ToolbarGroupByDropdown({
   onColumnChange,
   onColumnDelete,
   options,
+  onSearch,
+  loading,
+  onClose,
+  disableSearchFilter,
 }: ToolbarGroupByDropdownProps) {
   const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
     id: column.id,
@@ -88,6 +96,11 @@ export function ToolbarGroupByDropdown({
         searchable
         triggerProps={{children: label, style: {width: '100%'}}}
         menuWidth="300px"
+        menuTitle="Group By"
+        onSearch={onSearch}
+        onClose={onClose}
+        loading={loading}
+        disableSearchFilter={disableSearchFilter}
       />
       {canDelete ? (
         <Button

--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -40,7 +40,6 @@ interface ToolbarGroupByDropdownProps {
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;
-  disableSearchFilter?: boolean;
   loading?: boolean;
   onClose?: () => void;
   onSearch?: (search: string) => void;
@@ -55,7 +54,6 @@ export function ToolbarGroupByDropdown({
   onSearch,
   loading,
   onClose,
-  disableSearchFilter,
 }: ToolbarGroupByDropdownProps) {
   const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
     id: column.id,
@@ -100,7 +98,6 @@ export function ToolbarGroupByDropdown({
         onSearch={onSearch}
         onClose={onClose}
         loading={loading}
-        disableSearchFilter={disableSearchFilter}
       />
       {canDelete ? (
         <Button

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -36,7 +36,9 @@ const TraceItemAttributeContext = createContext<
 type TraceItemAttributeConfig = {
   enabled: boolean;
   traceItemType: TraceItemDataset;
+  disableDefaultAttributes?: boolean;
   projects?: Project[];
+  search?: string;
 };
 
 type TraceItemAttributeProviderProps = {
@@ -48,11 +50,15 @@ export function TraceItemAttributeProvider({
   traceItemType,
   enabled,
   projects,
+  search,
+  disableDefaultAttributes,
 }: TraceItemAttributeProviderProps) {
   const typedAttributesResult = useTraceItemAttributeConfig({
     traceItemType,
     enabled,
     projects,
+    search,
+    disableDefaultAttributes,
   });
 
   return (
@@ -66,6 +72,8 @@ function useTraceItemAttributeConfig({
   traceItemType,
   enabled,
   projects,
+  search,
+  disableDefaultAttributes,
 }: TraceItemAttributeConfig) {
   const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
     useTraceItemAttributeKeys({
@@ -73,6 +81,7 @@ function useTraceItemAttributeConfig({
       type: 'number',
       traceItemType,
       projects,
+      search,
     });
 
   const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
@@ -81,13 +90,16 @@ function useTraceItemAttributeConfig({
       type: 'string',
       traceItemType,
       projects,
+      search,
     });
 
   const allNumberAttributes = useMemo(() => {
-    const measurements = getDefaultNumberAttributes(traceItemType).map(measurement => [
-      measurement,
-      {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
-    ]);
+    const measurements = disableDefaultAttributes
+      ? []
+      : getDefaultNumberAttributes(traceItemType).map(measurement => [
+          measurement,
+          {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
+        ]);
 
     const secondaryAliases: TagCollection = Object.fromEntries(
       Object.values(numberAttributes ?? {})
@@ -99,13 +111,15 @@ function useTraceItemAttributeConfig({
       attributes: {...numberAttributes, ...Object.fromEntries(measurements)},
       secondaryAliases,
     };
-  }, [numberAttributes, traceItemType]);
+  }, [disableDefaultAttributes, numberAttributes, traceItemType]);
 
   const allStringAttributes = useMemo(() => {
-    const tags = getDefaultStringAttributes(traceItemType).map(tag => [
-      tag,
-      {key: tag, name: tag, kind: FieldKind.TAG},
-    ]);
+    const tags = disableDefaultAttributes
+      ? []
+      : getDefaultStringAttributes(traceItemType).map(tag => [
+          tag,
+          {key: tag, name: tag, kind: FieldKind.TAG},
+        ]);
 
     const secondaryAliases: TagCollection = Object.fromEntries(
       Object.values(stringAttributes ?? {})
@@ -117,7 +131,7 @@ function useTraceItemAttributeConfig({
       attributes: {...stringAttributes, ...Object.fromEntries(tags)},
       secondaryAliases,
     };
-  }, [traceItemType, stringAttributes]);
+  }, [disableDefaultAttributes, stringAttributes, traceItemType]);
 
   return {
     number: allNumberAttributes.attributes,

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -36,7 +36,6 @@ const TraceItemAttributeContext = createContext<
 type TraceItemAttributeConfig = {
   enabled: boolean;
   traceItemType: TraceItemDataset;
-  disableDefaultAttributes?: boolean;
   projects?: Project[];
   search?: string;
 };
@@ -51,14 +50,12 @@ export function TraceItemAttributeProvider({
   enabled,
   projects,
   search,
-  disableDefaultAttributes,
 }: TraceItemAttributeProviderProps) {
   const typedAttributesResult = useTraceItemAttributeConfig({
     traceItemType,
     enabled,
     projects,
     search,
-    disableDefaultAttributes,
   });
 
   return (
@@ -73,7 +70,6 @@ function useTraceItemAttributeConfig({
   enabled,
   projects,
   search,
-  disableDefaultAttributes,
 }: TraceItemAttributeConfig) {
   const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
     useTraceItemAttributeKeys({
@@ -94,12 +90,10 @@ function useTraceItemAttributeConfig({
     });
 
   const allNumberAttributes = useMemo(() => {
-    const measurements = disableDefaultAttributes
-      ? []
-      : getDefaultNumberAttributes(traceItemType).map(measurement => [
-          measurement,
-          {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
-        ]);
+    const measurements = getDefaultNumberAttributes(traceItemType).map(measurement => [
+      measurement,
+      {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
+    ]);
 
     const secondaryAliases: TagCollection = Object.fromEntries(
       Object.values(numberAttributes ?? {})
@@ -111,16 +105,13 @@ function useTraceItemAttributeConfig({
       attributes: {...numberAttributes, ...Object.fromEntries(measurements)},
       secondaryAliases,
     };
-  }, [disableDefaultAttributes, numberAttributes, traceItemType]);
+  }, [numberAttributes, traceItemType]);
 
   const allStringAttributes = useMemo(() => {
-    const tags = disableDefaultAttributes
-      ? []
-      : getDefaultStringAttributes(traceItemType).map(tag => [
-          tag,
-          {key: tag, name: tag, kind: FieldKind.TAG},
-        ]);
-
+    const tags = getDefaultStringAttributes(traceItemType).map(tag => [
+      tag,
+      {key: tag, name: tag, kind: FieldKind.TAG},
+    ]);
     const secondaryAliases: TagCollection = Object.fromEntries(
       Object.values(stringAttributes ?? {})
         .flatMap(value => value.secondaryAliases ?? [])
@@ -131,7 +122,7 @@ function useTraceItemAttributeConfig({
       attributes: {...stringAttributes, ...Object.fromEntries(tags)},
       secondaryAliases,
     };
-  }, [disableDefaultAttributes, stringAttributes, traceItemType]);
+  }, [stringAttributes, traceItemType]);
 
   return {
     number: allNumberAttributes.attributes,

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -14,6 +14,7 @@ import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/types';
 interface UseTraceItemAttributeKeysProps extends UseTraceItemAttributeBaseProps {
   enabled?: boolean;
   query?: string;
+  search?: string;
 }
 
 export function useTraceItemAttributeKeys({
@@ -22,6 +23,7 @@ export function useTraceItemAttributeKeys({
   traceItemType,
   projects,
   query,
+  search,
 }: UseTraceItemAttributeKeysProps) {
   const {selection} = usePageFilters();
 
@@ -53,8 +55,8 @@ export function useTraceItemAttributeKeys({
 
   const {data, isFetching, error} = useQuery<TagCollection>({
     enabled,
-    queryKey,
-    queryFn: () => getTraceItemAttributeKeys(),
+    queryKey: [...queryKey, search],
+    queryFn: () => getTraceItemAttributeKeys(search),
   });
 
   const previous = usePrevious(data, isFetching);

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -121,6 +121,24 @@ describe('SpansTabContent', () => {
         },
       }),
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+      match: [MockApiClient.matchQuery({attributeType: 'number'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [
+        {
+          key: 'project',
+          name: 'project',
+          attributeSource: {source_type: 'sentry'},
+        },
+      ],
+      match: [MockApiClient.matchQuery({attributeType: 'string'})],
+    });
   });
 
   it('should fire analytics once per change', async () => {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -61,6 +61,29 @@ describe('ExploreToolbar', () => {
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
       method: 'GET',
       body: [],
+      match: [MockApiClient.matchQuery({attributeType: 'number'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [
+        {
+          key: 'span.op',
+          name: 'span.op',
+          attributeSource: {source_type: 'sentry'},
+        },
+        {
+          key: 'span.description',
+          name: 'span.description',
+          attributeSource: {source_type: 'sentry'},
+        },
+        {
+          key: 'project',
+          name: 'project',
+          attributeSource: {source_type: 'sentry'},
+        },
+      ],
+      match: [MockApiClient.matchQuery({attributeType: 'string'})],
     });
   });
 

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -76,7 +76,7 @@ function ToolbarGroupByItem({
   onColumnChange,
   onColumnDelete,
 }: ToolbarGroupByItemProps) {
-  const [search, setSearch] = useState<string | undefined>(undefined);
+  const [search, setSearch] = useState<string>('');
   const debouncedSearch = useDebouncedValue(search, 200);
 
   return (
@@ -92,7 +92,7 @@ function ToolbarGroupByItem({
         onColumnDelete={onColumnDelete}
         groupBys={groupBys}
         onSearch={setSearch}
-        onClose={() => setSearch(undefined)}
+        onClose={() => setSearch('')}
       />
     </TraceItemAttributeProvider>
   );

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -120,9 +120,7 @@ function ToolbarGroupByItemContent({
     numberTags,
     stringTags,
     traceItemType: TraceItemDataset.SPANS,
-  })
-    // hacking a slice here since there is no limit on the backend endpoint and we want to speed up the interactions due to the re-rendering of the dropdown while typing
-    .slice(0, 200);
+  });
 
   const loading = numberTagsLoading || stringTagsLoading;
 

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -1,6 +1,7 @@
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 
 import type {SelectOption} from 'sentry/components/core/compactSelect';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {
   ToolbarFooter,
   ToolbarSection,
@@ -13,6 +14,8 @@ import {
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -22,16 +25,6 @@ interface ToolbarGroupByProps {
 }
 
 export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
-  const {tags: numberTags} = useTraceItemTags('number');
-  const {tags: stringTags} = useTraceItemTags('string');
-
-  const options: Array<SelectOption<string>> = useGroupByFields({
-    groupBys,
-    numberTags,
-    stringTags,
-    traceItemType: TraceItemDataset.SPANS,
-  });
-
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
       // automatically switch to aggregates mode when a group by is inserted/updated
@@ -50,13 +43,13 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
         <ToolbarSection data-test-id="section-group-by">
           <ToolbarGroupByHeader />
           {editableColumns.map((column, i) => (
-            <ToolbarGroupByDropdown
+            <ToolbarGroupByItem
               key={column.id}
               canDelete={editableColumns.length > 1}
               column={column}
               onColumnChange={c => updateColumnAtIndex(i, c)}
               onColumnDelete={() => deleteColumnAtIndex(i)}
-              options={options}
+              groupBys={groupBys}
             />
           ))}
           <ToolbarFooter>
@@ -65,5 +58,86 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
         </ToolbarSection>
       )}
     </DragNDropContext>
+  );
+}
+
+interface ToolbarGroupByItemProps {
+  canDelete: boolean;
+  column: Column<string>;
+  groupBys: readonly string[];
+  onColumnChange: (column: string) => void;
+  onColumnDelete: () => void;
+}
+
+function ToolbarGroupByItem({
+  groupBys,
+  canDelete,
+  column,
+  onColumnChange,
+  onColumnDelete,
+}: ToolbarGroupByItemProps) {
+  const [search, setSearch] = useState<string | undefined>(undefined);
+  const debouncedSearch = useDebouncedValue(search, 200);
+
+  return (
+    <TraceItemAttributeProvider
+      enabled
+      disableDefaultAttributes
+      traceItemType={TraceItemDataset.SPANS}
+      search={debouncedSearch}
+    >
+      <ToolbarGroupByItemContent
+        canDelete={canDelete}
+        column={column}
+        onColumnChange={onColumnChange}
+        onColumnDelete={onColumnDelete}
+        groupBys={groupBys}
+        onSearch={setSearch}
+        onClose={() => setSearch(undefined)}
+      />
+    </TraceItemAttributeProvider>
+  );
+}
+
+interface ToolbarGroupByItemContentProps extends ToolbarGroupByItemProps {
+  onClose: () => void;
+  onSearch: (search: string) => void;
+}
+
+function ToolbarGroupByItemContent({
+  groupBys,
+  canDelete,
+  column,
+  onColumnChange,
+  onColumnDelete,
+  onSearch,
+  onClose,
+}: ToolbarGroupByItemContentProps) {
+  const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
+  const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
+
+  const options: Array<SelectOption<string>> = useGroupByFields({
+    groupBys,
+    numberTags,
+    stringTags,
+    traceItemType: TraceItemDataset.SPANS,
+  })
+    // hacking a slice here since there is no limit on the backend endpoint and we want to speed up the interactions due to the re-rendering of the dropdown while typing
+    .slice(0, 200);
+
+  const loading = numberTagsLoading || stringTagsLoading;
+
+  return (
+    <ToolbarGroupByDropdown
+      disableSearchFilter
+      column={column}
+      options={options}
+      loading={loading}
+      onClose={onClose}
+      onSearch={onSearch}
+      canDelete={canDelete}
+      onColumnChange={onColumnChange}
+      onColumnDelete={onColumnDelete}
+    />
   );
 }

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -82,7 +82,6 @@ function ToolbarGroupByItem({
   return (
     <TraceItemAttributeProvider
       enabled
-      disableDefaultAttributes
       traceItemType={TraceItemDataset.SPANS}
       search={debouncedSearch}
     >
@@ -129,7 +128,6 @@ function ToolbarGroupByItemContent({
 
   return (
     <ToolbarGroupByDropdown
-      disableSearchFilter
       column={column}
       options={options}
       loading={loading}


### PR DESCRIPTION
This PR updates the Group By dropdown to support searching attributes via the API dealing with the 3000 attribute limit issue.