### PR TITLE
feat(forms): Allow forms to have a collapsible field inside them

### DIFF
--- a/static/app/components/forms/collapsibleSection.tsx
+++ b/static/app/components/forms/collapsibleSection.tsx
@@ -7,6 +7,7 @@ import type {FieldObject} from 'sentry/components/forms/types';
 export interface CollapsibleSectionProps extends Omit<FieldFromConfigProps, 'field'> {
   fields: FieldObject[];
   label: ReactNode | (() => React.ReactNode);
+  initiallyCollapsed?: boolean;
 }
 
 export default function CollapsibleSection(props: CollapsibleSectionProps) {
@@ -16,7 +17,7 @@ export default function CollapsibleSection(props: CollapsibleSectionProps) {
         typeof props.disabled === 'function' ? props.disabled(props) : props.disabled
       }
       collapsible
-      initiallyCollapsed
+      initiallyCollapsed={props.initiallyCollapsed}
       nested
       title={typeof props.label === 'function' ? props.label() : props.label}
       fields={props.fields}

--- a/static/app/components/forms/collapsibleSection.tsx
+++ b/static/app/components/forms/collapsibleSection.tsx
@@ -1,0 +1,25 @@
+import type {ReactNode} from 'react';
+
+import type {FieldFromConfigProps} from 'sentry/components/forms/fieldFromConfig';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import type {FieldObject} from 'sentry/components/forms/types';
+
+export interface CollapsibleSectionProps extends Omit<FieldFromConfigProps, 'field'> {
+  fields: FieldObject[];
+  label: ReactNode | (() => React.ReactNode);
+}
+
+export default function CollapsibleSection(props: CollapsibleSectionProps) {
+  return (
+    <JsonForm
+      disabled={
+        typeof props.disabled === 'function' ? props.disabled(props) : props.disabled
+      }
+      collapsible
+      initiallyCollapsed
+      nested
+      title={typeof props.label === 'function' ? props.label() : props.label}
+      fields={props.fields}
+    />
+  );
+}

--- a/static/app/components/forms/collapsibleSection.tsx
+++ b/static/app/components/forms/collapsibleSection.tsx
@@ -13,14 +13,13 @@ export interface CollapsibleSectionProps extends Omit<FieldFromConfigProps, 'fie
 export default function CollapsibleSection(props: CollapsibleSectionProps) {
   return (
     <JsonForm
+      {...props}
       disabled={
         typeof props.disabled === 'function' ? props.disabled(props) : props.disabled
       }
-      collapsible
-      initiallyCollapsed={props.initiallyCollapsed}
-      nested
       title={typeof props.label === 'function' ? props.label() : props.label}
-      fields={props.fields}
+      collapsible
+      nested
     />
   );
 }

--- a/static/app/components/forms/fieldFromConfig.tsx
+++ b/static/app/components/forms/fieldFromConfig.tsx
@@ -1,3 +1,6 @@
+import CollapsibleSection, {
+  type CollapsibleSectionProps,
+} from 'sentry/components/forms/collapsibleSection';
 import type {FieldGroupProps} from 'sentry/components/forms/fieldGroup/types';
 import SeparatorField from 'sentry/components/forms/fields/separatorField';
 import type {Field} from 'sentry/components/forms/types';
@@ -25,7 +28,7 @@ import TableField, {type TableFieldProps} from './fields/tableField';
 import TextareaField, {type TextareaFieldProps} from './fields/textareaField';
 import TextField, {type TextFieldProps} from './fields/textField';
 
-interface FieldFromConfigProps {
+export interface FieldFromConfigProps {
   field: Field;
   access?: Set<Scope>;
 
@@ -103,6 +106,8 @@ function FieldFromConfig(props: FieldFromConfigProps): React.ReactElement | null
       return <DateTimeField {...(componentProps as DateTimeFieldProps)} />;
     case 'custom':
       return field.Component(field);
+    case 'collapsible':
+      return <CollapsibleSection {...(componentProps as CollapsibleSectionProps)} />;
     default:
       return null;
   }

--- a/static/app/components/forms/form.stories.tsx
+++ b/static/app/components/forms/form.stories.tsx
@@ -55,20 +55,13 @@ export default Storybook.story('Form', story => {
 
   story('JsonForm - collapsible field w/ callbacks', () => {
     const [logs, setLogs] = useState<Array<[string, any]>>([]);
-    const makeAppendLog = (eventName: string) => {
-      return (...args: any[]) => {
-        setLogs(prev => [...prev, [eventName, args]]);
-      };
-    };
 
     return (
       <Grid columns="repeat(2, 1fr)" gap="md">
         <Form
-          onFieldChange={makeAppendLog('onFieldChange')}
-          onPreSubmit={makeAppendLog('onPreSubmit')}
-          onSubmit={makeAppendLog('onSubmit')}
-          onSubmitSuccess={makeAppendLog('onSubmitSuccess')}
-          onSubmitError={makeAppendLog('onSubmitError')}
+          onFieldChange={(...args) => {
+            setLogs(prev => [...prev, ['onFieldChange', args]]);
+          }}
         >
           <JsonForm
             fields={[
@@ -94,13 +87,13 @@ export default Storybook.story('Form', story => {
         </Form>
         <Container>
           <Heading as="h2">Callbacks</Heading>
-          <ul style={{listStyle: 'none', padding: 0, margin: 0}}>
+          <ol>
             {logs.map((log, i) => (
               <li key={i}>
                 <pre>{JSON.stringify(log)}</pre>
               </li>
             ))}
-          </ul>
+          </ol>
         </Container>
       </Grid>
     );

--- a/static/app/components/forms/form.stories.tsx
+++ b/static/app/components/forms/form.stories.tsx
@@ -1,0 +1,108 @@
+import {useState} from 'react';
+
+import {Container} from '@sentry/scraps/layout/container';
+import {Grid} from '@sentry/scraps/layout/grid';
+import {Heading} from '@sentry/scraps/text';
+
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import * as Storybook from 'sentry/stories';
+
+export default Storybook.story('Form', story => {
+  story('JsonForm - fields', () => (
+    <Form>
+      <JsonForm
+        title="Form"
+        fields={[
+          {
+            name: 'name',
+            type: 'text',
+            label: 'Name',
+          },
+        ]}
+      />
+    </Form>
+  ));
+
+  story('JsonForm - forms', () => (
+    <Form>
+      <JsonForm
+        forms={[
+          {
+            fields: [
+              {
+                name: 'name1',
+                type: 'text',
+                label: 'Name 1',
+              },
+            ],
+            title: 'Form 1',
+          },
+          {
+            fields: [
+              {
+                name: 'name2',
+                type: 'text',
+                label: 'Name 2',
+              },
+            ],
+            title: 'Form 2',
+          },
+        ]}
+      />
+    </Form>
+  ));
+
+  story('JsonForm - collapsible field w/ callbacks', () => {
+    const [logs, setLogs] = useState<Array<[string, any]>>([]);
+    const makeAppendLog = (eventName: string) => {
+      return (...args: any[]) => {
+        setLogs(prev => [...prev, [eventName, args]]);
+      };
+    };
+
+    return (
+      <Grid columns="repeat(2, 1fr)" gap="md">
+        <Form
+          onFieldChange={makeAppendLog('onFieldChange')}
+          onPreSubmit={makeAppendLog('onPreSubmit')}
+          onSubmit={makeAppendLog('onSubmit')}
+          onSubmitSuccess={makeAppendLog('onSubmitSuccess')}
+          onSubmitError={makeAppendLog('onSubmitError')}
+        >
+          <JsonForm
+            fields={[
+              {
+                name: 'name1',
+                type: 'text',
+                label: 'Name 1',
+              },
+              {
+                name: '',
+                type: 'collapsible',
+                label: 'additional field(s)',
+                fields: [
+                  {
+                    name: 'name2',
+                    type: 'text',
+                    label: 'Name 2',
+                  },
+                ],
+              },
+            ]}
+          />
+        </Form>
+        <Container>
+          <Heading as="h2">Callbacks</Heading>
+          <ul style={{listStyle: 'none', padding: 0, margin: 0}}>
+            {logs.map((log, i) => (
+              <li key={i}>
+                <pre>{JSON.stringify(log)}</pre>
+              </li>
+            ))}
+          </ul>
+        </Container>
+      </Grid>
+    );
+  });
+});

--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -1,5 +1,10 @@
-import {useCallback, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Container} from '@sentry/scraps/layout/container';
+import {Flex} from '@sentry/scraps/layout/flex';
+import {Text} from '@sentry/scraps/text';
 
 import FieldFromConfig from 'sentry/components/forms/fieldFromConfig';
 import Panel from 'sentry/components/panels/panel';
@@ -27,12 +32,19 @@ export interface FormPanelProps {
    * Disables the entire form
    */
   disabled?: boolean;
+
   features?: Record<string, any>;
+
   /**
    * The name of the field that should be highlighted
    */
   highlighted?: string;
   initiallyCollapsed?: boolean;
+
+  /**
+   * Used by the `collapsible` field type to adjust rendering of the form title
+   */
+  nested?: boolean;
   /**
    * Renders inside of PanelBody before PanelBody close
    */
@@ -47,7 +59,7 @@ export interface FormPanelProps {
   title?: React.ReactNode;
 }
 
-function FormPanel({
+export default function FormPanel({
   additionalFieldProps = {},
   title,
   fields,
@@ -57,10 +69,85 @@ function FormPanel({
   renderHeader,
   collapsible,
   initiallyCollapsed = false,
+  nested = false,
   ...otherProps
 }: FormPanelProps) {
   const [collapsed, setCollapse] = useState(initiallyCollapsed);
   const handleCollapseToggle = useCallback(() => setCollapse(current => !current), []);
+
+  const panelBody = (
+    <Fragment>
+      {typeof renderHeader === 'function' && renderHeader({title, fields})}
+
+      {fields.map(field => {
+        if (typeof field === 'function') {
+          return field();
+        }
+
+        const {defaultValue: _, ...fieldWithoutDefaultValue} = field;
+        const fieldConfig =
+          field.type === 'boolean' || field.type === 'bool'
+            ? field
+            : fieldWithoutDefaultValue;
+
+        // Allow the form panel disabled prop to override the fields
+        // disabled prop, with fallback to the fields disabled state.
+        if (disabled === true) {
+          fieldWithoutDefaultValue.disabled = true;
+          fieldWithoutDefaultValue.disabledReason = undefined;
+        }
+
+        return (
+          <FieldFromConfig
+            access={access}
+            disabled={disabled}
+            key={field.name}
+            {...otherProps}
+            {...additionalFieldProps}
+            field={fieldConfig}
+            highlighted={otherProps.highlighted === `#${field.name}`}
+          />
+        );
+      })}
+      {typeof renderFooter === 'function' && renderFooter({title, fields})}
+    </Fragment>
+  );
+
+  if (nested) {
+    return (
+      <Container padding="lg xl" data-test-id="collapsible-section-container">
+        <Flex padding="sm 0" data-test-id="header">
+          {title && (
+            <Button
+              priority="link"
+              onClick={collapsible ? handleCollapseToggle : undefined}
+              style={collapsible ? {cursor: 'pointer'} : undefined}
+              role={collapsible ? 'button' : undefined}
+              aria-label={collapsible ? t('Expand Options') : t('Panel')}
+              aria-expanded={!collapsed}
+            >
+              <Text size="sm" bold={false}>
+                <Flex align="center" gap="xs" justify="between">
+                  {title}
+
+                  <IconChevron
+                    data-test-id="form-panel-collapse-chevron"
+                    direction={collapsed ? 'down' : 'up'}
+                    size="xs"
+                  />
+                </Flex>
+              </Text>
+            </Button>
+          )}
+        </Flex>
+        <PanelBody hidden={collapsed}>
+          <Container border="primary" radius="md" padding="sm" data-test-id="body">
+            {panelBody}
+          </Container>
+        </PanelBody>
+      </Container>
+    );
+  }
 
   return (
     <Panel id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}>
@@ -89,46 +176,10 @@ function FormPanel({
           )}
         </PanelHeader>
       )}
-      <PanelBody hidden={collapsed}>
-        {typeof renderHeader === 'function' && renderHeader({title, fields})}
-
-        {fields.map(field => {
-          if (typeof field === 'function') {
-            return field();
-          }
-
-          const {defaultValue: _, ...fieldWithoutDefaultValue} = field;
-          const fieldConfig =
-            field.type === 'boolean' || field.type === 'bool'
-              ? field
-              : fieldWithoutDefaultValue;
-
-          // Allow the form panel disabled prop to override the fields
-          // disabled prop, with fallback to the fields disabled state.
-          if (disabled === true) {
-            fieldWithoutDefaultValue.disabled = true;
-            fieldWithoutDefaultValue.disabledReason = undefined;
-          }
-
-          return (
-            <FieldFromConfig
-              access={access}
-              disabled={disabled}
-              key={field.name}
-              {...otherProps}
-              {...additionalFieldProps}
-              field={fieldConfig}
-              highlighted={otherProps.highlighted === `#${field.name}`}
-            />
-          );
-        })}
-        {typeof renderFooter === 'function' && renderFooter({title, fields})}
-      </PanelBody>
+      <PanelBody hidden={collapsed}>{panelBody}</PanelBody>
     </Panel>
   );
 }
-
-export default FormPanel;
 
 const Collapse = styled('span')`
   cursor: pointer;

--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -120,16 +120,13 @@ export default function FormPanel({
           {title && (
             <Button
               priority="link"
-              onClick={collapsible ? handleCollapseToggle : undefined}
-              style={collapsible ? {cursor: 'pointer'} : undefined}
-              role={collapsible ? 'button' : undefined}
-              aria-label={collapsible ? t('Expand Options') : t('Panel')}
+              onClick={handleCollapseToggle}
+              aria-label={collapsed ? t('Expand Options') : t('Collapse Options')}
               aria-expanded={!collapsed}
             >
               <Text size="sm" bold={false}>
                 <Flex align="center" gap="xs" justify="between">
                   {title}
-
                   <IconChevron
                     data-test-id="form-panel-collapse-chevron"
                     direction={collapsed ? 'down' : 'up'}

--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -115,8 +115,8 @@ export default function FormPanel({
 
   if (nested) {
     return (
-      <Container padding="lg xl" data-test-id="collapsible-section-container">
-        <Flex padding="sm 0" data-test-id="header">
+      <Container padding="lg xl">
+        <Flex padding="sm 0">
           {title && (
             <Button
               priority="link"
@@ -125,13 +125,13 @@ export default function FormPanel({
               aria-expanded={!collapsed}
             >
               <Text size="sm" bold={false}>
-                <Flex align="center" gap="xs" justify="between">
-                  {title}
+                <Flex align="center" gap="xs">
                   <IconChevron
                     data-test-id="form-panel-collapse-chevron"
-                    direction={collapsed ? 'down' : 'up'}
+                    direction={collapsed ? 'right' : 'down'}
                     size="xs"
                   />
+                  {title}
                 </Flex>
               </Text>
             </Button>

--- a/static/app/components/forms/jsonForm.tsx
+++ b/static/app/components/forms/jsonForm.tsx
@@ -27,6 +27,11 @@ interface JsonFormProps
    * Fields that are grouped by "section"
    */
   forms?: JsonFormObject[];
+
+  /**
+   * INTERNAL FIELD: used by the `collapsible` field type to adjust rendering of the form title
+   */
+  nested?: boolean;
 }
 
 type State = {
@@ -40,6 +45,7 @@ interface ChildFormPanelProps
     | 'access'
     | 'disabled'
     | 'features'
+    | 'nested'
     | 'additionalFieldProps'
     | 'renderFooter'
     | 'renderHeader'
@@ -146,6 +152,7 @@ class JsonForm extends Component<JsonFormProps, State> {
       collapsible,
       initiallyCollapsed = false,
       fields,
+      nested,
       title,
       forms,
       disabled,
@@ -164,6 +171,7 @@ class JsonForm extends Component<JsonFormProps, State> {
       access,
       disabled,
       features,
+      nested,
       additionalFieldProps,
       renderFooter,
       renderHeader,

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -103,7 +103,6 @@ interface BaseField {
 // TODO(ts): These are field specific props. May not be needed as we convert
 // the fields as we can grab the props from them
 
-// Label is
 interface CollapsibleSectionType {
   fields: FieldObject[];
   type: 'collapsible';

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -105,6 +105,7 @@ interface BaseField {
 
 interface CollapsibleSectionType {
   fields: FieldObject[];
+  label: React.ReactNode | (() => React.ReactNode);
   type: 'collapsible';
   initiallyCollapsed?: boolean;
 }

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -103,6 +103,13 @@ interface BaseField {
 // TODO(ts): These are field specific props. May not be needed as we convert
 // the fields as we can grab the props from them
 
+// Label is
+interface CollapsibleSectionType {
+  fields: FieldObject[];
+  type: 'collapsible';
+  initiallyCollapsed?: boolean;
+}
+
 interface CustomType {
   Component: (arg: BaseField) => React.ReactElement;
   type: 'custom';
@@ -198,6 +205,7 @@ type SelectAsyncType = {
 } & SelectAsyncFieldProps;
 
 export type Field = (
+  | CollapsibleSectionType
   | CustomType
   | SelectControlType
   | InputType


### PR DESCRIPTION
I experimented a little with just nested forms, but the UI looked janky. So this is basically some types and decoration around putting a `<JsonForm/>` inside a `<JsonForm />`, taking all the things that work, and all the things that don't along with it.

**StoryBook**
There's a story that demonstrates some basics of `<Form><JsonForm/></Form>` at this url: `/stories/?name=app%2Fcomponents%2Fforms%2Fform.stories.tsx`

happily events and everything get wired up with the nested JsonForm inside the collapsable field 👍 

<img width="751" height="351" alt="SCR-20251202-mjay" src="https://github.com/user-attachments/assets/f79cfba1-ce31-4075-90a6-bb8acdec8082" />

