### PR TITLE
feat(explore): Wire up data fetching hooks for cross event queries

### DIFF
--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -249,6 +249,36 @@ describe('useFetchEventsTimeSeries', () => {
       })
     );
   });
+
+  it('supports cross-event querying', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: [],
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useFetchEventsTimeSeries(
+        DiscoverDatasets.SPANS,
+        {yAxis: 'epm()', logQuery: ['span.op:db*'], metricQuery: ['span.op:db*']},
+        REFERRER
+      )
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        method: 'GET',
+        query: expect.objectContaining({
+          logQuery: ['span.op:db*'],
+          metricQuery: ['span.op:db*'],
+        }),
+      })
+    );
+  });
 });
 
 const REFERRER = 'test-query';

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -6,6 +6,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {formatSearchStringForQueryParam} from 'sentry/utils/url/formatSearchStringForQueryParam';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
@@ -139,28 +140,13 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
     );
   }
 
-  let queryParam: string | undefined;
-  let logQueryParams: string[] | undefined;
-  let metricQueryParams: string[] | undefined;
-  let spanQueryParams: string[] | undefined;
-  if (query) {
-    queryParam = query instanceof MutableSearch ? query.formatString() : query;
-  }
-  if (Array.isArray(logQuery) && logQuery.length) {
-    logQueryParams = logQuery.map(q =>
-      q instanceof MutableSearch ? q.formatString() : q
-    );
-  }
-  if (Array.isArray(metricQuery) && metricQuery.length) {
-    metricQueryParams = metricQuery.map(q =>
-      q instanceof MutableSearch ? q.formatString() : q
-    );
-  }
-  if (Array.isArray(spanQuery) && spanQuery.length) {
-    spanQueryParams = spanQuery.map(q =>
-      q instanceof MutableSearch ? q.formatString() : q
-    );
-  }
+  const queryParam = formatSearchStringForQueryParam(query);
+  const logQueryParams =
+    logQuery?.map(formatSearchStringForQueryParam).filter(defined) ?? [];
+  const metricQueryParams =
+    metricQuery?.map(formatSearchStringForQueryParam).filter(defined) ?? [];
+  const spanQueryParams =
+    spanQuery?.map(formatSearchStringForQueryParam).filter(defined) ?? [];
 
   return useApiQuery<EventsTimeSeriesResponse>(
     [

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -50,13 +50,13 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   interval?: string;
   /**
-   * Query to apply to the log data set. Is an array of `MutableSearch.formatString()` strings.
+   * Query to apply in addition to the base `query` to the log data set, used for cross-event querying. Can be either an array of `MutableSearch` objects (preferred) or plain strings.
    */
-  logQuery?: string[];
+  logQuery?: Array<MutableSearch | string>;
   /**
-   * Query to apply to the metric data set. Is an array of `MutableSearch.formatString()` strings.
+   * Query to apply in addition to the base `query` to the metric data set, used for cross-event querying. Can be either an array of `MutableSearch` objects (preferred) or plain strings.
    */
-  metricQuery?: string[];
+  metricQuery?: Array<MutableSearch | string>;
   /**
    * Page filters to apply to the request. This applies the date selection, projects, and environments. By default uses the currently applied filters after waiting for them to become available. If `pageFilters` are passed as a prop, does not wait for readiness.
    */
@@ -78,9 +78,9 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   sort?: Sort;
   /**
-   * Query to apply to the span data set. Is an array of `MutableSearch.formatString()` strings.
+   * Query to apply in addition to the base `query` to the span data set, used for cross-event querying. Can be either an array of `MutableSearch` objects (preferred) or plain strings.
    */
-  spanQuery?: string[];
+  spanQuery?: Array<MutableSearch | string>;
   /**
    * Number of groups for a `groupBy` request. e.g., if `topEvents` is `5` and `groupBy` is `["transaction"]` this will group the results by `transaction` and fetch the top 5 results
    */

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -50,6 +50,14 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   interval?: string;
   /**
+   * Query to apply to the log data set. Can be either a `MutableSearch` object (preferred) or a plain string.
+   */
+  logQuery?: string[];
+  /**
+   * Query to apply to the metric data set. Can be either a `MutableSearch` object (preferred) or a plain string.
+   */
+  metricQuery?: string[];
+  /**
    * Page filters to apply to the request. This applies the date selection, projects, and environments. By default uses the currently applied filters after waiting for them to become available. If `pageFilters` are passed as a prop, does not wait for readiness.
    */
   pageFilters?: PageFilters;
@@ -69,6 +77,10 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    * Sort order for the results, only applies if `groupBy` is provided.
    */
   sort?: Sort;
+  /**
+   * Query to apply to the span data set. Can be either a `MutableSearch` object (preferred) or a plain string.
+   */
+  spanQuery?: string[];
   /**
    * Number of groups for a `groupBy` request. e.g., if `topEvents` is `5` and `groupBy` is `["transaction"]` this will group the results by `transaction` and fetch the top 5 results
    */
@@ -106,6 +118,9 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
     pageFilters,
     sort,
     topEvents,
+    logQuery,
+    metricQuery,
+    spanQuery,
   } = options;
 
   const organization = useOrganization();
@@ -153,6 +168,9 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
               : '1'
             : undefined,
           caseInsensitive: caseInsensitive ? 1 : 0,
+          ...(Array.isArray(logQuery) && logQuery.length > 0 ? {logQuery} : {}),
+          ...(Array.isArray(metricQuery) && metricQuery.length > 0 ? {metricQuery} : {}),
+          ...(Array.isArray(spanQuery) && spanQuery.length > 0 ? {spanQuery} : {}),
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -141,12 +141,9 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
   }
 
   const queryParam = formatSearchStringForQueryParam(query);
