### PR TITLE
stories: fix type loader signature and safety

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.stories.tsx
+++ b/static/app/components/charts/chartWidgetLoader.stories.tsx
@@ -5,7 +5,7 @@ import {CodeBlock} from 'sentry/components/core/code';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('ChartWidgetLoader', (story, APIReference) => {
-  APIReference(documentation?.props?.ChartWidgetLoader);
+  APIReference(documentation.props?.ChartWidgetLoader);
 
   story('Getting Started', () => {
     return (

--- a/static/app/components/charts/chartWidgetLoader.stories.tsx
+++ b/static/app/components/charts/chartWidgetLoader.stories.tsx
@@ -5,7 +5,7 @@ import {CodeBlock} from 'sentry/components/core/code';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('ChartWidgetLoader', (story, APIReference) => {
-  APIReference(documentation.props.ChartWidgetLoader);
+  APIReference(documentation?.props?.ChartWidgetLoader);
 
   story('Getting Started', () => {
     return (

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -37,7 +37,7 @@ import ButtonDocumentation from '!!type-loader!@sentry/scraps/button';
 
 export const documentation = {
   exports: {
-    module: ButtonDocumentation?.exports.module,
+    module: ButtonDocumentation.exports?.module,
     exports: {
       // Button has some exports that we don't want to document, strip them out until they are removed
       ...Object.fromEntries(

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -37,18 +37,18 @@ import ButtonDocumentation from '!!type-loader!@sentry/scraps/button';
 
 export const documentation = {
   exports: {
-    module: ButtonDocumentation.exports.module,
+    module: ButtonDocumentation?.exports.module,
     exports: {
       // Button has some exports that we don't want to document, strip them out until they are removed
       ...Object.fromEntries(
-        Object.entries(ButtonDocumentation.exports.exports).filter(
+        Object.entries(ButtonDocumentation?.exports?.exports ?? {}).filter(
           ([key]) => key !== 'StyledButton' && key !== 'ButtonBar'
         )
       ),
     },
   },
   props: {
-    ...ButtonDocumentation.props,
+    ...ButtonDocumentation?.props,
   },
 };
 
@@ -63,9 +63,8 @@ To create a basic button, wrap text in a `<Button>` and pass an `onClick` callba
 Buttons come in a few different styles: `muted` (default), `primary`, `warning`, `danger`, `transparent` and `link`.
 
 <Storybook.Demo>
-  <Button priority="muted">Muted (default)</Button>
+  <Button priority="default">Default (default)</Button>
   <Button priority="primary">Primary</Button>
-  <Button priority="warning">Warning</Button>
   <Button priority="danger">Danger</Button>
   <Button priority="transparent">Transparent</Button>
   <div style={{alignSelf: 'center'}}>
@@ -73,9 +72,8 @@ Buttons come in a few different styles: `muted` (default), `primary`, `warning`,
   </div>
 </Storybook.Demo>
 ```jsx
-<Button priority="muted">Muted (default)</Button>
+<Button priority="default">Default (default)</Button>
 <Button priority="primary">Primary</Button>
-<Button priority="warning">Warning</Button>
 <Button priority="danger">Danger</Button>
 <Button priority="transparent">Transparent</Button>
 <Button priority="link">Link</Button>

--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -6,7 +6,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('ButtonBar', (story, APIReference) => {
-  APIReference(documentation.props.ButtonBar);
+  APIReference(documentation?.props?.ButtonBar);
 
   story('Default', () => {
     const [active, setActive] = useState('One');

--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -6,7 +6,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('ButtonBar', (story, APIReference) => {
-  APIReference(documentation?.props?.ButtonBar);
+  APIReference(documentation.props?.ButtonBar);
 
   story('Default', () => {
     const [active, setActive] = useState('One');

--- a/static/app/components/core/input/input.stories.tsx
+++ b/static/app/components/core/input/input.stories.tsx
@@ -8,7 +8,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Input', (story, APIReference) => {
-  APIReference(documentation.props.Input);
+  APIReference(documentation?.props?.Input);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/input/input.stories.tsx
+++ b/static/app/components/core/input/input.stories.tsx
@@ -8,7 +8,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Input', (story, APIReference) => {
-  APIReference(documentation?.props?.Input);
+  APIReference(documentation.props?.Input);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/input/inputGroup.stories.tsx
+++ b/static/app/components/core/input/inputGroup.stories.tsx
@@ -10,7 +10,7 @@ import {space} from 'sentry/styles/space';
 import {InputGroup} from './inputGroup';
 
 export default Storybook.story('InputGroup', (story, APIReference) => {
-  APIReference(documentation?.props?.InputGroup);
+  APIReference(documentation.props?.InputGroup);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/input/inputGroup.stories.tsx
+++ b/static/app/components/core/input/inputGroup.stories.tsx
@@ -10,7 +10,7 @@ import {space} from 'sentry/styles/space';
 import {InputGroup} from './inputGroup';
 
 export default Storybook.story('InputGroup', (story, APIReference) => {
-  APIReference(documentation.props.InputGroup);
+  APIReference(documentation?.props?.InputGroup);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/input/numberDragInput.stories.tsx
+++ b/static/app/components/core/input/numberDragInput.stories.tsx
@@ -6,7 +6,7 @@ import {NumberDragInput} from 'sentry/components/core/input/numberDragInput';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('NumberDragInput', (story, APIReference) => {
-  APIReference(documentation?.props?.NumberDragInput);
+  APIReference(documentation.props?.NumberDragInput);
 
   story('Default', () => {
     const [horizontalValue, setHorizontalValue] = useState(10);

--- a/static/app/components/core/input/numberDragInput.stories.tsx
+++ b/static/app/components/core/input/numberDragInput.stories.tsx
@@ -6,7 +6,7 @@ import {NumberDragInput} from 'sentry/components/core/input/numberDragInput';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('NumberDragInput', (story, APIReference) => {
-  APIReference(documentation.props.NumberDragInput);
+  APIReference(documentation?.props?.NumberDragInput);
 
   story('Default', () => {
     const [horizontalValue, setHorizontalValue] = useState(10);

--- a/static/app/components/core/input/numberInput.stories.tsx
+++ b/static/app/components/core/input/numberInput.stories.tsx
@@ -6,7 +6,7 @@ import * as Storybook from 'sentry/stories';
 import {NumberInput} from './numberInput';
 
 export default Storybook.story('NumberInput', (story, APIReference) => {
-  APIReference(documentation.props.NumberInput);
+  APIReference(documentation?.props?.NumberInput);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/input/numberInput.stories.tsx
+++ b/static/app/components/core/input/numberInput.stories.tsx
@@ -6,7 +6,7 @@ import * as Storybook from 'sentry/stories';
 import {NumberInput} from './numberInput';
 
 export default Storybook.story('NumberInput', (story, APIReference) => {
-  APIReference(documentation?.props?.NumberInput);
+  APIReference(documentation.props?.NumberInput);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/menuListItem/menuListItem.stories.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.stories.tsx
@@ -6,7 +6,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('MenuListItem', (story, APIReference) => {
-  APIReference(documentation?.props?.MenuListItem);
+  APIReference(documentation.props?.MenuListItem);
 
   story('focused', () => {
     return <SizeVariants isFocused />;

--- a/static/app/components/core/menuListItem/menuListItem.stories.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.stories.tsx
@@ -6,7 +6,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('MenuListItem', (story, APIReference) => {
-  APIReference(documentation.props.MenuListItem);
+  APIReference(documentation?.props?.MenuListItem);
 
   story('focused', () => {
     return <SizeVariants isFocused />;

--- a/static/app/components/core/radio/radio.stories.tsx
+++ b/static/app/components/core/radio/radio.stories.tsx
@@ -7,7 +7,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Radio', (story, APIReference) => {
-  APIReference(documentation.props.Radio);
+  APIReference(documentation?.props?.Radio);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/radio/radio.stories.tsx
+++ b/static/app/components/core/radio/radio.stories.tsx
@@ -7,7 +7,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Radio', (story, APIReference) => {
-  APIReference(documentation?.props?.Radio);
+  APIReference(documentation.props?.Radio);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/select/select.stories.tsx
+++ b/static/app/components/core/select/select.stories.tsx
@@ -6,7 +6,7 @@ import {IconGraphBar} from 'sentry/icons/iconGraphBar';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('Select', (story, APIReference) => {
-  APIReference(documentation.props.Select);
+  APIReference(documentation?.props?.Select);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/select/select.stories.tsx
+++ b/static/app/components/core/select/select.stories.tsx
@@ -6,7 +6,7 @@ import {IconGraphBar} from 'sentry/icons/iconGraphBar';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('Select', (story, APIReference) => {
-  APIReference(documentation?.props?.Select);
+  APIReference(documentation.props?.Select);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/slider/slider.stories.tsx
+++ b/static/app/components/core/slider/slider.stories.tsx
@@ -9,7 +9,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Slider', (story, APIReference) => {
-  APIReference(documentation?.props?.Slider);
+  APIReference(documentation.props?.Slider);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/slider/slider.stories.tsx
+++ b/static/app/components/core/slider/slider.stories.tsx
@@ -9,7 +9,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Slider', (story, APIReference) => {
-  APIReference(documentation.props.Slider);
+  APIReference(documentation?.props?.Slider);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/switch/switch.stories.tsx
+++ b/static/app/components/core/switch/switch.stories.tsx
@@ -7,7 +7,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Switch', (story, APIReference) => {
-  APIReference(documentation?.props?.Switch);
+  APIReference(documentation.props?.Switch);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/switch/switch.stories.tsx
+++ b/static/app/components/core/switch/switch.stories.tsx
@@ -7,7 +7,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Switch', (story, APIReference) => {
-  APIReference(documentation.props.Switch);
+  APIReference(documentation?.props?.Switch);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/toast/toast.stories.tsx
+++ b/static/app/components/core/toast/toast.stories.tsx
@@ -19,7 +19,7 @@ function makeToastProps(type: 'success' | 'error' | 'loading' | 'undo'): ToastPr
   };
 }
 export default Storybook.story('Toast', (story, APIReference) => {
-  APIReference(documentation.props.Toast);
+  APIReference(documentation?.props?.Toast);
 
   story('Toast types', () => {
     return (

--- a/static/app/components/core/toast/toast.stories.tsx
+++ b/static/app/components/core/toast/toast.stories.tsx
@@ -19,7 +19,7 @@ function makeToastProps(type: 'success' | 'error' | 'loading' | 'undo'): ToastPr
   };
 }
 export default Storybook.story('Toast', (story, APIReference) => {
-  APIReference(documentation?.props?.Toast);
+  APIReference(documentation.props?.Toast);
 
   story('Toast types', () => {
     return (

--- a/static/app/components/dropdownMenu/index.stories.tsx
+++ b/static/app/components/dropdownMenu/index.stories.tsx
@@ -8,7 +8,7 @@ import {IconCopy, IconDelete, IconDownload, IconEdit} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('DropdownMenu', (story, APIReference) => {
-  APIReference(documentation.props.DropdownMenu);
+  APIReference(documentation?.props?.DropdownMenu);
 
   story('Default', () => {
     const items: MenuItemProps[] = [

--- a/static/app/components/dropdownMenu/index.stories.tsx
+++ b/static/app/components/dropdownMenu/index.stories.tsx
@@ -8,7 +8,7 @@ import {IconCopy, IconDelete, IconDownload, IconEdit} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('DropdownMenu', (story, APIReference) => {
-  APIReference(documentation?.props?.DropdownMenu);
+  APIReference(documentation.props?.DropdownMenu);
 
   story('Default', () => {
     const items: MenuItemProps[] = [

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -222,22 +222,20 @@ function StoryUsage() {
 
 function StoryAPI() {
   const {story} = useStory();
-  if (!story.exports.documentation && typeof story.exports.documentation !== 'object')
+
+  const documentation = story.exports.documentation as TypeLoader.TypeLoaderResult;
+
+  if (!documentation || !('props' in documentation)) {
     return null;
+  }
+
   return (
     <Fragment>
-      {Object.entries(
-        (story.exports.documentation as TypeLoader.TypeLoaderResult).props as Record<
-          string,
-          TypeLoader.ComponentDocWithFilename
-        >
-      ).map(([key, value]) => {
+      {Object.entries(documentation.props ?? {}).map(([key, value]) => {
         return <Storybook.APIReference key={key} componentProps={value} />;
       })}
     </Fragment>
   );
-
-  return null;
 }
 
 function StoryGrid(props: React.ComponentProps<typeof Grid>) {

--- a/static/app/types/type-loader.d.ts
+++ b/static/app/types/type-loader.d.ts
@@ -16,10 +16,13 @@ declare namespace TypeLoader {
 }
 
 declare module '!!type-loader!*' {
-  const TypeLoaderResult: {
-    props: Record<string, TypeLoader.ComponentDocWithFilename>;
-    exports: Record<string, {name: string; typeOnly: boolean}[]>;
-  };
+  const TypeLoaderResult:
+    | {
+        props: Record<string, TypeLoader.ComponentDocWithFilename>;
+        exports: Record<string, {name: string; typeOnly: boolean}[]>;
+      }
+    // If the type loader is not enabled, the return value is an empty module
+    | undefined;
 
   export default TypeLoaderResult;
 }

--- a/static/app/types/type-loader.d.ts
+++ b/static/app/types/type-loader.d.ts
@@ -22,7 +22,7 @@ declare module '!!type-loader!*' {
         exports: Record<string, {name: string; typeOnly: boolean}[]>;
       }
     // If the type loader is not enabled, the return value is an empty module
-    | undefined;
+    | Record<string, undefined>;
 
   export default TypeLoaderResult;
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -71,7 +71,7 @@ const releases = [
 ].filter(hasTimestamp);
 
 export default Storybook.story('TimeSeriesWidgetVisualization', (story, APIReference) => {
-  APIReference(documentation?.props?.TimeSeriesWidgetVisualization);
+  APIReference(documentation.props?.TimeSeriesWidgetVisualization);
 
   story('Getting Started', () => {
     return (

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -71,7 +71,7 @@ const releases = [
 ].filter(hasTimestamp);
 
 export default Storybook.story('TimeSeriesWidgetVisualization', (story, APIReference) => {
-  APIReference(documentation.props.TimeSeriesWidgetVisualization);
+  APIReference(documentation?.props?.TimeSeriesWidgetVisualization);
 
   story('Getting Started', () => {
     return (

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -13,7 +13,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from './widget';
 
 export default Storybook.story('Widget', (story, APIReference) => {
-  APIReference(documentation.props.Widget);
+  APIReference(documentation?.props?.Widget);
 
   story('Getting Started', () => {
     return (

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -13,7 +13,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from './widget';
 
 export default Storybook.story('Widget', (story, APIReference) => {
-  APIReference(documentation?.props?.Widget);
+  APIReference(documentation.props?.Widget);
 
   story('Getting Started', () => {
     return (


### PR DESCRIPTION
Fixes the type loader signature and uses optional chaining to avoid attempting to access documentation values when the type loader is not enabled.