### PR TITLE
ref(cells): force uptime-ips and tempest-ips endpoints to use control silo

### DIFF
--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -154,6 +154,8 @@ const patterns: RegExp[] = [
   new RegExp('^api/0/internal/beacon/$'),
   new RegExp('^api/0/internal/integration-proxy/$'),
   new RegExp('^api/0/internal/notifications/registered-templates/$'),
+  new RegExp('^api/0/uptime-ips/$'),
+  new RegExp('^api/0/tempest-ips/$'),
   new RegExp('^api/0/secret-scanning/github/$'),
   new RegExp('^api/hooks/mailgun/inbound/'),
   new RegExp('^auth-v2/'),


### PR DESCRIPTION
i forced them onto this list by temporarily marking the endpoints as `control_silo_endpoints` then running the `generate_controlsilo_urls` command, then reverting the endpoint changes.

they should eventually be made control-only, but the UI changes need to happen first.