### PR TITLE
 feature(explore-attr-breakdowns): Removing yAxis heuristic from selection hint

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -88,7 +88,7 @@ export function CohortComparison({
     setPage(0);
   }, [filteredRankedAttributes]);
 
-  const selectionHint = useMemo(() => {
+  const selectedRangeToDates = useMemo(() => {
     if (!selection) {
       return null;
     }
@@ -100,14 +100,12 @@ export function CohortComparison({
     startTimestamp = Math.min(startTimestamp, endTimestamp - 60_000);
 
     const userTimezone = getUserTimezone() || moment.tz.guess();
-    const startDate = moment
-      .tz(startTimestamp, userTimezone)
-      .format('MMM D YYYY h:mm A z');
-    const endDate = moment.tz(endTimestamp, userTimezone).format('MMM D YYYY h:mm A z');
+    const start = moment.tz(startTimestamp, userTimezone).format('MMM D YYYY h:mm A z');
+    const end = moment.tz(endTimestamp, userTimezone).format('MMM D YYYY h:mm A z');
 
     return {
-      selection: t(`Selection is data between %s - %s`, startDate, endDate),
-      baseline: t('Baseline is all other spans from your query'),
+      start,
+      end,
     };
   }, [selection]);
 
@@ -133,12 +131,18 @@ export function CohortComparison({
           <AttributeBreakdownsComponent.LoadingCharts />
         ) : (
           <Fragment>
-            {selectionHint && (
+            {selectedRangeToDates && (
               <SelectionHintContainer>
                 <SelectionHint color={theme.chart.getColorPalette(0)?.[0]}>
-                  {selectionHint.selection}
+                  {t(
+                    'Selection is data between %s - %s',
+                    selectedRangeToDates.start,
+                    selectedRangeToDates.end
+                  )}
                 </SelectionHint>
-                <SelectionHint color="#A29FAA">{selectionHint.baseline}</SelectionHint>
+                <SelectionHint color="#A29FAA">
+                  {t('Baseline is all other spans from your query')}
+                </SelectionHint>
               </SelectionHintContainer>
             )}
             {filteredRankedAttributes.length > 0 ? (

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -20,7 +20,6 @@ import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useAttributeBreakdownComparison from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
 import {useQueryParamsVisualizes} from 'sentry/views/explore/queryParams/context';
-import {prettifyAggregation} from 'sentry/views/explore/utils';
 
 import {Chart} from './cohortComparisonChart';
 import {AttributeBreakdownsComponent} from './styles';
@@ -29,7 +28,6 @@ type SortingMethod = 'rrr';
 
 const CHARTS_COLUMN_COUNT = 3;
 const CHARTS_PER_PAGE = CHARTS_COLUMN_COUNT * 4;
-const PERCENTILE_FUNCTION_PREFIXES = ['p50', 'p75', 'p90', 'p95', 'p99', 'avg'];
 
 export function CohortComparison({
   selection,
@@ -107,26 +105,11 @@ export function CohortComparison({
       .format('MMM D YYYY h:mm A z');
     const endDate = moment.tz(endTimestamp, userTimezone).format('MMM D YYYY h:mm A z');
 
-    // Check if yAxis is a percentile function (only these functions should include "and is greater than or equal to")
-    const yAxisLower = yAxis.toLowerCase();
-    const isPercentileFunction = PERCENTILE_FUNCTION_PREFIXES.some(prefix =>
-      yAxisLower.startsWith(prefix)
-    );
-
-    const formattedFunction = prettifyAggregation(yAxis) ?? yAxis;
-
     return {
-      selection: isPercentileFunction
-        ? t(
-            `Selection is data between %s - %s and is greater than or equal to %s`,
-            startDate,
-            endDate,
-            formattedFunction
-          )
-        : t(`Selection is data between %s - %s`, startDate, endDate),
+      selection: t(`Selection is data between %s - %s`, startDate, endDate),
       baseline: t('Baseline is all other spans from your query'),
     };
-  }, [selection, yAxis]);
+  }, [selection]);
 
   if (isError) {
     return <LoadingError message={t('Failed to load attribute breakdowns')} />;


### PR DESCRIPTION
- The message currently doesn't make sense, unless we attach the exact value of the aggregation, like the exact p95(span.duartion) threshold used below for selected cohort.
- Alsom I think that adding the value might confuse the users, it's an internal heuristic. 
<img width="857" height="509" alt="Screenshot 2025-11-26 at 8 15 23 PM" src="https://github.com/user-attachments/assets/a0a8703b-20b3-4ad9-975e-17330d5501ff" />

