### PR TITLE
feat(traces): Add cross event dropdown functionality

### DIFF
--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -143,12 +143,10 @@ describe('SpansTabContent', () => {
   });
 
   it('should fire analytics once per change', async () => {
-    render(
-      <Wrapper>
-        <SpansTabContent datePageFilterProps={datePageFilterProps} />
-      </Wrapper>,
-      {organization}
-    );
+    render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+      organization,
+      additionalWrapper: Wrapper,
+    });
 
     await screen.findByText(/No spans found/);
     expect(trackAnalytics).toHaveBeenCalledTimes(1);
@@ -187,12 +185,7 @@ describe('SpansTabContent', () => {
       return <SpansTabContent datePageFilterProps={datePageFilterProps} />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>,
-      {organization}
-    );
+    render(<Component />, {organization, additionalWrapper: Wrapper});
 
     const samples = screen.getByRole('tab', {name: 'Span Samples'});
     const aggregates = screen.getByRole('tab', {name: 'Aggregates'});
@@ -233,12 +226,10 @@ describe('SpansTabContent', () => {
   }, 20_000);
 
   it('opens toolbar when switching to aggregates tab', async () => {
-    render(
-      <Wrapper>
-        <SpansTabContent datePageFilterProps={datePageFilterProps} />
-      </Wrapper>,
-      {organization}
-    );
+    render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+      organization,
+      additionalWrapper: Wrapper,
+    });
 
     // by default the toolbar should be visible
     expect(screen.getByTestId('explore-span-toolbar')).toBeInTheDocument();
@@ -272,12 +263,10 @@ describe('SpansTabContent', () => {
 
   describe('case sensitivity', () => {
     it('renders the case sensitivity toggle', () => {
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
-      );
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
 
       const caseSensitivityToggle = screen.getByRole('button', {
         name: 'Ignore case',
@@ -287,10 +276,8 @@ describe('SpansTabContent', () => {
 
     it('toggles case sensitivity', async () => {
       const {router} = render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
+        <SpansTabContent datePageFilterProps={datePageFilterProps} />,
+        {organization, additionalWrapper: Wrapper}
       );
 
       const caseSensitivityToggle = screen.getByRole('button', {
@@ -315,12 +302,10 @@ describe('SpansTabContent', () => {
         body: {},
       });
 
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
-      );
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
 
       const caseSensitivityToggle = screen.getByRole('button', {
         name: 'Ignore case',
@@ -409,14 +394,10 @@ describe('SpansTabContent', () => {
     });
 
     it('should show hints', () => {
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {
-          organization,
-        }
-      );
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
 
       expect(screen.getByText('stringTag1')).toBeInTheDocument();
       expect(screen.getByText('stringTag2')).toBeInTheDocument();
@@ -441,12 +422,10 @@ describe('SpansTabContent', () => {
 
     describe('when the AI features are disabled', () => {
       it('does not display the Ask Seer combobox', async () => {
-        render(
-          <Wrapper>
-            <SpansTabContent datePageFilterProps={datePageFilterProps} />
-          </Wrapper>,
-          {organization: {...organization, features: []}}
-        );
+        render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+          organization: {...organization, features: []},
+          additionalWrapper: Wrapper,
+        });
 
         const input = screen.getByRole('combobox');
         await userEvent.click(input);
@@ -456,12 +435,10 @@ describe('SpansTabContent', () => {
     });
 
     it('brings along the query', async () => {
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
-      );
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
 
       const input = screen.getByRole('combobox');
       await userEvent.click(input);
@@ -482,12 +459,10 @@ describe('SpansTabContent', () => {
     });
 
     it('brings along the user input', async () => {
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
-      );
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
 
       const input = screen.getByRole('combobox');
       await userEvent.click(input);
@@ -506,12 +481,10 @@ describe('SpansTabContent', () => {
     });
 
     it('brings along only the query and the user input', async () => {
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
-      );
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
 
       const input = screen.getByRole('combobox');
       await userEvent.click(input);
@@ -533,12 +506,10 @@ describe('SpansTabContent', () => {
 
   describe('cross events', () => {
     it('displays the cross events dropdown', async () => {
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
-      );
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
 
       expect(
         screen.getByRole('button', {name: 'Add a cross event query'})
@@ -555,10 +526,8 @@ describe('SpansTabContent', () => {
 
     it('adds a cross event query', async () => {
       const {router} = render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {organization}
+        <SpansTabContent datePageFilterProps={datePageFilterProps} />,
+        {organization, additionalWrapper: Wrapper}
       );
 
       await userEvent.click(
@@ -576,25 +545,21 @@ describe('SpansTabContent', () => {
     });
 
     it('disables dropdown when there are 2 cross events', () => {
-      render(
-        <Wrapper>
-          <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </Wrapper>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {
-              pathname: '/organizations/org-slug/explore/traces/',
-              query: {
-                crossEvents: JSON.stringify([
-                  {query: '', type: 'spans'},
-                  {query: '', type: 'logs'},
-                ]),
-              },
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              crossEvents: JSON.stringify([
+                {query: '', type: 'spans'},
+                {query: '', type: 'logs'},
+              ]),
             },
           },
-        }
-      );
+        },
+      });
 
       expect(
         screen.getByRole('button', {name: 'Add a cross event query'})

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -2,6 +2,7 @@ import {useMemo, type Key} from 'react';
 import styled from '@emotion/styled';
 
 import {Grid} from '@sentry/scraps/layout';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -71,15 +72,20 @@ function CrossEventQueryingDropdown() {
   };
 
   return (
-    <DropdownMenu
-      triggerProps={{
-        size: 'md',
-        showChevron: false,
-        icon: <IconAdd />,
-      }}
-      items={crossEventDropdownItems}
-      onAction={onAction}
-    />
+    <Tooltip
+      title={t('For more targeted results, you can also cross reference other datasets')}
+    >
+      <DropdownMenu
+        onAction={onAction}
+        items={crossEventDropdownItems}
+        isDisabled={crossEvents?.length === 2}
+        triggerProps={{
+          size: 'md',
+          showChevron: false,
+          icon: <IconAdd />,
+        }}
+      />
+    </Tooltip>
   );
 }
 

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -83,6 +83,7 @@ function CrossEventQueryingDropdown() {
           size: 'md',
           showChevron: false,
           icon: <IconAdd />,
+          'aria-label': t('Add a cross event query'),
         }}
       />
     </Tooltip>

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -1,0 +1,246 @@
+import {useMemo, type Key} from 'react';
+import styled from '@emotion/styled';
+
+import {Grid} from '@sentry/scraps/layout';
+
+import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
+import * as Layout from 'sentry/components/layouts/thirds';
+import type {DatePageFilterProps} from 'sentry/components/organizations/datePageFilter';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import type {EAPSpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
+import {
+  EAPSpanSearchQueryBuilder,
+  useEAPSpanSearchQueryBuilderProps,
+} from 'sentry/components/performance/spanSearchQueryBuilder';
+import {
+  SearchQueryBuilderProvider,
+  useSearchQueryBuilder,
+} from 'sentry/components/searchQueryBuilder/context';
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
+import {TourElement} from 'sentry/components/tours/components';
+import {IconAdd} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  type AggregationKey,
+} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePrevious from 'sentry/utils/usePrevious';
+import SchemaHintsList from 'sentry/views/explore/components/schemaHints/schemaHintsList';
+import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
+import {ExploreSchemaHintsSection} from 'sentry/views/explore/components/styles';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {
+  useQueryParamsCrossEvents,
+  useQueryParamsFields,
+  useQueryParamsMode,
+  useQueryParamsQuery,
+  useSetQueryParams,
+  useSetQueryParamsCrossEvents,
+} from 'sentry/views/explore/queryParams/context';
+import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
+import {SpansTabSeerComboBox} from 'sentry/views/explore/spans/spansTabSeerComboBox';
+import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/spans/tour';
+import {findSuggestedColumns} from 'sentry/views/explore/utils';
+
+const crossEventDropdownItems: DropdownMenuProps['items'] = [
+  {key: 'spans', label: t('Spans')},
+  {key: 'logs', label: t('Logs')},
+  {key: 'metrics', label: t('Metrics')},
+];
+
+function CrossEventQueryingDropdown() {
+  const crossEvents = useQueryParamsCrossEvents();
+  const setCrossEvents = useSetQueryParamsCrossEvents();
+
+  const onAction = (key: Key) => {
+    if (typeof key !== 'string' || !isCrossEventType(key)) {
+      return;
+    }
+
+    if (!crossEvents || crossEvents.length === 0) {
+      setCrossEvents([{query: '', type: key}]);
+      return;
+    }
+  };
+
+  return (
+    <DropdownMenu
+      triggerProps={{
+        size: 'md',
+        showChevron: false,
+        icon: <IconAdd />,
+      }}
+      items={crossEventDropdownItems}
+      onAction={onAction}
+    />
+  );
+}
+
+function SpansSearchBar({
+  eapSpanSearchQueryBuilderProps,
+}: {
+  eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
+}) {
+  const {displayAskSeer} = useSearchQueryBuilder();
+
+  if (displayAskSeer) {
+    return <SpansTabSeerComboBox />;
+  }
+
+  return <EAPSpanSearchQueryBuilder autoFocus {...eapSpanSearchQueryBuilderProps} />;
+}
+
+interface SpanTabSearchSectionProps {
+  datePageFilterProps: DatePageFilterProps;
+}
+
+export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) {
+  const mode = useQueryParamsMode();
+  const fields = useQueryParamsFields();
+  const query = useQueryParamsQuery();
+  const setQueryParams = useSetQueryParams();
+  const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
+
+  const organization = useOrganization();
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
+  const hasCrossEventQuerying = organization.features.includes(
+    'traces-page-cross-event-querying'
+  );
+
+  const {
+    tags: numberTags,
+    isLoading: numberTagsLoading,
+    secondaryAliases: numberSecondaryAliases,
+  } = useTraceItemTags('number');
+  const {
+    tags: stringTags,
+    isLoading: stringTagsLoading,
+    secondaryAliases: stringSecondaryAliases,
+  } = useTraceItemTags('string');
+
+  const search = useMemo(() => new MutableSearch(query), [query]);
+  const oldSearch = usePrevious(search);
+
+  const hasRawSearchReplacement = organization.features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
+
+  const eapSpanSearchQueryBuilderProps = useMemo(
+    () => ({
+      initialQuery: query,
+      onSearch: (newQuery: string) => {
+        const newSearch = new MutableSearch(newQuery);
+        const suggestedColumns = findSuggestedColumns(newSearch, oldSearch, {
+          numberAttributes: numberTags,
+          stringAttributes: stringTags,
+        });
+
+        const existingFields = new Set(fields);
+        const newColumns = suggestedColumns.filter(col => !existingFields.has(col));
+
+        setQueryParams({
+          query: newQuery,
+          fields: newColumns.length ? [...fields, ...newColumns] : undefined,
+        });
+      },
+      searchSource: 'explore',
+      getFilterTokenWarning:
+        mode === Mode.SAMPLES
+          ? (key: string) => {
+              if (ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.includes(key as AggregationKey)) {
+                return t(
+                  "This key won't affect the results because samples mode does not support aggregate functions"
+                );
+              }
+              return undefined;
+            }
+          : undefined,
+      supportedAggregates:
+        mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+      numberTags,
+      stringTags,
+      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      matchKeySuggestions: [
+        {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+        {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+      ],
+      numberSecondaryAliases,
+      stringSecondaryAliases,
+      caseInsensitive,
+      onCaseInsensitiveClick: setCaseInsensitive,
+    }),
+    [
+      caseInsensitive,
+      fields,
+      hasRawSearchReplacement,
+      mode,
+      numberSecondaryAliases,
+      numberTags,
+      oldSearch,
+      query,
+      setCaseInsensitive,
+      setQueryParams,
+      stringSecondaryAliases,
+      stringTags,
+    ]
+  );
+
+  const eapSpanSearchQueryProviderProps = useEAPSpanSearchQueryBuilderProps(
+    eapSpanSearchQueryBuilderProps
+  );
+
+  return (
+    <Layout.Main width="full">
+      <SearchQueryBuilderProvider
+        enableAISearch={areAiFeaturesAllowed}
+        {...eapSpanSearchQueryProviderProps}
+      >
+        <TourElement<ExploreSpansTour>
+          tourContext={ExploreSpansTourContext}
+          id={ExploreSpansTour.SEARCH_BAR}
+          title={t('Start Your Search')}
+          description={t(
+            'Specify the keys you’d like to narrow your search down to (ex. span.operation) and then any values (ex. db, res, http, etc.).'
+          )}
+          position="bottom"
+          margin={-8}
+        >
+          <Grid gap="md" columns={{sm: '1fr', md: 'minmax(300px, auto) 1fr min-content'}}>
+            <StyledPageFilterBar condensed>
+              <ProjectPageFilter />
+              <EnvironmentPageFilter />
+              <DatePageFilter {...datePageFilterProps} />
+            </StyledPageFilterBar>
+            <SpansSearchBar
+              eapSpanSearchQueryBuilderProps={eapSpanSearchQueryBuilderProps}
+            />
+            {hasCrossEventQuerying ? <CrossEventQueryingDropdown /> : null}
+          </Grid>
+          <ExploreSchemaHintsSection>
+            <SchemaHintsList
+              supportedAggregates={
+                mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
+              }
+              numberTags={numberTags}
+              stringTags={stringTags}
+              isLoading={numberTagsLoading || stringTagsLoading}
+              exploreQuery={query}
+              source={SchemaHintsSources.EXPLORE}
+            />
+          </ExploreSchemaHintsSection>
+        </TourElement>
+      </SearchQueryBuilderProvider>
+    </Layout.Main>
+  );
+}
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  width: auto;
+`;

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -65,7 +65,8 @@ function CrossEventQueryingDropdown() {
 
     if (!crossEvents || crossEvents.length === 0) {
       setCrossEvents([{query: '', type: key}]);
-      return;
+    } else {
+      setCrossEvents([...crossEvents, {query: '', type: key}]);
     }
   };
 

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -24,6 +24,7 @@ import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {TourElement} from 'sentry/components/tours/components';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   type AggregationKey,
@@ -71,7 +72,7 @@ function CrossEventQueryingDropdown() {
     }
   };
 
-  const isDisabled = crossEvents?.length === 2;
+  const isDisabled = defined(crossEvents) && crossEvents.length >= 2;
   const tooltipTitle = isDisabled
     ? t('Maximum of 2 cross event queries allowed.')
     : t('For more targeted results, you can also cross reference other datasets.');

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -71,14 +71,17 @@ function CrossEventQueryingDropdown() {
     }
   };
 
+  const isDisabled = crossEvents?.length === 2;
+  const tooltipTitle = isDisabled
+    ? t('Maximum of 2 cross event queries allowed.')
+    : t('For more targeted results, you can also cross reference other datasets.');
+
   return (
-    <Tooltip
-      title={t('For more targeted results, you can also cross reference other datasets')}
-    >
+    <Tooltip title={tooltipTitle}>
       <DropdownMenu
         onAction={onAction}
         items={crossEventDropdownItems}
-        isDisabled={crossEvents?.length === 2}
+        isDisabled={isDisabled}
         triggerProps={{
           size: 'md',
           showChevron: false,


### PR DESCRIPTION
This PR adds in some refinements to the cross event dropdown, such as proper labels, ability to add a second cross event, and disabling itself when there are two cross events present.

I also moved the search section of the spans tab into its own file to keep things a bit more tidy, as well as refactoring the spans tab tests to use the `additionalWrapper` arg, over wrapping in the wrapper saving a couple lines.

Ticket: EXP-618
