### PR TITLE
fix(Replay): Rename Project ID Field in Query Response for Frontend

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -38,6 +38,9 @@ def _format_eap_timestamps(data: list[dict]) -> list[dict]:
             item["finished_at"] = datetime.fromtimestamp(
                 item["finished_at"], tz=timezone.utc
             ).isoformat()
+        # Rename agg_project_id to project_id for frontend compatibility
+        if "agg_project_id" in item:
+            item["project_id"] = item.pop("agg_project_id")
     return data
 
 


### PR DESCRIPTION
As the title says, this PR changes the field name in the EAP replay query response from agg_project_id to project_id. The reason for this is due to the following error when loading a replay:

<img width="1010" height="332" alt="image" src="https://github.com/user-attachments/assets/897b863d-c59b-4bcf-9eed-0465bc69b8ed" />

This can be traced to:

```
return projects.projects.find(p => p.id === replayRecord.project_id)?.slug ?? null;
```

in `useReplayProjectSlug.tsx` . Since `project_id` did not previously exist in the replayRecord, this would return null. Thus, we rename the field name for frontend compatability. The reason we do not change the SELECT alias from `agg_project_id` to `project_id` directly is because it creates a **name collision in the EAP query transpiler**.

When we use:
Function("min", parameters=[Column("project_id")], alias="project_id")
attribute_types = {"project_id": int}The name `project_id` refers to **both**:
1. The input column being aggregated (inside `min()`)
2. The output alias of the aggregation

This causes the transpiler to generate invalid ClickHouse SQL where the aggregation alias is referenced in the WHERE clause before it's defined.