### PR TITLE
fix(dashboards): Acquire lock when checking dashboard count for creation

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -446,16 +446,6 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:dashboards-edit", organization, actor=request.user):
             return Response(status=404)
 
-        dashboard_count = Dashboard.objects.filter(
-            organization=organization, prebuilt_id=None
-        ).count()
-        dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
-        if dashboard_limit >= 0 and dashboard_count >= dashboard_limit:
-            return Response(
-                f"You may not exceed {dashboard_limit} dashboards on your current plan.",
-                status=400,
-            )
-
         serializer = DashboardSerializer(
             data=request.data,
             context={
@@ -469,8 +459,30 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
+        # We need to acquire a lock so that a burst of concurrent create requests doesn't read
+        # stale count data and bypass the dashboard limit for an org.
+        dashboard_create_lock = locks.get(
+            f"dashboard:create:{organization.id}",
+            duration=5,
+            name="dashboard_create",
+        )
+
         try:
-            with transaction.atomic(router.db_for_write(Dashboard)):
+            with (
+                dashboard_create_lock.acquire(),
+                transaction.atomic(router.db_for_write(Dashboard)),
+            ):
+
+                dashboard_count = Dashboard.objects.filter(
+                    organization=organization, prebuilt_id=None
+                ).count()
+                dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
+                if dashboard_limit >= 0 and dashboard_count >= dashboard_limit:
+                    return Response(
+                        f"You may not exceed {dashboard_limit} dashboards on your current plan.",
+                        status=400,
+                    )
+
                 dashboard = serializer.save()
 
                 if features.has(
@@ -498,3 +510,5 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             request.data["title"] = Dashboard.incremental_title(organization, request.data["title"])
 
             return self.post(request, organization, retry=retry + 1)
+        except UnableToAcquireLock:
+            return Response("Unable to create dashboard, please try again", status=503)


### PR DESCRIPTION
Checking the count of dashboards against the plan limit should go under a lock. This is because if a user is able to burst request creating dashboards, the dashboards state may read a stale number and handle each POST request individually, allowing more than the limit of dashboards to be created.

This acquires a lock that's based on the org ID so per-org, the dashboard count should be accurate for each request. I wasn't able to write a concurrent test for it because it has some issues with silos and the authentication required in tests, but we can manually test this later and I added a test that at least validates a "burst" of requests avoids creating more dashboards.