### PR TITLE
fix(Replay): Include Timestamp Attribute in Trace Item

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -39,8 +39,8 @@ def query_replay_instance_eap(
     select = [
         Column("replay_id"),
         Function("min", parameters=[Column("project_id")], alias="agg_project_id"),
-        Function("min", parameters=[Column("timestamp")], alias="started_at"),
-        Function("max", parameters=[Column("timestamp")], alias="finished_at"),
+        Function("min", parameters=[Column("sentry.timestamp")], alias="started_at"),
+        Function("max", parameters=[Column("sentry.timestamp")], alias="finished_at"),
         Function("count", parameters=[Column("segment_id")], alias="count_segments"),
         Function("sum", parameters=[Column("count_error_events")], alias="count_errors"),
         Function("sum", parameters=[Column("count_warning_events")], alias="count_warnings"),
@@ -51,7 +51,10 @@ def query_replay_instance_eap(
                 Column("click_is_dead"),
                 Function(
                     "greaterOrEquals",
-                    [Column("timestamp"), int(datetime(year=2023, month=7, day=24).timestamp())],
+                    [
+                        Column("sentry.timestamp"),
+                        int(datetime(year=2023, month=7, day=24).timestamp()),
+                    ],
                 ),
             ],
             alias="count_dead_clicks",
@@ -62,7 +65,10 @@ def query_replay_instance_eap(
                 Column("click_is_rage"),
                 Function(
                     "greaterOrEquals",
-                    [Column("timestamp"), int(datetime(year=2023, month=7, day=24).timestamp())],
+                    [
+                        Column("sentry.timestamp"),
+                        int(datetime(year=2023, month=7, day=24).timestamp()),
+                    ],
                 ),
             ],
             alias="count_rage_clicks",
@@ -84,8 +90,7 @@ def query_replay_instance_eap(
         attribute_types={
             "replay_id": str,
             "project_id": int,
-            "timestamp": int,
-            "replay_start_timestamp": int,
+            "sentry.timestamp": int,
             "segment_id": int,
             "is_archived": int,
             "count_error_events": int,

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -367,7 +367,6 @@ def as_trace_item(
     # eventually use the trace_id in its rightful position.
     trace_item_context["attributes"]["replay_id"] = context["replay_id"]
     trace_item_context["attributes"]["segment_id"] = context["segment_id"]
-    trace_item_context["attributes"]["timestamp"] = int(trace_item_context["timestamp"])
 
     return new_trace_item(
         {

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -367,6 +367,7 @@ def as_trace_item(
     # eventually use the trace_id in its rightful position.
     trace_item_context["attributes"]["replay_id"] = context["replay_id"]
     trace_item_context["attributes"]["segment_id"] = context["segment_id"]
+    trace_item_context["attributes"]["timestamp"] = int(trace_item_context["timestamp"])
 
     return new_trace_item(
         {

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3860,7 +3860,6 @@ class ReplayEAPTestCase(BaseTestCase):
             "replay_id": replay_id,
             "segment_id": segment_id,
             "project_id": project.id,
-            "timestamp": int(timestamp.timestamp()),
             "category": category,
         }
 

--- a/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
+++ b/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
@@ -116,6 +116,9 @@ class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
         assert "started_at" in replay1_data
         assert "finished_at" in replay1_data
 
+        assert replay1_data["started_at"] is not None, "started_at should not be None"
+        assert replay1_data["finished_at"] is not None, "finished_at should not be None"
+
         assert replay1_data["count_dead_clicks"] == 3, "2 DEAD_CLICK + 1 RAGE_CLICK = 3 dead"
         assert replay1_data["count_rage_clicks"] == 1, "1 RAGE_CLICK = 1 rage"
 


### PR DESCRIPTION
This PR is in regards to the following issue: https://sentry.sentry.io/issues/7061220977/?alert_rule_id=14394965&alert_type=issue&notification_uuid=c59f28da-3fac-4c5f-8e8c-f54412d24dc5&project=11276&referrer=slack


Upon further exploration, it seems like the EAP replay query is unable to find any timestamp data:

<img width="439" height="323" alt="image" src="https://github.com/user-attachments/assets/a537ed40-437f-4d6a-9bfc-5fdb6eaf9fbe" />

This is likely because the timestamp column is not placed as an attribute when we create the trace item.


Relates to: https://linear.app/getsentry/issue/REPLAY-824/create-query-function-for-replay-details