### PR TITLE
fix(dashboards): linked dashboards not being populated on normal dashboard page

### DIFF
--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -14,6 +14,10 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {
+  usePopulateLinkedDashboards,
+  usePopulateLinkedDashboards,
+} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
 import {assignTempId} from './layoutUtils';
 import type {DashboardDetails, DashboardListItem} from './types';
@@ -64,11 +68,18 @@ function OrgDashboards({children}: OrgDashboardsProps) {
 
   let selectedDashboard = selectedDashboardState ?? fetchedSelectedDashboard;
 
+  const {dashboard: populatedPrebuiltDashboard, isLoading: isLinkedDashboardsLoading} =
+    usePopulateLinkedDashboards(
+      selectedDashboard?.prebuiltId
+        ? PREBUILT_DASHBOARDS[selectedDashboard.prebuiltId]
+        : undefined
+    );
+
   // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard
   if (selectedDashboard?.prebuiltId) {
     selectedDashboard = {
       ...selectedDashboard,
-      ...PREBUILT_DASHBOARDS[selectedDashboard.prebuiltId],
+      ...populatedPrebuiltDashboard,
     };
   }
 
@@ -171,7 +182,7 @@ function OrgDashboards({children}: OrgDashboardsProps) {
     [dashboardsError, selectedDashboardError, selectedDashboard, dashboards]
   );
 
-  if (isDashboardsPending || isSelectedDashboardLoading) {
+  if (isDashboardsPending || isSelectedDashboardLoading || isLinkedDashboardsLoading) {
     return (
       <Layout.Page withPadding>
         <LoadingIndicator />

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -13,11 +13,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {
-  usePopulateLinkedDashboards,
-  usePopulateLinkedDashboards,
-} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
+import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
 import {assignTempId} from './layoutUtils';
 import type {DashboardDetails, DashboardListItem} from './types';
@@ -68,18 +64,14 @@ function OrgDashboards({children}: OrgDashboardsProps) {
 
   let selectedDashboard = selectedDashboardState ?? fetchedSelectedDashboard;
 
-  const {dashboard: populatedPrebuiltDashboard, isLoading: isLinkedDashboardsLoading} =
-    usePopulateLinkedDashboards(
-      selectedDashboard?.prebuiltId
-        ? PREBUILT_DASHBOARDS[selectedDashboard.prebuiltId]
-        : undefined
-    );
+  const {dashboard: prebuiltDashboard, isLoading: isPrebuiltDashboardLoading} =
+    useGetPrebuiltDashboard(selectedDashboard?.prebuiltId);
 
   // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard
   if (selectedDashboard?.prebuiltId) {
     selectedDashboard = {
       ...selectedDashboard,
-      ...populatedPrebuiltDashboard,
+      ...prebuiltDashboard,
     };
   }
 
@@ -182,7 +174,7 @@ function OrgDashboards({children}: OrgDashboardsProps) {
     [dashboardsError, selectedDashboardError, selectedDashboard, dashboards]
   );
 
-  if (isDashboardsPending || isSelectedDashboardLoading || isLinkedDashboardsLoading) {
+  if (isDashboardsPending || isSelectedDashboardLoading || isPrebuiltDashboardLoading) {
     return (
       <Layout.Page withPadding>
         <LoadingIndicator />

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -1,19 +1,11 @@
-import {useMemo} from 'react';
-
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
-import {defined} from 'sentry/utils';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import DashboardDetail from 'sentry/views/dashboards/detail';
 import {DashboardState, type DashboardDetails} from 'sentry/views/dashboards/types';
+import {usePopulateLinkedDashboards} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
-import {
-  PREBUILT_DASHBOARDS,
-  type PrebuiltDashboard,
-  type PrebuiltDashboardId,
-} from './utils/prebuiltConfigs';
+import {PREBUILT_DASHBOARDS, type PrebuiltDashboardId} from './utils/prebuiltConfigs';
 
 type PrebuiltDashboardRendererProps = {
   prebuiltId: PrebuiltDashboardId;
@@ -21,10 +13,11 @@ type PrebuiltDashboardRendererProps = {
 
 export function PrebuiltDashboardRenderer({prebuiltId}: PrebuiltDashboardRendererProps) {
   const prebuiltDashboard = PREBUILT_DASHBOARDS[prebuiltId];
-  const {
-    dashboard: {title, widgets, filters},
-    isLoading,
-  } = usePopulateLinkedDashboards(prebuiltDashboard);
+  const {dashboard: populatedPrebuiltDashboard, isLoading} =
+    usePopulateLinkedDashboards(prebuiltDashboard);
+
+  const {title, filters} = prebuiltDashboard;
+  const widgets = populatedPrebuiltDashboard?.widgets ?? prebuiltDashboard.widgets;
 
   const location = useLocation();
   const router = useRouter();
@@ -60,65 +53,3 @@ export function PrebuiltDashboardRenderer({prebuiltId}: PrebuiltDashboardRendere
     </LoadingContainer>
   );
 }
-
-const usePopulateLinkedDashboards = (dashboard: PrebuiltDashboard) => {
-  const {widgets} = dashboard;
-  const organization = useOrganization();
-
-  const prebuiltIds = useMemo(
-    () =>
-      widgets
-        .flatMap(widget => {
-          return widget.queries
-            .flatMap(query => query.linkedDashboards ?? [])
-            .filter(defined);
-        })
-        .map(d => d.staticDashboardId)
-        .filter(defined),
-    [widgets]
-  );
-
-  const hasLinkedDashboards = prebuiltIds.length > 0;
-  const path = `/organizations/${organization.slug}/dashboards/`;
-
-  const {data, isLoading} = useApiQuery<DashboardDetails[]>(
-    [
-      path,
-      {
-        query: {prebuiltId: prebuiltIds.sort()},
-      },
-    ],
-    {
-      enabled: hasLinkedDashboards,
-      staleTime: 0,
-      retry: false,
-    }
-  );
-
-  return useMemo(() => {
-    if (!hasLinkedDashboards || !data) {
-      return {dashboard, isLoading: false};
-    }
-
-    const populatedDashboard = {
-      ...dashboard,
-      widgets: widgets.map(widget => ({
-        ...widget,
-        queries: widget.queries.map(query => ({
-          ...query,
-          linkedDashboards: query.linkedDashboards?.map(linkedDashboard => {
-            if (!linkedDashboard.staticDashboardId) {
-              return linkedDashboard;
-            }
-            const dashboardId = data.find(
-              d => d.prebuiltId === linkedDashboard.staticDashboardId
-            )?.id;
-            return dashboardId ? {...linkedDashboard, dashboardId} : linkedDashboard;
-          }),
-        })),
-      })),
-    };
-
-    return {dashboard: populatedDashboard, isLoading};
-  }, [dashboard, widgets, data, hasLinkedDashboards, isLoading]);
-};

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -3,7 +3,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useRouter from 'sentry/utils/useRouter';
 import DashboardDetail from 'sentry/views/dashboards/detail';
 import {DashboardState, type DashboardDetails} from 'sentry/views/dashboards/types';
-import {usePopulateLinkedDashboards} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
+import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
 import {PREBUILT_DASHBOARDS, type PrebuiltDashboardId} from './utils/prebuiltConfigs';
 
@@ -14,7 +14,7 @@ type PrebuiltDashboardRendererProps = {
 export function PrebuiltDashboardRenderer({prebuiltId}: PrebuiltDashboardRendererProps) {
   const prebuiltDashboard = PREBUILT_DASHBOARDS[prebuiltId];
   const {dashboard: populatedPrebuiltDashboard, isLoading} =
-    usePopulateLinkedDashboards(prebuiltDashboard);
+    useGetPrebuiltDashboard(prebuiltId);
 
   const {title, filters} = prebuiltDashboard;
   const widgets = populatedPrebuiltDashboard?.widgets ?? prebuiltDashboard.widgets;

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
@@ -23,7 +23,7 @@ const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString()
 export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'Backend Queries',
+  title: 'Queries',
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
@@ -11,7 +11,7 @@ import {SpanFields} from 'sentry/views/insights/types';
 export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'Backend Queries',
+  title: 'Query Details',
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
+++ b/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
@@ -4,9 +4,18 @@ import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardDetails} from 'sentry/views/dashboards/types';
-import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {
+  PREBUILT_DASHBOARDS,
+  PrebuiltDashboardId,
+  type PrebuiltDashboard,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 
-export const usePopulateLinkedDashboards = (dashboard?: PrebuiltDashboard) => {
+export const useGetPrebuiltDashboard = (prebuiltId?: PrebuiltDashboardId) => {
+  const prebuiltDashboard = prebuiltId ? PREBUILT_DASHBOARDS[prebuiltId] : undefined;
+  return usePopulateLinkedDashboards(prebuiltDashboard);
+};
+
+const usePopulateLinkedDashboards = (dashboard?: PrebuiltDashboard) => {
   const organization = useOrganization();
 
   const widgets = useMemo(() => dashboard?.widgets ?? [], [dashboard]);

--- a/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
+++ b/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
@@ -51,8 +51,12 @@ const usePopulateLinkedDashboards = (dashboard?: PrebuiltDashboard) => {
   );
 
   return useMemo(() => {
-    if (!hasLinkedDashboards || !data) {
+    if (!hasLinkedDashboards) {
       return {dashboard, isLoading: false};
+    }
+
+    if (!data) {
+      return {dashboard, isLoading};
     }
 
     const populatedDashboard = {

--- a/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
+++ b/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
@@ -1,0 +1,70 @@
+import {useMemo} from 'react';
+
+import {defined} from 'sentry/utils';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {DashboardDetails} from 'sentry/views/dashboards/types';
+import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+
+export const usePopulateLinkedDashboards = (dashboard?: PrebuiltDashboard) => {
+  const organization = useOrganization();
+
+  const widgets = useMemo(() => dashboard?.widgets ?? [], [dashboard]);
+
+  const prebuiltIds = useMemo(
+    () =>
+      widgets
+        .flatMap(widget => {
+          return widget.queries
+            .flatMap(query => query.linkedDashboards ?? [])
+            .filter(defined);
+        })
+        .map(d => d.staticDashboardId)
+        .filter(defined),
+    [widgets]
+  );
+
+  const hasLinkedDashboards = prebuiltIds.length > 0;
+  const path = `/organizations/${organization.slug}/dashboards/`;
+
+  const {data, isLoading} = useApiQuery<DashboardDetails[]>(
+    [
+      path,
+      {
+        query: {prebuiltId: prebuiltIds.sort()},
+      },
+    ],
+    {
+      enabled: hasLinkedDashboards,
+      staleTime: 0,
+      retry: false,
+    }
+  );
+
+  return useMemo(() => {
+    if (!hasLinkedDashboards || !data) {
+      return {dashboard, isLoading: false};
+    }
+
+    const populatedDashboard = {
+      ...dashboard,
+      widgets: widgets.map(widget => ({
+        ...widget,
+        queries: widget.queries.map(query => ({
+          ...query,
+          linkedDashboards: query.linkedDashboards?.map(linkedDashboard => {
+            if (!linkedDashboard.staticDashboardId) {
+              return linkedDashboard;
+            }
+            const dashboardId = data.find(
+              d => d.prebuiltId === linkedDashboard.staticDashboardId
+            )?.id;
+            return dashboardId ? {...linkedDashboard, dashboardId} : linkedDashboard;
+          }),
+        })),
+      })),
+    };
+
+    return {dashboard: populatedDashboard, isLoading};
+  }, [dashboard, widgets, data, hasLinkedDashboards, isLoading]);
+};


### PR DESCRIPTION
1. Fixes a bug where we were not populating the dashboard links on the regular dashboards page, it was only being done on the insights page via `prebuiltDashboardRenderer`
2. Extract prebuilt fetching logic into it's own util
3. Update query module dashboard names (on FE, separate backend PR to come)