### PR TITLE
ref(explorer): scan in reverse time order for short id queries

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -145,7 +145,7 @@ def query_replay_id_by_prefix(
 
         query = Query(
             match=Entity("replays"),
-            select=[Column("replay_id")],
+            select=[Column("replay_id"), Column("timestamp")],
             where=[
                 Condition(Column("project_id"), Op.IN, project_ids),
                 Condition(

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -162,6 +162,7 @@ def query_replay_id_by_prefix(
                 Condition(Column("timestamp"), Op.GTE, window_start),
                 Condition(Column("timestamp"), Op.LT, window_end),
             ],
+            orderby=[OrderBy(Column("timestamp"), Direction.DESC)],
             granularity=Granularity(3600),
             limit=Limit(1),
         )

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -89,8 +89,8 @@ def _get_full_trace_id(
         subquery_result = Spans.run_table_query(
             params=snuba_params,
             query_string=f"trace:{short_trace_id}",
-            selected_columns=["trace"],
-            orderby=[],
+            selected_columns=["trace", "timestamp"],
+            orderby=["-timestamp"],
             offset=0,
             limit=1,
             referrer=Referrer.SEER_RPC,


### PR DESCRIPTION
Optimization for a suboptimal query 😅. As noted in TODOs these are needle-in-the-haystack scans subject to improvement, this just scans backwards in hopes most traces explorer looks at are new