### PR TITLE
ref(crons): Update dependencies of 0087

### DIFF
--- a/src/sentry/workflow_engine/migrations/0087_relink_crons_to_compatible_issue_workflows.py
+++ b/src/sentry/workflow_engine/migrations/0087_relink_crons_to_compatible_issue_workflows.py
@@ -392,7 +392,7 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("workflow_engine", "0086_fix_cron_to_cron_workflow_links"),
-        ("monitors", "0009_backfill_monitor_detectors"),
+        ("monitors", "0013_delete_monitor_is_muted_field"),
     ]
 
     operations = [


### PR DESCRIPTION
Running this migration again, it's trying to query ther `is_muted`
column on the monitors table, which has since been deleted.