### PR TITLE
feat(agents): Show agent names in traces table

### DIFF
--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -140,7 +140,7 @@ interface UseHoverOverlayProps {
   underlineColor?: ColorOrAlias;
 }
 
-function isOverflown(el: Element): boolean {
+export function isOverflown(el: Element): boolean {
   // Safari seems to calculate scrollWidth incorrectly, causing isOverflown to always return true in some cases.
   // Adding a 2 pixel tolerance seems to account for this discrepancy.
   const tolerance =

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, memo, useCallback, useMemo, useRef, useState} from 'react';
+import {Fragment, memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {parseAsString, useQueryState} from 'nuqs';
 
@@ -372,6 +372,14 @@ function AgentTags({agents}: {agents: string[]}) {
     resizeObserverRef.current = observer;
     observer.observe(containerRef.current);
   }, [showAll]);
+
+  // Cleanup the resize observer when the component unmounts
+  useEffect(() => {
+    return () => {
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+    };
+  }, []);
 
   return (
     <Flex

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -123,7 +123,6 @@ export function TracesTable() {
       sorts: [{field: 'timestamp', kind: 'asc'}],
       samplingMode: SAMPLING_MODE.HIGH_ACCURACY,
       enabled: Boolean(tracesRequest.data && tracesRequest.data.data.length > 0),
-      limit: 100,
     },
     Referrer.TRACES_TABLE
   );


### PR DESCRIPTION
### Problem
The name of the trace root is often not helpful when debugging agents, especially when working with distributed traces.

### Solution
Display agent names instead of the trace root if available.
Allow clicking agents to filter the page by them.

https://github.com/user-attachments/assets/78564b87-76e8-400a-b0a8-13f2d613874c

