### PR TITLE
fix(typing): Add types to sentry.eventtypes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,7 +395,7 @@ module = [
     "sentry.dynamic_sampling.*",
     "sentry.eventstore.*",
     "sentry.eventstream.*",
-    "sentry.eventtypes.error",
+    "sentry.eventtypes.*",
     "sentry.explore.migrations.*",
     "sentry.feedback.migrations.*",
     "sentry.feedback.tasks.*",

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -45,7 +45,7 @@ from sentry.constants import (
 from sentry.culprit import generate_culprit
 from sentry.dynamic_sampling import record_latest_release
 from sentry.eventstream.base import GroupState
-from sentry.eventtypes import EventType
+from sentry.eventtypes.base import BaseEvent as EventType
 from sentry.eventtypes.transaction import TransactionEvent
 from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import (

--- a/src/sentry/eventtypes/__init__.py
+++ b/src/sentry/eventtypes/__init__.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from sentry.eventtypes.base import DefaultEvent
 from sentry.eventtypes.error import ErrorEvent
 from sentry.eventtypes.feedback import FeedbackEvent
@@ -24,16 +22,3 @@ default_manager.register(FeedbackEvent)
 
 get = default_manager.get
 register = default_manager.register
-
-EventType = Union[
-    DefaultEvent,
-    ErrorEvent,
-    CspEvent,
-    NelEvent,
-    HpkpEvent,
-    ExpectCTEvent,
-    ExpectStapleEvent,
-    TransactionEvent,
-    GenericEvent,
-    FeedbackEvent,
-]

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping, MutableMapping
+from typing import Any
 from warnings import warn
 
 from sentry.utils.safe import get_path
@@ -9,7 +11,7 @@ from sentry.utils.strings import strip, truncatechars
 class BaseEvent:
     key: str  # abstract
 
-    def get_metadata(self, data):
+    def get_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
         metadata = self.extract_metadata(data)
         title = data.get("title")
         if title is not None:
@@ -19,22 +21,22 @@ class BaseEvent:
 
         return metadata
 
-    def get_title(self, metadata):
+    def get_title(self, metadata: Mapping[str, str | None]) -> str:
         title = metadata.get("title")
         if title is not None:
             return title
         return self.compute_title(metadata) or "<untitled>"
 
-    def compute_title(self, metadata):
+    def compute_title(self, metadata: Mapping[str, str | None]) -> str | None:
         return None
 
-    def extract_metadata(self, metadata):
+    def extract_metadata(self, metadata: MutableMapping[str, Any]) -> dict[str, str]:
         return {}
 
-    def get_location(self, metadata):
+    def get_location(self, metadata: dict[str, str]) -> str | None:
         return None
 
-    def to_string(self, metadata):
+    def to_string(self, metadata: dict[str, str | None]) -> str:
         warn(DeprecationWarning("This method was replaced by get_title"), stacklevel=2)
         return self.get_title(metadata)
 
@@ -42,7 +44,7 @@ class BaseEvent:
 class DefaultEvent(BaseEvent):
     key = "default"
 
-    def extract_metadata(self, data):
+    def extract_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
         message = strip(
             get_path(data, "logentry", "formatted") or get_path(data, "logentry", "message")
         )

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 from sentry.utils.safe import get_path, trim
@@ -72,7 +72,7 @@ class ErrorEvent(BaseEvent):
 
         return rv
 
-    def compute_title(self, metadata: Metadata) -> str:
+    def compute_title(self, metadata: Mapping[str, str | None]) -> str:
         title = metadata.get("type")
         if title is not None:
             value = metadata.get("value")

--- a/src/sentry/eventtypes/feedback.py
+++ b/src/sentry/eventtypes/feedback.py
@@ -1,3 +1,6 @@
+from collections.abc import MutableMapping
+from typing import Any
+
 from sentry.eventtypes.base import BaseEvent
 from sentry.utils.safe import get_path
 
@@ -5,7 +8,7 @@ from sentry.utils.safe import get_path
 class FeedbackEvent(BaseEvent):
     key = "feedback"
 
-    def extract_metadata(self, data):
+    def extract_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
         contact_email = get_path(data, "contexts", "feedback", "contact_email")
         message = get_path(data, "contexts", "feedback", "message")
         name = get_path(data, "contexts", "feedback", "name")

--- a/src/sentry/eventtypes/manager.py
+++ b/src/sentry/eventtypes/manager.py
@@ -1,20 +1,25 @@
-class EventTypeManager:
-    def __init__(self):
-        self.__values = []
-        self.__lookup = {}
+from collections.abc import Iterator
 
-    def __iter__(self):
+from sentry.eventtypes.base import BaseEvent
+
+
+class EventTypeManager:
+    def __init__(self) -> None:
+        self.__values: list[type[BaseEvent]] = []
+        self.__lookup: dict[str, type[BaseEvent]] = {}
+
+    def __iter__(self) -> Iterator[type[BaseEvent]]:
         yield from self.__values
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         return key in self.__lookup
 
-    def get(self, key, **kwargs):
+    def get(self, key: str, **kwargs: object) -> type[BaseEvent]:
         return self.__lookup[key]
 
-    def exists(self, key):
+    def exists(self, key: str) -> bool:
         return key in self.__lookup
 
-    def register(self, cls):
+    def register(self, cls: type[BaseEvent]) -> None:
         self.__values.append(cls)
         self.__lookup[cls.key] = cls

--- a/src/sentry/eventtypes/nel.py
+++ b/src/sentry/eventtypes/nel.py
@@ -1,10 +1,15 @@
+from collections.abc import MutableMapping
+from typing import Any
+
 from .base import DefaultEvent
 
 
 class NelEvent(DefaultEvent):
     key = "nel"
 
-    def extract_metadata(self, data):
+    def extract_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
         metadata = super().extract_metadata(data)
-        metadata["uri"] = data.get("request").get("url")
+        request = data.get("request")
+        assert request is not None
+        metadata["uri"] = request.get("url")
         return metadata

--- a/src/sentry/eventtypes/transaction.py
+++ b/src/sentry/eventtypes/transaction.py
@@ -1,3 +1,6 @@
+from collections.abc import MutableMapping
+from typing import Any
+
 from sentry.utils.safe import get_path
 
 from .base import BaseEvent
@@ -6,10 +9,10 @@ from .base import BaseEvent
 class TransactionEvent(BaseEvent):
     key = "transaction"
 
-    def extract_metadata(self, data):
+    def extract_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
         description = get_path(data, "contexts", "trace", "description")
         transaction = get_path(data, "transaction")
         return {"title": description or transaction, "location": transaction}
 
-    def get_location(self, metadata):
+    def get_location(self, metadata: dict[str, str]) -> str:
         return metadata["location"]

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -163,7 +163,7 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
     """
 
     event_type = get_event_type(event.data)
-    event_metadata = dict(event_type.get_metadata(event.data))
+    event_metadata: dict[str, Any] = dict(event_type.get_metadata(event.data))
     event_metadata = dict(event_metadata)
     # Don't clobber existing metadata
     event_metadata.update(event.get_event_metadata())

--- a/src/sentry/services/eventstore/models.py
+++ b/src/sentry/services/eventstore/models.py
@@ -258,7 +258,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
             return title
 
         event_type_instance = eventtypes.get(event_type)()
-        return cast(str, event_type_instance.get_title(self.get_event_metadata()))
+        return event_type_instance.get_title(self.get_event_metadata())
 
     @property
     def culprit(self) -> str | None:
@@ -273,7 +273,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
         if column in self._snuba_data:
             return cast(str, self._snuba_data[column])
         et = eventtypes.get(self.get_event_type())()
-        return cast(Optional[str], et.get_location(self.get_event_metadata()))
+        return et.get_location(self.get_event_metadata())
 
     @classmethod
     def generate_node_id(cls, project_id: int, event_id: str) -> str:


### PR DESCRIPTION
Added some missing types and one assertion. (The assertion is a `is not None` in a case where it would've already thrown if `None`).
