### PR TITLE
ref(eap): Consolidate conditional aggregates

### DIFF
--- a/src/sentry/search/eap/ourlogs/definitions.py
+++ b/src/sentry/search/eap/ourlogs/definitions.py
@@ -11,7 +11,6 @@ from sentry.search.eap.ourlogs.attributes import (
 
 OURLOG_DEFINITIONS = ColumnDefinitions(
     aggregates=LOG_AGGREGATE_DEFINITIONS,
-    conditional_aggregates={},
     formulas={},
     columns=OURLOG_ATTRIBUTE_DEFINITIONS,
     contexts=OURLOG_VIRTUAL_CONTEXTS,

--- a/src/sentry/search/eap/profile_functions/definitions.py
+++ b/src/sentry/search/eap/profile_functions/definitions.py
@@ -9,7 +9,6 @@ from sentry.search.eap.profile_functions.attributes import (
 
 PROFILE_FUNCTIONS_DEFINITIONS = ColumnDefinitions(
     aggregates=PROFILE_FUNCTIONS_AGGREGATE_DEFINITIONS,
-    conditional_aggregates={},
     formulas={},
     columns=PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS,
     contexts=PROFILE_FUNCTIONS_VIRTUAL_CONTEXTS,

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -180,7 +180,7 @@ def resolve_bounded_sample(args: ResolvedArguments) -> tuple[AttributeKey, Trace
     return (attribute, filter)
 
 
-SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
+SPAN_AGGREGATE_DEFINITIONS = {
     "count_op": ConditionalAggregateDefinition(
         internal_function=Function.FUNCTION_COUNT,
         default_search_type="integer",
@@ -455,9 +455,6 @@ SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
         processor=lambda x: x > 0,
         extrapolation_mode_override=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     ),
-}
-
-SPAN_AGGREGATE_DEFINITIONS = {
     "sum": AggregateDefinition(
         internal_function=Function.FUNCTION_SUM,
         default_search_type="duration",

--- a/src/sentry/search/eap/spans/definitions.py
+++ b/src/sentry/search/eap/spans/definitions.py
@@ -1,17 +1,13 @@
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.search.eap.columns import ColumnDefinitions
-from sentry.search.eap.spans.aggregates import (
-    SPAN_AGGREGATE_DEFINITIONS,
-    SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS,
-)
+from sentry.search.eap.spans.aggregates import SPAN_AGGREGATE_DEFINITIONS
 from sentry.search.eap.spans.attributes import SPAN_ATTRIBUTE_DEFINITIONS, SPAN_VIRTUAL_CONTEXTS
 from sentry.search.eap.spans.filter_aliases import SPAN_FILTER_ALIAS_DEFINITIONS
 from sentry.search.eap.spans.formulas import SPAN_FORMULA_DEFINITIONS
 
 SPAN_DEFINITIONS = ColumnDefinitions(
     aggregates=SPAN_AGGREGATE_DEFINITIONS,
-    conditional_aggregates=SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS,
     formulas=SPAN_FORMULA_DEFINITIONS,
     columns=SPAN_ATTRIBUTE_DEFINITIONS,
     contexts=SPAN_VIRTUAL_CONTEXTS,

--- a/src/sentry/search/eap/trace_metrics/definitions.py
+++ b/src/sentry/search/eap/trace_metrics/definitions.py
@@ -10,7 +10,6 @@ from sentry.search.eap.trace_metrics.formulas import TRACE_METRICS_FORMULA_DEFIN
 
 TRACE_METRICS_DEFINITIONS = ColumnDefinitions(
     aggregates=TRACE_METRICS_AGGREGATE_DEFINITIONS,
-    conditional_aggregates={},
     formulas=TRACE_METRICS_FORMULA_DEFINITIONS,
     columns=TRACE_METRICS_ATTRIBUTE_DEFINITIONS,
     contexts=TRACE_METRICS_VIRTUAL_CONTEXTS,

--- a/src/sentry/search/eap/trace_metrics/types.py
+++ b/src/sentry/search/eap/trace_metrics/types.py
@@ -1,6 +1,13 @@
 from dataclasses import dataclass
 from typing import Literal
 
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
+    ComparisonFilter,
+    TraceItemFilter,
+)
+
 TraceMetricType = Literal["counter", "gauge", "distribution"]
 
 
@@ -9,3 +16,36 @@ class TraceMetric:
     metric_name: str
     metric_type: TraceMetricType
     metric_unit: str | None
+
+    def get_filter(self) -> TraceItemFilter:
+        filters = [
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name="sentry.metric_name", type=AttributeKey.Type.TYPE_STRING),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str=self.metric_name),
+                )
+            ),
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name="sentry.metric_type", type=AttributeKey.Type.TYPE_STRING),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str=self.metric_type),
+                )
+            ),
+        ]
+
+        if self.metric_unit:
+            filters.append(
+                TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(
+                            name="sentry.metric_unit", type=AttributeKey.Type.TYPE_STRING
+                        ),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=AttributeValue(val_str=self.metric_unit),
+                    )
+                )
+            )
+
+        return TraceItemFilter(and_filter=AndFilter(filters=filters))

--- a/src/sentry/search/eap/uptime_results/definitions.py
+++ b/src/sentry/search/eap/uptime_results/definitions.py
@@ -5,7 +5,6 @@ from sentry.search.eap.uptime_results.attributes import UPTIME_ATTRIBUTE_DEFINIT
 
 UPTIME_RESULT_DEFINITIONS = ColumnDefinitions(
     aggregates={},
-    conditional_aggregates={},
     formulas={},
     columns=UPTIME_ATTRIBUTE_DEFINITIONS,
     contexts={},


### PR DESCRIPTION
There was no good reason why conditional aggregates are in a separate map. Remove it and unify into the same map as all aggregate definitions.