### PR TITLE
feat(dashboards): Adds series display type support for Dashboard Issue Widgets

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -84,7 +84,8 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     organization: Organization,
     tags?: TagCollection,
     customMeasurements?: CustomMeasurementCollection,
-    api?: Client
+    api?: Client,
+    displayType?: DisplayType
   ) => Record<string, SelectValue<FieldValue>>;
   /**
    * List of supported display types for dataset.
@@ -100,6 +101,16 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     organization: Organization,
     pageFilters: PageFilters
   ) => TableData;
+  /**
+   * Default field to add to the widget query when adding a new field for series display type.
+   */
+  defaultSeriesField?: QueryFieldValue;
+  /**
+   * Default query to display when dataset is selected in the
+   * Widget Builder for series display type. Currently only used
+   * by the issues dataset.
+   */
+  defaultSeriesWidgetQuery?: WidgetQuery;
   /**
    * Configure enabling/disabling sort/direction options with an
    * optional message for why it is disabled.

--- a/static/app/views/dashboards/datasetConfig/issues.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.spec.tsx
@@ -91,29 +91,19 @@ describe('transformIssuesResponseToTable', () => {
   });
   it('transforms issues timeseries response to series', () => {
     expect(
-      transformIssuesResponseToSeries(
-        {
-          timeSeries: [
-            {
-              yAxis: 'count(new_issues)',
-              values: [{timestamp: 1763495560000, value: 10}],
-              meta: {
-                valueType: 'integer',
-                valueUnit: null,
-                interval: 10800000,
-              },
+      transformIssuesResponseToSeries({
+        timeSeries: [
+          {
+            yAxis: 'count(new_issues)',
+            values: [{timestamp: 1763495560000, value: 10}],
+            meta: {
+              valueType: 'integer',
+              valueUnit: null,
+              interval: 10800000,
             },
-          ],
-        },
-        {
-          name: '',
-          fields: ['count(new_issues)'],
-          columns: [],
-          aggregates: ['count(new_issues)'],
-          orderby: '',
-          conditions: '',
-        }
-      )
+          },
+        ],
+      })
     ).toEqual([expect.objectContaining({data: [{name: 1763495560000, value: 10}]})]);
   });
 });

--- a/static/app/views/dashboards/datasetConfig/issues.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.spec.tsx
@@ -4,7 +4,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {GroupStatus} from 'sentry/types/group';
-import {transformIssuesResponseToTable} from 'sentry/views/dashboards/datasetConfig/issues';
+import {
+  transformIssuesResponseToSeries,
+  transformIssuesResponseToTable,
+} from 'sentry/views/dashboards/datasetConfig/issues';
 
 describe('transformIssuesResponseToTable', () => {
   it('transforms issues response', () => {
@@ -85,5 +88,32 @@ describe('transformIssuesResponseToTable', () => {
         },
       })
     );
+  });
+  it('transforms issues timeseries response to series', () => {
+    expect(
+      transformIssuesResponseToSeries(
+        {
+          timeSeries: [
+            {
+              yAxis: 'count(new_issues)',
+              values: [{timestamp: 1763495560000, value: 10}],
+              meta: {
+                valueType: 'integer',
+                valueUnit: null,
+                interval: 10800000,
+              },
+            },
+          ],
+        },
+        {
+          name: '',
+          fields: ['count(new_issues)'],
+          columns: [],
+          aggregates: ['count(new_issues)'],
+          orderby: '',
+          conditions: '',
+        }
+      )
+    ).toEqual([expect.objectContaining({data: [{name: 1763495560000, value: 10}]})]);
   });
 });

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -303,12 +303,9 @@ function getIssuesSeriesRequest(
   >;
 }
 
-export function transformIssuesResponseToSeries(
-  data: IssuesSeriesResponse,
-  widgetQuery: WidgetQuery
-): Series[] {
+export function transformIssuesResponseToSeries(data: IssuesSeriesResponse): Series[] {
   return data.timeSeries.map(timeSeries => ({
-    seriesName: widgetQuery.name || timeSeries.yAxis,
+    seriesName: timeSeries.yAxis,
     data: timeSeries.values.map(item => ({
       name: item.timestamp,
       value: item.value ?? 0,

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -44,7 +44,7 @@ const DEFAULT_TABLE_WIDGET_QUERY: WidgetQuery = {
   orderby: IssueSortOptions.DATE,
 };
 
-export const DEFAULT_ISSUE_SERIES_WIDGET_QUERY: WidgetQuery = {
+const DEFAULT_ISSUE_SERIES_WIDGET_QUERY: WidgetQuery = {
   name: '',
   fields: ['count(new_issues)'],
   columns: [],

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -1,23 +1,29 @@
-import type {Client} from 'sentry/api';
+import {doEventsRequest} from 'sentry/actionCreators/events';
+import type {ApiResult, Client} from 'sentry/api';
 import {joinQuery, parseSearch, Token} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import type {PageFilters} from 'sentry/types/core';
+import type {Series} from 'sentry/types/echarts';
 import type {Group} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
+import type {Organization, OrganizationSummary} from 'sentry/types/organization';
 import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
+import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DEFAULT_TABLE_LIMIT, DisplayType} from 'sentry/views/dashboards/types';
 import {IssuesSearchBar} from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar';
 import {
   ISSUE_FIELD_TO_HEADER_MAP,
-  ISSUE_FIELDS,
+  ISSUE_TABLE_FIELDS,
 } from 'sentry/views/dashboards/widgetBuilder/issueWidget/fields';
 import {generateIssueWidgetFieldOptions} from 'sentry/views/dashboards/widgetBuilder/issueWidget/utils';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {useIssueListSearchBarDataProvider} from 'sentry/views/issueList/searchBar';
 import {
@@ -28,7 +34,7 @@ import {
 
 import type {DatasetConfig} from './base';
 
-const DEFAULT_WIDGET_QUERY: WidgetQuery = {
+const DEFAULT_TABLE_WIDGET_QUERY: WidgetQuery = {
   name: '',
   fields: ['issue', 'assignee', 'title'] as string[],
   columns: ['issue', 'assignee', 'title'],
@@ -38,12 +44,27 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   orderby: IssueSortOptions.DATE,
 };
 
+export const DEFAULT_ISSUE_SERIES_WIDGET_QUERY: WidgetQuery = {
+  name: '',
+  fields: ['count(new_issues)'],
+  columns: [],
+  fieldAliases: [],
+  aggregates: ['count(new_issues)'],
+  conditions: '',
+  orderby: '-count(new_issues)',
+};
+
 const DEFAULT_SORT = IssueSortOptions.DATE;
 const DEFAULT_EXPAND = ['owners'];
 
 const DEFAULT_FIELD: QueryFieldValue = {
   field: 'issue',
   kind: FieldValueKind.FIELD,
+};
+
+const DEFAULT_SERIES_FIELD: QueryFieldValue = {
+  function: ['count', 'new_issues', undefined, undefined],
+  kind: FieldValueKind.FUNCTION,
 };
 
 type EndpointParams = Partial<PageFilters['datetime']> & {
@@ -60,21 +81,40 @@ type EndpointParams = Partial<PageFilters['datetime']> & {
   statsPeriod?: string | null;
 };
 
-export const IssuesConfig: DatasetConfig<never, Group[]> = {
+export type IssuesSeriesResponse = {
+  timeSeries: TimeSeries[];
+  meta?: {
+    dataset: string;
+    end: number;
+    start: number;
+  };
+};
+
+export const IssuesConfig: DatasetConfig<IssuesSeriesResponse, Group[]> = {
   defaultField: DEFAULT_FIELD,
-  defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
+  defaultSeriesField: DEFAULT_SERIES_FIELD,
+  defaultWidgetQuery: DEFAULT_TABLE_WIDGET_QUERY,
+  defaultSeriesWidgetQuery: DEFAULT_ISSUE_SERIES_WIDGET_QUERY,
   enableEquations: false,
   disableSortOptions,
   getTableRequest,
   getCustomFieldRenderer: getIssueFieldRenderer,
   SearchBar: IssuesSearchBar,
   useSearchBarDataProvider: useIssueListSearchBarDataProvider,
+  transformSeries: transformIssuesResponseToSeries,
+  filterYAxisOptions,
   getTableSortOptions,
-  getTableFieldOptions: (_organization: Organization) =>
-    generateIssueWidgetFieldOptions(),
+  getTableFieldOptions: (organization, _tags, _customMeasurements, _api, displayType) =>
+    generateIssueWidgetFieldOptions(organization, displayType),
   getFieldHeaderMap: () => ISSUE_FIELD_TO_HEADER_MAP,
-  supportedDisplayTypes: [DisplayType.TABLE],
+  supportedDisplayTypes: [
+    DisplayType.TABLE,
+    DisplayType.AREA,
+    DisplayType.LINE,
+    DisplayType.BAR,
+  ],
   transformTable: transformIssuesResponseToTable,
+  getSeriesRequest: getIssuesSeriesRequest,
 };
 
 function disableSortOptions(_widgetQuery: WidgetQuery) {
@@ -174,7 +214,13 @@ export function transformIssuesResponseToTable(
 
   return {
     data: transformedTableResults,
-    meta: {fields: ISSUE_FIELDS},
+    meta: {fields: ISSUE_TABLE_FIELDS},
+  };
+}
+
+function filterYAxisOptions() {
+  return function (option: FieldValueOption) {
+    return option.value.kind === FieldValueKind.FUNCTION;
   };
 }
 
@@ -220,4 +266,52 @@ function getTableRequest(
       ...params,
     },
   });
+}
+
+function getIssuesSeriesRequest(
+  api: Client,
+  widget: Widget,
+  queryIndex: number,
+  organization: Organization,
+  pageFilters: PageFilters,
+  _onDemandControlContext?: OnDemandControlContext,
+  referrer?: string
+): Promise<ApiResult<IssuesSeriesResponse>> {
+  const requestData = getSeriesRequestData(
+    widget,
+    queryIndex,
+    organization,
+    pageFilters,
+    DiscoverDatasets.ISSUE_PLATFORM,
+    referrer
+  );
+
+  requestData.generatePathname = (_org: OrganizationSummary) =>
+    `/organizations/${organization.slug}/issues-timeseries/`;
+
+  requestData.queryExtras = {
+    ...requestData.queryExtras,
+    category: 'issue',
+  };
+
+  // TODO: For now we are reusing EventsStatsOptions which contains attributes
+  // not needed for issue requests.
+  const {dataset: _dataset, query: _query, ...prunedRequestData} = requestData;
+
+  return doEventsRequest<true>(api, prunedRequestData) as unknown as Promise<
+    ApiResult<IssuesSeriesResponse>
+  >;
+}
+
+export function transformIssuesResponseToSeries(
+  data: IssuesSeriesResponse,
+  widgetQuery: WidgetQuery
+): Series[] {
+  return data.timeSeries.map(timeSeries => ({
+    seriesName: widgetQuery.name || timeSeries.yAxis,
+    data: timeSeries.values.map(item => ({
+      name: item.timestamp,
+      value: item.value ?? 0,
+    })),
+  }));
 }

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -217,11 +217,11 @@ export function getWidgetInterval(
   if (selectedRange / (desiredPeriod * 60) > MAX_BIN_COUNT) {
     const highInterval = getInterval(
       datetimeObj,
-      widget.widgetType === WidgetType.SPANS ||
-        widget.widgetType === WidgetType.LOGS ||
-        (widget.widgetType === WidgetType.ISSUE && isChartDisplayType(widget.displayType))
+      widget.widgetType === WidgetType.SPANS || widget.widgetType === WidgetType.LOGS
         ? 'spans'
-        : 'high'
+        : widget.widgetType === WidgetType.ISSUE
+          ? 'issues'
+          : 'high'
     );
     // Only return high fidelity interval if desired interval is higher fidelity
     if (desiredPeriod < parsePeriodToHours(highInterval)) {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -217,7 +217,9 @@ export function getWidgetInterval(
   if (selectedRange / (desiredPeriod * 60) > MAX_BIN_COUNT) {
     const highInterval = getInterval(
       datetimeObj,
-      widget.widgetType === WidgetType.SPANS || widget.widgetType === WidgetType.LOGS
+      widget.widgetType === WidgetType.SPANS ||
+        widget.widgetType === WidgetType.LOGS ||
+        (widget.widgetType === WidgetType.ISSUE && isChartDisplayType(widget.displayType))
         ? 'spans'
         : 'high'
     );

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -11,12 +11,14 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {DisplayType} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {isChartDisplayType} from 'sentry/views/dashboards/utils';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 
 const typeIcons = {
   [DisplayType.AREA]: <IconGraph key="area" type="area" />,
@@ -47,10 +49,53 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
   const isEditing = useIsEditingWidget();
   const organization = useOrganization();
 
+  const allowIssueWidgetSeriesDisplayType = organization.features.includes(
+    'dashboards-issue-widget-series-display-type'
+  );
+
+  const shouldDisabledIssueDisplayType = (value: DisplayType) => {
+    return (
+      state.dataset === WidgetType.ISSUE &&
+      !allowIssueWidgetSeriesDisplayType &&
+      isChartDisplayType(value)
+    );
+  };
+
   const displayTypes = {...BASE_DISPLAY_TYPES};
   if (organization.features.includes('dashboards-details-widget')) {
     displayTypes[DisplayType.DETAILS] = t('Details');
   }
+
+  // Issue series widgets query a different data source from table widgets.
+  // Therefore we need to handle resetting the query on display type change due to incompatibility.
+  const handleIssueWidgetDisplayTypeChange = (newValue: DisplayType) => {
+    if (state.dataset === WidgetType.ISSUE && config.defaultSeriesWidgetQuery) {
+      const newDisplayIsChart = isChartDisplayType(newValue);
+      const oldDisplayIsChart = isChartDisplayType(state.displayType);
+      if (newDisplayIsChart === oldDisplayIsChart) {
+        // Data source does not change, so we just do a normal display type change.
+        dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: newValue,
+        });
+      } else {
+        // Data source changed between table and series, so we need to reset the query.
+        dispatch({
+          type: BuilderStateAction.SET_STATE,
+          payload: convertWidgetToBuilderStateParams({
+            widgetType: WidgetType.ISSUE,
+            queries: [
+              (newDisplayIsChart && config.defaultSeriesWidgetQuery) ||
+                config.defaultWidgetQuery,
+            ],
+            displayType: newValue,
+            interval: '',
+            title: state.title ?? '',
+          }),
+        });
+      }
+    }
+  };
 
   return (
     <Fragment>
@@ -72,7 +117,9 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
             // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             label: displayTypes[value],
             value,
-            disabled: !config.supportedDisplayTypes.includes(value as DisplayType),
+            disabled:
+              !config.supportedDisplayTypes.includes(value as DisplayType) ||
+              shouldDisabledIssueDisplayType(value as DisplayType),
           }))}
           clearable={false}
           onChange={(newValue: any) => {
@@ -81,19 +128,23 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
             }
             setError?.({...error, displayType: undefined});
 
-            dispatch({
-              type: BuilderStateAction.SET_DISPLAY_TYPE,
-              payload: newValue?.value,
-            });
-            if (
-              (newValue.value === DisplayType.TABLE ||
-                newValue.value === DisplayType.BIG_NUMBER) &&
-              state.query?.length
-            ) {
+            if (state.dataset === WidgetType.ISSUE) {
+              handleIssueWidgetDisplayTypeChange(newValue?.value);
+            } else {
               dispatch({
-                type: BuilderStateAction.SET_QUERY,
-                payload: [state.query[0]!],
+                type: BuilderStateAction.SET_DISPLAY_TYPE,
+                payload: newValue?.value,
               });
+              if (
+                (newValue.value === DisplayType.TABLE ||
+                  newValue.value === DisplayType.BIG_NUMBER) &&
+                state.query?.length
+              ) {
+                dispatch({
+                  type: BuilderStateAction.SET_QUERY,
+                  payload: [state.query[0]!],
+                });
+              }
             }
             trackAnalytics('dashboards_views.widget_builder.change', {
               from: source,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -209,6 +209,32 @@ describe('Visualize', () => {
     );
   });
 
+  it('adds the correct default new series when a default is provided for series display type', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+            query: {
+              yAxis: ['count(resolved_issues)'],
+              dataset: WidgetType.ISSUE,
+              displayType: DisplayType.BAR,
+            },
+          },
+          route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+        },
+      }
+    );
+
+    expect(screen.queryByText('new_issues')).not.toBeInTheDocument();
+    await userEvent.click(await screen.findByText('+ Add Series'));
+    expect(screen.getByText('new_issues')).toBeInTheDocument();
+  });
+
   it('maintains the selected aggregate when the column selection is changed and there are parameters', async () => {
     render(
       <WidgetBuilderProvider>

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -345,7 +345,13 @@ function Visualize({error, setError}: VisualizeProps) {
         customMeasurements
       );
     }
-    return datasetConfig.getTableFieldOptions(organization, tags, customMeasurements);
+    return datasetConfig.getTableFieldOptions(
+      organization,
+      tags,
+      customMeasurements,
+      undefined,
+      state.displayType
+    );
   }, [
     state.dataset,
     datasetConfig,
@@ -354,6 +360,7 @@ function Visualize({error, setError}: VisualizeProps) {
     customMeasurements,
     numericSpanTags,
     stringSpanTags,
+    state.displayType,
   ]);
 
   const aggregates = useMemo(
@@ -383,6 +390,10 @@ function Visualize({error, setError}: VisualizeProps) {
     'visibility-explore-equations'
   );
   const hasDrillDownFlows = useHasDrillDownFlows();
+
+  // Default field to add to the widget query when adding a new field.
+  const defaultField =
+    (isChartWidget && datasetConfig.defaultSeriesField) || datasetConfig.defaultField;
 
   return (
     <Fragment>
@@ -913,7 +924,7 @@ function Visualize({error, setError}: VisualizeProps) {
           onClick={() => {
             dispatch({
               type: updateAction,
-              payload: [...(fields ?? []), cloneDeep(datasetConfig.defaultField)],
+              payload: [...(fields ?? []), cloneDeep(defaultField)],
             });
 
             trackAnalytics('dashboards_views.widget_builder.change', {

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/fields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/fields.tsx
@@ -1,3 +1,6 @@
+import type {Aggregation} from 'sentry/utils/discover/fields';
+import {AggregationKey} from 'sentry/utils/fields';
+
 export type ColumnType =
   | 'boolean'
   | 'date'
@@ -25,9 +28,11 @@ export enum FieldKey {
   LIFETIME_USERS = 'lifetimeUsers',
   PROJECT = 'project',
   LINKS = 'links',
+  NEW_ISSUES = 'new_issues',
+  RESOLVED_ISSUES = 'resolved_issues',
 }
 
-export const ISSUE_FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
+export const ISSUE_TABLE_FIELDS: Readonly<Partial<Record<FieldKey, ColumnType>>> = {
   [FieldKey.ASSIGNEE]: 'string',
   [FieldKey.TITLE]: 'string',
   [FieldKey.ISSUE]: 'string',
@@ -47,7 +52,29 @@ export const ISSUE_FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   [FieldKey.LINKS]: 'string',
 };
 
+export const ISSUE_SERIES_FIELDS: Readonly<Partial<Record<FieldKey, ColumnType>>> = {
+  [FieldKey.NEW_ISSUES]: 'integer',
+  [FieldKey.RESOLVED_ISSUES]: 'integer',
+};
+
 export const ISSUE_FIELD_TO_HEADER_MAP = {
   [FieldKey.LIFETIME_EVENTS]: 'Lifetime Events',
   [FieldKey.LIFETIME_USERS]: 'Lifetime Users',
 };
+
+// issues-timeseries endpoint only supports count(new_issues) and count(resolved_issues)
+export const ISSUE_AGGREGATIONS: Readonly<Partial<Record<AggregationKey, Aggregation>>> =
+  {
+    [AggregationKey.COUNT]: {
+      isSortable: true,
+      outputType: null,
+      parameters: [
+        {
+          kind: 'column',
+          columnTypes: ['integer'],
+          defaultValue: FieldKey.NEW_ISSUES,
+          required: true,
+        },
+      ],
+    },
+  };

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/utils.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/utils.spec.tsx
@@ -1,8 +1,11 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {DisplayType} from 'sentry/views/dashboards/types';
 import {generateIssueWidgetFieldOptions} from 'sentry/views/dashboards/widgetBuilder/issueWidget/utils';
 
 describe('generateIssueWidgetFieldOptions', () => {
   it('returns default issue fields', () => {
-    const issueFields = generateIssueWidgetFieldOptions();
+    const issueFields = generateIssueWidgetFieldOptions(OrganizationFixture());
     expect(Object.keys(issueFields)).toEqual([
       'field:assignee',
       'field:events',
@@ -23,11 +26,15 @@ describe('generateIssueWidgetFieldOptions', () => {
       'field:users',
     ]);
   });
-  it('returns supplied issue fields', () => {
-    const issueFields = generateIssueWidgetFieldOptions({
-      assignee: 'string',
-      title: 'string',
-    });
-    expect(Object.keys(issueFields)).toEqual(['field:assignee', 'field:title']);
+  it('returns default issue fields for series display type', () => {
+    const issueFields = generateIssueWidgetFieldOptions(
+      OrganizationFixture(),
+      DisplayType.BAR
+    );
+    expect(Object.keys(issueFields)).toEqual([
+      'field:new_issues',
+      'field:resolved_issues',
+      'function:count',
+    ]);
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
@@ -1,13 +1,21 @@
 import type {SelectValue} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {isChartDisplayType} from 'sentry/views/dashboards/utils';
 import type {FieldValue} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 import type {ColumnType} from './fields';
-import {ISSUE_FIELDS} from './fields';
+import {ISSUE_AGGREGATIONS, ISSUE_SERIES_FIELDS, ISSUE_TABLE_FIELDS} from './fields';
 
 export function generateIssueWidgetFieldOptions(
-  issueFields: Record<string, ColumnType> = ISSUE_FIELDS
-) {
+  organization: Organization,
+  displayType: DisplayType = DisplayType.TABLE
+): Record<string, SelectValue<FieldValue>> {
+  const issueFields: Record<string, ColumnType> = isChartDisplayType(displayType)
+    ? ISSUE_SERIES_FIELDS
+    : ISSUE_TABLE_FIELDS;
   const fieldKeys = Object.keys(issueFields).sort();
   const fieldOptions: Record<string, SelectValue<FieldValue>> = {};
 
@@ -24,5 +32,15 @@ export function generateIssueWidgetFieldOptions(
     };
   });
 
-  return fieldOptions;
+  let aggregateOptions: Record<string, SelectValue<FieldValue>> = {};
+  if (displayType !== DisplayType.TABLE) {
+    aggregateOptions = generateFieldOptions({
+      organization,
+      tagKeys: [],
+      fieldKeys: [],
+      aggregations: ISSUE_AGGREGATIONS,
+    });
+  }
+
+  return {...fieldOptions, ...aggregateOptions};
 }

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
@@ -11,24 +11,6 @@ import {
 import IssueWidgetQueries from 'sentry/views/dashboards/widgetCard/issueWidgetQueries';
 
 describe('IssueWidgetQueries', () => {
-  const widget: Widget = {
-    id: '1',
-    title: 'Issues Widget',
-    displayType: DisplayType.TABLE,
-    interval: '5m',
-    queries: [
-      {
-        name: '',
-        fields: ['issue', 'assignee', 'title', 'culprit', 'status'],
-        columns: ['issue', 'assignee', 'title', 'culprit', 'status'],
-        aggregates: [],
-        conditions: 'assigned_or_suggested:#visibility timesSeen:>100',
-        orderby: '',
-      },
-    ],
-    widgetType: WidgetType.ISSUE,
-  };
-
   const selection = {
     projects: [1],
     environments: ['prod'],
@@ -42,108 +24,209 @@ describe('IssueWidgetQueries', () => {
 
   const organization = OrganizationFixture();
   const api = new MockApiClient();
-
-  it('does an issue query and passes correct tableResults to child component', async () => {
-    const mockFunction = jest.fn(() => {
-      return <div />;
-    });
-
-    MockApiClient.clearMockResponses();
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/',
-      method: 'GET',
-      body: [
+  describe('table display type', () => {
+    const widget: Widget = {
+      id: '1',
+      title: 'Issues Widget',
+      displayType: DisplayType.TABLE,
+      interval: '5m',
+      queries: [
         {
-          id: '1',
-          title: 'Error: Failed',
-          project: {
-            id: '3',
-          },
-          status: 'unresolved',
-          owners: [
-            {
-              type: 'ownershipRule',
-              owner: 'user:2',
-            },
-          ],
-          lifetime: {count: 10, userCount: 5},
-          count: 6,
-          userCount: 3,
-          firstSeen: '2022-01-01T13:04:02Z',
+          name: '',
+          fields: ['issue', 'assignee', 'title', 'culprit', 'status'],
+          columns: ['issue', 'assignee', 'title', 'culprit', 'status'],
+          aggregates: [],
+          conditions: 'assigned_or_suggested:#visibility timesSeen:>100',
+          orderby: '',
         },
       ],
-    });
+      widgetType: WidgetType.ISSUE,
+    };
 
-    render(
-      <IssueWidgetQueries
-        api={api}
-        organization={organization}
-        widget={widget}
-        selection={{
-          projects: [1],
-          environments: ['prod'],
-          datetime: {
-            period: '14d',
-            start: null,
-            end: null,
-            utc: false,
+    it('does an issue query and passes correct tableResults to child component', async () => {
+      const mockFunction = jest.fn(() => {
+        return <div />;
+      });
+
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        method: 'GET',
+        body: [
+          {
+            id: '1',
+            title: 'Error: Failed',
+            project: {
+              id: '3',
+            },
+            status: 'unresolved',
+            owners: [
+              {
+                type: 'ownershipRule',
+                owner: 'user:2',
+              },
+            ],
+            lifetime: {count: 10, userCount: 5},
+            count: 6,
+            userCount: 3,
+            firstSeen: '2022-01-01T13:04:02Z',
           },
-        }}
-      >
-        {mockFunction}
-      </IssueWidgetQueries>
-    );
+        ],
+      });
 
-    await waitFor(() =>
-      expect(mockFunction).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tableResults: [
-            expect.objectContaining({
-              data: [
-                expect.objectContaining({
-                  id: '1',
-                  title: 'Error: Failed',
-                  status: 'unresolved',
-                  lifetimeEvents: 10,
-                  lifetimeUsers: 5,
-                  events: 6,
-                  users: 3,
-                  firstSeen: '2022-01-01T13:04:02Z',
-                }),
-              ],
-            }),
-          ],
-        })
-      )
-    );
-  });
+      render(
+        <IssueWidgetQueries
+          api={api}
+          organization={organization}
+          widget={widget}
+          selection={{
+            projects: [1],
+            environments: ['prod'],
+            datetime: {
+              period: '14d',
+              start: null,
+              end: null,
+              utc: false,
+            },
+          }}
+        >
+          {mockFunction}
+        </IssueWidgetQueries>
+      );
 
-  it('appends dashboard filters to issue request', async () => {
-    const mock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/',
-      body: [],
+      await waitFor(() =>
+        expect(mockFunction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tableResults: [
+              expect.objectContaining({
+                data: [
+                  expect.objectContaining({
+                    id: '1',
+                    title: 'Error: Failed',
+                    status: 'unresolved',
+                    lifetimeEvents: 10,
+                    lifetimeUsers: 5,
+                    events: 6,
+                    users: 3,
+                    firstSeen: '2022-01-01T13:04:02Z',
+                  }),
+                ],
+              }),
+            ],
+          })
+        )
+      );
     });
-    render(
-      <IssueWidgetQueries
-        api={api}
-        organization={organization}
-        widget={widget}
-        selection={selection}
-        dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.2.0', 'abc@1.3.0']}}
-      >
-        {() => <div data-test-id="child" />}
-      </IssueWidgetQueries>
-    );
 
-    await screen.findByTestId('child');
-    expect(mock).toHaveBeenCalledWith(
-      '/organizations/org-slug/issues/',
-      expect.objectContaining({
-        data: expect.objectContaining({
-          query:
-            'assigned_or_suggested:#visibility timesSeen:>100 release:["abc@1.2.0","abc@1.3.0"] ',
-        }),
-      })
-    );
+    it('appends dashboard filters to issue request', async () => {
+      const mock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        body: [],
+      });
+      render(
+        <IssueWidgetQueries
+          api={api}
+          organization={organization}
+          widget={widget}
+          selection={selection}
+          dashboardFilters={{[DashboardFilterKeys.RELEASE]: ['abc@1.2.0', 'abc@1.3.0']}}
+        >
+          {() => <div data-test-id="child" />}
+        </IssueWidgetQueries>
+      );
+
+      await screen.findByTestId('child');
+      expect(mock).toHaveBeenCalledWith(
+        '/organizations/org-slug/issues/',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            query:
+              'assigned_or_suggested:#visibility timesSeen:>100 release:["abc@1.2.0","abc@1.3.0"] ',
+          }),
+        })
+      );
+    });
+  });
+  describe('series display type', () => {
+    const widget: Widget = {
+      id: '1',
+      title: 'Issues Widget',
+      displayType: DisplayType.BAR,
+      interval: '5m',
+      queries: [
+        {
+          name: '',
+          fields: ['count(new_issues)'],
+          columns: [],
+          aggregates: ['count(new_issues)'],
+          conditions: '',
+          orderby: '-count(new_issues)',
+        },
+      ],
+      widgetType: WidgetType.ISSUE,
+    };
+
+    let issuesTimeseriesMock: jest.Mock;
+
+    beforeEach(() => {
+      issuesTimeseriesMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues-timeseries/',
+        body: {
+          timeSeries: [
+            {
+              yAxis: 'count(new_issues)',
+              values: [{timestamp: '1763495560000', value: 10}],
+            },
+          ],
+          meta: {
+            interval: 10800000,
+            valueType: 'integer',
+            valueUnit: null,
+          },
+        },
+      });
+    });
+
+    afterEach(() => {
+      MockApiClient.clearMockResponses();
+    });
+
+    it('does an issues-timeseries query and passes results to child component', async () => {
+      const mockFunction = jest.fn(() => {
+        return <div />;
+      });
+      render(
+        <IssueWidgetQueries
+          api={api}
+          organization={organization}
+          widget={widget}
+          selection={selection}
+        >
+          {mockFunction}
+        </IssueWidgetQueries>
+      );
+
+      expect(issuesTimeseriesMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/issues-timeseries/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            category: 'issue',
+            yAxis: ['count(new_issues)'],
+          }),
+        })
+      );
+      await waitFor(() =>
+        expect(mockFunction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            timeseriesResults: [
+              expect.objectContaining({
+                data: [{name: '1763495560000', value: 10}],
+                seriesName: 'count(new_issues)',
+              }),
+            ],
+          })
+        )
+      );
+    });
   });
 });

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -6,7 +6,10 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import {IssuesConfig} from 'sentry/views/dashboards/datasetConfig/issues';
+import {
+  IssuesConfig,
+  type IssuesSeriesResponse,
+} from 'sentry/views/dashboards/datasetConfig/issues';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import type {WidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 
@@ -61,7 +64,7 @@ function IssueWidgetQueries({
 
   return getDynamicText({
     value: (
-      <GenericWidgetQueries<never, Group[]>
+      <GenericWidgetQueries<IssuesSeriesResponse, Group[]>
         queue={queue}
         config={config}
         api={api}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -80,8 +80,22 @@ export function WidgetCardDataLoader({
         dashboardFilters={dashboardFilters}
         onDataFetchStart={onDataFetchStart}
       >
-        {({tableResults, errorMessage, loading}) => (
-          <Fragment>{children({tableResults, errorMessage, loading})}</Fragment>
+        {({
+          tableResults,
+          timeseriesResults,
+          timeseriesResultsTypes,
+          errorMessage,
+          loading,
+        }) => (
+          <Fragment>
+            {children({
+              tableResults,
+              timeseriesResults,
+              timeseriesResultsTypes,
+              errorMessage,
+              loading,
+            })}
+          </Fragment>
         )}
       </IssueWidgetQueries>
     );


### PR DESCRIPTION
Adds timeseries support to Issue type widgets in dashboards. Feature is gated on the `displayType` dropdown by checking for the `dashboards-issue-widget-series-display-type` feature flag. 

**Current feature limitations:**
- Currently for Issue timeseries widgets, only `count(new_issues)` and `count(resolved_issues` are supported yAxes.
- Query search filtering is not supported by the backing endpoint (TODO: hide this element in the UI)
- Group by is supported by the endpoint, but only by `release` (TODO: this is not yet added to the UI, handle in follow up PR)

**Implementation notes:**
- Uses the new `/issues-timeseries` endpoint
    - Adds a new `IssuesSeriesResponse` type to match the response payload received in the frontend
    - Due to the `/issues-timeseries` endpoint not sharing query parameters with the `/issues` endpoint for tables, specialized logic has been added to handle resetting the widget builder state when switching between table and series display types:
        - `typeSelector.tsx` has been updated to reset the current query state on change
        - `generateIssueWidgetFieldOptions` updated to accept display type and return results based on table or series display
    - Adds new options to widget dataset configs:
        - `defaultSeriesField` which represents the default field for a series/chart display widget. Used as the default when adding a new yAxis to an Issue series widget.
        - `defaultSeriesWidgetQuery` which represents the default widget query for a series/chart display. This is used for Issue widgets when switching between table and series display views to set the default query.

<img width="673" height="654" alt="image" src="https://github.com/user-attachments/assets/12f26f41-a73e-45e6-a21e-c9e68e499af9" />
