### PR TITLE
feat(filters): Add common errors inbound filter toggle

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1143,6 +1143,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "filters:react-hydration-errors": options.get("filters:react-hydration-errors", "1")
             in ("1", True),
             "filters:chunk-load-error": options.get("filters:chunk-load-error", "1") == "1",
+            "filters:common-errors": options.get("filters:common-errors", "1") == "1",
             f"filters:{FilterTypes.RELEASES}": "\n".join(
                 options.get(f"sentry:{FilterTypes.RELEASES}", [])
             ),

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -154,6 +154,7 @@ DETAILED_PROJECT = {
         "filters:blacklisted_ips": "",
         "filters:react-hydration-errors": True,
         "filters:chunk-load-error": True,
+        "filters:common-errors": True,
         "filters:releases": "",
         "filters:error_messages": "",
         "feedback:branding": True,

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -883,6 +883,11 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     "filters:chunk-load-error",
                     "1" if bool(options["filters:chunk-load-error"]) else "0",
                 )
+            if "filters:common-errors" in options:
+                project.update_option(
+                    "filters:common-errors",
+                    "1" if bool(options["filters:common-errors"]) else "0",
+                )
             if "filters:blacklisted_ips" in options:
                 project.update_option(
                     "sentry:blacklisted_ips",

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -23,6 +23,7 @@ class FilterStatKeys:
     RELEASE_VERSION = "release-version"
     ERROR_MESSAGE = "error-message"
     BROWSER_EXTENSION = "browser-extensions"
+    COMMON_ERRORS = "common-errors"
     LEGACY_BROWSER = "legacy-browsers"
     LOCALHOST = "localhost"
     WEB_CRAWLER = "web-crawlers"
@@ -38,6 +39,7 @@ FILTER_STAT_KEYS_TO_VALUES = {
     FilterStatKeys.RELEASE_VERSION: TSDBModel.project_total_received_release_version,
     FilterStatKeys.ERROR_MESSAGE: TSDBModel.project_total_received_error_message,
     FilterStatKeys.BROWSER_EXTENSION: TSDBModel.project_total_received_browser_extensions,
+    FilterStatKeys.COMMON_ERRORS: TSDBModel.project_total_received_common_errors,
     FilterStatKeys.LEGACY_BROWSER: TSDBModel.project_total_received_legacy_browsers,
     FilterStatKeys.LOCALHOST: TSDBModel.project_total_received_localhost,
     FilterStatKeys.WEB_CRAWLER: TSDBModel.project_total_received_web_crawlers,
@@ -73,6 +75,7 @@ def get_all_filter_specs():
         _browser_extensions_filter,
         _legacy_browsers_filter,
         _web_crawlers_filter,
+        _common_errors_filter,
         _healthcheck_filter,
     ]
 
@@ -170,7 +173,7 @@ def _filter_from_filter_id(filter_id):
 
 class _FilterSerializer(serializers.Serializer):
     active = serializers.BooleanField(
-        help_text="Toggle the browser-extensions, localhost, filtered-transaction, or web-crawlers filter on or off.",
+        help_text="Toggle the browser-extensions, common-errors, localhost, filtered-transaction, or web-crawlers filter on or off.",
         required=False,
     )
 
@@ -289,6 +292,13 @@ _web_crawlers_filter = _FilterSpec(
     name="Filter out known web crawlers",
     description="Some crawlers may execute pages in incompatible ways which then cause errors that"
     " are unlikely to be seen by a normal user.",
+)
+
+_common_errors_filter = _FilterSpec(
+    id=FilterStatKeys.COMMON_ERRORS,
+    name="Filter out noisy errors",
+    description="Filters out errors that are typically not actionable, such as network errors, "
+    "aborted requests, and browser-specific quirks like ResizeObserver loop limit exceeded.",
 )
 
 

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -77,6 +77,7 @@ OPTION_KEYS = frozenset(
         "mail:subject_template",
         "filters:react-hydration-errors",
         "filters:chunk-load-error",
+        "filters:common-errors",
         "relay.cardinality-limiter.limits",
     ]
 )

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -64,6 +64,9 @@ register(key="filters:react-hydration-errors", epoch_defaults={1: "1"})
 # Default NextJS chunk load error filter
 register(key="filters:chunk-load-error", epoch_defaults={1: "1"})
 
