### PR TITLE
chore(ACI): Clean up remaining incorrect type casings

### DIFF
--- a/src/sentry/testutils/helpers/data_blobs.py
+++ b/src/sentry/testutils/helpers/data_blobs.py
@@ -756,60 +756,60 @@ JIRA_SERVER_ACTION_DATA_BLOBS = [
 ]
 
 EMAIL_ACTION_DATA_BLOBS: list[dict[str, Any]] = [
-    # IssueOwners (targetIdentifier is "None")
+    # IssueOwners (target_identifier is "None")
     {
-        "targetType": "IssueOwners",
+        "target_type": "IssueOwners",
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "targetIdentifier": "None",
+        "target_identifier": "None",
         "fallthrough_type": "ActiveMembers",
         "uuid": "2e8847d7-8fe4-44d2-8a16-e25040329790",
     },
-    # NoOne Fallthrough (targetIdentifier is "")
+    # NoOne fallthrough (target_identifier is "")
     {
-        "targetType": "IssueOwners",
-        "targetIdentifier": "",
+        "target_type": "IssueOwners",
+        "target_identifier": "",
         "id": "sentry.mail.actions.NotifyEmailAction",
         "fallthrough_type": "NoOne",
         "uuid": "fb039430-0848-4fc4-89b4-bc7689a9f851",
     },
-    # AllMembers Fallthrough (targetIdentifier is None)
+    # AllMembers fallthrough (target_identifier is None)
     {
-        "targetType": "IssueOwners",
+        "target_type": "IssueOwners",
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "targetIdentifier": None,
+        "target_identifier": None,
         "fallthrough_type": "AllMembers",
         "uuid": "41f13756-8f90-4afe-b162-55268c6e3cdb",
     },
-    # NoOne Fallthrough (targetIdentifier is "None")
+    # NoOne fallthrough (target_identifier is "None")
     {
-        "targetType": "IssueOwners",
+        "target_type": "IssueOwners",
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "targetIdentifier": "None",
+        "target_identifier": "None",
         "fallthrough_type": "NoOne",
         "uuid": "99c9b517-0a0f-47f0-b3ff-2a9cd2fd9c49",
     },
-    # ActiveMembers Fallthrough
+    # ActiveMembers fallthrough
     {
-        "targetType": "Member",
+        "target_type": "Member",
         "fallthrough_type": "ActiveMembers",
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "targetIdentifier": 3234013,
+        "target_identifier": 3234013,
         "uuid": "6e83337b-9561-4167-a208-27d6bdf5e613",
     },
     # Member Email
     {
         "id": "sentry.mail.actions.NotifyEmailAction",
-        "targetIdentifier": 2160509,
-        "targetType": "Member",
+        "target_identifier": 2160509,
+        "target_type": "Member",
         "uuid": "42c3e1d6-4004-4a51-a90b-13d3404f1e55",
     },
     # Team Email
     {
-        "targetType": "Team",
+        "target_type": "Team",
         "id": "sentry.mail.actions.NotifyEmailAction",
         "fallthrough_type": "AllMembers",
         "uuid": "71b445cf-573b-4e0c-86bc-8dfbad93c480",
-        "targetIdentifier": 188022,
+        "target_identifier": 188022,
     },
 ]
 

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -99,7 +99,7 @@ class EmailFieldMappingKeys(StrEnum):
     """
 
     FALLTHROUGH_TYPE_KEY = "fallthrough_type"
-    TARGET_TYPE_KEY = "targetType"
+    TARGET_TYPE_KEY = "target_type"
 
 
 class ActionFieldMapping(TypedDict):
@@ -161,7 +161,7 @@ ACTION_FIELD_MAPPINGS: dict[str, ActionFieldMapping] = {
     ),
     ActionType.EMAIL: ActionFieldMapping(
         id="sentry.mail.actions.NotifyEmailAction",
-        target_identifier_key="targetIdentifier",
+        target_identifier_key="target_identifier",
     ),
     ActionType.PLUGIN: ActionFieldMapping(
         id="sentry.rules.actions.notify_event.NotifyEventAction",

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -543,55 +543,55 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
         self.HEALED_EMAIL_ACTION_DATA_BLOBS = [
             # IssueOwners (targetIdentifier is "None")
             {
-                "targetType": ActionTargetType.ISSUE_OWNERS.value,
+                "target_type": ActionTargetType.ISSUE_OWNERS.value,
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS,
             },
             # NoOne Fallthrough (targetIdentifier is "")
             {
-                "targetType": ActionTargetType.ISSUE_OWNERS.value,
+                "target_type": ActionTargetType.ISSUE_OWNERS.value,
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "fallthrough_type": FallthroughChoiceType.NO_ONE,
             },
             # AllMembers Fallthrough (targetIdentifier is None)
             {
-                "targetType": ActionTargetType.ISSUE_OWNERS.value,
+                "target_type": ActionTargetType.ISSUE_OWNERS.value,
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "fallthrough_type": "AllMembers",
             },
             # NoOne Fallthrough (targetIdentifier is "None")
             {
-                "targetType": ActionTargetType.ISSUE_OWNERS.value,
+                "target_type": ActionTargetType.ISSUE_OWNERS.value,
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "fallthrough_type": FallthroughChoiceType.NO_ONE,
             },
             # ActiveMembers Fallthrough
             {
-                "targetType": ActionTargetType.MEMBER.value,
+                "target_type": ActionTargetType.MEMBER.value,
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "3234013",
+                "target_identifier": "3234013",
             },
             # Member Email
             {
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "2160509",
-                "targetType": ActionTargetType.MEMBER.value,
+                "target_identifier": "2160509",
+                "target_type": ActionTargetType.MEMBER.value,
             },
             # Team Email
             {
-                "targetType": ActionTargetType.TEAM.value,
+                "target_type": ActionTargetType.TEAM.value,
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "188022",
+                "target_identifier": "188022",
             },
         ]
 
     def test_build_rule_action_blob(self) -> None:
         for expected, healed in zip(EMAIL_ACTION_DATA_BLOBS, self.HEALED_EMAIL_ACTION_DATA_BLOBS):
             action_data = pop_keys_from_data_blob(expected, Action.Type.EMAIL)
-            # pop the targetType from the action_data
-            target_type = EmailActionHelper.get_target_type_object(action_data.pop("targetType"))
+            # pop the target_type from the action_data
+            target_type = EmailActionHelper.get_target_type_object(action_data.pop("target_type"))
             # Handle all possible targetIdentifier formats
-            target_identifier: str | None = str(expected["targetIdentifier"])
+            target_identifier: str | None = str(expected["target_identifier"])
             if target_identifier in ("None", "", None):
                 target_identifier = None
 
@@ -623,7 +623,7 @@ class TestEmailIssueAlertHandler(BaseWorkflowTest):
         assert blob == {
             "fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS,
             "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
+            "target_type": "IssueOwners",
         }
 
 


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/103694 except the data isn't stored like this in the db so we thankfully don't have to run a migration - this was just incorrect in tests.