### PR TITLE
fix(rules): Skip none on combined rule serialization

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -377,7 +377,9 @@ class CombinedRuleSerializer(Serializer):
 
         serialized_alert_rules = serialize(alert_rules, user=user)
         serialized_alert_rule_map_by_id = {
-            serialized_alert["id"]: serialized_alert for serialized_alert in serialized_alert_rules
+            serialized_alert["id"]: serialized_alert
+            for serialized_alert in serialized_alert_rules
+            if serialized_alert
         }
 
         serialized_issue_rules = serialize(
@@ -386,7 +388,9 @@ class CombinedRuleSerializer(Serializer):
             serializer=RuleSerializer(expand=self.expand),
         )
         serialized_issue_rule_map_by_id = {
-            serialized_rule["id"]: serialized_rule for serialized_rule in serialized_issue_rules
+            serialized_rule["id"]: serialized_rule
+            for serialized_rule in serialized_issue_rules
+            if serialized_rule
         }
 
         uptime_detectors = [


### PR DESCRIPTION
Filter out `None` values during combined rule serialization - these are hitting exceptions during the individual serialization and returning `None` in the [base serializer](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/base.py#L120-L122), mainly due to RPC failures looking up related integrations. It's better to at least return what we can rather than error completely.

Fixes SENTRY-5E0V