### PR TITLE
fix(aci): update issue alert migrator to look up cron monitor for specific project

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -93,6 +93,7 @@ class IssueAlertMigrator:
                 with in_test_hide_transaction_boundary():
                     monitor = Monitor.objects.get(
                         slug=monitor_slug,
+                        project_id=self.project.id,
                         organization_id=self.organization.id,
                     )
                     detector = Detector.objects.get(


### PR DESCRIPTION
Cron monitor slugs are only unique per project, so we need to add the project_id when getting the monitor for migrating an issue alert rule.