### PR TITLE
ref(eap): Remove AnyResolved type

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -54,6 +54,7 @@ class ResolvedColumn:
     # Indicates this attribute is a secondary alias for the attribute.
     # It exists for compatibility or convenience reasons and should NOT be preferred.
     secondary_alias: bool = False
+    is_aggregate: bool
 
     def process_column(self, value: Any) -> Any:
         """Given the value from results, return a processed value if a processor is defined otherwise return it"""
@@ -80,6 +81,18 @@ class ResolvedColumn:
             return self.internal_type
         else:
             return constants.TYPE_MAP[self.search_type]
+
+    @property
+    def proto_definition(
+        self,
+    ) -> (
+        LiteralValue
+        | AttributeKey
+        | AttributeAggregation
+        | AttributeConditionalAggregation
+        | Column.BinaryFormula
+    ):
+        raise NotImplementedError
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -573,17 +586,6 @@ def project_term_resolver(
         return [int(val) for val in raw_value]
     else:
         return int(raw_value)
-
-
-# Any of the resolved attributes, mostly to clean typing up so there's not this giant list all over the code
-AnyResolved = (
-    ResolvedAttribute
-    | ResolvedAggregate
-    | ResolvedConditionalAggregate
-    | ResolvedFormula
-    | ResolvedEquation
-    | ResolvedLiteral
-)
 
 
 @dataclass(frozen=True)

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -42,13 +42,13 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     AggregateDefinition,
-    AnyResolved,
     AttributeArgumentDefinition,
     ColumnDefinitions,
     ConditionalAggregateDefinition,
     FormulaDefinition,
     ResolvedAggregate,
     ResolvedAttribute,
+    ResolvedColumn,
     ResolvedConditionalAggregate,
     ResolvedEquation,
     ResolvedFormula,
@@ -1081,7 +1081,7 @@ class SearchResolver:
         return self._resolved_function_cache[alias]
 
     def resolve_equations(self, equations: list[str]) -> tuple[
-        list[AnyResolved],
+        list[ResolvedColumn],
         list[VirtualColumnDefinition],
     ]:
         formulas = []
@@ -1093,7 +1093,7 @@ class SearchResolver:
         return formulas, contexts
 
     def resolve_equation(self, equation: str) -> tuple[
-        AnyResolved,
+        ResolvedColumn,
         list[VirtualColumnDefinition],
     ]:
         """Resolve an equation creating a ResolvedEquation object, we don't just return a Column.BinaryFormula since

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1068,6 +1068,7 @@ class SearchResolver:
             )
 
         resolved_function = function_definition.resolve(
+            resolver=self,
             alias=alias,
             search_type=search_type,
             resolved_arguments=resolved_arguments,

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeKey,
@@ -28,6 +28,9 @@ from sentry.search.eap.normalizer import unquote_literal
 from sentry.search.eap.spans.utils import WEB_VITALS_MEASUREMENTS, transform_vital_score_to_ratio
 from sentry.search.eap.validator import literal_validator, number_validator
 
+if TYPE_CHECKING:
+    from sentry.search.eap.resolver import SearchResolver
+
 
 def count_processor(count_value: int | None) -> int:
     if count_value is None:
@@ -41,7 +44,9 @@ SPANS_ALWAYS_PRESENT_ATTRIBUTES = [
 ]
 
 
-def resolve_count_op(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
+def resolve_count_op(
+    _: "SearchResolver", args: ResolvedArguments
+) -> tuple[AttributeKey, TraceItemFilter]:
     op_value = cast(str, args[0])
 
     filter = TraceItemFilter(
@@ -57,7 +62,9 @@ def resolve_count_op(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFi
     return (AttributeKey(name="sentry.op", type=AttributeKey.TYPE_STRING), filter)
 
 
-def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
+def resolve_key_eq_value_filter(
+    _: "SearchResolver", args: ResolvedArguments
+) -> tuple[AttributeKey, TraceItemFilter]:
     aggregate_key = cast(AttributeKey, args[0])
     key = cast(AttributeKey, args[1])
     operator = cast(str, args[2])
@@ -103,7 +110,9 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
     return (aggregate_key, trace_filter)
 
 
-def resolve_count_starts(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
+def resolve_count_starts(
+    _: "SearchResolver", args: ResolvedArguments
+) -> tuple[AttributeKey, TraceItemFilter]:
     attribute = cast(AttributeKey, args[0])
     filter = TraceItemFilter(
         exists_filter=ExistsFilter(
@@ -114,7 +123,9 @@ def resolve_count_starts(args: ResolvedArguments) -> tuple[AttributeKey, TraceIt
 
 
 # TODO: We should eventually update the frontend to query the ratio column directly
-def resolve_count_scores(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
+def resolve_count_scores(
+    _: "SearchResolver", args: ResolvedArguments
+) -> tuple[AttributeKey, TraceItemFilter]:
     score_attribute = cast(AttributeKey, args[0])
     ratio_attribute = transform_vital_score_to_ratio([score_attribute])
     filter = TraceItemFilter(exists_filter=ExistsFilter(key=ratio_attribute))
@@ -122,7 +133,9 @@ def resolve_count_scores(args: ResolvedArguments) -> tuple[AttributeKey, TraceIt
     return (ratio_attribute, filter)
 
 
-def resolve_http_response_count(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
+def resolve_http_response_count(
+    _: "SearchResolver", args: ResolvedArguments
+) -> tuple[AttributeKey, TraceItemFilter]:
     code = cast(Literal[1, 2, 3, 4, 5], args[0])
     codes = constants.RESPONSE_CODE_MAP[code]
 
@@ -148,7 +161,9 @@ def resolve_http_response_count(args: ResolvedArguments) -> tuple[AttributeKey, 
     return (status_code_attribute, filter)
 
 
-def resolve_bounded_sample(args: ResolvedArguments) -> tuple[AttributeKey, TraceItemFilter]:
+def resolve_bounded_sample(
+    _: "SearchResolver", args: ResolvedArguments
+) -> tuple[AttributeKey, TraceItemFilter]:
     attribute = cast(AttributeKey, args[0])
     lower_bound = cast(float, args[1])
     upper_bound = cast(float | None, args[2])

--- a/src/sentry/search/eap/trace_metrics/config.py
+++ b/src/sentry/search/eap/trace_metrics/config.py
@@ -6,14 +6,14 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Attrib
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     AndFilter,
     ComparisonFilter,
+    ExistsFilter,
     TraceItemFilter,
 )
 
 from sentry.exceptions import InvalidSearchQuery
-from sentry.search.eap.columns import ResolvedTraceMetricAggregate, ResolvedTraceMetricFormula
+from sentry.search.eap.columns import ResolvedArguments
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import MetricType, SearchResolverConfig
-from sentry.search.events import fields
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -39,55 +39,7 @@ class TraceMetricsSearchResolverConfig(SearchResolverConfig):
         if extra_conditions := self._extra_conditions_from_metric(search_resolver):
             return extra_conditions
 
-        # then try to parse metric from the aggregations
-        if extra_conditions := self._extra_conditions_from_columns(
-            search_resolver, selected_columns, equations
-        ):
-            return extra_conditions
-
         return None
-
-    def _extra_conditions_from_columns(
-        self,
-        search_resolver: SearchResolver,
-        selected_columns: list[str] | None,
-        equations: list[str] | None,
-    ) -> TraceItemFilter | None:
-        selected_metrics: set[Metric] = set()
-
-        if selected_columns:
-            stripped_columns = [column.strip() for column in selected_columns]
-            for column in stripped_columns:
-                match = fields.is_function(column)
-                if not match:
-                    continue
-
-                resolved_function, _ = search_resolver.resolve_function(column)
-
-                if not isinstance(
-                    resolved_function, ResolvedTraceMetricAggregate
-                ) and not isinstance(resolved_function, ResolvedTraceMetricFormula):
-                    continue
-
-                if not resolved_function.metric_name or not resolved_function.metric_type:
-                    continue
-
-                metric = Metric(
-                    metric_name=resolved_function.metric_name,
-                    metric_type=resolved_function.metric_type,
-                    metric_unit=resolved_function.metric_unit,
-                )
-                selected_metrics.add(metric)
-
-        if not selected_metrics:
-            return None
-
-        if len(selected_metrics) > 1:
-            raise InvalidSearchQuery("Cannot aggregate multiple metrics in 1 query.")
-
-        selected_metric = selected_metrics.pop()
-
-        return get_metric_filter(search_resolver, selected_metric)
 
     def _extra_conditions_from_metric(
         self,
@@ -107,8 +59,16 @@ class TraceMetricsSearchResolverConfig(SearchResolverConfig):
 
 def get_metric_filter(
     search_resolver: SearchResolver,
-    metric: Metric,
+    metric: Metric | None,
 ) -> TraceItemFilter:
+    if metric is None:
+        # no metric was specified so we assume they meant to query all metrics
+        org_col, _ = search_resolver.resolve_column("organization.id")
+        if not isinstance(org_col.proto_definition, AttributeKey):
+            raise ValueError("Unable to resolve organization.id")
+        # using org id exists as a dummy condition as it's always true
+        return TraceItemFilter(exists_filter=ExistsFilter(key=org_col.proto_definition))
+
     metric_name, _ = search_resolver.resolve_column("metric.name")
     if not isinstance(metric_name.proto_definition, AttributeKey):
         raise ValueError("Unable to resolve metric.name")
@@ -149,6 +109,38 @@ def get_metric_filter(
         )
 
     return TraceItemFilter(and_filter=AndFilter(filters=filters))
+
+
+def resolve_metric_arguments(args: ResolvedArguments) -> tuple[AttributeKey, Metric | None]:
+    if not isinstance(args[0], AttributeKey):
+        raise InvalidSearchQuery("Not a valid attribute")
+
+    attribute_key: AttributeKey = args[0]
+
+    metric_name = None
+    metric_type = None
+    metric_unit = None
+
+    if all(isinstance(arg, str) and arg != "" for arg in args[1:]):
+        # a metric was passed
+        metric_name = cast(str, args[1])
+        metric_type = cast(MetricType, args[2])
+        metric_unit = None if args[3] == "-" else cast(str, args[3])
+
+        metric = Metric(
+            metric_name=metric_name,
+            metric_type=metric_type,
+            metric_unit=metric_unit,
+        )
+        return attribute_key, metric
+
+    if all(arg == "" for arg in args[1:]):
+        # no metrics were specified, assume we query all metrics
+        return attribute_key, None
+
+    raise InvalidSearchQuery(
+        f"Trace metric aggregates expect the full metric to be specified, got name:{args[1]} type:{args[2]} unit:{args[3]}"
+    )
 
 
 ALLOWED_METRIC_TYPES: list[MetricType] = ["counter", "gauge", "distribution"]

--- a/src/sentry/search/eap/trace_metrics/definitions.py
+++ b/src/sentry/search/eap/trace_metrics/definitions.py
@@ -1,7 +1,10 @@
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.search.eap.columns import ColumnDefinitions
-from sentry.search.eap.trace_metrics.aggregates import TRACE_METRICS_AGGREGATE_DEFINITIONS
+from sentry.search.eap.trace_metrics.aggregates import (
+    TRACE_METRICS_AGGREGATE_DEFINITIONS,
+    TRACE_METRICS_CONDITIONAL_AGGREGATE_DEFINITIONS,
+)
 from sentry.search.eap.trace_metrics.attributes import (
     TRACE_METRICS_ATTRIBUTE_DEFINITIONS,
     TRACE_METRICS_VIRTUAL_CONTEXTS,
@@ -10,7 +13,7 @@ from sentry.search.eap.trace_metrics.formulas import TRACE_METRICS_FORMULA_DEFIN
 
 TRACE_METRICS_DEFINITIONS = ColumnDefinitions(
     aggregates=TRACE_METRICS_AGGREGATE_DEFINITIONS,
-    conditional_aggregates={},
+    conditional_aggregates=TRACE_METRICS_CONDITIONAL_AGGREGATE_DEFINITIONS,
     formulas=TRACE_METRICS_FORMULA_DEFINITIONS,
     columns=TRACE_METRICS_ATTRIBUTE_DEFINITIONS,
     contexts=TRACE_METRICS_VIRTUAL_CONTEXTS,

--- a/src/sentry/search/eap/trace_metrics/formulas.py
+++ b/src/sentry/search/eap/trace_metrics/formulas.py
@@ -1,12 +1,10 @@
-from typing import cast
-
+from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
+    AttributeConditionalAggregation,
+)
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
 from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
-    AttributeAggregation,
-    AttributeKey,
-    Function,
-)
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Function
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.columns import (
@@ -14,15 +12,24 @@ from sentry.search.eap.columns import (
     FormulaDefinition,
     ResolvedArguments,
     ResolverSettings,
-    TraceMetricFormulaDefinition,
     ValueArgumentDefinition,
 )
-from sentry.search.eap.trace_metrics.config import TraceMetricsSearchResolverConfig
+from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.trace_metrics.config import (
+    Metric,
+    TraceMetricsSearchResolverConfig,
+    get_metric_filter,
+    resolve_metric_arguments,
+)
 from sentry.search.eap.validator import literal_validator
 
 
 def _rate_internal(
-    divisor: int, metric_type: str, settings: ResolverSettings
+    divisor: int,
+    metric: Metric | None,
+    settings: ResolverSettings,
+    attribute_key: AttributeKey,
+    metric_filter: TraceItemFilter,
 ) -> Column.BinaryFormula:
     """
     Calculate rate per X for trace metrics using the value attribute.
@@ -40,14 +47,20 @@ def _rate_internal(
         else settings["snuba_params"].interval
     )
 
-    metric_type = search_config.metric_type if search_config.metric_type else metric_type
+    if search_config.metric_type:
+        metric_type = search_config.metric_type
+    elif metric is not None:
+        metric_type = metric.metric_type
+    else:
+        metric_type = None
 
     if metric_type == "counter":
         return Column.BinaryFormula(
             left=Column(
-                aggregation=AttributeAggregation(
+                conditional_aggregation=AttributeConditionalAggregation(
                     aggregate=Function.FUNCTION_SUM,
-                    key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.value"),
+                    key=attribute_key,
+                    filter=metric_filter,
                     extrapolation_mode=extrapolation_mode,
                 ),
             ),
@@ -59,9 +72,10 @@ def _rate_internal(
 
     return Column.BinaryFormula(
         left=Column(
-            aggregation=AttributeAggregation(
+            conditional_aggregation=AttributeConditionalAggregation(
                 aggregate=Function.FUNCTION_COUNT,
-                key=AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT),
+                key=attribute_key,
+                filter=metric_filter,
                 extrapolation_mode=extrapolation_mode,
             ),
         ),
@@ -72,24 +86,30 @@ def _rate_internal(
     )
 
 
-def per_second(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+def per_second(
+    resolver: "SearchResolver", args: ResolvedArguments, settings: ResolverSettings
+) -> Column.BinaryFormula:
     """
     Calculate rate per second for trace metrics using the value attribute.
     """
-    metric_type = cast(str, args[2]) if len(args) >= 3 and args[2] else "counter"
-    return _rate_internal(1, metric_type, settings)
+    attribute_key, metric = resolve_metric_arguments(args)
+    metric_filter = get_metric_filter(resolver, metric)
+    return _rate_internal(1, metric, settings, attribute_key, metric_filter)
 
 
-def per_minute(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+def per_minute(
+    resolver: "SearchResolver", args: ResolvedArguments, settings: ResolverSettings
+) -> Column.BinaryFormula:
     """
     Calculate rate per minute for trace metrics using the value attribute.
     """
-    metric_type = cast(str, args[2]) if len(args) >= 3 and args[2] else "counter"
-    return _rate_internal(60, metric_type, settings)
+    attribute_key, metric = resolve_metric_arguments(args)
+    metric_filter = get_metric_filter(resolver, metric)
+    return _rate_internal(60, metric, settings, attribute_key, metric_filter)
 
 
 TRACE_METRICS_FORMULA_DEFINITIONS: dict[str, FormulaDefinition] = {
-    "per_second": TraceMetricFormulaDefinition(
+    "per_second": FormulaDefinition(
         default_search_type="rate",
         arguments=[
             AttributeArgumentDefinition(
@@ -118,7 +138,7 @@ TRACE_METRICS_FORMULA_DEFINITIONS: dict[str, FormulaDefinition] = {
         is_aggregate=True,
         infer_search_type_from_arguments=False,
     ),
-    "per_minute": TraceMetricFormulaDefinition(
+    "per_minute": FormulaDefinition(
         default_search_type="rate",
         arguments=[
             AttributeArgumentDefinition(


### PR DESCRIPTION
Turns out, we have a ConditionalAggregateDefinition that handles what we needed for metrics. So this removes the special casing for trace metrics and consolidate it with the existing definitions.