### PR TITLE
fix(date-page-filter): Fallback to max pickable days when absolute ra…

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -29,7 +29,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {Environment, MinimalProject, Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {DAY} from 'sentry/utils/formatters';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
 
@@ -336,8 +335,10 @@ export function initializeUrlState({
     }
 
     if (start && end) {
-      const difference = new Date(end).getTime() - new Date(start).getTime();
-      if (difference > maxPickableDays * DAY) {
+      const periodStart = new Date(start);
+      const maxPeriod = parseStatsPeriod(`${maxPickableDays}d`);
+      const maxStart = new Date(maxPeriod.start);
+      if (periodStart.getTime() < maxStart.getTime()) {
         shouldUseMaxPickableDays = true;
         pageFilters.datetime = {
           period: `${maxPickableDays}d`,

--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -509,6 +510,33 @@ describe('PageFiltersContainer', () => {
         expect(PageFiltersStore.getState().selection).toEqual({
           datetime: {
             period: '3d',
+            utc: null,
+            start: null,
+            end: null,
+          },
+          environments: [],
+          projects: [],
+        })
+      );
+
+      expect(router.push).not.toHaveBeenCalled();
+    });
+
+    it('applies maxPickableDays if the query parms are in the past', async () => {
+      const start = moment().subtract(21, 'days').format('YYYY-MM-DDTHH:mm:ss');
+      const end = moment().subtract(20, 'days').format('YYYY-MM-DDTHH:mm:ss');
+      renderComponent(
+        <PageFiltersContainer maxPickableDays={7} />,
+        changeQuery(router, {start, end}),
+        organization
+      );
+
+      expect(router.push).not.toHaveBeenCalled();
+
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection).toEqual({
+          datetime: {
+            period: '7d',
             utc: null,
             start: null,
             end: null,


### PR DESCRIPTION
…nge too far

When an absolute date range is too far in the past, we should fall back to using the max pickable days.