### PR TITLE
feat(spans-migration): add post migration warnings to new monitors UI

### DIFF
--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -9,7 +9,11 @@ import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components
 import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
 import {MetricDetectorDetailsSidebar} from 'sentry/views/detectors/components/details/metric/sidebar';
 import {MetricTimePeriodSelect} from 'sentry/views/detectors/components/details/metric/timePeriodSelect';
-import {TransactionsDatasetWarning} from 'sentry/views/detectors/components/details/metric/transactionsDatasetWarning';
+import {
+  MigratedAlertWarning,
+  TransactionsDatasetWarning,
+} from 'sentry/views/detectors/components/details/metric/transactionsDatasetWarning';
+import {useIsMigratedExtrapolation} from 'sentry/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 
@@ -26,6 +30,11 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
   const eventTypes = snubaQuery?.eventTypes ?? [];
   const interval = snubaQuery?.timeWindow;
   const detectorDataset = getDetectorDataset(snubaDataset, eventTypes);
+  const extrapolationMode = snubaQuery?.extrapolationMode;
+  const showExtrapolationModeWarning = useIsMigratedExtrapolation({
+    dataset: detectorDataset,
+    extrapolationMode,
+  });
 
   const intervalSeconds = dataSource.queryObj?.snubaQuery.timeWindow;
 
@@ -37,6 +46,7 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
           {detectorDataset === DetectorDataset.TRANSACTIONS && (
             <TransactionsDatasetWarning />
           )}
