### PR TITLE
fix(mcp-onboarding): Support fullstack JS platforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -786,6 +786,14 @@ export const agentMonitoringPlatforms: ReadonlySet<PlatformKey> = new Set([
 ]);
 
 export const mcpMonitoringPlatforms: ReadonlySet<PlatformKey> = new Set([
+  'javascript-astro',
+  'javascript-nextjs',
+  'javascript-nuxt',
+  'javascript-react-router',
+  'javascript-remix',
+  'javascript-solidstart',
+  'javascript-sveltekit',
+  'javascript-tanstackstart-react',
   ...platformKeys.filter(id => id.startsWith('node')),
   ...platformKeys.filter(id => id.startsWith('python')),
 ]);

--- a/static/app/gettingStartedDocs/javascript-astro/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/index.tsx
@@ -3,6 +3,7 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
@@ -32,6 +33,7 @@ const docs: Docs = {
     packageName: '@sentry/astro',
   }),
   agentMonitoringOnboarding: agentMonitoring,
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-astro/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/index.tsx
@@ -3,11 +3,11 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
 import {feedback} from './feedback';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 

--- a/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
@@ -3,6 +3,7 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 import {tct} from 'sentry/locale';
 
 import {agentMonitoring} from './agentMonitoring';
@@ -87,6 +88,7 @@ const docs: Docs = {
     packageName: '@sentry/nextjs',
   }),
   agentMonitoringOnboarding: agentMonitoring,
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
@@ -3,12 +3,12 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 import {tct} from 'sentry/locale';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
 import {feedback} from './feedback';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {performance} from './performance';
 import {replay} from './replay';

--- a/static/app/gettingStartedDocs/javascript-nextjs/mcp.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/mcp.tsx
@@ -1,5 +1,5 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const mcp = getNodeMcpOnboarding({
-  packageName: '@sentry/astro',
+  packageName: '@sentry/nextjs',
 });

--- a/static/app/gettingStartedDocs/javascript-nuxt/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/index.tsx
@@ -3,6 +3,7 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
@@ -31,6 +32,7 @@ const docs: Docs = {
     packageName: '@sentry/nuxt',
   }),
   agentMonitoringOnboarding: agentMonitoring,
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-nuxt/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/index.tsx
@@ -3,11 +3,11 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
 import {feedback} from './feedback';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';

--- a/static/app/gettingStartedDocs/javascript-nuxt/mcp.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/mcp.tsx
@@ -1,5 +1,5 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const mcp = getNodeMcpOnboarding({
-  packageName: '@sentry/astro',
+  packageName: '@sentry/nuxt',
 });

--- a/static/app/gettingStartedDocs/javascript-react-router/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/index.tsx
@@ -2,6 +2,7 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
@@ -32,6 +33,7 @@ const docs: Docs = {
     docsPlatform: 'react-router',
     packageName: '@sentry/react-router',
   }),
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-react-router/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/index.tsx
@@ -2,11 +2,11 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
 import {feedback} from './feedback';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {performance} from './performance';
 import {replay} from './replay';

--- a/static/app/gettingStartedDocs/javascript-react-router/mcp.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/mcp.tsx
@@ -1,5 +1,5 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const mcp = getNodeMcpOnboarding({
-  packageName: '@sentry/astro',
+  packageName: '@sentry/react-router',
 });

--- a/static/app/gettingStartedDocs/javascript-remix/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/index.tsx
@@ -3,11 +3,11 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
 import {feedback} from './feedback';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 

--- a/static/app/gettingStartedDocs/javascript-remix/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/index.tsx
@@ -3,6 +3,7 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
@@ -32,6 +33,7 @@ const docs: Docs = {
     docsPlatform: 'remix',
     packageName: '@sentry/remix',
   }),
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-remix/mcp.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/mcp.tsx
@@ -1,5 +1,5 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const mcp = getNodeMcpOnboarding({
-  packageName: '@sentry/astro',
+  packageName: '@sentry/remix',
 });

--- a/static/app/gettingStartedDocs/javascript-solidstart/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/index.tsx
@@ -3,6 +3,7 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
@@ -31,6 +32,7 @@ const docs: Docs = {
     docsPlatform: 'solidstart',
     packageName: '@sentry/solidstart',
   }),
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-solidstart/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/index.tsx
@@ -3,11 +3,11 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profiling} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
 import {feedback} from './feedback';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';

--- a/static/app/gettingStartedDocs/javascript-solidstart/mcp.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/mcp.tsx
@@ -1,5 +1,5 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const mcp = getNodeMcpOnboarding({
-  packageName: '@sentry/astro',
+  packageName: '@sentry/solidstart',
 });

--- a/static/app/gettingStartedDocs/javascript-sveltekit/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-sveltekit/index.tsx
@@ -3,6 +3,7 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
@@ -32,6 +33,7 @@ const docs: Docs = {
     docsPlatform: 'sveltekit',
     packageName: '@sentry/sveltekit',
   }),
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-sveltekit/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-sveltekit/index.tsx
@@ -3,11 +3,11 @@ import {featureFlag} from 'sentry/gettingStartedDocs/javascript/featureFlag';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {crashReport} from './crashReport';
 import {feedback} from './feedback';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 

--- a/static/app/gettingStartedDocs/javascript-sveltekit/mcp.tsx
+++ b/static/app/gettingStartedDocs/javascript-sveltekit/mcp.tsx
@@ -1,5 +1,5 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const mcp = getNodeMcpOnboarding({
-  packageName: '@sentry/astro',
+  packageName: '@sentry/sveltekit',
 });

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/index.tsx
@@ -2,9 +2,9 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
-import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
+import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 
 const docs: Docs = {

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/index.tsx
@@ -2,6 +2,7 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {logsFullStack} from 'sentry/gettingStartedDocs/javascript/logs';
 import {metricsFullStack} from 'sentry/gettingStartedDocs/javascript/metrics';
 import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling';
+import {mcp} from 'sentry/gettingStartedDocs/node/mcp';
 
 import {agentMonitoring} from './agentMonitoring';
 import {onboarding} from './onboarding';
@@ -24,6 +25,7 @@ const docs: Docs = {
     docsPlatform: 'tanstackstart-react',
     packageName: '@sentry/tanstackstart-react',
   }),
+  mcpOnboarding: mcp,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/mcp.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/mcp.tsx
@@ -1,5 +1,5 @@
 import {getNodeMcpOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 export const mcp = getNodeMcpOnboarding({
-  packageName: '@sentry/astro',
+  packageName: '@sentry/tanstackstart-react',
 });

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -799,7 +799,7 @@ export const getNodeMcpOnboarding = ({
     const mcpSdkStep: ContentBlock[] = [
       {
         type: 'text',
-        text: tct('Initialize the Sentry SDK with [code:Sentry.init()] call.', {
+        text: tct('Initialize the Sentry SDK by calling [code:Sentry.init()]:', {
           code: <code />,
         }),
       },


### PR DESCRIPTION
Display onboarding instructions for full stack JS platforms.

- part of [TET-1469: Enable more platforms for Agent and MCP monitoring](https://linear.app/getsentry/issue/TET-1469/enable-more-platforms-for-agent-and-mcp-monitoring)