### PR TITLE
feat(billing): Add formatting configuration to DATA_CATEGORY_INFO formatting

### DIFF
--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
@@ -66,15 +66,9 @@ describe('mapStatsToChart', () => {
 });
 
 describe('mapReservedToChart', () => {
-  it('should apply GIGABYTE multiplier for byte categories (attachments)', () => {
+  it('should apply GIGABYTE multiplier for byte categories', () => {
     const reserved = 5; // 5 GB
     const result = mapReservedToChart(reserved, DataCategory.ATTACHMENTS);
-    expect(result).toBe(reserved * GIGABYTE);
-  });
-
-  it('should apply GIGABYTE multiplier for byte categories (log bytes)', () => {
-    const reserved = 10; // 10 GB
-    const result = mapReservedToChart(reserved, DataCategory.LOG_BYTE);
     expect(result).toBe(reserved * GIGABYTE);
   });
 
@@ -84,15 +78,9 @@ describe('mapReservedToChart', () => {
     expect(result).toBe(reserved * MILLISECONDS_IN_HOUR);
   });
 
-  it('should apply multiplier of 1 for count categories (errors)', () => {
+  it('should apply multiplier of 1 for count categories', () => {
     const reserved = 50000;
     const result = mapReservedToChart(reserved, DataCategory.ERRORS);
-    expect(result).toBe(reserved);
-  });
-
-  it('should apply multiplier of 1 for count categories (transactions)', () => {
-    const reserved = 100000;
-    const result = mapReservedToChart(reserved, DataCategory.TRANSACTIONS);
     expect(result).toBe(reserved);
   });
 

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -33,7 +33,6 @@ import {
   getTooltipFormatter,
 } from 'sentry/views/organizationStats/usageChart/utils';
 
-import {GIGABYTE} from 'getsentry/constants';
 import {
   ReservedBudgetCategoryType,
   type BillingMetricHistory,
@@ -50,9 +49,9 @@ import {
   isUnlimitedReserved,
 } from 'getsentry/utils/billing';
 import {
+  getCategoryInfoFromPlural,
   getPlanCategoryName,
   hasCategoryFeature,
-  isByteCategory,
   isPartOfReservedBudget,
 } from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
@@ -181,15 +180,14 @@ function chartTooltip(category: DataCategory, displayMode: 'usage' | 'cost') {
   });
 }
 
-function mapReservedToChart(reserved: number | null, category: DataCategory) {
+export function mapReservedToChart(reserved: number | null, category: DataCategory) {
   if (isUnlimitedReserved(reserved)) {
     return 0;
   }
 
-  if (isByteCategory(category)) {
-    return typeof reserved === 'number' ? reserved * GIGABYTE : 0;
-  }
-  return reserved || 0;
+  const categoryInfo = getCategoryInfoFromPlural(category);
+  const multiplier = categoryInfo?.formatting.reservedMultiplier ?? 1;
+  return typeof reserved === 'number' ? reserved * multiplier : 0;
 }
 
 function defaultChartData(): ChartStats {

--- a/static/gsApp/views/subscriptionPage/usageAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.tsx
@@ -24,7 +24,11 @@ import {
   isUnlimitedReserved,
   UsageAction,
 } from 'getsentry/utils/billing';
-import {getPlanCategoryName, sortCategoriesWithKeys} from 'getsentry/utils/dataCategory';
+import {
+  getCategoryInfoFromPlural,
+  getPlanCategoryName,
+  sortCategoriesWithKeys,
+} from 'getsentry/utils/dataCategory';
 
 import {ButtonWrapper, SubscriptionBody} from './styles';
 
@@ -64,13 +68,16 @@ function UsageAlert({subscription, usage}: Props) {
       hadCustomDynamicSampling: subscription.hadCustomDynamicSampling,
     });
 
+    const categoryInfo = getCategoryInfoFromPlural(category);
+    const isAbbreviated = categoryInfo?.formatting.projectedAbbreviated ?? true;
+
     const formattedAmount = formatReservedWithUnits(projected, category, {
-      isAbbreviated: category !== DataCategory.ATTACHMENTS,
+      isAbbreviated,
     });
 
-    return category === DataCategory.ATTACHMENTS
-      ? `${formattedAmount} of attachments`
-      : `${formattedAmount} ${displayName}`;
+    return isAbbreviated
+      ? `${formattedAmount} ${displayName}`
+      : `${formattedAmount} of ${displayName}`;
   }
 
   function projectedCategoryOverages() {


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1812/stack-2-migrate-chart-functions-to-use-formatting-config
Continues from https://github.com/getsentry/sentry/pull/104023

- Update `mapReservedToChart` to use `formatting.reservedMultiplier` instead of `isByteCategory()` check with `GIGABYTE` constant
- Update `formatProjected` to use `formatting.projectedAbbreviated` instead of hardcoded `category !== DataCategory.ATTACHMENTS` check
- Export `mapReservedToChart` and add unit tests for multiplier logic
