### PR TITLE
feat(dashboards): wrap dashboard controls in flag if prebuilt dashboard

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -88,7 +88,7 @@ function Controls({
   const api = useApi();
   const navigate = useNavigate();
   const hasPrebuiltControlsFeature = organization.features.includes(
-    'organizations:dashboards-prebuilt-controls'
+    'dashboards-prebuilt-controls'
   );
 
   const {duplicatePrebuiltDashboard, isLoading: isLoadingDuplicatePrebuiltDashboard} =

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -87,6 +87,9 @@ function Controls({
   const {teams: userTeams} = useUserTeams();
   const api = useApi();
   const navigate = useNavigate();
+  const hasPrebuiltControlsFeature = organization.features.includes(
+    'organizations:dashboards-prebuilt-controls'
+  );
 
   const {duplicatePrebuiltDashboard, isLoading: isLoadingDuplicatePrebuiltDashboard} =
     useDuplicatePrebuiltDashboard({
@@ -96,6 +99,10 @@ function Controls({
     });
 
   const isPrebuiltDashboard = defined(dashboard.prebuiltId);
+
+  if (isPrebuiltDashboard && !hasPrebuiltControlsFeature) {
+    return null;
+  }
 
   if ([DashboardState.EDIT, DashboardState.PENDING_DELETE].includes(dashboardState)) {
     return (


### PR DESCRIPTION
See BROWSE-152 for details

We don't want to show controls like duplicate/favourite on prebuilt dashboards until all modules are ported over. Perhaps we might EA this separately too, but it's all under a flag so we have the flexibility.