### PR TITLE
fix(dashboards): Filter out prebuilt dashboards from add to dashboard dropdown options

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -687,4 +687,47 @@ describe('add to dashboard modal', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('does not show prebuilt dashboards in the list of options', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [
+        {...testDashboardListItem, widgetDisplay: [DisplayType.AREA]},
+        {
+          ...testDashboardListItem,
+          title: 'Other Dashboard',
+          id: '2',
+          widgetDisplay: [DisplayType.AREA],
+        },
+        {
+          ...testDashboardListItem,
+          title: 'Prebuilt Dashboard',
+          id: '3',
+          widgetDisplay: [DisplayType.AREA],
+          prebuiltId: 1,
+        },
+      ],
+    });
+    render(
+      <AddToDashboardModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => undefined}
+        organization={initialData.organization}
+        widget={widget}
+        selection={defaultSelection}
+        location={LocationFixture()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Dashboard')).toBeEnabled();
+    });
+    await selectEvent.openMenu(screen.getByText('Select Dashboard'));
+    expect(screen.queryByText('Prebuilt Dashboard')).not.toBeInTheDocument();
+    expect(screen.getByText('Test Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Other Dashboard')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -261,6 +261,7 @@ function AddToDashboardModal({
           tooltipOptions: {position: 'right', isHoverable: true},
         },
         ...dashboards
+          .filter(dashboard => dashboard.prebuiltId === undefined) // Cannot add to prebuilt dashboards
           .filter(dashboard =>
             // if adding from a dashboard, currentDashboardId will be set and we'll remove it from the list of options
             currentDashboardId ? dashboard.id !== currentDashboardId : true

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -19,6 +19,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -261,7 +262,7 @@ function AddToDashboardModal({
           tooltipOptions: {position: 'right', isHoverable: true},
         },
         ...dashboards
-          .filter(dashboard => dashboard.prebuiltId === undefined) // Cannot add to prebuilt dashboards
+          .filter(dashboard => !defined(dashboard.prebuiltId)) // Cannot add to prebuilt dashboards
           .filter(dashboard =>
             // if adding from a dashboard, currentDashboardId will be set and we'll remove it from the list of options
             currentDashboardId ? dashboard.id !== currentDashboardId : true


### PR DESCRIPTION
Filters out prebuilt dashboards from the add to dashboard modal options, since prebuilt dashboards cannot be edited.