### PR TITLE
chore(deletions): Improve cleanup multiprocess worker logging

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -28,6 +28,7 @@ TRANSACTION_PREFIX = "cleanup"
 DELETES_BY_PROJECT_CHUNK_SIZE = 100
 
 if TYPE_CHECKING:
+    from sentry.db.deletion import BulkDeleteQuery
     from sentry.db.models.base import BaseModel
 
     # TypeVar for concrete subclasses of BaseModel
@@ -70,7 +71,7 @@ def get_organization(value: str) -> int | None:
 # and child proc
 _STOP_WORKER: Final = "91650ec271ae4b3e8a67cdc909d80f8c"
 _WorkQueue: TypeAlias = (
-    "Queue[Literal['91650ec271ae4b3e8a67cdc909d80f8c'] | tuple[str, tuple[int, ...]]]"
+    "Queue[Literal['91650ec271ae4b3e8a67cdc909d80f8c'] | tuple[str, tuple[int, ...], int | None]]"
 )
 
 API_TOKEN_TTL_IN_DAYS = 30
@@ -80,6 +81,16 @@ def debug_output(msg: str) -> None:
     if os.environ.get("SENTRY_CLEANUP_SILENT", None):
         return
     click.echo(msg)
+
+
+def _format_chunk_ids(chunk: tuple[int, ...]) -> str:
+    """Format chunk IDs for logging: show all if small, or first/last if large."""
+    if len(chunk) == 0:
+        return "[]"
+    elif len(chunk) <= 10:
+        return str(list(chunk))
+    else:
+        return f"[{chunk[0]}, ..., {chunk[-1]}] ({len(chunk)} total)"
 
 
 def multiprocess_worker(task_queue: _WorkQueue) -> None:
@@ -99,10 +110,15 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
         j = task_queue.get()
         if j == _STOP_WORKER:
             task_queue.task_done()
-
             return
 
-        model_name, chunk = j
+        # Handle both old format (model_name, chunk) and new format (model_name, chunk, project_id)
+        if len(j) == 2:
+            model_name, chunk = j  # type: ignore[unreachable]
+            project_id = None
+        else:
+            model_name, chunk, project_id = j
+
         if options.get("cleanup.abort_execution"):
             logger.warning("Cleanup worker aborting due to cleanup.abort_execution flag")
             task_queue.task_done()
@@ -112,7 +128,7 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             with sentry_sdk.start_transaction(
                 op="cleanup", name=f"{TRANSACTION_PREFIX}.multiprocess_worker"
             ):
-                task_execution(model_name, chunk)
+                task_execution(model_name, chunk, project_id)
         except Exception:
             metrics.incr(
                 "cleanup.error",
@@ -120,15 +136,36 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
                 tags={"model": model_name, "type": "multiprocess_worker"},
                 sample_rate=1.0,
             )
+            ids_str = _format_chunk_ids(chunk)
             if os.environ.get("SENTRY_CLEANUP_SILENT", None):
-                capture_exception(tags={"model": model_name})
+                tags: dict[str, Any] = {
+                    "model": model_name,
+                    "chunk_size": len(chunk),
+                    "chunk_ids": ids_str,
+                }
+                if project_id is not None:
+                    tags["project_id"] = project_id
+                capture_exception(tags=tags)
             else:
-                logger.exception("Error processing chunk of %s objects", model_name)
+                logger.exception(
+                    "Error processing chunk of %s objects (IDs: %s project_id=%s)",
+                    model_name,
+                    ids_str,
+                    project_id,
+                )
         finally:
             task_queue.task_done()
 
 
-def task_execution(model_name: str, chunk: tuple[int, ...]) -> None:
+def task_execution(model_name: str, chunk: tuple[int, ...], project_id: int | None) -> None:
+    """
+    Execute deletion for a chunk of objects.
+
+    Logs:
+    - Start: how many objects are about to be processed
+    - Each iteration: progress through the deletion task
+    - End: completion summary
+    """
     from sentry import deletions, models, similarity
     from sentry.utils import metrics
     from sentry.utils.imports import import_string
@@ -144,6 +181,14 @@ def task_execution(model_name: str, chunk: tuple[int, ...]) -> None:
         similarity,
     ]
 
+    ids_str = _format_chunk_ids(chunk)
+    chunk_size = len(chunk)
+
+    # Log start of chunk processing
+    debug_output(
+        f"[START] Processing {chunk_size} {model_name} objects (IDs: {ids_str} project_id={project_id})"
+    )
+
     model = import_string(model_name)
     task = deletions.get(
         model=model,
@@ -152,11 +197,26 @@ def task_execution(model_name: str, chunk: tuple[int, ...]) -> None:
         transaction_id=uuid4().hex,
     )
 
