### PR TITLE
ref(explorer): rm type from attributes response

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -1017,7 +1017,6 @@ def _make_get_trace_request(
         - timestamp: ISO 8601 timestamp, Z suffix.
         - attributes: A dictionary of dictionaries, where the keys are the attribute names.
           - attributes[name].value: The value of the attribute (primitives only)
-          - attributes[name].type: The type of the attribute ("str", "int", "double", "bool")
     """
     organization = cast(Organization, resolver.params.organization)
     projects = list(resolver.params.projects)
@@ -1073,35 +1072,29 @@ def _make_get_trace_request(
                 if a.key.type == STRING:
                     attr_dict[public_alias] = {
                         "value": a.value.val_str,
-                        "type": "str",
                     }
                 elif a.key.type == DOUBLE:
                     attr_dict[public_alias] = {
                         "value": a.value.val_double,
-                        "type": "double",
                     }
                 elif a.key.type == BOOLEAN:
                     attr_dict[public_alias] = {
                         "value": a.value.val_bool,
-                        "type": "bool",
                     }
                 elif a.key.type == INT:
                     if r and r.search_type == "boolean":
                         attr_dict[public_alias] = {
                             "value": a.value.val_int == 1,
-                            "type": "bool",
                         }
                     else:
                         attr_dict[public_alias] = {
                             "value": a.value.val_int,
-                            "type": "int",
                         }
 
                     if public_alias == "project.id":
                         # Enrich with project slug, alias "project"
                         attr_dict["project"] = {
                             "value": resolver.params.project_id_map.get(a.value.val_int, "Unknown"),
-                            "type": "str",
                         }
 
             item_dicts.append(

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -1064,38 +1064,38 @@ def _make_get_trace_request(
             attr_dict: dict[str, dict[str, Any]] = {}
             for a in item.attributes:
                 r = resolved_attrs_by_internal_name.get(a.key.name)
-                public_alias = r.public_alias if r else a.key.name
+                name = r.public_alias if r else a.key.name
 
-                if public_alias.startswith("sentry._internal"):
+                if name.startswith("sentry._internal"):
                     continue
 
-                if public_alias == "project_id":  # Same internal name, normalize to project.id
-                    public_alias = "project.id"
+                if name == "project_id":  # Same internal name, normalize to project.id
+                    name = "project.id"
 
                 # Note - custom attrs not in the definitions can only be returned as strings or doubles.
                 if a.key.type == STRING:
-                    attr_dict[public_alias] = {
+                    attr_dict[name] = {
                         "value": a.value.val_str,
                     }
                 elif a.key.type == DOUBLE:
-                    attr_dict[public_alias] = {
+                    attr_dict[name] = {
                         "value": a.value.val_double,
                     }
                 elif a.key.type == BOOLEAN:
-                    attr_dict[public_alias] = {
+                    attr_dict[name] = {
                         "value": a.value.val_bool,
                     }
                 elif a.key.type == INT:
                     if r and r.search_type == "boolean":
-                        attr_dict[public_alias] = {
+                        attr_dict[name] = {
                             "value": a.value.val_int == 1,
                         }
                     else:
-                        attr_dict[public_alias] = {
+                        attr_dict[name] = {
                             "value": a.value.val_int,
                         }
 
-                    if public_alias == "project.id":
+                    if name == "project.id":
                         # Enrich with project slug, alias "project"
                         attr_dict["project"] = {
                             "value": resolver.params.project_id_map.get(a.value.val_int, "Unknown"),

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -1065,6 +1065,10 @@ def _make_get_trace_request(
             for a in item.attributes:
                 r = resolved_attrs_by_internal_name.get(a.key.name)
                 public_alias = r.public_alias if r else a.key.name
+
+                if public_alias.startswith("sentry._internal"):
+                    continue
+
                 if public_alias == "project_id":  # Same internal name, normalize to project.id
                     public_alias = "project.id"
 

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -1915,18 +1915,17 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
         ts = datetime.fromisoformat(auth_log["timestamp"]).timestamp()
         assert int(ts) == auth_log_expected.timestamp.seconds
 
-        for name, value, type in [
-            ("message", "User authentication failed", "str"),
-            ("project", self.project.slug, "str"),
-            ("project.id", self.project.id, "int"),
-            ("severity", "ERROR", "str"),
-            ("my-string-attribute", "custom value", "str"),
-            ("my-boolean-attribute", True, "double"),
-            ("my-double-attribute", 1.23, "double"),
-            ("my-integer-attribute", 123, "double"),
+        for name, value in [
+            ("message", "User authentication failed"),
+            ("project", self.project.slug),
+            ("project.id", self.project.id),
+            ("severity", "ERROR"),
+            ("my-string-attribute", "custom value"),
+            ("my-boolean-attribute", True),
+            ("my-double-attribute", 1.23),
+            ("my-integer-attribute", 123),
         ]:
             assert auth_log["attributes"][name]["value"] == value, name
-            assert auth_log["attributes"][name]["type"] == type, f"{name} type mismatch"
 
     def test_get_log_attributes_for_trace_substring_filter(self) -> None:
         result = get_log_attributes_for_trace(
@@ -2066,21 +2065,20 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
         ts = datetime.fromisoformat(http_metric["timestamp"]).timestamp()
         assert int(ts) == http_metric_expected.timestamp.seconds
 
-        for name, value, type in [
-            ("metric.name", "http.request.duration", "str"),
-            ("metric.type", "distribution", "str"),
-            ("value", 125.5, "double"),
-            ("project", self.project.slug, "str"),
-            ("project.id", self.project.id, "int"),
-            ("http.method", "GET", "str"),
-            ("http.status_code", 200, "double"),
-            ("my-string-attribute", "custom value", "str"),
-            ("my-boolean-attribute", True, "double"),
-            ("my-double-attribute", 1.23, "double"),
-            ("my-integer-attribute", 123, "double"),
+        for name, value in [
+            ("metric.name", "http.request.duration"),
+            ("metric.type", "distribution"),
+            ("value", 125.5),
+            ("project", self.project.slug),
+            ("project.id", self.project.id),
+            ("http.method", "GET"),
+            ("http.status_code", 200),
+            ("my-string-attribute", "custom value"),
+            ("my-boolean-attribute", True),
+            ("my-double-attribute", 1.23),
+            ("my-integer-attribute", 123),
         ]:
             assert http_metric["attributes"][name]["value"] == value, name
-            assert http_metric["attributes"][name]["type"] == type, f"{name} type mismatch"
 
     def test_get_metric_attributes_for_trace_name_filter(self) -> None:
         # Test substring match (fails)


### PR DESCRIPTION
unused, saves bandwidth. Can be easily added back later w the dict value format