### PR TITLE
feat(dashboards): don't allow duplication of prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -106,8 +106,16 @@ function DashboardGrid({
             onConfirm: () => handleDuplicateDashboard(dashboard, 'grid'),
           });
         },
-        disabled: hasReachedDashboardLimit || isLoadingDashboardsLimit,
-        tooltip: limitMessage,
+        disabled:
+          hasReachedDashboardLimit ||
+          isLoadingDashboardsLimit ||
+          (organization.features.includes('dashboards-prebuilt-controls') &&
+            defined(dashboard.prebuiltId)),
+        tooltip:
+          organization.features.includes('dashboards-prebuilt-controls') &&
+          defined(dashboard.prebuiltId)
+            ? t('Prebuilt dashboards cannot be duplicated')
+            : limitMessage,
         tooltipOptions: {
           isHoverable: true,
         },

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -109,11 +109,11 @@ function DashboardGrid({
         disabled:
           hasReachedDashboardLimit ||
           isLoadingDashboardsLimit ||
-          (organization.features.includes('dashboards-prebuilt-controls') &&
-            defined(dashboard.prebuiltId)),
+          (defined(dashboard.prebuiltId) &&
+            !organization.features.includes('dashboards-prebuilt-controls')),
         tooltip:
-          organization.features.includes('dashboards-prebuilt-controls') &&
-          defined(dashboard.prebuiltId)
+          defined(dashboard.prebuiltId) &&
+          !organization.features.includes('dashboards-prebuilt-controls')
             ? t('Prebuilt dashboards cannot be duplicated')
             : limitMessage,
         tooltipOptions: {

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -300,12 +300,12 @@ function DashboardTable({
                   disabled={
                     hasReachedDashboardLimit ||
                     isLoadingDashboardsLimit ||
-                    (organization.features.includes('dashboards-prebuilt-controls') &&
-                      defined(dataRow.prebuiltId))
+                    (defined(dataRow.prebuiltId) &&
+                      !organization.features.includes('dashboards-prebuilt-controls'))
                   }
                   title={
-                    organization.features.includes('dashboards-prebuilt-controls') &&
-                    defined(dataRow.prebuiltId)
+                    defined(dataRow.prebuiltId) &&
+                    !organization.features.includes('dashboards-prebuilt-controls')
                       ? t('Prebuilt dashboards cannot be duplicated')
                       : limitMessage
                   }

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -297,8 +297,18 @@ function DashboardTable({
                   data-test-id="dashboard-duplicate"
                   icon={<IconCopy />}
                   size="sm"
-                  disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
-                  title={limitMessage}
+                  disabled={
+                    hasReachedDashboardLimit ||
+                    isLoadingDashboardsLimit ||
+                    (organization.features.includes('dashboards-prebuilt-controls') &&
+                      defined(dataRow.prebuiltId))
+                  }
+                  title={
+                    organization.features.includes('dashboards-prebuilt-controls') &&
+                    defined(dataRow.prebuiltId)
+                      ? t('Prebuilt dashboards cannot be duplicated')
+                      : limitMessage
+                  }
                 />
               )}
             </DashboardCreateLimitWrapper>


### PR DESCRIPTION
Don't allow prebuilt dashboards to be duplicated from the dashboard home page if the feature is not enabled
<img width="1293" height="159" alt="image" src="https://github.com/user-attachments/assets/4943112f-125b-4676-a51a-9b27e342f47b" />