### PR TITLE
feat(replays): Quick poc of replays on the events endpoint

### DIFF
--- a/src/sentry/search/eap/replays/attributes.py
+++ b/src/sentry/search/eap/replays/attributes.py
@@ -1,0 +1,33 @@
+from sentry.search.eap import constants
+from sentry.search.eap.columns import (
+    ResolvedAttribute,
+    VirtualColumnDefinition,
+    project_context_constructor,
+    project_term_resolver,
+)
+from sentry.search.eap.common_columns import COMMON_COLUMNS
+from sentry.utils.validators import is_event_id_or_list
+
+# TODO(wmak): Most of this is copy paste from the other attribute definitions, just trying to get a quick POC
+REPLAY_ATTRIBUTE_DEFINITIONS = {
+    column.public_alias: column
+    for column in COMMON_COLUMNS
+    + [
+        ResolvedAttribute(
+            public_alias="id",
+            internal_name="sentry.item_id",
+            search_type="string",
+            validator=is_event_id_or_list,
+        ),
+    ]
+}
+
+
+REPLAY_VIRTUAL_CONTEXTS = {
+    key: VirtualColumnDefinition(
+        constructor=project_context_constructor(key),
+        term_resolver=project_term_resolver,
+        filter_column="project.id",
+    )
+    for key in constants.PROJECT_FIELDS
+}

--- a/src/sentry/search/eap/replays/definitions.py
+++ b/src/sentry/search/eap/replays/definitions.py
@@ -1,0 +1,19 @@
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
+
+from sentry.search.eap.columns import ColumnDefinitions
+from sentry.search.eap.replays.attributes import (
+    REPLAY_ATTRIBUTE_DEFINITIONS,
+    REPLAY_VIRTUAL_CONTEXTS,
+)
+
+REPLAY_DEFINITIONS = ColumnDefinitions(
+    aggregates={},
+    conditional_aggregates={},
+    formulas={},
+    columns=REPLAY_ATTRIBUTE_DEFINITIONS,
+    contexts=REPLAY_VIRTUAL_CONTEXTS,
+    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_REPLAY,
+    filter_aliases={},
+    column_to_alias=None,
+    alias_to_column=None,
+)

--- a/src/sentry/snuba/replays.py
+++ b/src/sentry/snuba/replays.py
@@ -1,0 +1,52 @@
+import logging
+
+import sentry_sdk
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken
+
+from sentry.search.eap.replays.definitions import REPLAY_DEFINITIONS
+from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
+from sentry.search.events.types import SAMPLING_MODES, SnubaParams
+from sentry.snuba import rpc_dataset_common
+
+logger = logging.getLogger(__name__)
+
+
+class Replays(rpc_dataset_common.RPCBase):
+    DEFINITIONS = REPLAY_DEFINITIONS
+
+    @classmethod
+    @sentry_sdk.trace
+    def run_table_query(
+        cls,
+        *,
+        params: SnubaParams,
+        query_string: str,
+        selected_columns: list[str],
+        orderby: list[str] | None,
+        offset: int,
+        limit: int,
+        referrer: str,
+        config: SearchResolverConfig,
+        sampling_mode: SAMPLING_MODES | None = None,
+        equations: list[str] | None = None,
+        search_resolver: SearchResolver | None = None,
+        page_token: PageToken | None = None,
+        additional_queries: AdditionalQueries | None = None,
+    ) -> EAPResponse:
+        return cls._run_table_query(
+            rpc_dataset_common.TableQuery(
+                query_string=query_string,
+                selected_columns=selected_columns,
+                equations=equations,
+                orderby=orderby,
+                offset=offset,
+                limit=limit,
+                referrer=referrer,
+                sampling_mode=sampling_mode,
+                page_token=page_token,
+                resolver=search_resolver or cls.get_resolver(params, config),
+                additional_queries=additional_queries,
+            ),
+            params.debug,
+        )

--- a/src/sentry/snuba/utils.py
+++ b/src/sentry/snuba/utils.py
@@ -18,6 +18,7 @@ from sentry.snuba import (
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.profile_functions import ProfileFunctions
+from sentry.snuba.replays import Replays
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.uptime_results import UptimeResults
@@ -39,6 +40,7 @@ DATASET_OPTIONS = {
     "issuePlatform": issue_platform,
     "profileFunctions": functions,
     "profile_functions": ProfileFunctions,
+    "replays": Replays,
     "spans": Spans,
     "spansIndexed": spans_indexed,
     "spansMetrics": spans_metrics,
@@ -47,10 +49,11 @@ DATASET_OPTIONS = {
 }
 DEPRECATED_LABELS = {"ourlogs"}
 RPC_DATASETS = {
+    OurLogs,
     ProfileFunctions,
+    Replays,
     Spans,
     TraceMetrics,
-    OurLogs,
     UptimeResults,
 }
 DATASET_LABELS = {

--- a/tests/snuba/api/endpoints/test_organization_events_replays.py
+++ b/tests/snuba/api/endpoints/test_organization_events_replays.py
@@ -1,0 +1,43 @@
+from uuid import uuid4
+
+import pytest
+
+from sentry.testutils.cases import ReplaysSnubaTestCase
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+
+
+class OrganizationEventsReplaysEndpointTest(
+    OrganizationEventsEndpointTestBase, ReplaysSnubaTestCase
+):
+    dataset = "replays"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.features = {
+            "organizations:session-replay": True,
+        }
+
+    @pytest.mark.querybuilder
+    def test_simple(self) -> None:
+        replay_ids = [uuid4().hex, uuid4().hex]
+        self.store_replays(
+            [
+                self.create_replay(self.ten_mins_ago, replay_id=replay_id)
+                for replay_id in replay_ids
+            ],
+            is_eap=True,
+        )
+        response = self.do_request(
+            {
+                "field": ["id"],
+                "query": "",
+                "orderby": "-id",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 2
+        for replay_id in replay_ids:
+            assert replay_id in [row["id"] for row in data]


### PR DESCRIPTION
- This adds a replays dataset to the events endpoint since we're going to be adding replays to EAP
- I need to go through all the attributes on replays still and figure out if any of them will have different public aliases etc. but for now I just want to get the base work up of allowing these queries