### PR TITLE
fix(aci): Add dataset and query formatting to metric issue

### DIFF
--- a/static/app/views/detectors/components/details/metric/detect.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.spec.tsx
@@ -1,4 +1,7 @@
-import {MetricDetectorFixture} from 'sentry-fixture/detectors';
+import {
+  AnomalyDetectionConditionGroupFixture,
+  MetricDetectorFixture,
+} from 'sentry-fixture/detectors';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -59,16 +62,16 @@ describe('MetricDetectorDetailsDetect', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders dynamic detection notice', () => {
+  it('renders dynamic detection', () => {
     const detector = MetricDetectorFixture({
       config: {detectionType: 'dynamic'},
+      conditionGroup: AnomalyDetectionConditionGroupFixture(),
     });
 
     render(<MetricDetectorDetailsDetect detector={detector} />);
 
     expect(screen.getByText('Dynamic threshold')).toBeInTheDocument();
-    expect(
-      screen.getByText('Sentry will automatically update priority.')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Trend: Above and Below')).toBeInTheDocument();
+    expect(screen.getByText('Responsiveness: High')).toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Grid} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 
 import {Flex} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
@@ -25,6 +25,11 @@ import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 import {PriorityDot} from 'sentry/views/detectors/components/priorityDot';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
+import {
+  getSensitivityLabel,
+  getThresholdTypeLabel,
+  isAnomalyDetectionComparison,
+} from 'sentry/views/detectors/utils/anomalyDetectionLabels';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 
 function getDetectorTypeLabel(detector: MetricDetector) {
@@ -84,6 +89,22 @@ export function getConditionDescription({
     typeof condition.comparison === 'number' ? String(condition.comparison) : '';
   const unit = getMetricDetectorSuffix(config.detectionType, aggregate);
 
+  if (config.detectionType === 'dynamic') {
+    if (isAnomalyDetectionComparison(condition.comparison)) {
+      const sensitivityLabel = getSensitivityLabel(condition.comparison.sensitivity);
+      const directionLabel = getThresholdTypeLabel(condition.comparison.thresholdType);
+      return (
+        <Stack>
+          <div>{t('Trend: %(direction)s', {direction: directionLabel})}</div>
+          <div>
+            {t('Responsiveness: %(sensitivity)s', {sensitivity: sensitivityLabel})}
+          </div>
+        </Stack>
+      );
+    }
+    return t('Dynamic threshold');
+  }
+
   if (config.detectionType === 'percent') {
     const direction =
       condition.type === DataConditionType.GREATER ? t('higher') : t('lower');
@@ -117,10 +138,6 @@ export function getConditionDescription({
 }
 
 function DetectorPriorities({detector}: {detector: MetricDetector}) {
-  if (detector.config.detectionType === 'dynamic') {
-    return <div>{t('Sentry will automatically update priority.')}</div>;
-  }
-
   const conditions = detector.conditionGroup?.conditions || [];
 
   return (

--- a/static/app/views/detectors/utils/anomalyDetectionLabels.tsx
+++ b/static/app/views/detectors/utils/anomalyDetectionLabels.tsx
@@ -1,0 +1,52 @@
+import {t} from 'sentry/locale';
+import type {AnomalyDetectionComparison} from 'sentry/types/workflowEngine/detectors';
+import {
+  AlertRuleSensitivity,
+  AlertRuleThresholdType,
+} from 'sentry/views/alerts/rules/metric/types';
+
+/**
+ * Type guard to check if a condition comparison is an anomaly detection comparison
+ */
+export function isAnomalyDetectionComparison(
+  comparison: unknown
+): comparison is AnomalyDetectionComparison {
+  return (
+    typeof comparison === 'object' &&
+    comparison !== null &&
+    'sensitivity' in comparison &&
+    'thresholdType' in comparison
+  );
+}
+
+/**
+ * Get the display label for an anomaly detection sensitivity level
+ */
+export function getSensitivityLabel(sensitivity: AlertRuleSensitivity): string {
+  switch (sensitivity) {
+    case AlertRuleSensitivity.HIGH:
+      return t('High');
+    case AlertRuleSensitivity.MEDIUM:
+      return t('Medium');
+    case AlertRuleSensitivity.LOW:
+      return t('Low');
+    default:
+      return t('Unknown');
+  }
+}
+
+/**
+ * Get the display label for an anomaly detection threshold type (direction)
+ */
+export function getThresholdTypeLabel(thresholdType: AlertRuleThresholdType): string {
+  switch (thresholdType) {
+    case AlertRuleThresholdType.ABOVE:
+      return t('Above');
+    case AlertRuleThresholdType.BELOW:
+      return t('Below');
+    case AlertRuleThresholdType.ABOVE_AND_BELOW:
+      return t('Above and Below');
+    default:
+      return t('Unknown');
+  }
+}

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -104,14 +104,16 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(screen.getByText('Subtitle')).toBeInTheDocument();
 
     // Check key-value pairs
-    expect(screen.getByText('Aggregate')).toBeInTheDocument();
-    expect(screen.getByText('count()')).toBeInTheDocument();
-    expect(screen.getByText('Query')).toBeInTheDocument();
-    expect(screen.getByText('is:unresolved')).toBeInTheDocument();
-    expect(screen.getByText('Interval')).toBeInTheDocument();
-    expect(screen.getByText('1 minute')).toBeInTheDocument();
-    expect(screen.getByText('Above 100')).toBeInTheDocument();
-    expect(screen.getByText('Evaluated Value')).toBeInTheDocument();
-    expect(screen.getByText('150')).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Dataset'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Errors'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Aggregate'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'count()'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Query'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'is:unresolved'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Interval'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '1 minute'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Above 100'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Evaluated Value'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '150'})).toBeInTheDocument();
   });
 });

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -19,7 +19,12 @@ import type {
   UptimeDetector,
   UptimeSubscriptionDataSource,
 } from 'sentry/types/workflowEngine/detectors';
-import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
+import {
+  AlertRuleSensitivity,
+  AlertRuleThresholdType,
+  Dataset,
+  EventTypes,
+} from 'sentry/views/alerts/rules/metric/types';
 import {
   MonitorStatus,
   ScheduleType,
@@ -49,6 +54,19 @@ function DataConditionFixture(params: Partial<MetricCondition> = {}): MetricCond
   };
 }
 
+export function AnomalyDetectionConditionFixture(
+  params: Partial<MetricCondition> = {}
+): MetricCondition {
+  return DataConditionFixture({
+    comparison: {
+      sensitivity: AlertRuleSensitivity.HIGH,
+      seasonality: 'auto',
+      thresholdType: AlertRuleThresholdType.ABOVE_AND_BELOW,
+    },
+    ...params,
+  });
+}
+
 function DataConditionGroupFixture(
   params: Partial<MetricConditionGroup> = {}
 ): MetricConditionGroup {
@@ -67,6 +85,15 @@ function DataConditionGroupFixture(
     logicType: DataConditionGroupLogicType.ANY,
     ...params,
   };
+}
+
+export function AnomalyDetectionConditionGroupFixture(
+  params: Partial<MetricConditionGroup> = {}
+): MetricConditionGroup {
+  return DataConditionGroupFixture({
+    conditions: [AnomalyDetectionConditionFixture()],
+    ...params,
+  });
 }
 
 export function MetricDetectorFixture(

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -54,7 +54,7 @@ function DataConditionFixture(params: Partial<MetricCondition> = {}): MetricCond
   };
 }
 
-export function AnomalyDetectionConditionFixture(
+function AnomalyDetectionConditionFixture(
   params: Partial<MetricCondition> = {}
 ): MetricCondition {
   return DataConditionFixture({


### PR DESCRIPTION
Some followup work on the issue details info:

- Query is rendered with FormattedQuery 
- Displays the dataset
- Uses the dataset config to format the aggregate
- Renders a correct label for dynamic thresholds (doesn't work yet in practice because backend isn't sending the config yet)

<img width="1508" height="656" alt="CleanShot 2025-12-02 at 14 06 31@2x" src="https://github.com/user-attachments/assets/19fb7896-e66a-4980-b72a-00be6b3390e7" />
