### PR TITLE
feat(dashboards): enable new visulization widget for span widgets

### DIFF
--- a/static/app/utils/timeSeries/transformLegacySeriesToPlottables.spec.tsx
+++ b/static/app/utils/timeSeries/transformLegacySeriesToPlottables.spec.tsx
@@ -88,31 +88,31 @@ describe('transformLegacySeriesToPlottables', () => {
     expect(sessionResult[1]!.timeSeries.yAxis).toBe('sum(session)');
     expect(sessionResult[0]!.timeSeries.values).toEqual([
       {
-        timestamp: 172979640000,
+        timestamp: 172979640,
         value: 100,
         incomplete: false,
       },
       {
-        timestamp: 172980000000,
+        timestamp: 172980000,
         value: 200,
         incomplete: false,
       },
     ]);
     expect(sessionResult[1]!.timeSeries.values).toEqual([
       {
-        timestamp: 172979640000,
+        timestamp: 172979640,
         value: 300,
         incomplete: false,
       },
       {
-        timestamp: 172980000000,
+        timestamp: 172980000,
         value: 400,
         incomplete: false,
       },
     ]);
     expect(sessionResult[0]!.timeSeries.meta.valueType).toBe('percentage');
     expect(sessionResult[1]!.timeSeries.meta.valueType).toBe('number');
-    expect(sessionResult[0]!.timeSeries.meta.interval).toBe(360000);
-    expect(sessionResult[1]!.timeSeries.meta.interval).toBe(360000);
+    expect(sessionResult[0]!.timeSeries.meta.interval).toBe(360);
+    expect(sessionResult[1]!.timeSeries.meta.interval).toBe(360);
   });
 });

--- a/static/app/utils/timeSeries/transformLegacySeriesToPlottables.tsx
+++ b/static/app/utils/timeSeries/transformLegacySeriesToPlottables.tsx
@@ -49,7 +49,7 @@ function createEventsStatsFromSeries(
   return {
     data: series.data.map(dataUnit => [
       typeof dataUnit.name === 'number'
-        ? dataUnit.name
+        ? dataUnit.name / 1000
         : new Date(dataUnit.name).getTime() / 1000,
       [{count: dataUnit.value, comparisonCount: undefined}],
     ]),

--- a/static/app/views/dashboards/utils/widgetCanUseTimeSeriesVisualization.tsx
+++ b/static/app/views/dashboards/utils/widgetCanUseTimeSeriesVisualization.tsx
@@ -1,6 +1,9 @@
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 
-const SUPPORTED_WIDGET_TYPES = new Set<WidgetType>([WidgetType.RELEASE]);
+const SUPPORTED_WIDGET_TYPES = new Set<WidgetType>([
+  WidgetType.RELEASE,
+  WidgetType.SPANS,
+]);
 
 const SUPPORTED_DISPLAY_TYPES = new Set<DisplayType>([
   DisplayType.LINE,


### PR DESCRIPTION
Enable new visualization widget with spans dataset

Tested in a few places, here's an example in queries
<img width="1233" height="381" alt="image" src="https://github.com/user-attachments/assets/05cd209f-1a5b-4278-b052-0858832d4a6b" />
