### PR TITLE
fix(cursor-agent): ui handling of when you have more than 1 integration

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -147,10 +147,10 @@ describe('AutofixRootCause', () => {
     await userEvent.click(dropdownTrigger);
 
     // Click the Cursor option in the dropdown
-    await userEvent.click(await screen.findByText('Send to Cursor Cloud Agent'));
+    await userEvent.click(await screen.findByText('Send to Cursor'));
 
     expect(JSON.parse(localStorage.getItem('autofix:rootCauseActionPreference')!)).toBe(
-      'cursor_background_agent'
+      'cursor:cursor-integration-id'
     );
   });
 
@@ -204,13 +204,13 @@ describe('AutofixRootCause', () => {
 
     localStorage.setItem(
       'autofix:rootCauseActionPreference',
-      JSON.stringify('cursor_background_agent')
+      JSON.stringify('cursor:cursor-integration-id')
     );
 
     render(<AutofixRootCause {...defaultProps} />);
 
     expect(
-      await screen.findByRole('button', {name: 'Send to Cursor Cloud Agent'})
+      await screen.findByRole('button', {name: 'Send to Cursor'})
     ).toBeInTheDocument();
 
     // Verify Seer option is in the dropdown
@@ -249,6 +249,6 @@ describe('AutofixRootCause', () => {
     });
     await userEvent.click(dropdownTrigger);
 
-    expect(await screen.findByText('Send to Cursor Cloud Agent')).toBeInTheDocument();
+    expect(await screen.findByText('Send to Cursor')).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -986,7 +986,7 @@ describe('ProjectSeer', () => {
 
       // The integration selector should be visible with multiple integrations
       const integrationSelect = await screen.findByRole('textbox', {
-        name: /Cursor Integration/i,
+        name: /Select Configuration/i,
       });
       expect(integrationSelect).toBeInTheDocument();
 
@@ -1089,7 +1089,7 @@ describe('ProjectSeer', () => {
 
       // Find and click the integration selector
       const integrationSelect = await screen.findByRole('textbox', {
-        name: /Cursor Integration/i,
+        name: /Select Configuration/i,
       });
 
       act(() => {
@@ -1100,7 +1100,7 @@ describe('ProjectSeer', () => {
 
       // Select the second integration
       const secondIntegration = await screen.findByText(
-        'Cursor - user2@example.com/api-key-2'
+        'Cursor - user2@example.com/api-key-2 (456)'
       );
       await userEvent.click(secondIntegration);
 
@@ -1193,7 +1193,7 @@ describe('ProjectSeer', () => {
 
       // The integration selector should NOT be visible with only one integration
       expect(
-        screen.queryByRole('textbox', {name: /Cursor Integration/i})
+        screen.queryByRole('textbox', {name: /Select Configuration/i})
       ).not.toBeInTheDocument();
     });
   });

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -904,5 +904,297 @@ describe('ProjectSeer', () => {
         );
       });
     });
+
+    it('shows integration selector when multiple cursor integrations exist', async () => {
+      MockApiClient.clearMockResponses();
+
+      const orgWithCursorFeature = OrganizationFixture({
+        features: ['autofix-seer-preferences', 'integrations-cursor'],
+      });
+
+      const initialProject: Project = {
+        ...project,
+        autofixAutomationTuning: 'medium',
+        seerScannerAutomation: true,
+      };
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
+        method: 'GET',
+        body: {
+          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
+          billing: {hasAutofixQuota: true, hasScannerQuota: true},
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/repos/`,
+        query: {status: 'active'},
+        method: 'GET',
+        body: [],
+      });
+
+      // Mock multiple cursor integrations
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/integrations/coding-agents/`,
+        method: 'GET',
+        body: {
+          integrations: [
+            {
+              id: '123',
+              name: 'Cursor - user1@example.com/api-key-1',
+              provider: 'cursor',
+            },
+            {
+              id: '456',
+              name: 'Cursor - user2@example.com/api-key-2',
+              provider: 'cursor',
+            },
+          ],
+        },
+      });
+
+      // Mock preferences with automation_handoff using first integration
+      MockApiClient.addMockResponse({
+        url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/seer/preferences/`,
+        method: 'GET',
+        body: {
+          preference: {
+            repositories: [],
+            automated_run_stopping_point: 'root_cause',
+            automation_handoff: {
+              handoff_point: 'root_cause',
+              target: 'cursor_background_agent',
+              integration_id: 123,
+              auto_create_pr: false,
+            },
+          },
+          code_mapping_repos: [],
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/`,
+        method: 'PUT',
+        body: {},
+      });
+
+      render(<ProjectSeer />, {
+        organization: orgWithCursorFeature,
+        outletContext: {project: initialProject},
+      });
+
+      // The integration selector should be visible with multiple integrations
+      const integrationSelect = await screen.findByRole('textbox', {
+        name: /Cursor Integration/i,
+      });
+      expect(integrationSelect).toBeInTheDocument();
+
+      // The auto-create PR toggle should also be visible
+      expect(
+        screen.getByRole('checkbox', {name: /Auto-Create Pull Requests/i})
+      ).toBeInTheDocument();
+    });
+
+    it('calls update mutation when switching integration', async () => {
+      MockApiClient.clearMockResponses();
+
+      const orgWithCursorFeature = OrganizationFixture({
+        features: ['autofix-seer-preferences', 'integrations-cursor'],
+      });
+
+      const initialProject: Project = {
+        ...project,
+        autofixAutomationTuning: 'medium',
+        seerScannerAutomation: true,
+      };
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
+        method: 'GET',
+        body: {
+          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
+          billing: {hasAutofixQuota: true, hasScannerQuota: true},
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/repos/`,
+        query: {status: 'active'},
+        method: 'GET',
+        body: [],
+      });
+
+      // Mock multiple cursor integrations
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/integrations/coding-agents/`,
+        method: 'GET',
+        body: {
+          integrations: [
+            {
+              id: '123',
+              name: 'Cursor - user1@example.com/api-key-1',
+              provider: 'cursor',
+            },
+            {
+              id: '456',
+              name: 'Cursor - user2@example.com/api-key-2',
+              provider: 'cursor',
+            },
+          ],
+        },
+      });
+
+      // Mock preferences with automation_handoff using first integration
+      MockApiClient.addMockResponse({
+        url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/seer/preferences/`,
+        method: 'GET',
+        body: {
+          preference: {
+            repositories: [],
+            automated_run_stopping_point: 'root_cause',
+            automation_handoff: {
+              handoff_point: 'root_cause',
+              target: 'cursor_background_agent',
+              integration_id: 123,
+              auto_create_pr: false,
+            },
+          },
+          code_mapping_repos: [],
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/`,
+        method: 'PUT',
+        body: {},
+      });
+
+      // Mock for the Form's empty apiEndpoint POST
+      MockApiClient.addMockResponse({
+        url: '',
+        method: 'POST',
+        body: {},
+      });
+
+      const seerPreferencesPostRequest = MockApiClient.addMockResponse({
+        url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/seer/preferences/`,
+        method: 'POST',
+      });
+
+      render(<ProjectSeer />, {
+        organization: orgWithCursorFeature,
+        outletContext: {project: initialProject},
+      });
+
+      // Find and click the integration selector
+      const integrationSelect = await screen.findByRole('textbox', {
+        name: /Cursor Integration/i,
+      });
+
+      act(() => {
+        integrationSelect.focus();
+      });
+
+      await userEvent.click(integrationSelect);
+
+      // Select the second integration
+      const secondIntegration = await screen.findByText(
+        'Cursor - user2@example.com/api-key-2'
+      );
+      await userEvent.click(secondIntegration);
+
+      // Wait for the POST request to be called with the new integration ID
+      await waitFor(() => {
+        expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            data: expect.objectContaining({
+              automation_handoff: expect.objectContaining({
+                integration_id: 456,
+              }),
+              repositories: expect.any(Array),
+            }),
+          })
+        );
+      });
+    });
+
+    it('does not show integration selector with single cursor integration', async () => {
+      MockApiClient.clearMockResponses();
+
+      const orgWithCursorFeature = OrganizationFixture({
+        features: ['autofix-seer-preferences', 'integrations-cursor'],
+      });
+
+      const initialProject: Project = {
+        ...project,
+        autofixAutomationTuning: 'medium',
+        seerScannerAutomation: true,
+      };
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
+        method: 'GET',
+        body: {
+          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
+          billing: {hasAutofixQuota: true, hasScannerQuota: true},
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/repos/`,
+        query: {status: 'active'},
+        method: 'GET',
+        body: [],
+      });
+
+      // Mock single cursor integration
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithCursorFeature.slug}/integrations/coding-agents/`,
+        method: 'GET',
+        body: {
+          integrations: [
+            {
+              id: '123',
+              name: 'Cursor',
+              provider: 'cursor',
+            },
+          ],
+        },
+      });
+
+      // Mock preferences with automation_handoff
+      MockApiClient.addMockResponse({
+        url: `/projects/${orgWithCursorFeature.slug}/${project.slug}/seer/preferences/`,
+        method: 'GET',
+        body: {
+          preference: {
+            repositories: [],
+            automated_run_stopping_point: 'root_cause',
+            automation_handoff: {
+              handoff_point: 'root_cause',
+              target: 'cursor_background_agent',
+              integration_id: 123,
+              auto_create_pr: false,
+            },
+          },
+          code_mapping_repos: [],
+        },
+      });
+
+      render(<ProjectSeer />, {
+        organization: orgWithCursorFeature,
+        outletContext: {project: initialProject},
+      });
+
+      // Wait for the page to load
+      await screen.findByRole('checkbox', {name: /Auto-Create Pull Requests/i});
+
+      // The integration selector should NOT be visible with only one integration
+      expect(
+        screen.queryByRole('textbox', {name: /Cursor Integration/i})
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -101,14 +101,24 @@ const autofixAutomationToggleField = {
   }),
 } satisfies FieldObject;
 
+interface CursorIntegration {
+  id: string;
+  name: string;
+  provider: string;
+}
+
 function CodingAgentSettings({
   preference,
   handleAutoCreatePrChange,
+  handleIntegrationChange,
   canWriteProject,
   isAutomationOn,
+  cursorIntegrations,
 }: {
   canWriteProject: boolean;
+  cursorIntegrations: CursorIntegration[];
   handleAutoCreatePrChange: (value: boolean) => void;
+  handleIntegrationChange: (integrationId: number) => void;
   preference: ProjectSeerPreferences | null | undefined;
   isAutomationOn?: boolean;
 }) {
@@ -116,36 +126,63 @@ function CodingAgentSettings({
     return null;
   }
 
-  const initialValue = preference?.automation_handoff?.auto_create_pr ?? false;
+  const autoCreatePrValue = preference?.automation_handoff?.auto_create_pr ?? false;
+  const selectedIntegrationId = preference?.automation_handoff?.integration_id;
+
+  const integrationOptions = cursorIntegrations.map(integration => ({
+    value: integration.id,
+    label: `${integration.name} (${integration.id})`,
+  }));
+
+  const fields: FieldObject[] = [];
+
+  // Only show integration selector if there are multiple integrations
+  if (cursorIntegrations.length > 1) {
+    fields.push({
+      name: 'integration_id',
+      label: t('Select Configuration'),
+      help: t(
+        'You have multiple configurations installed. Select which one to use for hand off.'
+      ),
+      type: 'choice',
+      options: integrationOptions,
+      saveOnBlur: true,
+      getData: () => ({}),
+      getValue: () => String(selectedIntegrationId),
+      disabled: !canWriteProject,
+      onChange: (value: string) => handleIntegrationChange(parseInt(value, 10)),
+    } satisfies FieldObject);
+  }
+
+  fields.push({
+    name: 'auto_create_pr',
+    label: t('Auto-Create Pull Requests'),
+    help: t(
+      'When enabled, Cursor Cloud Agents will automatically create pull requests after hand off.'
+    ),
+    saveOnBlur: true,
+    type: 'boolean',
+    getData: () => ({}),
+    getValue: () => autoCreatePrValue,
+    disabled: !canWriteProject,
+    onChange: handleAutoCreatePrChange,
+  } satisfies FieldObject);
 
   return (
     <Form
-      key={`coding-agent-settings-${initialValue}`}
+      key={`coding-agent-settings-${autoCreatePrValue}-${selectedIntegrationId}`}
       apiMethod="POST"
       saveOnBlur
       initialData={{
-        auto_create_pr: initialValue,
+        auto_create_pr: autoCreatePrValue,
+        integration_id: String(selectedIntegrationId),
       }}
     >
       <JsonForm
         forms={[
           {
             title: t('Cursor Agent Settings'),
-            fields: [
-              {
-                name: 'auto_create_pr',
-                label: t('Auto-Create Pull Requests'),
-                help: t(
-                  'When enabled, Cursor Cloud Agents will automatically create pull requests after hand off.'
-                ),
-                saveOnBlur: true,
-                type: 'boolean',
-                getData: () => ({}),
-                getValue: () => initialValue,
-                disabled: !canWriteProject,
-                onChange: handleAutoCreatePrChange,
-              } satisfies FieldObject,
-            ],
+            fields,
           },
         ]}
       />
@@ -163,9 +200,13 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
   const isTriageSignalsFeatureOn = project.features.includes('triage-signals-v0');
   const canWriteProject = hasEveryAccess(['project:read'], {organization, project});
 
-  const cursorIntegration = codingAgentIntegrations?.integrations.find(
-    integration => integration.provider === 'cursor'
-  );
+  const cursorIntegrations =
+    codingAgentIntegrations?.integrations.filter(
+      integration => integration.provider === 'cursor'
+    ) ?? [];
+
+  // For backwards compatibility, use the first cursor integration as default
+  const cursorIntegration = cursorIntegrations[0];
 
   const handleSubmitSuccess = useCallback(
     (resp: Project) => {
@@ -224,6 +265,23 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
         automation_handoff: {
           ...preference.automation_handoff,
           auto_create_pr: value,
+        },
+      });
+    },
+    [preference, updateProjectSeerPreferences]
+  );
+
+  const handleIntegrationChange = useCallback(
+    (integrationId: number) => {
+      if (!preference?.automation_handoff) {
+        return;
+      }
+      updateProjectSeerPreferences({
+        repositories: preference?.repositories || [],
+        automated_run_stopping_point: preference?.automated_run_stopping_point,
+        automation_handoff: {
+          ...preference.automation_handoff,
+          integration_id: integrationId,
         },
       });
     },
@@ -368,7 +426,9 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
         preference={preference}
         handleAutoCreatePrChange={handleAutoCreatePrChange}
         isAutomationOn={automationTuning && automationTuning !== 'off'}
+        handleIntegrationChange={handleIntegrationChange}
         canWriteProject={canWriteProject}
+        cursorIntegrations={cursorIntegrations}
       />
     </Fragment>
   );


### PR DESCRIPTION
People installed multiple cursor integrations and previously this caused issues, this changes it on the UI so

1. You can configure which cursor integration to use for automation handoff:
<img width="2916" height="458" alt="CleanShot 2025-11-26 at 03 39 24@2x" src="https://github.com/user-attachments/assets/30376d56-b723-4d15-a7ae-712981fe7013" />

2. You can select which integration to manually call from the seer drawer:
    - Because existing integrations don't have unique names, there's no way to distinguish between them except their IDs, so as a fallback I have it show the ID in small text ONLY if at least 2 of the same integrations have the same name, otherwise #103989 will fix this and give it unique names)
    <img width="906" height="562" alt="CleanShot 2025-11-26 at 03 26 41@2x" src="https://github.com/user-attachments/assets/16a33cd0-953e-4f1a-a107-cd382f10b60a" />
