### PR TITLE
chore(aci): bump offset for fake IDs

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/utils.py
+++ b/src/sentry/incidents/endpoints/serializers/utils.py
@@ -1,4 +1,4 @@
-OFFSET = 10**9
+OFFSET = 10**10
 
 
 def get_fake_id_from_object_id(obj_id: int) -> int:

--- a/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.core.cache import cache
 
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.utils import OFFSET
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     WorkflowEngineDetectorSerializer,
 )
@@ -21,8 +22,6 @@ from sentry.workflow_engine.models.action_alertruletriggeraction import ActionAl
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
 )
-
-OFFSET = 10**9
 
 
 class TestDetectorSerializer(TestWorkflowEngineSerializer):


### PR DESCRIPTION
I'm a bit concerned that we have 500 million+ open periods already. Bump the offset for fake IDs to 10 billion so there's a vastly reduced risk of us running into it with real open period IDs.