### PR TITLE
feat: Split tooltip for adjacent traces in two

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button/linkButton';
+import type {TooltipProps} from '@sentry/scraps/tooltip';
 
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {IconChevron} from 'sentry/icons';
@@ -20,11 +21,13 @@ type TraceLinkNavigationButtonProps = {
   attributes: TraceItemResponseAttribute[];
   currentTraceStartTimestamp: number;
   direction: ConnectedTraceConnection;
+  tooltipProps: TooltipProps;
 };
 
 export function TraceLinkNavigationButton({
   direction,
   attributes,
+  tooltipProps,
   currentTraceStartTimestamp,
 }: TraceLinkNavigationButtonProps) {
   const organization = useOrganization();
@@ -89,6 +92,8 @@ export function TraceLinkNavigationButton({
       size="xs"
       icon={<IconChevron direction={iconDirection} />}
       aria-label={ariaLabel}
+      tooltipProps={tooltipProps}
+      title={tooltipProps.title}
       onClick={closeSpanDetailsDrawer}
       disabled={!traceId || isTraceLoading || !isTraceAvailable}
       to={getTraceDetailsUrl({

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton.tsx
@@ -1,11 +1,11 @@
 import {useMemo} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button/linkButton';
-import type {TooltipProps} from '@sentry/scraps/tooltip';
+import {ExternalLink} from '@sentry/scraps/link';
 
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {IconChevron} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -21,13 +21,11 @@ type TraceLinkNavigationButtonProps = {
   attributes: TraceItemResponseAttribute[];
   currentTraceStartTimestamp: number;
   direction: ConnectedTraceConnection;
-  tooltipProps: TooltipProps;
 };
 
 export function TraceLinkNavigationButton({
   direction,
   attributes,
-  tooltipProps,
   currentTraceStartTimestamp,
 }: TraceLinkNavigationButtonProps) {
   const organization = useOrganization();
@@ -44,6 +42,7 @@ export function TraceLinkNavigationButton({
     adjacentTraceStartTimestamp,
     iconDirection,
     ariaLabel,
+    title,
   } = useMemo(() => {
     if (direction === 'previous') {
       return {
@@ -51,6 +50,11 @@ export function TraceLinkNavigationButton({
         adjacentTraceStartTimestamp: linkedTraceWindowTimestamp,
         iconDirection: 'left' as const,
         ariaLabel: t('Previous Trace'),
+        title: tct(`Go to the previous trace of the same session. [link:Learn More]`, {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+          ),
+        }),
       };
     }
     return {
@@ -58,6 +62,11 @@ export function TraceLinkNavigationButton({
       adjacentTraceStartTimestamp: currentTraceStartTimestamp,
       iconDirection: 'right' as const,
       ariaLabel: t('Next Trace'),
+      title: tct(`Go to the next trace of the same session. [link:Learn More]`, {
+        link: (
+          <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+        ),
+      }),
     };
   }, [direction, currentTraceStartTimestamp, linkedTraceWindowTimestamp]);
 
@@ -92,8 +101,12 @@ export function TraceLinkNavigationButton({
       size="xs"
       icon={<IconChevron direction={iconDirection} />}
       aria-label={ariaLabel}
-      tooltipProps={tooltipProps}
-      title={tooltipProps.title}
+      tooltipProps={{
+        position: 'top',
+        delay: 400,
+        isHoverable: true,
+      }}
+      title={title}
       onClick={closeSpanDetailsDrawer}
       disabled={!traceId || isTraceLoading || !isTraceAvailable}
       to={getTraceDetailsUrl({

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
@@ -1,6 +1,5 @@
 import {ButtonBar} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {tct} from 'sentry/locale';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
@@ -28,19 +27,7 @@ export function TraceLinksNavigation({
   }
 
   return (
-    <Tooltip
-      position="top"
-      delay={400}
-      isHoverable
-      title={tct(
-        `Go to the previous or next trace of the same session. [link:Learn More]`,
-        {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
-          ),
-        }
-      )}
-    >
+    <div>
       <ButtonBar merged gap="0">
         <TraceLinkNavigationButton
           direction="previous"
@@ -48,6 +35,19 @@ export function TraceLinksNavigation({
           currentTraceStartTimestamp={
             new Date(rootEventResults.data.timestamp).getTime() / 1000
           }
+          tooltipProps={{
+            position: 'top',
+            delay: 400,
+            isHoverable: true,
+            title: tct(
+              `Go to the previous trace of the same session. [link:Learn More]`,
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+                ),
+              }
+            ),
+          }}
         />
         <TraceLinkNavigationButton
           direction="next"
@@ -55,8 +55,18 @@ export function TraceLinksNavigation({
           currentTraceStartTimestamp={
             new Date(rootEventResults.data.timestamp).getTime() / 1000
           }
+          tooltipProps={{
+            position: 'top',
+            delay: 400,
+            isHoverable: true,
+            title: tct(`Go to the next trace of the same session. [link:Learn More]`, {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
+              ),
+            }),
+          }}
         />
       </ButtonBar>
-    </Tooltip>
+    </div>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceLinksNavigation/traceLinksNavigation.tsx
@@ -1,7 +1,5 @@
 import {ButtonBar} from '@sentry/scraps/button';
-import {ExternalLink} from '@sentry/scraps/link';
 
-import {tct} from 'sentry/locale';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
 import {TraceLinkNavigationButton} from 'sentry/views/performance/newTraceDetails/traceLinksNavigation/traceLinkNavigationButton';
@@ -35,19 +33,6 @@ export function TraceLinksNavigation({
           currentTraceStartTimestamp={
             new Date(rootEventResults.data.timestamp).getTime() / 1000
           }
-          tooltipProps={{
-            position: 'top',
-            delay: 400,
-            isHoverable: true,
-            title: tct(
-              `Go to the previous trace of the same session. [link:Learn More]`,
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
-                ),
-              }
-            ),
-          }}
         />
         <TraceLinkNavigationButton
           direction="next"
@@ -55,16 +40,6 @@ export function TraceLinksNavigation({
           currentTraceStartTimestamp={
             new Date(rootEventResults.data.timestamp).getTime() / 1000
           }
-          tooltipProps={{
-            position: 'top',
-            delay: 400,
-            isHoverable: true,
-            title: tct(`Go to the next trace of the same session. [link:Learn More]`, {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/concepts/key-terms/tracing/trace-view/#previous-and-next-traces" />
-              ),
-            }),
-          }}
         />
       </ButtonBar>
     </div>


### PR DESCRIPTION
The adjacent traces did have one tooltip for both buttons. To increase UX, they were split now into two:

<img width="628" height="169" alt="Screenshot 2025-12-01 at 10 25 11" src="https://github.com/user-attachments/assets/a35cca60-5f24-4192-b29a-d166d5888b67" />