### PR TITLE
fix(Replay): Use Sentry Prefix for Project_id

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -55,7 +55,7 @@ def query_replay_instance_eap(
 
     select = [
         Column("replay_id"),
-        Function("min", parameters=[Column("project_id")], alias="agg_project_id"),
+        Function("min", parameters=[Column("sentry.project_id")], alias="agg_project_id"),
         Function("min", parameters=[Column("sentry.timestamp")], alias="started_at"),
         Function("max", parameters=[Column("sentry.timestamp")], alias="finished_at"),
         Function("count", parameters=[Column("segment_id")], alias="count_segments"),
@@ -106,7 +106,7 @@ def query_replay_instance_eap(
     settings = Settings(
         attribute_types={
             "replay_id": str,
-            "project_id": int,
+            "sentry.project_id": int,
             "sentry.timestamp": float,
             "segment_id": int,
             "is_archived": int,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3859,7 +3859,6 @@ class ReplayEAPTestCase(BaseTestCase):
         breadcrumb_data = {
             "replay_id": replay_id,
             "segment_id": segment_id,
-            "project_id": project.id,
             "category": category,
         }
 


### PR DESCRIPTION
As title says, this PR uses sentry prefix to query for project_id (`sentry.project_id`), as it was causing the following issue:
<img width="1010" height="332" alt="image" src="https://github.com/user-attachments/assets/d815978e-9a03-4a10-a6a4-42eb0a29f692" />

The reason this is causing an issue is because `project_id` itself is not queryable as an attribute, since it is a top level protobuf field, which causes the following line to be null on the frontend:

```
return projects.projects.find(p => p.id === replayRecord.project_id)?.slug ?? null;
```


Thus, we change our query to use the sentry prefix to receive the proper data. The reason this was not caught in a unit test previously is because we were manually adding the project_id in the attributes dummy data, allowing it to be queried. To test this new change, we remove the attribute and see that it still works as expected.