### PR TITLE
feat: create new task for organization contributor reset

### DIFF
--- a/src/sentry/tasks/organization_contributors.py
+++ b/src/sentry/tasks/organization_contributors.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+
+from django.utils import timezone
+
+from sentry.models.organizationcontributors import OrganizationContributors
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import integrations_tasks
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.organization_contributors.reset_num_actions_for_organization",
+    namespace=integrations_tasks,
+    silo_mode=SiloMode.REGION,
+)
+def reset_num_actions_for_organization_contributors(organization_id: int) -> None:
+    """
+    Reset num_actions for all OrganizationContributors rows in the given organization.
+    """
+    updated_count = (
+        OrganizationContributors.objects.filter(organization_id=organization_id)
+        .exclude(num_actions=0)
+        .update(num_actions=0, date_updated=timezone.now())
+    )
+    logger.info(
+        "organization_contributors.reset_num_actions",
+        extra={"organization_id": organization_id, "rows_updated": updated_count},
+    )

--- a/src/sentry/tasks/organization_contributors.py
+++ b/src/sentry/tasks/organization_contributors.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @instrumented_task(
-    name="sentry.tasks.organization_contributors.reset_num_actions_for_organization",
+    name="sentry.tasks.organization_contributors.reset_num_actions_for_organization_contributors",
     namespace=integrations_tasks,
     silo_mode=SiloMode.REGION,
 )

--- a/tests/sentry/tasks/test_organization_contributors.py
+++ b/tests/sentry/tasks/test_organization_contributors.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from sentry.models.organizationcontributors import OrganizationContributors
+from sentry.tasks.organization_contributors import reset_num_actions_for_organization_contributors
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+
+class ResetNumActionsForOrganizationContributorsTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        with assume_test_silo_mode("CONTROL"):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                external_id="github:1",
+                provider="github",
+            )
+
+    @patch("sentry.tasks.organization_contributors.logger")
+    def test_resets_num_actions_for_all_contributors(self, mock_logger):
+        """Test that num_actions is reset to 0 for all contributors in organization."""
+        contributor1 = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="user1",
+            alias="User One",
+            num_actions=5,
+        )
+        contributor2 = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="user2",
+            alias="User Two",
+            num_actions=10,
+        )
+        contributor3 = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="user3",
+            alias="User Three",
+            num_actions=1,
+        )
+
+        reset_num_actions_for_organization_contributors(self.organization.id)
+
+        mock_logger.info.assert_called_once_with(
+            "organization_contributors.reset_num_actions",
+            extra={"organization_id": self.organization.id, "rows_updated": 3},
+        )
+
+        contributor1.refresh_from_db()
+        contributor2.refresh_from_db()
+        contributor3.refresh_from_db()
+
+        assert contributor1.num_actions == 0
+        assert contributor2.num_actions == 0
+        assert contributor3.num_actions == 0
+
+    def test_skips_contributors_already_at_zero(self):
+        """Test that contributors with num_actions=0 are not updated (optimization)."""
+        contributor_zero = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="user_zero",
+            alias="User Zero",
+            num_actions=0,
+        )
+        contributor_nonzero = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="user_nonzero",
+            alias="User NonZero",
+            num_actions=5,
+        )
+
+        original_date_updated = contributor_zero.date_updated
+
+        reset_num_actions_for_organization_contributors(self.organization.id)
+
+        contributor_zero.refresh_from_db()
+        contributor_nonzero.refresh_from_db()
+
+        assert contributor_zero.date_updated == original_date_updated
+        assert contributor_zero.num_actions == 0
+
+        assert contributor_nonzero.num_actions == 0
+        assert contributor_nonzero.date_updated > original_date_updated
+
+    def test_only_updates_specified_organization(self):
+        """Test that only contributors from the specified organization are updated."""
+        other_organization = self.create_organization()
+
+        # Create contributor in target organization
+        contributor_in_org = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="user_in_org",
+            alias="User In Org",
+            num_actions=5,
+        )
+
+        contributor_other_org = OrganizationContributors.objects.create(
+            organization=other_organization,
+            integration_id=self.integration.id,
+            external_identifier="user_other_org",
+            alias="User Other Org",
+            num_actions=10,
+        )
+
+        reset_num_actions_for_organization_contributors(self.organization.id)
+
+        contributor_in_org.refresh_from_db()
+        contributor_other_org.refresh_from_db()
+
+        assert contributor_in_org.num_actions == 0
+        assert contributor_other_org.num_actions == 10


### PR DESCRIPTION
This PR aims to create a new task to be spawned in 2 places:
- Trial end
- billing period start

which will reset the organization contributors for a sentry org and all it's respective integrations to 0.

Closes https://linear.app/getsentry/issue/ENG-5940/create-new-job-for-updating-num-actions-rows-to-0-for-an-org


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