+    # Track deletion iterations (task.chunk() may need multiple calls to fully delete)
+    iteration = 0
     while True:
-        debug_output(f"Processing chunk of {len(chunk)} {model_name} objects")
-        metrics.incr("cleanup.chunk_processed", tags={"model": model_name}, amount=len(chunk))
-        if not task.chunk(apply_filter=True):
+        iteration += 1
+        has_more = task.chunk(apply_filter=True)
+
+        debug_output(
+            f"[ITERATION {iteration}] {model_name} chunk (project_id={project_id} has_more={has_more})"
+        )
+
+        if not has_more:
             break
+
+    # Increment metric once per chunk, after all iterations complete
+    metrics.incr("cleanup.chunk_processed", tags={"model": model_name}, amount=chunk_size)
+
+    # Log completion
+    debug_output(
+        f"[COMPLETE] Finished {chunk_size} {model_name} objects in {iteration} iteration(s) (IDs: {ids_str} project_id={project_id})"
+    )
 
 
 @click.command()
@@ -671,6 +731,40 @@ def run_bulk_query_deletes(
                 )
 
 
+def _schedule_bulk_delete_chunks(
+    task_queue: _WorkQueue,
+    q: BulkDeleteQuery,  # Imported locally in functions that use it
+    model_tp: type[BaseModel],
+    project_id: int | None,
+    context_str: str = "",
+) -> tuple[int, int]:
+    """
+    Schedule chunks from a BulkDeleteQuery into the task queue.
+
+    Returns:
+        Tuple of (chunk_count, total_objects)
+    """
+    imp = ".".join((model_tp.__module__, model_tp.__name__))
+    chunk_count = 0
+    total_objects = 0
+
+    for chunk in q.iterator(chunk_size=DELETES_BY_PROJECT_CHUNK_SIZE):
+        task_queue.put((imp, chunk, project_id))
+        chunk_count += 1
+        total_objects += len(chunk)
+
+    if chunk_count > 0:
+        debug_output(
+            f"[SCHEDULED] {chunk_count} chunks ({total_objects} total {model_tp.__name__} objects project_id={project_id}{context_str})"
+        )
+    else:
+        debug_output(
+            f"[SCHEDULED] No {model_tp.__name__} objects found to delete (project_id={project_id}{context_str})"
+        )
+
+    return chunk_count, total_objects
+
+
 def run_bulk_deletes_in_deletes(
     task_queue: _WorkQueue,
     deletes: list[tuple[type[BaseModel], str, str]],
@@ -695,8 +789,6 @@ def run_bulk_deletes_in_deletes(
             debug_output(f"Removing {model_tp.__name__} for days={days} project={project or '*'}")
             models_attempted.add(model_tp.__name__.lower())
             try:
-                imp = ".".join((model_tp.__module__, model_tp.__name__))
-
                 q = BulkDeleteQuery(
                     model=model_tp,
                     dtfield=dtfield,
@@ -704,9 +796,7 @@ def run_bulk_deletes_in_deletes(
                     project_id=project_id,
                     order_by=order_by,
                 )
-
-                for chunk in q.iterator(chunk_size=100):
-                    task_queue.put((imp, chunk))
+                _schedule_bulk_delete_chunks(task_queue, q, model_tp, project_id)
 
             except Exception:
                 capture_exception(tags={"model": model_tp.__name__})
@@ -755,8 +845,6 @@ def run_bulk_deletes_by_project(
                 )
 
                 try:
-                    imp = ".".join((model_tp.__module__, model_tp.__name__))
-
                     q = BulkDeleteQuery(
                         model=model_tp,
                         dtfield=dtfield,
@@ -765,8 +853,7 @@ def run_bulk_deletes_by_project(
                         order_by=order_by,
                     )
 
-                    for chunk in q.iterator(chunk_size=DELETES_BY_PROJECT_CHUNK_SIZE):
-                        task_queue.put((imp, chunk))
+                    _schedule_bulk_delete_chunks(task_queue, q, model_tp, project_id_for_deletion)
                 except Exception:
                     capture_exception(
                         tags={"model": model_tp.__name__, "project_id": project_id_for_deletion}
@@ -813,7 +900,6 @@ def run_bulk_deletes_by_organization(
                     f"Removing {model_tp.__name__} for days={days} organization={organization_id_for_deletion}"
                 )
                 try:
-                    imp = ".".join((model_tp.__module__, model_tp.__name__))
                     q = BulkDeleteQuery(
                         model=model_tp,
                         dtfield=dtfield,
@@ -821,9 +907,13 @@ def run_bulk_deletes_by_organization(
                         organization_id=organization_id_for_deletion,
                         order_by=order_by,
                     )
-
-                    for chunk in q.iterator(chunk_size=100):
-                        task_queue.put((imp, chunk))
+                    _schedule_bulk_delete_chunks(
+                        task_queue,
+                        q,
+                        model_tp,
+                        None,
+                        context_str=f" organization_id={organization_id_for_deletion}",
+                    )
                 except Exception:
                     capture_exception(
                         tags={

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -20,11 +20,11 @@ class SynchronousTaskQueue:
 
     def __init__(self) -> None:
         # You can use this to inspect the calls to the queue.
-        self.put_calls: list[tuple[str, tuple[int, ...]]] = []
+        self.put_calls: list[tuple[str, tuple[int, ...], int | None]] = []
 
-    def put(self, item: tuple[str, tuple[int, ...]]) -> None:
+    def put(self, item: tuple[str, tuple[int, ...], int | None]) -> None:
         self.put_calls.append(item)
-        task_execution(item[0], item[1])
+        task_execution(item[0], item[1], item[2])
 
     def join(self) -> None:
         pass
@@ -133,6 +133,7 @@ class RunBulkQueryDeletesByProjectTest(TestCase):
     def test_run_bulk_query_deletes_by_project(self) -> None:
         """Test that the function runs bulk query deletes by project as expected."""
         days = 30
+        project = self.project  # Get the default project for verification
         # Creating the groups in out of order to test that the chunks are created in the correct order.
         self.create_group(last_seen=before_now(days=days + 4))
         self.create_group()
@@ -166,8 +167,57 @@ class RunBulkQueryDeletesByProjectTest(TestCase):
         # Verify we deleted all expected groups (order may vary due to non-unique last_seen)
         all_deleted_ids: set[int] = set()
         for call in task_queue.put_calls:
-            assert call[0] == "sentry.models.group.Group"
-            all_deleted_ids.update(call[1])
+            model_name, chunk_ids, call_project_id = call
+            assert model_name == "sentry.models.group.Group"
+            assert call_project_id == project.id
+            all_deleted_ids.update(chunk_ids)
         assert all_deleted_ids == set(ids)
 
         assert Group.objects.all().count() == 1
+
+    def test_project_id_passed_to_task_queue(self) -> None:
+        """Test that the correct project_id is passed for each chunk."""
+        days = 30
+        # Create two projects with groups
+        project1 = self.create_project()
+        project2 = self.create_project()
+
+        # Create groups for project1 (old enough to delete)
+        self.create_group(project=project1, last_seen=before_now(days=days + 1))
+        self.create_group(project=project1, last_seen=before_now(days=days + 2))
+
+        # Create groups for project2 (old enough to delete)
+        self.create_group(project=project2, last_seen=before_now(days=days + 1))
+
+        # Create a group that should NOT be deleted (too recent)
+        self.create_group(project=project1)
+
+        with (
+            assume_test_silo_mode(SiloMode.REGION),
+            patch("sentry.runner.commands.cleanup.DELETES_BY_PROJECT_CHUNK_SIZE", 10),
+        ):
+            task_queue = SynchronousTaskQueue()
+
+            models_attempted: set[str] = set()
+            run_bulk_deletes_by_project(
+                task_queue=task_queue,  # type: ignore[arg-type]
+                project_id=None,
+                start_from_project_id=None,
+                is_filtered=lambda model: False,
+                days=days,
+                models_attempted=models_attempted,
+            )
+
+        # Collect project_ids from task queue calls for Group model
+        group_calls = [call for call in task_queue.put_calls if "Group" in call[0]]
+
+        # Verify each call has the correct project_id
+        project_ids_seen: set[int] = set()
+        for call in group_calls:
+            model_name, chunk_ids, call_project_id = call
+            assert call_project_id is not None
+            project_ids_seen.add(call_project_id)
+
+        # Should have seen both projects
+        assert project1.id in project_ids_seen
+        assert project2.id in project_ids_seen


### PR DESCRIPTION
During cleanup we schedule internal workers to handle chunks of deletions, these worker now have context of the project_id being worked and add it to logs, allowing us to track specific projects' group deletions.
Also corrected the reporting of `cleanup.chunk_processed` metric which seems to increase by the full chunk on every step, inflating the metric.