### PR TITLE
fix(typing): Add types to eventstream tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -737,7 +737,7 @@ module = [
     "tests.sentry.digests.*",
     "tests.sentry.discover.translation.*",
     "tests.sentry.event_manager.test_event_manager",
-    "tests.sentry.eventstream.kafka.*",
+    "tests.sentry.eventstream.*",
     "tests.sentry.eventtypes.*",
     "tests.sentry.flags.*",
     "tests.sentry.grouping.*",

--- a/tests/sentry/eventstream/test_eap.py
+++ b/tests/sentry/eventstream/test_eap.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sentry_protos.snuba.v1.endpoint_delete_trace_items_pb2 import DeleteTraceItemsResponse
@@ -11,13 +11,13 @@ from sentry.testutils.cases import TestCase
 
 
 class TestEAPDeletion(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.organization_id = 1
         self.project_id = 123
         self.group_ids = [1, 2, 3]
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_deletion_with_error_dataset(self, mock_rpc):
+    def test_deletion_with_error_dataset(self, mock_rpc: MagicMock) -> None:
         mock_rpc.return_value = DeleteTraceItemsResponse(
             meta=ResponseMeta(),
             matching_items_count=150,
@@ -45,7 +45,7 @@ class TestEAPDeletion(TestCase):
         )
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_multiple_group_ids(self, mock_rpc):
+    def test_multiple_group_ids(self, mock_rpc: MagicMock) -> None:
         mock_rpc.return_value = DeleteTraceItemsResponse(
             meta=ResponseMeta(),
             matching_items_count=500,
@@ -64,7 +64,7 @@ class TestEAPDeletion(TestCase):
         assert list(group_filter.comparison_filter.value.val_int_array.values) == many_group_ids
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_eap_deletion_disabled_skips_deletion(self, mock_rpc):
+    def test_eap_deletion_disabled_skips_deletion(self, mock_rpc: MagicMock) -> None:
         with self.options({"eventstream.eap.deletion-enabled": False}):
             delete_events_from_eap(
                 self.organization_id, self.project_id, self.group_ids, Dataset.Events
@@ -72,7 +72,7 @@ class TestEAPDeletion(TestCase):
 
         mock_rpc.assert_not_called()
 
-    def test_empty_group_ids_raises_error(self):
+    def test_empty_group_ids_raises_error(self) -> None:
         with pytest.raises(ValueError, match="group_ids must not be empty"):
             delete_groups_from_eap_rpc(
                 organization_id=self.organization_id,
@@ -81,7 +81,7 @@ class TestEAPDeletion(TestCase):
             )
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_exception_does_not_propagate(self, mock_rpc):
+    def test_exception_does_not_propagate(self, mock_rpc: MagicMock) -> None:
         mock_rpc.side_effect = Exception("RPC connection failed")
 
         # Should not raise - exception should be caught

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -22,7 +22,7 @@ class ItemHelpersTest(TestCase):
         )
         return group_event
 
-    def test_encode_attributes_basic(self):
+    def test_encode_attributes_basic(self) -> None:
         event_data = {
             "string_field": "test",
             "int_field": 123,
@@ -42,7 +42,7 @@ class ItemHelpersTest(TestCase):
         assert result["float_field"] == AnyValue(double_value=45.67)
         assert result["bool_field"] == AnyValue(bool_value=True)
 
-    def test_encode_attributes_with_ignore_fields(self):
+    def test_encode_attributes_with_ignore_fields(self) -> None:
         event_data = {
             "keep_field": "value1",
             "ignore_field": "value2",
@@ -60,7 +60,7 @@ class ItemHelpersTest(TestCase):
         assert "another_keep" in result
         assert "ignore_field" not in result
 
-    def test_encode_attributes_with_multiple_ignore_fields(self):
+    def test_encode_attributes_with_multiple_ignore_fields(self) -> None:
         event_data = {
             "field1": "value1",
             "field2": "value2",
@@ -78,7 +78,7 @@ class ItemHelpersTest(TestCase):
         assert "field2" in result
         assert "field3" not in result
 
-    def test_encode_attributes_with_group_id(self):
+    def test_encode_attributes_with_group_id(self) -> None:
         event_data = {"field": "value", "tags": []}
 
         event = self.create_group_event(event_data)
@@ -87,7 +87,7 @@ class ItemHelpersTest(TestCase):
         assert result["group_id"] == AnyValue(int_value=event.group.id)
         assert result["field"] == AnyValue(string_value="value")
 
-    def test_encode_attributes_without_group_id(self):
+    def test_encode_attributes_without_group_id(self) -> None:
         event_data = {"field": "value", "tags": []}
 
         event = Event(
@@ -101,7 +101,7 @@ class ItemHelpersTest(TestCase):
         assert "group_id" not in result
         assert result["field"] == AnyValue(string_value="value")
 
-    def test_encode_attributes_with_tags(self):
+    def test_encode_attributes_with_tags(self) -> None:
         event_data = {
             "field": "value",
             "tags": [
@@ -123,7 +123,7 @@ class ItemHelpersTest(TestCase):
         assert result["tags[release]"] == AnyValue(string_value="1.0.0")
         assert result["tags[level]"] == AnyValue(string_value="error")
 
-    def test_encode_attributes_with_empty_tags(self):
+    def test_encode_attributes_with_empty_tags(self) -> None:
         event_data = {"field": "value", "tags": []}
 
         event = Event(
@@ -138,7 +138,7 @@ class ItemHelpersTest(TestCase):
         # No tags[] keys should be present
         assert not any(key.startswith("tags[") for key in result.keys())
 
-    def test_encode_attributes_with_integer_tag_values(self):
+    def test_encode_attributes_with_integer_tag_values(self) -> None:
         event_data = {
             "field": "value",
             "tags": [
@@ -154,7 +154,7 @@ class ItemHelpersTest(TestCase):
         assert result["tags[string_tag]"] == AnyValue(string_value="value")
         assert result["group_id"] == AnyValue(int_value=event.group.id)
 
-    def test_encode_attributes_empty_event_data(self):
+    def test_encode_attributes_empty_event_data(self) -> None:
         event_data: dict[str, Any] = {"tags": []}
 
         event = Event(
@@ -169,7 +169,7 @@ class ItemHelpersTest(TestCase):
         assert len(result) == 1
         assert result["tags"] == AnyValue(array_value=ArrayValue(values=[]))
 
-    def test_encode_attributes_with_complex_types(self):
+    def test_encode_attributes_with_complex_types(self) -> None:
         event_data = {
             "list_field": [1, 2, 3],
             "dict_field": {"nested": "value"},
@@ -201,7 +201,7 @@ class ItemHelpersTest(TestCase):
             )
         )
 
-    def test_serialize_event_data_as_item_basic(self):
+    def test_serialize_event_data_as_item_basic(self) -> None:
         project = self.create_project()
 
         event_data = {
@@ -226,7 +226,7 @@ class ItemHelpersTest(TestCase):
         # Check that received field is not set (protobuf optional field)
         assert not result.HasField("received")
 
-    def test_serialize_event_data_as_item_with_received(self):
+    def test_serialize_event_data_as_item_with_received(self) -> None:
         project = self.create_project()
 
         event_data = {
@@ -247,7 +247,7 @@ class ItemHelpersTest(TestCase):
         assert result.HasField("received")
         assert result.received.seconds == 1234567900
 
-    def test_serialize_event_data_as_item_with_custom_retention_days(self):
+    def test_serialize_event_data_as_item_with_custom_retention_days(self) -> None:
         project = self.create_project()
 
         event_data = {
@@ -268,7 +268,7 @@ class ItemHelpersTest(TestCase):
 
         assert result.retention_days == 30
 
-    def test_serialize_event_data_as_item_ignores_specified_fields(self):
+    def test_serialize_event_data_as_item_ignores_specified_fields(self) -> None:
         project = self.create_project()
 
         event_data = {
@@ -295,7 +295,7 @@ class ItemHelpersTest(TestCase):
         # tags should be encoded with tags[] prefix
         assert result.attributes["tags[level]"] == AnyValue(string_value="info")
 
-    def test_serialize_event_data_as_item_with_multiple_attributes(self):
+    def test_serialize_event_data_as_item_with_multiple_attributes(self) -> None:
         project = self.create_project()
 
         event_data = {


### PR DESCRIPTION
# Summary
Added some missing test types.

# Test Plan
`mypy` no errors
`pytest tests/sentry/eventstream` no failures