### PR TITLE
fix(ui): Allow empty createdBy for starred views

### DIFF
--- a/static/app/components/savedEntityTable.tsx
+++ b/static/app/components/savedEntityTable.tsx
@@ -271,7 +271,14 @@ SavedEntityTable.CellTimeSince = function CellTimeSince({date}: {date: string | 
   return <TimeSince date={date} unitStyle="short" />;
 };
 
-SavedEntityTable.CellUser = function CellUser({user}: {user: AvatarUser}) {
+SavedEntityTable.CellUser = function CellUser({user}: {user: AvatarUser | null}) {
+  if (!user) {
+    return (
+      <SavedEntityTable.CellTextContent>
+        {t('Unknown User')}
+      </SavedEntityTable.CellTextContent>
+    );
+  }
   return <UserAvatar user={user} size={20} hasTooltip />;
 };
 

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -28,7 +28,7 @@ export enum GroupSearchViewCreatedBy {
 }
 
 export type StarredGroupSearchView = {
-  createdBy: AvatarUser;
+  createdBy: AvatarUser | null;
   dateCreated: string;
   dateUpdated: string;
   environments: string[];


### PR DESCRIPTION
Relates to [ISWF-719: TypeError: Cannot read properties of null (reading 'id'): /issues/:groupId/](https://linear.app/getsentry/issue/ISWF-719/typeerror-cannot-read-properties-of-null-reading-id-issuesgroupid)