-  const logQueryParams =
-    logQuery?.map(formatSearchStringForQueryParam).filter(defined) ?? [];
-  const metricQueryParams =
-    metricQuery?.map(formatSearchStringForQueryParam).filter(defined) ?? [];
-  const spanQueryParams =
-    spanQuery?.map(formatSearchStringForQueryParam).filter(defined) ?? [];
+  const logQueryParams = logQuery?.map(formatSearchStringForQueryParam);
+  const metricQueryParams = metricQuery?.map(formatSearchStringForQueryParam);
+  const spanQueryParams = spanQuery?.map(formatSearchStringForQueryParam);
 
   return useApiQuery<EventsTimeSeriesResponse>(
     [

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -50,11 +50,11 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   interval?: string;
   /**
-   * Query to apply to the log data set. Can be either a `MutableSearch` object (preferred) or a plain string.
+   * Query to apply to the log data set. Is an array of `MutableSearch.formatString()` strings.
    */
   logQuery?: string[];
   /**
-   * Query to apply to the metric data set. Can be either a `MutableSearch` object (preferred) or a plain string.
+   * Query to apply to the metric data set. Is an array of `MutableSearch.formatString()` strings.
    */
   metricQuery?: string[];
   /**
@@ -78,7 +78,7 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   sort?: Sort;
   /**
-   * Query to apply to the span data set. Can be either a `MutableSearch` object (preferred) or a plain string.
+   * Query to apply to the span data set. Is an array of `MutableSearch.formatString()` strings.
    */
   spanQuery?: string[];
   /**

--- a/static/app/utils/url/formatSearchStringForQueryParam.spec.tsx
+++ b/static/app/utils/url/formatSearchStringForQueryParam.spec.tsx
@@ -1,0 +1,16 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {formatSearchStringForQueryParam} from 'sentry/utils/url/formatSearchStringForQueryParam';
+
+describe('formatSearchStringForQueryParam', () => {
+  it('should format a search string for use as a query parameter', () => {
+    expect(formatSearchStringForQueryParam('test')).toBe('test');
+  });
+
+  it('should format a MutableSearch object for use as a query parameter', () => {
+    expect(formatSearchStringForQueryParam(new MutableSearch('test'))).toBe('test');
+  });
+
+  it('should return undefined if the query is undefined', () => {
+    expect(formatSearchStringForQueryParam(undefined)).toBeUndefined();
+  });
+});

--- a/static/app/utils/url/formatSearchStringForQueryParam.tsx
+++ b/static/app/utils/url/formatSearchStringForQueryParam.tsx
@@ -1,0 +1,24 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+
+/**
+ * Formats a search string for use as a query parameter.
+ * This is useful for cases where we need to pass a search string to an API
+ * that expects a query parameter, but we want to ensure that the string is
+ * properly formatted for the API.
+ *
+ * @param query - The search string to format.
+ * @returns The formatted search string.
+ */
+export function formatSearchStringForQueryParam(
+  query: MutableSearch | string | undefined
+): string | undefined {
+  if (typeof query === 'undefined') {
+    return undefined;
+  }
+
+  if (query instanceof MutableSearch) {
+    return query.formatString();
+  }
+
+  return query;
+}

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -106,23 +106,6 @@ describe('useCrossEventQueries', () => {
     });
   });
 
