### PR TITLE
fix(dashboards): Fix trigger for single value global filter selector

### DIFF
--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -289,10 +289,10 @@ function FilterSelector({
     </Flex>
   );
 
-  const renderFilterSelectorTrigger = () => (
+  const renderFilterSelectorTrigger = (filterValues: string[]) => (
     <FilterSelectorTrigger
       globalFilter={globalFilter}
-      activeFilterValues={stagedFilterValues}
+      activeFilterValues={filterValues}
       operator={stagedOperator}
       options={options}
       queryResult={queryResult}
@@ -320,7 +320,7 @@ function FilterSelector({
         }
         menuHeaderTrailingItems={renderMenuHeaderTrailingItems}
         triggerProps={{
-          children: renderFilterSelectorTrigger(),
+          children: renderFilterSelectorTrigger(activeFilterValues),
         }}
       />
     );
@@ -376,7 +376,7 @@ function FilterSelector({
       }
       menuHeaderTrailingItems={renderMenuHeaderTrailingItems}
       triggerProps={{
-        children: renderFilterSelectorTrigger(),
+        children: renderFilterSelectorTrigger(stagedFilterValues),
       }}
     />
   );


### PR DESCRIPTION
For non multi select filters, we don't externally manage staged filter values (which we do for multi selects via `HybridFilter`). So instead of passing in staged values into the trigger for single select filters, we should pass in the actual active filter values parsed from the global filter value.