+          {showExtrapolationModeWarning && <MigratedAlertWarning detector={detector} />}
           <MetricTimePeriodSelect dataset={detectorDataset} interval={interval} />
           {snubaQuery && (
             <MetricDetectorDetailsChart detector={detector} snubaQuery={snubaQuery} />

--- a/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
+++ b/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
@@ -38,7 +38,7 @@ export function MigratedAlertWarning({detector}: {detector: MetricDetector}) {
 
   return (
     <Alert.Container>
-      <Alert type="warning">
+      <Alert type="info">
         {tctCode(
           'This alert has been migrated from a transaction-based alert to a span-based alert. We have set a different extrapolation mode to mimic the previous alert behavior but this mode will be deprecated. Please [editLink:edit] the thresholds to match the regular extrapolation mode.',
           {

--- a/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
+++ b/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
@@ -1,7 +1,10 @@
 import {Alert} from 'sentry/components/core/alert';
-import {ExternalLink} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import {tctCode} from 'sentry/locale';
+import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
+import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 export const TRANSACTIONS_DATASET_DEPRECATION_MESSAGE = tctCode(
   'The transaction dataset is being deprecated. Please use Span alerts instead. Spans are a superset of transactions, you can isolate transactions by using the [code:is_transaction:true] filter. Please read these [FAQLink:FAQs] for more information.',
@@ -22,4 +25,27 @@ export function TransactionsDatasetWarning() {
   }
 
   return <Alert type="warning">{TRANSACTIONS_DATASET_DEPRECATION_MESSAGE}</Alert>;
+}
+
+export function MigratedAlertWarning({detector}: {detector: MetricDetector}) {
+  const organization = useOrganization();
+  const canEdit = useCanEditDetector({
+    detectorType: detector.type,
+    projectId: detector.projectId,
+  });
+
+  const editLink = `${makeMonitorDetailsPathname(organization.slug, detector.id)}edit/`;
+
+  return (
+    <Alert.Container>
+      <Alert type="warning">
+        {tctCode(
+          'This alert has been migrated from a transaction-based alert to a span-based alert. We have set a different extrapolation mode to mimic the previous alert behavior but this mode will be deprecated. Please [editLink:edit] the thresholds to match the regular extrapolation mode.',
+          {
+            editLink: <Link to={editLink} disabled={!canEdit} />,
+          }
+        )}
+      </Alert>
+    </Alert.Container>
+  );
 }

--- a/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
+++ b/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
@@ -40,9 +40,15 @@ export function MigratedAlertWarning({detector}: {detector: MetricDetector}) {
     <Alert.Container>
       <Alert type="info">
         {tctCode(
-          'This alert has been migrated from a transaction-based alert to a span-based alert. We have set a different extrapolation mode to mimic the previous alert behavior but this mode will be deprecated. Please [editLink:edit] the thresholds to match the regular extrapolation mode.',
+          'To match the original behaviour, we’ve migrated this alert from a transaction-based alert to a span-based alert using a special compatibility mode. When you have a moment, please [editLink:edit] the alert updating its thresholds to account for [samplingLink:sampling].',
           {
             editLink: <Link to={editLink} disabled={!canEdit} />,
+            samplingLink: (
+              <ExternalLink
+                href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
+                openInNewTab
+              />
+            ),
           }
         )}
       </Alert>

--- a/static/app/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation.tsx
+++ b/static/app/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation.tsx
@@ -1,0 +1,17 @@
+import {ExtrapolationMode} from 'sentry/views/alerts/rules/metric/types';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+
+export function useIsMigratedExtrapolation({
+  extrapolationMode,
+  dataset,
+}: {
+  dataset: DetectorDataset;
+  extrapolationMode: ExtrapolationMode | undefined;
+}) {
+  return !!(
+    dataset === DetectorDataset.SPANS &&
+    extrapolationMode &&
+    (extrapolationMode === ExtrapolationMode.SERVER_WEIGHTED ||
+      extrapolationMode === ExtrapolationMode.NONE)
+  );
+}

--- a/static/app/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation.tsx
+++ b/static/app/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation.tsx
@@ -8,6 +8,16 @@ export function useIsMigratedExtrapolation({
   dataset: DetectorDataset;
   extrapolationMode: ExtrapolationMode | undefined;
 }) {
+  return getIsMigratedExtrapolation({dataset, extrapolationMode});
+}
+
+export function getIsMigratedExtrapolation({
+  dataset,
+  extrapolationMode,
+}: {
+  dataset: DetectorDataset;
+  extrapolationMode: ExtrapolationMode | undefined;
+}) {
   return !!(
     dataset === DetectorDataset.SPANS &&
     extrapolationMode &&

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -1,16 +1,17 @@
-import {Fragment, useContext, useEffect, type ReactNode} from 'react';
+import {Fragment, useContext, useEffect} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import toNumber from 'lodash/toNumber';
 
 import {Alert} from '@sentry/scraps/alert/alert';
 import {Button} from '@sentry/scraps/button/button';
+import {ExternalLink} from '@sentry/scraps/link/link';
 
 import {Disclosure} from 'sentry/components/core/disclosure';
 import {Flex, Stack} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text/heading';
 import {Text} from 'sentry/components/core/text/text';
-import {Tooltip} from 'sentry/components/core/tooltip';
+import {Tooltip, type TooltipProps} from 'sentry/components/core/tooltip';
 import type {RadioOption} from 'sentry/components/forms/controls/radioGroup';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SegmentedRadioField from 'sentry/components/forms/fields/segmentedRadioField';
@@ -489,9 +490,20 @@ function DetectSection() {
             {showThresholdWarning && (
               <WarningIcon
                 id="thresholds-warning-icon"
-                title={t(
-                  'Your thresholds may need to be adjusted after the change in extrapolation mode'
-                )}
+                tooltipProps={{
+                  isHoverable: true,
+                  title: tct(
+                    'Your thresholds may need to be adjusted to take into account [samplingLink:sampling].',
+                    {
+                      samplingLink: (
+                        <ExternalLink
+                          href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
+                          openInNewTab
+                        />
+                      ),
+                    }
+                  ),
+                }}
               />
             )}
           </HeadingContainer>
@@ -617,8 +629,14 @@ function MigratedAlertWarningListener() {
       <Alert.Container>
         <Alert type="info">
           {tct(
-            'This chart may look different from the alert details chart. This is expected as the extrapolation mode has been changed. Once the alert has been saved, your alert will be switched to use the extrapolation mode represented here. To be alerted correctly, please edit your [thresholdsLink:thresholds]. For more information, check out this FAQ!',
+            'The thresholds on this chart may look off. This is because, once saved, alerts will now take into account [samplingLink:sampling rate]. Before clicking save, take the time to update your [thresholdsLink:thresholds]. Cancel to continue running this alert in compatibility mode.',
             {
+              samplingLink: (
+                <ExternalLink
+                  href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
+                  openInNewTab
+                />
+              ),
               thresholdsLink: (
                 <Button
                   priority="link"
@@ -640,9 +658,9 @@ function MigratedAlertWarningListener() {
   return null;
 }
 
-function WarningIcon({title, id}: {id: string; title: ReactNode}) {
+function WarningIcon({id, tooltipProps}: {id: string; tooltipProps?: TooltipProps}) {
   return (
-    <Tooltip title={title} skipWrapper>
+    <Tooltip title={tooltipProps?.title} skipWrapper {...tooltipProps}>
       <StyledIconWarning id={id} size="md" color="warning" />
     </Tooltip>
   );

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -26,6 +26,7 @@ import {
   ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
 import {useDetectorChartAxisBounds} from 'sentry/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds';
+import {useIsMigratedExtrapolation} from 'sentry/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation';
 import {getBackendDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useIncidentMarkers} from 'sentry/views/detectors/hooks/useIncidentMarkers';
@@ -160,6 +161,15 @@ export function MetricDetectorChart({
       interval,
     });
 
+  const shouldAlterExtrapolationMode = useIsMigratedExtrapolation({
+    dataset: detectorDataset,
+    extrapolationMode,
+  });
+
+  const adjustedExtrapolationMode = shouldAlterExtrapolationMode
+    ? ExtrapolationMode.UNKNOWN
+    : extrapolationMode;
+
   const {series, comparisonSeries, isLoading, error} = useMetricDetectorSeries({
     detectorDataset,
     dataset,
@@ -171,7 +181,7 @@ export function MetricDetectorChart({
     statsPeriod: selectedTimePeriod,
     comparisonDelta,
     eventTypes,
-    extrapolationMode,
+    extrapolationMode: adjustedExtrapolationMode,
   });
 
   const {maxValue: thresholdMaxValue, additionalSeries: thresholdAdditionalSeries} =

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -167,7 +167,7 @@ export function MetricDetectorChart({
   });
 
   const adjustedExtrapolationMode = shouldAlterExtrapolationMode
-    ? ExtrapolationMode.UNKNOWN
+    ? ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED
     : extrapolationMode;
 
   const {series, comparisonSeries, isLoading, error} = useMetricDetectorSeries({

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -21,6 +21,7 @@ import {
   Dataset,
   ExtrapolationMode,
 } from 'sentry/views/alerts/rules/metric/types';
+import {getIsMigratedExtrapolation} from 'sentry/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
@@ -310,10 +311,18 @@ function createDataSource(data: MetricDetectorFormData): NewDataSource {
   const datasetConfig = getDatasetConfig(data.dataset);
   const {eventTypes, query} = datasetConfig.separateEventTypesFromQuery(data.query);
 
+  const isUsingMigratedExtrapolation = getIsMigratedExtrapolation({
+    dataset: data.dataset,
+    extrapolationMode: data.extrapolationMode,
+  });
+  const adjustedExtrapolationMode = isUsingMigratedExtrapolation
+    ? ExtrapolationMode.UNKNOWN
+    : data.extrapolationMode;
+
   return {
     queryType: getQueryType(data.dataset),
     dataset: getBackendDataset(data.dataset),
-    extrapolationMode: data.extrapolationMode,
+    extrapolationMode: adjustedExtrapolationMode,
     query,
     aggregate: datasetConfig.toApiAggregate(data.aggregateFunction),
     timeWindow: data.interval,

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -316,7 +316,7 @@ function createDataSource(data: MetricDetectorFormData): NewDataSource {
     extrapolationMode: data.extrapolationMode,
   });
   const adjustedExtrapolationMode = isUsingMigratedExtrapolation
-    ? ExtrapolationMode.UNKNOWN
+    ? ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED
     : data.extrapolationMode;
 
   return {

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -935,7 +935,7 @@ describe('DetectorEdit', () => {
       expect(screen.getByRole('button', {name: 'p75'})).toBeDisabled();
     });
 
-    it('preserves SERVER_WEIGHTED extrapolation mode when editing and saving', async () => {
+    it('changes SERVER_WEIGHTED extrapolation mode to UNKNOWN when editing and saving', async () => {
       const spanDetectorWithExtrapolation = MetricDetectorFixture({
         id: '1',
         name: 'Span Detector with Extrapolation',
@@ -990,13 +990,14 @@ describe('DetectorEdit', () => {
         await screen.findByRole('link', {name: 'Span Detector with Extrapolation'})
       ).toBeInTheDocument();
 
-      // Verify events-stats is called with 'serverOnly' extrapolation mode for the chart
+      // Verify events-stats is called with 'sampleWeightd' extrapolation mode for the chart
+      // as we want to switch the extrapolation mode when saving
       await waitFor(() => {
         expect(eventsStatsRequest).toHaveBeenCalledWith(
           `/organizations/${organization.slug}/events-stats/`,
           expect.objectContaining({
             query: expect.objectContaining({
-              extrapolationMode: 'serverOnly',
+              extrapolationMode: 'sampleWeighted',
               sampling: SAMPLING_MODE.NORMAL,
             }),
           })
@@ -1020,7 +1021,7 @@ describe('DetectorEdit', () => {
             data: expect.objectContaining({
               dataSources: expect.arrayContaining([
                 expect.objectContaining({
-                  extrapolationMode: ExtrapolationMode.SERVER_WEIGHTED,
+                  extrapolationMode: ExtrapolationMode.UNKNOWN,
                 }),
               ]),
             }),

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -935,7 +935,7 @@ describe('DetectorEdit', () => {
       expect(screen.getByRole('button', {name: 'p75'})).toBeDisabled();
     });
 
-    it('changes SERVER_WEIGHTED extrapolation mode to UNKNOWN when editing and saving', async () => {
+    it('changes SERVER_WEIGHTED extrapolation mode to CLIEND_AND_SERVER_WEIGHTED when editing and saving', async () => {
       const spanDetectorWithExtrapolation = MetricDetectorFixture({
         id: '1',
         name: 'Span Detector with Extrapolation',
@@ -1021,7 +1021,7 @@ describe('DetectorEdit', () => {
             data: expect.objectContaining({
               dataSources: expect.arrayContaining([
                 expect.objectContaining({
-                  extrapolationMode: ExtrapolationMode.UNKNOWN,
+                  extrapolationMode: ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED,
                 }),
               ]),
             }),


### PR DESCRIPTION
In addition to https://github.com/getsentry/sentry/pull/104125/ we're adding the same warnings to the new alerts UI. This is what it looks like here:

**Monitor details page**
<img width="1232" height="820" alt="image" src="https://github.com/user-attachments/assets/accf0cd4-c41a-4090-ae5b-d521910ada5d" />

**Edit monitor page**
<img width="1218" height="1037" alt="image" src="https://github.com/user-attachments/assets/9d80e33e-1456-4913-a6cd-b7284b15b78f" />

