### PR TITLE
chore(anomaly detection): improve graph details 

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -245,23 +245,9 @@ export function useMetricDetectorChart({
 
     const filtered = [];
 
-    if (
-      thresholdType === AlertRuleThresholdType.ABOVE ||
-      thresholdType === AlertRuleThresholdType.ABOVE_AND_BELOW
-    ) {
-      filtered.push(upperThreshold);
-    }
-
-    if (
-      thresholdType === AlertRuleThresholdType.BELOW ||
-      thresholdType === AlertRuleThresholdType.ABOVE_AND_BELOW
-    ) {
-      filtered.push(lowerThreshold);
-    }
-
-    if (seerValue) {
-      filtered.push(seerValue);
-    }
+    if (thresholdType !== AlertRuleThresholdType.BELOW) filtered.push(upperThreshold);
+    if (thresholdType !== AlertRuleThresholdType.ABOVE) filtered.push(lowerThreshold);
+    if (seerValue) filtered.push(seerValue);
 
     return filtered.filter((s): s is NonNullable<typeof s> => !!s);
   }, [anomalyThresholdSeries, detector.conditionGroup]);

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -34,6 +34,7 @@ import {
 import {useMetricDetectorAnomalyThresholds} from 'sentry/views/detectors/hooks/useMetricDetectorAnomalyThresholds';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
 import {useMetricDetectorThresholdSeries} from 'sentry/views/detectors/hooks/useMetricDetectorThresholdSeries';
+import {useMetricTimestamps} from 'sentry/views/detectors/hooks/useMetricTimestamps';
 import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {getDetectorChartFormatters} from 'sentry/views/detectors/utils/detectorChartFormatting';
 
@@ -182,33 +183,7 @@ export function useMetricDetectorChart({
     end,
   });
 
-  const metricTimestamps = useMemo(() => {
-    const firstSeries = series[0];
-    if (!firstSeries?.data.length) {
-      return {start: undefined, end: undefined};
-    }
-    const data = firstSeries.data;
-    const firstPoint = data[0];
-    const lastPoint = data[data.length - 1];
-
-    if (!firstPoint || !lastPoint) {
-      return {start: undefined, end: undefined};
-    }
-
-    const firstTimestamp =
-      typeof firstPoint.name === 'number'
-        ? firstPoint.name
-        : new Date(firstPoint.name).getTime();
-    const lastTimestamp =
-      typeof lastPoint.name === 'number'
-        ? lastPoint.name
-        : new Date(lastPoint.name).getTime();
-
-    return {
-      start: Math.floor(firstTimestamp / 1000),
-      end: Math.floor(lastTimestamp / 1000),
-    };
-  }, [series]);
+  const metricTimestamps = useMetricTimestamps(series);
 
   const {maxValue: thresholdMaxValue, additionalSeries: thresholdAdditionalSeries} =
     useMetricDetectorThresholdSeries({

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -73,10 +73,12 @@ function MetricDetectorForm() {
 }
 
 export function EditExistingMetricDetectorForm({detector}: {detector: Detector}) {
+  const metricDetector = detector.type === 'metric_issue' ? detector : undefined;
+
   return (
     <EditDetectorLayout
       detector={detector}
-      previewChart={<MetricDetectorPreviewChart />}
+      previewChart={<MetricDetectorPreviewChart detector={metricDetector} />}
       formDataToEndpointPayload={metricDetectorFormDataToEndpointPayload}
       savedDetectorToFormData={metricSavedDetectorToFormData}
       mapFormErrors={mapMetricDetectorFormErrors}

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -28,6 +28,7 @@ import {
 import {useDetectorChartAxisBounds} from 'sentry/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds';
 import {getBackendDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+import {useFilteredAnomalyThresholdSeries} from 'sentry/views/detectors/hooks/useFilteredAnomalyThresholdSeries';
 import {useIncidentMarkers} from 'sentry/views/detectors/hooks/useIncidentMarkers';
 import type {IncidentPeriod} from 'sentry/views/detectors/hooks/useIncidentMarkers';
 import {useMetricDetectorAnomalyPeriods} from 'sentry/views/detectors/hooks/useMetricDetectorAnomalyPeriods';
@@ -260,26 +261,11 @@ export function MetricDetectorChart({
     series: shouldFetchThresholds ? series : [],
   });
 
-  const filteredAnomalyThresholdSeries = useMemo(() => {
-    if (
-      !detectorId ||
-      !anomalyThresholdSeries.length ||
-      !isAnomalyDetection ||
-      thresholdType === undefined
-    ) {
-      return [];
-    }
-
-    const [upperThreshold, lowerThreshold, seerValue] = anomalyThresholdSeries;
-
-    const filtered = [];
-
-    if (thresholdType !== AlertRuleThresholdType.BELOW) filtered.push(upperThreshold);
-    if (thresholdType !== AlertRuleThresholdType.ABOVE) filtered.push(lowerThreshold);
-    if (seerValue) filtered.push(seerValue);
-
-    return filtered.filter((s): s is NonNullable<typeof s> => !!s);
-  }, [detectorId, anomalyThresholdSeries, isAnomalyDetection, thresholdType]);
+  const filteredAnomalyThresholdSeries = useFilteredAnomalyThresholdSeries({
+    anomalyThresholdSeries: detectorId ? anomalyThresholdSeries : [],
+    isAnomalyDetection,
+    thresholdType,
+  });
 
   const {maxValue, minValue} = useDetectorChartAxisBounds({series, thresholdMaxValue});
 

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -35,6 +35,7 @@ import {useMetricDetectorAnomalyPeriods} from 'sentry/views/detectors/hooks/useM
 import {useMetricDetectorAnomalyThresholds} from 'sentry/views/detectors/hooks/useMetricDetectorAnomalyThresholds';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
 import {useMetricDetectorThresholdSeries} from 'sentry/views/detectors/hooks/useMetricDetectorThresholdSeries';
+import {useMetricTimestamps} from 'sentry/views/detectors/hooks/useMetricTimestamps';
 import {useTimePeriodSelection} from 'sentry/views/detectors/hooks/useTimePeriodSelection';
 import {getDetectorChartFormatters} from 'sentry/views/detectors/utils/detectorChartFormatting';
 
@@ -225,33 +226,7 @@ export function MetricDetectorChart({
     markLineTooltip: anomalyMarklineTooltip,
   });
 
-  const metricTimestamps = useMemo(() => {
-    const firstSeries = series[0];
-    if (!firstSeries?.data.length) {
-      return {start: undefined, end: undefined};
-    }
-    const data = firstSeries.data;
-    const firstPoint = data[0];
-    const lastPoint = data[data.length - 1];
-
-    if (!firstPoint || !lastPoint) {
-      return {start: undefined, end: undefined};
-    }
-
-    const firstTimestamp =
-      typeof firstPoint.name === 'number'
-        ? firstPoint.name
-        : new Date(firstPoint.name).getTime();
-    const lastTimestamp =
-      typeof lastPoint.name === 'number'
-        ? lastPoint.name
-        : new Date(lastPoint.name).getTime();
-
-    return {
-      start: Math.floor(firstTimestamp / 1000),
-      end: Math.floor(lastTimestamp / 1000),
-    };
-  }, [series]);
+  const metricTimestamps = useMetricTimestamps(series);
 
   const shouldFetchThresholds = Boolean(detectorId && isAnomalyDetection);
   const {anomalyThresholdSeries} = useMetricDetectorAnomalyThresholds({

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -274,23 +274,9 @@ export function MetricDetectorChart({
 
     const filtered = [];
 
-    if (
-      thresholdType === AlertRuleThresholdType.ABOVE ||
-      thresholdType === AlertRuleThresholdType.ABOVE_AND_BELOW
-    ) {
-      filtered.push(upperThreshold);
-    }
-
-    if (
-      thresholdType === AlertRuleThresholdType.BELOW ||
-      thresholdType === AlertRuleThresholdType.ABOVE_AND_BELOW
-    ) {
-      filtered.push(lowerThreshold);
-    }
-
-    if (seerValue) {
-      filtered.push(seerValue);
-    }
+    if (thresholdType !== AlertRuleThresholdType.BELOW) filtered.push(upperThreshold);
+    if (thresholdType !== AlertRuleThresholdType.ABOVE) filtered.push(lowerThreshold);
+    if (seerValue) filtered.push(seerValue);
 
     return filtered.filter((s): s is NonNullable<typeof s> => !!s);
   }, [detectorId, anomalyThresholdSeries, isAnomalyDetection, thresholdType]);

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -230,7 +230,7 @@ export function MetricDetectorChart({
 
   const shouldFetchThresholds = Boolean(detectorId && isAnomalyDetection);
   const {anomalyThresholdSeries} = useMetricDetectorAnomalyThresholds({
-    detectorId: detectorId ?? 'skip',
+    detectorId: detectorId ?? '',
     startTimestamp: metricTimestamps.start,
     endTimestamp: metricTimestamps.end,
     series: shouldFetchThresholds ? series : [],

--- a/static/app/views/detectors/components/forms/metric/previewChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/previewChart.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 
+import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {MetricDetectorChart} from 'sentry/views/detectors/components/forms/metric/metricDetectorChart';
 import {
   createConditions,
@@ -9,7 +10,13 @@ import {
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 
-export function MetricDetectorPreviewChart() {
+interface MetricDetectorPreviewChartProps {
+  detector?: MetricDetector;
+}
+
+export function MetricDetectorPreviewChart({
+  detector,
+}: MetricDetectorPreviewChartProps = {}) {
   // Get all the form fields needed for the chart
   const dataset = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.dataset);
   const aggregateFunction = useMetricDetectorFormField(
@@ -92,6 +99,7 @@ export function MetricDetectorPreviewChart() {
       sensitivity={sensitivity}
       thresholdType={thresholdType}
       extrapolationMode={extrapolationMode}
+      detectorId={detector?.id}
     />
   );
 }

--- a/static/app/views/detectors/hooks/useFilteredAnomalyThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useFilteredAnomalyThresholdSeries.tsx
@@ -1,0 +1,71 @@
+import {useMemo} from 'react';
+
+import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import {AlertRuleThresholdType} from 'sentry/views/alerts/rules/metric/types';
+
+interface UseFilteredAnomalyThresholdSeriesProps {
+  anomalyThresholdSeries: any[];
+  /**
+   * The detector object - used in details view
+   */
+  detector?: MetricDetector;
+  /**
+   * Whether this is anomaly detection - used in forms view
+   */
+  isAnomalyDetection?: boolean;
+  /**
+   * The threshold type - used in forms view
+   */
+  thresholdType?: AlertRuleThresholdType;
+}
+
+/**
+ * Filters anomaly threshold series based on the threshold type configuration.
+ * Returns upper threshold, lower threshold, and/or seer value based on whether
+ * the alert is configured for ABOVE, BELOW, or ABOVE_AND_BELOW thresholds.
+ */
+export function useFilteredAnomalyThresholdSeries({
+  anomalyThresholdSeries,
+  detector,
+  isAnomalyDetection,
+  thresholdType: directThresholdType,
+}: UseFilteredAnomalyThresholdSeriesProps) {
+  return useMemo(() => {
+    if (!anomalyThresholdSeries.length) {
+      return [];
+    }
+
+    let thresholdType: AlertRuleThresholdType | undefined;
+
+    if (detector) {
+      const condition = detector.conditionGroup?.conditions[0];
+      if (!condition || condition.type !== 'anomaly_detection') {
+        return [];
+      }
+
+      if (typeof condition.comparison === 'number') {
+        return [];
+      }
+
+      thresholdType = condition.comparison.thresholdType;
+    } else {
+      if (!isAnomalyDetection) {
+        return [];
+      }
+      thresholdType = directThresholdType;
+    }
+
+    if (thresholdType === undefined) {
+      return [];
+    }
+
+    const [upperThreshold, lowerThreshold, seerValue] = anomalyThresholdSeries;
+
+    const filtered = [];
+    if (thresholdType !== AlertRuleThresholdType.BELOW) filtered.push(upperThreshold);
+    if (thresholdType !== AlertRuleThresholdType.ABOVE) filtered.push(lowerThreshold);
+    if (seerValue) filtered.push(seerValue);
+
+    return filtered.filter((s): s is NonNullable<typeof s> => !!s);
+  }, [anomalyThresholdSeries, detector, isAnomalyDetection, directThresholdType]);
+}

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.tsx
@@ -96,9 +96,9 @@ export function useMetricDetectorAnomalyThresholds({
       const anomalyPoint = anomalyMap.get(timestamp);
 
       if (anomalyPoint) {
-        upperBoundData.push([timestamp, anomalyPoint.yhat_upper]);
-        lowerBoundData.push([timestamp, anomalyPoint.yhat_lower]);
-        seerValueData.push([timestamp, anomalyPoint.value]);
+        upperBoundData.push([timestamp, Math.round(anomalyPoint.yhat_upper)]);
+        lowerBoundData.push([timestamp, Math.round(anomalyPoint.yhat_lower)]);
+        seerValueData.push([timestamp, Math.round(anomalyPoint.value)]);
       }
     });
 

--- a/static/app/views/detectors/hooks/useMetricTimestamps.tsx
+++ b/static/app/views/detectors/hooks/useMetricTimestamps.tsx
@@ -1,0 +1,38 @@
+import {useMemo} from 'react';
+
+import type {Series} from 'sentry/types/echarts';
+
+interface MetricTimestamps {
+  end: number | undefined;
+  start: number | undefined;
+}
+
+export function useMetricTimestamps(series: Series[]): MetricTimestamps {
+  return useMemo(() => {
+    const firstSeries = series[0];
+    if (!firstSeries?.data.length) {
+      return {start: undefined, end: undefined};
+    }
+    const data = firstSeries.data;
+    const firstPoint = data[0];
+    const lastPoint = data[data.length - 1];
+
+    if (!firstPoint || !lastPoint) {
+      return {start: undefined, end: undefined};
+    }
+
+    const firstTimestamp =
+      typeof firstPoint.name === 'number'
+        ? firstPoint.name
+        : new Date(firstPoint.name).getTime();
+    const lastTimestamp =
+      typeof lastPoint.name === 'number'
+        ? lastPoint.name
+        : new Date(lastPoint.name).getTime();
+
+    return {
+      start: Math.floor(firstTimestamp / 1000),
+      end: Math.floor(lastTimestamp / 1000),
+    };
+  }, [series]);
+}


### PR DESCRIPTION
A couple improvements to the metric detector graph:
- rounds seer values to the nearest whole number
- only show upper/lower bounds threshold based on threshold type
- add thresholds to graph preview in the edit view
