### PR TITLE
feat(dashboards): register "details" widget as valid widget on the backend

### DIFF
--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -168,6 +168,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
     TABLE = 4
     BIG_NUMBER = 6
     TOP_N = 7
+    DETAILS = 8
     TYPES = [
         (LINE_CHART, "line"),
         (AREA_CHART, "area"),
@@ -176,6 +177,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
         (TABLE, "table"),
         (BIG_NUMBER, "big_number"),
         (TOP_N, "top_n"),
+        (DETAILS, "details"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 


### PR DESCRIPTION
Prevents the `"detail" is not a valid choice` error when trying to save a details widget
complements https://github.com/getsentry/sentry/pull/104059