### PR TITLE
feat(explore-attr-breakdowns-tooltip): Adding action btn background on hover in PROD

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/utils.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/utils.tsx
@@ -68,12 +68,12 @@ function createActionButton(
 ): string {
   return [
     '  <div',
+    `    class="attribute-breakdowns-tooltip-action-button"`,
     `    data-tooltip-action="${action}"`,
     `    data-tooltip-action-key="${escapedAttributeName}"`,
     `    data-tooltip-action-value="${escapedValue}"`,
+    `    data-hover-background="${actionBackground}"`,
     '    style="width: 100%; padding: 8px 15px; cursor: pointer; text-align: left;"',
-    `    onmouseover="this.style.background='${actionBackground}'"`,
-    '    onmouseout="this.style.background=\'\'"',
     '  >',
     `    ${label}`,
     '  </div>',

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -136,13 +136,35 @@ export function useAttributeBreakdownsTooltip({
       }
     };
 
+    // Handle hover effects via event delegation (CSP-compliant alternative to inline onmouseover/onmouseout)
+    const handleMouseOver = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (target.classList.contains('attribute-breakdowns-tooltip-action-button')) {
+        const hoverBg = target.getAttribute('data-hover-background');
+        if (hoverBg) {
+          target.style.background = hoverBg;
+        }
+      }
+    };
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (target.classList.contains('attribute-breakdowns-tooltip-action-button')) {
+        target.style.background = '';
+      }
+    };
+
     // TODO Abdullah Khan: For now, attaching the listener to document.body
     // Tried using a more specific selector causes weird race conditions, will need to investigate.
     document.addEventListener('click', handleClickActions);
+    document.addEventListener('mouseover', handleMouseOver);
+    document.addEventListener('mouseout', handleMouseOut);
 
     // eslint-disable-next-line consistent-return
     return () => {
       document.removeEventListener('click', handleClickActions);
+      document.removeEventListener('mouseover', handleMouseOver);
+      document.removeEventListener('mouseout', handleMouseOut);
     };
   }, [frozenPosition, copyToClipboard, addSearchFilter, setGroupBys]);
 


### PR DESCRIPTION
The inline onmouseover and onmouseout event handlers are being stripped in production because of our Content Security Policy (CSP).

Using an alternative to achieve this effect:

https://github.com/user-attachments/assets/f2afdaaa-574f-422e-ae70-8f9cacbf2875