### PR TITLE
test(issues): Move issue details tests off deprecatedRouterMocks

### DIFF
--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -193,6 +193,12 @@ describe('GroupActions', () => {
         method: 'DELETE',
         body: {},
       });
+      const initialRouterConfig = {
+        location: {
+          pathname: `/organizations/${org.slug}/issues/${group.id}/`,
+        },
+        route: `/organizations/:orgId/issues/:groupId/`,
+      };
       const {router} = render(
         <Fragment>
           <GlobalModal />
@@ -200,6 +206,7 @@ describe('GroupActions', () => {
         </Fragment>,
         {
           organization: org,
+          initialRouterConfig,
         }
       );
 
@@ -237,6 +244,12 @@ describe('GroupActions', () => {
         method: 'DELETE',
         body: {},
       });
+      const initialRouterConfig = {
+        location: {
+          pathname: `/organizations/${org.slug}/issues/${issuePlatformGroup.id}/`,
+        },
+        route: `/organizations/:orgId/issues/:groupId/`,
+      };
       const {router} = render(
         <Fragment>
           <GlobalModal />
@@ -249,6 +262,7 @@ describe('GroupActions', () => {
         </Fragment>,
         {
           organization: org,
+          initialRouterConfig,
         }
       );
 
@@ -329,7 +343,6 @@ describe('GroupActions', () => {
       <GroupActions group={group} project={project} disabled={false} event={null} />,
       {
         organization,
-        deprecatedRouterMocks: true,
       }
     );
 

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -1,7 +1,6 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {GroupsFixture} from 'sentry-fixture/groups';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -28,9 +27,12 @@ describe('Issues Similar View', () => {
   });
 
   const group = GroupFixture();
-  const router = RouterFixture({
-    params: {orgId: 'org-slug', groupId: group.id},
-  });
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/org-slug/issues/${group.id}/similar/`,
+    },
+    route: `/organizations/:orgId/issues/:groupId/similar/`,
+  };
 
   const scores = [
     {'exception:stacktrace:pairs': 0.375},
@@ -89,8 +91,7 @@ describe('Issues Similar View', () => {
 
   it('renders with mocked data', async () => {
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
@@ -110,8 +111,7 @@ describe('Issues Similar View', () => {
     });
 
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     renderGlobalModal();
 
@@ -135,8 +135,7 @@ describe('Issues Similar View', () => {
 
   it('correctly shows merge count', async () => {
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     renderGlobalModal();
 
@@ -155,8 +154,7 @@ describe('Issues Similar View', () => {
     });
 
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     renderGlobalModal();
 
@@ -181,9 +179,12 @@ describe('Issues Similar Embeddings View', () => {
     features: ['similarity-view'],
   });
 
-  const router = RouterFixture({
-    params: {orgId: 'org-slug', groupId: group.id},
-  });
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/org-slug/issues/${group.id}/similar/`,
+    },
+    route: `/organizations/:orgId/issues/:groupId/similar/`,
+  };
 
   const similarEmbeddingsScores = [
     {exception: 0.01, shouldBeGrouped: 'Yes'},
@@ -245,8 +246,7 @@ describe('Issues Similar Embeddings View', () => {
 
   it('renders with mocked data', async () => {
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
 
     await waitFor(() => expect(mock).toHaveBeenCalled());
@@ -264,8 +264,7 @@ describe('Issues Similar Embeddings View', () => {
     });
 
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     renderGlobalModal();
 
@@ -289,8 +288,7 @@ describe('Issues Similar Embeddings View', () => {
 
   it('correctly shows merge count', async () => {
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     renderGlobalModal();
 
@@ -309,8 +307,7 @@ describe('Issues Similar Embeddings View', () => {
     });
 
     render(<GroupSimilarIssues />, {
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
     renderGlobalModal();
 

--- a/static/app/views/issueDetails/streamline/eventList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.spec.tsx
@@ -1,9 +1,7 @@
 import {EventsStatsFixture} from 'sentry-fixture/events';
 import {GroupFixture} from 'sentry-fixture/group';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 
 import {render, renderHook, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -21,6 +19,13 @@ describe('EventList', () => {
   const group = GroupFixture();
   const persistantQuery = `issue:${group.shortId}`;
   const totalCount = 100;
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
+    },
+    route: `/organizations/:orgId/issues/:groupId/events/`,
+  };
 
   let mockEventList: jest.Mock;
   let mockEventListMeta: jest.Mock;
@@ -73,16 +78,7 @@ describe('EventList', () => {
 
   function renderAllEvents() {
     render(<EventList group={group} />, {
-      organization,
-
-      router: RouterFixture({
-        location: LocationFixture({
-          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
-        }),
-        routes: [{name: '', path: 'events/'}],
-      }),
-
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
   }
 
@@ -133,17 +129,13 @@ describe('EventList', () => {
       },
     };
     render(<EventList group={group} />, {
-      organization,
-
-      router: RouterFixture({
-        location: LocationFixture({
-          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
+      initialRouterConfig: {
+        ...initialRouterConfig,
+        location: {
+          ...initialRouterConfig.location,
           query: locationQuery.query,
-        }),
-        routes: [{name: '', path: 'events/'}],
-      }),
-
-      deprecatedRouterMocks: true,
+        },
+      },
     });
 
     const expectedArgs = [

--- a/static/app/views/issueDetails/streamline/eventMissingBanner.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventMissingBanner.spec.tsx
@@ -1,19 +1,18 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EventMissingBanner} from 'sentry/views/issueDetails/streamline/eventMissingBanner';
 
 describe('EventMissingBanner', () => {
   it('renders elements for known event IDs', () => {
-    const organization = OrganizationFixture();
-    const router = RouterFixture({params: {groupId: 'group-1', eventId: 'recommended'}});
+    const initialRouterConfig = {
+      location: {
+        pathname: `/organizations/org-slug/issues/group-1/events/recommended/`,
+      },
+      route: `/organizations/:orgId/issues/:groupId/events/:eventId/`,
+    };
 
     render(<EventMissingBanner />, {
-      organization,
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
 
     // Header
@@ -27,13 +26,15 @@ describe('EventMissingBanner', () => {
   });
 
   it('renders elements for specific event IDs', () => {
-    const organization = OrganizationFixture();
-    const router = RouterFixture({params: {groupId: 'group-1', eventId: 'abc123'}});
+    const initialRouterConfig = {
+      location: {
+        pathname: `/organizations/org-slug/issues/group-1/events/abc123/`,
+      },
+      route: `/organizations/:orgId/issues/:groupId/events/:eventId/`,
+    };
 
     render(<EventMissingBanner />, {
-      organization,
-      router,
-      deprecatedRouterMocks: true,
+      initialRouterConfig,
     });
 
     // Header


### PR DESCRIPTION
Migrate issue details tests to the in memory react router instead of entirely mocked. A few tests here were manually updating mocks and rerendering.
