### PR TITLE
fix(aci): Make workflow evaluation logs conditional

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -551,6 +551,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-single-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable logging to debug workflow engine process workflows
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable logging workflow evaluations (bypasses sample rate when enabled)
+    manager.add("organizations:workflow-engine-log-evaluations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable firing actions for workflow engine issue alerts
     manager.add("organizations:workflow-engine-trigger-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logs to debug metric alert dual processing

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3302,6 +3302,12 @@ register(
     default=50,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "workflow_engine.evaluation_log_sample_rate",
+    type=Float,
+    default=0.1,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -448,7 +448,10 @@ def process_workflows(
         fire_actions,
     )
 
-    workflow_evaluation_data = WorkflowEvaluationData(event=event_data.event)
+    organization = event_data.event.project.organization
+    workflow_evaluation_data = WorkflowEvaluationData(
+        event=event_data.event, organization=organization
+    )
 
     try:
         event_detectors = get_detectors_for_event(event_data, detector)
@@ -459,7 +462,6 @@ def process_workflows(
         log_context.add_extras(
             detector_id=event_detectors.preferred_detector.id, group_id=event_data.group.id
         )
-        organization = event_data.event.project.organization
 
         # set the detector / org information asap, this is used in `get_environment_by_event` as well.
         WorkflowEventContext.set(

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -73,7 +73,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
             batch_client, event_data, event_start_time=activity.datetime, detector=detector
         )
 
-    evaluation.to_log(logger)
+    evaluation.log_to(logger)
 
     metrics.incr(
         "workflow_engine.tasks.process_workflows.activity_update.executed",
@@ -137,7 +137,7 @@ def process_workflows_event(
                 batch_client, event_data, event_start_time=event_start_time
             )
 
-    evaluation.to_log(logger)
+    evaluation.log_to(logger)
     duration = time.time() - start_time
     is_slow = duration > 1.0
     # We want full coverage for particularly slow cases, plus a random sampling.

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -9,6 +9,7 @@ from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow import workflow_status_update_handler
@@ -137,6 +138,7 @@ class TestProcessWorkflowActivity(TestCase):
         self.activity.save()
         self.detector = self.create_detector(type=MetricIssue.slug)
 
+    @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
     @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
     def test_process_workflow_activity__no_workflows(self, mock_logger) -> None:
         with mock.patch(
@@ -166,6 +168,7 @@ class TestProcessWorkflowActivity(TestCase):
                 },
             )
 
+    @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
     @mock.patch(
         "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
         return_value=(set(), {}),
@@ -246,6 +249,7 @@ class TestProcessWorkflowActivity(TestCase):
 
         mock_filter_actions.assert_called_once_with({self.action_group}, expected_event_data)
 
+    @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
     @mock.patch("sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers")
     @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
     def test_process_workflow_activity__success_logs(

--- a/tests/sentry/workflow_engine/test_types.py
+++ b/tests/sentry/workflow_engine/test_types.py
@@ -1,0 +1,56 @@
+from unittest import mock
+
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import Feature
+from sentry.testutils.helpers.options import override_options
+from sentry.workflow_engine.types import WorkflowEvaluation, WorkflowEvaluationData
+
+
+class TestWorkflowEvaluationLogTo(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.event = self.store_event(data={}, project_id=self.project.id)
+
+        self.evaluation_data = WorkflowEvaluationData(
+            event=self.event,
+            organization=self.organization,
+        )
+
+    def test_log_to_always_logs_with_feature_enabled(self):
+        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+
+        mock_logger = mock.MagicMock()
+
+        with Feature({"organizations:workflow-engine-log-evaluations": True}):
+            with override_options({"workflow_engine.evaluation_log_sample_rate": 0.0}):
+                assert evaluation.log_to(mock_logger) is True
+
+    def test_log_to_respects_sample_rate_when_feature_disabled(self):
+        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        mock_logger = mock.MagicMock()
+
+        with Feature({"organizations:workflow-engine-log-evaluations": False}):
+            with override_options({"workflow_engine.evaluation_log_sample_rate": 0.0}):
+                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.5):
+                    assert not evaluation.log_to(mock_logger), "Should not log with 0% sample rate"
+
+            with override_options({"workflow_engine.evaluation_log_sample_rate": 1.0}):
+                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.5):
+                    assert evaluation.log_to(mock_logger), "Should log with 100% sample rate"
+
+    def test_log_to_samples_correctly(self):
+        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        mock_logger = mock.MagicMock()
+
+        with Feature({"organizations:workflow-engine-log-evaluations": False}):
+            with override_options({"workflow_engine.evaluation_log_sample_rate": 0.1}):
+                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.05):
+                    assert evaluation.log_to(mock_logger), "Should log when random < sample_rate"
+
+                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.15):
+                    assert not evaluation.log_to(
+                        mock_logger
+                    ), "Should not log when random >= sample_rate"


### PR DESCRIPTION
Workflow evaluation logs are extremely high volume. This is often quite useful, but it makes log management expensive.
While we find the right balance, this makes the sample rate configurable (defaulting to 10%) and makes it possible to opt in whole orgs to total logging for cases where we're actively investigating.
