### PR TITLE
fix(group_update): Handle last_seen integer overflow on groups

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any
 
 from django.db import DataError
-from django.db.models import Expression, F
+from django.db.models import F
 
 from sentry.db import models
 from sentry.signals import buffer_incr_complete
@@ -172,7 +172,7 @@ class Buffer(Service):
         created = False
 
         if not signal_only:
-            update_kwargs: dict[str, Expression] = {c: F(c) + v for c, v in columns.items()}
+            update_kwargs: dict[str, Any] = {c: F(c) + v for c, v in columns.items()}
 
             if extra:
                 # Because of the group.update() below, we need to parse

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -214,7 +214,7 @@ class Buffer(Service):
                             # Catch NumericValueOutOfRange when times_seen exceeds 32-bit limit
                             if (
                                 isinstance(e.__cause__, psycopg2.errors.NumericValueOutOfRange)
-                                and "times_seen" in columns
+                                and "times_seen" in update_kwargs
                             ):
                                 # Cap times_seen to BoundedPositiveIntegerField.MAX_VALUE and retry the update
                                 update_kwargs["times_seen"] = BoundedPositiveIntegerField.MAX_VALUE


### PR DESCRIPTION
Using error upsampling groups can cross the MAX_INT value of last_seen, handle these errors and cap the value to deal with these errors for now.
