### PR TITLE
feat(explore): Add in cross event search bars

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -72,3 +72,5 @@ export const SENTRY_LOG_STRING_TAGS: string[] = [
 ];
 
 export const SENTRY_LOG_NUMBER_TAGS: string[] = [OurLogKnownFieldKey.SEVERITY_NUMBER];
+
+export const MAX_CROSS_EVENT_QUERIES = 2;

--- a/static/app/views/explore/queryParams/crossEvent.ts
+++ b/static/app/views/explore/queryParams/crossEvent.ts
@@ -2,7 +2,7 @@ import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';
 
-type CrossEventType = 'logs' | 'spans' | 'metrics';
+export type CrossEventType = 'logs' | 'spans' | 'metrics';
 
 export interface CrossEvent {
   query: string;

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -633,5 +633,28 @@ describe('SpansTabContent', () => {
         screen.getByPlaceholderText('Search for metrics, users, tags, and more')
       ).toBeInTheDocument();
     });
+
+    it('displays the cross event query limit alert', () => {
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              crossEvents: JSON.stringify([
+                {query: '', type: 'spans'},
+                {query: '', type: 'logs'},
+                {query: '', type: 'metrics'},
+              ]),
+            },
+          },
+        },
+      });
+
+      expect(
+        screen.getByText('You can add up to a maximum of 2 cross event queries.')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -572,5 +572,66 @@ describe('SpansTabContent', () => {
         screen.getByRole('button', {name: 'Add a cross event query'})
       ).toBeDisabled();
     });
