### PR TITLE
fix(aci): handle fake alert rule ids in AlertRuleDetector lookup

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_alertrule_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_alertrule_detector_index.py
@@ -16,6 +16,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams
+from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.models.organization import Organization
 from sentry.workflow_engine.endpoints.serializers.alertrule_detector_serializer import (
     AlertRuleDetectorSerializer,
@@ -24,6 +25,7 @@ from sentry.workflow_engine.endpoints.validators.alertrule_detector import (
     AlertRuleDetectorValidator,
 )
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
+from sentry.workflow_engine.models.detector import Detector
 
 
 @region_silo_endpoint
@@ -69,7 +71,26 @@ class OrganizationAlertRuleDetectorIndexEndpoint(OrganizationEndpoint):
             queryset = queryset.filter(rule_id=rule_id)
 
         alert_rule_detector = queryset.first()
-        if not alert_rule_detector:
-            raise ResourceDoesNotExist
 
-        return Response(serialize(alert_rule_detector, request.user))
+        if alert_rule_detector:
+            return Response(serialize(alert_rule_detector, request.user))
+
+        # Fallback: if alert_rule_id was provided but no AlertRuleDetector was found,
+        # try looking up Detector directly using calculated detector_id
+        if alert_rule_id:
+            try:
+                calculated_detector_id = get_object_id_from_fake_id(int(alert_rule_id))
+                detector = Detector.objects.get(id=calculated_detector_id)
+
+                if detector:
+                    return Response(
+                        {
+                            "detectorId": str(detector.id),
+                            "alertRuleId": str(alert_rule_id),
+                            "ruleId": None,
+                        }
+                    )
+            except (ValueError, Detector.DoesNotExist):
+                pass
+
+        raise ResourceDoesNotExist

--- a/src/sentry/workflow_engine/endpoints/organization_alertrule_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_alertrule_detector_index.py
@@ -80,7 +80,9 @@ class OrganizationAlertRuleDetectorIndexEndpoint(OrganizationEndpoint):
         if alert_rule_id:
             try:
                 calculated_detector_id = get_object_id_from_fake_id(int(alert_rule_id))
-                detector = Detector.objects.get(id=calculated_detector_id)
+                detector = Detector.objects.get(
+                    id=calculated_detector_id, project__organization=organization
+                )
 
                 if detector:
                     return Response(


### PR DESCRIPTION
When looking up a Detector via alert rule id, it's possible that there is no corresponding row in the AlertRuleDetector table. We then assume that the alert rule id that was passed is a fake id, so we can use get_object_id_from_fake_id() to get the detector.