### PR TITLE
feat(alerts): Allow bumping max snuba subscription limit

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -2,7 +2,6 @@ import logging
 from copy import deepcopy
 from datetime import UTC, datetime
 
-from django.conf import settings
 from django.db.models import Case, DateTimeField, IntegerField, OuterRef, Q, Subquery, Value, When
 from django.db.models.functions import Coalesce
 from django.http.response import HttpResponseBase
@@ -48,6 +47,7 @@ from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
+from sentry.incidents.utils.subscription_limits import get_max_metric_alert_subscriptions
 from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
@@ -201,7 +201,7 @@ class AlertRuleIndexMixin(Endpoint):
                 count_hits=True,
             )
         response[ALERT_RULES_COUNT_HEADER] = len(alert_rules)
-        response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
+        response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = get_max_metric_alert_subscriptions(organization)
         return response
 
 
@@ -474,7 +474,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             cursor_cls=StringCursor if case_insensitive else Cursor,
             case_insensitive=case_insensitive,
         )
-        response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
+        response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = get_max_metric_alert_subscriptions(organization)
         return response
 
 

--- a/src/sentry/incidents/utils/subscription_limits.py
+++ b/src/sentry/incidents/utils/subscription_limits.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+
+from sentry import options
+from sentry.models.organization import Organization
+
+
+def get_max_metric_alert_subscriptions(organization: Organization) -> int:
+    if organization.id in options.get("metric_alerts.extended_max_subscriptions_orgs") and (
+        extended_max_specs := options.get("metric_alerts.extended_max_subscriptions")
+    ):
+        return extended_max_specs
+
+    return settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2503,6 +2503,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register("metric_alerts.extended_max_subscriptions", default=1250, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register(
+    "metric_alerts.extended_max_subscriptions_orgs", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # SDK Crash Detection
 #
 # The project ID belongs to the sentry organization: https://sentry.sentry.io/projects/cocoa-sdk-crashes/?project=4505469596663808.

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, ClassVar, Self, override
 
-from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils import timezone
@@ -16,6 +15,7 @@ from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_model
 from sentry.db.models.manager.base import BaseManager
 from sentry.deletions.base import ModelRelation
+from sentry.incidents.utils.subscription_limits import get_max_metric_alert_subscriptions
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.models.team import Team
 from sentry.users.models.user import User
@@ -219,7 +219,7 @@ class QuerySubscriptionDataSourceHandler(DataSourceTypeHandler[QuerySubscription
     @override
     @staticmethod
     def get_instance_limit(org: Organization) -> int | None:
-        return settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
+        return get_max_metric_alert_subscriptions(org)
 
     @override
     @staticmethod

--- a/tests/sentry/snuba/test_models.py
+++ b/tests/sentry/snuba/test_models.py
@@ -82,6 +82,18 @@ class QuerySubscriptionDataSourceHandlerTest(TestCase):
         with self.settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=42):
             assert QuerySubscriptionDataSourceHandler.get_instance_limit(self.organization) == 42
 
+    def test_get_instance_limit_with_override(self) -> None:
+        with self.settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=42):
+            with self.options(
+                {
+                    "metric_alerts.extended_max_subscriptions_orgs": [self.organization.id],
+                    "metric_alerts.extended_max_subscriptions": 100,
+                }
+            ):
+                assert (
+                    QuerySubscriptionDataSourceHandler.get_instance_limit(self.organization) == 100
+                )
+
     def test_get_current_instance_count(self) -> None:
         new_org = self.create_organization()
         new_project = self.create_project(organization=new_org)


### PR DESCRIPTION
Some orgs need a higher subscriptions limit, so adding options
to enable extending the limits for these orgs. 