### PR TITLE
fix(types): Fix return type of `update_with_returning`

### DIFF
--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -31,7 +31,9 @@ class BaseQuerySet(QuerySet[M, R]):
         qs._with_post_update_signal = self._with_post_update_signal
         return qs
 
-    def update_with_returning(self, returned_fields: list[str], **kwargs: Any) -> list[tuple[int]]:
+    def update_with_returning(
+        self, returned_fields: list[str], **kwargs: Any
+    ) -> list[tuple[Any, ...]]:
         """
         Copied and modified from `Queryset.update()` to support `RETURNING <returned_fields>`
         """


### PR DESCRIPTION
We have a custom queryset method called `update_with_returning`, modeled after the built-in Django queryset `update` method, which adds the ability to pull data from the updated rows. Though we're currently only using it to pull data from an a single integer column, there's nothing to say that's the only kind of data we _could_ return (and in fact, we're about to use it to return data from multiple, non-int columns). This therefore fixes the return type to be `Any` n-tuples rather than `int` 1-tuples.