### PR TITLE
chore(search-bar): Tidy up search query builder flags

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackCategories.spec.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.spec.tsx
@@ -26,7 +26,6 @@ const mockUseOrganizationSeerSetup = jest.mocked(useOrganizationSeerSetup);
 describe('FeedbackCategories', () => {
   const mockOrganization = OrganizationFixture({
     slug: 'org-slug',
-    features: ['search-query-builder-wildcard-operators'],
   });
 
   const mockCategories = [

--- a/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
@@ -13,7 +13,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 
-function getSearchTermForLabel(label: string, hasWildcardOps: boolean) {
+function getSearchTermForLabel(label: string) {
   /**
    * Return exactly what we have to pass to the search API
    * The search API uses a very similar (almost exactly the same, except wildcards) escape logic to JSON.stringify, so doing it twice just "makes it work"
@@ -26,14 +26,12 @@ function getSearchTermForLabel(label: string, hasWildcardOps: boolean) {
   const toPassToSearch = escapeFilterValue(JSON.stringify(JSON.stringify(label)));
   // Now, add the wildcards to the string (second spot and second-last spot, since we want them inside the second pair of quotes)
   // The first and last quotes are added by the second JSON.stringify, we just manually add them back
-  return hasWildcardOps
-    ? `"${toPassToSearch.slice(1, -1)}"`
-    : `"*${toPassToSearch.slice(1, -1)}*"`;
+  return `"${toPassToSearch.slice(1, -1)}"`;
 }
 
-function getSearchTermForLabelList(labels: string[], hasWildcardOps: boolean) {
+function getSearchTermForLabelList(labels: string[]) {
   labels.sort();
-  const searchTerms = labels.map(label => getSearchTermForLabel(label, hasWildcardOps));
+  const searchTerms = labels.map(label => getSearchTermForLabel(label));
   return `[${searchTerms.join(',')}]`;
 }
 
@@ -48,10 +46,6 @@ export default function FeedbackCategories() {
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
-
-  const hasWildcardOperators = organization.features.includes(
-    'search-query-builder-wildcard-operators'
-  );
 
   useEffect(() => {
     // Analytics for the rendered state. Should match the conditions below.
@@ -114,7 +108,7 @@ export default function FeedbackCategories() {
   }) => {
     // Create search terms for primary label and all associated labels
     const allLabels = [category.primaryLabel, ...category.associatedLabels];
-    const exactSearchTerm = getSearchTermForLabelList(allLabels, hasWildcardOperators);
+    const exactSearchTerm = getSearchTermForLabelList(allLabels);
     const currentFilters = searchConditions.getFilterValues('ai_categorization.labels');
 
     // Only show a tag as selected if it is the only filter, and the search term matches exactly
@@ -127,7 +121,7 @@ export default function FeedbackCategories() {
   }) => {
     const allLabels = [category.primaryLabel, ...category.associatedLabels];
 
-    const exactSearchTerm = getSearchTermForLabelList(allLabels, hasWildcardOperators);
+    const exactSearchTerm = getSearchTermForLabelList(allLabels);
 
     const isSelected = isCategorySelected(category);
 
@@ -139,19 +133,11 @@ export default function FeedbackCategories() {
       newSearchConditions.removeFilter('ai_categorization.labels');
 
       // Don't escape the search term, since we want wildcards to work; escape the string ourselves before adding the wildcards
-      if (hasWildcardOperators) {
-        newSearchConditions.addContainsFilterValue(
-          'ai_categorization.labels',
-          exactSearchTerm,
-          false
-        );
-      } else {
-        newSearchConditions.addFilterValue(
-          'ai_categorization.labels',
-          exactSearchTerm,
-          false
-        );
-      }
+      newSearchConditions.addContainsFilterValue(
+        'ai_categorization.labels',
+        exactSearchTerm,
+        false
+      );
 
       trackAnalytics('feedback.summary.category-selected', {
         organization,

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -57,17 +57,13 @@ function FilterKey({token}: {token: TokenResult<Token.FILTER>}) {
 
 function Filter({token}: {token: TokenResult<Token.FILTER>}) {
   const {getFieldDefinition} = useSearchQueryBuilder();
-  const hasWildcardOperators = useOrganization().features.includes(
-    'search-query-builder-wildcard-operators'
-  );
   const label = useMemo(
     () =>
       getOperatorInfo({
         filterToken: token,
-        hasWildcardOperators,
         fieldDefinition: getFieldDefinition(token.key.text),
       }).label,
-    [hasWildcardOperators, token, getFieldDefinition]
+    [token, getFieldDefinition]
   );
 
   return (

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1027,12 +1027,7 @@ describe('SearchQueryBuilder', () => {
     it('can add a new token by clicking a key suggestion', async () => {
       const mockOnChange = jest.fn();
       render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />, {
-        organization: {
-          features: [
-            'search-query-builder-input-flow-changes',
-            'search-query-builder-default-to-contains',
-          ],
-        },
+        organization: {features: ['search-query-builder-input-flow-changes']},
       });
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
@@ -1098,7 +1093,7 @@ describe('SearchQueryBuilder', () => {
       jest.restoreAllMocks();
 
       // Should have focus on the operator option
-      const operatorOption = await screen.findByRole('option', {name: 'is'});
+      const operatorOption = await screen.findByRole('option', {name: 'contains'});
       expect(operatorOption).toHaveFocus();
       await userEvent.click(operatorOption);
 
@@ -1112,7 +1107,9 @@ describe('SearchQueryBuilder', () => {
       ).toBeInTheDocument();
 
       // Should have a filter token "browser.name:foo"
-      expect(screen.getByRole('row', {name: 'browser.name:foo'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('row', {name: `browser.name:${WildcardOperators.CONTAINS}foo`})
+      ).toBeInTheDocument();
     });
 
     it('can add parens by typing', async () => {
@@ -1184,12 +1181,7 @@ describe('SearchQueryBuilder', () => {
 
     it('converts text to filter when typing <filter>:', async () => {
       render(<SearchQueryBuilder {...defaultProps} />, {
-        organization: {
-          features: [
-            'search-query-builder-input-flow-changes',
-            'search-query-builder-default-to-contains',
-          ],
-        },
+        organization: {features: ['search-query-builder-input-flow-changes']},
       });
       await userEvent.click(getLastInput());
 
@@ -1221,12 +1213,7 @@ describe('SearchQueryBuilder', () => {
 
     it('selects [Filtered] from dropdown', async () => {
       render(<SearchQueryBuilder {...defaultProps} />, {
-        organization: {
-          features: [
-            'search-query-builder-input-flow-changes',
-            'search-query-builder-default-to-contains',
-          ],
-        },
+        organization: {features: ['search-query-builder-input-flow-changes']},
       });
       await userEvent.click(getLastInput());
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4263,8 +4263,7 @@ describe('SearchQueryBuilder', () => {
           {...defaultProps}
           caseInsensitive={1}
           onCaseInsensitiveClick={() => Promise.resolve(new URLSearchParams())}
-        />,
-        {organization: {features: ['search-query-builder-case-insensitivity']}}
+        />
       );
 
       expect(await screen.findByRole('button', {name: 'Match case'})).toBeInTheDocument();

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -226,8 +226,7 @@ describe('SearchQueryBuilder', () => {
 
       it('renders swap to is for * when using a wildcard operator', async () => {
         render(
-          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />,
-          {organization: {features: ['search-query-builder-wildcard-operators']}}
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
         );
 
         await userEvent.click(
@@ -1031,7 +1030,6 @@ describe('SearchQueryBuilder', () => {
         organization: {
           features: [
             'search-query-builder-input-flow-changes',
-            'search-query-builder-wildcard-operators',
             'search-query-builder-default-to-contains',
           ],
         },
@@ -1189,7 +1187,6 @@ describe('SearchQueryBuilder', () => {
         organization: {
           features: [
             'search-query-builder-input-flow-changes',
-            'search-query-builder-wildcard-operators',
             'search-query-builder-default-to-contains',
           ],
         },
@@ -1227,7 +1224,6 @@ describe('SearchQueryBuilder', () => {
         organization: {
           features: [
             'search-query-builder-input-flow-changes',
-            'search-query-builder-wildcard-operators',
             'search-query-builder-default-to-contains',
           ],
         },
@@ -2590,8 +2586,7 @@ describe('SearchQueryBuilder', () => {
 
       it('string filters have the correct operator options', async () => {
         render(
-          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />,
-          {organization: {features: ['search-query-builder-wildcard-operators']}}
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
         );
         await userEvent.click(
           screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
@@ -4289,7 +4284,7 @@ describe('SearchQueryBuilder', () => {
       await userEvent.type(screen.getByRole('textbox'), 'randomValue');
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getByText('span.description')
+        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
       );
 
       expect(
@@ -4309,7 +4304,7 @@ describe('SearchQueryBuilder', () => {
       await userEvent.type(screen.getByRole('textbox'), 'random value');
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getByText('span.description')
+        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
       );
 
       expect(
@@ -4323,8 +4318,7 @@ describe('SearchQueryBuilder', () => {
           {...defaultProps}
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
-        />,
-        {organization: {features: ['search-query-builder-wildcard-operators']}}
+        />
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'test*');
@@ -4336,216 +4330,206 @@ describe('SearchQueryBuilder', () => {
       expect(options[1]).toHaveTextContent('span.description is test*');
     });
 
-    describe('with wildcard operators enabled', () => {
-      describe('selecting suggestions', () => {
-        it('should replace raw search keys with defined key:contains:value', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
+    describe('selecting suggestions', () => {
+      it('should replace raw search keys with defined key:contains:value', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
 
-          await userEvent.type(screen.getByRole('textbox'), 'randomValue');
+        await userEvent.type(screen.getByRole('textbox'), 'randomValue');
 
-          await userEvent.click(
-            within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
-          );
+        await userEvent.click(
+          within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
+        );
 
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
-            })
-          ).toBeInTheDocument();
-        });
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
+          })
+        ).toBeInTheDocument();
+      });
 
-        it('should replace raw search keys with defined key:contains:"value space', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
+      it('should replace raw search keys with defined key:contains:"value space', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
 
-          await userEvent.type(screen.getByRole('textbox'), 'random value');
+        await userEvent.type(screen.getByRole('textbox'), 'random value');
 
-          await userEvent.click(
-            within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
-          );
+        await userEvent.click(
+          within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
+        );
 
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}"random value"`,
-            })
-          ).toBeInTheDocument();
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}"random value"`,
+          })
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe('pasting text', () => {
+      it('should not replace raw search keys on paste', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.paste('randomValue');
+
+        // Should have the pasted text
+        expect(screen.getByRole('row', {name: 'randomValue'})).toBeInTheDocument();
+      });
+
+      it('not should replace raw search keys on paste, leaving other tokens intact', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:firefox span.description:test"
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.paste('randomValue');
+        await userEvent.keyboard('{Escape}');
+
+        // leaves unrelated filter key tokens intact
+        expect(
+          screen.getByRole('row', {name: 'browser.name:firefox'})
+        ).toBeInTheDocument();
+
+        // leaves the same filter key minus the wildcard contains operator intact
+        expect(
+          screen.getByRole('row', {name: 'span.description:test'})
+        ).toBeInTheDocument();
+
+        // Should have the pasted text
+        expect(screen.getByRole('row', {name: 'randomValue'})).toBeInTheDocument();
+        // Focus should be at the end of the pasted text
+        expect(
+          screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+        ).toHaveFocus();
+      });
+    });
+
+    describe('on commit', () => {
+      it('should replace the raw search key with the defined key:value', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.keyboard('randomValue{Enter}');
+
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
+          })
+        ).toBeInTheDocument();
+        expect(getLastInput()).toHaveFocus();
+      });
+    });
+
+    describe('on blur', () => {
+      it('should not replace the raw search key with the defined key:value', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
+
+        const input = getLastInput();
+        await userEvent.click(input);
+        await userEvent.keyboard('randomValue');
+        await userEvent.click(document.body);
+
+        expect(screen.getByRole('row', {name: `randomValue`})).toBeInTheDocument();
+        expect(getLastInput()).toHaveFocus();
+      });
+    });
+
+    describe('on exit', () => {
+      it('should replace the raw search key with the defined key:value', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
+
+        const input = getLastInput();
+        await userEvent.click(input);
+        await userEvent.keyboard('randomValue');
+        await userEvent.keyboard('{Enter}');
+
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
+          })
+        ).toBeInTheDocument();
+        expect(getLastInput()).toHaveFocus();
+      });
+    });
+
+    describe('selecting from filter key suggestions', () => {
+      beforeEach(() => {
+        MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/recent-searches/',
+          body: [{query: 'a or b'}, {query: 'some recent query'}],
         });
       });
 
-      describe('pasting text', () => {
-        it('should not replace raw search keys on paste', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
+      it('should replace the raw search key with the defined key:value', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            recentSearches={SavedSearchType.ISSUE}
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
 
-          await userEvent.click(getLastInput());
-          await userEvent.paste('randomValue');
+        await userEvent.click(getLastInput());
 
-          // Should have the pasted text
-          expect(screen.getByRole('row', {name: 'randomValue'})).toBeInTheDocument();
-        });
+        const aOrBOption = await screen.findByRole('option', {name: 'a or b'});
+        expect(aOrBOption).toBeInTheDocument();
 
-        it('not should replace raw search keys on paste, leaving other tokens intact', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery="browser.name:firefox span.description:test"
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
+        await userEvent.hover(aOrBOption);
+        await userEvent.keyboard('{enter}{enter}');
 
-          await userEvent.click(getLastInput());
-          await userEvent.paste('randomValue');
-          await userEvent.keyboard('{Escape}');
+        expect(
+          await screen.findByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}a`,
+          })
+        ).toBeInTheDocument();
 
-          // leaves unrelated filter key tokens intact
-          expect(
-            screen.getByRole('row', {name: 'browser.name:firefox'})
-          ).toBeInTheDocument();
+        expect(await screen.findByRole('row', {name: 'OR'})).toBeInTheDocument();
 
-          // leaves the same filter key minus the wildcard contains operator intact
-          expect(
-            screen.getByRole('row', {name: 'span.description:test'})
-          ).toBeInTheDocument();
-
-          // Should have the pasted text
-          expect(screen.getByRole('row', {name: 'randomValue'})).toBeInTheDocument();
-          // Focus should be at the end of the pasted text
-          expect(
-            screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
-          ).toHaveFocus();
-        });
-      });
-
-      describe('on commit', () => {
-        it('should replace the raw search key with the defined key:value', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          await userEvent.click(getLastInput());
-          await userEvent.keyboard('randomValue{Enter}');
-
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
-            })
-          ).toBeInTheDocument();
-          expect(getLastInput()).toHaveFocus();
-        });
-      });
-
-      describe('on blur', () => {
-        it('should not replace the raw search key with the defined key:value', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          const input = getLastInput();
-          await userEvent.click(input);
-          await userEvent.keyboard('randomValue');
-          await userEvent.click(document.body);
-
-          expect(screen.getByRole('row', {name: `randomValue`})).toBeInTheDocument();
-          expect(getLastInput()).toHaveFocus();
-        });
-      });
-
-      describe('on exit', () => {
-        it('should replace the raw search key with the defined key:value', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          const input = getLastInput();
-          await userEvent.click(input);
-          await userEvent.keyboard('randomValue');
-          await userEvent.keyboard('{Enter}');
-
-          expect(
-            screen.getByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
-            })
-          ).toBeInTheDocument();
-          expect(getLastInput()).toHaveFocus();
-        });
-      });
-
-      describe('selecting from filter key suggestions', () => {
-        beforeEach(() => {
-          MockApiClient.addMockResponse({
-            url: '/organizations/org-slug/recent-searches/',
-            body: [{query: 'a or b'}, {query: 'some recent query'}],
-          });
-        });
-
-        it('should replace the raw search key with the defined key:value', async () => {
-          render(
-            <SearchQueryBuilder
-              {...defaultProps}
-              initialQuery=""
-              recentSearches={SavedSearchType.ISSUE}
-              replaceRawSearchKeys={['span.description']}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
-          );
-
-          await userEvent.click(getLastInput());
-
-          const aOrBOption = await screen.findByRole('option', {name: 'a or b'});
-          expect(aOrBOption).toBeInTheDocument();
-
-          await userEvent.hover(aOrBOption);
-          await userEvent.keyboard('{enter}{enter}');
-
-          expect(
-            await screen.findByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}a`,
-            })
-          ).toBeInTheDocument();
-
-          expect(await screen.findByRole('row', {name: 'OR'})).toBeInTheDocument();
-
-          expect(
-            await screen.findByRole('row', {
-              name: `span.description:${WildcardOperators.CONTAINS}b`,
-            })
-          ).toBeInTheDocument();
-        });
+        expect(
+          await screen.findByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}b`,
+          })
+        ).toBeInTheDocument();
       });
     });
   });
@@ -4922,8 +4906,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:firefox"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -4964,8 +4947,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:[firefox,chrome]"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5008,8 +4990,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:firefox"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5054,8 +5035,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:[firefox,chrome]"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5102,8 +5082,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:firefox"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5143,8 +5122,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:[firefox,chrome]"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5187,8 +5165,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:firefox"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5233,8 +5210,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:[firefox,chrome]"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5281,8 +5257,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:firefox"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5323,8 +5298,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:[firefox,chrome]"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5367,8 +5341,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:firefox"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {
@@ -5413,8 +5386,7 @@ describe('SearchQueryBuilder', () => {
               {...defaultProps}
               initialQuery="browser.name:[firefox,chrome]"
               onChange={mockOnChange}
-            />,
-            {organization: {features: ['search-query-builder-wildcard-operators']}}
+            />
           );
 
           const editOpBtn = screen.getByRole('button', {

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -32,7 +32,6 @@ import type {SavedSearchType, Tag, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import PanelProvider from 'sentry/utils/panelProvider';
 import {useDimensions} from 'sentry/utils/useDimensions';
-import useOrganization from 'sentry/utils/useOrganization';
 
 export interface SearchQueryBuilderProps {
   /**
@@ -198,10 +197,6 @@ function ActionButtons({
     onCaseInsensitiveClick,
   } = useSearchQueryBuilder();
 
-  const hasCaseSensitiveSearch = useOrganization().features.includes(
-    'search-query-builder-case-insensitivity'
-  );
-
   if (disabled) {
     return null;
   }
@@ -212,7 +207,7 @@ function ActionButtons({
   return (
     <ButtonsWrapper ref={ref}>
       {trailingItems}
-      {defined(onCaseInsensitiveClick) && hasCaseSensitiveSearch ? (
+      {defined(onCaseInsensitiveClick) ? (
         <Tooltip title={caseInsensitiveLabel}>
           <ActionButton
             aria-label={caseInsensitiveLabel}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -54,10 +54,6 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     getFieldDefinition(getKeyName(token.key))
   );
 
-  const hasDefaultToContains = organization.features.includes(
-    'search-query-builder-default-to-contains'
-  );
-
   const handleSelectKey = useCallback(
     (keyName: string) => {
       const newFieldDef = getFieldDefinition(keyName);
@@ -112,7 +108,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT',
         tokens: [token],
-        text: getInitialFilterText(keyName, newFieldDef, hasDefaultToContains),
+        text: getInitialFilterText(keyName, newFieldDef),
         focusOverride: {
           itemKey: item.key.toString(),
           part: 'value',
@@ -126,7 +122,6 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       currentInputValueRef,
       dispatch,
       getFieldDefinition,
-      hasDefaultToContains,
       item.key,
       onCommit,
       organization,

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -54,9 +54,9 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     getFieldDefinition(getKeyName(token.key))
   );
 
-  const hasWildcardOperators =
-    organization.features.includes('search-query-builder-wildcard-operators') &&
-    organization.features.includes('search-query-builder-default-to-contains');
+  const hasDefaultToContains = organization.features.includes(
+    'search-query-builder-default-to-contains'
+  );
 
   const handleSelectKey = useCallback(
     (keyName: string) => {
@@ -112,7 +112,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT',
         tokens: [token],
-        text: getInitialFilterText(keyName, newFieldDef, hasWildcardOperators),
+        text: getInitialFilterText(keyName, newFieldDef, hasDefaultToContains),
         focusOverride: {
           itemKey: item.key.toString(),
           part: 'value',
@@ -126,7 +126,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       currentInputValueRef,
       dispatch,
       getFieldDefinition,
-      hasWildcardOperators,
+      hasDefaultToContains,
       item.key,
       onCommit,
       organization,

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -90,12 +90,10 @@ function FilterKeyOperatorLabel({
 
 export function getOperatorInfo({
   filterToken,
-  hasWildcardOperators,
   fieldDefinition,
 }: {
   fieldDefinition: FieldDefinition | null;
   filterToken: TokenResult<Token.FILTER>;
-  hasWildcardOperators: boolean;
 }): {
   label: ReactNode;
   operator: TermOperator;
@@ -121,10 +119,7 @@ export function getOperatorInfo({
     };
   }
 
-  const {operator, label} = getLabelAndOperatorFromToken(
-    filterToken,
-    hasWildcardOperators
-  );
+  const {operator, label} = getLabelAndOperatorFromToken(filterToken);
 
   if (filterToken.filter === FilterType.IS) {
     return {
@@ -207,11 +202,7 @@ export function getOperatorInfo({
   return {
     operator,
     label: <OpLabel>{label}</OpLabel>,
-    options: getValidOpsForFilter({
-      filterToken,
-      hasWildcardOperators,
-      fieldDefinition,
-    })
+    options: getValidOpsForFilter({filterToken, fieldDefinition})
       .filter(op => op !== TermOperator.EQUAL)
       .map((op): SelectOption<TermOperator> => {
         const optionOpLabel = OP_LABELS[op] ?? op;
@@ -227,9 +218,6 @@ export function getOperatorInfo({
 
 export function FilterOperator({state, item, token, onOpenChange}: FilterOperatorProps) {
   const organization = useOrganization();
-  const hasWildcardOperators = organization.features.includes(
-    'search-query-builder-wildcard-operators'
-  );
   const {
     dispatch,
     searchSource,
@@ -246,10 +234,9 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
     () =>
       getOperatorInfo({
         filterToken: token,
-        hasWildcardOperators,
         fieldDefinition: getFieldDefinition(token.key.text),
       }),
-    [token, hasWildcardOperators, getFieldDefinition]
+    [token, getFieldDefinition]
   );
 
   const onlyOperator = token.filter === FilterType.IS || token.filter === FilterType.HAS;

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -67,12 +67,10 @@ export function isAggregateFilterToken(
 
 export function getValidOpsForFilter({
   filterToken,
-  hasWildcardOperators,
   fieldDefinition,
 }: {
   fieldDefinition: FieldDefinition | null;
   filterToken: TokenResult<Token.FILTER>;
-  hasWildcardOperators: boolean;
 }): readonly TermOperator[] {
   // If the token is invalid we want to use the possible expected types as our filter type
   const validTypes = filterToken.invalid?.expectedType ?? [filterToken.filter];
@@ -101,7 +99,6 @@ export function getValidOpsForFilter({
   // - Field definition does not allow wildcard operators
   // - Field definition is a string field
   if (
-    !hasWildcardOperators ||
     !areWildcardOperatorsAllowed(fieldDefinition) ||
     fieldDefinition?.valueType !== FieldValueType.STRING
   ) {
@@ -210,27 +207,16 @@ export function convertTokenTypeToValueType(tokenType: Token): FieldValueType {
   }
 }
 
-export function getLabelAndOperatorFromToken(
-  token: TokenResult<Token.FILTER>,
-  hasWildcardOperators: boolean
-) {
+export function getLabelAndOperatorFromToken(token: TokenResult<Token.FILTER>) {
   let operator = token.operator;
 
-  if (hasWildcardOperators && token.negated && token.operator === TermOperator.CONTAINS) {
+  if (token.negated && token.operator === TermOperator.CONTAINS) {
     operator = TermOperator.DOES_NOT_CONTAIN;
-  } else if (
-    hasWildcardOperators &&
-    token.negated &&
-    token.operator === TermOperator.STARTS_WITH
-  ) {
+  } else if (token.negated && token.operator === TermOperator.STARTS_WITH) {
     operator = TermOperator.DOES_NOT_START_WITH;
-  } else if (
-    hasWildcardOperators &&
-    token.negated &&
-    token.operator === TermOperator.ENDS_WITH
-  ) {
+  } else if (token.negated && token.operator === TermOperator.ENDS_WITH) {
     operator = TermOperator.DOES_NOT_END_WITH;
-  } else if (hasWildcardOperators && token.operator === TermOperator.ENDS_WITH) {
+  } else if (token.operator === TermOperator.ENDS_WITH) {
     operator = TermOperator.ENDS_WITH;
   } else if (token.negated) {
     operator = TermOperator.NOT_EQUAL;

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -102,12 +102,12 @@ function replaceFocusedWordWithFilter(
   cursorPosition: number,
   key: string,
   getFieldDefinition: FieldDefinitionGetter,
-  hasWildcardOperators: boolean
+  hasDefaultToContains: boolean
 ) {
   return replaceFocusedWord(
     value,
     cursorPosition,
-    getInitialFilterText(key, getFieldDefinition(key), hasWildcardOperators)
+    getInitialFilterText(key, getFieldDefinition(key), hasDefaultToContains)
   );
 }
 
@@ -273,9 +273,9 @@ function SearchQueryBuilderInputInternal({
   const hasInputChangeFlows = organization.features.includes(
     'search-query-builder-input-flow-changes'
   );
-  const hasWildcardOperators =
-    organization.features.includes('search-query-builder-wildcard-operators') &&
-    organization.features.includes('search-query-builder-default-to-contains');
+  const hasDefaultToContains = organization.features.includes(
+    'search-query-builder-default-to-contains'
+  );
 
   const updateSelectionIndex = useCallback(() => {
     setSelectionIndex(inputRef.current?.selectionStart ?? 0);
@@ -517,7 +517,7 @@ function SearchQueryBuilderInputInternal({
               selectionIndex,
               value,
               getFieldDefinition,
-              hasWildcardOperators
+              hasDefaultToContains
             ),
             focusOverride: calculateNextFocusForFilter(
               state,
@@ -621,7 +621,7 @@ function SearchQueryBuilderInputInternal({
                     selectionIndex,
                     filterValue,
                     getFieldDefinition,
-                    hasWildcardOperators
+                    hasDefaultToContains
                   ),
                   focusOverride: calculateNextFocusForFilter(
                     state,
@@ -665,7 +665,7 @@ function SearchQueryBuilderInputInternal({
                 selectionIndex,
                 filterKey,
                 getFieldDefinition,
-                hasWildcardOperators
+                hasDefaultToContains
               ),
               focusOverride: calculateNextFocusForFilter(
                 state,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -101,13 +101,12 @@ function replaceFocusedWordWithFilter(
   value: string,
   cursorPosition: number,
   key: string,
-  getFieldDefinition: FieldDefinitionGetter,
-  hasDefaultToContains: boolean
+  getFieldDefinition: FieldDefinitionGetter
 ) {
   return replaceFocusedWord(
     value,
     cursorPosition,
-    getInitialFilterText(key, getFieldDefinition(key), hasDefaultToContains)
+    getInitialFilterText(key, getFieldDefinition(key))
   );
 }
 
@@ -272,9 +271,6 @@ function SearchQueryBuilderInputInternal({
   const organization = useOrganization();
   const hasInputChangeFlows = organization.features.includes(
     'search-query-builder-input-flow-changes'
-  );
-  const hasDefaultToContains = organization.features.includes(
-    'search-query-builder-default-to-contains'
   );
 
   const updateSelectionIndex = useCallback(() => {
@@ -516,8 +512,7 @@ function SearchQueryBuilderInputInternal({
               inputValue,
               selectionIndex,
               value,
-              getFieldDefinition,
-              hasDefaultToContains
+              getFieldDefinition
             ),
             focusOverride: calculateNextFocusForFilter(
               state,
@@ -620,8 +615,7 @@ function SearchQueryBuilderInputInternal({
                     inputValue,
                     selectionIndex,
                     filterValue,
-                    getFieldDefinition,
-                    hasDefaultToContains
+                    getFieldDefinition
                   ),
                   focusOverride: calculateNextFocusForFilter(
                     state,
@@ -664,8 +658,7 @@ function SearchQueryBuilderInputInternal({
                 inputValue,
                 selectionIndex,
                 filterKey,
-                getFieldDefinition,
-                hasDefaultToContains
+                getFieldDefinition
               ),
               focusOverride: calculateNextFocusForFilter(
                 state,

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -174,9 +174,6 @@ export function useSortedFilterKeyItems({
   } = useSearchQueryBuilder();
 
   const organization = useOrganization();
-  const hasWildcardOperators = organization.features.includes(
-    'search-query-builder-wildcard-operators'
-  );
   const hasAskSeerConsentFlowChanges = organization.features.includes(
     'gen-ai-consent-flow-removal'
   );
@@ -289,9 +286,7 @@ export function useSortedFilterKeyItems({
             : inputValue;
 
           return [
-            ...(hasWildcardOperators
-              ? [createRawSearchFilterContainsValueItem(key, value)]
-              : []),
+            createRawSearchFilterContainsValueItem(key, value),
             createRawSearchFilterIsValueItem(key, value),
           ];
         }) ?? [];
@@ -367,7 +362,6 @@ export function useSortedFilterKeyItems({
     gaveSeerConsent,
     getFieldDefinition,
     hasAskSeerConsentFlowChanges,
-    hasWildcardOperators,
     includeSuggestions,
     inputValue,
     matchKeySuggestions,

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -117,16 +117,12 @@ function getInitialValueType(fieldDefinition: FieldDefinition | null) {
 
 export function getInitialFilterText(
   key: string,
-  fieldDefinition: FieldDefinition | null,
-  hasDefaultToContains: boolean
+  fieldDefinition: FieldDefinition | null
 ) {
   const defaultValue = getDefaultFilterValue({fieldDefinition});
 
   const keyText = getInitialFilterKeyText(key, fieldDefinition);
   const valueType = getInitialValueType(fieldDefinition);
-
-  const allowDefaultToContains =
-    hasDefaultToContains && areWildcardOperatorsAllowed(fieldDefinition);
 
   switch (valueType) {
     case FieldValueType.INTEGER:
@@ -136,7 +132,7 @@ export function getInitialFilterText(
     case FieldValueType.PERCENTAGE:
       return `${keyText}:>${defaultValue}`;
     case FieldValueType.STRING: {
-      return allowDefaultToContains
+      return areWildcardOperatorsAllowed(fieldDefinition)
         ? `${keyText}:${WildcardOperators.CONTAINS}${defaultValue}`
         : `${keyText}:${defaultValue}`;
     }

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -118,15 +118,15 @@ function getInitialValueType(fieldDefinition: FieldDefinition | null) {
 export function getInitialFilterText(
   key: string,
   fieldDefinition: FieldDefinition | null,
-  hasWildcardOperators: boolean
+  hasDefaultToContains: boolean
 ) {
   const defaultValue = getDefaultFilterValue({fieldDefinition});
 
   const keyText = getInitialFilterKeyText(key, fieldDefinition);
   const valueType = getInitialValueType(fieldDefinition);
 
-  const allowContainsOperator =
-    hasWildcardOperators && areWildcardOperatorsAllowed(fieldDefinition);
+  const allowDefaultToContains =
+    hasDefaultToContains && areWildcardOperatorsAllowed(fieldDefinition);
 
   switch (valueType) {
     case FieldValueType.INTEGER:
@@ -136,7 +136,7 @@ export function getInitialFilterText(
     case FieldValueType.PERCENTAGE:
       return `${keyText}:>${defaultValue}`;
     case FieldValueType.STRING: {
-      return allowContainsOperator
+      return allowDefaultToContains
         ? `${keyText}:${WildcardOperators.CONTAINS}${defaultValue}`
         : `${keyText}:${defaultValue}`;
     }

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -133,8 +133,7 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
             if (valueType && !IGNORE_DEFAULT_VALUES.includes(valueType)) {
               defaultFilterValue = getInitialFilterText(
                 selectedFilterKey.key,
-                fieldDefinition,
-                false
+                fieldDefinition
               );
             }
 

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -89,11 +89,7 @@ function FilterSelector({
       };
     }
 
-    const operatorInfo = getOperatorInfo({
-      filterToken,
-      hasWildcardOperators: true,
-      fieldDefinition,
-    });
+    const operatorInfo = getOperatorInfo({filterToken, fieldDefinition});
 
     return {
       initialOperator: operatorInfo?.operator ?? TermOperator.DEFAULT,
@@ -251,7 +247,7 @@ function FilterSelector({
 
     if (stagedOperator !== initialOperator) {
       const newToken = parseFilterValue(newValue, globalFilter)[0] ?? filterToken;
-      newValue = modifyFilterOperatorQuery(newToken.text, newToken, stagedOperator, true);
+      newValue = modifyFilterOperatorQuery(newToken.text, newToken, stagedOperator);
     }
 
     onUpdateFilter({

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -73,7 +73,6 @@ function useNativeOperatorFilter(
       globalFilterToken &&
       getOperatorInfo({
         filterToken: globalFilterToken,
-        hasWildcardOperators: false,
         fieldDefinition: getFieldDefinitionForDataset(
           globalFilter.tag,
           globalFilter.dataset

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -117,8 +117,7 @@ export function newNumericFilterQuery(
   const newFilterQuery = modifyFilterOperatorQuery(
     newFilterValue,
     newFilterToken,
-    newOperator,
-    false
+    newOperator
   );
   return newFilterQuery;
 }

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -62,7 +62,7 @@ export function getFilterToken(
   const {tag, value} = globalFilter;
   let filterValue = value;
   if (value === '') {
-    filterValue = getInitialFilterText(tag.key, fieldDefinition, false);
+    filterValue = getInitialFilterText(tag.key, fieldDefinition);
   }
   const filterTokens = parseFilterValue(filterValue, globalFilter);
   return filterTokens[0] ?? null;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -3,6 +3,7 @@ import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import type {TagValue} from 'sentry/types/group';
 import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -133,7 +134,10 @@ describe('SpansSearchBar', () => {
     await userEvent.keyboard('{enter}');
 
     await waitFor(() => {
-      expect(onSearch).toHaveBeenCalledWith('span.op:function', expect.anything());
+      expect(onSearch).toHaveBeenCalledWith(
+        `span.op:${WildcardOperators.CONTAINS}function`,
+        expect.anything()
+      );
     });
   });
 

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -30,9 +30,7 @@ const datePageFilterProps: DatePageFilterProps = {
 };
 
 describe('LogsTabContent', () => {
-  const {organization, project, setupPageFilters} = initializeLogsTest({
-    orgFeatures: ['search-query-builder-case-insensitivity'],
-  });
+  const {organization, project, setupPageFilters} = initializeLogsTest();
 
   let eventTableMock: jest.Mock;
   let eventsTimeSeriesMock: jest.Mock;

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -65,7 +65,6 @@ describe('SpansTabContent', () => {
         'gen-ai-features',
         'gen-ai-explore-traces',
         'gen-ai-explore-traces-consent-ui',
-        'search-query-builder-case-insensitivity',
         'traces-page-cross-event-querying',
       ],
     },


### PR DESCRIPTION
This PR removes the following flags from their use in the UI, as they have been fully rolled out to all users:
- `search-query-builder-wildcard-operators`
- `search-query-builder-case-insensitivity`
- `search-query-builder-default-to-contains`