### PR TITLE
fix(explorer): fix copy and add nav for log/metric by trace tools

### DIFF
--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -181,8 +181,8 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
     const traceId = args.trace_id || '';
     const shortTraceId = traceId.slice(0, 8);
     return isLoading
-      ? `Double-clicking on metric '${metricName}' from trace ${shortTraceId}...`
-      : `Double-clicked on metric '${metricName}' from trace ${shortTraceId}`;
+      ? `Double-clicking on metric '${metricName}' in trace ${shortTraceId}...`
+      : `Double-clicked on metric '${metricName}' in trace ${shortTraceId}`;
   },
 
   get_log_attributes: (args, isLoading) => {
@@ -190,8 +190,8 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
     const traceId = args.trace_id || '';
     const shortTraceId = traceId.slice(0, 8);
     return isLoading
-      ? `Examining logs matching '*${message.slice(0, 20)}*' from trace ${shortTraceId}...`
-      : `Examined logs matching '*${message.slice(0, 20)}*' from trace ${shortTraceId}`;
+      ? `Examining logs matching '*${message.slice(0, 20)}*' in trace ${shortTraceId}...`
+      : `Examined logs matching '*${message.slice(0, 20)}*' in trace ${shortTraceId}`;
   },
 };
 

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -521,7 +521,7 @@ export function buildToolLinkUrl(
 
       // TODO: Currently no way to pass substring filter to this page, update with params.log_message_substring when it's supported.
       return {
-        pathname: `/explore/logs/trace/${trace_id}/`,
+        pathname: `/organizations/${orgSlug}/explore/logs/trace/${trace_id}/`,
         query: {tab: 'logs'},
       };
     }
@@ -533,7 +533,7 @@ export function buildToolLinkUrl(
 
       // TODO: Currently no way to pass name filter to this page, update with params.metric_name when it's supported.
       return {
-        pathname: `/explore/metrics/trace/${trace_id}/`,
+        pathname: `/organizations/${orgSlug}/explore/metrics/trace/${trace_id}/`,
         query: {tab: 'metrics'},
       };
     }

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -186,12 +186,12 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
   },
 
   get_log_attributes: (args, isLoading) => {
-    const logMessage = args.log_message || '';
+    const message = args.log_message_substring || '';
     const traceId = args.trace_id || '';
     const shortTraceId = traceId.slice(0, 8);
     return isLoading
-      ? `Examining logs matching '*${logMessage.slice(0, 20)}*' from trace ${shortTraceId}...`
-      : `Examined logs matching '*${logMessage.slice(0, 20)}*' from trace ${shortTraceId}`;
+      ? `Examining logs matching '*${message.slice(0, 20)}*' from trace ${shortTraceId}...`
+      : `Examined logs matching '*${message.slice(0, 20)}*' from trace ${shortTraceId}`;
   },
 };
 
@@ -511,6 +511,28 @@ export function buildToolLinkUrl(
       return {
         pathname: `/organizations/${orgSlug}/explore/profiling/profile/${project.slug}/${profile_id}/flamegraph/`,
         ...(thread_id && {query: {tid: thread_id}}),
+      };
+    }
+    case 'get_log_attributes': {
+      const {trace_id} = toolLink.params;
+      if (!trace_id) {
+        return null;
+      }
+
+      // TODO: Currently no way to pass substring filter to this page, update with params.log_message_substring when it's supported.
+      return {
+        pathname: `/explore/logs/trace/${trace_id}/?tab=logs`,
+      };
+    }
+    case 'get_metric_attributes': {
+      const {trace_id} = toolLink.params;
+      if (!trace_id) {
+        return null;
+      }
+
+      // TODO: Currently no way to pass name filter to this page, update with params.metric_name when it's supported.
+      return {
+        pathname: `/explore/metrics/trace/${trace_id}/?tab=metrics`,
       };
     }
     default:

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -521,7 +521,8 @@ export function buildToolLinkUrl(
 
       // TODO: Currently no way to pass substring filter to this page, update with params.log_message_substring when it's supported.
       return {
-        pathname: `/explore/logs/trace/${trace_id}/?tab=logs`,
+        pathname: `/explore/logs/trace/${trace_id}/`,
+        query: {tab: 'logs'},
       };
     }
     case 'get_metric_attributes': {
@@ -532,7 +533,8 @@ export function buildToolLinkUrl(
 
       // TODO: Currently no way to pass name filter to this page, update with params.metric_name when it's supported.
       return {
-        pathname: `/explore/metrics/trace/${trace_id}/?tab=metrics`,
+        pathname: `/explore/metrics/trace/${trace_id}/`,
+        query: {tab: 'metrics'},
       };
     }
     default:


### PR DESCRIPTION
fixes log copy (currently using the wrong arg) and closes [AIML-1645: Add nav links for metric and log attr tools](https://linear.app/getsentry/issue/AIML-1645/add-nav-links-for-metric-and-log-attr-tools)

requires https://github.com/getsentry/seer/pull/4152