### PR TITLE
ref(explorer): add copy and nav for errors search

### DIFF
--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -373,9 +373,7 @@ export function buildToolLinkUrl(
 
         const {y_axes} = toolLink.params;
         if (y_axes) {
-          const axes = Array.isArray(y_axes) ? y_axes : [y_axes];
-          const stringifiedAxes = axes.map(axis => JSON.stringify(axis));
-          queryParams.yAxis = stringifiedAxes;
+          queryParams.yAxis = y_axes;
         }
 
         if (sort) {

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -43,6 +43,12 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
         : `Searched for issues${projectInfo}: '${question}'`;
     }
 
+    if (dataset === 'errors') {
+      return isLoading
+        ? `Searching for errors${projectInfo}: '${question}'...`
+        : `Searched for errors${projectInfo}: '${question}'`;
+    }
+
     // Default to spans
     return isLoading
       ? `Querying spans${projectInfo}: '${question}'...`
@@ -339,6 +345,45 @@ export function buildToolLinkUrl(
 
         return {
           pathname: `/organizations/${orgSlug}/issues/`,
+          query: queryParams,
+        };
+      }
+
+      if (dataset === 'errors') {
+        const queryParams: Record<string, any> = {
+          dataset: 'errors',
+          queryDataset: 'error-events',
+          query: query || '',
+          project: null,
+        };
+
+        if (stats_period) {
+          queryParams.statsPeriod = stats_period;
+        }
+
+        // If project_slugs is provided, look up the project IDs
+        if (project_slugs && project_slugs.length > 0 && projects) {
+          const projectIds = project_slugs
+            .map((slug: string) => projects.find(p => p.slug === slug)?.id)
+            .filter((id: string | undefined) => id !== undefined);
+          if (projectIds.length > 0) {
+            queryParams.project = projectIds;
+          }
+        }
+
+        const {y_axes} = toolLink.params;
+        if (y_axes) {
+          const axes = Array.isArray(y_axes) ? y_axes : [y_axes];
+          const stringifiedAxes = axes.map(axis => JSON.stringify(axis));
+          queryParams.yAxis = stringifiedAxes;
+        }
+
+        if (sort) {
+          queryParams.sort = sort;
+        }
+
+        return {
+          pathname: `/organizations/${orgSlug}/explore/discover/homepage/`,
           query: queryParams,
         };
       }


### PR DESCRIPTION
closes [AIML-1720: Add copy+nav for error search tool](https://linear.app/getsentry/issue/AIML-1720/add-copynav-for-error-search-tool)

same params as for spans, but we always expect y_axes to be a list