### PR TITLE
feat(issue-details): Show Unsymbolicated exception value, type and module in Raw view

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
@@ -71,15 +71,20 @@ export default function RawContent({
     <Fragment>
       {values.map((exc, excIdx) => {
         if (!isNative) {
+          const exceptionValue =
+            type === 'original' ? exc.value : exc.rawValue || exc.value;
+          const exceptionType = type === 'original' ? exc.type : exc.rawType || exc.type;
+
           const nonNativeContent = exc.stacktrace ? (
             rawStacktraceContent({
               data: type === 'original' ? exc.stacktrace : exc.rawStacktrace,
               platform,
               exception: exc,
+              isMinified: type === 'minified',
             })
           ) : (
             <div>
-              {exc.type}: {exc.value}
+              {exceptionType}: {exceptionValue}
             </div>
           );
           return (

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
@@ -2,7 +2,6 @@ import {ExceptionValueFixture} from 'sentry-fixture/exceptionValue';
 import {FrameFixture} from 'sentry-fixture/frame';
 
 import displayRawContent, {
-  getJavaExceptionSummary,
   getJavaFrame,
 } from 'sentry/components/events/interfaces/crashContent/stackTrace/rawContent';
 import type {StacktraceType} from 'sentry/types/stacktrace';
@@ -54,29 +53,119 @@ describe('RawStacktraceContent', () => {
     });
   });
 
-  describe('getJavaExceptionSummary()', () => {
-    it('takes a type and value', () => {
+  describe('getExceptionSummary()', () => {
+    it('renders non-minified exception for java platform', () => {
+      const exception = ExceptionValueFixture({
+        module: 'com.example.app',
+        type: 'CustomException',
+        value: 'Original error message',
+      });
+
       expect(
-        getJavaExceptionSummary(
-          ExceptionValueFixture({
-            type: 'Baz',
-            value: 'message',
-            module: undefined,
-          })
-        )
-      ).toBe('Baz: message');
+        displayRawContent({
+          data: {
+            hasSystemFrames: false,
+            framesOmitted: null,
+            registers: {},
+            frames: [],
+          },
+          platform: 'java',
+          exception,
+          isMinified: false,
+        })
+      ).toBe('com.example.app.CustomException: Original error message');
     });
 
-    it('takes a module name', () => {
+    it('renders minified exception using raw values for java platform', () => {
+      const exception = ExceptionValueFixture({
+        module: 'com.example.app',
+        type: 'CustomException',
+        value: 'Original error message',
+        rawModule: 'c.d.e',
+        rawType: 'a',
+        rawValue: 'Obfuscated error',
+      });
+
       expect(
-        getJavaExceptionSummary(
-          ExceptionValueFixture({
-            module: 'foo.bar',
-            type: 'Baz',
-            value: 'message',
-          })
-        )
-      ).toBe('foo.bar.Baz: message');
+        displayRawContent({
+          data: {
+            hasSystemFrames: false,
+            framesOmitted: null,
+            registers: {},
+            frames: [],
+          },
+          platform: 'java',
+          exception,
+          isMinified: true,
+        })
+      ).toBe('c.d.e.a: Obfuscated error');
+    });
+
+    it('falls back to deobfuscated values when raw values are missing', () => {
+      const exception = ExceptionValueFixture({
+        module: 'com.example.app',
+        type: 'CustomException',
+        value: 'Original error message',
+      });
+
+      expect(
+        displayRawContent({
+          data: {
+            hasSystemFrames: false,
+            framesOmitted: null,
+            registers: {},
+            frames: [],
+          },
+          platform: 'java',
+          exception,
+          isMinified: true,
+        })
+      ).toBe('com.example.app.CustomException: Original error message');
+    });
+
+    it('renders minified exception for non-java platforms', () => {
+      const exception = ExceptionValueFixture({
+        type: 'CustomError',
+        value: 'Original error message',
+        rawType: 'Error',
+        rawValue: 'Obfuscated error',
+      });
+
+      expect(
+        displayRawContent({
+          data: {
+            hasSystemFrames: false,
+            framesOmitted: null,
+            registers: {},
+            frames: [],
+          },
+          platform: 'javascript',
+          exception,
+          isMinified: true,
+        })
+      ).toBe('Error: Obfuscated error');
+    });
+
+    it('handles exception without module for java platform', () => {
+      const exception = ExceptionValueFixture({
+        type: 'IllegalStateException',
+        value: 'Oops!',
+        module: undefined,
+      });
+
+      expect(
+        displayRawContent({
+          data: {
+            hasSystemFrames: false,
+            framesOmitted: null,
+            registers: {},
+            frames: [],
+          },
+          platform: 'java',
+          exception,
+          isMinified: false,
+        })
+      ).toBe('IllegalStateException: Oops!');
     });
   });
 

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -269,6 +269,7 @@ export function TraceEventDataSection({
                 hasSimilarityEmbeddingsFeature: false,
                 includeLocation: true,
                 rawTrace: true,
+                isMinified: useMinified,
               });
             })
             .filter(Boolean)
@@ -282,6 +283,7 @@ export function TraceEventDataSection({
           hasSimilarityEmbeddingsFeature: false,
           includeLocation: true,
           rawTrace: true,
+          isMinified: useMinified,
         });
       }
       if (entry.type === EntryType.THREADS) {
@@ -302,6 +304,7 @@ export function TraceEventDataSection({
                 hasSimilarityEmbeddingsFeature: false,
                 includeLocation: true,
                 rawTrace: true,
+                isMinified: useMinified,
               })
             );
           }


### PR DESCRIPTION
Follow up on #104238 
Closes https://github.com/getsentry/sentry-java/issues/4937#issuecomment-3607241035

`on class xg.d` down here is minified:

<img width="1144" height="321" alt="Google Chrome 2025-12-03 17 44 16" src="https://github.com/user-attachments/assets/af860b29-259b-4c98-8afd-500ed9199522" />
