### PR TITLE
fix(dashboards): queries page table overflows

### DIFF
--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -52,7 +52,9 @@ type Props = {
 
 function SortableWidget(props: Props) {
   const widgetRef = useRef<HTMLDivElement>(null);
-  const [tableWidths, setTableWidths] = useState<number[]>();
+  const [tableWidths, setTableWidths] = useState<number[]>(
+    props.widget.tableWidths ?? []
+  );
   const [queries, setQueries] = useState<WidgetQuery[]>();
   const {
     widget,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
@@ -110,6 +110,7 @@ export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.SPANS,
       interval: '',
+      tableWidths: [-1, -1, -1, -1],
       queries: [
         {
           name: '',

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -571,7 +571,11 @@ function TableComponent({
           tableData={tableData}
           frameless
           scrollable
-          fit="max-content"
+          fit={
+            widget?.tableWidths?.length && widget?.tableWidths?.length > 0
+              ? undefined
+              : 'max-content'
+          }
           aliases={aliases}
           onChangeSort={onWidgetTableSort}
           sort={sort}


### PR DESCRIPTION
Prior to this change, the queries table would overflow and the other columns would not be visible if the query was long. The user would have to horizontally scroll which is not an ideal experience.

This PR makes the table dynamic, so that all columns are visible on load (but the user can resize columns if they choose). If the table widths are manually defined, `max-content` is disabled and the hardcoded table widths are respected.

**Before**
<img width="1354" height="772" alt="image" src="https://github.com/user-attachments/assets/b73cc7a2-710b-4506-8380-3e952630b794" />

**After**
<img width="1145" height="710" alt="image" src="https://github.com/user-attachments/assets/871f7500-ad3d-4b4f-9bb2-64dbac3a00b8" />
