### PR TITLE
ref(issues): move top issues tab to top

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -29,6 +29,14 @@ export function IssuesSecondaryNav() {
           <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="issues_feed">
             {t('Feed')}
           </SecondaryNav.Item>
+          {hasTopIssuesUI && (
+            <SecondaryNav.Item
+              to={`${baseUrl}/dynamic-groups/`}
+              analyticsItemName="issues_dynamic_groups"
+            >
+              {t('Top Issues')}
+            </SecondaryNav.Item>
+          )}
         </SecondaryNav.Section>
         <SecondaryNav.Section id="issues-types">
           {Object.values(ISSUE_TAXONOMY_CONFIG).map(({key, label}) => (
@@ -58,16 +66,6 @@ export function IssuesSecondaryNav() {
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <IssueViews sectionRef={sectionRef} />
-        {hasTopIssuesUI && (
-          <SecondaryNav.Section id="issues-dynamic-groups">
-            <SecondaryNav.Item
-              to={`${baseUrl}/dynamic-groups/`}
-              analyticsItemName="issues_dynamic_groups"
-            >
-              {t('Top Issues')}
-            </SecondaryNav.Item>
-          </SecondaryNav.Section>
-        )}
         <ConfigureSection baseUrl={baseUrl} />
       </SecondaryNav.Body>
     </Fragment>


### PR DESCRIPTION
Put top issues next to feed. Still feature flagged.
<img width="210" height="331" alt="Screenshot 2025-11-26 at 10 10 29 AM" src="https://github.com/user-attachments/assets/a353654d-e52b-4f9d-8b0e-0ebafcba1204" />
