### PR TITLE
chore(aci): log created WAGS action ids

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -456,7 +456,9 @@ def process_workflows(
         if not event_detectors:
             raise Detector.DoesNotExist("No Detectors associated with the issue were found")
 
-        log_context.add_extras(detector_id=event_detectors.preferred_detector.id)
+        log_context.add_extras(
+            detector_id=event_detectors.preferred_detector.id, group_id=event_data.group.id
+        )
         organization = event_data.event.project.organization
 
         # set the detector / org information asap, this is used in `get_environment_by_event` as well.


### PR DESCRIPTION
This log should help debug the action interval issue.

`attempted_action_ids` will show the WAGS we attempted to create for action_ids for a group. There are currently no shared action_ids between workflows so these should uniquely identify workflows.
`created_action_ids` will show the WAGS we successfully created.