### PR TITLE
feat(dashboards): don't filter out any span ops in query module

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
@@ -9,12 +9,10 @@ import {
   QUERIES_PER_MINUTE_TEXT,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/constants';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
-import {EXCLUDED_DB_OPS} from 'sentry/views/insights/database/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 const BASE_FILTERS = {
   [SpanFields.SPAN_CATEGORY]: ModuleName.DB,
-  [`!${SpanFields.SPAN_OP}`]: `[${EXCLUDED_DB_OPS.join(',')}]`,
   has: SpanFields.NORMALIZED_DESCRIPTION,
 };
 


### PR DESCRIPTION
Don't filter out span.op's in the db module under the hood. To make the data the most clear we'll show them everything