### PR TITLE
feat: Add organizationcontributor seat type

### DIFF
--- a/src/sentry/quotas/types.py
+++ b/src/sentry/quotas/types.py
@@ -1,6 +1,7 @@
 from typing import TypeAlias, Union
 
+from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.monitors.models import Monitor
 from sentry.workflow_engine.models import Detector
 
-SeatObject: TypeAlias = Union[Monitor, Detector]
+SeatObject: TypeAlias = Union[Monitor, Detector, OrganizationContributors]


### PR DESCRIPTION
Adds a new model as a potential seat type


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
