### PR TITLE
chore(sentry apps): Token id and info in logs for failing refresh

### DIFF
--- a/src/sentry/sentry_apps/token_exchange/refresher.py
+++ b/src/sentry/sentry_apps/token_exchange/refresher.py
@@ -60,7 +60,11 @@ class Refresher:
                 if token is not None:
                     logger.warning(
                         "refresher.outbox-failure",
-                        extra=context,
+                        extra={
+                            **context,
+                            "token_id": token.id,
+                            "last_characters": token.token_last_characters,
+                        },
                         exc_info=e,
                     )
                     return token


### PR DESCRIPTION
It seems like we're returning bad tokens but shouldn't these already been committed???