### PR TITLE
ref(aci): Add config property to detector issue evidence data

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -34,6 +34,7 @@ class EvidenceData(Generic[DataPacketEvaluationType]):
     detector_id: int
     data_packet_source_id: int
     conditions: list[dict[str, Any]]
+    config: dict[str, Any] = dataclasses.field(default_factory=dict, kw_only=True)
     data_sources: list[dict[str, Any]] = dataclasses.field(default_factory=list, kw_only=True)
 
 


### PR DESCRIPTION
We need the detector config to be saved on the issue occurrences in order to know what the threshold was when it was triggered.

This first step (this PR) only adds the property to the EvidenceData dataclass so that we don't run into errors while the deploy is going out. A followup PR will add the correct config data into the occurrence.