### PR TITLE
chore(agents): add capture message for missing required gen_ai attributes

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -98,6 +98,8 @@ describe('getHighlightedSpanAttributes', () => {
     const attributes = {
       'gen_ai.origin': 'auto.ai.openai',
       'gen_ai.request.model': 'gpt-4',
+      'sdk.name': 'sentry.python',
+      'sdk.version': '2.0.0',
       // Missing: gen_ai.system, gen_ai.operation.name, gen_ai.agent.name
     };
 
@@ -117,6 +119,8 @@ describe('getHighlightedSpanAttributes', () => {
           span_operation: 'gen_ai.chat',
           missing_attributes: 'gen_ai.system,gen_ai.operation.name,gen_ai.agent.name',
           origin: 'auto.ai.openai',
+          sdk_name: 'sentry.python',
+          sdk_version: '2.0.0',
         },
       }
     );
@@ -167,5 +171,35 @@ describe('getHighlightedSpanAttributes', () => {
     });
 
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('should use unknown for sdk_name and sdk_version when not provided', () => {
+    const attributes = {
+      'gen_ai.origin': 'auto.ai.openai',
+      // No sdk.name or sdk.version
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      spanId: '123',
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Gen AI span missing required attributes',
+      {
+        level: 'warning',
+        tags: {
+          feature: 'agent-monitoring',
+          span_type: 'gen_ai',
+          span_operation: 'gen_ai.chat',
+          missing_attributes:
+            'gen_ai.system,gen_ai.request.model,gen_ai.operation.name,gen_ai.agent.name',
+          origin: 'auto.ai.openai',
+          sdk_name: 'unknown',
+          sdk_version: 'unknown',
+        },
+      }
+    );
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -93,4 +93,79 @@ describe('getHighlightedSpanAttributes', () => {
 
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
+
+  it('should emit Sentry error when gen_ai span with auto.ai origin is missing required attributes', () => {
+    const attributes = {
+      'gen_ai.origin': 'auto.ai.openai',
+      'gen_ai.request.model': 'gpt-4',
+      // Missing: gen_ai.system, gen_ai.operation.name, gen_ai.agent.name
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      spanId: '123',
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Gen AI span missing required attributes',
+      {
+        level: 'warning',
+        tags: {
+          feature: 'agent-monitoring',
+          span_type: 'gen_ai',
+          span_operation: 'gen_ai.chat',
+          missing_attributes: 'gen_ai.system,gen_ai.operation.name,gen_ai.agent.name',
+          origin: 'auto.ai.openai',
+        },
+      }
+    );
+  });
+
+  it('should not emit Sentry error when gen_ai span has all required attributes', () => {
+    const attributes = {
+      'gen_ai.origin': 'auto.ai.openai',
+      'gen_ai.system': 'openai',
+      'gen_ai.request.model': 'gpt-4',
+      'gen_ai.operation.name': 'chat',
+      'gen_ai.agent.name': 'my-agent',
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      spanId: '123',
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('should not emit Sentry error when origin does not start with auto.ai', () => {
+    const attributes = {
+      'gen_ai.origin': 'manual.openai',
+      // Missing required attributes
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      spanId: '123',
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('should not emit Sentry error when origin is not defined', () => {
+    const attributes = {
+      // Missing required attributes and no origin
+    };
+
+    getHighlightedSpanAttributes({
+      op: 'gen_ai.chat',
+      spanId: '123',
+      attributes,
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -98,6 +98,7 @@ describe('getHighlightedSpanAttributes', () => {
     const attributes = {
       'gen_ai.origin': 'auto.ai.openai',
       'gen_ai.request.model': 'gpt-4',
+      'gen_ai.usage.total_cost': '0.05',
       'sdk.name': 'sentry.python',
       'sdk.version': '2.0.0',
       // Missing: gen_ai.system, gen_ai.operation.name, gen_ai.agent.name
@@ -119,8 +120,8 @@ describe('getHighlightedSpanAttributes', () => {
           span_operation: 'gen_ai.chat',
           missing_attributes: 'gen_ai.system,gen_ai.operation.name,gen_ai.agent.name',
           origin: 'auto.ai.openai',
-          sdk_name: 'sentry.python',
-          sdk_version: '2.0.0',
+          sdk: 'sentry.python@2.0.0',
+          span_id: '123',
         },
       }
     );
@@ -131,6 +132,7 @@ describe('getHighlightedSpanAttributes', () => {
       'gen_ai.origin': 'auto.ai.openai',
       'gen_ai.system': 'openai',
       'gen_ai.request.model': 'gpt-4',
+      'gen_ai.usage.total_cost': '0.05',
       'gen_ai.operation.name': 'chat',
       'gen_ai.agent.name': 'my-agent',
     };
@@ -173,7 +175,7 @@ describe('getHighlightedSpanAttributes', () => {
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 
-  it('should use unknown for sdk_name and sdk_version when not provided', () => {
+  it('should use unknown for sdk when not provided', () => {
     const attributes = {
       'gen_ai.origin': 'auto.ai.openai',
       // No sdk.name or sdk.version
@@ -181,7 +183,7 @@ describe('getHighlightedSpanAttributes', () => {
 
     getHighlightedSpanAttributes({
       op: 'gen_ai.chat',
-      spanId: '123',
+      spanId: '456',
       attributes,
     });
 
@@ -196,8 +198,8 @@ describe('getHighlightedSpanAttributes', () => {
           missing_attributes:
             'gen_ai.system,gen_ai.request.model,gen_ai.operation.name,gen_ai.agent.name',
           origin: 'auto.ai.openai',
-          sdk_name: 'unknown',
-          sdk_version: 'unknown',
+          sdk: 'unknown',
+          span_id: '456',
         },
       }
     );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -192,6 +192,9 @@ function getAISpanAttributes({
     typeof origin === 'string' &&
     origin.startsWith('auto.ai')
   ) {
+    const sdkName = attributes['sdk.name'];
+    const sdkVersion = attributes['sdk.version'];
+
     Sentry.captureMessage('Gen AI span missing required attributes', {
       level: 'warning',
       tags: {
@@ -200,6 +203,8 @@ function getAISpanAttributes({
         span_operation: op || 'unknown',
         missing_attributes: missingGenAIAttributes.join(','),
         origin,
+        sdk_name: sdkName?.toString() || 'unknown',
+        sdk_version: sdkVersion?.toString() || 'unknown',
       },
     });
   }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -203,8 +203,9 @@ function getAISpanAttributes({
         span_operation: op || 'unknown',
         missing_attributes: missingGenAIAttributes.join(','),
         origin,
-        sdk_name: sdkName?.toString() || 'unknown',
-        sdk_version: sdkVersion?.toString() || 'unknown',
+        sdk:
+          [sdkName?.toString(), sdkVersion?.toString()].filter(Boolean).join('@') ||
+          'unknown',
       },
     });
   }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -206,6 +206,7 @@ function getAISpanAttributes({
         sdk:
           [sdkName?.toString(), sdkVersion?.toString()].filter(Boolean).join('@') ||
           'unknown',
+        span_id: spanId,
       },
     });
   }


### PR DESCRIPTION
- Add a capture message for the required attributes for client spans [according to our documentation](https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module/#common-span-attributes)
- Only capture when the origin is `auto.ai.*`
- Add SDK version and name to the tags, so we know which versions are affected by this and we don't get alarmed by older versions exhibiting this behaviour
- Also add the span id so we can investigate if something looks fishy

Closes TET-1529