### PR TITLE
ref(grouping): Invalidate grouphash caches when data changes

### DIFF
--- a/src/sentry/grouping/ingest/caching.py
+++ b/src/sentry/grouping/ingest/caching.py
@@ -1,0 +1,9 @@
+# Note: These functions are in their own module to avoid circular imports.
+
+
+def get_grouphash_existence_cache_key(hash_value: str, project_id: int) -> str:
+    return f"secondary_grouphash_existence:{project_id}:{hash_value}"
+
+
+def get_grouphash_object_cache_key(hash_value: str, project_id: int) -> str:
+    return f"grouphash_with_assigned_group:{project_id}:{hash_value}"

--- a/src/sentry/grouping/ingest/caching.py
+++ b/src/sentry/grouping/ingest/caching.py
@@ -1,9 +1,53 @@
 # Note: These functions are in their own module to avoid circular imports.
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from django.core.cache import cache
+
+from sentry import options
+
+if TYPE_CHECKING:
+    from sentry.models.grouphash import GroupHash
+
+
 def get_grouphash_existence_cache_key(hash_value: str, project_id: int) -> str:
     return f"secondary_grouphash_existence:{project_id}:{hash_value}"
 
 
 def get_grouphash_object_cache_key(hash_value: str, project_id: int) -> str:
     return f"grouphash_with_assigned_group:{project_id}:{hash_value}"
+
+
+def invalidate_grouphash_cache_on_save(instance: GroupHash, **kwargs: Any) -> None:
+    # TODO: `GroupHash.project` is nullable for some reason, even though it's never ever null. If we
+    # fix that, we can remove this check.
+    if not instance.project:
+        return
+
+    if not options.get("grouping.use_ingest_grouphash_caching"):
+        return
+
+    # `create` call - grouphash hasn't had a chance to be cached yet, so nothing to invalidate
+    if not instance.id:
+        return
+
+    cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
+    cache.delete(cache_key)
+
+
+def invalidate_grouphash_caches_on_delete(instance: GroupHash, **kwargs: Any) -> None:
+    # TODO: `GroupHash.project` is nullable for some reason, even though it's never ever null. If we
+    # fix that, we can remove this check.
+    if not instance.project:
+        return
+
+    if not options.get("grouping.use_ingest_grouphash_caching"):
+        return
+
+    object_cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
+    existence_cache_key = get_grouphash_existence_cache_key(instance.hash, instance.project.id)
+
+    cache.delete_many([object_cache_key, existence_cache_key])

--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from django.core.cache import cache
 from django.db import models
+from django.db.models.signals import pre_delete, pre_save
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from sentry import options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -14,12 +17,48 @@ from sentry.db.models import (
     region_silo_model,
 )
 from sentry.db.models.base import sane_repr
+from sentry.db.models.manager.base import BaseManager
+from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.grouping.ingest.caching import (
+    get_grouphash_object_cache_key,
+    invalidate_grouphash_cache_on_save,
+    invalidate_grouphash_caches_on_delete,
+)
 from sentry.types.grouphash_metadata import has_fingerprint_data
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
 if TYPE_CHECKING:
     from sentry.models.grouphashmetadata import GroupHashMetadata
+
+
+# Use a custom queryset class so we can invalidate the relevant cache entries when data is updated.
+# Note that we don't need to write custom methods for saving or deleting because those send built-in
+# Django signals we can listen for (see end of file). We also don't have to override the model's
+# `update` method because our base model class already does that, with a method that calls the
+# queryset's `update`.
+class GroupHashQuerySet(BaseQuerySet):
+    def update(self, **kwargs: Any) -> int:
+        if not options.get("grouping.use_ingest_grouphash_caching"):
+            return super().update(**kwargs)
+
+        cache_keys = [
+            get_grouphash_object_cache_key(hash_value, project_id)
+            for hash_value, project_id in (
+                self.update_with_returning(  # This is where the actual update occurs
+                    ["hash", "project_id"], **kwargs
+                )
+            )
+        ]
+
+        cache.delete_many(cache_keys)
+
+        return len(cache_keys)
+
+
+class GroupHashModelManager(BaseManager["GroupHash"]):
+    def get_queryset(self) -> GroupHashQuerySet:
+        return GroupHashQuerySet(self.model, using=self._db)
 
 
 @region_silo_model
