### PR TITLE
test(issues): Remove deprecated router mocks from events

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -1,7 +1,5 @@
 import {EventFixture} from 'sentry-fixture/event';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -76,7 +74,6 @@ describe('EventTagsTree', () => {
   it('renders tag tree', async () => {
     render(<EventTags projectSlug={project.slug} event={event} />, {
       organization,
-      deprecatedRouterMocks: true,
     });
     expect(mockDetailedProject).toHaveBeenCalled();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -132,7 +129,6 @@ describe('EventTagsTree', () => {
     });
     render(<EventTags projectSlug={project.slug} event={releaseEvent} />, {
       organization,
-      deprecatedRouterMocks: true,
     });
     expect(mockDetailedProject).toHaveBeenCalled();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -190,7 +186,6 @@ describe('EventTagsTree', () => {
       const uniqueTagsEvent = EventFixture({tags: [tag], projectID: project.id});
       render(<EventTags projectSlug={project.slug} event={uniqueTagsEvent} />, {
         organization,
-        deprecatedRouterMocks: true,
       });
       expect(mockDetailedProject).toHaveBeenCalled();
       expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -238,7 +233,6 @@ describe('EventTagsTree', () => {
     });
     render(<EventTags projectSlug={project.slug} event={errorTagEvent} />, {
       organization,
-      deprecatedRouterMocks: true,
     });
     expect(mockDetailedProject).toHaveBeenCalled();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -261,7 +255,6 @@ describe('EventTagsTree', () => {
     });
     render(<EventTags projectSlug={project.slug} event={uniqueTagsEvent} />, {
       organization,
-      deprecatedRouterMocks: true,
     });
     expect(mockDetailedProject).toHaveBeenCalled();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -287,7 +280,6 @@ describe('EventTagsTree', () => {
     });
     render(<EventTags projectSlug={highlightProject.slug} event={highlightsEvent} />, {
       organization,
-      deprecatedRouterMocks: true,
     });
     expect(mockHighlightProject).toHaveBeenCalled();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -327,7 +319,6 @@ describe('EventTagsTree', () => {
     });
     render(<EventTags projectSlug={highlightProject.slug} event={highlightsEvent} />, {
       organization: readAccessOrganization,
-      deprecatedRouterMocks: true,
     });
     expect(mockHighlightProject).toHaveBeenCalled();
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -344,16 +335,16 @@ describe('EventTagsTree', () => {
     const highlightsEvent = EventFixture({
       tags: [{key: 'useless-tag', value: 'not so much'}],
     });
-    const issueDetailsRouter = RouterFixture({
-      location: LocationFixture({
-        pathname: `/organizations/${organization.slug}/issues/${event.groupID}/`,
-      }),
-    });
 
     render(<EventTags projectSlug={project.slug} event={highlightsEvent} />, {
       organization,
-      router: issueDetailsRouter,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/${event.groupID}/`,
+          query: {},
+        },
+        route: '/organizations/:orgId/issues/:groupId/',
+      },
     });
     expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
@@ -15,10 +15,7 @@ describe('Breadcrumb Data Default', () => {
     id: '0',
   });
 
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {query: {project: '0'}},
-    },
+  const {organization} = initializeOrg({
     projects: [project],
   });
 
@@ -70,8 +67,13 @@ describe('Breadcrumb Data Default', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: '0'},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 
@@ -113,8 +115,13 @@ describe('Breadcrumb Data Default', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: '0'},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
@@ -12,10 +12,7 @@ import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 describe('Breadcrumb Data Exception', () => {
   const project = ProjectFixture({id: '0'});
 
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {query: {project: project.id}},
-    },
+  const {organization} = initializeOrg({
     projects: [project],
   });
 
@@ -65,8 +62,13 @@ describe('Breadcrumb Data Exception', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: project.id},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 
@@ -106,8 +108,13 @@ describe('Breadcrumb Data Exception', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: project.id},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
@@ -12,10 +12,7 @@ import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 describe('Breadcrumb Data Http', () => {
   const project = ProjectFixture({id: '0'});
 
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {query: {project: project.id}},
-    },
+  const {organization} = initializeOrg({
     projects: [project],
   });
 
@@ -65,8 +62,13 @@ describe('Breadcrumb Data Http', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: project.id},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 
@@ -101,8 +103,13 @@ describe('Breadcrumb Data Http', () => {
       />,
       {
         organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: project.id},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -51,10 +51,7 @@ describe('Exception Content', () => {
       body: projectDetails,
     });
 
-    const {organization: org, router} = initializeOrg({
-      router: {
-        location: {query: {project: project.id}},
-      },
+    const {organization: org} = initializeOrg({
       projects: [project],
     });
 
@@ -147,8 +144,13 @@ describe('Exception Content', () => {
       />,
       {
         organization: org,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${org.slug}/issues/`,
+            query: {project: project.id},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 
@@ -214,7 +216,13 @@ describe('Exception Content', () => {
         newestFirst
       />,
       {
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       }
     );
 
@@ -285,7 +293,15 @@ describe('Exception Content', () => {
         projectSlug={project.slug}
         newestFirst
       />,
-      {deprecatedRouterMocks: true}
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
+      }
     );
 
     expect(screen.getByRole('heading', {name: 'ValueError'})).toBeInTheDocument();
@@ -331,7 +347,13 @@ describe('Exception Content', () => {
 
     it('displays exception group tree under first exception', () => {
       render(<Content {...defaultProps} />, {
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       });
 
       expect(
@@ -349,7 +371,13 @@ describe('Exception Content', () => {
 
     it('displays exception group tree in first frame when there is no other context', () => {
       render(<Content {...defaultProps} />, {
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       });
 
       const exceptions = screen.getAllByTestId('exception-value');
@@ -362,7 +390,13 @@ describe('Exception Content', () => {
 
     it('hides sub-groups by default', async () => {
       render(<Content {...defaultProps} />, {
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       });
 
       // There are 4 values, but 1 should be hidden
@@ -388,7 +422,13 @@ describe('Exception Content', () => {
 
     it('auto-opens sub-groups when clicking link in tree', async () => {
       render(<Content {...defaultProps} />, {
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       });
 
       expect(screen.queryByRole('heading', {name: 'ValueError'})).not.toBeInTheDocument();
@@ -439,7 +479,13 @@ describe('Exception Content', () => {
 
     it('only expands the first 3 exceptions by default', () => {
       render(<Content {...defaultProps} />, {
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       });
 
       // both toggle headings are visible because they are not exception group chained exceptions
@@ -458,7 +504,13 @@ describe('Exception Content', () => {
 
     it('can expand and collapse all exceptions', async () => {
       render(<Content {...defaultProps} />, {
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/',
+        },
       });
 
       const collapseButtons = screen.getAllByRole('button', {name: 'Collapse Section'});
@@ -540,7 +592,13 @@ describe('Exception Content', () => {
         </LineCoverageProvider>,
         {
           organization: orgWithCodecov,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: {
+            location: {
+              pathname: `/organizations/${orgWithCodecov.slug}/issues/`,
+              query: {},
+            },
+            route: '/organizations/:orgId/issues/',
+          },
         }
       );
 

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -115,10 +115,7 @@ describe('Frame Variables', () => {
           other: '<Class at 0x12345>',
         }}
         platform="python"
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     expect(


### PR DESCRIPTION
Bulk pr for the remaining tests in the events directory. Instead of mock routers, we're now using a full featured memory router.

One test needed a few useRouter mocks to match a specific router setup
