### PR TITLE
refactor(replay): remove unused components in platform icons

### DIFF
--- a/static/app/components/core/avatar/avatarList.tsx
+++ b/static/app/components/core/avatar/avatarList.tsx
@@ -165,6 +165,7 @@ const AvatarListWrapper = styled('div')`
 
 const AvatarStyle = (p: {theme: Theme}) => css`
   border: 2px solid ${p.theme.background};
+  margin-left: -8px;
   cursor: default;
 
   &:hover {

--- a/static/app/components/core/avatar/avatarList.tsx
+++ b/static/app/components/core/avatar/avatarList.tsx
@@ -165,7 +165,6 @@ const AvatarListWrapper = styled('div')`
 
 const AvatarStyle = (p: {theme: Theme}) => css`
   border: 2px solid ${p.theme.background};
-  margin-left: -8px;
   cursor: default;
 
   &:hover {

--- a/static/app/components/platformList.tsx
+++ b/static/app/components/platformList.tsx
@@ -1,4 +1,3 @@
-import type {Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
@@ -62,41 +61,19 @@ function getOverlapWidth(size: number) {
   return Math.round(size / 4);
 }
 
-const commonStyles = ({theme}: {theme: Theme}) => css`
-  cursor: default;
-  border-radius: ${theme.borderRadius};
-  box-shadow: 0 0 0 1px ${theme.background};
-  :hover {
-    z-index: 1;
-  }
-`;
-
 const PlatformIcons = styled('div')`
   display: flex;
 `;
 
-const InnerWrapper = styled('div')`
-  display: flex;
-  position: relative;
-`;
-
 const StyledPlatformIcon = styled(PlatformIcon)`
-  ${p => commonStyles(p)};
-`;
-
-const Counter = styled('div')`
-  ${p => commonStyles(p)};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-weight: ${p => p.theme.fontWeight.bold};
-  font-size: ${p => p.theme.fontSize.xs};
-  background-color: ${p => p.theme.gray200};
-  color: ${p => p.theme.subText};
-  padding: 0 1px;
-  position: absolute;
-  right: -1px;
+  cursor: default;
+  border-radius: ${p => p.theme.borderRadius};
+  box-shadow: 0 0 0 1px ${p => p.theme.background};
+  :hover {
+    z-index: 1;
+  }
+  height: ${p => p.size}px;
+  min-width: ${p => p.size}px;
 `;
 
 const Wrapper = styled('div')<WrapperProps>`
@@ -110,14 +87,5 @@ const Wrapper = styled('div')<WrapperProps>`
         margin-left: ${p.size * -1 + getOverlapWidth(p.size)}px;
       }
     `}
-  }
-
-  ${InnerWrapper} {
-    padding-right: ${p => p.size / 2 + 1}px;
-  }
-
-  ${Counter} {
-    height: ${p => p.size}px;
-    min-width: ${p => p.size}px;
   }
 `;


### PR DESCRIPTION
Related to [REPLAY-814](https://linear.app/getsentry/issue/REPLAY-814/implement-new-ui-for-replay-page)

No visual changes. Purely housekeeping PR that removes unnecessary components, and properly sets widths and height for the platform icons

