### PR TITLE
feat(ACI): Add RPC methods for sentryapp installations

### DIFF
--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -72,6 +72,32 @@ class DatabaseBackedAppService(AppService):
             return None
         return serialize_sentry_app(sentry_app)
 
+    def get_installation_by_sentry_app_id(
+        self, sentry_app_id: int, organization_id: int
+    ) -> RpcSentryAppInstallation | None:
+        try:
+            install = SentryAppInstallation.objects.select_related("sentry_app").get(
+                sentry_app_id=sentry_app_id,
+                organization_id=organization_id,
+                status=SentryAppInstallationStatus.INSTALLED,
+            )
+            return serialize_sentry_app_installation(install)
+        except SentryAppInstallation.DoesNotExist:
+            return None
+
+    def get_installation_by_uuid(
+        self, uuid: str, organization_id: int
+    ) -> RpcSentryAppInstallation | None:
+        try:
+            install = SentryAppInstallation.objects.select_related("sentry_app").get(
+                uuid=uuid,
+                organization_id=organization_id,
+                status=SentryAppInstallationStatus.INSTALLED,
+            )
+            return serialize_sentry_app_installation(install)
+        except SentryAppInstallation.DoesNotExist:
+            return None
+
     def get_installation_by_id(self, *, id: int) -> RpcSentryAppInstallation | None:
         try:
             install = SentryAppInstallation.objects.select_related("sentry_app").get(

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -84,6 +84,20 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_installation_by_sentry_app_id(
+        self, sentry_app_id: int, organization_id: int
+    ) -> RpcSentryAppInstallation | None:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def get_installation_by_uuid(
+        self, uuid: str, organization_id: int
+    ) -> RpcSentryAppInstallation | None:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_sentry_app_by_slug(self, *, slug: str) -> RpcSentryApp | None:
         pass
 


### PR DESCRIPTION
Add RPC methods from https://github.com/getsentry/sentry/pull/103790/ so that we can look up sentry app installations by the sentryapp id and the installation uuid.