### PR TITLE
ref(testing): Make fingerprints work for all sample events

### DIFF
--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -250,15 +250,19 @@ def load_data(
                     }
             measurements.update(measurement_markers)
 
-        if fingerprint is not None:
+    if fingerprint is not None:
+        if data.get("type") == "transaction":
             for f in fingerprint:
                 f_data = f.split("-", 1)
                 if len(f_data) < 2:
                     raise ValueError(
                         "Invalid performance fingerprint data. Format must be 'group_type-fingerprint'."
                     )
+        else:
+            if not isinstance(fingerprint, list):
+                raise ValueError("Invalid fingerprint. Fingerprint must be a list of strings.")
 
-            data["fingerprint"] = fingerprint
+        data["fingerprint"] = fingerprint
 
     if event_id is not None:
         data["event_id"] = event_id


### PR DESCRIPTION
Recently, in the process of trying to work around a test failure, I found myself wanting to be able to specify a sample event's fingerprint. It seemed like it would work - the `load_data` function in the `sentry.utils.samples` module takes a `fingerprint` parameter - but it didn't. It turns out that currently the `fingerprint` parameter is only used in the `if data.get("type") == "transaction"` branch. To make it work for all event types, this PR pulls the fingerprint code out of that branch to the main level of the function, preserving the old behavior in a separate `if data.get("type") == "transaction"` sub-branch.