### PR TITLE
refactor(replays): Update live badge styling and indicator color

### DIFF
--- a/static/app/components/replays/replayBadge.tsx
+++ b/static/app/components/replays/replayBadge.tsx
@@ -105,9 +105,14 @@ export default function ReplayBadge({replay}: Props) {
             </Text>
           </div>
           {isLive ? (
-            <Tooltip title={LIVE_TOOLTIP_MESSAGE}>
+            <LiveContainer align="center" gap="xs">
+              <Tooltip title={LIVE_TOOLTIP_MESSAGE}>
+                <Text bold variant="danger" data-test-id="live-badge">
+                  {t('LIVE')}
+                </Text>
+              </Tooltip>
               <LiveIndicator />
-            </Tooltip>
+            </LiveContainer>
           ) : null}
         </Flex>
 
@@ -137,6 +142,10 @@ export default function ReplayBadge({replay}: Props) {
     </Wrapper>
   );
 }
+
+const LiveContainer = styled(Flex)`
+  margin-left: ${p => p.theme.space.md};
+`;
 
 const Wrapper = styled(Grid)`
   white-space: nowrap;

--- a/static/app/components/replays/replayBadge.tsx
+++ b/static/app/components/replays/replayBadge.tsx
@@ -98,21 +98,21 @@ export default function ReplayBadge({replay}: Props) {
       />
 
       <Flex direction="column" gap="xs" justify="center">
-        <Flex direction="row" align="center">
+        <Flex direction="row" align="center" gap="sm">
           <div>
             <Text size="md" bold ellipsis data-underline-on-hover>
               {replay.user.display_name || t('Anonymous User')}
             </Text>
           </div>
           {isLive ? (
-            <LiveContainer align="center" gap="xs">
-              <Tooltip title={LIVE_TOOLTIP_MESSAGE}>
+            <Flex align="center" gap="xs">
+              <Tooltip title={LIVE_TOOLTIP_MESSAGE} underlineColor="danger">
                 <Text bold variant="danger" data-test-id="live-badge">
                   {t('LIVE')}
                 </Text>
               </Tooltip>
               <LiveIndicator />
-            </LiveContainer>
+            </Flex>
           ) : null}
         </Flex>
 
@@ -142,10 +142,6 @@ export default function ReplayBadge({replay}: Props) {
     </Wrapper>
   );
 }
-
-const LiveContainer = styled(Flex)`
-  margin-left: ${p => p.theme.space.md};
-`;
 
 const Wrapper = styled(Grid)`
   white-space: nowrap;

