### PR TITLE
feat(self-hosted): Manually bump metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sentry
-version = 25.11.1
+version = 25.12.0.dev0
 description = A realtime logging and aggregation server.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This job failed on post release script: https://github.com/getsentry/publish/issues/6727

Bumping this manually as the automation failed