### PR TITLE
fix(java): Allow frame removals during symbolication

### DIFF
--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -246,7 +246,7 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
                     new_frame = dict(raw_frame)
                     _merge_frame(new_frame, returned)
                     new_frames.append(new_frame)
-            else:
+            elif not _handles_frame(raw_frame, data.get("platform", "unknown")):
                 new_frames.append(raw_frame)
 
         sinfo.stacktrace["frames"] = new_frames


### PR DESCRIPTION
Since the introduction of https://github.com/getsentry/symbolicator/pull/1817 Symbolicator can actually remove frames, not only expand/remap them, so this change is necessary to not display synthetic frames generated by R8/proguard. 

NOTE: We only apply this logic for `java` frames to account for mixed stacktraces.

## Before
<img width="1474" height="396" alt="Google Chrome 2025-12-03 13 03 20" src="https://github.com/user-attachments/assets/ca6b2326-03d1-420c-8bc0-6ed6777f290d" />


## After
<img width="1107" height="357" alt="Finder 2025-12-03 14 17 53" src="https://github.com/user-attachments/assets/be5df668-eae8-4f5a-9be6-188b7f4ebc49" />
