### PR TITLE
fix(logs) Disable logging for the CSSUTILS logger

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1256,6 +1256,8 @@ LOGGING: LoggingConfig = {
             "propagate": False,
         },
         "toronado": {"level": "ERROR", "handlers": ["null"], "propagate": False},
+        "toronado.cssutils": {"level": "ERROR", "handlers": ["null"], "propagate": False},
+        "CSSUTILS": {"level": "ERROR", "handlers": ["null"], "propagate": False},
         "urllib3.connectionpool": {
             "level": "ERROR",
             "handlers": ["console"],


### PR DESCRIPTION
We already have logs disabled for the `toronado` logger, which should disable logs for `toronado.cssutils` and `CSSUTILS` loggers as well.