+
+    it('adds a cross event search bar when cross event added', async () => {
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Add a cross event query'})
+      );
+
+      expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Logs'}));
+
+      expect(
+        screen.getByPlaceholderText('Search for logs, users, tags, and more')
+      ).toBeInTheDocument();
+    });
+
+    it('can remove a cross event query', async () => {
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {crossEvents: JSON.stringify([{query: '', type: 'logs'}])},
+          },
+        },
+      });
+
+      expect(
+        await screen.findByPlaceholderText('Search for logs, users, tags, and more')
+      ).toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText('Remove cross event search for logs'));
+
+      expect(
+        screen.queryByPlaceholderText('Search for logs, users, tags, and more')
+      ).not.toBeInTheDocument();
+    });
+
+    it('changes the cross event search bar when dataset changed', async () => {
+      render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
+        organization,
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {crossEvents: JSON.stringify([{query: '', type: 'logs'}])},
+          },
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: /Logs/}));
+      await userEvent.click(screen.getByRole('option', {name: 'Metrics'}));
+
+      expect(
+        screen.getByPlaceholderText('Search for metrics, users, tags, and more')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -42,6 +42,7 @@ import {
   TraceItemSearchQueryBuilder,
   useSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {MAX_CROSS_EVENT_QUERIES} from 'sentry/views/explore/constants';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -84,9 +85,10 @@ function CrossEventQueryingDropdown() {
     }
   };
 
-  const isDisabled = defined(crossEvents) && crossEvents.length >= 2;
+  const isDisabled =
+    defined(crossEvents) && crossEvents.length >= MAX_CROSS_EVENT_QUERIES;
   const tooltipTitle = isDisabled
-    ? t('Maximum of 2 cross event queries allowed.')
+    ? t('Maximum of %s cross event queries allowed.', MAX_CROSS_EVENT_QUERIES)
     : t('For more targeted results, you can also cross reference other datasets.');
 
   return (
@@ -211,7 +213,7 @@ function SpansTabCrossEventSearchBars() {
     return null;
   }
 
-  return crossEvents.slice(0, 2).map((crossEvent, index) => {
+  return crossEvents.slice(0, MAX_CROSS_EVENT_QUERIES).map((crossEvent, index) => {
     const traceItemType =
       crossEvent.type === 'spans'
         ? TraceItemDataset.SPANS
@@ -414,10 +416,13 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
             {hasCrossEventQueryingFlag ? <CrossEventQueryingDropdown /> : null}
             {hasCrossEvents ? <SpansTabCrossEventSearchBars /> : null}
           </Grid>
-          {hasCrossEvents && crossEvents.length > 2 ? (
+          {hasCrossEvents && crossEvents.length > MAX_CROSS_EVENT_QUERIES ? (
             <Container paddingTop="md">
               <Alert type="warning">
-                {t('You can add up to a maximum of 2 cross event queries.')}
+                {t(
+                  'You can add up to a maximum of %s cross event queries.',
+                  MAX_CROSS_EVENT_QUERIES
+                )}
               </Alert>
             </Container>
           ) : null}

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -1,7 +1,9 @@
-import {useMemo, type Key} from 'react';
+import {Fragment, memo, useMemo, type Key} from 'react';
 import styled from '@emotion/styled';
 
-import {Grid} from '@sentry/scraps/layout';
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Container, Grid} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
@@ -22,7 +24,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/context';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {TourElement} from 'sentry/components/tours/components';
-import {IconAdd} from 'sentry/icons';
+import {IconAdd, IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {
@@ -35,8 +37,13 @@ import usePrevious from 'sentry/utils/usePrevious';
 import SchemaHintsList from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
 import {ExploreSchemaHintsSection} from 'sentry/views/explore/components/styles';
+import {
+  TraceItemSearchQueryBuilder,
+  useSearchQueryBuilderProps,
+} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {
   useQueryParamsCrossEvents,
   useQueryParamsFields,
@@ -45,9 +52,13 @@ import {
   useSetQueryParams,
   useSetQueryParamsCrossEvents,
 } from 'sentry/views/explore/queryParams/context';
-import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
+import {
+  isCrossEventType,
+  type CrossEventType,
+} from 'sentry/views/explore/queryParams/crossEvent';
 import {SpansTabSeerComboBox} from 'sentry/views/explore/spans/spansTabSeerComboBox';
 import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/spans/tour';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {findSuggestedColumns} from 'sentry/views/explore/utils';
 
 const crossEventDropdownItems: DropdownMenuProps['items'] = [
@@ -79,19 +90,183 @@ function CrossEventQueryingDropdown() {
 
   return (
     <Tooltip title={tooltipTitle}>
-      <DropdownMenu
-        onAction={onAction}
-        items={crossEventDropdownItems}
-        isDisabled={isDisabled}
-        triggerProps={{
-          size: 'md',
-          showChevron: false,
-          icon: <IconAdd />,
-          'aria-label': t('Add a cross event query'),
-        }}
-      />
+      <Container width="100%">
+        {triggerProps => (
+          <DropdownMenu
+            onAction={onAction}
+            items={crossEventDropdownItems}
+            isDisabled={isDisabled}
+            triggerProps={{
+              ...triggerProps,
+              size: 'md',
+              showChevron: false,
+              icon: <IconAdd />,
+              'aria-label': t('Add a cross event query'),
+            }}
+          />
+        )}
+      </Container>
     </Tooltip>
   );
+}
+
+interface SpansTabCrossEventSearchBarProps {
+  index: number;
+  query: string;
+  type: CrossEventType;
+}
+
+const SpansTabCrossEventSearchBar = memo(
+  ({index, query, type}: SpansTabCrossEventSearchBarProps) => {
+    const mode = useQueryParamsMode();
+    const crossEvents = useQueryParamsCrossEvents();
+    const setCrossEvents = useSetQueryParamsCrossEvents();
+
+    const {tags: numberAttributes, secondaryAliases: numberSecondaryAliases} =
+      useTraceItemTags('number');
+    const {tags: stringAttributes, secondaryAliases: stringSecondaryAliases} =
+      useTraceItemTags('string');
+
+    const traceItemType =
+      type === 'spans'
+        ? TraceItemDataset.SPANS
+        : type === 'logs'
+          ? TraceItemDataset.LOGS
+          : TraceItemDataset.TRACEMETRICS;
+
+    const eapSpanSearchQueryBuilderProps = useMemo(
+      () => ({
+        initialQuery: query,
+        onSearch: (newQuery: string) => {
+          if (!crossEvents) return;
+
+          setCrossEvents?.(
+            crossEvents.map((c, i) => {
+              if (i === index) return {query: newQuery, type};
+              return c;
+            })
+          );
+        },
+        searchSource: 'explore',
+        getFilterTokenWarning:
+          mode === Mode.SAMPLES
+            ? (key: string) => {
+                if (
+                  ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.includes(key as AggregationKey)
+                ) {
+                  return t(
+                    "This key won't affect the results because samples mode does not support aggregate functions"
+                  );
+                }
+                return undefined;
+              }
+            : undefined,
+        supportedAggregates:
+          mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+        numberAttributes,
+        stringAttributes,
+        matchKeySuggestions: [
+          {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
+          {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
+        ],
+        numberSecondaryAliases,
+        stringSecondaryAliases,
+      }),
+      [
+        crossEvents,
+        index,
+        mode,
+        numberSecondaryAliases,
+        numberAttributes,
+        query,
+        setCrossEvents,
+        stringSecondaryAliases,
+        stringAttributes,
+        type,
+      ]
+    );
+
+    const searchQueryBuilderProps = useSearchQueryBuilderProps({
+      itemType: traceItemType,
+      ...eapSpanSearchQueryBuilderProps,
+    });
+
+    return (
+      <SearchQueryBuilderProvider {...searchQueryBuilderProps}>
+        <TraceItemSearchQueryBuilder
+          itemType={traceItemType}
+          {...eapSpanSearchQueryBuilderProps}
+        />
+      </SearchQueryBuilderProvider>
+    );
+  }
+);
+
+function SpansTabCrossEventSearchBars() {
+  const crossEvents = useQueryParamsCrossEvents();
+  const setCrossEvents = useSetQueryParamsCrossEvents();
+
+  if (!crossEvents || crossEvents.length === 0) {
+    return null;
+  }
+
+  return crossEvents.map((crossEvent, index) => {
+    const traceItemType =
+      crossEvent.type === 'spans'
+        ? TraceItemDataset.SPANS
+        : crossEvent.type === 'logs'
+          ? TraceItemDataset.LOGS
+          : TraceItemDataset.TRACEMETRICS;
+
+    return (
+      <Fragment key={`${crossEvent.type}-${index}`}>
+        <div />
+        <Container justifySelf="end" width={{sm: '100%', md: '100%'}}>
+          {props => (
+            <CompactSelect
+              {...props}
+              menuTitle={t('Dataset')}
+              aria-label={t('Modify dataset to cross reference')}
+              value={crossEvent.type}
+              triggerProps={{
+                prefix: t('with'),
+                ...props,
+              }}
+              options={[
+                {value: 'spans', label: t('Spans')},
+                {value: 'logs', label: t('Logs')},
+                {value: 'metrics', label: t('Metrics')},
+              ]}
+              onChange={({value: newValue}) => {
+                if (!isCrossEventType(newValue)) return;
+
+                setCrossEvents(
+                  crossEvents.map((c, i) => {
+                    if (i === index) return {query: '', type: newValue};
+                    return c;
+                  })
+                );
+              }}
+            />
+          )}
+        </Container>
+        <TraceItemAttributeProvider traceItemType={traceItemType} enabled>
+          <SpansTabCrossEventSearchBar
+            index={index}
+            query={crossEvent.query}
+            type={crossEvent.type}
+          />
+        </TraceItemAttributeProvider>
+        <Button
+          icon={<IconDelete />}
+          aria-label={t('Remove cross event search for %s', crossEvent.type)}
+          onClick={() => {
+            setCrossEvents(crossEvents.filter((_, i) => i !== index));
+          }}
+        />
+      </Fragment>
+    );
+  });
 }
 
 function SpansSearchBar({
@@ -116,15 +291,22 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
   const mode = useQueryParamsMode();
   const fields = useQueryParamsFields();
   const query = useQueryParamsQuery();
+  const crossEvents = useQueryParamsCrossEvents();
   const setQueryParams = useSetQueryParams();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
 
   const organization = useOrganization();
   const areAiFeaturesAllowed =
     !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
-  const hasCrossEventQuerying = organization.features.includes(
+  const hasRawSearchReplacement = organization.features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
+  const hasCrossEventQueryingFlag = organization.features.includes(
     'traces-page-cross-event-querying'
   );
+
+  const hasCrossEvents =
+    hasCrossEventQueryingFlag && defined(crossEvents) && crossEvents.length > 0;
 
   const {
     tags: numberTags,
@@ -139,10 +321,6 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
 
   const search = useMemo(() => new MutableSearch(query), [query]);
   const oldSearch = usePrevious(search);
-
-  const hasRawSearchReplacement = organization.features.includes(
-    'search-query-builder-raw-search-replacement'
-  );
 
   const eapSpanSearchQueryBuilderProps = useMemo(
     () => ({
@@ -224,7 +402,13 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
           position="bottom"
           margin={-8}
         >
-          <Grid gap="md" columns={{sm: '1fr', md: 'minmax(300px, auto) 1fr min-content'}}>
+          <Grid
+            gap="md"
+            columns={{
+              sm: '1fr',
+              md: 'minmax(175px, auto) minmax(125px, auto) 1fr min-content',
+            }}
+          >
             <StyledPageFilterBar condensed>
               <ProjectPageFilter />
               <EnvironmentPageFilter />
@@ -233,20 +417,23 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
             <SpansSearchBar
               eapSpanSearchQueryBuilderProps={eapSpanSearchQueryBuilderProps}
             />
-            {hasCrossEventQuerying ? <CrossEventQueryingDropdown /> : null}
+            {hasCrossEventQueryingFlag ? <CrossEventQueryingDropdown /> : null}
+            {hasCrossEvents ? <SpansTabCrossEventSearchBars /> : null}
           </Grid>
-          <ExploreSchemaHintsSection>
-            <SchemaHintsList
-              supportedAggregates={
-                mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
-              }
-              numberTags={numberTags}
-              stringTags={stringTags}
-              isLoading={numberTagsLoading || stringTagsLoading}
-              exploreQuery={query}
-              source={SchemaHintsSources.EXPLORE}
-            />
-          </ExploreSchemaHintsSection>
+          {hasCrossEvents ? null : (
+            <ExploreSchemaHintsSection>
+              <SchemaHintsList
+                supportedAggregates={
+                  mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES
+                }
+                numberTags={numberTags}
+                stringTags={stringTags}
+                isLoading={numberTagsLoading || stringTagsLoading}
+                exploreQuery={query}
+                source={SchemaHintsSources.EXPLORE}
+              />
+            </ExploreSchemaHintsSection>
+          )}
         </TourElement>
       </SearchQueryBuilderProvider>
     </Layout.Main>
@@ -255,4 +442,5 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
 
 const StyledPageFilterBar = styled(PageFilterBar)`
   width: auto;
+  grid-column: span 2;
 `;

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -1,6 +1,7 @@
 import {Fragment, memo, useMemo, type Key} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Container, Grid} from '@sentry/scraps/layout';
@@ -210,7 +211,7 @@ function SpansTabCrossEventSearchBars() {
     return null;
   }
 
-  return crossEvents.map((crossEvent, index) => {
+  return crossEvents.slice(0, 2).map((crossEvent, index) => {
     const traceItemType =
       crossEvent.type === 'spans'
         ? TraceItemDataset.SPANS
@@ -413,6 +414,13 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
             {hasCrossEventQueryingFlag ? <CrossEventQueryingDropdown /> : null}
             {hasCrossEvents ? <SpansTabCrossEventSearchBars /> : null}
           </Grid>
+          {hasCrossEvents && crossEvents.length > 2 ? (
+            <Container paddingTop="md">
+              <Alert type="warning">
+                {t('You can add up to a maximum of 2 cross event queries.')}
+              </Alert>
+            </Container>
+          ) : null}
           {hasCrossEvents ? null : (
             <ExploreSchemaHintsSection>
               <SchemaHintsList

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -220,8 +220,7 @@ function SpansTabCrossEventSearchBars() {
 
     return (
       <Fragment key={`${crossEvent.type}-${index}`}>
-        <div />
-        <Container justifySelf="end" width={{sm: '100%', md: '100%'}}>
+        <Container justifySelf="end" width={{sm: '100%', md: 'min-content'}}>
           {props => (
             <CompactSelect
               {...props}
@@ -402,13 +401,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
           position="bottom"
           margin={-8}
         >
-          <Grid
-            gap="md"
-            columns={{
-              sm: '1fr',
-              md: 'minmax(175px, auto) minmax(125px, auto) 1fr min-content',
-            }}
-          >
+          <Grid gap="md" columns={{sm: '1fr', md: 'minmax(300px, auto) 1fr min-content'}}>
             <StyledPageFilterBar condensed>
               <ProjectPageFilter />
               <EnvironmentPageFilter />
@@ -442,5 +435,4 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
 
 const StyledPageFilterBar = styled(PageFilterBar)`
   width: auto;
-  grid-column: span 2;
 `;


### PR DESCRIPTION
This PR setups the spans search query section to dynamically render search bars based off the `crossEvents` query param. Users can add in up to two additional search bars, as well as remove them. The search bars also respect the selected type in the dataset selector.

Tickets: EXP-619, EXP-620, EXP-622

Example:

https://github.com/user-attachments/assets/66ceb1dd-99f7-449d-87f6-9848006813e0