### PR TITLE
chore(hybridcloud) Align keys used for organization snowflakeids

### DIFF
--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -14,6 +14,7 @@ from sentry.hybridcloud.services.control_organization_provisioning import (
     serialize_slug_reservation,
 )
 from sentry.hybridcloud.services.organization_mapping.serial import serialize_organization_mapping
+from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
@@ -63,9 +64,6 @@ class InvalidOrganizationProvisioningException(Exception):
     pass
 
 
-REDIS_KEY_PREFIX = "control_org"
-
-
 class DatabaseBackedControlOrganizationProvisioningService(
     ControlOrganizationProvisioningRpcService
 ):
@@ -95,8 +93,7 @@ class DatabaseBackedControlOrganizationProvisioningService(
 
     @staticmethod
     def _generate_org_snowflake_id(region_name: str) -> int:
-        redis_key = f"{REDIS_KEY_PREFIX}_{region_name}"
-        return generate_snowflake_id(redis_key)
+        return generate_snowflake_id(Organization.snowflake_redis_key)
 
     @staticmethod
     def _generate_org_slug(region_name: str, slug: str) -> str:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -404,10 +404,6 @@ class Factories:
                 category=OutboxCategory.ORGANIZATION_UPDATE,
             ).drain_shard()
 
-            with assume_test_silo_mode(SiloMode.CONTROL):
-                # Remove the reservation now that we're done with it.
-                OrganizationSlugReservation.objects.filter(organization_id=org.id).delete()
-
         if owner:
             Factories.create_member(organization=org, user_id=owner.id, role="owner")
         return org

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -404,6 +404,11 @@ class Factories:
                 category=OutboxCategory.ORGANIZATION_UPDATE,
             ).drain_shard()
 
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                # Remove the reservation now that we're done with it.
+                # print('remove slug reservation in factories')
+                OrganizationSlugReservation.objects.filter(organization_id=org.id).delete()
+
         if owner:
             Factories.create_member(organization=org, user_id=owner.id, role="owner")
         return org

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -406,7 +406,6 @@ class Factories:
 
             with assume_test_silo_mode(SiloMode.CONTROL):
                 # Remove the reservation now that we're done with it.
-                # print('remove slug reservation in factories')
                 OrganizationSlugReservation.objects.filter(organization_id=org.id).delete()
 
         if owner:


### PR DESCRIPTION
Using two different keys for organization snowflakeids results in duplicate sequence values when both are used. We end up using both as organizations created by `Factories.create_organization()` use the key from `Organization` while organizations created via the API endpoint use the module level key. Having the same key allows monolith mode deployments (and tests) that use a shared redis to not generate overlapping sequence values.

Refs #103967
