### PR TITLE
feat(encryption): Add EncryptedJSONField

### DIFF
--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -7,10 +7,11 @@ from typing import Any, Literal, TypedDict
 
 import sentry_sdk
 from cryptography.fernet import InvalidToken
+from django.db import models
 from django.db.models import CharField, Field
 
 from sentry import options
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 from sentry.utils.security.encrypted_field_key_store import FernetKeyStore
 
 logger = logging.getLogger(__name__)
@@ -321,3 +322,104 @@ class EncryptedCharField(EncryptedField, CharField):
         if isinstance(db_value, bytes):
             db_value = db_value.decode("utf-8")
         return db_value
+
+
+class EncryptedJSONField(EncryptedField, models.JSONField):
+    """
+    An encrypted field that stores JSON data.
+
+    This field is a drop-in replacement for JSONField that adds encryption.
+    Data is stored as jsonb in the database with the encrypted payload wrapped
+    in a structure: {"sentry_encrypted_field_value": "enc:method:key_id:data"}
+
+    This allows for:
+    - Reuse of EncryptedField's encryption logic via composition
+    - Fallback to unencrypted JSON for backward compatibility
+    - Easy identification of encrypted vs unencrypted data
+    - True jsonb storage for database compatibility
+
+    The field handles:
+    - Encryption: Python object → JSON → encrypt → wrap in JSON object → store as jsonb
+    - Decryption: load jsonb → check for wrapper → decrypt → parse JSON → Python object
+    - Fallback: If no wrapper present, return parsed JSON as-is
+    """
+
+    _encrypted_field_key = "sentry_encrypted_field_value"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @sentry_sdk.trace
+    def get_prep_value(self, value: Any) -> dict | None:
+        """
+        Prepare value for database storage.
+
+        Flow: Python object → JSON string → encrypt → wrap in dict → return
+        """
+        if value is None:
+            return None
+
+        # First, serialize the Python object to JSON string
+        json_string = json.dumps(value)
+
+        # Encrypt the JSON string using the EncryptedField
+        # This will return something like "enc:fernet:key_id:base64data"
+        encrypted_value = super().get_prep_value(json_string)
+
+        if encrypted_value is None:
+            return None
+
+        # Wrap the encrypted string in a dict for jsonb storage
+        # This will be stored as jsonb, not as a string
+        return {self._encrypted_field_key: encrypted_value}
+
+    @sentry_sdk.trace
+    def to_python(self, value: Any) -> Any:
+        """
+        Convert database value to Python object.
+
+        Flow:
+        1. Value from database (already parsed as dict if jsonb)
+        2. Check for encrypted wrapper structure
+        3. If encrypted: decrypt → parse JSON → return Python object
+        4. If not encrypted (fallback): return value as-is
+        """
+        if value is None:
+            return value
+
+        # If value is a string, it might be from form input or serialization
+        # Parse it first
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (ValueError, TypeError):
+                # If it can't be parsed, return as-is
+                return value
+
+        # If it's not a dict at this point, return as-is
+        if not isinstance(value, dict):
+            return value
+
+        # Check if this is our encrypted wrapper structure
+        if self._encrypted_field_key in value and len(value) == 1:
+            # Extract the encrypted value and decrypt it
+            encrypted_value = value[self._encrypted_field_key]
+            decrypted_bytes = super().to_python(encrypted_value)
+
+            # Convert bytes to string if needed
+            if isinstance(decrypted_bytes, bytes):
+                decrypted_string = decrypted_bytes.decode("utf-8")
+            else:
+                decrypted_string = decrypted_bytes
+
+            # Parse the decrypted JSON string back to Python object
+            try:
+                return json.loads(decrypted_string)
+            except (ValueError, TypeError) as e:
+                logger.warning("Failed to parse decrypted JSON: %s", e)
+                # Fallback: return the original value
+                return value
+
+        # Fallback: No encrypted wrapper found, return the value as-is
+        # This handles backward compatibility with unencrypted data
+        return value

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -346,9 +346,6 @@ class EncryptedJSONField(EncryptedField, models.JSONField):
 
     _encrypted_field_key = "sentry_encrypted_field_value"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     @sentry_sdk.trace
     def get_prep_value(self, value: Any) -> dict | None:
         """

--- a/src/sentry/db/models/fields/encryption.py
+++ b/src/sentry/db/models/fields/encryption.py
@@ -100,7 +100,7 @@ class EncryptedField(Field):
             return f"{marker}:{encoded_data}"
 
     @sentry_sdk.trace
-    def get_prep_value(self, value: Any) -> str | None:
+    def get_prep_value(self, value: Any) -> Any:
         """Encrypt the value before saving to database."""
         value = super().get_prep_value(value)
         if value is None:

--- a/tests/sentry/db/models/fields/test_encryption.py
+++ b/tests/sentry/db/models/fields/test_encryption.py
@@ -10,8 +10,10 @@ from sentry.db.models.fields.encryption import (
     MARKER_PLAINTEXT,
     EncryptedCharField,
     EncryptedField,
+    EncryptedJSONField,
 )
 from sentry.testutils.helpers import override_options
+from sentry.utils import json
 from sentry.utils.security.encrypted_field_key_store import FernetKeyStore
 
 ENCRYPTION_METHODS = ("plaintext", "fernet")
@@ -506,3 +508,274 @@ def test_encrypted_char_field_null_value():
             )
             raw_value = cursor.fetchone()[0]
             assert raw_value is None
+
+
+# EncryptedJSONField Tests
+
+
+def test_encrypted_json_field_plaintext_encryption():
+    """Test EncryptedJSONField encryption with plaintext method."""
+    with override_options({"database.encryption.method": "plaintext"}):
+        field = EncryptedJSONField()
+
+        test_data = {"key": "value", "nested": {"data": [1, 2, 3]}}
+        encrypted = field.get_prep_value(test_data)
+
+        # Should be a dict (will be stored as jsonb)
+        assert isinstance(encrypted, dict)
+        assert EncryptedJSONField._encrypted_field_key in encrypted
+        assert encrypted[EncryptedJSONField._encrypted_field_key].startswith(MARKER_PLAINTEXT)
+
+        # Decrypt and verify
+        decrypted = field.to_python(encrypted)
+        assert decrypted == test_data
+
+
+def test_encrypted_json_field_fernet_encryption(fernet_keys_store):
+    """Test EncryptedJSONField encryption with Fernet method."""
+    key_id, _ = fernet_keys_store
+
+    with (
+        override_settings(DATABASE_ENCRYPTION_SETTINGS={"fernet_primary_key_id": key_id}),
+        override_options({"database.encryption.method": "fernet"}),
+    ):
+        field = EncryptedJSONField()
+
+        test_data = {"user": "john", "email": "john@example.com", "age": 30}
+        encrypted = field.get_prep_value(test_data)
+
+        # Should be a dict (will be stored as jsonb)
+        assert isinstance(encrypted, dict)
+        assert EncryptedJSONField._encrypted_field_key in encrypted
+        assert encrypted[EncryptedJSONField._encrypted_field_key].startswith(MARKER_FERNET)
+
+        # Decrypt and verify
+        decrypted = field.to_python(encrypted)
+        assert decrypted == test_data
+
+
+@pytest.mark.parametrize("encryption_method", ENCRYPTION_METHODS)
+@pytest.mark.parametrize(
+    "test_value",
+    [
+        {"simple": "dict"},
+        {"nested": {"data": {"deep": "value"}}},
+        {"list": [1, 2, 3, 4, 5]},
+        {"mixed": [{"a": 1}, {"b": 2}]},
+        {"unicode": "你好世界"},
+        {"special": "!@#$%^&*()"},
+        {},
+        {"empty_string": ""},
+        {"null_value": None},
+        {"boolean": True},
+        {"numbers": 123.456},
+        # test case when JSON contains encrypted field key used to store it
+        {EncryptedJSONField._encrypted_field_key: "value"},
+    ],
+)
+def test_encrypted_json_field_roundtrip(encryption_method, test_value, fernet_keys_store):
+    """Test that JSON encryption and decryption work correctly in roundtrip."""
+    key_id, _ = fernet_keys_store
+
+    with (
+        override_settings(DATABASE_ENCRYPTION_SETTINGS={"fernet_primary_key_id": key_id}),
+        override_options({"database.encryption.method": encryption_method}),
+    ):
+        field = EncryptedJSONField()
+
+        encrypted = field.get_prep_value(test_value)
+        decrypted = field.to_python(encrypted)
+
+        assert decrypted == test_value
+
+
+def test_encrypted_json_field_fallback_unencrypted():
+    """Test that EncryptedJSONField falls back to unencrypted JSON."""
+    field = EncryptedJSONField()
+
+    # Simulate unencrypted JSON data already in the database (as dict from jsonb)
+    unencrypted_data = {"legacy": "data", "from": "migration"}
+
+    # Should be able to read it without encryption
+    decrypted = field.to_python(unencrypted_data)
+    assert decrypted == {"legacy": "data", "from": "migration"}
+
+
+def test_encrypted_json_field_fallback_with_similar_structure():
+    """Test fallback when JSON has similar but not exact encryption structure."""
+    field = EncryptedJSONField()
+
+    # Data that has the key but is not our encryption format (has extra keys)
+    similar_data = {EncryptedJSONField._encrypted_field_key: "regular_value", "other": "data"}
+
+    # Should return as-is since it doesn't match our exact structure (has extra keys)
+    decrypted = field.to_python(similar_data)
+    assert decrypted == {EncryptedJSONField._encrypted_field_key: "regular_value", "other": "data"}
+
+
+class EncryptedJSONFieldModel(models.Model):
+    id = models.AutoField(primary_key=True)
+    data = EncryptedJSONField(null=True, blank=True)
+
+    class Meta:
+        app_label = "fixtures"
+
+
+@pytest.mark.django_db
+def test_encrypted_json_field_fernet_end_to_end(fernet_keys_store):
+    """Test complete save/retrieve cycle with EncryptedJSONField and Fernet."""
+    key_id, _fernet_key = fernet_keys_store
+
+    with (
+        override_settings(DATABASE_ENCRYPTION_SETTINGS={"fernet_primary_key_id": key_id}),
+        override_options({"database.encryption.method": "fernet"}),
+    ):
+        test_data = {
+            "sensitive": "data",
+            "user": {"id": 123, "email": "user@example.com"},
+            "tokens": ["token1", "token2"],
+        }
+
+        model_instance = EncryptedJSONFieldModel.objects.create(data=test_data)
+        assert model_instance.id is not None
+
+        # Verify the data was correctly encrypted and decrypted
+        retrieved_instance = EncryptedJSONFieldModel.objects.get(id=model_instance.id)
+        assert retrieved_instance.data == test_data
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT data FROM fixtures_encryptedjsonfieldmodel WHERE id = %s",
+                [model_instance.id],
+            )
+            raw_value = cursor.fetchone()[0]
+
+            # raw_value is a string and needs to be parsed
+            json_value = json.loads(raw_value)
+            assert EncryptedJSONField._encrypted_field_key in json_value
+            assert json_value["sentry_encrypted_field_value"].startswith(MARKER_FERNET)
+
+            assert "sensitive" not in raw_value
+            assert "user@example.com" not in raw_value
+
+
+@pytest.mark.django_db
+def test_encrypted_json_field_plaintext_end_to_end():
+    """Test complete save/retrieve cycle with EncryptedJSONField and plaintext."""
+    with override_options({"database.encryption.method": "plaintext"}):
+        test_data = {"plain": "data", "numbers": [1, 2, 3]}
+
+        model_instance = EncryptedJSONFieldModel.objects.create(data=test_data)
+        assert model_instance.id is not None
+
+        # Verify the data was correctly encrypted and decrypted
+        retrieved_instance = EncryptedJSONFieldModel.objects.get(id=model_instance.id)
+        assert retrieved_instance.data == test_data
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT data FROM fixtures_encryptedjsonfieldmodel WHERE id = %s",
+                [model_instance.id],
+            )
+            raw_value = cursor.fetchone()[0]
+
+            json_value = json.loads(raw_value)
+            assert "sentry_encrypted_field_value" in json_value
+            assert json_value["sentry_encrypted_field_value"].startswith(MARKER_PLAINTEXT)
+
+
+@pytest.mark.django_db
+def test_encrypted_json_field_migration_compatibility(fernet_keys_store):
+    """Test that EncryptedJSONField can read unencrypted legacy data."""
+    key_id, _fernet_key = fernet_keys_store
+
+    legacy_data = {"legacy": True, "migrated": False}
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO fixtures_encryptedjsonfieldmodel (data) VALUES (%s::jsonb) RETURNING id",
+            [json.dumps(legacy_data)],
+        )
+        inserted_id = cursor.fetchone()[0]
+
+    # Now try to read it with EncryptedJSONField
+    with (
+        override_settings(DATABASE_ENCRYPTION_SETTINGS={"fernet_primary_key_id": key_id}),
+        override_options({"database.encryption.method": "fernet"}),
+    ):
+        retrieved_instance = EncryptedJSONFieldModel.objects.get(id=inserted_id)
+
+        # Should fall back to reading unencrypted data
+        assert retrieved_instance.data == legacy_data
+
+        # Now update it - should encrypt on save
+        retrieved_instance.data = {"legacy": True, "migrated": True}
+        retrieved_instance.save()
+
+        # Verify it's now encrypted
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT data FROM fixtures_encryptedjsonfieldmodel WHERE id = %s",
+                [inserted_id],
+            )
+            raw_value = cursor.fetchone()[0]
+
+            # raw_value is a string
+            json_value = json.loads(raw_value)
+            assert "sentry_encrypted_field_value" in json_value
+            assert json_value["sentry_encrypted_field_value"].startswith(MARKER_FERNET)
+
+
+@pytest.mark.django_db
+def test_encrypted_json_field_fake_encrypted_format_fallback(fernet_keys_store):
+    """
+    Test that EncryptedJSONField falls back gracefully when data has the encrypted
+    wrapper structure but contains non-encrypted plain text values.
+
+    This simulates a scenario where data was manually inserted or corrupted to look
+    like encrypted data but is actually just plain text.
+    """
+    key_id, _fernet_key = fernet_keys_store
+
+    # Directly insert a value that looks like our encrypted format but isn't actually encrypted
+    fake_encrypted_data = {
+        EncryptedJSONField._encrypted_field_key: "this is just plain text, not encrypted"
+    }
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO fixtures_encryptedjsonfieldmodel (data) VALUES (%s::jsonb) RETURNING id",
+            [json.dumps(fake_encrypted_data)],
+        )
+        inserted_id = cursor.fetchone()[0]
+
+    # Try to read it back with EncryptedJSONField
+    with (
+        override_settings(DATABASE_ENCRYPTION_SETTINGS={"fernet_primary_key_id": key_id}),
+        override_options({"database.encryption.method": "fernet"}),
+    ):
+        retrieved_instance = EncryptedJSONFieldModel.objects.get(id=inserted_id)
+
+        # Should fall back to returning the original structure since decryption fails
+        assert retrieved_instance.data == fake_encrypted_data
+
+    # Test with a value that looks more like our encrypted format but still isn't valid
+    fake_fernet_like = {
+        EncryptedJSONField._encrypted_field_key: f"{MARKER_FERNET}:some_key:not_real_encrypted_data"
+    }
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO fixtures_encryptedjsonfieldmodel (data) VALUES (%s::jsonb) RETURNING id",
+            [json.dumps(fake_fernet_like)],
+        )
+        inserted_id = cursor.fetchone()[0]
+
+    with (
+        override_settings(DATABASE_ENCRYPTION_SETTINGS={"fernet_primary_key_id": key_id}),
+        override_options({"database.encryption.method": "fernet"}),
+    ):
+        retrieved_instance = EncryptedJSONFieldModel.objects.get(id=inserted_id)
+
+        # Should fall back to returning the original structure
+        assert retrieved_instance.data == fake_fernet_like


### PR DESCRIPTION
Introduces encrypted version of Django's `JSONField`, and it is a drop-in replacement for it.

Since Django's field uses `jsonb` postgres field under the hood, we have to save encrypted value as a valid JSON, we can't save it as text or binary data.

Data is stored as jsonb in the database with the encrypted payload wrapped in a structure: `{"sentry_encrypted_field_value": "enc:method:key_id:data"}` (`sentry_encrypted_field_value` is picked to avoid conflicts with current key values, but even if it happens, and we can't decrypt it, we will return it as-is, we won't crash).

Basically how it works:
- Encryption: Python dict object → JSON to string → encrypt → wrap in JSON object (under `sentry_encrypted_field_value` key)  → store as jsonb
- Decryption: load jsonb → check for wrapper (check if `sentry_encrypted_field_value` is present) → decrypt → parse JSON → Python dict  object
- Fallback: If no wrapper present, return parsed JSON as-is

Closes [TET-512: Create EncryptedJSONField](https://linear.app/getsentry/issue/TET-512/create-encryptedjsonfield)
