### PR TITLE
feat(project-selector): Support multiple selection in form project selector component

### DIFF
--- a/static/app/components/forms/fields/sentryProjectSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.spec.tsx
@@ -58,4 +58,29 @@ describe('SentryProjectSelectorField', () => {
     expect(screen.getByText('Main projects')).toBeInTheDocument();
     expect(screen.getByText('Other')).toBeInTheDocument();
   });
+
+  it('can select multiple values', async () => {
+    const mock = jest.fn();
+    const projects = [
+      ProjectFixture({id: '1', slug: 'project-a'}),
+      ProjectFixture({id: '2', slug: 'project-b'}),
+      ProjectFixture({id: '3', slug: 'project-c'}),
+    ];
+    render(
+      <SentryProjectSelectorField
+        onChange={mock}
+        name="projects"
+        projects={projects}
+        multiple
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await selectEvent.select(input, 'project-a');
+    expect(mock).toHaveBeenLastCalledWith(['1'], expect.anything());
+
+    await selectEvent.select(input, 'project-b');
+    expect(mock).toHaveBeenLastCalledWith(['1', '2'], expect.anything());
+  });
 });

--- a/static/app/components/forms/fields/sentryProjectSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.tsx
@@ -47,12 +47,14 @@ function SelectedProjectMultiValueLabel({
   return (
     <components.MultiValueLabel data={data} {...props}>
       <Flex align="center" gap="xs">
-        <IdBadge
-          project={data.project}
-          avatarSize={14}
-          avatarProps={{consistentWidth: true}}
-          hideName
-        />
+        {data.project ? (
+          <IdBadge
+            project={data.project}
+            avatarSize={14}
+            avatarProps={{consistentWidth: true}}
+            hideName
+          />
+        ) : null}
         {children}
       </Flex>
     </components.MultiValueLabel>

--- a/static/app/components/forms/fields/sentryProjectSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.tsx
@@ -1,3 +1,5 @@
+import {Flex} from 'sentry/components/core/layout';
+import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
@@ -5,6 +7,10 @@ import type {Project} from 'sentry/types/project';
 // XXX(epurkhiser): This is wrong, it should not be inheriting these props
 import type {InputFieldProps} from './inputField';
 import SelectField from './selectField';
+
+const OVERRIDE_COMPONENTS = {
+  MultiValueLabel: SelectedProjectMultiValueLabel,
+};
 
 /**
  * Function used to group projects by returning the key of the group
@@ -32,6 +38,27 @@ export interface RenderFieldProps extends InputFieldProps {
   valueIsSlug?: boolean;
 }
 
+// When in multi-select mode, this adds the project badget to the selected badges
+function SelectedProjectMultiValueLabel({
+  data,
+  children,
+  ...props
+}: React.ComponentProps<typeof components.MultiValueLabel>) {
+  return (
+    <components.MultiValueLabel data={data} {...props}>
+      <Flex align="center" gap="xs">
+        <IdBadge
+          project={data.project}
+          avatarSize={14}
+          avatarProps={{consistentWidth: true}}
+          hideName
+        />
+        {children}
+      </Flex>
+    </components.MultiValueLabel>
+  );
+}
+
 function SentryProjectSelectorField({
   projects,
   groupProjects,
@@ -45,6 +72,7 @@ function SentryProjectSelectorField({
     return {
       value: project[valueIsSlug ? 'slug' : 'id'],
       label: project.slug,
+      project,
       leadingItems: (
         <IdBadge
           project={project}
@@ -68,7 +96,14 @@ function SentryProjectSelectorField({
       : // Otherwise just map projects to the options
         projects?.map(projectToOption);
 
-  return <SelectField placeholder={placeholder} options={projectOptions} {...props} />;
+  return (
+    <SelectField
+      placeholder={placeholder}
+      options={projectOptions}
+      components={OVERRIDE_COMPONENTS}
+      {...props}
+    />
+  );
 }
 
 export default SentryProjectSelectorField;


### PR DESCRIPTION
Adds support for using `multiple` on the project selector for forms. Overrides the multi select value label so that it renders a platform icon.

<img width="826" height="158" alt="CleanShot 2025-12-01 at 14 25 42@2x" src="https://github.com/user-attachments/assets/e7ab2da9-a620-4ac8-8859-31a48c275e14" />
