### PR TITLE
feat(dashboards): add details widget to query summary page

### DIFF
--- a/static/app/components/core/code/codeBlock.tsx
+++ b/static/app/components/core/code/codeBlock.tsx
@@ -219,11 +219,13 @@ const FlexSpacer = styled('div')`
 
 const Wrapper = styled('div')<{isRounded: boolean}>`
   position: relative;
+  height: 100%;
   background: var(--prism-block-background);
   border-radius: ${p => (p.isRounded ? p.theme.borderRadius : '0px')};
 
   pre {
     margin: 0;
+    height: 100%;
   }
 
   &[data-render-inline='true'] pre {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
@@ -45,7 +45,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
         },
       ],
       widgetType: WidgetType.SPANS,
-      layout: {w: 2, h: 1, x: 2, y: 0, minH: 1},
+      layout: {y: 0, x: 2, h: 1, w: 2, minH: 1},
     },
     {
       id: 'metrics-duration',
@@ -66,7 +66,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
         },
       ],
       widgetType: WidgetType.SPANS,
-      layout: {w: 2, h: 1, x: 0, y: 0, minH: 1},
+      layout: {y: 0, x: 0, h: 1, w: 2, minH: 1},
     },
     {
       id: 'metrics-time-spent',
@@ -87,7 +87,31 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
         },
       ],
       widgetType: WidgetType.SPANS,
-      layout: {w: 2, h: 1, x: 4, y: 0, minH: 1},
+      layout: {y: 0, x: 4, h: 1, w: 2, minH: 1},
+    },
+    {
+      id: 'example-query',
+      title: 'Example Query',
+      description: '',
+      displayType: DisplayType.DETAILS,
+      thresholds: null,
+      interval: '1h',
+      queries: [
+        {
+          name: '',
+          fields: ['id', 'span.op', 'span.group', 'span.description', 'span.category'],
+          aggregates: [],
+          columns: ['id', 'span.op', 'span.group', 'span.description', 'span.category'],
+          fieldAliases: [],
+          conditions: '',
+          orderby: 'id',
+          onDemand: [],
+          linkedDashboards: [],
+        },
+      ],
+      limit: 1,
+      widgetType: WidgetType.SPANS,
+      layout: {y: 1, x: 0, h: 2, w: 6, minH: 2},
     },
     {
       id: 'transactions-with-query',
@@ -111,7 +135,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
         },
       ],
       widgetType: WidgetType.SPANS,
-      layout: {w: 6, h: 2, x: 0, y: 3, minH: 2},
+      layout: {y: 5, x: 0, h: 2, w: 6, minH: 2},
     },
     {
       id: 'metrics-throughput-line',
@@ -135,7 +159,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
         },
       ],
       widgetType: WidgetType.SPANS,
-      layout: {w: 3, h: 2, x: 0, y: 1, minH: 2},
+      layout: {y: 3, x: 0, h: 2, w: 3, minH: 2},
     },
     {
       id: 'metrics-duration-line',
@@ -158,7 +182,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           isHidden: false,
         },
       ],
-      layout: {w: 3, h: 2, x: 3, y: 1, minH: 2},
+      layout: {y: 3, x: 3, h: 2, w: 3, minH: 2},
     },
   ],
 };

