### PR TITLE
feat(aci): Add detector config to issues created by detectors

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -396,6 +396,7 @@ class StatefulDetectorHandler(
             "conditions": [
                 result.condition.get_snapshot() for result in evaluation_result.condition_results
             ],
+            "config": self.detector.config,
             "data_sources": self._build_evidence_data_sources(data_packet),
         }
 

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -51,6 +51,7 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
             "alert_id": self.alert_rule.id,
             "data_packet_source_id": str(self.query_subscription.id),
             "conditions": conditions,
+            "config": self.detector.config,
             "data_sources": [
                 {
                     "id": str(self.data_source.id),

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -101,6 +101,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
                     "condition_result": DetectorPriorityLevel.OK.value,
                 },
             ],
+            config={},
             data_sources=[],
             alert_id=self.alert_rule.id,
         )
@@ -127,6 +128,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
                     "condition_result": DetectorPriorityLevel.HIGH.value,
                 },
             ],
+            config={},
             data_sources=[],
             alert_id=self.alert_rule.id,
         )


### PR DESCRIPTION
We need the detector config to be saved on the issue occurrences in order to know what the threshold was when it was triggered.

Followup to https://github.com/getsentry/sentry/pull/104330 - this actually adds the data into the occurrence.