+# Default common errors filter
+register(key="filters:common-errors", epoch_defaults={1: "1"})
+
 # Default breakdowns config
 register(
     key="sentry:breakdowns",

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -102,6 +102,8 @@ class TSDBModel(Enum):
     project_total_received_discarded = 610
     # the number of events filtered because they refer to a healthcheck endpoint
     project_total_healthcheck = 611
+    # the number of events filtered by common errors filter
+    project_total_received_common_errors = 612
 
     servicehook_fired = 700
 

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -613,8 +613,7 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                   apiMethod="PUT"
                   apiEndpoint={projectEndpoint}
                   initialData={{
-                    'filters:common-errors':
-                      project.options?.['filters:common-errors'],
+                    'filters:common-errors': project.options?.['filters:common-errors'],
                   }}
                   saveOnBlur
                   onFieldChange={(name, value) => {

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -608,6 +608,41 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                   />
                 </NestedForm>
               </PanelItem>
+              <PanelItem noPadding>
+                <NestedForm
+                  apiMethod="PUT"
+                  apiEndpoint={projectEndpoint}
+                  initialData={{
+                    'filters:common-errors':
+                      project.options?.['filters:common-errors'],
+                  }}
+                  saveOnBlur
+                  onFieldChange={(name, value) => {
+                    trackAnalytics('settings.inbound_filter_updated', {
+                      organization,
+                      project_id: parseInt(project.id, 10),
+                      filter: name,
+                      new_state: value ? 'enabled' : 'disabled',
+                    });
+                  }}
+                  onSubmitSuccess={(
+                    response // This will update our project context
+                  ) => ProjectsStore.onUpdateSuccess(response)}
+                >
+                  <FieldFromConfig
+                    getData={getOptionsData}
+                    field={{
+                      type: 'boolean',
+                      name: 'filters:common-errors',
+                      label: t('Filter out noisy errors'),
+                      help: t(
+                        'Filters out errors that are typically not actionable, such as network errors, aborted requests, ResizeObserver loop errors, and other browser-specific quirks.'
+                      ),
+                      disabled: !hasAccess,
+                    }}
+                  />
+                </NestedForm>
+              </PanelItem>
             </PanelBody>
           </Panel>
 

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -650,6 +650,7 @@ class ProjectUpdateTest(APITestCase):
             "feedback:branding": False,
             "filters:react-hydration-errors": True,
             "filters:chunk-load-error": True,
+            "filters:common-errors": True,
         }
         with (
             self.feature(
@@ -794,6 +795,7 @@ class ProjectUpdateTest(APITestCase):
             ).exists()
         assert project.get_option("filters:react-hydration-errors", "1")
         assert project.get_option("filters:chunk-load-error", "1")
+        assert project.get_option("filters:common-errors", "1")
 
         self.project.update_option(
             "relay.cardinality-limiter.limits",
@@ -1084,6 +1086,17 @@ class ProjectUpdateTest(APITestCase):
         resp = self.get_success_response(self.org_slug, self.proj_slug, options=options)
         assert self.project.get_option("filters:chunk-load-error") == "1"
         assert resp.data["options"]["filters:chunk-load-error"] is True
+
+    def test_common_errors(self) -> None:
+        options = {"filters:common-errors": False}
+        resp = self.get_success_response(self.org_slug, self.proj_slug, options=options)
+        assert self.project.get_option("filters:common-errors") == "0"
+        assert resp.data["options"]["filters:common-errors"] is False
+
+        options = {"filters:common-errors": True}
+        resp = self.get_success_response(self.org_slug, self.proj_slug, options=options)
+        assert self.project.get_option("filters:common-errors") == "1"
+        assert resp.data["options"]["filters:common-errors"] is True
 
     def test_relay_pii_config(self) -> None:
         value = '{"applications": {"freeform": []}}'

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -281,6 +281,7 @@ def test_project_config_uses_filter_features(
     default_project.update_option("sentry:releases", releases)
     default_project.update_option("filters:react-hydration-errors", "0")
     default_project.update_option("filters:chunk-load-error", "0")
+    default_project.update_option("filters:common-errors", "0")
 
     if has_blacklisted_ips:
         default_project.update_option("sentry:blacklisted_ips", blacklisted_ips)


### PR DESCRIPTION
## Summary

Adds a new **Filter out noisy errors** toggle to the inbound filters settings page. This filter catches commonly occurring errors that are typically not actionable, such as:

- Network errors (Failed to fetch, Network Error, etc.)
- Aborted requests (AbortError)
- ResizeObserver loop errors
- Timeout errors
- Non-Error promise rejections
- And other browser-specific quirks

The filter logic is already implemented in Relay - this PR adds the UI toggle and backend support to enable/disable it per project.

## Changes

- Added `filters:common-errors` project option (enabled by default)
- Added toggle to inbound filters settings UI
- Added API serialization and endpoint handling
- Added TSDB model for tracking filtered events
- Added tests

ref: https://github.com/getsentry/relay/pull/5415