### PR TITLE
fix(dashboards): user created dashboards should not have titles that match prebuilt ones

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -677,6 +677,20 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         help_text="Permissions that restrict users from editing dashboards",
     )
 
+    def validate_title(self, title):
+        """Prevent users from creating dashboards with reserved titles."""
+        # Import from the endpoint file where PREBUILT_DASHBOARDS is defined
+        from sentry.dashboards.endpoints.organization_dashboards import PREBUILT_DASHBOARDS
+
+        reserved_titles = {dashboard["title"] for dashboard in PREBUILT_DASHBOARDS}
+
+        if title in reserved_titles:
+            raise serializers.ValidationError(
+                f"Dashboard title '{title}' is reserved. Please choose a different title."
+            )
+
+        return title
+
     def validate_projects(self, projects):
         from sentry.api.validators import validate_project_ids
 

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -62,9 +62,33 @@ MAX_RETRIES = 2
 
 # Do not delete or modify existing entries. These enums are required to match ids in the frontend.
 class PrebuiltDashboardId(IntEnum):
+    # FRONTEND ONLY
     FRONTEND_SESSION_HEALTH = 1
+    FRONTEND_OVERVIEW = 4
+    FRONTEND_WEB_VITALS = 5
+    FRONTEND_WEB_VITALS_SUMMARY = 6
+    FRONTEND_ASSETS = 7
+    FRONTEND_ASSETS_SUMMARY = 8
+
+    # BACKEND ONLY
+    BACKEND_OVERVIEW = 9
     BACKEND_QUERIES = 2
     BACKEND_QUERIES_SUMMARY = 3
+    BACKEND_CACHES = 10
+    BACKEND_QUEUES = 11
+    BACKEND_QUEUES_SUMMARY = 12
+
+    # MOBILE ONLY
+    MOBILE_OVERVIEW = 13
+    MOBILE_VITALS = 14
+    MOBILE_APP_START = 15
+    MOBILE_SCREEN_LOAD = 16
+    MOBILE_SCREEN_RENDERING = 17
+    MOBILE_SESSION_HEALTH = 18
+
+    # MULTIPLE PLATFORMS
+    HTTP = 19
+    HTTP_SUMMARY = 20
 
 
 class PrebuiltDashboard(TypedDict):
@@ -81,9 +105,35 @@ class PrebuiltDashboard(TypedDict):
 # Note B: Consider storing all dashboard and widget data in the database instead of relying on matching
 # prebuilt_id on the frontend, if there are issues.
 PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
+    # FRONTEND ONLY
     {
         "prebuilt_id": PrebuiltDashboardId.FRONTEND_SESSION_HEALTH,
         "title": "Frontend Session Health",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_OVERVIEW,
+        "title": "Overview",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_WEB_VITALS,
+        "title": "Web Vitals",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_WEB_VITALS_SUMMARY,
+        "title": "Web Vitals Summary",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_ASSETS,
+        "title": "Assets",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_ASSETS_SUMMARY,
+        "title": "Assets Summary",
+    },
+    # BACKEND ONLY
+    {
+        "prebuilt_id": PrebuiltDashboardId.BACKEND_OVERVIEW,
+        "title": "Backend Overview",
     },
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_QUERIES,
@@ -92,6 +142,52 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY,
         "title": "Query Summary",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.BACKEND_CACHES,
+        "title": "Caches",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.BACKEND_QUEUES,
+        "title": "Queues",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.BACKEND_QUEUES_SUMMARY,
+        "title": "Queue Summary",
+    },
+    # MOBILE ONLY
+    {
+        "prebuilt_id": PrebuiltDashboardId.MOBILE_OVERVIEW,
+        "title": "Mobile Overview",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.MOBILE_VITALS,
+        "title": "Mobile Vitals",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.MOBILE_APP_START,
+        "title": "Mobile App Start",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.MOBILE_SCREEN_LOAD,
+        "title": "Mobile Screen Load",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.MOBILE_SCREEN_RENDERING,
+        "title": "Mobile Screen Rendering",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.MOBILE_SESSION_HEALTH,
+        "title": "Mobile Session Health",
+    },
+    # MULTIPLE PLATFORMS
+    {
+        "prebuilt_id": PrebuiltDashboardId.HTTP,
+        "title": "HTTP",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.HTTP_SUMMARY,
+        "title": "HTTP Summary",
     },
 ]
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2003,3 +2003,32 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             assert response.status_code == 200
             assert len(response.data) == 1
             assert response.data[0]["prebuiltId"] == PrebuiltDashboardId.FRONTEND_SESSION_HEALTH
+
+    def test_fails_to_create_dashboard_when_using_prebuilt_title(self) -> None:
+        data = {
+            "title": "Queries Overview",
+            "widgets": [
+                {
+                    "displayType": "line",
+                    "interval": "5m",
+                    "title": "Spans",
+                    "limit": 5,
+                    "widgetType": "spans",
+                    "queries": [
+                        {
+                            "name": "Spans",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.do_request("post", self.url, data=data)
+        assert response.status_code == 400
+        assert (
+            response.data["title"][0]
+            == "Dashboard title 'Queries Overview' is reserved. Please choose a different title."
+        )


### PR DESCRIPTION
1. Adds a check in the dashboard serializer to check if the title matches an existing one, a user should not be able to create one that matches a prebuilt one
2. Register all dashboards we plan to build to avoid any future conflicts