### PR TITLE
fix(grouping): Use underscores in test hash values

### DIFF
--- a/tests/sentry/event_manager/grouping/test_group_creation_lock.py
+++ b/tests/sentry/event_manager/grouping/test_group_creation_lock.py
@@ -70,7 +70,7 @@ def test_group_creation_race(default_project, lock_disabled) -> None:
         with (
             patch(
                 "sentry.grouping.ingest.hashing._calculate_event_grouping",
-                return_value=(["pound sign", "octothorpe"], {}),
+                return_value=(["pound_sign", "octothorpe"], {}),
             ),
             patch(
                 "sentry.event_manager._get_group_processing_kwargs",

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -170,7 +170,7 @@ def _assert_and_snapshot_results(
 class GroupHashMetadataTest(TestCase):
     def test_check_grouphashes_for_positive_fingerprint_match(self) -> None:
         grouphash1 = GroupHash.objects.create(hash="dogs", project_id=self.project.id)
-        grouphash2 = GroupHash.objects.create(hash="are great", project_id=self.project.id)
+        grouphash2 = GroupHash.objects.create(hash="are_great", project_id=self.project.id)
 
         for fingerprint1, fingerprint2, expected_result in [
             # All combos of default, hybrid (matching or not), custom (matching or not), and missing

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -451,7 +451,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         The seer API can return hashes which don't have a group id attached.
         Test that these groups are not returned.
         """
-        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        existing_grouphash = GroupHash.objects.create(hash="dogs_are_great", project=self.project)
         assert existing_grouphash.group_id is None
 
         # Create metadata for the grouphash so it has a creation date
@@ -460,7 +460,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
-                    "parent_hash": "dogs are great",
+                    "parent_hash": "dogs_are_great",
                     "should_group": True,
                     "stacktrace_distance": 0.01,
                 },
@@ -487,7 +487,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "get_similarity_data_from_seer.parent_hash_missing_group",
             extra={
                 "hash": self.event.get_primary_hash(),
-                "parent_hash": "dogs are great",
+                "parent_hash": "dogs_are_great",
                 "parent_gh_age_in_sec": mock.ANY,  # See below
                 "project_id": self.project.id,
                 "event_id": self.event.event_id,

--- a/tests/sentry/models/test_grouphash.py
+++ b/tests/sentry/models/test_grouphash.py
@@ -21,7 +21,7 @@ class GetAssociatedFingerprintTest(TestCase):
             "client_fingerprint": json.dumps(raw_fingerprint),
         }
 
-        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        grouphash = GroupHash.objects.create(hash="yay_dogs", project_id=self.project.id)
         GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
 
         assert grouphash.get_associated_fingerprint() == resolved_fingerprint
@@ -43,7 +43,7 @@ class GetAssociatedFingerprintTest(TestCase):
             "client_fingerprint": json.dumps(raw_fingerprint),
         }
 
-        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        grouphash = GroupHash.objects.create(hash="yay_dogs", project_id=self.project.id)
         GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
 
         assert grouphash.get_associated_fingerprint() == resolved_fingerprint
@@ -63,19 +63,19 @@ class GetAssociatedFingerprintTest(TestCase):
             "client_fingerprint": str(raw_fingerprint),
         }
 
-        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        grouphash = GroupHash.objects.create(hash="yay_dogs", project_id=self.project.id)
         GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
 
         assert grouphash.get_associated_fingerprint() is None
 
     def test_no_metadata(self) -> None:
-        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        grouphash = GroupHash.objects.create(hash="yay_dogs", project_id=self.project.id)
 
         assert grouphash.metadata is None
         assert grouphash.get_associated_fingerprint() is None
 
     def test_no_hashing_metadata(self) -> None:
-        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        grouphash = GroupHash.objects.create(hash="yay_dogs", project_id=self.project.id)
         GroupHashMetadata.objects.create(grouphash=grouphash)
 
         assert grouphash.metadata and grouphash.metadata.hashing_metadata is None
@@ -88,7 +88,7 @@ class GetAssociatedFingerprintTest(TestCase):
             "num_stacktraces": 1,
         }
 
-        grouphash = GroupHash.objects.create(hash="yay dogs", project_id=self.project.id)
+        grouphash = GroupHash.objects.create(hash="yay_dogs", project_id=self.project.id)
         GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
 
         assert grouphash.get_associated_fingerprint() is None

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -107,7 +107,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_metrics_incr: MagicMock,
         mock_record_circuit_breaker_error: MagicMock,
     ):
-        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        existing_grouphash = GroupHash.objects.create(hash="dogs_are_great", project=self.project)
         assert existing_grouphash.group_id is None
 
         cases: list[tuple[Any, str]] = [
@@ -144,7 +144,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                         {
                             # hash value matches the `GroupHash` created above, but that `GroupHash`
                             # has no associated group
-                            "parent_hash": "dogs are great",
+                            "parent_hash": "dogs_are_great",
                             "should_group": True,
                             "stacktrace_distance": 0.01,
                         }
@@ -329,7 +329,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_seer_similarity_request: MagicMock,
         mock_seer_deletion_request: MagicMock,
     ):
-        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        existing_grouphash = GroupHash.objects.create(hash="dogs_are_great", project=self.project)
         assert existing_grouphash.group_id is None
 
         # Set the grouphash creation date to yesterday
@@ -341,7 +341,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             {
                 "responses": [
                     {
-                        "parent_hash": "dogs are great",
+                        "parent_hash": "dogs_are_great",
                         "should_group": True,
                         "stacktrace_distance": 0.01,
                     }
@@ -352,12 +352,12 @@ class GetSimilarityDataFromSeerTest(TestCase):
         get_similarity_data_from_seer(self.request_params)
 
         assert mock_seer_deletion_request.delay.call_count == 1
-        mock_seer_deletion_request.delay.assert_called_with(self.project.id, ["dogs are great"])
+        mock_seer_deletion_request.delay.assert_called_with(self.project.id, ["dogs_are_great"])
 
         # Now do it all over again, but with a hash that's just been created
 
         newly_created_grouphash = GroupHash.objects.create(
-            hash="adopt, don't shop", project=self.project
+            hash="adopt_dont_shop", project=self.project
         )
         assert newly_created_grouphash.group_id is None
 
@@ -370,7 +370,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             {
                 "responses": [
                     {
-                        "parent_hash": "adopt, don't shop",
+                        "parent_hash": "adopt_dont_shop",
                         "should_group": True,
                         "stacktrace_distance": 0.01,
                     }
@@ -418,19 +418,19 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_grouphash_objects_filter: MagicMock,
     ):
         existing_grouphash_no_group = GroupHash.objects.create(
-            hash="dogs are great", project=self.project
+            hash="dogs_are_great", project=self.project
         )
         GroupHashMetadata.objects.create(grouphash=existing_grouphash_no_group)
         assert existing_grouphash_no_group.group_id is None
         existing_grouphash_with_group = GroupHash.objects.create(
-            hash="adopt, don't shop", project=self.project, group=self.group
+            hash="adopt_dont_shop", project=self.project, group=self.group
         )
 
         mock_seer_similarity_request.return_value = self._make_response(
             {
                 "responses": [
                     {
-                        "parent_hash": "dogs are great",
+                        "parent_hash": "dogs_are_great",
                         "should_group": True,
                         "stacktrace_distance": 0.01,
                     }
@@ -459,7 +459,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         assert results == [
             SeerSimilarIssueData(
                 parent_group_id=self.group.id,
-                parent_hash="dogs are great",
+                parent_hash="dogs_are_great",
                 should_group=True,
                 stacktrace_distance=0.01,
             )
@@ -471,9 +471,8 @@ class GetSimilarityDataFromSeerTest(TestCase):
         self,
         mock_seer_similarity_request: MagicMock,
         mock_logger: MagicMock,
-        # mock_grouphash_objects_filter: MagicMock,
     ):
-        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        existing_grouphash = GroupHash.objects.create(hash="dogs_are_great", project=self.project)
         GroupHashMetadata.objects.create(grouphash=existing_grouphash)
         assert existing_grouphash.group_id is None
 
@@ -481,7 +480,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             {
                 "responses": [
                     {
-                        "parent_hash": "dogs are great",
+                        "parent_hash": "dogs_are_great",
                         "should_group": True,
                         "stacktrace_distance": 0.01,
                     }

--- a/tests/sentry/seer/similarity/test_types.py
+++ b/tests/sentry/seer/similarity/test_types.py
@@ -95,12 +95,12 @@ class SeerSimilarIssueDataTest(TestCase):
             SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)
 
     def test_from_raw_grouphash_with_no_group(self) -> None:
-        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        existing_grouphash = GroupHash.objects.create(hash="dogs_are_great", project=self.project)
         assert existing_grouphash.group_id is None
 
         with pytest.raises(SimilarHashMissingGroupError):
             raw_similar_issue_data = {
-                "parent_hash": "dogs are great",
+                "parent_hash": "dogs_are_great",
                 "should_group": True,
                 "stacktrace_distance": 0.01,
             }


### PR DESCRIPTION
This changes a number of our tests to remove the spaces from test hash values. Until now it hasn't been an issue, but we'll soon be using hash values in cache keys, a context in which spaces aren't allowed. (In prod there never are spaces, so we only need to worry about tests.)