### PR TITLE
fix(tests) Unskip test that was previously flaky

### DIFF
--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -4,7 +4,6 @@ import re
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-import pytest
 from django.test import override_settings
 from django.urls import reverse
 
@@ -184,7 +183,6 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         )
         OrganizationMemberTeam.objects.get(organizationmember_id=org_member.id, team_id=team.id)
 
-    @pytest.mark.skip("flaky: INFRENG-210")
     def test_valid_slugs(self) -> None:
         valid_slugs = ["santry", "downtown-canada", "1234-foo"]
         for input_slug in valid_slugs:


### PR DESCRIPTION
Unskip a test that was marked flaky due to incorrect redis state during tests. The inconsistent redis state has been corrected and this test should be stable again.

Refs INFRENG-210