--- a/static/app/components/replays/replayBadge.tsx
+++ b/static/app/components/replays/replayBadge.tsx
@@ -106,12 +106,12 @@ export default function ReplayBadge({replay}: Props) {
           </div>
           {isLive ? (
             <Flex align="center" gap="xs">
-              <Tooltip title={LIVE_TOOLTIP_MESSAGE} underlineColor="danger">
-                <Text bold variant="danger" data-test-id="live-badge">
-                  {t('LIVE')}
-                </Text>
+              <Text bold variant="danger" data-test-id="live-badge">
+                {t('LIVE')}
+              </Text>
+              <Tooltip title={LIVE_TOOLTIP_MESSAGE}>
+                <LiveIndicator />
               </Tooltip>
-              <LiveIndicator />
             </Flex>
           ) : null}
         </Flex>

--- a/static/app/components/replays/replayLiveIndicator.tsx
+++ b/static/app/components/replays/replayLiveIndicator.tsx
@@ -32,7 +32,7 @@ const pulse = keyframes`
 `;
 
 export const LiveIndicator = styled('div')`
-  background: ${p => p.theme.dangerText};
+  background: ${p => p.theme.danger};
   height: 8px;
   width: 8px;
   position: relative;
@@ -48,7 +48,7 @@ export const LiveIndicator = styled('div')`
   &:before {
     content: '';
     animation: ${pulse} 3s ease-out infinite;
-    border: 6px solid ${p => p.theme.dangerText};
+    border: 6px solid ${p => p.theme.danger};
     position: absolute;
     border-radius: 50%;
     height: 20px;

--- a/static/app/components/replays/replayLiveIndicator.tsx
+++ b/static/app/components/replays/replayLiveIndicator.tsx
@@ -1,6 +1,10 @@
 import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import {t} from 'sentry/locale';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -30,6 +34,19 @@ const pulse = keyframes`
     opacity: 0;
   }
 `;
+
+export function LiveBadge() {
+  return (
+    <Flex align="center" gap="xs">
+      <Text bold variant="danger" data-test-id="live-badge">
+        {t('LIVE')}
+      </Text>
+      <Tooltip title={LIVE_TOOLTIP_MESSAGE} underlineColor="danger" showUnderline>
+        <LiveIndicator />
+      </Tooltip>
+    </Flex>
+  );
+}
 
 export const LiveIndicator = styled('div')`
   background: ${p => p.theme.danger};

--- a/static/app/components/replays/replayLiveIndicator.tsx
+++ b/static/app/components/replays/replayLiveIndicator.tsx
@@ -32,13 +32,12 @@ const pulse = keyframes`
 `;
 
 export const LiveIndicator = styled('div')`
-  background: ${p => p.theme.successText};
+  background: ${p => p.theme.dangerText};
   height: 8px;
   width: 8px;
   position: relative;
   border-radius: 50%;
-  margin-left: ${p => p.theme.space.sm};
-  margin-right: ${p => p.theme.space.sm};
+  margin-bottom: 2px;
 
   @media (prefers-reduced-motion: reduce) {
     &:before {
@@ -49,7 +48,7 @@ export const LiveIndicator = styled('div')`
   &:before {
     content: '';
     animation: ${pulse} 3s ease-out infinite;
-    border: 6px solid ${p => p.theme.successText};
+    border: 6px solid ${p => p.theme.dangerText};
     position: absolute;
     border-radius: 50%;
     height: 20px;

--- a/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
@@ -1,9 +1,5 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
-
 import {Button} from 'sentry/components/core/button';
 import {Link} from 'sentry/components/core/link';
 import UserBadge from 'sentry/components/idBadge/userBadge';
@@ -13,8 +9,7 @@ import ReplayLoadingState from 'sentry/components/replays/player/replayLoadingSt
 import {
   getLiveDurationMs,
   getReplayExpiresAtMs,
-  LIVE_TOOLTIP_MESSAGE,
-  LiveIndicator,
+  LiveBadge,
 } from 'sentry/components/replays/replayLiveIndicator';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCalendar, IconRefresh} from 'sentry/icons';
@@ -134,20 +129,7 @@ export default function ReplayDetailsUserBadge({readerResult}: Props) {
                 isTooltipHoverable
                 unitStyle="regular"
               />
-              {showLiveIndicator ? (
-                <Tooltip
-                  title={LIVE_TOOLTIP_MESSAGE}
-                  underlineColor="danger"
-                  showUnderline
-                >
-                  <Flex align="center" gap="xs">
-                    <Text bold variant="danger" data-test-id="live-badge">
-                      {t('LIVE')}
-                    </Text>
-                    <LiveIndicator />
-                  </Flex>
-                </Tooltip>
-              ) : null}
+              {showLiveIndicator ? <LiveBadge /> : null}
               <Button
                 title={t('Replay is outdated. Refresh for latest activity.')}
                 data-test-id="refresh-button"

--- a/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
@@ -137,7 +137,7 @@ export default function ReplayDetailsUserBadge({readerResult}: Props) {
               {showLiveIndicator ? (
                 <Tooltip
                   title={LIVE_TOOLTIP_MESSAGE}
-                  underlineColor="success"
+                  underlineColor="danger"
                   showUnderline
                 >
                   <Flex align="center" gap="xs">

--- a/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsUserBadge.tsx
@@ -140,8 +140,8 @@ export default function ReplayDetailsUserBadge({readerResult}: Props) {
                   underlineColor="success"
                   showUnderline
                 >
-                  <Flex align="center">
-                    <Text bold variant="success" data-test-id="live-badge">
+                  <Flex align="center" gap="xs">
+                    <Text bold variant="danger" data-test-id="live-badge">
                       {t('LIVE')}
                     </Text>
                     <LiveIndicator />


### PR DESCRIPTION
> Related to [REPLAY-814: Implement new UI for Replay Page](https://linear.app/getsentry/issue/REPLAY-814/implement-new-ui-for-replay-page)

@Jesse-Box mentioned he wanted the LIVE design to be red, and shown in the index page. 