### PR TITLE
fix(eap-resolver): escape sequences should also be translated in a `in` query

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -513,6 +513,11 @@ class SearchValue(NamedTuple):
             return f"({"|".join(map(translate_wildcard, self.raw_value))})"
         elif isinstance(self.raw_value, str):
             return translate_escape_sequences(self.raw_value)
+        elif isinstance(self.raw_value, (list, tuple)):
+            # Non-wildcard lists should also have escape sequences translated
+            return [
+                translate_escape_sequences(v) if isinstance(v, str) else v for v in self.raw_value
+            ]
         return self.raw_value
 
     def to_query_string(self) -> str:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6943,3 +6943,35 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         )
         assert in_query.status_code == 200, in_query.content
         assert is_query.data["data"] == in_query.data["data"]
+
+    def test_in_query_with_numeric_values(self) -> None:
+        span1 = self.create_span(
+            {"data": {"ai_total_tokens_used": 100}},
+            start_ts=self.ten_mins_ago,
+        )
+        span2 = self.create_span(
+            {"data": {"ai_total_tokens_used": 200}},
+            start_ts=self.ten_mins_ago,
+        )
+        span3 = self.create_span(
+            {"data": {"ai_total_tokens_used": 300}},
+            start_ts=self.ten_mins_ago,
+        )
+
+        self.store_spans([span1, span2, span3], is_eap=True)
+
+        in_query = self.do_request(
+            {
+                "field": ["id", "ai.total_tokens.used"],
+                "query": "ai.total_tokens.used:[100, 200]",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+        assert in_query.status_code == 200, in_query.content
+        assert len(in_query.data["data"]) == 2
+
+        returned_ids = {row["id"] for row in in_query.data["data"]}
+        assert returned_ids == {span1["span_id"], span2["span_id"]}
+
+        assert span3["span_id"] not in returned_ids

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6933,7 +6933,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         )
         assert is_query.status_code == 200, is_query.content
 
-        contains_query = self.do_request(
+        in_query = self.do_request(
             {
                 "field": ["span.description"],
                 "query": 'span.description:["foo \\*"]',
@@ -6941,5 +6941,5 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "dataset": "spans",
             }
         )
-        assert contains_query.status_code == 200, contains_query.content
-        assert is_query.data["data"] == contains_query.data["data"]
+        assert in_query.status_code == 200, in_query.content
+        assert is_query.data["data"] == in_query.data["data"]

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6916,9 +6916,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         self.store_spans(
             [
                 self.create_span(
-                    {
-                        "description": "SELECT (group_id AS _snuba_group_id), (ifNull(uniq((nullIf(user, %s) AS _snuba_tags[sentry%s])), %s) AS _snuba_count) FROM errors_dist PREWHERE in(_snuba_group_id, tuple(%s)) WHERE equals(deleted, *"
-                    },
+                    {"description": "foo *"},
                     start_ts=self.ten_mins_ago,
                 ),
             ],
@@ -6928,7 +6926,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         is_query = self.do_request(
             {
                 "field": ["span.description"],
-                "query": 'span.description:"SELECT (group_id AS _snuba_group_id), (ifNull(uniq((nullIf(user, %s) AS _snuba_tags[sentry%s])), %s) AS _snuba_count) FROM errors_dist PREWHERE in(_snuba_group_id, tuple(%s)) WHERE equals(deleted, \\*"',
+                "query": 'span.description:"foo \\*"',
                 "project": self.project.id,
                 "dataset": "spans",
             }
@@ -6938,7 +6936,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         contains_query = self.do_request(
             {
                 "field": ["span.description"],
-                "query": 'span.description:["SELECT (group_id AS _snuba_group_id), (ifNull(uniq((nullIf(user, %s) AS _snuba_tags[sentry%s])), %s) AS _snuba_count) FROM errors_dist PREWHERE in(_snuba_group_id, tuple(%s)) WHERE equals(deleted, \\*"]',
+                "query": 'span.description:["foo \\*"]',
                 "project": self.project.id,
                 "dataset": "spans",
             }

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6925,23 +6925,23 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             is_eap=True,
         )
 
-        is_response = self.do_request(
+        is_query = self.do_request(
             {
                 "field": ["span.description"],
-                "query": 'span.description:"SELECT (group_id AS _snuba_group_id), (ifNull(uniq((nullIf(user, %s) AS _snuba_tags[sentry%s])), %s) AS _snuba_count) FROM errors_dist PREWHERE in(_snuba_group_id, tuple(%s)) WHERE equals(deleted, *"',
+                "query": 'span.description:"SELECT (group_id AS _snuba_group_id), (ifNull(uniq((nullIf(user, %s) AS _snuba_tags[sentry%s])), %s) AS _snuba_count) FROM errors_dist PREWHERE in(_snuba_group_id, tuple(%s)) WHERE equals(deleted, \\*"',
                 "project": self.project.id,
                 "dataset": "spans",
             }
         )
-        assert is_response.status_code == 200, is_response.content
+        assert is_query.status_code == 200, is_query.content
 
-        contains_response = self.do_request(
+        contains_query = self.do_request(
             {
                 "field": ["span.description"],
-                "query": 'span.description:["SELECT (group_id AS _snuba_group_id), (ifNull(uniq((nullIf(user, %s) AS _snuba_tags[sentry%s])), %s) AS _snuba_count) FROM errors_dist PREWHERE in(_snuba_group_id, tuple(%s)) WHERE equals(deleted, *)"]',
+                "query": 'span.description:["SELECT (group_id AS _snuba_group_id), (ifNull(uniq((nullIf(user, %s) AS _snuba_tags[sentry%s])), %s) AS _snuba_count) FROM errors_dist PREWHERE in(_snuba_group_id, tuple(%s)) WHERE equals(deleted, \\*"]',
                 "project": self.project.id,
                 "dataset": "spans",
             }
         )
-        assert contains_response.status_code == 200, contains_response.content
-        assert is_response.data["data"] == contains_response.data["data"]
+        assert contains_query.status_code == 200, contains_query.content
+        assert is_query.data["data"] == contains_query.data["data"]


### PR DESCRIPTION
Resolves [BROWSE-164](https://linear.app/getsentry/issue/BROWSE-164/truncated-queries-affect-filtering-on-query-summary)

If you use a `in` query with escaped characters, we should also translate them for the elements in the array, the same as we do for a regular `is` query. This is so we never have discrepancies between the results of queries `attribute:[a]` and `attribute:a`