@@ -40,6 +79,11 @@ class GroupHash(Model):
         choices=[(State.LOCKED_IN_MIGRATION, _("Locked (Migration in Progress)"))], null=True
     )
     date_added = models.DateTimeField(default=timezone.now, null=True)
+
+    # Custom manager in order to override the queryset `update` method, so that we can invalidate
+    # the grouphash cache used during ingest when `GroupHash.objects.update` is called (such as when
+    # we merge groups).
+    objects: ClassVar[GroupHashModelManager] = GroupHashModelManager()
 
     class Meta:
         app_label = "sentry"
@@ -78,3 +122,15 @@ class GroupHash(Model):
         # stringified ones can't be parsed and will cause this error
         except JSONDecodeError:
             return None
+
+
+# Calling `save` on the model uses the built-in method, which sends save signals. You can't call
+# `save` on queryset. This handler deletes the grouphash from the `GroupHash` object cache.
+pre_save.connect(invalidate_grouphash_cache_on_save, sender=GroupHash, weak=False)
+
+# Calling `delete` on the model or the queryset calls `Collector.delete` which sends delete signals
+# if you're acting on multiple rows and/or the model has dependencies (but not if not). Fortunately,
+# `GroupHashMetadata` depends on `GroupHash` so the latter doesn't qualify for fast deletes and the
+# signals are sent. This handler deletes the grouphash from both the `GroupHash` object cache and
+# the grouphash existence boolean cache.
+pre_delete.connect(invalidate_grouphash_caches_on_delete, sender=GroupHash, weak=False)

