### PR TITLE
add appcontexts to event data

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -1,5 +1,6 @@
 import type {CloudResourceContext} from '@sentry/core';
 
+import type {AppContext} from 'sentry/components/events/contexts/knownContext/app';
 import type {CultureContext} from 'sentry/components/events/contexts/knownContext/culture';
 import type {MissingInstrumentationContext} from 'sentry/components/events/contexts/knownContext/missingInstrumentation';
 import type {
@@ -636,6 +637,7 @@ export type EventContexts = {
   'Current Culture'?: CultureContext;
   'Memory Info'?: MemoryInfoContext;
   'ThreadPool Info'?: ThreadPoolInfoContext;
+  app?: AppContext;
   browser?: BrowserContext;
   client_os?: OSContext;
   cloud_resource?: CloudResourceContext;


### PR DESCRIPTION
noticed that `AppContext` was missing from `EventData` despite being in the event response (noticed it exists under mobile user feedback)

<img width="701" height="249" alt="image" src="https://github.com/user-attachments/assets/382524f2-b1fe-482b-8b6a-0b56e951fba2" />
