### PR TITLE
fix/iconSizes/issuesAndFeedback

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -137,25 +137,25 @@ export default function FeedbackListItem({
 
             {hasComments && (
               <Tooltip title={t('Has Activity')} containerDisplayMode="flex">
-                <IconChat color="gray500" size="sm" />
+                <IconChat color="subText" size="xs" />
               </Tooltip>
             )}
 
             {hasLinkedError && (
               <Tooltip title={t('Linked Error')} containerDisplayMode="flex">
-                <IconFatal color="red400" size="xs" />
+                <IconFatal color="dangerText" size="xs" />
               </Tooltip>
             )}
 
             {hasReplayId && (
               <Tooltip title={t('Linked Replay')} containerDisplayMode="flex">
-                <IconPlay size="xs" />
+                <IconPlay size="xs" color="subText" />
               </Tooltip>
             )}
 
             {hasAttachments && (
               <Tooltip title={t('Has Screenshot')} containerDisplayMode="flex">
-                <IconImage size="xs" />
+                <IconImage size="xs" color="subText" />
               </Tooltip>
             )}
 

--- a/static/app/components/group/issueSeerBadge.tsx
+++ b/static/app/components/group/issueSeerBadge.tsx
@@ -50,7 +50,7 @@ function IssueSeerBadge({group}: IssueSeerBadgeProps) {
           query: {...location.query, seerDrawer: true},
         }}
       >
-        <IconSeer size="sm" />
+        <IconSeer size="xs" />
         {seerFixable && <p>{t('Quick Fix')}</p>}
       </SeerLink>
     </Tooltip>


### PR DESCRIPTION
## Problems
* IconSeer in issues had a size of `sm` when all the other icons were `xs`
* IconChat in Feedback had a size of `sm` when all the other icons were `xs`
* Icons weren't using aliases

## Screenshots
### Issues Before
<img width="932" height="162" alt="CleanShot 2025-12-02 at 16 02 50@2x" src="https://github.com/user-attachments/assets/38732428-5d80-4404-85b9-75fbd7197f6f" />

### Issues After
<img width="933" height="164" alt="CleanShot 2025-12-02 at 16 03 46@2x" src="https://github.com/user-attachments/assets/3c2b6bc0-6c0c-4631-bb6e-e31cf87a6f30" />

### User Feedback Before
<img width="747" height="168" alt="CleanShot 2025-12-02 at 16 09 01@2x" src="https://github.com/user-attachments/assets/90079a7d-17d7-4d7b-a8b8-c7b2e9190f66" />

### User Feedback After
<img width="749" height="177" alt="CleanShot 2025-12-02 at 16 09 08@2x" src="https://github.com/user-attachments/assets/f054915d-4461-437a-8bbb-7aa48344ec14" />