### PR TITLE
chore(eco): remove halt for unfurlable link

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -186,7 +186,6 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
                 # Link can't be unfurled
                 if link_type is None or args is None:
-                    lifecycle.record_halt("Unfurlable link", extra={"url": url})
                     continue
 
                 if (


### PR DESCRIPTION
This is extremely noisy and doesn't add any value