### PR TITLE
feat(aci): Add an open in explore button to metric detector charts

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -1,14 +1,15 @@
 import {useMemo} from 'react';
 import {type Theme} from '@emotion/react';
-import styled from '@emotion/styled';
 import type {YAXisComponentOption} from 'echarts';
 
+import Feature from 'sentry/components/acl/feature';
 import {AreaChart, type AreaChartProps} from 'sentry/components/charts/areaChart';
 import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
 import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import {Alert} from 'sentry/components/core/alert';
-import {Flex} from 'sentry/components/core/layout';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Container, Flex} from 'sentry/components/core/layout';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
 import {IconWarning} from 'sentry/icons';
@@ -16,13 +17,16 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {GroupOpenPeriod} from 'sentry/types/group';
 import type {MetricDetector, SnubaQuery} from 'sentry/types/workflowEngine/detectors';
+import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   buildDetectorZoomQuery,
   computeZoomRangeMs,
 } from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
+import {getDetectorOpenInDestination} from 'sentry/views/detectors/components/details/metric/getDetectorOpenInDestination';
 import {useDetectorChartAxisBounds} from 'sentry/views/detectors/components/details/metric/utils/useDetectorChartAxisBounds';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
@@ -370,9 +374,76 @@ export function useMetricDetectorChart({
   };
 }
 
