### PR TITLE
Modified: Background color of Secondary nav bar

### DIFF
--- a/static/app/views/nav/secondary/secondarySidebar.tsx
+++ b/static/app/views/nav/secondary/secondarySidebar.tsx
@@ -87,7 +87,7 @@ export function SecondarySidebar() {
 }
 
 const SecondarySidebarWrapper = styled(NavTourElement)`
-  background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface200)};
+  background: ${p => p.theme.backgroundSecondary};
   border-right: 1px solid
     ${p => (p.theme.isChonk ? p.theme.border : p.theme.translucentGray200)};
   position: relative;

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -112,6 +112,5 @@ const StickyBottomSection = styled(SecondaryNav.Section, {
       position: sticky;
       bottom: 0;
       z-index: 1;
-      background: ${p.theme.isChonk ? p.theme.background : p.theme.surface200};
     `}
 `;

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -112,5 +112,6 @@ const StickyBottomSection = styled(SecondaryNav.Section, {
       position: sticky;
       bottom: 0;
       z-index: 1;
+      background: ${p.theme.backgroundSecondary};
     `}
 `;


### PR DESCRIPTION
## Problem
Based on UI2 Feedback we're reverting the decision to have a flatter navigation look

> "Finally, one more thing I noticed while writing this is that the 2 navigation bars on the left and the main container all have the same background color now,which didn't use to be the case on the old design. I think changing the right navbar to have a slightly different background color makes all the main UI elements more distinguishable as well."

> "Yeah, like originally color differentiation between nav panels and main data created the feeling of a funnel where the most important data is on the bottom of a box you are looking at. In new variant it’s plain, so you are looking at everything at once, like a cube net."

### Light Before
<img width="2880" height="1803" alt="CleanShot 2025-12-01 at 15 59 47@2x" src="https://github.com/user-attachments/assets/9c272c08-14b9-4741-a13c-824bf9cd3f40" />

### Light After
<img width="2880" height="1801" alt="CleanShot 2025-12-01 at 16 00 08@2x" src="https://github.com/user-attachments/assets/9ef86a2e-90a9-4ba7-af75-16f8b08a4463" />

### Dark Before
<img width="2880" height="1801" alt="CleanShot 2025-12-01 at 16 00 42@2x" src="https://github.com/user-attachments/assets/7814aca8-e289-4e92-a074-90330710f3d8" />

### Dark After
<img width="2880" height="1801" alt="CleanShot 2025-12-01 at 16 01 11@2x" src="https://github.com/user-attachments/assets/0519597f-053e-4b3c-be46-e700a5ee7328" />
