### PR TITLE
feat(triage signals): Logging related updates

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -335,7 +335,7 @@ def run_automation(
                 "Triage signals V0: skipping alert automation, event count < 10",
                 extra={
                     "group_id": group.id,
-                    "project_id": group.project.id,
+                    "project_slug": group.project.slug,
                     "event_count": times_seen,
                 },
             )
@@ -348,9 +348,9 @@ def run_automation(
         except (AssertionError, AttributeError):
             times_seen = group.times_seen
         logger.info(
-            "Triage signals V0: %s: run_automation called: project_id=%s, source=%s, times_seen=%s",
+            "Triage signals V0: %s: run_automation called: project_slug=%s, source=%s, times_seen=%s",
             group.id,
-            group.project.id,
+            group.project.slug,
             source.value,
             times_seen,
         )
@@ -395,20 +395,20 @@ def run_automation(
 
     stopping_point = None
     if features.has("organizations:triage-signals-v0-org", group.organization):
-        logger.info("Triage signals V0: %s: generating stopping point", group.id)
         fixability_stopping_point = _get_stopping_point_from_fixability(fixability_score)
-        logger.info("Fixability-based stopping point: %s", fixability_stopping_point)
 
         # Fetch user preference and apply as upper bound
         user_preference = _fetch_user_preference(group.project.id)
-        logger.info("User preference stopping point: %s", user_preference)
 
         stopping_point = _apply_user_preference_upper_bound(
             fixability_stopping_point, user_preference
         )
         logger.info(
-            "Triage signals V0: %s: Final stopping point after upper bound: %s",
+            "Triage signals V0 stopping point for group=%s project=%s: fixability=%s, user preference=%s, final=%s",
             group.id,
+            group.project.slug,
+            fixability_stopping_point,
+            user_preference,
             stopping_point,
         )
 

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -60,7 +60,11 @@ def generate_issue_summary_only(group_id: int) -> None:
     )
 
     group = Group.objects.get(id=group_id)
-    logger.info("Task: generate_issue_summary_only, group_id=%s", group_id)
+    logger.info(
+        "Task: generate_issue_summary_only, group_id=%s project_slug=%s",
+        group_id,
+        group.project.slug,
+    )
     get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
@@ -84,7 +88,11 @@ def run_automation_only_task(group_id: int) -> None:
     from sentry.seer.autofix.issue_summary import run_automation
 
     group = Group.objects.get(id=group_id)
-    logger.info("Task: run_automation_only_task, group_id=%s", group_id)
+    logger.info(
+        "Task: run_automation_only_task, group_id=%s project_slug=%s",
+        group_id,
+        group.project.slug,
+    )
 
     event = group.get_latest_event()
 

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -60,11 +60,7 @@ def generate_issue_summary_only(group_id: int) -> None:
     )
 
     group = Group.objects.get(id=group_id)
-    logger.info(
-        "Task: generate_issue_summary_only, group_id=%s project_slug=%s",
-        group_id,
-        group.project.slug,
-    )
+    logger.info("Task: generate_issue_summary_only, group_id=%s", group_id)
     get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
@@ -88,11 +84,7 @@ def run_automation_only_task(group_id: int) -> None:
     from sentry.seer.autofix.issue_summary import run_automation
 
     group = Group.objects.get(id=group_id)
-    logger.info(
-        "Task: run_automation_only_task, group_id=%s project_slug=%s",
-        group_id,
-        group.project.slug,
-    )
+    logger.info("Task: run_automation_only_task, group_id=%s", group_id)
 
     event = group.get_latest_event()
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1643,7 +1643,6 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             # Check if summary exists in cache
             cache_key = get_issue_summary_cache_key(group.id)
             if cache.get(cache_key) is not None:
-                logger.info("Triage signals V0: %s: summary already exists, skipping", group.id)
                 return
 
             # Early returns for eligibility checks (cheap checks first)
@@ -1658,7 +1657,11 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             # Rate limit check must be last, after cache.add succeeds, to avoid wasting quota
             if is_seer_scanner_rate_limited(group.project, group.organization):
                 return
-            logger.info("Triage signals V0: %s: generating summary", group.id)
+            logger.info(
+                "Triage signals V0:group=%s project=%s: generating summary",
+                group.id,
+                group.project.slug,
+            )
             generate_issue_summary_only.delay(group.id)
         else:
             # Event count >= 10: run automation
@@ -1687,7 +1690,11 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             cache_key = get_issue_summary_cache_key(group.id)
             if cache.get(cache_key) is not None:
                 # Summary exists, run automation directly
-                logger.info("Triage signals V0: %s: summary exists, running automation", group.id)
+                logger.info(
+                    "Triage signals V0:group=%s project=%s: summary exists, running automation",
+                    group.id,
+                    group.project.slug,
+                )
                 run_automation_only_task.delay(group.id)
             else:
                 # Rate limit check before generating summary
@@ -1696,8 +1703,9 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
 
                 # No summary yet, generate summary + run automation in one go
                 logger.info(
-                    "Triage signals V0: %s: no summary, generating summary + running automation",
+                    "Triage signals V0:group=%s project=%s: no summary, generating summary + running automation",
                     group.id,
+                    group.project.slug,
                 )
                 generate_summary_and_run_automation.delay(group.id)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1661,6 +1661,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
                 "Triage signals V0:group=%s project=%s: generating summary",
                 group.id,
                 group.project.slug,
+                extra={"group_id": group.id, "project_slug": group.project.slug},
             )
             generate_issue_summary_only.delay(group.id)
         else:
@@ -1694,6 +1695,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
                     "Triage signals V0:group=%s project=%s: summary exists, running automation",
                     group.id,
                     group.project.slug,
+                    extra={"group_id": group.id, "project_slug": group.project.slug},
                 )
                 run_automation_only_task.delay(group.id)
             else:
@@ -1706,6 +1708,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
                     "Triage signals V0:group=%s project=%s: no summary, generating summary + running automation",
                     group.id,
                     group.project.slug,
+                    extra={"group_id": group.id, "project_slug": group.project.slug},
                 )
                 generate_summary_and_run_automation.delay(group.id)
 


### PR DESCRIPTION
## PR Details
+ Log project slug instead of project id for triage signals logs now that it's open to all projects inside the sentry org.
+ Removed some logs and simplified some others. 
