### PR TITLE
fix(ui): Size limitations ai spans message

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -287,9 +287,8 @@ function MessagesArrayRenderer({
     <Container paddingBottom="lg">
       <Alert type="muted">
         {tct(
-          'Due to [link:size limitations], the oldest [count] got dropped from the history.',
+          'Due to [link:size limitations], the oldest messages got dropped from the history.',
           {
-            count: tn('message', '%s messages', truncatedMessages),
             link: (
               <ExternalLink href="https://develop.sentry.dev/sdk/expected-features/data-handling/#variable-size" />
             ),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -7,7 +7,7 @@ import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {Button} from 'sentry/components/core/button';
-import {t, tct, tn} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';


### PR DESCRIPTION
SDK is now incorrectly sending characters instead of messages.
Hiding this in UI until it's fixed in SDK.
<img width="902" height="228" alt="CleanShot 2025-12-03 at 15 06 34" src="https://github.com/user-attachments/assets/06560712-146e-4649-bd33-bf216b2975a1" />
