### PR TITLE
feat(insights): Adds sub region selectors to web vitals pages

### DIFF
--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -34,6 +34,7 @@ import PerformanceScoreBreakdownChartWidget from 'sentry/views/insights/common/c
 import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useWebVitalsDrawer} from 'sentry/views/insights/common/utils/useWebVitalsDrawer';
+import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName, SpanFields, type SubregionCode} from 'sentry/views/insights/types';
@@ -158,6 +159,7 @@ function PageOverview() {
             <TopMenuContainer>
               <ModulePageFilterBar moduleName={ModuleName.VITAL} />
               <BrowserTypeSelector />
+              <SubregionSelector />
             </TopMenuContainer>
             <Flex>
               <ChartContainer>

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
@@ -84,9 +84,21 @@ describe('WebVitalsLandingPage', () => {
       initialRouterConfig,
     });
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
-    // Table query
+    // geo subregion query
     expect(eventsMock).toHaveBeenNthCalledWith(
       1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          dataset: 'spans',
+          field: ['user.geo.subregion', 'count()'],
+          query: 'has:user.geo.subregion',
+        }),
+      })
+    );
+    // Table query
+    expect(eventsMock).toHaveBeenNthCalledWith(
+      2,
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
@@ -117,7 +129,7 @@ describe('WebVitalsLandingPage', () => {
     );
     // Raw web vital metric tile queries
     expect(eventsMock).toHaveBeenNthCalledWith(
-      2,
+      3,
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
@@ -137,7 +149,7 @@ describe('WebVitalsLandingPage', () => {
     );
     // Project performance score ring query
     expect(eventsMock).toHaveBeenNthCalledWith(
-      3,
+      4,
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -25,6 +25,7 @@ import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modul
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {useWebVitalsDrawer} from 'sentry/views/insights/common/utils/useWebVitalsDrawer';
+import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {ModuleName, SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 const WEB_VITALS_COUNT = 5;
@@ -78,6 +79,7 @@ function WebVitalsLandingPage() {
                 extraFilters={
                   <Fragment>
                     <BrowserTypeSelector />
+                    <SubregionSelector />
                   </Fragment>
                 }
               />


### PR DESCRIPTION
Adds the sub region selector component to the Web vitals landing and page overview
<img width="624" height="138" alt="image" src="https://github.com/user-attachments/assets/e7497fa7-0cc3-45ac-96df-43304e03427c" />