-  it('slices queries to MAX_CROSS_EVENT_QUERIES', () => {
-    const {result} = renderHookWithProviders(() => useCrossEventQueries(), {
-      additionalWrapper: Wrapper([
-        {type: 'logs', query: 'test:a'},
-        {type: 'metrics', query: 'test:b'},
-        {type: 'spans', query: 'test:c'},
-      ]),
-    });
-
-    // Verify explicit behavior for slicing
-    expect(result.current).toStrictEqual({
-      logQuery: ['test:a'],
-      metricQuery: ['test:b'],
-      spanQuery: [],
-    });
-  });
-
   it('ignores queries with invalid types', () => {
     const {result} = renderHookWithProviders(() => useCrossEventQueries(), {
       additionalWrapper: Wrapper([

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -1,0 +1,98 @@
+import {useMemo, type ReactNode} from 'react';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useResettableState} from 'sentry/utils/useResettableState';
+import {useCrossEventQueries} from 'sentry/views/explore/hooks/useCrossEventQueries';
+import {
+  defaultAggregateFields,
+  defaultAggregateSortBys,
+  defaultFields,
+  defaultQuery,
+  defaultSortBys,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
+import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
+import {defaultCursor} from 'sentry/views/explore/queryParams/cursor';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+
+const mockSetQueryParams = jest.fn();
+
+function Wrapper(crossEvents?: CrossEvent[]) {
+  return function ({children}: {children: ReactNode}) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [query] = useResettableState(defaultQuery);
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const readableQueryParams = useMemo(
+      () =>
+        new ReadableQueryParams({
+          aggregateCursor: defaultCursor(),
+          aggregateFields: defaultAggregateFields(),
+          aggregateSortBys: defaultAggregateSortBys(defaultAggregateFields()),
+          cursor: defaultCursor(),
+          extrapolate: true,
+          fields: defaultFields(),
+          mode: Mode.AGGREGATE,
+          query,
+          sortBys: defaultSortBys(defaultFields()),
+          crossEvents,
+        }),
+      [query]
+    );
+
+    return (
+      <QueryParamsContextProvider
+        isUsingDefaultFields={false}
+        queryParams={readableQueryParams}
+        setQueryParams={mockSetQueryParams}
+        shouldManageFields={false}
+      >
+        {children}
+      </QueryParamsContextProvider>
+    );
+  };
+}
+
+describe('useCrossEventQueries', () => {
+  it('returns undefined if there are no cross event queries', () => {
+    const {result} = renderHookWithProviders(() => useCrossEventQueries(), {
+      additionalWrapper: Wrapper(),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns object of array of queries', () => {
+    const {result} = renderHookWithProviders(() => useCrossEventQueries(), {
+      additionalWrapper: Wrapper([
+        {type: 'logs', query: 'test:a'},
+        {type: 'metrics', query: 'test:b'},
+        {type: 'spans', query: 'test:c'},
+      ]),
+    });
+
+    expect(result.current).toStrictEqual({
+      logQueries: ['test:a'],
+      metricQueries: ['test:b'],
+      spanQueries: ['test:c'],
+    });
+  });
+
+  it('appends queries with the same types', () => {
+    const {result} = renderHookWithProviders(() => useCrossEventQueries(), {
+      additionalWrapper: Wrapper([
+        {type: 'spans', query: 'test:a'},
+        {type: 'spans', query: 'test:b'},
+        {type: 'spans', query: 'test:c'},
+      ]),
+    });
+
+    expect(result.current).toStrictEqual({
+      logQueries: [],
+      metricQueries: [],
+      spanQueries: ['test:a', 'test:b', 'test:c'],
+    });
+  });
+});

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -74,9 +74,9 @@ describe('useCrossEventQueries', () => {
     });
 
     expect(result.current).toStrictEqual({
-      logQueries: ['test:a'],
-      metricQueries: ['test:b'],
-      spanQueries: ['test:c'],
+      logQuery: ['test:a'],
+      metricQuery: ['test:b'],
+      spanQuery: ['test:c'],
     });
   });
 
@@ -90,9 +90,9 @@ describe('useCrossEventQueries', () => {
     });
 
     expect(result.current).toStrictEqual({
-      logQueries: [],
-      metricQueries: [],
-      spanQueries: ['test:a', 'test:b', 'test:c'],
+      logQuery: [],
+      metricQuery: [],
+      spanQuery: ['test:a', 'test:b', 'test:c'],
     });
   });
 });

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -3,6 +3,7 @@ import {useMemo} from 'react';
 import {defined} from 'sentry/utils';
 import {MAX_CROSS_EVENT_QUERIES} from 'sentry/views/explore/constants';
 import {useQueryParamsCrossEvents} from 'sentry/views/explore/queryParams/context';
+import {isCrossEventType} from 'sentry/views/explore/queryParams/crossEvent';
 
 export function useCrossEventQueries() {
   const crossEvents = useQueryParamsCrossEvents();
@@ -14,7 +15,9 @@ export function useCrossEventQueries() {
 
     // We only want to include the first MAX_CROSS_EVENT_QUERIES cross events in the
     // actual API request to avoid overwhelming the backend.
-    const slicedCrossEvents = crossEvents.slice(0, MAX_CROSS_EVENT_QUERIES);
+    const slicedCrossEvents = crossEvents
+      .filter(crossEvent => isCrossEventType(crossEvent.type))
+      .slice(0, MAX_CROSS_EVENT_QUERIES);
 
     const logQuery: string[] = [];
     const metricQuery: string[] = [];

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -16,15 +16,15 @@ export function useCrossEventQueries() {
     switch (crossEvent.type) {
       case 'spans':
         spanQuery.push(crossEvent.query);
-        continue;
+        break;
       case 'logs':
         logQuery.push(crossEvent.query);
-        continue;
+        break;
       case 'metrics':
         metricQuery.push(crossEvent.query);
-        continue;
+        break;
       default:
-        continue;
+        break;
     }
   }
 

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -1,32 +1,36 @@
+import {useMemo} from 'react';
+
 import {defined} from 'sentry/utils';
 import {useQueryParamsCrossEvents} from 'sentry/views/explore/queryParams/context';
 
 export function useCrossEventQueries() {
   const crossEvents = useQueryParamsCrossEvents();
 
-  if (!defined(crossEvents) || crossEvents.length === 0) {
-    return undefined;
-  }
-
-  const logQuery: string[] = [];
-  const metricQuery: string[] = [];
-  const spanQuery: string[] = [];
-
-  for (const crossEvent of crossEvents) {
-    switch (crossEvent.type) {
-      case 'spans':
-        spanQuery.push(crossEvent.query);
-        break;
-      case 'logs':
-        logQuery.push(crossEvent.query);
-        break;
-      case 'metrics':
-        metricQuery.push(crossEvent.query);
-        break;
-      default:
-        break;
+  return useMemo(() => {
+    if (!defined(crossEvents) || crossEvents.length === 0) {
+      return undefined;
     }
-  }
 
-  return {spanQuery, logQuery, metricQuery};
+    const logQuery: string[] = [];
+    const metricQuery: string[] = [];
+    const spanQuery: string[] = [];
+
+    for (const crossEvent of crossEvents) {
+      switch (crossEvent.type) {
+        case 'spans':
+          spanQuery.push(crossEvent.query);
+          break;
+        case 'logs':
+          logQuery.push(crossEvent.query);
+          break;
+        case 'metrics':
+          metricQuery.push(crossEvent.query);
+          break;
+        default:
+          break;
+      }
+    }
+
+    return {spanQuery, logQuery, metricQuery};
+  }, [crossEvents]);
 }

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import {defined} from 'sentry/utils';
+import {MAX_CROSS_EVENT_QUERIES} from 'sentry/views/explore/constants';
 import {useQueryParamsCrossEvents} from 'sentry/views/explore/queryParams/context';
 
 export function useCrossEventQueries() {
@@ -11,11 +12,15 @@ export function useCrossEventQueries() {
       return undefined;
     }
 
+    // We only want to include the first MAX_CROSS_EVENT_QUERIES cross events in the
+    // actual API request to avoid overwhelming the backend.
+    const slicedCrossEvents = crossEvents.slice(0, MAX_CROSS_EVENT_QUERIES);
+
     const logQuery: string[] = [];
     const metricQuery: string[] = [];
     const spanQuery: string[] = [];
 
-    for (const crossEvent of crossEvents) {
+    for (const crossEvent of slicedCrossEvents) {
       switch (crossEvent.type) {
         case 'spans':
           spanQuery.push(crossEvent.query);

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -1,0 +1,32 @@
+import {defined} from 'sentry/utils';
+import {useQueryParamsCrossEvents} from 'sentry/views/explore/queryParams/context';
+
+export function useCrossEventQueries() {
+  const crossEvents = useQueryParamsCrossEvents();
+
+  if (!defined(crossEvents) || crossEvents.length === 0) {
+    return undefined;
+  }
+
+  const logQuery: string[] = [];
+  const metricQuery: string[] = [];
+  const spanQuery: string[] = [];
+
+  for (const crossEvent of crossEvents) {
+    switch (crossEvent.type) {
+      case 'spans':
+        spanQuery.push(crossEvent.query);
+        continue;
+      case 'logs':
+        logQuery.push(crossEvent.query);
+        continue;
+      case 'metrics':
+        metricQuery.push(crossEvent.query);
+        continue;
+      default:
+        continue;
+    }
+  }
+
+  return {spanQuery, logQuery, metricQuery};
+}

--- a/static/app/views/explore/hooks/useExploreTracesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreTracesTable.tsx
@@ -37,6 +37,9 @@ export function useExploreTracesTable({
     sort: '-timestamp',
     cursor,
     caseInsensitive: queryExtras?.caseInsensitive,
+    logQuery: queryExtras?.logQuery,
+    metricQuery: queryExtras?.metricQuery,
+    spanQuery: queryExtras?.spanQuery,
   });
 
   return useMemo(() => {

--- a/static/app/views/explore/hooks/useExploreTracesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreTracesTable.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {decodeScalar} from 'sentry/utils/queryString';
-import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useTraces} from 'sentry/views/explore/hooks/useTraces';
 
@@ -12,9 +11,9 @@ interface UseExploreTracesTableOptions {
   query: string;
   queryExtras?: {
     caseInsensitive?: CaseInsensitive;
-    logQuery?: Array<MutableSearch | string>;
-    metricQuery?: Array<MutableSearch | string>;
-    spanQuery?: Array<MutableSearch | string>;
+    logQuery?: string[];
+    metricQuery?: string[];
+    spanQuery?: string[];
   };
 }
 

--- a/static/app/views/explore/hooks/useExploreTracesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreTracesTable.tsx
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {decodeScalar} from 'sentry/utils/queryString';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useTraces} from 'sentry/views/explore/hooks/useTraces';
 
@@ -11,9 +12,9 @@ interface UseExploreTracesTableOptions {
   query: string;
   queryExtras?: {
     caseInsensitive?: CaseInsensitive;
-    logQuery?: string[];
-    metricQuery?: string[];
-    spanQuery?: string[];
+    logQuery?: Array<MutableSearch | string>;
+    metricQuery?: Array<MutableSearch | string>;
+    spanQuery?: Array<MutableSearch | string>;
   };
 }
 

--- a/static/app/views/explore/hooks/useExploreTracesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreTracesTable.tsx
@@ -9,7 +9,12 @@ interface UseExploreTracesTableOptions {
   enabled: boolean;
   limit: number;
   query: string;
-  queryExtras?: {caseInsensitive?: CaseInsensitive};
+  queryExtras?: {
+    caseInsensitive?: CaseInsensitive;
+    logQuery?: string[];
+    metricQuery?: string[];
+    spanQuery?: string[];
+  };
 }
 
 export interface TracesTableResult {

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -23,7 +23,10 @@ export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
 export type RPCQueryExtras = {
   caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
+  logQuery?: string[];
+  metricQuery?: string[];
   samplingMode?: SamplingMode;
+  spanQuery?: string[];
 };
 
 interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -1,4 +1,5 @@
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 export const SAMPLING_MODE = {
   NORMAL: 'NORMAL',
@@ -23,10 +24,10 @@ export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
 export type RPCQueryExtras = {
   caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
-  logQuery?: string[];
-  metricQuery?: string[];
+  logQuery?: Array<MutableSearch | string>;
+  metricQuery?: Array<MutableSearch | string>;
   samplingMode?: SamplingMode;
-  spanQuery?: string[];
+  spanQuery?: Array<MutableSearch | string>;
 };
 
 interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -1,5 +1,4 @@
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
-import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 export const SAMPLING_MODE = {
   NORMAL: 'NORMAL',
@@ -24,10 +23,10 @@ export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
 export type RPCQueryExtras = {
   caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
-  logQuery?: Array<MutableSearch | string>;
-  metricQuery?: Array<MutableSearch | string>;
+  logQuery?: string[];
+  metricQuery?: string[];
   samplingMode?: SamplingMode;
-  spanQuery?: Array<MutableSearch | string>;
+  spanQuery?: string[];
 };
 
 interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -66,8 +66,11 @@ interface UseTracesOptions
   enabled?: boolean;
   keepPreviousData?: boolean;
   limit?: number;
+  logQuery?: string[];
+  metricQuery?: string[];
   query?: string | string[];
   sort?: 'timestamp' | '-timestamp';
+  spanQuery?: string[];
 }
 
 type UseTracesResult = Omit<UseApiQueryResult<TraceResults, RequestError>, 'error'> & {
@@ -84,6 +87,9 @@ export function useTraces({
   sort,
   keepPreviousData,
   refetchInterval,
+  logQuery,
+  metricQuery,
+  spanQuery,
 }: UseTracesOptions): UseTracesResult {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -102,6 +108,9 @@ export function useTraces({
       cursor,
       breakdownSlices: BREAKDOWN_SLICES,
       caseInsensitive,
+      ...(Array.isArray(logQuery) && logQuery.length > 0 ? {logQuery} : {}),
+      ...(Array.isArray(metricQuery) && metricQuery.length > 0 ? {metricQuery} : {}),
+      ...(Array.isArray(spanQuery) && spanQuery.length > 0 ? {spanQuery} : {}),
     },
   };
 

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -9,6 +9,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {UseApiQueryOptions, UseApiQueryResult} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -66,11 +67,11 @@ interface UseTracesOptions
   enabled?: boolean;
   keepPreviousData?: boolean;
   limit?: number;
-  logQuery?: string[];
-  metricQuery?: string[];
+  logQuery?: Array<MutableSearch | string>;
+  metricQuery?: Array<MutableSearch | string>;
   query?: string | string[];
   sort?: 'timestamp' | '-timestamp';
-  spanQuery?: string[];
+  spanQuery?: Array<MutableSearch | string>;
 }
 
 type UseTracesResult = Omit<UseApiQueryResult<TraceResults, RequestError>, 'error'> & {

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -9,7 +9,6 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {UseApiQueryOptions, UseApiQueryResult} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -67,11 +66,11 @@ interface UseTracesOptions
   enabled?: boolean;
   keepPreviousData?: boolean;
   limit?: number;
-  logQuery?: Array<MutableSearch | string>;
-  metricQuery?: Array<MutableSearch | string>;
+  logQuery?: string[];
+  metricQuery?: string[];
   query?: string | string[];
   sort?: 'timestamp' | '-timestamp';
-  spanQuery?: Array<MutableSearch | string>;
+  spanQuery?: string[];
 }
 
 type UseTracesResult = Omit<UseApiQueryResult<TraceResults, RequestError>, 'error'> & {

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -218,7 +218,7 @@ function SpanTabContentSection({
     enabled: isReady && queryType === 'aggregate',
     queryExtras: {
       caseInsensitive,
-      ...(hasCrossEventQueries ? crossEventQueries : {}),
+      ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
     },
   });
   const spansTableResult = useExploreSpansTable({
@@ -227,7 +227,7 @@ function SpanTabContentSection({
     enabled: isReady && queryType === 'samples',
     queryExtras: {
       caseInsensitive,
-      ...(hasCrossEventQueries ? crossEventQueries : {}),
+      ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
     },
   });
   const tracesTableResult = useExploreTracesTable({
@@ -236,7 +236,7 @@ function SpanTabContentSection({
     enabled: isReady && queryType === 'traces',
     queryExtras: {
       caseInsensitive,
-      ...(hasCrossEventQueries ? crossEventQueries : {}),
+      ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
     },
   });
 
@@ -246,7 +246,7 @@ function SpanTabContentSection({
       enabled: isReady,
       queryExtras: {
         caseInsensitive,
-        ...(hasCrossEventQueries ? crossEventQueries : {}),
+        ...(hasCrossEventQueries && defined(crossEventQueries) ? crossEventQueries : {}),
       },
     });
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -35,6 +35,7 @@ import {
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {useCrossEventQueries} from 'sentry/views/explore/hooks/useCrossEventQueries';
 import {useExploreAggregatesTable} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import {useExploreSpansTable} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {useExploreTimeseries} from 'sentry/views/explore/hooks/useExploreTimeseries';
@@ -197,6 +198,12 @@ function SpanTabContentSection({
   const id = useQueryParamsId();
   const [tab, setTab] = useTab();
   const [caseInsensitive] = useCaseInsensitivity();
+  const crossEventQueries = useCrossEventQueries();
+
+  const organization = useOrganization();
+  const hasCrossEventQueries = organization.features.includes(
+    'traces-page-cross-event-querying'
+  );
 
   const queryType: 'aggregate' | 'samples' | 'traces' =
     tab === Mode.AGGREGATE ? 'aggregate' : tab === Tab.TRACE ? 'traces' : 'samples';
@@ -209,26 +216,38 @@ function SpanTabContentSection({
     query,
     limit,
     enabled: isReady && queryType === 'aggregate',
-    queryExtras: {caseInsensitive},
+    queryExtras: {
+      caseInsensitive,
+      ...(hasCrossEventQueries ? crossEventQueries : {}),
+    },
   });
   const spansTableResult = useExploreSpansTable({
     query,
     limit,
     enabled: isReady && queryType === 'samples',
-    queryExtras: {caseInsensitive},
+    queryExtras: {
+      caseInsensitive,
+      ...(hasCrossEventQueries ? crossEventQueries : {}),
+    },
   });
   const tracesTableResult = useExploreTracesTable({
     query,
     limit,
     enabled: isReady && queryType === 'traces',
-    queryExtras: {caseInsensitive},
+    queryExtras: {
+      caseInsensitive,
+      ...(hasCrossEventQueries ? crossEventQueries : {}),
+    },
   });
 
   const {result: timeseriesResult, samplingMode: timeseriesSamplingMode} =
     useExploreTimeseries({
       query,
       enabled: isReady,
-      queryExtras: {caseInsensitive},
+      queryExtras: {
+        caseInsensitive,
+        ...(hasCrossEventQueries ? crossEventQueries : {}),
+      },
     });
 
   const confidences = useMemo(

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -43,10 +43,13 @@ interface Options<Fields> {
   enabled?: boolean;
   fields?: string[];
   interval?: string;
+  logQuery?: string[];
+  metricQuery?: string[];
   orderby?: string | string[];
   referrer?: string;
   samplingMode?: SamplingMode;
   search?: MutableSearch;
+  spanQuery?: string[];
   topEvents?: number;
   yAxis?: Fields;
 }
@@ -69,6 +72,9 @@ export const useSortedTimeSeries = <
     samplingMode,
     disableAggregateExtrapolation,
     caseInsensitive,
+    logQuery,
+    metricQuery,
+    spanQuery,
   } = options;
 
   const pageFilters = usePageFilters();
@@ -110,6 +116,9 @@ export const useSortedTimeSeries = <
       pageFilters: pageFilters.selection,
       sort: decodeSorts(orderby)[0],
       caseInsensitive: Boolean(caseInsensitive),
+      logQuery,
+      metricQuery,
+      spanQuery,
       interval,
       sampling: samplingMode,
       extrapolate: !disableAggregateExtrapolation,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -43,13 +43,13 @@ interface Options<Fields> {
   enabled?: boolean;
   fields?: string[];
   interval?: string;
-  logQuery?: string[];
-  metricQuery?: string[];
+  logQuery?: Array<MutableSearch | string>;
+  metricQuery?: Array<MutableSearch | string>;
   orderby?: string | string[];
   referrer?: string;
   samplingMode?: SamplingMode;
   search?: MutableSearch;
-  spanQuery?: string[];
+  spanQuery?: Array<MutableSearch | string>;
   topEvents?: number;
   yAxis?: Fields;
 }

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -43,13 +43,13 @@ interface Options<Fields> {
   enabled?: boolean;
   fields?: string[];
   interval?: string;
-  logQuery?: Array<MutableSearch | string>;
-  metricQuery?: Array<MutableSearch | string>;
+  logQuery?: string[];
+  metricQuery?: string[];
   orderby?: string | string[];
   referrer?: string;
   samplingMode?: SamplingMode;
   search?: MutableSearch;
-  spanQuery?: Array<MutableSearch | string>;
+  spanQuery?: string[];
   topEvents?: number;
   yAxis?: Fields;
 }

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -112,6 +112,9 @@ function useSpansQueryBase<T>({
     caseInsensitive: queryExtras?.caseInsensitive,
     samplingMode: queryExtras?.samplingMode,
     disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation,
+    logQuery: queryExtras?.logQuery,
+    metricQuery: queryExtras?.metricQuery,
+    spanQuery: queryExtras?.spanQuery,
   });
 
   if (trackResponseAnalytics) {
@@ -127,9 +130,12 @@ type WrappedDiscoverTimeseriesQueryProps = {
   cursor?: string;
   enabled?: boolean;
   initialData?: any;
+  logQuery?: string[];
+  metricQuery?: string[];
   overriddenRoute?: string;
   referrer?: string;
   samplingMode?: SamplingMode;
+  spanQuery?: string[];
 };
 
 function useWrappedDiscoverTimeseriesQueryBase<T>({
@@ -141,6 +147,9 @@ function useWrappedDiscoverTimeseriesQueryBase<T>({
   overriddenRoute,
   samplingMode,
   caseInsensitive,
+  logQuery,
+  metricQuery,
+  spanQuery,
 }: WrappedDiscoverTimeseriesQueryProps) {
   const location = useLocation();
   const organization = useOrganization();
@@ -179,6 +188,9 @@ function useWrappedDiscoverTimeseriesQueryBase<T>({
           ? samplingMode
           : undefined,
       caseInsensitive,
+      logQuery,
+      metricQuery,
+      spanQuery,
     }),
     options: {
       enabled,
@@ -239,10 +251,13 @@ type WrappedDiscoverQueryProps<T> = {
   initialData?: T;
   keepPreviousData?: boolean;
   limit?: number;
+  logQuery?: string[];
+  metricQuery?: string[];
   noPagination?: boolean;
   referrer?: string;
   refetchInterval?: number;
   samplingMode?: SamplingMode;
+  spanQuery?: string[];
 };
 
 function useWrappedDiscoverQueryBase<T>({
@@ -261,13 +276,16 @@ function useWrappedDiscoverQueryBase<T>({
   additionalQueryKey,
   refetchInterval,
   caseInsensitive,
+  logQuery,
+  metricQuery,
+  spanQuery,
 }: WrappedDiscoverQueryProps<T> & {
   pageFiltersReady: boolean;
 }) {
   const location = useLocation();
   const organization = useOrganization();
 
-  const queryExtras: Record<string, string> = {};
+  const queryExtras: Record<string, string | string[]> = {};
   if (
     [DiscoverDatasets.SPANS, DiscoverDatasets.TRACEMETRICS].includes(
       eventView.dataset as DiscoverDatasets
@@ -279,6 +297,18 @@ function useWrappedDiscoverQueryBase<T>({
 
     if (typeof caseInsensitive === 'number') {
       queryExtras.caseInsensitive = caseInsensitive.toString();
+    }
+
+    if (Array.isArray(logQuery) && logQuery.length > 0) {
+      queryExtras.logQuery = logQuery;
+    }
+
+    if (Array.isArray(metricQuery) && metricQuery.length > 0) {
+      queryExtras.metricQuery = metricQuery;
+    }
+
+    if (Array.isArray(spanQuery) && spanQuery.length > 0) {
+      queryExtras.spanQuery = spanQuery;
     }
 
     if (disableAggregateExtrapolation) {

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -295,25 +295,25 @@ function useWrappedDiscoverQueryBase<T>({
       queryExtras.sampling = samplingMode;
     }
 
-    if (typeof caseInsensitive === 'number') {
-      queryExtras.caseInsensitive = caseInsensitive.toString();
-    }
-
-    if (Array.isArray(logQuery) && logQuery.length > 0) {
-      queryExtras.logQuery = logQuery;
-    }
-
-    if (Array.isArray(metricQuery) && metricQuery.length > 0) {
-      queryExtras.metricQuery = metricQuery;
-    }
-
-    if (Array.isArray(spanQuery) && spanQuery.length > 0) {
-      queryExtras.spanQuery = spanQuery;
-    }
-
     if (disableAggregateExtrapolation) {
       queryExtras.disableAggregateExtrapolation = '1';
     }
+  }
+
+  if (typeof caseInsensitive === 'number') {
+    queryExtras.caseInsensitive = caseInsensitive.toString();
+  }
+
+  if (Array.isArray(logQuery) && logQuery.length > 0) {
+    queryExtras.logQuery = logQuery;
+  }
+
+  if (Array.isArray(metricQuery) && metricQuery.length > 0) {
+    queryExtras.metricQuery = metricQuery;
+  }
+
+  if (Array.isArray(spanQuery) && spanQuery.length > 0) {
+    queryExtras.spanQuery = spanQuery;
   }
 
   if (allowAggregateConditions !== undefined) {

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -12,7 +12,6 @@ import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuer
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {keepPreviousData as keepPreviousDataFn} from 'sentry/utils/queryClient';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -131,12 +130,12 @@ type WrappedDiscoverTimeseriesQueryProps = {
   cursor?: string;
   enabled?: boolean;
   initialData?: any;
-  logQuery?: Array<MutableSearch | string>;
-  metricQuery?: Array<MutableSearch | string>;
+  logQuery?: string[];
+  metricQuery?: string[];
   overriddenRoute?: string;
   referrer?: string;
   samplingMode?: SamplingMode;
-  spanQuery?: Array<MutableSearch | string>;
+  spanQuery?: string[];
 };
 
 function useWrappedDiscoverTimeseriesQueryBase<T>({
@@ -252,13 +251,13 @@ type WrappedDiscoverQueryProps<T> = {
   initialData?: T;
   keepPreviousData?: boolean;
   limit?: number;
-  logQuery?: Array<MutableSearch | string>;
-  metricQuery?: Array<MutableSearch | string>;
+  logQuery?: string[];
+  metricQuery?: string[];
   noPagination?: boolean;
   referrer?: string;
   refetchInterval?: number;
   samplingMode?: SamplingMode;
-  spanQuery?: Array<MutableSearch | string>;
+  spanQuery?: string[];
 };
 
 function useWrappedDiscoverQueryBase<T>({
@@ -306,21 +305,15 @@ function useWrappedDiscoverQueryBase<T>({
   }
 
   if (Array.isArray(logQuery) && logQuery.length > 0) {
-    queryExtras.logQuery = logQuery.map(query =>
-      query instanceof MutableSearch ? query.formatString() : query
-    );
+    queryExtras.logQuery = logQuery;
   }
 
   if (Array.isArray(metricQuery) && metricQuery.length > 0) {
-    queryExtras.metricQuery = metricQuery.map(query =>
-      query instanceof MutableSearch ? query.formatString() : query
-    );
+    queryExtras.metricQuery = metricQuery;
   }
 
   if (Array.isArray(spanQuery) && spanQuery.length > 0) {
-    queryExtras.spanQuery = spanQuery.map(query =>
-      query instanceof MutableSearch ? query.formatString() : query
-    );
+    queryExtras.spanQuery = spanQuery;
   }
 
   if (allowAggregateConditions !== undefined) {

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -12,6 +12,7 @@ import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuer
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {keepPreviousData as keepPreviousDataFn} from 'sentry/utils/queryClient';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -130,12 +131,12 @@ type WrappedDiscoverTimeseriesQueryProps = {
   cursor?: string;
   enabled?: boolean;
   initialData?: any;
-  logQuery?: string[];
-  metricQuery?: string[];
+  logQuery?: Array<MutableSearch | string>;
+  metricQuery?: Array<MutableSearch | string>;
   overriddenRoute?: string;
   referrer?: string;
   samplingMode?: SamplingMode;
-  spanQuery?: string[];
+  spanQuery?: Array<MutableSearch | string>;
 };
 
 function useWrappedDiscoverTimeseriesQueryBase<T>({
@@ -251,13 +252,13 @@ type WrappedDiscoverQueryProps<T> = {
   initialData?: T;
   keepPreviousData?: boolean;
   limit?: number;
-  logQuery?: string[];
-  metricQuery?: string[];
+  logQuery?: Array<MutableSearch | string>;
+  metricQuery?: Array<MutableSearch | string>;
   noPagination?: boolean;
   referrer?: string;
   refetchInterval?: number;
   samplingMode?: SamplingMode;
-  spanQuery?: string[];
+  spanQuery?: Array<MutableSearch | string>;
 };
 
 function useWrappedDiscoverQueryBase<T>({
@@ -305,15 +306,21 @@ function useWrappedDiscoverQueryBase<T>({
   }
 
   if (Array.isArray(logQuery) && logQuery.length > 0) {
-    queryExtras.logQuery = logQuery;
+    queryExtras.logQuery = logQuery.map(query =>
+      query instanceof MutableSearch ? query.formatString() : query
+    );
   }
 
   if (Array.isArray(metricQuery) && metricQuery.length > 0) {
-    queryExtras.metricQuery = metricQuery;
+    queryExtras.metricQuery = metricQuery.map(query =>
+      query instanceof MutableSearch ? query.formatString() : query
+    );
   }
 
   if (Array.isArray(spanQuery) && spanQuery.length > 0) {
-    queryExtras.spanQuery = spanQuery;
+    queryExtras.spanQuery = spanQuery.map(query =>
+      query instanceof MutableSearch ? query.formatString() : query
+    );
   }
 
   if (allowAggregateConditions !== undefined) {


### PR DESCRIPTION
This pull request introduces support for cross-event querying in several hooks and components, enabling the ability to filter and query across logs, metrics, and spans. The main changes include the addition of a new hook for handling cross-event queries, updates to options and query parameter interfaces to accept new query types, and propagation of these queries throughout the codebase.

Ticket: EXP-621

- **Cross-event querying support:**
  - Added the `useCrossEventQueries` hook along with tests, enabling extraction and organization of queries for logs, metrics, and spans from context, with safeguards for maximum query limits and type validation.
- **Interface and options updates:**
  - Extended options interfaces for time series, traces, and table hooks to accept `logQuery`, `metricQuery`, and `spanQuery` arrays, ensuring these queries can be propagated to API requests.
- **Query propagation and API integration:**
  - Updated query construction logic in hooks and helper functions to include the new cross-event query parameters when present, ensuring these filters are sent to the backend.