### PR TITLE
typing(tests): Minor changes

### DIFF
--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -68,7 +68,7 @@ from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.services import eventstore
-from sentry.services.eventstore.models import Event
+from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.signals import (
     first_event_with_minified_stack_trace_received,
     first_insight_span_received,
@@ -2786,6 +2786,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             assert group.level == 40
             assert group.issue_category == GroupCategory.PERFORMANCE
             assert group.issue_type == PerformanceNPlusOneGroupType
+            assert isinstance(event, GroupEvent)
             assert event.occurrence
             assert event.occurrence.evidence_display == [
                 IssueEvidence(
@@ -2945,7 +2946,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         }
     )
     def test_perf_issue_slow_db_issue_is_created(self) -> None:
-        def attempt_to_generate_slow_db_issue() -> Event:
+        def attempt_to_generate_slow_db_issue() -> GroupEvent:
             return self.create_performance_issue(
                 event_data=make_event(**get_event("slow-db/slow-db-spans")),
                 issue_type=PerformanceSlowDBQueryGroupType,

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -378,6 +378,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
     def test_performance_issues_content(self) -> None:
         """Test that a GitHub issue created from a performance issue has the expected title and description"""
         event = self.create_performance_issue()
+        assert event.group is not None
         description = self.install.get_group_description(event.group, event)
         assert "db - SELECT `books_author`.`id`, `books_author" in description
         title = self.install.get_group_title(event.group, event)

--- a/tests/sentry/integrations/slack/notifications/test_escalating.py
+++ b/tests/sentry/integrations/slack/notifications/test_escalating.py
@@ -58,6 +58,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         and block kit is enabled.
         """
         event = self.create_performance_issue()
+        assert event.group is not None
         with self.tasks():
             self.create_notification(event.group).send()
 

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -55,6 +55,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         with block kit enabled.
         """
         event = self.create_performance_issue()
+        assert event.group is not None
         notification = self.create_notification(event.group)
 
         with self.tasks():

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -65,6 +65,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         and block kit is enabled.
         """
         event = self.create_performance_issue()
+        assert event.group is not None
         with self.tasks():
             self.create_notification(event.group).send()
 

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
@@ -68,6 +68,7 @@ class SlackResolvedInPullRequestNotificationTest(
         and block kit is enabled.
         """
         event = self.create_performance_issue()
+        assert event.group is not None
         notification = self.create_notification(event.group)
         with self.tasks():
             notification.send()

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -845,6 +845,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     def test_build_performance_issue(self) -> None:
         event = self.create_performance_issue()
+        assert event.group is not None
         with self.feature("organizations:performance-issues"):
             blocks = SlackIssuesMessageBuilder(event.group, event).build()
         assert isinstance(blocks, dict)

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -482,6 +482,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
     def test_perf_issue(self) -> None:
         event_1 = self.create_performance_issue()
         event_2 = self.create_performance_issue()
+        assert event_1.group is not None
 
         self.login_as(user=self.user)
 

--- a/tests/sentry/issues/endpoints/test_group_tagkey_details.py
+++ b/tests/sentry/issues/endpoints/test_group_tagkey_details.py
@@ -36,6 +36,7 @@ class GroupTagDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
             fingerprint="group1",
             contexts={"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
         )
+        assert event.group is not None
 
         self.login_as(user=self.user)
 

--- a/tests/sentry/issues/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/issues/endpoints/test_group_tagkey_values.py
@@ -51,6 +51,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
             fingerprint="group1",
             contexts={"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
         )
+        assert event.group is not None
 
         self.login_as(user=self.user)
 

--- a/tests/sentry/issues/endpoints/test_group_tags.py
+++ b/tests/sentry/issues/endpoints/test_group_tags.py
@@ -80,6 +80,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
             fingerprint="group5",
             contexts={"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
         )
+        assert event.group is not None
 
         self.login_as(user=self.user)
 

--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -21,7 +21,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import GroupInbox
 from sentry.sentry_metrics.client.snuba import build_mri
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.services.eventstore.models import Event
+from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.testutils.cases import BaseMetricsTestCase, PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.group import GroupSubStatus
@@ -80,7 +80,7 @@ class HistoricGroupCounts(
 ):
     """Test that querying Snuba for the hourly counts for groups works as expected."""
 
-    def _create_hourly_bucket(self, count: int, event: Event) -> GroupsCountResponse:
+    def _create_hourly_bucket(self, count: int, event: Event | GroupEvent) -> GroupsCountResponse:
         """It simplifies writing the expected data structures"""
         assert event.group_id is not None
         return {

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -9,6 +9,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.projectownership import ProjectOwnership
 from sentry.models.rule import Rule
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
+from sentry.services.eventstore.models import GroupEvent
 from sentry.tasks.post_process import post_process_group
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -252,6 +253,8 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase):
 
     def test_full_integration_performance(self) -> None:
         event = self.create_performance_issue()
+        assert isinstance(event, GroupEvent)
+        assert event.group is not None
         action_data = {
             "id": "sentry.mail.actions.NotifyEmailAction",
             "targetType": "Member",

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -112,6 +112,7 @@ class GroupSnoozeTest(
             event_data["user"]["id"] = str(i)
             event = self.create_performance_issue(event_data=event_data)
         perf_group = event.group
+        assert perf_group is not None
         snooze = GroupSnooze.objects.create(group=perf_group, user_count=10, user_window=60)
         assert not snooze.is_valid(test_rates=True)
 
@@ -149,6 +150,7 @@ class GroupSnoozeTest(
         """Test when a performance issue is ignored until it happens 10 times in a day"""
         for i in range(0, 10):
             event = self.create_performance_issue()
+        assert event.group is not None
         snooze = GroupSnooze.objects.create(group=event.group, count=10, window=24 * 60)
         assert not snooze.is_valid(test_rates=True)
 

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -34,6 +34,7 @@ USER_COUNT = 2
 
 class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTestCase):
     def add_event(self, fingerprint: str, backend: Backend, event_type: str = "error") -> None:
+        event: Event | GroupEvent | None
         if event_type == "performance":
             event = self.create_performance_issue()
         elif event_type == "generic":
@@ -47,9 +48,9 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
             )
             assert group_info is not None
             group = group_info.group
-            event: Event | GroupEvent | None = group.get_latest_event()
+            event = group.get_latest_event()
         else:
-            event: Event | GroupEvent = self.store_event(
+            event = self.store_event(
                 data={
                     "message": "oh no",
                     "timestamp": before_now(days=1).isoformat(),

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -14,6 +14,7 @@ from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
 from sentry.mail.analytics import EmailNotificationSent
 from sentry.models.projectownership import ProjectOwnership
+from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest, TestCase
 from sentry.testutils.helpers.analytics import (
@@ -46,9 +47,9 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
             )
             assert group_info is not None
             group = group_info.group
-            event = group.get_latest_event()
+            event: Event | GroupEvent | None = group.get_latest_event()
         else:
-            event = self.store_event(
+            event: Event | GroupEvent = self.store_event(
                 data={
                     "message": "oh no",
                     "timestamp": before_now(days=1).isoformat(),

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -59,6 +59,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
                 project_id=self.project.id,
             )
 
+        assert event is not None
         backend.add(
             self.key, event_to_record(event, [self.rule]), increment_delay=0, maximum_delay=0
         )

--- a/tests/sentry/replays/endpoints/test_organization_replay_count.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_count.py
@@ -277,6 +277,9 @@ class OrganizationReplayCountEndpointTest(
                 "replay": {"replay_id": "z" * 32},  # a replay id that doesn't exist
             },
         )
+        assert issue1.group is not None
+        assert issue2.group is not None
+        assert issue3.group is not None
 
         query = {
             "query": f"issue.id:[{issue1.group.id}, {issue2.group.id}, {issue3.group.id}]",

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -465,6 +465,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         transaction = self.create_performance_issue(tags=[["foo", "bar"]])
 
         perf_issue = transaction.group
+        assert perf_issue is not None
         perf_issue.update(first_seen=prev_hour)
         Activity.objects.create(
             project=self.project,
@@ -533,6 +534,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         transaction = self.create_performance_issue(tags=[["foo", "bar"]])
 
         perf_issue = transaction.group
+        assert perf_issue is not None
         perf_issue.update(first_seen=timezone.now() - timedelta(weeks=3))
         Activity.objects.create(
             project=self.project,

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -816,6 +816,7 @@ class ApplyDelayedTest(ProcessDelayedAlertConditionsTestBase):
             )
         group5 = event5.group
         assert group5
+        assert isinstance(event5, GroupEvent)
         self.push_to_hash(
             self.project.id,
             rule5.id,

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -21,6 +21,7 @@ from sentry.rules import init_registry
 from sentry.rules.conditions import EventCondition
 from sentry.rules.filters.base import EventFilter
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY, RuleProcessor
+from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.redis import mock_redis_buffer
@@ -233,6 +234,7 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
                 contexts=contexts,
             )
 
+        assert isinstance(perf_event, GroupEvent)
         start_timestamp = datetime(2020, 9, 1, 3, 8, 24, 880386, tzinfo=UTC)
         rp = RuleProcessor(
             perf_event,
@@ -252,6 +254,7 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
         rulegroup_to_events = buffer.backend.get_hash(
             model=Project, field={"project_id": self.project.id}
         )
+        assert perf_event.group is not None
         assert rulegroup_to_events == {
             f"{self.rule.id}:{perf_event.group.id}": json.dumps(
                 {

--- a/tests/sentry/services/eventstore/snuba/test_backend.py
+++ b/tests/sentry/services/eventstore/snuba/test_backend.py
@@ -388,6 +388,7 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
 
     def test_transaction_get_next_prev_event_id(self) -> None:
         group = self.transaction_event_2.group
+        assert group is not None
         _filter = Filter(
             project_ids=[self.project2.id],
             group_ids=[group.id],

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -202,6 +202,8 @@ class DailySummaryTest(
             self.perf_event2 = self.create_performance_issue(
                 fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group6"
             )
+            assert self.perf_event.group is not None
+            assert self.perf_event2.group is not None
 
     @with_feature("organizations:daily-summary")
     @mock.patch("sentry.tasks.summaries.daily_summary.prepare_summary_data")

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -415,6 +415,8 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         perf_event_2 = self.create_performance_issue(
             fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group2"
         )
+        assert perf_event_1.group is not None
+        assert perf_event_2.group is not None
         perf_event_1.group.update(substatus=GroupSubStatus.ONGOING)
         perf_event_2.group.update(substatus=GroupSubStatus.ONGOING)
 

--- a/tests/snuba/api/endpoints/test_group_event_details.py
+++ b/tests/snuba/api/endpoints/test_group_event_details.py
@@ -98,6 +98,7 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
     def test_perf_issue_latest(self) -> None:
         event = self.create_performance_issue()
+        assert event.group is not None
         url = f"/api/0/issues/{event.group.id}/events/latest/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
@@ -105,6 +106,7 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
     def test_perf_issue_oldest(self) -> None:
         event = self.create_performance_issue()
+        assert event.group is not None
         url = f"/api/0/issues/{event.group.id}/events/oldest/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
@@ -112,6 +114,7 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
     def test_perf_issue_event_id(self) -> None:
         event = self.create_performance_issue()
+        assert event.group is not None
         url = f"/api/0/issues/{event.group.id}/events/{event.event_id}/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
@@ -119,6 +122,7 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
     def test_invalid_query(self) -> None:
         event = self.create_performance_issue()
+        assert event.group is not None
         url = f"/api/0/issues/{event.group.id}/events/{event.event_id}/"
         response = self.client.get(url, format="json", data={"query": "release.version:foobar"})
         assert response.status_code == 400

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -591,6 +591,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
 
     def test_performance_short_group_id(self) -> None:
         event = self.create_performance_issue()
+        assert event.group is not None
         query = {
             "field": ["count()"],
             "statsPeriod": "1h",
@@ -604,6 +605,8 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
     def test_multiple_performance_short_group_ids_filter(self) -> None:
         event1 = self.create_performance_issue()
         event2 = self.create_performance_issue()
+        assert event1.group is not None
+        assert event2.group is not None
 
         query = {
             "field": ["count()"],
@@ -6327,6 +6330,7 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
     def test_performance_issue_id_filter(self) -> None:
         event = self.create_performance_issue()
 
+        assert event.group is not None
         query = {
             "field": ["count()"],
             "statsPeriod": "2h",
@@ -6394,6 +6398,7 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
 
     def test_performance_short_group_id(self) -> None:
         event = self.create_performance_issue()
+        assert event.group is not None
         query = {
             "field": ["count()"],
             "statsPeriod": "1h",
@@ -6407,6 +6412,8 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
     def test_multiple_performance_short_group_ids_filter(self) -> None:
         event1 = self.create_performance_issue()
         event2 = self.create_performance_issue()
+        assert event1.group is not None
+        assert event2.group is not None
 
         query = {
             "field": ["count()"],
@@ -6474,6 +6481,7 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
             },
             user_data=user_data,
         )
+        assert event.group is not None
 
         query = {
             "field": [

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -306,6 +306,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase, Performance
         assert response.data["id"] == str(self.cur_transaction_event.event_id)
         assert response.data["nextEventID"] == str(self.next_transaction_event.event_id)
         assert response.data["previousEventID"] == str(self.prev_transaction_event.event_id)
+        assert self.cur_transaction_event.group is not None
         assert response.data["groupID"] == str(self.cur_transaction_event.group.id)
 
     def test_no_previous_event(self) -> None:
@@ -324,6 +325,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase, Performance
         assert response.data["id"] == str(self.prev_transaction_event.event_id)
         assert response.data["previousEventID"] is None
         assert response.data["nextEventID"] == self.cur_transaction_event.event_id
+        assert self.prev_transaction_event.group is not None
         assert response.data["groupID"] == str(self.prev_transaction_event.group.id)
 
     def test_ignores_different_group(self) -> None:


### PR DESCRIPTION
If running `mypy` locally, we get these errors, however, the CI runs with `PYTHONWARNINGS=error::RuntimeWarning mypy`, thus, it won't complain about these.