### PR TITLE
fix(aci): accept str instead of int for extrapolation mode in validator

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -125,7 +125,10 @@ def update_alert_rule(
         partial=True,
     )
     if validator.is_valid():
-        if data.get("dataset") == Dataset.EventsAnalyticsPlatform.value:
+        if (
+            data.get("dataset", alert_rule.snuba_query.dataset)
+            == Dataset.EventsAnalyticsPlatform.value
+        ):
             if data.get("extrapolation_mode"):
                 old_extrapolation_mode = ExtrapolationMode(
                     alert_rule.snuba_query.extrapolation_mode

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -165,7 +165,10 @@ def is_invalid_extrapolation_mode(old_extrapolation_mode, new_extrapolation_mode
         old_extrapolation_mode = ExtrapolationMode(old_extrapolation_mode).name.lower()
     if type(old_extrapolation_mode) is ExtrapolationMode:
         old_extrapolation_mode = old_extrapolation_mode.name.lower()
-    if ExtrapolationMode.from_str(new_extrapolation_mode) is None:
+    if (
+        new_extrapolation_mode is not None
+        and ExtrapolationMode.from_str(new_extrapolation_mode) is None
+    ):
         return True
     if (
         new_extrapolation_mode == ExtrapolationMode.SERVER_WEIGHTED.name.lower()

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -175,7 +175,9 @@ def is_invalid_extrapolation_mode(old_extrapolation_mode, new_extrapolation_mode
     return False
 
 
-def format_extrapolation_mode(extrapolation_mode) -> ExtrapolationMode:
+def format_extrapolation_mode(extrapolation_mode) -> ExtrapolationMode | None:
+    if extrapolation_mode is None:
+        return None
     if type(extrapolation_mode) is int:
         return ExtrapolationMode(extrapolation_mode)
     if type(extrapolation_mode) is ExtrapolationMode:

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -159,9 +159,13 @@ class MetricIssueConditionGroupValidator(BaseDataConditionGroupValidator):
 def is_invalid_extrapolation_mode(old_extrapolation_mode, new_extrapolation_mode) -> bool:
     if type(new_extrapolation_mode) is int:
         new_extrapolation_mode = ExtrapolationMode(new_extrapolation_mode).name.lower()
+    if type(new_extrapolation_mode) is ExtrapolationMode:
+        new_extrapolation_mode = new_extrapolation_mode.name.lower()
     if type(old_extrapolation_mode) is int:
         old_extrapolation_mode = ExtrapolationMode(old_extrapolation_mode).name.lower()
-    if new_extrapolation_mode not in [name for name, value in ExtrapolationMode.as_text_choices()]:
+    if type(old_extrapolation_mode) is ExtrapolationMode:
+        old_extrapolation_mode = old_extrapolation_mode.name.lower()
+    if ExtrapolationMode.from_str(new_extrapolation_mode) is None:
         return True
     if (
         new_extrapolation_mode == ExtrapolationMode.SERVER_WEIGHTED.name.lower()

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -43,6 +43,13 @@ class ExtrapolationMode(Enum):
     def as_text_choices(cls):
         return tuple((mode.name.lower(), mode.value) for mode in cls)
 
+    @classmethod
+    def from_str(cls, name: str):
+        for mode in cls:
+            if mode.name.lower() == name:
+                return mode
+        return None
+
 
 @region_silo_model
 class SnubaQuery(Model):

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -87,7 +87,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         required=False,
         allow_empty=False,
     )
-    extrapolation_mode = serializers.IntegerField(required=False, allow_null=True)
+    extrapolation_mode = serializers.CharField(required=False, allow_null=True)
 
     class Meta:
         model = QuerySubscription
@@ -408,7 +408,15 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
     def create_source(self, validated_data) -> QuerySubscription:
         extrapolation_mode = validated_data.get("extrapolation_mode")
         if extrapolation_mode is not None:
-            extrapolation_mode = ExtrapolationMode(extrapolation_mode)
+            extrapolation_mode_options = ExtrapolationMode.as_text_choices()
+            for name, value in extrapolation_mode_options:
+                if name == extrapolation_mode:
+                    extrapolation_mode = ExtrapolationMode(value)
+                    break
+            if type(extrapolation_mode) is not ExtrapolationMode:
+                raise serializers.ValidationError(
+                    f"Invalid extrapolation mode: {extrapolation_mode}"
+                )
         snuba_query = create_snuba_query(
             query_type=validated_data["query_type"],
             dataset=validated_data["dataset"],

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -89,7 +89,7 @@ def update_snuba_query(
     resolution,
     environment,
     event_types,
-    extrapolation_mode=None,
+    extrapolation_mode: ExtrapolationMode | None = None,
 ):
     """
     Updates a SnubaQuery. Triggers updates to any related QuerySubscriptions.
@@ -131,7 +131,7 @@ def update_snuba_query(
             resolution=int(resolution.total_seconds()),
             environment=environment,
             extrapolation_mode=(
-                extrapolation_mode
+                extrapolation_mode.value
                 if extrapolation_mode is not None
                 else snuba_query.extrapolation_mode
             ),

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -133,7 +133,7 @@ def update_snuba_query(
             extrapolation_mode=(
                 extrapolation_mode
                 if extrapolation_mode is not None
-                else ExtrapolationMode.UNKNOWN.value
+                else snuba_query.extrapolation_mode
             ),
         )
         if new_event_types:

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -1315,12 +1315,11 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         }
 
         validator = MetricIssueDetectorValidator(data=data, context=self.context)
-        assert validator.is_valid(), validator.errors
-        with self.assertRaisesMessage(
-            ValidationError,
-            expected_message="Invalid extrapolation mode: blah",
-        ):
-            validator.save()
+        assert not validator.is_valid(), validator.errors
+        assert (
+            validator.errors["dataSources"]["extrapolationMode"][0]
+            == "Invalid extrapolation mode: blah"
+        )
 
     def test_nonexistent_extrapolation_mode_update(self) -> None:
         data = {
@@ -1361,9 +1360,9 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         update_validator = MetricIssueDetectorValidator(
             instance=detector, data=update_data, context=self.context, partial=True
         )
-        assert update_validator.is_valid(), update_validator.errors
-        with self.assertRaisesMessage(
-            ValidationError,
-            expected_message="Invalid extrapolation mode for this detector type.",
-        ):
-            update_validator.save()
+
+        assert not update_validator.is_valid(), update_validator.errors
+        assert (
+            update_validator.errors["dataSources"]["extrapolationMode"][0]
+            == "Invalid extrapolation mode: blah"
+        )


### PR DESCRIPTION
Slack thread for context: https://sentry.slack.com/archives/C07H2DHMSS0/p1764091469147239

Extrapolation mode would not be accepted as a string in the validator (which is what it gets passed to the backend as) so it was throwing an error on detector updates. Along with this I had to fix some tests and other logic that went into validating the extrapolation mode so we ensure we're comparing correct types.