--- a/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
@@ -25,6 +25,7 @@ export function DetailsWidgetVisualization(props: DetailsWidgetVisualizationProp
     return (
       <DatabaseSpanDescription
         showBorder={false}
+        shouldClipHeight={false}
         groupId={spanGroup}
         preliminaryDescription={spanDescription}
       />

--- a/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
 
-import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
-import {FullSpanDescription} from 'sentry/views/insights/common/components/fullSpanDescription';
+import {DatabaseSpanDescription} from 'sentry/views/insights/common/components/spanDescription';
 import {resolveSpanModule} from 'sentry/views/insights/common/utils/resolveSpanModule';
-import {SpanFields, type SpanResponse} from 'sentry/views/insights/types';
+import {ModuleName, SpanFields, type SpanResponse} from 'sentry/views/insights/types';
 
 import {DEEMPHASIS_COLOR_NAME, LOADING_PLACEHOLDER} from './settings';
 
@@ -15,39 +14,28 @@ interface DetailsWidgetVisualizationProps {
 export function DetailsWidgetVisualization(props: DetailsWidgetVisualizationProps) {
   const {span} = props;
 
-  const spanOp = span[SpanFields.SPAN_OP];
-  const spanDescription = span[SpanFields.SPAN_DESCRIPTION];
+  const spanOp = span[SpanFields.SPAN_OP] ?? '';
+  const spanDescription = span[SpanFields.SPAN_DESCRIPTION] ?? '';
   const spanGroup = span[SpanFields.SPAN_GROUP];
   const spanCategory = span[SpanFields.SPAN_CATEGORY];
 
   const moduleName = resolveSpanModule(spanOp, spanCategory);
 
-  if (spanOp === 'db') {
+  if (moduleName === ModuleName.DB) {
     return (
-      <FullSpanDescription
-        group={spanGroup}
-        shortDescription={spanDescription}
-        moduleName={moduleName}
+      <DatabaseSpanDescription
+        showBorder={false}
+        groupId={spanGroup}
+        preliminaryDescription={spanDescription}
       />
     );
   }
 
-  // String values don't support differences, thresholds, max values, or anything else.
-  return (
-    <Wrapper>
-      {spanOp} - {spanDescription}
-    </Wrapper>
-  );
+  return <Wrapper>{`${spanOp} - ${spanDescription}`}</Wrapper>;
 }
 
 function Wrapper({children}: any) {
-  return (
-    <GrowingWrapper>
-      <AutoResizeParent>
-        <AutoSizedText>{children}</AutoSizedText>
-      </AutoResizeParent>
-    </GrowingWrapper>
-  );
+  return <GrowingWrapper>{children}</GrowingWrapper>;
 }
 
 // Takes up 100% of the parent. If within flex context, grows to fill.
@@ -57,21 +45,6 @@ const GrowingWrapper = styled('div')`
   flex-grow: 1;
   height: 100%;
   width: 100%;
-`;
-
-const AutoResizeParent = styled('div')`
-  position: absolute;
-  inset: 0;
-
-  color: ${p => p.theme.headingColor};
-
-  container-type: size;
-  container-name: auto-resize-parent;
-
-  * {
-    line-height: 1;
-    text-align: left !important;
-  }
 `;
 
 const LoadingPlaceholder = styled('span')`

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -29,6 +29,7 @@ interface Props {
   groupId: SpanResponse[SpanFields.SPAN_GROUP];
   op: SpanResponse[SpanFields.SPAN_OP];
   preliminaryDescription?: string;
+  shouldClipHeight?: boolean;
   showBorder?: boolean;
 }
 
@@ -38,6 +39,7 @@ export function DatabaseSpanDescription({
   groupId,
   preliminaryDescription,
   showBorder = true,
+  shouldClipHeight = true,
 }: Omit<Props, 'op'>) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -138,11 +140,15 @@ export function DatabaseSpanDescription({
           <LoadingIndicator mini />
         </WithPadding>
       ) : (
-        <QueryClippedBox clipHeight={500} isExpanded={isExpanded}>
+        <QueryWrapper
+          clipHeight={500}
+          isExpanded={isExpanded}
+          shouldClipHeight={shouldClipHeight}
+        >
           <CodeBlock language={system === 'mongodb' ? 'json' : 'sql'} isRounded={false}>
             {formattedDescription ?? ''}
           </CodeBlock>
-        </QueryClippedBox>
+        </QueryWrapper>
       )}
 
       {!areIndexedSpansLoading && (
@@ -166,13 +172,16 @@ export function DatabaseSpanDescription({
   );
 }
 
-function QueryClippedBox(props: any) {
-  const {isExpanded, children} = props;
+function QueryWrapper(props: any) {
+  const {isExpanded, children, shouldClipHeight} = props;
+
+  if (!shouldClipHeight) {
+    return <StyledFullBox>{children}</StyledFullBox>;
+  }
 
   if (isExpanded) {
     return children;
   }
-
   return <StyledClippedBox {...props} />;
 }
 
@@ -192,10 +201,14 @@ const WithPadding = styled('div')`
 
 const StyledClippedBox = styled(ClippedBox)`
   padding: 0;
-  height: 100%;
-  background: ${p => p.theme.backgroundSecondary};
 
   > div > div {
     z-index: 1;
   }
+`;
+
+const StyledFullBox = styled('div')`
+  padding: 0;
+  height: 100%;
+  overflow-y: auto;
 `;

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -29,6 +29,7 @@ interface Props {
   groupId: SpanResponse[SpanFields.SPAN_GROUP];
   op: SpanResponse[SpanFields.SPAN_OP];
   preliminaryDescription?: string;
+  showBorder?: boolean;
 }
 
 const formatter = new SQLishFormatter();
@@ -36,6 +37,7 @@ const formatter = new SQLishFormatter();
 export function DatabaseSpanDescription({
   groupId,
   preliminaryDescription,
+  showBorder = true,
 }: Omit<Props, 'op'>) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -130,7 +132,7 @@ export function DatabaseSpanDescription({
   }, [preliminaryDescription, indexedSpan, system]);
 
   return (
-    <Frame>
+    <Frame showBorder={showBorder}>
       {areIndexedSpansLoading ? (
         <WithPadding>
           <LoadingIndicator mini />
@@ -174,9 +176,12 @@ function QueryClippedBox(props: any) {
   return <StyledClippedBox {...props} />;
 }
 
-const Frame = styled('div')`
-  border: solid 1px ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
+const Frame = styled('div')<{showBorder: boolean}>`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: ${p => (p.showBorder ? `solid 1px ${p.theme.border}` : 'none')};
+  border-radius: ${p => (p.showBorder ? p.theme.borderRadius : '0')};
   overflow: hidden;
 `;
 
@@ -187,6 +192,8 @@ const WithPadding = styled('div')`
 
 const StyledClippedBox = styled(ClippedBox)`
   padding: 0;
+  height: 100%;
+  background: ${p => p.theme.backgroundSecondary};
 
   > div > div {
     z-index: 1;


### PR DESCRIPTION
1. Add details widget to query summary page
2. Add LOC to query summary
3. Update layout accordingy
4. Update styling to the db query description so it vertically scrolls, cales and looks better

Before
<img width="1397" height="446" alt="image" src="https://github.com/user-attachments/assets/dfe93222-7946-4a8f-8c56-080885e5d5f8" /> 
<img width="669" height="490" alt="image" src="https://github.com/user-attachments/assets/f8c1866d-1631-4616-ac1d-42974f933dc3" />

After (it's hard to screenshot this, but there is a scroll bar now)
<img width="1218" height="425" alt="image" src="https://github.com/user-attachments/assets/0d92fcf6-330a-4a22-9317-346f74b6c082" /> 
<img width="636" height="474" alt="image" src="https://github.com/user-attachments/assets/d43a2e3d-669e-4626-9c63-43fe694c38fd" />
