### PR TITLE
feat(aci): Format percentage based thresholds/data

### DIFF
--- a/static/app/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds.tsx
+++ b/static/app/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds.tsx
@@ -1,0 +1,57 @@
+import {useMemo} from 'react';
+
+import type {Series} from 'sentry/types/echarts';
+
+interface UseChartAxisBoundsProps {
+  series: Series[];
+  thresholdMaxValue: number | undefined;
+}
+
+interface ChartAxisBounds {
+  maxValue: number;
+  minValue: number;
+}
+
+/**
+ * Calculates y-axis bounds for detector charts based on series data and threshold values.
+ * Adds padding to ensure all data points and thresholds are visible.
+ */
+export function useDetectorChartAxisBounds({
+  series,
+  thresholdMaxValue,
+}: UseChartAxisBoundsProps): ChartAxisBounds {
+  return useMemo(() => {
+    if (series.length === 0) {
+      return {maxValue: 0, minValue: 0};
+    }
+
+    const allSeriesValues = series.flatMap(s =>
+      s.data
+        .map(point => point.value)
+        .filter(val => typeof val === 'number' && !isNaN(val))
+    );
+
+    if (allSeriesValues.length === 0) {
+      return {maxValue: 0, minValue: 0};
+    }
+
+    const seriesMax = Math.max(...allSeriesValues);
+    const seriesMin = Math.min(...allSeriesValues);
+
+    // Combine with threshold max and round to nearest whole number
+    const combinedMax = thresholdMaxValue
+      ? Math.max(seriesMax, thresholdMaxValue)
+      : seriesMax;
+
+    const roundedMax = Math.round(combinedMax);
+
+    // Add padding to the bounds
+    const maxPadding = roundedMax * 0.1;
+    const minPadding = seriesMin * 0.1;
+
+    return {
+      maxValue: roundedMax + maxPadding,
+      minValue: Math.max(0, seriesMin - minPadding),
+    };
+  }, [series, thresholdMaxValue]);
+}


### PR DESCRIPTION
- fixes an issue where release dataset wasn't formatted correctly on aci details
- fixes thresholds on % based charts being (10 being rendered as 10k percent instead of 0.1
- removes yAxis min for percentage based charts since its a bit more useful sometimes to see 90 -> 100%

<img width="1072" height="201" alt="image" src="https://github.com/user-attachments/assets/7a46a227-e5b9-47b6-961f-3c7baf56c0b8" />
