### PR TITLE
fix(waterfall): Relax "next_trace" lookup to just the trace id

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindLinkedTraces.ts
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindLinkedTraces.ts
@@ -38,7 +38,6 @@ export function useFindAdjacentTrace({
     let _projectId: number | undefined = undefined;
     let _environment: string | undefined = undefined;
     let _currentTraceId: string | undefined;
-    let _currentSpanId: string | undefined;
     let _adjacentTraceAttribute: TraceItemResponseAttribute | undefined = undefined;
 
     for (const a of attributes ?? []) {
@@ -48,8 +47,6 @@ export function useFindAdjacentTrace({
         _environment = a.value;
       } else if (a.name === 'trace' && a.type === 'str') {
         _currentTraceId = a.value;
-      } else if (a.name === 'transaction.span_id' && a.type === 'str') {
-        _currentSpanId = a.value;
       } else if (a.name === 'previous_trace' && a.type === 'str') {
         _adjacentTraceAttribute = a;
       }

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindLinkedTraces.ts
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/useFindLinkedTraces.ts
@@ -30,7 +30,6 @@ export function useFindAdjacentTrace({
     projectId,
     environment,
     currentTraceId,
-    currentSpanId,
     adjacentTraceId,
     adjacentTraceSpanId,
     hasAdjacentTraceLink,
@@ -74,7 +73,6 @@ export function useFindAdjacentTrace({
       projectId: _projectId,
       environment: _environment,
       currentTraceId: _currentTraceId,
-      currentSpanId: _currentSpanId,
       hasAdjacentTraceLink: _hasAdjacentTraceLink,
       adjacentTraceSampled: _adjacentTraceSampledFlag === '1',
       adjacentTraceId: _adjacentTraceId,
@@ -84,7 +82,12 @@ export function useFindAdjacentTrace({
 
   const searchQuery =
     direction === 'next'
-      ? `sentry.previous_trace:${currentTraceId}-${currentSpanId}-1`
+      ? // relaxed the next trace lookup to match spans containing only the
+        // traceId and not the spanId of the current trace root. We can't
+        // always be sure that the current trace root is indeed the span the
+        // next span would link towards, because sometimes the root might be a web
+        // vital span instead of the actual intial span from the SDK's perspective.
+        `sentry.previous_trace:${currentTraceId}-*-1`
       : `id:${adjacentTraceSpanId} trace:${adjacentTraceId}`;
 
   const enabled =


### PR DESCRIPTION
For the "Next Trace" button, we'd previously, search for spans matching the exact trace and span id of the current trace root span. However, in some cases, the product considers another span the trace root span than our SDK. An example is a web vital (INP) span, which happened slightly before the navigation span started but was only added by the SDK retroactively. In the product, we consider the web vital span the trace root, while in the SDK we assigned the previous_trace span link to the navigation span. 

To still correctly find the next trace span, this PR now relaxes the search criteria for the next trace, to search for a span with the `previous_trace` attribute containing the current trace's traceId, but _any_ spanId. This works well as long as there's only one `previous_trace` span link per trace. If there are multiple, we'd take the first one, which also isn't the end of the world. However, in the SDK, we make sure to only set the link once per trace. => I think this works well enough.

h/t @bcoe for the "contains" idea 🙏  