### PR TITLE
fix(dashboards): can't save details widget

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -308,7 +308,7 @@ function useWidgetBuilderState(): {
             setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])], options);
             setQuery(query?.slice(0, 1), options);
           } else if (action.payload === DisplayType.DETAILS) {
-            setLimit(undefined, options);
+            setLimit(1, options);
             setSort([], options);
             setYAxis([], options);
             setLegendAlias([], options);

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -7,7 +7,6 @@ import {
   type Widget,
   type WidgetQuery,
 } from 'sentry/views/dashboards/types';
-import {isChartDisplayType} from 'sentry/views/dashboards/utils';
 import {
   serializeSorts,
   type WidgetBuilderState,
@@ -70,7 +69,12 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     };
   });
 
-  const limit = isChartDisplayType(state.displayType) ? state.limit : undefined;
+  const limit = [DisplayType.BIG_NUMBER, DisplayType.TABLE].includes(
+    state.displayType ?? DisplayType.TABLE
+  )
+    ? undefined
+    : state.limit;
+
   return {
     title: state.title ?? '',
     description: state.description,


### PR DESCRIPTION
1. Was getting the error `"limit is required. The maximum limit is $5."`. We should be setting the limit to 1, as we're fetching one example span.
2. Addresses https://github.com/getsentry/sentry/pull/104059/files#r2569576441