### PR TITLE
feat(crons): Always create detectors for all monitors in MonitorValidator

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -46,7 +46,6 @@ from sentry.monitors.serializers import (
     MonitorSerializer,
     MonitorSerializerResponse,
 )
-from sentry.monitors.utils import ensure_cron_detector
 from sentry.monitors.validators import MonitorBulkEditValidator, MonitorValidator
 from sentry.search.utils import tokenize_query
 from sentry.types.actor import Actor
@@ -285,7 +284,6 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
             return self.respond(validator.errors, status=400)
 
         monitor = validator.save()
-        ensure_cron_detector(monitor)
         return self.respond(serialize(monitor, request.user), status=201)
 
     @extend_schema(

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -41,6 +41,7 @@ from sentry.monitors.schedule import get_next_schedule, get_prev_schedule
 from sentry.monitors.types import CrontabSchedule, slugify_monitor_slug
 from sentry.monitors.utils import (
     create_issue_alert_rule,
+    ensure_cron_detector,
     get_checkin_margin,
     get_max_runtime,
     signal_monitor_created,
@@ -373,16 +374,22 @@ class MonitorValidator(CamelSnakeSerializer):
             config=validated_data["config"],
         )
 
-        # Skip quota operations if requested by context (e.g., detector flow handles this)
-        if not self.context.get("skip_quota", False):
+        # When called from the new detector flow, skip detector and quota operations
+        # since they're handled at a higher level by the detector validator
+        from_detector_flow = self.context.get("from_detector_flow", False)
+
+        if not from_detector_flow:
+            detector = ensure_cron_detector(monitor)
+            assert detector
+
             # Attempt to assign a seat for this monitor
             seat_outcome = quotas.backend.assign_seat(DataCategory.MONITOR_SEAT, monitor)
             if seat_outcome != Outcome.ACCEPTED:
+                detector.update(enabled=False)
                 monitor.update(status=ObjectStatus.DISABLED)
 
         request = self.context["request"]
         signal_monitor_created(project, request.user, False, monitor, request)
-
         validated_issue_alert_rule = validated_data.get("alert_rule")
         if validated_issue_alert_rule:
             issue_alert_rule_id = create_issue_alert_rule(
@@ -643,12 +650,9 @@ class MonitorDataSourceValidator(BaseDataSourceValidator[Monitor]):
         if self.instance:
             monitor_instance = self.instance
 
-        # Skip quota operations - the detector validator handles seat assignment
-        context = {**self.context, "skip_quota": True}
-
         monitor_validator = MonitorValidator(
             data=monitor_data,
-            context=context,
+            context={**self.context, "from_detector_flow": True},
             instance=monitor_instance,
             partial=self.partial,
         )

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -589,6 +589,10 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         assert rule is not None
         assert rule.environment_id == self.environment.id
 
+        # Verify the detector was created
+        detector = get_detector_for_monitor(monitor)
+        assert detector is not None
+
     def test_checkin_margin_zero(self) -> None:
         # Invalid checkin margin
         #

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -19,6 +19,7 @@ from sentry.monitors.models import (
     is_monitor_muted,
 )
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
+from sentry.monitors.utils import get_detector_for_monitor
 from sentry.monitors.validators import (
     MonitorDataSourceValidator,
     MonitorIncidentDetectorValidator,
@@ -261,6 +262,11 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert assign_seat.called
         monitor.refresh_from_db()
         assert monitor.status == ObjectStatus.DISABLED
+
+        # Verify the detector is also disabled when quota is exceeded
+        detector = get_detector_for_monitor(monitor)
+        assert detector is not None
+        assert detector.enabled is False
 
     def test_invalid_schedule(self):
         data = {


### PR DESCRIPTION
Previously, detectors were created as part of the endpoint, _after_ detector → alerts linking happened. This changes it so detectors are crated immediately after the cron monitor is created. 

Changes:
- Moved ensure_cron_detector() call from endpoint into MonitorValidator.create()
- Detector is created BEFORE alert_rule creation, allowing IssueAlertMigrator
  to find and link it to workflows
- Added skip_detector_creation context flag to prevent duplicate creation
  when using MonitorDataSourceValidator (new detector flow)
- Updated tests to verify detector creation

This ensures both the old (MonitorValidator) and new (detector API) flows
correctly create detectors for all monitors.

Part of [NEW-593: Cron Monitor Alerts are not linked to monitor when created via the old flow](https://linear.app/getsentry/issue/NEW-593/cron-monitor-alerts-are-not-linked-to-monitor-when-created-via-the-old)