### PR TITLE
fix(issues): Handle None users in GroupSearchView serializer

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -54,6 +54,7 @@ class GroupSearchViewSerializer(Serializer):
                 filter={"user_ids": [view.user_id for view in item_list if view.user_id]},
                 as_user=user,
             )
+            if user is not None
         }
 
         for item in item_list:


### PR DESCRIPTION
Fixes [ISWF-719](https://linear.app/getsentry/issue/ISWF-719)

When user_service.serialize_many() returns None for a deleted user, the dict
comprehension would crash with: TypeError: 'NoneType' object is not
subscriptable

The fix filters out None values when building the serialized_users dict.
Views with users that can't be serialized will now have createdBy: None
instead of crashing the entire endpoint.