### PR TITLE
fix(reprocessing): require `event:admin` when deleting remaining events

### DIFF
--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -28,12 +28,13 @@ class GroupReprocessingEndpoint(GroupEndpoint):
 
         max_events = request.data.get("maxEvents")
         if max_events is not None:
-            max_events = int(max_events)
+            try:
+                max_events = int(max_events)
+            except (ValueError, TypeError):
+                return self.respond({"error": "maxEvents must be at least 1"}, status=400)
 
             if max_events <= 0:
                 return self.respond({"error": "maxEvents must be at least 1"}, status=400)
-        else:
-            max_events = None
 
         remaining_events = request.data.get("remainingEvents")
         if remaining_events not in ("delete", "keep"):

--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -39,7 +39,7 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         if remaining_events not in ("delete", "keep"):
             return self.respond({"error": "remainingEvents must be delete or keep"}, status=400)
 
-        if remaining_events == "delete" and not request.access.has_permission("event:admin"):
+        if remaining_events == "delete" and not request.access.has_scope("event:admin"):
             return self.respond(
                 {"error": "you do not have permission to delete remaining events"}, status=403
             )

--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -27,7 +27,7 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         """
 
         max_events = request.data.get("maxEvents")
-        if max_events:
+        if max_events is not None:
             max_events = int(max_events)
 
             if max_events <= 0:

--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -39,6 +39,11 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         if remaining_events not in ("delete", "keep"):
             return self.respond({"error": "remainingEvents must be delete or keep"}, status=400)
 
+        if remaining_events == "delete" and not request.access.has_permission("event:admin"):
+            return self.respond(
+                {"error": "you do not have permission to delete remaining events"}, status=403
+            )
+
         reprocess_group.delay(
             project_id=group.project_id,
             group_id=group.id,

--- a/tests/sentry/issues/endpoints/test_group_reprocessing.py
+++ b/tests/sentry/issues/endpoints/test_group_reprocessing.py
@@ -1,11 +1,11 @@
-from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from sentry.testutils.cases import APITestCase
 
 
-@mock.patch("sentry.issues.endpoints.group_reprocessing.reprocess_group")
+@patch("sentry.issues.endpoints.group_reprocessing.reprocess_group")
 class GroupReprocessingTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         # Create an event which will create the group
@@ -19,7 +19,9 @@ class GroupReprocessingTest(APITestCase):
         self.group = event.group
         self.url = f"/api/0/issues/{self.group.id}/reprocessing/"
 
-    def test_reprocess_without_admin_scope_and_delete_remaining_events(self, mock_reprocess):
+    def test_reprocess_without_admin_scope_and_delete_remaining_events(
+        self, mock_reprocess: MagicMock
+    ) -> None:
         """Test that users without event:admin scope cannot delete remaining events."""
         # Disable event:admin scope for members
         self.organization.update_option("sentry:events_member_admin", False)
@@ -45,7 +47,9 @@ class GroupReprocessingTest(APITestCase):
         assert response.status_code == 403
         assert response.data == {"error": "you do not have permission to delete remaining events"}
 
-    def test_reprocess_with_admin_scope_and_delete_remaining_events(self, mock_reprocess):
+    def test_reprocess_with_admin_scope_and_delete_remaining_events(
+        self, mock_reprocess: MagicMock
+    ) -> None:
         """Test that users with event:admin scope can delete remaining events."""
         # Create a user with admin scope
         admin_user = self.create_user()
@@ -68,7 +72,9 @@ class GroupReprocessingTest(APITestCase):
         # Should succeed (200) because admin has event:admin scope
         assert response.status_code == 200
 
-    def test_reprocess_without_admin_scope_and_keep_remaining_events(self, mock_reprocess):
+    def test_reprocess_without_admin_scope_and_keep_remaining_events(
+        self, mock_reprocess: MagicMock
+    ) -> None:
         """Test that users without event:admin scope can keep remaining events."""
         # Disable event:admin scope for members
         self.organization.update_option("sentry:events_member_admin", False)
@@ -94,7 +100,7 @@ class GroupReprocessingTest(APITestCase):
         # Should succeed (200) because keeping events doesn't require admin scope
         assert response.status_code == 200
 
-    def test_reprocess_with_max_events_validation(self, mock_reprocess):
+    def test_reprocess_with_max_events_validation(self, mock_reprocess: MagicMock) -> None:
         """Test maxEvents parameter validation."""
         # Test with non-numeric maxEvents
         response = self.client.post(
@@ -147,7 +153,7 @@ class GroupReprocessingTest(APITestCase):
 
         assert response.status_code == 200
 
-    def test_reprocess_with_remaining_events_validation(self, mock_reprocess):
+    def test_reprocess_with_remaining_events_validation(self, mock_reprocess: MagicMock) -> None:
         """Test remainingEvents parameter validation."""
         # Test with invalid remainingEvents
         response = self.client.post(

--- a/tests/sentry/issues/endpoints/test_group_reprocessing.py
+++ b/tests/sentry/issues/endpoints/test_group_reprocessing.py
@@ -1,0 +1,136 @@
+from unittest import mock
+
+from sentry.testutils.cases import APITestCase
+
+
+@mock.patch("sentry.issues.endpoints.group_reprocessing.reprocess_group")
+class GroupReprocessingTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        # Create an event which will create the group
+        event = self.store_event(
+            data={
+                "message": "hello world",
+                "fingerprint": ["group1"],
+            },
+            project_id=self.project.id,
+        )
+        self.group = event.group
+        self.url = f"/api/0/issues/{self.group.id}/reprocessing/"
+
+    def test_reprocess_without_admin_scope_and_delete_remaining_events(self, mock_reprocess):
+        """Test that users without event:admin scope cannot delete remaining events."""
+        # Disable event:admin scope for members
+        self.organization.update_option("sentry:events_member_admin", False)
+
+        # Create a member user (not owner/admin)
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(member_user)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "remainingEvents": "delete",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data == {"error": "you do not have permission to delete remaining events"}
+
+    def test_reprocess_with_admin_scope_and_delete_remaining_events(self, mock_reprocess):
+        """Test that users with event:admin scope can delete remaining events."""
+        # Create a user with admin scope
+        admin_user = self.create_user()
+        self.create_member(
+            user=admin_user,
+            organization=self.organization,
+            role="admin",
+            teams=[self.team],
+        )
+        self.login_as(user=admin_user)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "remainingEvents": "delete",
+            },
+            format="json",
+        )
+
+        # Should succeed (200) because admin has event:admin scope
+        assert response.status_code == 200
+
+    def test_reprocess_without_admin_scope_and_keep_remaining_events(self, mock_reprocess):
+        """Test that users without event:admin scope can keep remaining events."""
+        # Disable event:admin scope for members
+        self.organization.update_option("sentry:events_member_admin", False)
+
+        # Create a member user (not owner/admin)
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(member_user)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "remainingEvents": "keep",
+            },
+            format="json",
+        )
+
+        # Should succeed (200) because keeping events doesn't require admin scope
+        assert response.status_code == 200
+
+    def test_reprocess_with_max_events_validation(self, mock_reprocess):
+        """Test maxEvents parameter validation."""
+        # Test with invalid maxEvents (0)
+        response = self.client.post(
+            self.url,
+            data={
+                "maxEvents": 0,
+                "remainingEvents": "keep",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"error": "maxEvents must be at least 1"}
+
+        # Test with valid maxEvents
+        response = self.client.post(
+            self.url,
+            data={
+                "maxEvents": 5,
+                "remainingEvents": "keep",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+
+    def test_reprocess_with_remaining_events_validation(self, mock_reprocess):
+        """Test remainingEvents parameter validation."""
+        # Test with invalid remainingEvents
+        response = self.client.post(
+            self.url,
+            data={
+                "remainingEvents": "invalid",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"error": "remainingEvents must be delete or keep"}

--- a/tests/sentry/issues/endpoints/test_group_reprocessing.py
+++ b/tests/sentry/issues/endpoints/test_group_reprocessing.py
@@ -96,11 +96,37 @@ class GroupReprocessingTest(APITestCase):
 
     def test_reprocess_with_max_events_validation(self, mock_reprocess):
         """Test maxEvents parameter validation."""
-        # Test with invalid maxEvents (0)
+        # Test with non-numeric maxEvents
+        response = self.client.post(
+            self.url,
+            data={
+                "maxEvents": "abc",
+                "remainingEvents": "keep",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"error": "maxEvents must be at least 1"}
+
+        # Test with zero maxEvents
         response = self.client.post(
             self.url,
             data={
                 "maxEvents": 0,
+                "remainingEvents": "keep",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"error": "maxEvents must be at least 1"}
+
+        # Test with negative maxEvents
+        response = self.client.post(
+            self.url,
+            data={
+                "maxEvents": -5,
                 "remainingEvents": "keep",
             },
             format="json",


### PR DESCRIPTION
https://linear.app/getsentry/issue/SEC-870/