### PR TITLE
feat(span-migration): add post migration warnings and UI changes in old alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -39,7 +39,10 @@ import type {Anomaly, Incident} from 'sentry/views/alerts/types';
 import {AlertRuleStatus} from 'sentry/views/alerts/types';
 import {alertDetailsLink} from 'sentry/views/alerts/utils';
 import {DEPRECATED_TRANSACTION_ALERTS} from 'sentry/views/alerts/wizard/options';
-import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
+import {
+  getAlertTypeFromAggregateDataset,
+  getTraceItemTypeForDatasetAndEventType,
+} from 'sentry/views/alerts/wizard/utils';
 
 import type {TimePeriodType} from './constants';
 import {SELECTOR_RELATIVE_PERIODS} from './constants';
@@ -110,7 +113,7 @@ export default function MetricDetailsBody({
     );
   }
 
-  const {dataset, aggregate, query} = rule;
+  const {dataset, aggregate, query, eventTypes, extrapolationMode} = rule;
 
   const eventType = extractEventTypeFilterFromRule(rule);
   const queryWithTypeFilter =
@@ -143,9 +146,12 @@ export default function MetricDetailsBody({
   const deprecateTransactionsAlertsWarning =
     ruleType && DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
 
+  const traceItemType = getTraceItemTypeForDatasetAndEventType(dataset, eventTypes);
+
   const showExtrapolationModeWarning = getIsMigratedExtrapolationMode(
-    rule.extrapolationMode,
-    rule.dataset
+    extrapolationMode,
+    dataset,
+    traceItemType
   );
 
   return (

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -29,7 +29,6 @@ import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {
   AlertRuleComparisonType,
   Dataset,
-  ExtrapolationMode,
   TimePeriod,
 } from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
@@ -48,7 +47,7 @@ import MetricChart from './metricChart';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
 import {MetricDetailsSidebar} from './sidebar';
-import {getFilter, getPeriodInterval} from './utils';
+import {getFilter, getIsMigratedExtrapolationMode, getPeriodInterval} from './utils';
 
 interface MetricDetailsBodyProps {
   timePeriod: TimePeriodType;
@@ -144,11 +143,9 @@ export default function MetricDetailsBody({
   const deprecateTransactionsAlertsWarning =
     ruleType && DEPRECATED_TRANSACTION_ALERTS.includes(ruleType);
 
-  const showExtrapolationModeWarning = !!(
-    rule.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
-    rule.extrapolationMode &&
-    (rule.extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
-      rule.extrapolationMode === ExtrapolationMode.NONE)
+  const showExtrapolationModeWarning = getIsMigratedExtrapolationMode(
+    rule.extrapolationMode,
+    rule.dataset
   );
 
   return (

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -347,7 +347,7 @@ function MigratedAlertWarning({
   if (isEnabled) {
     return (
       <Alert.Container>
-        <Alert type="warning">
+        <Alert type="info">
           {tctCode(
             'This alert has been migrated from a transaction-based alert to a span-based alert. We have set a different extrapolation mode to mimic the previous alert behavior but this mode will be deprecated. Please [editLink:edit] the thresholds to match the regular extrapolation mode.',
             {

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -349,9 +349,15 @@ function MigratedAlertWarning({
       <Alert.Container>
         <Alert type="info">
           {tctCode(
-            'This alert has been migrated from a transaction-based alert to a span-based alert. We have set a different extrapolation mode to mimic the previous alert behavior but this mode will be deprecated. Please [editLink:edit] the thresholds to match the regular extrapolation mode.',
+            'To match the original behaviour, we’ve migrated this alert from a transaction-based alert to a span-based alert using a special compatibility mode. When you have a moment, please [editLink:edit] the alert updating its thresholds to account for [samplingLink:sampling].',
             {
               editLink: <Link to={editLink} />,
+              samplingLink: (
+                <ExternalLink
+                  href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
+                  openInNewTab
+                />
+              ),
             }
           )}
         </Alert>

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -50,6 +50,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
+import {getIsMigratedExtrapolationMode} from 'sentry/views/alerts/rules/metric/details/utils';
 import {makeDefaultCta} from 'sentry/views/alerts/rules/metric/metricRulePresets';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {
@@ -246,6 +247,18 @@ export default function MetricChart({
         traceItemType,
       });
 
+      const disableEapButton = getIsMigratedExtrapolationMode(
+        rule.extrapolationMode,
+        rule.dataset,
+        traceItemType
+      );
+
+      const disabledTooltip = disableEapButton
+        ? t(
+            'This alert cannot be opened in Explore as the extrapolation mode cannot be represented in Explore.'
+          )
+        : undefined;
+
       const resolvedPercent =
         (100 *
           Math.max(
@@ -306,7 +319,12 @@ export default function MetricChart({
               })
             ) ? (
               <Feature features="visibility-explore-view">
-                <LinkButton size="sm" {...props}>
+                <LinkButton
+                  size="sm"
+                  disabled={disableEapButton}
+                  title={disabledTooltip}
+                  {...props}
+                >
                   {buttonText}
                 </LinkButton>
               </Feature>

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -255,7 +255,7 @@ export default function MetricChart({
 
       const disabledTooltip = disableEapButton
         ? t(
-            'This alert cannot be opened in Explore as the extrapolation mode cannot be represented in Explore.'
+            'This alert cannot be opened in Explore until you update thresholds and resave.'
           )
         : undefined;
 

--- a/static/app/views/alerts/rules/metric/details/utils.tsx
+++ b/static/app/views/alerts/rules/metric/details/utils.tsx
@@ -17,6 +17,7 @@ import {
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
 import type {Incident} from 'sentry/views/alerts/types';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 /**
  * Retrieve start/end date of a metric alert incident for the events graph
@@ -130,10 +131,12 @@ export function getViableDateRange({
 
 export function getIsMigratedExtrapolationMode(
   extrapolationMode: ExtrapolationMode | undefined,
-  dataset: Dataset
+  dataset: Dataset,
+  traceItemType: TraceItemDataset | undefined | null
 ) {
   return !!(
     dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
+    traceItemType === TraceItemDataset.SPANS &&
     extrapolationMode &&
     (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
       extrapolationMode === ExtrapolationMode.NONE)

--- a/static/app/views/alerts/rules/metric/details/utils.tsx
+++ b/static/app/views/alerts/rules/metric/details/utils.tsx
@@ -8,8 +8,12 @@ import {
   TIME_WINDOWS,
   type TimePeriodType,
 } from 'sentry/views/alerts/rules/metric/details/constants';
-import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
-import {Dataset, TimePeriod} from 'sentry/views/alerts/rules/metric/types';
+import {
+  Dataset,
+  ExtrapolationMode,
+  TimePeriod,
+  type MetricRule,
+} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
 import type {Incident} from 'sentry/views/alerts/types';
@@ -122,4 +126,16 @@ export function getViableDateRange({
     start: viableStartDate,
     end: viableEndDate,
   };
+}
+
+export function getIsMigratedExtrapolationMode(
+  extrapolationMode: ExtrapolationMode | undefined,
+  dataset: Dataset
+) {
+  return !!(
+    dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
+    extrapolationMode &&
+    (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
+      extrapolationMode === ExtrapolationMode.NONE)
+  );
 }

--- a/static/app/views/alerts/rules/metric/details/utils.tsx
+++ b/static/app/views/alerts/rules/metric/details/utils.tsx
@@ -134,13 +134,11 @@ export function getIsMigratedExtrapolationMode(
   dataset: Dataset,
   traceItemType: TraceItemDataset | undefined | null
 ) {
-  return (
-    !!(
-      dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
-      traceItemType === TraceItemDataset.SPANS &&
-      extrapolationMode &&
-      (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
-        extrapolationMode === ExtrapolationMode.NONE)
-    ) || true
+  return !!(
+    dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
+    traceItemType === TraceItemDataset.SPANS &&
+    extrapolationMode &&
+    (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
+      extrapolationMode === ExtrapolationMode.NONE)
   );
 }

--- a/static/app/views/alerts/rules/metric/details/utils.tsx
+++ b/static/app/views/alerts/rules/metric/details/utils.tsx
@@ -134,11 +134,13 @@ export function getIsMigratedExtrapolationMode(
   dataset: Dataset,
   traceItemType: TraceItemDataset | undefined | null
 ) {
-  return !!(
-    dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
-    traceItemType === TraceItemDataset.SPANS &&
-    extrapolationMode &&
-    (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
-      extrapolationMode === ExtrapolationMode.NONE)
+  return (
+    !!(
+      dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
+      traceItemType === TraceItemDataset.SPANS &&
+      extrapolationMode &&
+      (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
+        extrapolationMode === ExtrapolationMode.NONE)
+    ) || true
   );
 }

--- a/static/app/views/alerts/rules/metric/edit.spec.tsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.tsx
@@ -267,7 +267,7 @@ describe('MetricRulesEdit', () => {
     ).toBeInTheDocument();
   });
 
-  it('preserves SERVER_WEIGHTED extrapolation mode when editing and saving', async () => {
+  it('changes SERVER_WEIGHTED extrapolation mode to UNKNOWN when editing and saving', async () => {
     const {organization, project} = initializeOrg();
     const ruleWithExtrapolation = MetricRuleFixture({
       id: '5',
@@ -317,7 +317,7 @@ describe('MetricRulesEdit', () => {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          extrapolationMode: 'serverOnly',
+          extrapolationMode: 'sampleWeighted',
           sampling: SAMPLING_MODE.NORMAL,
         }),
       })
@@ -335,14 +335,14 @@ describe('MetricRulesEdit', () => {
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+          extrapolationMode: ExtrapolationMode.UNKNOWN,
         }),
         method: 'PUT',
       })
     );
   });
 
-  it('preserves NONE extrapolation mode when editing and saving', async () => {
+  it('changes NONE extrapolation mode to UNKNOWN when editing and saving', async () => {
     const {organization, project} = initializeOrg();
     const ruleWithNoExtrapolation = MetricRuleFixture({
       id: '6',
@@ -392,8 +392,8 @@ describe('MetricRulesEdit', () => {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          extrapolationMode: 'none',
-          sampling: SAMPLING_MODE.HIGH_ACCURACY,
+          extrapolationMode: 'sampleWeighted',
+          sampling: SAMPLING_MODE.NORMAL,
         }),
       })
     );
@@ -410,7 +410,7 @@ describe('MetricRulesEdit', () => {
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          extrapolationMode: ExtrapolationMode.NONE,
+          extrapolationMode: ExtrapolationMode.UNKNOWN,
         }),
         method: 'PUT',
       })

--- a/static/app/views/alerts/rules/metric/edit.spec.tsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.tsx
@@ -267,7 +267,7 @@ describe('MetricRulesEdit', () => {
     ).toBeInTheDocument();
   });
 
-  it('changes SERVER_WEIGHTED extrapolation mode to UNKNOWN when editing and saving', async () => {
+  it('changes SERVER_WEIGHTED extrapolation mode to CLIENT_AND_SERVER_WEIGHTED when editing and saving', async () => {
     const {organization, project} = initializeOrg();
     const ruleWithExtrapolation = MetricRuleFixture({
       id: '5',
@@ -276,7 +276,7 @@ describe('MetricRulesEdit', () => {
       aggregate: 'count()',
       query: '',
       eventTypes: [EventTypes.TRACE_ITEM_SPAN],
-      extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+      extrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
     });
 
     MockApiClient.addMockResponse({
@@ -342,7 +342,7 @@ describe('MetricRulesEdit', () => {
     );
   });
 
-  it('changes NONE extrapolation mode to UNKNOWN when editing and saving', async () => {
+  it('changes NONE extrapolation mode to CLIENT_AND_SERVER_WEIGHTED when editing and saving', async () => {
     const {organization, project} = initializeOrg();
     const ruleWithNoExtrapolation = MetricRuleFixture({
       id: '6',
@@ -410,7 +410,7 @@ describe('MetricRulesEdit', () => {
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          extrapolationMode: ExtrapolationMode.UNKNOWN,
+          extrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
         }),
         method: 'PUT',
       })

--- a/static/app/views/alerts/rules/metric/edit.spec.tsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.tsx
@@ -276,7 +276,7 @@ describe('MetricRulesEdit', () => {
       aggregate: 'count()',
       query: '',
       eventTypes: [EventTypes.TRACE_ITEM_SPAN],
-      extrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
+      extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/alerts/rules/metric/edit.spec.tsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.tsx
@@ -335,7 +335,7 @@ describe('MetricRulesEdit', () => {
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          extrapolationMode: ExtrapolationMode.UNKNOWN,
+          extrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
         }),
         method: 'PUT',
       })

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
@@ -7,6 +7,7 @@ import {
   AlertRuleComparisonType,
   Dataset,
   EventTypes,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 import type {AlertType} from 'sentry/views/alerts/wizard/options';
 
@@ -109,6 +110,33 @@ describe('RuleConditionsForm', () => {
       screen.getByText(
         'Your low sample count may impact the accuracy of this alert. Edit your query or increase your sampling rate.'
       )
+    ).toBeInTheDocument();
+  });
+
+  it('renders extrapolation mode warning', async () => {
+    render(
+      <RuleConditionsForm
+        {...props}
+        eventTypes={[EventTypes.TRACE_ITEM_SPAN]}
+        dataset={Dataset.EVENTS_ANALYTICS_PLATFORM}
+        extrapolationMode={ExtrapolationMode.SERVER_WEIGHTED}
+        organization={organization}
+        router={router}
+        isLowConfidenceChartData
+      />,
+      {
+        organization: {
+          ...organization,
+          features: ['search-query-builder-alerts', 'visibility-explore-view'],
+        },
+      }
+    );
+
+    await screen.findByPlaceholderText(
+      'Filter transactions by URL, tags, and other properties\u2026'
+    );
+    expect(
+      screen.getByText(/This chart may look different from the alert details chart./)
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
@@ -136,7 +136,7 @@ describe('RuleConditionsForm', () => {
       'Filter transactions by URL, tags, and other properties\u2026'
     );
     expect(
-      screen.getByText(/This chart may look different from the alert details chart./)
+      screen.getByText(/The thresholds on this chart may look off./)
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -55,6 +55,7 @@ import {getHasTag} from 'sentry/utils/tag';
 import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
 import withTags from 'sentry/utils/withTags';
+import {getIsMigratedExtrapolationMode} from 'sentry/views/alerts/rules/metric/details/utils';
 import WizardField from 'sentry/views/alerts/rules/metric/wizardField';
 import {getProjectOptions, isEapAlertType} from 'sentry/views/alerts/rules/utils';
 import {
@@ -583,11 +584,10 @@ class RuleConditionsForm extends PureComponent<Props, State> {
       organization.features.includes('performance-transaction-deprecation-banner') &&
       DEPRECATED_TRANSACTION_ALERTS.includes(alertType);
 
-    const showExtrapolationModeChangeWarning = !!(
-      dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
-      extrapolationMode &&
-      (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
-        extrapolationMode === ExtrapolationMode.NONE)
+    const showExtrapolationModeChangeWarning = getIsMigratedExtrapolationMode(
+      extrapolationMode,
+      dataset,
+      traceItemType
     );
 
     return (

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -610,7 +610,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
           <Alert.Container>
             <Alert type="info">
               {tct(
-                'This chart may look different from the alert details chart. This is expected as the extrapolation mode has been changed. Once the alert has been saved, your alert will be switched to use the extrapolation mode represented here. To be alerted correctly, please edit your [thresholdsLink:thresholds]. For more information, check out this FAQ!',
+                'The thresholds on this chart may look off. This is because, once saved, alerts will now take into account [samplingLink:sampling rate]. Before clicking save, take the time to update your [thresholdsLink:thresholds]. Click cancel to continue running this alert in compatibility mode.',
                 {
                   thresholdsLink: (
                     <Button
@@ -621,6 +621,12 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                           .getElementById('thresholds-warning-icon')
                           ?.scrollIntoView({behavior: 'smooth'});
                       }}
+                    />
+                  ),
+                  samplingLink: (
+                    <ExternalLink
+                      href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
+                      openInNewTab
                     />
                   ),
                 }

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -18,6 +18,7 @@ import {
   AlertRuleSensitivity,
   Dataset,
   EventTypes,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 
 jest.mock('sentry/actionCreators/indicator');
@@ -706,6 +707,45 @@ describe('Incident Rules Form', () => {
             thresholdPeriod: 1,
             thresholdType: 0,
             timeWindow: 60,
+          }),
+        })
+      );
+    });
+
+    it('changes extrapolation mode when editing migrated transaction alert rule', async () => {
+      organization.features = [
+        ...organization.features,
+        'performance-view',
+        'visibility-explore-view',
+        'discover-saved-queries-deprecation',
+      ];
+      const metricRule = MetricRuleFixture();
+      createWrapper({
+        rule: {
+          ...metricRule,
+          aggregate: 'count(span.duration)',
+          eventTypes: ['trace_item_span'],
+          dataset: 'events_analytics_platform',
+          extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+        },
+        ruleId: rule.id,
+      });
+
+      await userEvent.click(screen.getByLabelText('Save Rule'));
+
+      expect(editRule).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            aggregate: 'count(span.duration)',
+            dataset: 'events_analytics_platform',
+            eventTypes: ['trace_item_span'],
+            id: '4',
+            name: 'My Incident Rule',
+            projects: ['project-slug'],
+            query: '',
+            queryType: 1,
+            extrapolationMode: ExtrapolationMode.UNKNOWN,
           }),
         })
       );

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -745,7 +745,7 @@ describe('Incident Rules Form', () => {
             projects: ['project-slug'],
             query: '',
             queryType: 1,
-            extrapolationMode: ExtrapolationMode.UNKNOWN,
+            extrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
           }),
         })
       );

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -50,6 +50,7 @@ import {
 } from 'sentry/utils/onDemandMetrics/features';
 import withProjects from 'sentry/utils/withProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
+import {getIsMigratedExtrapolationMode} from 'sentry/views/alerts/rules/metric/details/utils';
 import {IncompatibleAlertQuery} from 'sentry/views/alerts/rules/metric/incompatibleAlertQuery';
 import {OnDemandThresholdChecker} from 'sentry/views/alerts/rules/metric/onDemandThresholdChecker';
 import RuleNameOwnerForm from 'sentry/views/alerts/rules/metric/ruleNameOwnerForm';
@@ -1377,11 +1378,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const showErrorMigrationWarning =
       !!ruleId && isMigration && ruleNeedsErrorMigration(rule);
 
-    const showExtrapolationModeChangeWarning = !!(
-      dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
-      extrapolationMode &&
-      (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
-        extrapolationMode === ExtrapolationMode.NONE)
+    const showExtrapolationModeChangeWarning = getIsMigratedExtrapolationMode(
+      extrapolationMode,
+      dataset
     );
 
     // Rendering the main form body

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -792,6 +792,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         const detectionType = detectionTypes.get(comparisonType) ?? '';
         const dataset = this.determinePerformanceDataset();
         this.setState({loading: true});
+        const traceItemType = getTraceItemTypeForDatasetAndEventType(dataset, eventTypes);
         // Add or update is just the PUT/POST to the org alert-rules api
         // we're splatting the full rule in, then overwriting all the data?
         const [data, , resp] = await addOrUpdateRule(
@@ -820,7 +821,12 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             sensitivity: sensitivity ?? null,
             seasonality: seasonality ?? null,
             detectionType,
-            extrapolationMode: this.isDuplicateRule ? undefined : extrapolationMode,
+            // We want to change the extrapolation mode to unknown once a migrated alert rule is edited
+            extrapolationMode: this.isDuplicateRule
+              ? undefined
+              : getIsMigratedExtrapolationMode(extrapolationMode, dataset, traceItemType)
+                ? ExtrapolationMode.UNKNOWN
+                : extrapolationMode,
           },
           {
             duplicateRule: this.isDuplicateRule ? 'true' : 'false',
@@ -1378,9 +1384,12 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const showErrorMigrationWarning =
       !!ruleId && isMigration && ruleNeedsErrorMigration(rule);
 
+    const traceItemType = getTraceItemTypeForDatasetAndEventType(dataset, eventTypes);
+
     const showExtrapolationModeChangeWarning = getIsMigratedExtrapolationMode(
       extrapolationMode,
-      dataset
+      dataset,
+      traceItemType
     );
 
     // Rendering the main form body

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -3,7 +3,8 @@ import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
-import {Tooltip} from '@sentry/scraps/tooltip/tooltip';
+import {ExternalLink} from '@sentry/scraps/link/link';
+import {Tooltip, type TooltipProps} from '@sentry/scraps/tooltip/tooltip';
 
 import type {Indicator} from 'sentry/actionCreators/indicator';
 import {
@@ -821,11 +822,11 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             sensitivity: sensitivity ?? null,
             seasonality: seasonality ?? null,
             detectionType,
-            // We want to change the extrapolation mode to unknown once a migrated alert rule is edited
+            // We want to change the extrapolation mode to sample weighted once a migrated alert rule is edited
             extrapolationMode: this.isDuplicateRule
               ? undefined
               : getIsMigratedExtrapolationMode(extrapolationMode, dataset, traceItemType)
-                ? ExtrapolationMode.UNKNOWN
+                ? ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED
                 : extrapolationMode,
           },
           {
@@ -1498,9 +1499,20 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
                         {t('Set thresholds')}
                         {showExtrapolationModeChangeWarning && (
                           <WarningIcon
-                            title={t(
-                              'Your thresholds may need to be adjusted after the change in extrapolation mode'
-                            )}
+                            tooltipProps={{
+                              title: tct(
+                                'Your thresholds may need to be adjusted to take into account [samplingLink:sampling].',
+                                {
+                                  samplingLink: (
+                                    <ExternalLink
+                                      href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
+                                      openInNewTab
+                                    />
+                                  ),
+                                }
+                              ),
+                              isHoverable: true,
+                            }}
                             id="thresholds-warning-icon"
                           />
                         )}
@@ -1561,9 +1573,9 @@ function getTimeWindowFromDataset(
   return defaultWindow;
 }
 
-function WarningIcon({title, id}: {id: string; title: ReactNode}) {
+function WarningIcon({tooltipProps, id}: {id: string; tooltipProps?: TooltipProps}) {
   return (
-    <Tooltip title={title} skipWrapper>
+    <Tooltip {...tooltipProps} title={tooltipProps?.title} skipWrapper>
       <StyledIconWarning id={id} size="md" color="warning" />
     </Tooltip>
   );

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -9,6 +9,7 @@ import {
   AlertRuleComparisonType,
   AlertRuleThresholdType,
   Dataset,
+  ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -256,6 +257,55 @@ describe('Incident Rules Create', () => {
           referrer: 'api.organization-event-stats',
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
+        },
+      })
+    );
+  });
+
+  it('uses unknown extrapolation mode for editing a migrated alert', async () => {
+    const {organization, project, router} = initializeOrg();
+
+    render(
+      <TriggersChart
+        theme={theme}
+        api={api}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        query=""
+        timeWindow={1}
+        aggregate="count(span.duration)"
+        dataset={Dataset.EVENTS_ANALYTICS_PLATFORM}
+        triggers={[]}
+        environment={null}
+        comparisonType={AlertRuleComparisonType.COUNT}
+        resolveThreshold={null}
+        thresholdType={AlertRuleThresholdType.BELOW}
+        newAlertOrQuery
+        onDataLoaded={() => {}}
+        isQueryValid
+        showTotalCount
+        traceItemType={TraceItemDataset.SPANS}
+        extrapolationMode={ExtrapolationMode.NONE}
+      />
+    );
+
+    expect(await screen.findByTestId('area-chart')).toBeInTheDocument();
+    expect(await screen.findByTestId('alert-total-events')).toBeInTheDocument();
+
+    expect(eventStatsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          interval: '1m',
+          project: [2],
+          query: '',
+          statsPeriod: '14d',
+          yAxis: 'count(span.duration)',
+          referrer: 'api.organization-event-stats',
+          dataset: 'spans',
+          sampling: SAMPLING_MODE.NORMAL,
+          extrapolationMode: 'sampleWeighted',
         },
       })
     );

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -262,7 +262,7 @@ describe('Incident Rules Create', () => {
     );
   });
 
-  it('uses unknown extrapolation mode for editing a migrated alert', async () => {
+  it('uses sample weighted extrapolation mode for editing a migrated alert', async () => {
     const {organization, project, router} = initializeOrg();
 
     render(

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -46,6 +46,7 @@ import {
 import {capitalize} from 'sentry/utils/string/capitalize';
 import withApi from 'sentry/utils/withApi';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
+import {getIsMigratedExtrapolationMode} from 'sentry/views/alerts/rules/metric/details/utils';
 import {
   AlertRuleComparisonType,
   Dataset,
@@ -603,14 +604,20 @@ class TriggersChart extends PureComponent<Props, State> {
       partial: false,
       sampling:
         dataset === Dataset.EVENTS_ANALYTICS_PLATFORM &&
-        this.props.traceItemType === TraceItemDataset.SPANS
-          ? extrapolationMode === ExtrapolationMode.NONE
-            ? SAMPLING_MODE.HIGH_ACCURACY
-            : SAMPLING_MODE.NORMAL
+        traceItemType === TraceItemDataset.SPANS
+          ? getIsMigratedExtrapolationMode(extrapolationMode, dataset, traceItemType)
+            ? SAMPLING_MODE.NORMAL
+            : extrapolationMode === ExtrapolationMode.NONE
+              ? SAMPLING_MODE.HIGH_ACCURACY
+              : SAMPLING_MODE.NORMAL
           : undefined,
 
+      // we want to show the regular extrapolated chart as we are changing the extrapolation to this
+      // once a migrated alert is saved
       extrapolationMode: extrapolationMode
-        ? EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
+        ? getIsMigratedExtrapolationMode(extrapolationMode, dataset, traceItemType)
+          ? EAP_EXTRAPOLATION_MODE_MAP[ExtrapolationMode.UNKNOWN]
+          : EAP_EXTRAPOLATION_MODE_MAP[extrapolationMode]
         : undefined,
     };
 

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -175,7 +175,9 @@ class TriggersChart extends PureComponent<Props, State> {
     // we want to show the regular extrapolated chart as we are changing the extrapolation to UNKNOWN
     // once a migrated alert is saved
     if (getIsMigratedExtrapolationMode(extrapolationMode, dataset, traceItemType)) {
-      this.setState({adjustedExtrapolationMode: ExtrapolationMode.UNKNOWN});
+      this.setState({
+        adjustedExtrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
+      });
     } else {
       this.setState({adjustedExtrapolationMode: extrapolationMode});
     }

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -207,7 +207,11 @@ class TriggersChart extends PureComponent<Props, State> {
         this.fetchTotalCount();
       }
     }
-    if (prevProps.extrapolationMode !== this.props.extrapolationMode) {
+    if (
+      prevProps.extrapolationMode !== this.props.extrapolationMode ||
+      prevProps.dataset !== dataset ||
+      prevProps.traceItemType !== traceItemType
+    ) {
       if (getIsMigratedExtrapolationMode(extrapolationMode, dataset, traceItemType)) {
         this.setState({
           adjustedExtrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -184,8 +184,17 @@ class TriggersChart extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const {query, environment, timeWindow, aggregate, projects, showTotalCount} =
-      this.props;
+    const {
+      query,
+      environment,
+      timeWindow,
+      aggregate,
+      projects,
+      showTotalCount,
+      extrapolationMode,
+      dataset,
+      traceItemType,
+    } = this.props;
     const {statsPeriod} = this.state;
     if (
       !isEqual(prevProps.projects, projects) ||
@@ -196,6 +205,15 @@ class TriggersChart extends PureComponent<Props, State> {
     ) {
       if (showTotalCount && !isSessionAggregate(aggregate)) {
         this.fetchTotalCount();
+      }
+    }
+    if (prevProps.extrapolationMode !== this.props.extrapolationMode) {
+      if (getIsMigratedExtrapolationMode(extrapolationMode, dataset, traceItemType)) {
+        this.setState({
+          adjustedExtrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
+        });
+      } else {
+        this.setState({adjustedExtrapolationMode: extrapolationMode});
       }
     }
   }


### PR DESCRIPTION
This PR just handles the old alerts UI, the fixes for the new UI will come in another PR. We're checking extrapolation modes and trace item types to make sure this shows up on any alert with the altered extrapolation mode. The text on the banners is still up for discussion (i haven't consulted Ben yet so they will probably change and I won't merge until then) Here are the warnings:

**Alert Details**
<img width="1208" height="697" alt="image" src="https://github.com/user-attachments/assets/574d330a-337b-4198-8098-18c626fdfc67" />

**Edit Form**
<img width="1140" height="842" alt="image" src="https://github.com/user-attachments/assets/f5881208-590b-422b-8eb4-406877985fd9" />