### PR TITLE
feat(relay-config): add possible values for `gen_ai.operation.name` to the `AI_OPERATION_TYPE_MAP` so that we can then directly query it that way

### DIFF
--- a/src/sentry/relay/config/ai_operation_type_map.py
+++ b/src/sentry/relay/config/ai_operation_type_map.py
@@ -12,9 +12,11 @@ AI_OPERATION_TYPE_MAP: dict[AI_OPERATION_TYPE_VALUE, list[str]] = {
         "ai.pipeline.stream_text",
         "ai.pipeline.stream_object",
         "gen_ai.create_agent",
+        "invoke_agent",
+        "create_agent",
     ],
-    "tool": ["gen_ai.execute_tool"],
-    "handoff": ["gen_ai.handoff"],
+    "tool": ["gen_ai.execute_tool", "execute_tool"],
+    "handoff": ["gen_ai.handoff", "handoff"],
     "ai_client": ["*"],  # default fallback
 }
 

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -150,6 +150,10 @@ def test_global_config_ai_operation_type_map() -> None:
         "gen_ai.create_agent": "agent",
         "gen_ai.execute_tool": "tool",
         "gen_ai.handoff": "handoff",
+        "invoke_agent": "agent",
+        "create_agent": "agent",
+        "execute_tool": "tool",
+        "handoff": "handoff",
     }
 
     operation_types = ai_operation_type_map["operationTypes"]


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-1525/update-relay-logic-to-use-gen-aioperationname