### PR TITLE
ref(redis) Don't use redis-blaster for snowflake ids v3

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -195,6 +195,7 @@ SENTRY_WEEKLY_REPORTS_REDIS_CLUSTER = "default"
 SENTRY_HYBRIDCLOUD_DELETIONS_REDIS_CLUSTER = "default"
 SENTRY_SESSION_STORE_REDIS_CLUSTER = "default"
 SENTRY_AUTH_IDPMIGRATION_REDIS_CLUSTER = "default"
+SENTRY_SNOWFLAKE_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses


### PR DESCRIPTION
Redo of the changes in #103967 along with a removal of the skip introduced in #104057. With the keys used for snowflakes aligned (as of #104075) we shouldn't have flaky results anymore.

Refs INFRENG-210
