### PR TITLE
fix(triage signals): Add re-try to fixability generated with delay

### DIFF
--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -69,7 +69,7 @@ def generate_issue_summary_only(group_id: int) -> None:
     try:
         _ = get_and_update_group_fixability_score(group, force_generate=True)
     except Exception:
-        time.sleep(10)
+        time.sleep(6)  # wait for 6 seconds before retrying for summary to be stored to databse
         _ = get_and_update_group_fixability_score(group, force_generate=True)
 
 

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from datetime import datetime, timedelta
 
 from sentry.models.group import Group
@@ -65,7 +66,11 @@ def generate_issue_summary_only(group_id: int) -> None:
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
 
-    _ = get_and_update_group_fixability_score(group, force_generate=True)
+    try:
+        _ = get_and_update_group_fixability_score(group, force_generate=True)
+    except Exception:
+        time.sleep(10)
+        _ = get_and_update_group_fixability_score(group, force_generate=True)
 
 
 @instrumented_task(


### PR DESCRIPTION
## PR Details
+ This PR adds a retry with a small delay to address the fixability score failing. It's failing (in rare instances) due to a race condition where Seer tries to read the issue summary from the database before it's written. 
+ Will fix these two issue: 
   + https://sentry.sentry.io/issues/7065447919/?project=1&query=is%3Aunresolved%20%22generate_issue_summary_only%22&referrer=issue-stream&scrollTo=solution&seerDrawer=true
   + https://sentry.sentry.io/issues/7082675053/events/latest/?notification_uuid=f05d996d-84a2-4d1f-b35f-6d2892c3e5d5&project=6178942&referrer=latest-event
