### PR TITLE
fix(ui): replace static gray with theme tokens in integrations settings

### DIFF
--- a/static/app/views/settings/organizationIntegrations/constants.tsx
+++ b/static/app/views/settings/organizationIntegrations/constants.tsx
@@ -3,16 +3,6 @@ export const NOT_INSTALLED = 'Not Installed';
 export const PENDING = 'Pending';
 export const DISABLED = 'Disabled';
 export const PENDING_DELETION = 'Pending Deletion';
-const LEARN_MORE = 'Learn More';
-
-export const COLORS = {
-  [INSTALLED]: 'success',
-  [NOT_INSTALLED]: 'gray300',
-  [DISABLED]: 'gray300',
-  [PENDING_DELETION]: 'gray300',
-  [PENDING]: 'pink300',
-  [LEARN_MORE]: 'gray300',
-} as const;
 
 /**
  * Integrations in the integration directory should be sorted by their popularity (weight).

--- a/static/app/views/settings/organizationIntegrations/integrationStatus.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationStatus.tsx
@@ -1,32 +1,44 @@
-import {useTheme} from '@emotion/react';
+import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
 
 import CircleIndicator from 'sentry/components/circleIndicator';
 import {space} from 'sentry/styles/space';
 import type {IntegrationInstallationStatus} from 'sentry/types/integrations';
+import {
+  DISABLED,
+  INSTALLED,
+  NOT_INSTALLED,
+  PENDING,
+  PENDING_DELETION,
+} from 'sentry/views/settings/organizationIntegrations/constants';
 
-import {COLORS} from './constants';
+const LEARN_MORE = 'Learn More';
+const COLORS = {
+  [INSTALLED]: 'success',
+  [NOT_INSTALLED]: 'muted',
+  [DISABLED]: 'muted',
+  [PENDING_DELETION]: 'muted',
+  [PENDING]: 'promotion',
+  [LEARN_MORE]: 'primary',
+} as const satisfies Record<string, keyof Theme['tokens']['content']>;
 
 type StatusProps = {
   status: IntegrationInstallationStatus;
 };
 
-const StatusWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
 const IntegrationStatus = styled(({status, ...p}: StatusProps) => {
   const theme = useTheme();
 
   return (
-    <StatusWrapper>
-      <CircleIndicator size={6} color={theme[COLORS[status]]} />
+    <Flex align="center">
+      <CircleIndicator size={6} color={theme.tokens.content[COLORS[status]]} />
       <div {...p}>{status}</div>
-    </StatusWrapper>
+    </Flex>
   );
 })`
-  color: ${p => p.theme[COLORS[p.status]]};
+  color: ${p => p.theme.tokens.content[COLORS[p.status]]};
   margin-left: ${space(0.5)};
   font-weight: light;
   margin-right: ${space(0.75)};


### PR DESCRIPTION
| before | after |
|--------|--------|
| <img width="1215" height="764" alt="Screenshot 2025-12-03 at 11 18 07" src="https://github.com/user-attachments/assets/a3e7d4e4-7bc3-4466-8464-a99ce8fa2070" /> | <img width="1215" height="764" alt="Screenshot 2025-12-03 at 11 17 41" src="https://github.com/user-attachments/assets/61e5af52-c3ac-40b2-915c-eca589eb5873" /> |
| <img width="1215" height="764" alt="Screenshot 2025-12-03 at 11 18 04" src="https://github.com/user-attachments/assets/908aa56a-98b5-4770-ab01-1a8d8a718ca5" /> | <img width="1215" height="764" alt="Screenshot 2025-12-03 at 11 17 47" src="https://github.com/user-attachments/assets/eaea12fa-ccc6-42a6-8c25-ee10cfff3edf" /> | 