+interface OpenInButtonProps {
+  detector: MetricDetector;
+}
+
+function OpenInButton({detector}: OpenInButtonProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const destination = getDetectorOpenInDestination({
+    detector,
+    organization,
+    statsPeriod: decodeScalar(location.query.statsPeriod),
+    start: decodeScalar(location.query.start),
+    end: decodeScalar(location.query.end),
+  });
+
+  if (!destination?.to) {
+    return null;
+  }
+
+  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
+  const isEapDataset = snubaQuery.dataset === 'events_analytics_platform';
+  const featureFlag = isEapDataset ? 'visibility-explore-view' : 'discover-basic';
+
+  return (
+    <Feature features={featureFlag}>
+      <LinkButton size="xs" to={destination.to}>
+        {destination.buttonText}
+      </LinkButton>
+    </Feature>
+  );
+}
+
+function ChartContainer({
+  children,
+  overflow,
+}: {
+  children: React.ReactNode;
+  overflow?: 'hidden';
+}) {
+  return (
+    <Container border="muted" radius="md" overflow={overflow}>
+      {children}
+    </Container>
+  );
+}
+
+function ChartBody({children}: {children: React.ReactNode}) {
+  return <Container padding="lg">{children}</Container>;
+}
+
+function ChartFooter({detector}: {detector: MetricDetector}) {
+  return (
+    <Flex justify="end" padding="lg" borderTop="muted">
+      <OpenInButton detector={detector} />
+    </Flex>
+  );
+}
+
 export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChartProps) {
   const location = useLocation();
+  const organization = useOrganization();
   const dateParams = normalizeDateTimeParams(location.query);
+
+  const destination = getDetectorOpenInDestination({
+    detector,
+    organization,
+    statsPeriod: decodeScalar(location.query.statsPeriod),
+    start: decodeScalar(location.query.start),
+    end: decodeScalar(location.query.end),
+  });
 
   const {data: openPeriods = []} = useOpenPeriods({
     detectorId: detector.id,
@@ -388,47 +459,45 @@ export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChar
 
   if (isLoading) {
     return (
-      <Flex height={CHART_HEIGHT} justify="center" align="center">
-        <Placeholder height={`${CHART_HEIGHT}px`} />
-      </Flex>
+      <ChartContainer>
+        <ChartBody>
+          <Flex height={CHART_HEIGHT} justify="center" align="center">
+            <Placeholder height={`${CHART_HEIGHT}px`} />
+          </Flex>
+        </ChartBody>
+        {destination && <ChartFooter detector={detector} />}
+      </ChartContainer>
     );
   }
   if (error || !chartProps) {
     const errorMessage =
       typeof error?.responseJSON?.detail === 'string' ? error.responseJSON.detail : null;
     return (
-      <ChartContainer style={{overflow: 'hidden'}}>
+      <ChartContainer overflow="hidden">
         {errorMessage && (
           <Alert system type="error">
             {errorMessage}
           </Alert>
         )}
-        <ChartContainerBody>
+        <ChartBody>
           <Flex justify="center" align="center">
             <ErrorPanel height={`${CHART_HEIGHT - 45}px`}>
               <IconWarning color="gray300" size="lg" />
               <div>{t('Error loading chart data')}</div>
             </ErrorPanel>
           </Flex>
-        </ChartContainerBody>
+        </ChartBody>
+        {destination && <ChartFooter detector={detector} />}
       </ChartContainer>
     );
   }
 
   return (
     <ChartContainer>
-      <ChartContainerBody>
+      <ChartBody>
         <AreaChart {...chartProps} />
-      </ChartContainerBody>
+      </ChartBody>
+      {destination && <ChartFooter detector={detector} />}
     </ChartContainer>
   );
 }
-
-const ChartContainer = styled('div')`
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-`;
-
-const ChartContainerBody = styled('div')`
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.lg} ${p => p.theme.space.xs};
-`;

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -393,12 +393,8 @@ function OpenInButton({detector}: OpenInButtonProps) {
     return null;
   }
 
-  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
-  const isEapDataset = snubaQuery.dataset === 'events_analytics_platform';
-  const featureFlag = isEapDataset ? 'visibility-explore-view' : 'discover-basic';
-
   return (
-    <Feature features={featureFlag}>
+    <Feature features="visibility-explore-view">
       <LinkButton size="xs" to={destination.to}>
         {destination.buttonText}
       </LinkButton>

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
@@ -1,0 +1,251 @@
+import {
+  MetricDetectorFixture,
+  SnubaQueryDataSourceFixture,
+} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
+
+import {getDetectorOpenInDestination} from './getDetectorOpenInDestination';
+
+describe('getDetectorOpenInDestination', () => {
+  const organization = OrganizationFixture({
+    features: ['discover-basic', 'visibility-explore-view'],
+  });
+
+  describe('Errors dataset', () => {
+    it('returns "Open in Discover" for errors dataset', () => {
+      const detector = MetricDetectorFixture({
+        dataSources: [
+          SnubaQueryDataSourceFixture({
+            queryObj: {
+              id: '1',
+              status: 1,
+              subscription: '1',
+              snubaQuery: {
+                id: '1',
+                aggregate: 'count()',
+                dataset: Dataset.ERRORS,
+                eventTypes: [EventTypes.ERROR],
+                query: 'is:unresolved',
+                timeWindow: 300,
+                environment: 'prod',
+              },
+            },
+          }),
+        ],
+      });
+
+      const result = getDetectorOpenInDestination({
+        detector,
+        organization,
+        statsPeriod: '7d',
+      });
+
+      expect(result?.buttonText).toBe('Open in Discover');
+      expect(result?.to).toEqual(
+        expect.objectContaining({
+          pathname: expect.stringContaining('/discover/results/'),
+          query: expect.objectContaining({
+            dataset: 'errors',
+            query: 'event.type:error is:unresolved',
+            interval: '5m',
+            statsPeriod: '7d',
+            project: '1',
+            environment: 'prod',
+          }),
+        })
+      );
+    });
+  });
+
+  describe('Transactions dataset', () => {
+    it('returns "Open in Discover" for transactions dataset', () => {
+      const detector = MetricDetectorFixture({
+        dataSources: [
+          SnubaQueryDataSourceFixture({
+            queryObj: {
+              id: '1',
+              status: 1,
+              subscription: '1',
+              snubaQuery: {
+                id: '1',
+                aggregate: 'p95(transaction.duration)',
+                dataset: Dataset.TRANSACTIONS,
+                eventTypes: [EventTypes.TRANSACTION],
+                query: 'transaction:/api/users',
+                timeWindow: 600,
+                environment: 'prod',
+              },
+            },
+          }),
+        ],
+      });
+
+      const result = getDetectorOpenInDestination({
+        detector,
+        organization,
+        statsPeriod: '14d',
+      });
+
+      expect(result?.buttonText).toBe('Open in Discover');
+      expect(result?.to).toEqual(
+        expect.objectContaining({
+          pathname: expect.stringContaining('/discover/results/'),
+          query: expect.objectContaining({
+            dataset: 'transactions',
+            query: 'transaction:/api/users',
+            interval: '10m',
+            statsPeriod: '14d',
+            project: '1',
+            environment: 'prod',
+          }),
+        })
+      );
+    });
+  });
+
+  describe('Spans dataset', () => {
+    it('returns "Open in Explore" for spans dataset', () => {
+      const detector = MetricDetectorFixture({
+        dataSources: [
+          SnubaQueryDataSourceFixture({
+            queryObj: {
+              id: '1',
+              status: 1,
+              subscription: '1',
+              snubaQuery: {
+                id: '1',
+                aggregate: 'count()',
+                dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                eventTypes: [],
+                query: 'span.op:http',
+                timeWindow: 300,
+                environment: 'prod',
+              },
+            },
+          }),
+        ],
+      });
+
+      const result = getDetectorOpenInDestination({
+        detector,
+        organization,
+        statsPeriod: '7d',
+      });
+
+      expect(result?.buttonText).toBe('Open in Explore');
+      expect(result?.to).toContain('/explore/traces/');
+      expect(result?.to).toContain('query=span.op%3Ahttp');
+      expect(result?.to).toContain('interval=5m');
+      expect(result?.to).toContain('environment=prod');
+      expect(result?.to).toContain(
+        'visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22count%28%29%22%5D%7D'
+      );
+      expect(result?.to).toContain('project=1');
+    });
+
+    describe('Logs', () => {
+      it('returns "Open in Logs" with correct query parameters', () => {
+        const detector = MetricDetectorFixture({
+          dataSources: [
+            SnubaQueryDataSourceFixture({
+              queryObj: {
+                id: '1',
+                status: 1,
+                subscription: '1',
+                snubaQuery: {
+                  id: '1',
+                  aggregate: 'count()',
+                  dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                  eventTypes: [EventTypes.TRACE_ITEM_LOG],
+                  query: 'log.level:error',
+                  timeWindow: 300,
+                  environment: 'prod',
+                },
+              },
+            }),
+          ],
+        });
+
+        const result = getDetectorOpenInDestination({
+          detector,
+          organization,
+          statsPeriod: '24h',
+        });
+
+        expect(result?.buttonText).toBe('Open in Logs');
+        expect(result?.to).toContain('/explore/logs/');
+        expect(result?.to).toContain('statsPeriod=24h');
+        expect(result?.to).toContain('project=1');
+        expect(result?.to).toContain('environment=prod');
+        expect(result?.to).toContain('logsAggregate=count');
+        expect(result?.to).toContain('logsQuery=log.level%3Aerror');
+      });
+    });
+
+    describe('Releases dataset', () => {
+      it('returns null for releases/crash-free dataset', () => {
+        const detector = MetricDetectorFixture({
+          dataSources: [
+            SnubaQueryDataSourceFixture({
+              queryObj: {
+                id: '1',
+                status: 1,
+                subscription: '1',
+                snubaQuery: {
+                  id: '1',
+                  aggregate: 'crash_free_rate(session)',
+                  dataset: Dataset.SESSIONS,
+                  eventTypes: [],
+                  query: '',
+                  timeWindow: 3600,
+                },
+              },
+            }),
+          ],
+        });
+
+        const result = getDetectorOpenInDestination({
+          detector,
+          organization,
+          statsPeriod: '7d',
+        });
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('time period handling', () => {
+      it('uses statsPeriod when provided', () => {
+        const detector = MetricDetectorFixture({
+          dataSources: [
+            SnubaQueryDataSourceFixture({
+              queryObj: {
+                id: '1',
+                status: 1,
+                subscription: '1',
+                snubaQuery: {
+                  id: '1',
+                  aggregate: 'count()',
+                  dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                  eventTypes: [],
+                  query: '',
+                  timeWindow: 300,
+                },
+              },
+            }),
+          ],
+        });
+
+        const result = getDetectorOpenInDestination({
+          detector,
+          organization,
+          statsPeriod: '14d',
+        });
+
+        expect(result?.to).toContain('statsPeriod=14d');
+      });
+    });
+  });
+});

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
@@ -60,7 +60,7 @@ describe('getDetectorOpenInDestination', () => {
   });
 
   describe('Transactions dataset', () => {
-    it('returns "Open in Discover" for transactions dataset', () => {
+    it('returns "Open in Explore" for transactions dataset', () => {
       const detector = MetricDetectorFixture({
         dataSources: [
           SnubaQueryDataSourceFixture({
@@ -88,20 +88,17 @@ describe('getDetectorOpenInDestination', () => {
         statsPeriod: '14d',
       });
 
-      expect(result?.buttonText).toBe('Open in Discover');
-      expect(result?.to).toEqual(
-        expect.objectContaining({
-          pathname: expect.stringContaining('/discover/results/'),
-          query: expect.objectContaining({
-            dataset: 'transactions',
-            query: 'transaction:/api/users',
-            interval: '10m',
-            statsPeriod: '14d',
-            project: '1',
-            environment: 'prod',
-          }),
-        })
+      expect(result?.buttonText).toBe('Open in Explore');
+      expect(result?.to).toContain('/explore/traces/');
+      expect(result?.to).toContain(
+        'query=is_transaction%3Atrue%20transaction%3A%2Fapi%2Fusers'
       );
+      expect(result?.to).toContain('interval=10m');
+      expect(result?.to).toContain('environment=prod');
+      expect(result?.to).toContain(
+        'visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p95%28transaction.duration%29%22%5D%7D'
+      );
+      expect(result?.to).toContain('project=1');
     });
   });
 

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
@@ -1,0 +1,205 @@
+import type {LocationDescriptor} from 'history';
+
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils';
+import EventView from 'sentry/utils/discover/eventView';
+import {getAggregateAlias, parseFunction} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+import {getLogsUrl} from 'sentry/views/explore/logs/utils';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {DEFAULT_PROJECT_THRESHOLD} from 'sentry/views/performance/data';
+
+interface GetDetectorExploreUrlOptions {
+  detector: MetricDetector;
+  organization: Organization;
+  end?: string | null;
+  start?: string | null;
+  statsPeriod?: string | null;
+}
+
+interface OpenInDestination {
+  buttonText: string;
+  to: LocationDescriptor;
+}
+
+function convertTimeWindowSecondsToInterval(timeWindowSeconds: number): string {
+  if (timeWindowSeconds >= 3600) {
+    return `${Math.floor(timeWindowSeconds / 3600)}h`;
+  }
+  return `${Math.floor(timeWindowSeconds / 60)}m`;
+}
+
+function getDetectorDiscoverUrl({
+  detector,
+  organization,
+  statsPeriod,
+  start,
+  end,
+}: GetDetectorExploreUrlOptions): LocationDescriptor {
+  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
+  const projectId = Number(detector.projectId);
+  const datasetConfig = getDatasetConfig(
+    getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes)
+  );
+
+  const aggregateAlias = getAggregateAlias(snubaQuery.aggregate);
+
+  const timePeriodFields =
+    statsPeriod && !start && !end
+      ? {range: statsPeriod}
+      : {start: start ?? undefined, end: end ?? undefined};
+
+  const fields =
+    snubaQuery.dataset === Dataset.ERRORS
+      ? ['issue', 'count()', 'count_unique(user)']
+      : [
+          'transaction',
+          'project',
+          snubaQuery.aggregate,
+          'count_unique(user)',
+          `user_misery(${DEFAULT_PROJECT_THRESHOLD})`,
+        ];
+
+  const eventView = EventView.fromSavedQuery({
+    id: undefined,
+    name: detector.name || 'Transactions',
+    dataset:
+      snubaQuery.dataset === Dataset.ERRORS
+        ? DiscoverDatasets.ERRORS
+        : DiscoverDatasets.TRANSACTIONS,
+    fields,
+    orderby: `-${aggregateAlias}`,
+    query: datasetConfig.toSnubaQueryString(snubaQuery),
+    version: 2,
+    projects: [projectId],
+    environment: snubaQuery.environment ? [snubaQuery.environment] : undefined,
+    ...timePeriodFields,
+  });
+
+  if (!eventView) {
+    return '';
+  }
+
+  const {query, ...toObject} = eventView.getResultsViewUrlTarget(organization, false);
+  const timeWindowString = convertTimeWindowSecondsToInterval(snubaQuery.timeWindow);
+
+  return normalizeUrl({
+    query: {...query, interval: timeWindowString},
+    ...toObject,
+  });
+}
+
+function getDetectorExploreUrl({
+  detector,
+  organization,
+  statsPeriod,
+  start,
+  end,
+}: GetDetectorExploreUrlOptions): string {
+  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
+  const interval = convertTimeWindowSecondsToInterval(snubaQuery.timeWindow);
+  const projectId = Number(detector.projectId);
+
+  return getExploreUrl({
+    organization,
+    selection: {
+      datetime: {
+        period: statsPeriod ?? null,
+        start: statsPeriod ? null : (start ?? null),
+        end: statsPeriod ? null : (end ?? null),
+        utc: null,
+      },
+      environments: snubaQuery.environment ? [snubaQuery.environment] : [],
+      projects: [projectId],
+    },
+    interval,
+    visualize: [
+      {
+        chartType: ChartType.LINE,
+        yAxes: [snubaQuery.aggregate],
+      },
+    ],
+    query: snubaQuery.query,
+  });
+}
+
+function getDetectorLogsUrl({
+  detector,
+  organization,
+  statsPeriod,
+  start,
+  end,
+}: GetDetectorExploreUrlOptions): string {
+  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
+  const parsed = snubaQuery.aggregate ? parseFunction(snubaQuery.aggregate) : null;
+
+  return getLogsUrl({
+    organization,
+    selection: {
+      datetime: {
+        period: statsPeriod ?? null,
+        start: start ?? null,
+        end: end ?? null,
+        utc: null,
+      },
+      environments: snubaQuery.environment ? [snubaQuery.environment] : [],
+      projects: [Number(detector.projectId)],
+    },
+    query: snubaQuery.query,
+    aggregateFn: parsed?.name,
+    aggregateParam: parsed?.arguments[0],
+  });
+}
+
+/**
+ * Get the "Open in" button text and destination URL for a metric detector.
+ *
+ * Returns the appropriate destination based on the detector's dataset:
+ * - SPANS: Open in Explore
+ * - LOGS: Open in Logs
+ * - ERRORS/TRANSACTIONS: Open in Discover
+ */
+export function getDetectorOpenInDestination(
+  options: GetDetectorExploreUrlOptions
+): OpenInDestination | null {
+  const {detector} = options;
+  const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
+
+  if (!defined(snubaQuery)) {
+    return null;
+  }
+
+  const dataset = getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes);
+
+  switch (dataset) {
+    case DetectorDataset.LOGS:
+      return {
+        buttonText: t('Open in Logs'),
+        to: getDetectorLogsUrl(options),
+      };
+    case DetectorDataset.SPANS:
+      return {
+        buttonText: t('Open in Explore'),
+        to: getDetectorExploreUrl(options),
+      };
+    case DetectorDataset.ERRORS:
+    case DetectorDataset.TRANSACTIONS:
+      return {
+        buttonText: t('Open in Discover'),
+        to: getDetectorDiscoverUrl(options),
+      };
+    case DetectorDataset.RELEASES:
+      // Releases/crash-free alerts don't have a corresponding explore view
+      return null;
+    default:
+      return null;
+  }
+}

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
@@ -107,6 +107,12 @@ function getDetectorExploreUrl({
   const snubaQuery = detector.dataSources[0].queryObj.snubaQuery;
   const interval = convertTimeWindowSecondsToInterval(snubaQuery.timeWindow);
   const projectId = Number(detector.projectId);
+  const dataset = getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes);
+
+  const query =
+    dataset === DetectorDataset.TRANSACTIONS
+      ? `is_transaction:true ${snubaQuery.query}`.trim()
+      : snubaQuery.query;
 
   return getExploreUrl({
     organization,
@@ -127,7 +133,7 @@ function getDetectorExploreUrl({
         yAxes: [snubaQuery.aggregate],
       },
     ],
-    query: snubaQuery.query,
+    query,
   });
 }
 
@@ -163,9 +169,9 @@ function getDetectorLogsUrl({
  * Get the "Open in" button text and destination URL for a metric detector.
  *
  * Returns the appropriate destination based on the detector's dataset:
- * - SPANS: Open in Explore
+ * - SPANS/TRANSACTIONS: Open in Explore
  * - LOGS: Open in Logs
- * - ERRORS/TRANSACTIONS: Open in Discover
+ * - ERRORS: Open in Discover
  */
 export function getDetectorOpenInDestination(
   options: GetDetectorExploreUrlOptions
@@ -190,8 +196,12 @@ export function getDetectorOpenInDestination(
         buttonText: t('Open in Explore'),
         to: getDetectorExploreUrl(options),
       };
-    case DetectorDataset.ERRORS:
     case DetectorDataset.TRANSACTIONS:
+      return {
+        buttonText: t('Open in Explore'),
+        to: getDetectorExploreUrl(options),
+      };
+    case DetectorDataset.ERRORS:
       return {
         buttonText: t('Open in Discover'),
         to: getDetectorDiscoverUrl(options),


### PR DESCRIPTION
Works similarly to the one in metric alerts. Gives the user an easy way to delve deeper into what's going on.

<img width="1526" height="906" alt="CleanShot 2025-12-02 at 16 38 46@2x" src="https://github.com/user-attachments/assets/801036fe-cdcf-4ba7-aa81-07d560b4fd74" />
