### PR TITLE
chore(tests): skip flaky test

### DIFF
--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.test import override_settings
 from django.urls import reverse
 
@@ -183,6 +184,7 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         )
         OrganizationMemberTeam.objects.get(organizationmember_id=org_member.id, team_id=team.id)
 
+    @pytest.mark.skip("flaky")
     def test_valid_slugs(self) -> None:
         valid_slugs = ["santry", "downtown-canada", "1234-foo"]
         for input_slug in valid_slugs:

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -184,7 +184,7 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         )
         OrganizationMemberTeam.objects.get(organizationmember_id=org_member.id, team_id=team.id)
 
-    @pytest.mark.skip("flaky")
+    @pytest.mark.skip("flaky: INFRENG-210")
     def test_valid_slugs(self) -> None:
         valid_slugs = ["santry", "downtown-canada", "1234-foo"]
         for input_slug in valid_slugs:


### PR DESCRIPTION
Skip `tests/sentry/core/endpoints/test_organization_index.py::OrganizationsCreateTest::test_valid_slugs`