### PR TITLE
feat: Apply max pickable days to insights

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t, tct} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useParams} from 'sentry/utils/useParams';
 import ResourceSummaryCharts from 'sentry/views/insights/browser/resources/components/charts/resourceSummaryCharts';
 import RenderBlockingSelector from 'sentry/views/insights/browser/resources/components/renderBlockingSelector';
@@ -173,8 +175,16 @@ function ResourceSummary() {
 }
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="resource" pageTitle={`${DATA_TYPE} ${t('Summary')}`}>
+    <ModulePageProviders
+      moduleName="resource"
+      pageTitle={`${DATA_TYPE} ${t('Summary')}`}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <ResourceSummary />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
@@ -4,7 +4,9 @@ import styled from '@emotion/styled';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {DEFAULT_RESOURCE_FILTERS} from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
 import ResourceView from 'sentry/views/insights/browser/resources/components/resourceView';
 import {DEFAULT_RESOURCE_TYPES} from 'sentry/views/insights/browser/resources/settings';
@@ -70,10 +72,15 @@ function ResourcesLandingPage() {
 }
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
     <ModulePageProviders
       moduleName="resource"
       analyticEventName="insight.page_loads.assets"
+      maxPickableDays={maxPickableDays.maxPickableDays}
     >
       <ResourcesLandingPage />
     </ModulePageProviders>

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -7,10 +7,12 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
@@ -202,8 +204,15 @@ function PageOverview() {
 }
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="vital">
+    <ModulePageProviders
+      moduleName="vital"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <PageOverview />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -6,8 +6,10 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import BrowserTypeSelector from 'sentry/views/insights/browser/webVitals/components/browserTypeSelector';
 import {PerformanceScoreChart} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
 import {PagePerformanceTable} from 'sentry/views/insights/browser/webVitals/components/tables/pagePerformanceTable';
