### PR TITLE
JWT Cleanups

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -148,12 +148,17 @@ def verify_signature(request) -> bool:
     kid = jwt.peek_header(token)["kid"]
     key = public_keys[kid]
 
+    # OpenID standard for `id_token_signing_alg_values_supported` is a JSON Array.
+    # Please take a look at the OpenID Provider Metadata:
+    # https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+    algorithms: list[str] = open_id_config["id_token_signing_alg_values_supported"]
+
     try:
         decoded = jwt.decode(
             token,
             key,
             audience=options.get("msteams.client-id"),
-            algorithms=open_id_config["id_token_signing_alg_values_supported"],
+            algorithms=algorithms,
         )
     except Exception as err:
         logger.exception("msteams.webhook.invalid-token-with-verify")

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -70,7 +70,7 @@ def decode(
     # sentry.integrations.msteams.webhook.verify_signature which isn't checked by mypy yet,
     # and I am too afraid to change this.  One day (hah!) all will be checked by mypy and
     # this can be safely fixed.
-    options = {"verify": True}
+    options = {}
     kwargs = dict()
     if audience is False:
         options["verify_aud"] = False

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -65,11 +65,6 @@ def decode(
     """
     # TODO: We do not currently have type-safety for keys suitable for decoding *and*
     # encoding vs those only suitable for decoding.
-    # TODO(flub): The algorithms parameter really does not need to be optional and should be
-    # a straight list[str].  However this is used by some unclear code in
-    # sentry.integrations.msteams.webhook.verify_signature which isn't checked by mypy yet,
-    # and I am too afraid to change this.  One day (hah!) all will be checked by mypy and
-    # this can be safely fixed.
     options = {}
     kwargs = dict()
     if audience is False:


### PR DESCRIPTION
Just a few JWT library cleanups:

1. Remove the unused `verify` option, as it's been deprecated from `pyjwt>=2.x` (so it doesn't confuse people). I'm relying on the `verify_signature` option to be True by default, but I can be convinced to be more explicit by setting `verify_signature`.
2. Remove the comment about algorithms. I've decided to keep the None, as using a mutable default param is generally a bad idea.

References for the `verify` option deprecation and `verify_signature` defaulting to True:
- https://pyjwt.readthedocs.io/en/stable/changelog.html#dropped-deprecated-verify-param-in-jwt-decode
- https://pyjwt.readthedocs.io/en/2.4.0/api.html?highlight=verify_signature#jwt.decode

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