--- a/tests/sentry/models/test_grouphash.py
+++ b/tests/sentry/models/test_grouphash.py
@@ -1,6 +1,19 @@
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+
+from sentry import options
+from sentry.grouping.ingest.caching import (
+    get_grouphash_existence_cache_key,
+    get_grouphash_object_cache_key,
+    invalidate_grouphash_cache_on_save,
+    invalidate_grouphash_caches_on_delete,
+)
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.mocking import count_matching_calls
 from sentry.types.grouphash_metadata import (
     FingerprintHashingMetadata,
     SaltedStacktraceHashingMetadata,
@@ -92,3 +105,261 @@ class GetAssociatedFingerprintTest(TestCase):
         GroupHashMetadata.objects.create(grouphash=grouphash, hashing_metadata=hashing_metadata)
 
         assert grouphash.get_associated_fingerprint() is None
+
+
+class CacheInvalidationTest(TestCase):
+    """
+    Test that the caches we use for grouphashes during ingest (one for secondary grouphash existence
+    and one for the `GroupHash` objects themselves) are invalidated when their contents might become
+    stale.
+
+    For `delete` we test both caches, but for `update` we only need to test the latter cache, since
+    it doesn't change whether or not a grouphash exists. We also only need to test the latter cache
+    for `save` - not because you can't change existence with a `save` call, but because we only
+    track existence of secondary grouphashes, and we never create a secondary grouphash if it
+    doesn't already exist.
+    """
+
+    def test_removes_from_cache_on_queryset_update(self) -> None:
+        project = self.project
+        get_cache_key = get_grouphash_object_cache_key
+        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+
+        maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
+        charlie_key = get_cache_key(hash_value="charlie", project_id=project.id)
+        dogs_key = get_cache_key(hash_value="dogs_are_great", project_id=project.id)
+
+        group1 = self.create_group(project)
+        group2 = self.create_group(project)
+
+        grouphash1 = GroupHash.objects.create(project=project, group=group1, hash="maisey")
+        grouphash2 = GroupHash.objects.create(project=project, group=group1, hash="charlie")
+        grouphash3 = GroupHash.objects.create(project=project, group=group1, hash="dogs_are_great")
+
+        cache.set(maisey_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_key, grouphash3, cache_expiry_seconds)
+
+        assert maisey_key in cache
+        assert charlie_key in cache
+        assert dogs_key in cache
+
+        GroupHash.objects.filter(hash__in=["maisey", "charlie"]).update(group=group2)
+
+        # The updated grouphashes have been removed from the cache, but the one we didn't update is
+        # still there
+        assert maisey_key not in cache
+        assert charlie_key not in cache
+        assert dogs_key in cache
+
+    def test_removes_from_cache_on_model_update(self) -> None:
+        project = self.project
+        get_cache_key = get_grouphash_object_cache_key
+        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+
+        maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
+        charlie_key = get_cache_key(hash_value="charlie", project_id=project.id)
+        dogs_key = get_cache_key(hash_value="dogs_are_great", project_id=project.id)
+
+        group1 = self.create_group(project)
+        group2 = self.create_group(project)
+
+        grouphash1 = GroupHash.objects.create(project=project, group=group1, hash="maisey")
+        grouphash2 = GroupHash.objects.create(project=project, group=group1, hash="charlie")
+        grouphash3 = GroupHash.objects.create(project=project, group=group1, hash="dogs_are_great")
+
+        cache.set(maisey_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_key, grouphash3, cache_expiry_seconds)
+
+        assert maisey_key in cache
+        assert charlie_key in cache
+        assert dogs_key in cache
+
+        grouphash1.update(group=group2)
+        grouphash2.update(group=group2)
+
+        # The updated grouphashes have been removed from the cache, but the one we didn't update is
+        # still there
+        assert maisey_key not in cache
+        assert charlie_key not in cache
+        assert dogs_key in cache
+
+    def test_removes_from_cache_on_model_save(self) -> None:
+        project = self.project
+        get_cache_key = get_grouphash_object_cache_key
+        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+
+        maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
+        charlie_key = get_cache_key(hash_value="charlie", project_id=project.id)
+        dogs_key = get_cache_key(hash_value="dogs_are_great", project_id=project.id)
+
+        group1 = self.create_group(project)
+        group2 = self.create_group(project)
+
+        grouphash1 = GroupHash.objects.create(project=project, group=group1, hash="maisey")
+        grouphash2 = GroupHash.objects.create(project=project, group=group1, hash="charlie")
+        grouphash3 = GroupHash.objects.create(project=project, group=group1, hash="dogs_are_great")
+
+        cache.set(maisey_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_key, grouphash3, cache_expiry_seconds)
+
+        assert maisey_key in cache
+        assert charlie_key in cache
+        assert dogs_key in cache
+
+        grouphash1.group = group2
+        grouphash1.save()
+        grouphash2.group = group2
+        grouphash2.save()
+
+        # The grouphashes on which we called `save` have been removed from the cache, but the one we
+        # didn't update is still there
+        assert maisey_key not in cache
+        assert charlie_key not in cache
+        assert dogs_key in cache
+
+    def test_removes_from_cache_on_queryset_delete(self) -> None:
+        project = self.project
+        get_object_cache_key = get_grouphash_object_cache_key
+        get_existence_cache_key = get_grouphash_existence_cache_key
+        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+
+        maisey_object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
+        charlie_object_key = get_object_cache_key(hash_value="charlie", project_id=project.id)
+        dogs_object_key = get_object_cache_key(hash_value="dogs_are_great", project_id=project.id)
+        maisey_existence_key = get_existence_cache_key(hash_value="maisey", project_id=project.id)
+        charlie_existence_key = get_existence_cache_key(hash_value="charlie", project_id=project.id)
+        dogs_existence_key = get_existence_cache_key(
+            hash_value="dogs_are_great", project_id=project.id
+        )
+
+        group = self.create_group(project)
+
+        grouphash1 = GroupHash.objects.create(project=project, group=group, hash="maisey")
+        grouphash2 = GroupHash.objects.create(project=project, group=group, hash="charlie")
+        grouphash3 = GroupHash.objects.create(project=project, group=group, hash="dogs_are_great")
+
+        cache.set(maisey_object_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_object_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_object_key, grouphash3, cache_expiry_seconds)
+        cache.set(maisey_existence_key, True, cache_expiry_seconds)
+        cache.set(charlie_existence_key, True, cache_expiry_seconds)
+        cache.set(dogs_existence_key, True, cache_expiry_seconds)
+
+        assert maisey_object_key in cache
+        assert charlie_object_key in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key in cache
+        assert charlie_existence_key in cache
+        assert dogs_existence_key in cache
+
+        GroupHash.objects.filter(hash__in=["maisey", "charlie"]).delete()
+
+        # The deleted grouphashes have been removed from the cache, but the one we didn't delete is
+        # still there
+        assert maisey_object_key not in cache
+        assert charlie_object_key not in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key not in cache
+        assert charlie_existence_key not in cache
+        assert dogs_existence_key in cache
+
+    def test_removes_from_cache_on_model_delete(self) -> None:
+        project = self.project
+        get_object_cache_key = get_grouphash_object_cache_key
+        get_existence_cache_key = get_grouphash_existence_cache_key
+        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+
+        maisey_object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
+        charlie_object_key = get_object_cache_key(hash_value="charlie", project_id=project.id)
+        dogs_object_key = get_object_cache_key(hash_value="dogs_are_great", project_id=project.id)
+        maisey_existence_key = get_existence_cache_key(hash_value="maisey", project_id=project.id)
+        charlie_existence_key = get_existence_cache_key(hash_value="charlie", project_id=project.id)
+        dogs_existence_key = get_existence_cache_key(
+            hash_value="dogs_are_great", project_id=project.id
+        )
+
+        group = self.create_group(project)
+
+        grouphash1 = GroupHash.objects.create(project=project, group=group, hash="maisey")
+        grouphash2 = GroupHash.objects.create(project=project, group=group, hash="charlie")
+        grouphash3 = GroupHash.objects.create(project=project, group=group, hash="dogs_are_great")
+
+        cache.set(maisey_object_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_object_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_object_key, grouphash3, cache_expiry_seconds)
+        cache.set(maisey_existence_key, True, cache_expiry_seconds)
+        cache.set(charlie_existence_key, True, cache_expiry_seconds)
+        cache.set(dogs_existence_key, True, cache_expiry_seconds)
+
+        assert maisey_object_key in cache
+        assert charlie_object_key in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key in cache
+        assert charlie_existence_key in cache
+        assert dogs_existence_key in cache
+
+        grouphash1.delete()
+        grouphash2.delete()
+
+        # The deleted grouphashes have been removed from the cache, but the one we didn't delete is
+        # still there
+        assert maisey_object_key not in cache
+        assert charlie_object_key not in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key not in cache
+        assert charlie_existence_key not in cache
+        assert dogs_existence_key in cache
+
+    @patch("sentry.grouping.ingest.caching.cache.delete")
+    def test_no_ops_on_grouphash_creation(self, cache_delete_mock: MagicMock) -> None:
+        project = self.project
+        get_cache_key = get_grouphash_object_cache_key
+        maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
+
+        group1 = self.create_group(project)
+        group2 = self.create_group(project)
+
+        grouphash = GroupHash.objects.create(project=project, group=group1, hash="maisey")
+
+        # We listen to the `pre_save` signal, which gets triggered by both `create` and `save`
+        # calls, but there's only something to invalidate in the latter case, so we bail early
+        # during grouphash creation.
+        assert count_matching_calls(cache_delete_mock, maisey_key) == 0
+
+        grouphash.group = group2
+        grouphash.save()
+
+        assert count_matching_calls(cache_delete_mock, maisey_key) == 1
+
+    @patch("sentry.grouping.ingest.caching.cache.delete")
+    @patch("sentry.grouping.ingest.caching.cache.delete_many")
+    def test_no_ops_when_caching_is_disabled(
+        self, cache_delete_many_mock: MagicMock, cache_delete_mock: MagicMock
+    ) -> None:
+        project = self.project
+        get_object_cache_key = get_grouphash_object_cache_key
+        get_existence_cache_key = get_grouphash_existence_cache_key
+
+        object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
+        existence_key = get_existence_cache_key(hash_value="maisey", project_id=project.id)
+
+        group = self.create_group(project)
+
+        grouphash = GroupHash.objects.create(project=project, group=group, hash="maisey")
+
+        with override_options({"grouping.use_ingest_grouphash_caching": False}):
+            invalidate_grouphash_cache_on_save(grouphash)
+            invalidate_grouphash_caches_on_delete(grouphash)
+
+            assert count_matching_calls(cache_delete_mock, object_key) == 0
+            assert count_matching_calls(cache_delete_many_mock, [object_key, existence_key]) == 0
+
+        with override_options({"grouping.use_ingest_grouphash_caching": True}):
+            invalidate_grouphash_cache_on_save(grouphash)
+            invalidate_grouphash_caches_on_delete(grouphash)
+
+            assert count_matching_calls(cache_delete_mock, object_key) == 1
+            assert count_matching_calls(cache_delete_many_mock, [object_key, existence_key]) == 1


### PR DESCRIPTION
We are about to start caching both the existence of secondary grouphashes and `GroupHash` objects themselves, to relieve pressure on postgres during ingest. To prevent either kind of data from getting stale, we want to remove the requisite entries from the cache whenever a `GroupHash` object is saved, updated, or deleted.

This PR does that by adding signal handlers for the built-in `pre_save` and `pre_delete` signals, and adding a custom model manager to the `GroupHash` class in order to override the `update` method (since there is no built-in `pre_update` signal).