@@ -145,8 +147,16 @@ export function WebVitalMetersPlaceholder() {
 }
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="vital" analyticEventName="insight.page_loads.vital">
+    <ModulePageProviders
+      moduleName="vital"
+      analyticEventName="insight.page_loads.vital"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <WebVitalsLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import keyBy from 'lodash/keyBy';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import {DataCategory} from 'sentry/types/core';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {CacheSamplePanel} from 'sentry/views/insights/cache/components/samplePanel';
 import {
   isAValidSort,
@@ -135,8 +137,16 @@ export function CacheLandingPage() {
 }
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="cache" analyticEventName="insight.page_loads.cache">
+    <ModulePageProviders
+      moduleName="cache"
+      analyticEventName="insight.page_loads.cache"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <CacheLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/common/components/insightsModuleDatePageFilter.tsx
+++ b/static/app/views/insights/common/components/insightsModuleDatePageFilter.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -7,6 +8,9 @@ import {
 } from 'sentry/components/organizations/datePageFilter';
 import {IconBusiness} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
+import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import useOrganization from 'sentry/utils/useOrganization';
 import {QUERY_DATE_RANGE_LIMIT} from 'sentry/views/insights/settings';
 
@@ -15,35 +19,49 @@ const DISABLED_OPTIONS = ['90d'];
 export function InsightsModuleDatePageFilter() {
   const organization = useOrganization();
 
-  const hasDateRangeQueryLimit = organization.features.includes(
-    'insights-query-date-range-limit'
-  );
+  const legacyDateFilterProps: DatePageFilterProps = useMemo(() => {
+    const dateFilterProps: DatePageFilterProps = {};
 
-  const dateFilterProps: DatePageFilterProps = {};
-  if (hasDateRangeQueryLimit) {
-    dateFilterProps.relativeOptions = ({arbitraryOptions}) => {
-      return {
-        ...arbitraryOptions,
-        '1h': t('Last 1 hour'),
-        '24h': t('Last 24 hours'),
-        '7d': t('Last 7 days'),
-        '14d': t('Last 14 days'),
-        '30d': t('Last 30 days'),
-        '90d': <DisabledDateOption value={t('Last 90 days')} />,
+    const hasDateRangeQueryLimit = organization.features.includes(
+      'insights-query-date-range-limit'
+    );
+
+    if (hasDateRangeQueryLimit) {
+      dateFilterProps.relativeOptions = ({arbitraryOptions}) => {
+        return {
+          ...arbitraryOptions,
+          '1h': t('Last 1 hour'),
+          '24h': t('Last 24 hours'),
+          '7d': t('Last 7 days'),
+          '14d': t('Last 14 days'),
+          '30d': t('Last 30 days'),
+          '90d': <DisabledDateOption value={t('Last 90 days')} />,
+        };
       };
-    };
 
-    dateFilterProps.maxPickableDays = QUERY_DATE_RANGE_LIMIT;
-    dateFilterProps.isOptionDisabled = ({value}) => {
-      if (!DISABLED_OPTIONS.includes(value)) {
-        return false;
-      }
-      return true;
-    };
-    dateFilterProps.menuFooter = <UpsellFooterHook />;
-  }
+      dateFilterProps.maxPickableDays = QUERY_DATE_RANGE_LIMIT;
+      dateFilterProps.isOptionDisabled = ({value}) => {
+        if (!DISABLED_OPTIONS.includes(value)) {
+          return false;
+        }
+        return true;
+      };
+      dateFilterProps.menuFooter = <UpsellFooterHook />;
+    }
 
-  return <DatePageFilter {...dateFilterProps} />;
+    return dateFilterProps;
+  }, [organization]);
+
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+  const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
+
+  const props = organization.features.includes('downsampled-page-filter')
+    ? datePageFilterProps
+    : legacyDateFilterProps;
+
+  return <DatePageFilter {...props} />;
 }
 
 function DisabledDateOption({value}: {value: string}) {

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -5,10 +5,12 @@ import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
@@ -196,12 +198,20 @@ function AlertBanner(props: Omit<AlertProps, 'type' | 'showIcon'>) {
 const LIMIT = 25;
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   const hasDashboardsPlatformizedQueries = useHasDashboardsPlatformizedQueries();
   if (hasDashboardsPlatformizedQueries) {
     return <PlatformizedQueriesOverview />;
   }
   return (
-    <ModulePageProviders moduleName="db" analyticEventName="insight.page_loads.db">
+    <ModulePageProviders
+      moduleName="db"
+      analyticEventName="insight.page_loads.db"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <DatabaseLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -4,10 +4,12 @@ import styled from '@emotion/styled';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useParams} from 'sentry/utils/useParams';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import InsightIssuesList from 'sentry/views/insights/common/components/issues';
@@ -268,13 +270,21 @@ const DescriptionContainer = styled(ModuleLayout.Full)`
 `;
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   const hasDashboardsPlatformizedQueries = useHasDashboardsPlatformizedQueries();
   if (hasDashboardsPlatformizedQueries) {
     return <PlatformizedQuerySummaryPage />;
   }
 
   return (
-    <ModulePageProviders moduleName="db" pageTitle={t('Query Summary')}>
+    <ModulePageProviders
+      moduleName="db"
+      pageTitle={t('Query Summary')}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <DatabaseSpanSummaryPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/database/views/platformizedOverview.tsx
+++ b/static/app/views/insights/database/views/platformizedOverview.tsx
@@ -1,10 +1,19 @@
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 
 export function PlatformizedQueriesOverview() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="db">
+    <ModulePageProviders
+      moduleName="db"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.BACKEND_QUERIES} />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/database/views/platformizedSummaryPage.tsx
+++ b/static/app/views/insights/database/views/platformizedSummaryPage.tsx
@@ -1,10 +1,19 @@
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 
 export function PlatformizedQuerySummaryPage() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="db">
+    <ModulePageProviders
+      moduleName="db"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <PrebuiltDashboardRenderer
         prebuiltId={PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY}
       />

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -5,10 +5,12 @@ import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
 import {ExternalLink} from 'sentry/components/core/link';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t, tct} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeList, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import useProjects from 'sentry/utils/useProjects';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
@@ -263,8 +265,16 @@ const DEFAULT_SORT = {
 const TRANSACTIONS_TABLE_ROW_COUNT = 20;
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="http" pageTitle={t('Domain Summary')}>
+    <ModulePageProviders
+      moduleName="http"
+      pageTitle={t('Domain Summary')}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <HTTPDomainSummaryPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
@@ -147,8 +149,16 @@ const DEFAULT_SORT = {
 const DOMAIN_TABLE_ROW_COUNT = 10;
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="http" analyticEventName="insight.page_loads.http">
+    <ModulePageProviders
+      moduleName="http"
+      analyticEventName="insight.page_loads.http"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <HTTPLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -9,10 +9,13 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
@@ -42,6 +45,11 @@ import {
 import {ModuleName} from 'sentry/views/insights/types';
 
 function ScreensLandingPage() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+  const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
+
   const moduleName = ModuleName.MOBILE_VITALS;
   const navigate = useNavigate();
   const location = useLocation();
@@ -262,7 +270,7 @@ function ScreensLandingPage() {
                     <PageFilterBar condensed>
                       <InsightsProjectSelector onChange={handleProjectChange} />
                       <InsightsEnvironmentSelector />
-                      <DatePageFilter />
+                      <DatePageFilter {...datePageFilterProps} />
                     </PageFilterBar>
                     <PageFilterBar condensed>
                       <ReleaseComparisonSelector primaryOnly moduleName={moduleName} />

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -259,7 +259,10 @@ function ScreensLandingPage() {
   });
 
   return (
-    <ModulePageProviders moduleName={ModuleName.MOBILE_VITALS}>
+    <ModulePageProviders
+      moduleName={ModuleName.MOBILE_VITALS}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <Layout.Page>
         <PageAlertProvider>
           <ModuleFeature moduleName={moduleName}>

--- a/static/app/views/insights/pages/backend/am1BackendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/am1BackendOverviewPage.tsx
@@ -5,7 +5,10 @@ import Feature from 'sentry/components/acl/feature';
 import {ExternalLink} from 'sentry/components/core/link';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {
+  DatePageFilter,
+  type DatePageFilterProps,
+} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
@@ -81,8 +84,14 @@ const BACKEND_COLUMN_TITLES = [
   {title: 'user misery', tooltip: USER_MISERY_TOOLTIP},
 ];
 
+interface AM1BackendOverviewPageProps {
+  datePageFilterProps: DatePageFilterProps;
+}
+
 // Am1 customers do not have EAP, so we need to use the old frontend overview page for now
-export function Am1BackendOverviewPage() {
+export function Am1BackendOverviewPage({
+  datePageFilterProps,
+}: AM1BackendOverviewPageProps) {
   const theme = useTheme();
   const organization = useOrganization();
   const location = useLocation();
@@ -233,7 +242,7 @@ export function Am1BackendOverviewPage() {
                 <PageFilterBar condensed>
                   <ProjectPageFilter />
                   <EnvironmentPageFilter />
-                  <DatePageFilter />
+                  <DatePageFilter {...datePageFilterProps} />
                 </PageFilterBar>
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar

--- a/static/app/views/insights/pages/domainOverviewPageProviders.tsx
+++ b/static/app/views/insights/pages/domainOverviewPageProviders.tsx
@@ -12,7 +12,7 @@ import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
 interface DomainOverviewPageProvidersProps {
   children: ReactNode;
-  maxPickableDays?: DatePageFilterProps['maxPickableDays'];
+  maxPickableDays: DatePageFilterProps['maxPickableDays'];
 }
 
 export function DomainOverviewPageProviders({

--- a/static/app/views/insights/pages/frontend/am1OverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/am1OverviewPage.tsx
@@ -5,7 +5,10 @@ import Feature from 'sentry/components/acl/feature';
 import {ExternalLink} from 'sentry/components/core/link';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {
+  DatePageFilter,
+  type DatePageFilterProps,
+} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
@@ -76,8 +79,14 @@ const FRONTEND_COLUMN_TITLES = [
   {title: 'user misery', tooltip: USER_MISERY_TOOLTIP},
 ];
 
+interface Am1FrontendOverviewPageProps {
+  datePageFilterProps: DatePageFilterProps;
+}
+
 // Am1 customers do not have EAP, so we need to use the old frontend overview page for now
-export function Am1FrontendOverviewPage() {
+export function Am1FrontendOverviewPage({
+  datePageFilterProps,
+}: Am1FrontendOverviewPageProps) {
   useOverviewPageTrackPageload();
   const theme = useTheme();
 
@@ -212,7 +221,7 @@ export function Am1FrontendOverviewPage() {
                 <PageFilterBar condensed>
                   <ProjectPageFilter />
                   <EnvironmentPageFilter />
-                  <DatePageFilter />
+                  <DatePageFilter {...datePageFilterProps} />
                 </PageFilterBar>
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar

--- a/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
@@ -4,7 +4,10 @@ import styled from '@emotion/styled';
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {
+  DatePageFilter,
+  type DatePageFilterProps,
+} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
@@ -76,8 +79,12 @@ const REACT_NATIVE_COLUMN_TITLES = [
   {title: 'user misery'},
 ];
 
+interface Am1MobileOverviewPageProps {
+  datePageFilterProps: DatePageFilterProps;
+}
+
 // Am1 customers do not have EAP, so we need to use the old frontend overview page for now
-export function Am1MobileOverviewPage() {
+export function Am1MobileOverviewPage({datePageFilterProps}: Am1MobileOverviewPageProps) {
   useOverviewPageTrackPageload();
 
   const theme = useTheme();
@@ -206,7 +213,7 @@ export function Am1MobileOverviewPage() {
                 <PageFilterBar condensed>
                   <ProjectPageFilter />
                   <EnvironmentPageFilter />
-                  <DatePageFilter />
+                  <DatePageFilter {...datePageFilterProps} />
                 </PageFilterBar>
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -281,7 +281,7 @@ function MobileOverviewPageWithProviders() {
   const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
   const useEap = useInsightsEap();
   return (
-    <DomainOverviewPageProviders>
+    <DomainOverviewPageProviders maxPickableDays={maxPickableDays.maxPickableDays}>
       {useEap ? (
         <EAPMobileOverviewPage datePageFilterProps={datePageFilterProps} />
       ) : (

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -3,8 +3,12 @@ import styled from '@emotion/styled';
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {
+  DatePageFilter,
+  type DatePageFilterProps,
+} from 'sentry/components/organizations/datePageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
@@ -16,7 +20,9 @@ import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHa
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -60,7 +66,11 @@ import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
-function EAPMobileOverviewPage() {
+interface EAPMobileOverviewPageProps {
+  datePageFilterProps: DatePageFilterProps;
+}
+
+function EAPMobileOverviewPage({datePageFilterProps}: EAPMobileOverviewPageProps) {
   useOverviewPageTrackPageload();
 
   const organization = useOrganization();
@@ -222,7 +232,7 @@ function EAPMobileOverviewPage() {
                 <PageFilterBar condensed>
                   <InsightsProjectSelector />
                   <InsightsEnvironmentSelector />
-                  <DatePageFilter />
+                  <DatePageFilter {...datePageFilterProps} />
                 </PageFilterBar>
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
@@ -265,10 +275,18 @@ function EAPMobileOverviewPage() {
 }
 
 function MobileOverviewPageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+  const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
   const useEap = useInsightsEap();
   return (
     <DomainOverviewPageProviders>
-      {useEap ? <EAPMobileOverviewPage /> : <Am1MobileOverviewPage />}
+      {useEap ? (
+        <EAPMobileOverviewPage datePageFilterProps={datePageFilterProps} />
+      ) : (
+        <Am1MobileOverviewPage datePageFilterProps={datePageFilterProps} />
+      )}
     </DomainOverviewPageProviders>
   );
 }

--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -2,6 +2,7 @@ import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
+import {type DatePageFilterProps} from 'sentry/components/organizations/datePageFilter';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -41,7 +42,11 @@ const decodeTableType = (value: any): TableType => {
 const TableControl = SegmentedControl<TableType>;
 const TableControlItem = SegmentedControl.Item<TableType>;
 
-export function LaravelOverviewPage() {
+interface LaravelOverPageProps {
+  datePageFilterProps: DatePageFilterProps;
+}
+
+export function LaravelOverviewPage({datePageFilterProps}: LaravelOverPageProps) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
@@ -82,7 +87,7 @@ export function LaravelOverviewPage() {
   }
 
   return (
-    <PlatformLandingPageLayout>
+    <PlatformLandingPageLayout datePageFilterProps={datePageFilterProps}>
       <WidgetGrid>
         <WidgetGrid.Position1>
           <OverviewRequestsChartWidget />

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
+import {type DatePageFilterProps} from 'sentry/components/organizations/datePageFilter';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -33,7 +34,11 @@ function isTableType(value: any): value is TableType {
 const TableControl = SegmentedControl<TableType>;
 const TableControlItem = SegmentedControl.Item<TableType>;
 
-export function NextJsOverviewPage() {
+interface NextJsOverviewPageProps {
+  datePageFilterProps: DatePageFilterProps;
+}
+
+export function NextJsOverviewPage({datePageFilterProps}: NextJsOverviewPageProps) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
@@ -85,7 +90,7 @@ export function NextJsOverviewPage() {
   );
 
   return (
-    <PlatformLandingPageLayout>
+    <PlatformLandingPageLayout datePageFilterProps={datePageFilterProps}>
       <WidgetGrid>
         <WidgetGrid.Position1>
           <OverviewPageloadsChartWidget />

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -1,9 +1,13 @@
+import {type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {
+  DatePageFilter,
+  type DatePageFilterProps,
+} from 'sentry/components/organizations/datePageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -32,7 +36,15 @@ function getFreeTextFromQuery(query: string) {
   return '';
 }
 
-export function PlatformLandingPageLayout({children}: {children: React.ReactNode}) {
+interface PlatformLandingPageLayoutProps {
+  children: ReactNode;
+  datePageFilterProps: DatePageFilterProps;
+}
+
+export function PlatformLandingPageLayout({
+  children,
+  datePageFilterProps,
+}: PlatformLandingPageLayoutProps) {
   const location = useLocation();
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
@@ -56,7 +68,7 @@ export function PlatformLandingPageLayout({children}: {children: React.ReactNode
                 <PageFilterBar condensed>
                   <InsightsProjectSelector />
                   <InsightsEnvironmentSelector />
-                  <DatePageFilter />
+                  <DatePageFilter {...datePageFilterProps} />
                 </PageFilterBar>
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -4,9 +4,11 @@ import styled from '@emotion/styled';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {DurationUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import useOrganization from 'sentry/utils/useOrganization';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
@@ -153,8 +155,16 @@ function DestinationSummaryPage() {
 }
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="queue" pageTitle={t('Destination Summary')}>
+    <ModulePageProviders
+      moduleName="queue"
+      pageTitle={t('Destination Summary')}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <DestinationSummaryPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/queues/views/queuesLandingPage.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.tsx
@@ -5,11 +5,13 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
@@ -105,8 +107,16 @@ function QueuesLandingPage() {
 }
 
 function PageWithProviders() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
   return (
-    <ModulePageProviders moduleName="queue" analyticEventName="insight.page_loads.queue">
+    <ModulePageProviders
+      moduleName="queue"
+      analyticEventName="insight.page_loads.queue"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <QueuesLandingPage />
     </ModulePageProviders>
   );


### PR DESCRIPTION
This applies the max pickable days to the insights pages. It uses only spans because for am1, spans get the same max pickable days as transactions. Unlike on transaction summary, where some of the data is explicitly using transactions with no fallback to spans.