### PR TITLE
fix(waterfall): Prefer specific root events in trace root lookup

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
@@ -57,6 +57,8 @@ export const getRepresentativeTraceEvent = (
     return {type: 'uptime_check', event: traceChild.value};
   }
 
+  let preferredRootEvent: TraceTree.TraceEvent | null = null;
+  let eapRootEvent: TraceTree.TraceEvent | null = null;
   let rootEvent: TraceTree.TraceEvent | null = null;
   let candidateEvent: TraceTree.TraceEvent | null = null;
   let firstEvent: TraceTree.TraceEvent | null = null;
@@ -75,8 +77,18 @@ export const getRepresentativeTraceEvent = (
       }
 
       if (isEAPTransaction(event)) {
-        // If we find a root EAP transaction, we can stop looking and use it for the title.
-        break;
+        // We prefer certain root events over conventional root events.
+        // These make better titles in the waterfall view and make linked
+        // trace navigations work.
+        if (event.op && CANDIDATE_TRACE_TITLE_OPS.includes(event.op)) {
+          preferredRootEvent = event;
+          break;
+        }
+
+        // Otherwise, we still prefer the first EAP root event over the conventional root event
+        if (!eapRootEvent) {
+          eapRootEvent = event;
+        }
       }
       // Otherwise we keep looking for a root eap transaction. If we don't find one, we use other roots, like standalone spans.
       continue;
@@ -103,7 +115,8 @@ export const getRepresentativeTraceEvent = (
   }
 
   return {
-    event: rootEvent ?? candidateEvent ?? firstEvent,
+    event:
+      preferredRootEvent ?? eapRootEvent ?? rootEvent ?? candidateEvent ?? firstEvent,
     type: 'span',
   };
 };

--- a/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
@@ -57,7 +57,7 @@ export const getRepresentativeTraceEvent = (
   }
 
   let preferredRootEvent: TraceTree.TraceEvent | null = null;
-  let rootEvent: TraceTree.TraceEvent | null = null;
+  let firstRootEvent: TraceTree.TraceEvent | null = null;
   let candidateEvent: TraceTree.TraceEvent | null = null;
   let firstEvent: TraceTree.TraceEvent | null = null;
 
@@ -67,7 +67,9 @@ export const getRepresentativeTraceEvent = (
     : [...traceNode.value.transactions, ...traceNode.value.orphan_errors];
   for (const event of events) {
     if (isRootEvent(event)) {
-      rootEvent = event;
+      if (!firstRootEvent) {
+        firstRootEvent = event;
+      }
 
       if (hasPreferredOp(event)) {
         preferredRootEvent = event;
@@ -92,7 +94,7 @@ export const getRepresentativeTraceEvent = (
   }
 
   return {
-    event: preferredRootEvent ?? rootEvent ?? candidateEvent ?? firstEvent,
+    event: preferredRootEvent ?? firstRootEvent ?? candidateEvent ?? firstEvent,
     type: 'span',
   };
 };


### PR DESCRIPTION
This PR fixes two issues but to be honest, I'm a bit unsure of all consequences. Would appreciate a thorough review from someone who actually knows the waterfall view :)

1. While fixing #104047, I also noticed that we had a similar problem for the "previous trace" button:

   If we look at a trace in the waterfall where the first root span is not a navigation/pageload span but e.g. a web vital span, we can't look up the trace's `previous_trace` link. Therefore, we can only show the disabled "previous trace" button in the UI, although there actually is a previous trace. 

2. For EAP-based traces, it seems like we always took the first transaction event as the title of the current trace. This sometimes led to a bit sub optimal titles in my opinion. I noticed we had a more selective logic for none-EAP events, where we preferred the `pageload`, `navigation` and `ui.load` events over the "first" event. 

To fix both of these issues, this PR ports the none-EAP logic of selecting a trace root to all trace root events (including EAP). 

Before: 
<img width="1216" height="686" alt="image" src="https://github.com/user-attachments/assets/aac5c87b-a737-430e-a29f-0e8b9f8b2459" />


After:
<img width="1234" height="698" alt="image" src="https://github.com/user-attachments/assets/2fa22eac-074b-4791-b61b-9d8c0c180c13" />
