### PR TITLE
feat(preprod): Add date_built support to artifact assemble endpoint (EME-631)

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -78,6 +78,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict[str, Any
             # Optional metadata
             "build_configuration": {"type": "string"},
             "release_notes": {"type": "string"},
+            "date_built": {"type": "string"},
             # VCS parameters - allow empty strings to support clearing auto-filled values
             "head_sha": {"type": "string", "pattern": "^(|[0-9a-f]{40})$"},
             "base_sha": {"type": "string", "pattern": "^(|[0-9a-f]{40})$"},
@@ -97,6 +98,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict[str, Any
         "chunks": "The chunks field is required and must be provided as an array of 40-character hexadecimal strings.",
         "build_configuration": "The build_configuration field must be a string.",
         "release_notes": "The release_notes field msut be a string.",
+        "date_built": "The date_built field must be an ISO 8601 formatted date-time string.",
         "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
         "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
         "provider": "The provider field must be a string with maximum length of 255 characters containing the domain of the VCS provider (ex. github.com)",
@@ -204,6 +206,7 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                 checksum=checksum,
                 build_configuration_name=data.get("build_configuration"),
                 release_notes=data.get("release_notes"),
+                date_built=data.get("date_built"),
                 head_sha=data.get("head_sha"),
                 base_sha=data.get("base_sha"),
                 provider=data.get("provider"),

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -41,6 +41,7 @@ class ValidatePreprodArtifactSchemaTest(TestCase):
             "checksum": "a" * 40,
             "chunks": ["b" * 40, "c" * 40],
             "build_configuration": "release",
+            "date_built": "2025-11-26T10:30:00",
             "head_sha": "e" * 40,
             "base_sha": "f" * 40,
             "provider": "github",
@@ -160,6 +161,21 @@ class ValidatePreprodArtifactSchemaTest(TestCase):
     def test_pr_number_invalid(self) -> None:
         """Test invalid pr_number returns error."""
         body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "pr_number": 0})
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is not None
+        assert result == {}
+
+    def test_date_built_valid_string(self) -> None:
+        """Test valid date_built string is accepted."""
+        data = {"checksum": "a" * 40, "chunks": [], "date_built": "2025-11-26T10:30:00"}
+        body = orjson.dumps(data)
+        result, error = validate_preprod_artifact_schema(body)
+        assert error is None
+        assert result == data
+
+    def test_date_built_wrong_type(self) -> None:
+        """Test non-string date_built returns error."""
+        body = orjson.dumps({"checksum": "a" * 40, "chunks": [], "date_built": 123})
         result, error = validate_preprod_artifact_schema(body)
         assert error is not None
         assert result == {}

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -114,6 +114,29 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         # Clean up
         delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
 
+    def test_create_preprod_artifact_with_date_built(self) -> None:
+        """Test that create_preprod_artifact stores date_built field"""
+        content = b"test preprod artifact with date_built"
+        total_checksum = sha1(content).hexdigest()
+        date_built_str = "2025-11-26T10:30:00"
+
+        # Create preprod artifact with date_built
+        artifact = create_preprod_artifact(
+            org_id=self.organization.id,
+            project_id=self.project.id,
+            checksum=total_checksum,
+            build_configuration_name="release",
+            date_built=date_built_str,
+        )
+        assert artifact is not None
+
+        # Verify the artifact was created with date_built
+        assert artifact.date_built is not None
+        assert artifact.date_built.isoformat() == date_built_str
+
+        # Clean up
+        delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
+
     def test_assemble_preprod_artifact_with_commit_comparison(self) -> None:
         content = b"test preprod artifact with commit comparison"
         fileobj = ContentFile(content)


### PR DESCRIPTION
## Summary

Adds backend support for capturing build timestamps for Android artifacts via the assemble endpoint. This allows sentry-cli to pass `date_built` when uploading APK/AAB files.

Unlike iOS, Android artifacts don't contain reliable build timestamps due to reproducible builds, so the timestamp must be captured at build time by the Gradle plugin and passed through sentry-cli. See discussion in [EME-631 Android date_built](https://linear.app/getsentry/issue/EME-631/android-date-built)

## Changes

- **API Schema**: Add `date_built` field to assemble endpoint schema validation
- **Task Function**: Parse ISO 8601 date strings to datetime objects and store in database
- **Database**: Uses existing `PreprodArtifact.date_built` field (no migration needed)
- **Tests**: Add schema validation tests and integration test for artifact creation

## Related

- See [EME-631 Android date_built](https://linear.app/getsentry/issue/EME-631/android-date-built) for a discussion on this.
- iOS implementation: EME-632, #475 (launchpad)
- Requires corresponding changes in sentry-cli and sentry-android-gradle-plugin