### PR TITLE
test(settings): Remove deprecated router mocks settings

### DIFF
--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
@@ -1,6 +1,5 @@
 import {AuthenticatorsFixture} from 'sentry-fixture/authenticators';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {setWindowLocation} from 'sentry-test/utils';
@@ -33,10 +32,6 @@ describe('AccountSecurityEnroll', () => {
       ],
     });
 
-    const router = RouterFixture({
-      params: {authId: authenticator.authId},
-    });
-
     beforeEach(() => {
       setWindowLocation('https://example.test');
       window.__initialData = {
@@ -58,8 +53,12 @@ describe('AccountSecurityEnroll', () => {
 
     it('does not have enrolled circle indicator', async () => {
       render(<AccountSecurityEnroll />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/account/security/mfa/${authenticator.authId}/enroll/`,
+          },
+          route: '/settings/account/security/mfa/:authId/enroll/',
+        },
       });
 
       await waitFor(() => {
@@ -71,8 +70,12 @@ describe('AccountSecurityEnroll', () => {
 
     it('has qrcode component', async () => {
       render(<AccountSecurityEnroll />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/account/security/mfa/${authenticator.authId}/enroll/`,
+          },
+          route: '/settings/account/security/mfa/:authId/enroll/',
+        },
       });
 
       await waitFor(() => {
@@ -101,8 +104,12 @@ describe('AccountSecurityEnroll', () => {
       });
 
       render(<AccountSecurityEnroll />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/account/security/mfa/${authenticator.authId}/enroll/`,
+          },
+          route: '/settings/account/security/mfa/:authId/enroll/',
+        },
       });
 
       await waitFor(() => {
@@ -148,8 +155,12 @@ describe('AccountSecurityEnroll', () => {
       });
 
       render(<AccountSecurityEnroll />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/account/security/mfa/${authenticator.authId}/enroll/`,
+          },
+          route: '/settings/account/security/mfa/:authId/enroll/',
+        },
       });
 
       await waitFor(() => {
@@ -184,21 +195,17 @@ describe('AccountSecurityEnroll', () => {
         statusCode: 400,
       });
 
-      const routerWithMock = RouterFixture({
-        params: {authId: authenticator.authId},
-      });
-
-      render(<AccountSecurityEnroll />, {
-        router: routerWithMock,
-        deprecatedRouterMocks: true,
+      const {router} = render(<AccountSecurityEnroll />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/account/security/mfa/${authenticator.authId}/enroll/`,
+          },
+          route: '/settings/account/security/mfa/:authId/enroll/',
+        },
       });
 
       await waitFor(() => {
-        expect(routerWithMock.push).toHaveBeenCalledWith(
-          expect.objectContaining({
-            pathname: '/settings/account/security/',
-          })
-        );
+        expect(router.location.pathname).toBe('/settings/account/security/');
       });
     });
   });

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.tsx
@@ -1,5 +1,4 @@
 import {DeprecatedApiKeyFixture} from 'sentry-fixture/deprecatedApiKey';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -7,11 +6,6 @@ import OrganizationApiKeyDetails from 'sentry/views/settings/organizationApiKeys
 
 describe('OrganizationApiKeyDetails', () => {
   const apiKey = DeprecatedApiKeyFixture();
-  const router = RouterFixture({
-    params: {
-      apiKey: apiKey.id,
-    },
-  });
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -23,8 +17,12 @@ describe('OrganizationApiKeyDetails', () => {
 
   it('renders', async () => {
     render(<OrganizationApiKeyDetails />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/org-slug/api-keys/${apiKey.id}/`,
+        },
+        route: '/settings/:orgId/api-keys/:apiKey/',
+      },
     });
 
     expect(await screen.findByRole('textbox', {name: 'API Key'})).toBeInTheDocument();

--- a/static/app/views/settings/organizationDeveloperSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.spec.tsx
@@ -1,9 +1,6 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -16,7 +13,7 @@ import {
 import OrganizationDeveloperSettings from 'sentry/views/settings/organizationDeveloperSettings/index';
 
 describe('Organization Developer Settings', () => {
-  const {organization: org} = initializeOrg();
+  const org = OrganizationFixture();
   const sentryApp = SentryAppFixture({
     scopes: [
       'team:read',
@@ -39,7 +36,7 @@ describe('Organization Developer Settings', () => {
         body: [],
       });
       render(<OrganizationDeveloperSettings />, {
-        deprecatedRouterMocks: true,
+        organization: org,
       });
       await waitFor(() => {
         expect(
@@ -78,7 +75,7 @@ describe('Organization Developer Settings', () => {
 
     it('internal integrations list is empty', async () => {
       render(<OrganizationDeveloperSettings />, {
-        deprecatedRouterMocks: true,
+        organization: org,
       });
       expect(
         await screen.findByText('No internal integrations have been created yet.')
@@ -86,12 +83,15 @@ describe('Organization Developer Settings', () => {
     });
 
     it('public integrations list contains 1 item', async () => {
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
       render(<OrganizationDeveloperSettings />, {
-        router,
-        deprecatedRouterMocks: true,
+        organization: org,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${org.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
       expect(await screen.findByText('Sample App')).toBeInTheDocument();
       expect(screen.getByText('unpublished')).toBeInTheDocument();
@@ -103,12 +103,15 @@ describe('Organization Developer Settings', () => {
         method: 'DELETE',
         body: [],
       });
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
       render(<OrganizationDeveloperSettings />, {
-        router,
-        deprecatedRouterMocks: true,
+        organization: org,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${org.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
 
       const deleteButton = await screen.findByRole('button', {name: 'Delete'});
@@ -133,13 +136,16 @@ describe('Organization Developer Settings', () => {
         url: `/sentry-apps/${sentryApp.slug}/publish-request/`,
         method: 'POST',
       });
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
 
       render(<OrganizationDeveloperSettings />, {
-        router,
-        deprecatedRouterMocks: true,
+        organization: org,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${org.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
 
       const publishButton = await screen.findByRole('button', {name: 'Publish'});
@@ -242,35 +248,44 @@ describe('Organization Developer Settings', () => {
       });
     });
     it('shows the published status', async () => {
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
       render(<OrganizationDeveloperSettings />, {
-        router,
-        deprecatedRouterMocks: true,
+        organization: org,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${org.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
       expect(await screen.findByText('published')).toBeInTheDocument();
     });
 
     it('trash button is disabled', async () => {
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
       render(<OrganizationDeveloperSettings />, {
-        router,
-        deprecatedRouterMocks: true,
+        organization: org,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${org.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
       const deleteButton = await screen.findByRole('button', {name: 'Delete'});
       expect(deleteButton).toBeDisabled();
     });
 
     it('publish button is disabled', async () => {
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
       render(<OrganizationDeveloperSettings />, {
-        router,
-        deprecatedRouterMocks: true,
+        organization: org,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${org.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
       const publishButton = await screen.findByRole('button', {name: 'Publish'});
       expect(publishButton).toBeDisabled();
@@ -289,7 +304,7 @@ describe('Organization Developer Settings', () => {
 
     it('allows deleting', async () => {
       render(<OrganizationDeveloperSettings />, {
-        deprecatedRouterMocks: true,
+        organization: org,
       });
       const deleteButton = await screen.findByRole('button', {name: 'Delete'});
       expect(deleteButton).toBeEnabled();
@@ -297,7 +312,7 @@ describe('Organization Developer Settings', () => {
 
     it('publish button does not exist', () => {
       render(<OrganizationDeveloperSettings />, {
-        deprecatedRouterMocks: true,
+        organization: org,
       });
       expect(screen.queryByText('Publish')).not.toBeInTheDocument();
     });
@@ -312,26 +327,30 @@ describe('Organization Developer Settings', () => {
       });
     });
     it('trash button is disabled', async () => {
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
       render(<OrganizationDeveloperSettings />, {
-        router,
         organization: newOrg,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${newOrg.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
       const deleteButton = await screen.findByRole('button', {name: 'Delete'});
       expect(deleteButton).toBeDisabled();
     });
 
     it('publish button is disabled', async () => {
-      const router = RouterFixture({
-        location: LocationFixture({query: {type: 'public'}}),
-      });
       render(<OrganizationDeveloperSettings />, {
         organization: newOrg,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${newOrg.slug}/developer-settings/`,
+            query: {type: 'public'},
+          },
+          route: '/settings/:orgId/developer-settings/',
+        },
       });
       const publishButton = await screen.findByRole('button', {name: 'Publish'});
       expect(publishButton).toBeDisabled();

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
@@ -1,4 +1,3 @@
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {SentryAppWebhookRequestFixture} from 'sentry-fixture/sentryAppWebhookRequest';
 
@@ -72,20 +71,26 @@ describe('Sentry Application Dashboard', () => {
     });
 
     it('shows the total install/uninstall stats', async () => {
-      const router = RouterFixture({params: {appSlug: sentryApp.slug}});
       render(<SentryApplicationDashboard />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/org-slug/developer-settings/${sentryApp.slug}/dashboard/`,
+          },
+          route: '/settings/:orgId/developer-settings/:appSlug/dashboard/',
+        },
       });
       expect(await screen.findByTestId('installs')).toHaveTextContent('Total installs5');
       expect(screen.getByTestId('uninstalls')).toHaveTextContent('Total uninstalls2');
     });
 
     it('shows the request log', async () => {
-      const router = RouterFixture({params: {appSlug: sentryApp.slug}});
       render(<SentryApplicationDashboard />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/org-slug/developer-settings/${sentryApp.slug}/dashboard/`,
+          },
+          route: '/settings/:orgId/developer-settings/:appSlug/dashboard/',
+        },
       });
       // The mock response has 1 request
       expect(await screen.findByTestId('request-item')).toBeInTheDocument();
@@ -103,10 +108,13 @@ describe('Sentry Application Dashboard', () => {
         body: [],
       });
 
-      const router = RouterFixture({params: {appSlug: sentryApp.slug}});
       render(<SentryApplicationDashboard />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/org-slug/developer-settings/${sentryApp.slug}/dashboard/`,
+          },
+          route: '/settings/:orgId/developer-settings/:appSlug/dashboard/',
+        },
       });
 
       expect(
@@ -115,10 +123,13 @@ describe('Sentry Application Dashboard', () => {
     });
 
     it('shows integration and interactions chart', async () => {
-      const router = RouterFixture({params: {appSlug: sentryApp.slug}});
       render(<SentryApplicationDashboard />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/org-slug/developer-settings/${sentryApp.slug}/dashboard/`,
+          },
+          route: '/settings/:orgId/developer-settings/:appSlug/dashboard/',
+        },
       });
 
       expect(await screen.findAllByTestId('chart')).toHaveLength(3);
@@ -167,10 +178,13 @@ describe('Sentry Application Dashboard', () => {
     });
 
     it('shows the request log', async () => {
-      const router = RouterFixture({params: {appSlug: sentryApp.slug}});
       render(<SentryApplicationDashboard />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/org-slug/developer-settings/${sentryApp.slug}/dashboard/`,
+          },
+          route: '/settings/:orgId/developer-settings/:appSlug/dashboard/',
+        },
       });
       expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
       // The mock response has 1 request
@@ -191,10 +205,13 @@ describe('Sentry Application Dashboard', () => {
         body: [],
       });
 
-      const router = RouterFixture({params: {appSlug: sentryApp.slug}});
       render(<SentryApplicationDashboard />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/org-slug/developer-settings/${sentryApp.slug}/dashboard/`,
+          },
+          route: '/settings/:orgId/developer-settings/:appSlug/dashboard/',
+        },
       });
       expect(
         await screen.findByText('No requests found in the last 30 days.')
@@ -202,10 +219,13 @@ describe('Sentry Application Dashboard', () => {
     });
 
     it('shows the component interactions in a line chart', async () => {
-      const router = RouterFixture({params: {appSlug: sentryApp.slug}});
       render(<SentryApplicationDashboard />, {
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/org-slug/developer-settings/${sentryApp.slug}/dashboard/`,
+          },
+          route: '/settings/:orgId/developer-settings/:appSlug/dashboard/',
+        },
       });
 
       expect(await screen.findByTestId('chart')).toBeInTheDocument();

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -2,7 +2,6 @@ import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   act,
   render,
@@ -25,7 +24,7 @@ jest.mock('sentry/utils/analytics');
 
 describe('OrganizationGeneralSettings', () => {
   const ENDPOINT = '/organizations/org-slug/';
-  const {organization, router} = initializeOrg();
+  const organization = OrganizationFixture();
   let configState: Config;
 
   beforeEach(() => {
@@ -50,7 +49,7 @@ describe('OrganizationGeneralSettings', () => {
 
   it('can enable "early adopter"', async () => {
     render(<OrganizationGeneralSettings />, {
-      deprecatedRouterMocks: true,
+      organization,
     });
     const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
@@ -76,7 +75,6 @@ describe('OrganizationGeneralSettings', () => {
     });
     render(<OrganizationGeneralSettings />, {
       organization: organizationWithCodecovFeature,
-      deprecatedRouterMocks: true,
     });
     const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
@@ -100,9 +98,14 @@ describe('OrganizationGeneralSettings', () => {
   });
 
   it('changes org slug and redirects to new slug', async () => {
-    render(<OrganizationGeneralSettings />, {
-      router,
-      deprecatedRouterMocks: true,
+    const {router} = render(<OrganizationGeneralSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${organization.slug}/`,
+        },
+        route: '/settings/:orgId/',
+      },
     });
     const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
@@ -124,9 +127,7 @@ describe('OrganizationGeneralSettings', () => {
       );
     });
     await waitFor(() => {
-      expect(router.replace).toHaveBeenCalledWith(
-        expect.objectContaining({pathname: '/settings/new-slug/'})
-      );
+      expect(router.location.pathname).toBe('/settings/new-slug/');
     });
   });
 
@@ -142,7 +143,6 @@ describe('OrganizationGeneralSettings', () => {
 
     render(<OrganizationGeneralSettings />, {
       organization: org,
-      deprecatedRouterMocks: true,
     });
 
     const input = screen.getByRole('textbox', {name: /slug/i});
@@ -172,7 +172,6 @@ describe('OrganizationGeneralSettings', () => {
 
     render(<OrganizationGeneralSettings />, {
       organization: readOnlyOrg,
-      deprecatedRouterMocks: true,
     });
 
     const formElements = [
@@ -197,8 +196,6 @@ describe('OrganizationGeneralSettings', () => {
       organization: OrganizationFixture({
         access: ['org:write'],
       }),
-
-      deprecatedRouterMocks: true,
     });
 
     expect(
@@ -211,7 +208,6 @@ describe('OrganizationGeneralSettings', () => {
 
     render(<OrganizationGeneralSettings />, {
       organization: OrganizationFixture({access: ['org:admin']}),
-      deprecatedRouterMocks: true,
     });
     renderGlobalModal();
 

--- a/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
@@ -1,6 +1,5 @@
 import {DocIntegrationFixture} from 'sentry-fixture/docIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -9,9 +8,6 @@ import DocIntegrationDetailedView from 'sentry/views/settings/organizationIntegr
 describe('DocIntegrationDetailedView', () => {
   const organization = OrganizationFixture();
   const doc = DocIntegrationFixture();
-  const router = RouterFixture({
-    params: {orgId: organization.slug, integrationSlug: doc.slug},
-  });
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -24,8 +20,12 @@ describe('DocIntegrationDetailedView', () => {
     });
     render(<DocIntegrationDetailedView />, {
       organization,
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${organization.slug}/document-integrations/${doc.slug}`,
+        },
+        route: '/settings/:orgId/document-integrations/:integrationSlug',
+      },
     });
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();


### PR DESCRIPTION
Bulk pr for the remaining tests in the settings directory. Instead of mock routers, we're now using a full featured memory router
