### PR TITLE
feat(replay): Allow network config to be expandable

### DIFF
--- a/static/app/components/replays/replayTagsTableRow.tsx
+++ b/static/app/components/replays/replayTagsTableRow.tsx
@@ -28,6 +28,12 @@ const expandedViewKeys = [
   'sdk.replay.unmaskedViewClasses',
   // Flutter
   'sdk.replay.maskingRules',
+
+  // Network request/response
+  'sdk.replay.networkDetailAllowUrls',
+  'sdk.replay.networkDetailDenyUrls',
+  'sdk.replay.networkRequestHeaders',
+  'sdk.replay.networkResponseHeaders',
 ];
 
 const releaseKeys = ['release', 'releases'];


### PR DESCRIPTION
These network configuration values are lists, so they need to be added to this list so that they are expandable in the UI.
