### PR TITLE
perf(segment-enrichment): Get rules from Redis instead of project options

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/normalization.py
+++ b/src/sentry/ingest/transaction_clusterer/normalization.py
@@ -7,7 +7,7 @@ from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.datasource import TRANSACTION_SOURCE_SANITIZED
-from sentry.ingest.transaction_clusterer.rules import get_sorted_rules
+from sentry.ingest.transaction_clusterer.rules import get_sorted_rules_from_redis
 from sentry.models.project import Project
 from sentry.spans.consumers.process_segments.types import CompatibleSpan, attribute_value
 
@@ -134,7 +134,7 @@ def _apply_clustering_rules(
     assert segment_name is not None
     segment_name_parts = segment_name.split("/")
 
-    rules = get_sorted_rules(ClustererNamespace.TRANSACTIONS, project)
+    rules = get_sorted_rules_from_redis(ClustererNamespace.TRANSACTIONS, project)
     for rule, _ in rules:
         if clustered_name := _apply_clustering_rule_to_segment_name(segment_name_parts, rule):
             segment_span["name"] = clustered_name

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -54,6 +54,10 @@ class RedisRuleStore:
         data = client.hgetall(key)
         return {rule: int(timestamp) for rule, timestamp in data.items()}
 
+    def read_sorted(self, project: Project) -> list[tuple[ReplacementRule, int]]:
+        rule_set = self.read(project)
+        return _sort(rule_set)
+
     def write(self, project: Project, rules: RuleSet) -> None:
         client = get_redis_client()
         key = self._get_rules_key(project)
@@ -93,14 +97,10 @@ class ProjectOptionRuleStore:
         self.last_read = rules
         return rules
 
-    def _sort(self, rules: RuleSet) -> list[tuple[ReplacementRule, int]]:
-        """Sort rules by number of slashes, i.e. depth of the rule"""
-        return sorted(rules.items(), key=lambda p: p[0].count("/"), reverse=True)
-
     def write(self, project: Project, rules: RuleSet) -> None:
         """Writes the rules to project options, sorted by depth."""
         # we make sure the database stores lists such that they are json round trippable
-        converted_rules = [list(tup) for tup in self._sort(rules)]
+        converted_rules = [list(tup) for tup in _sort(rules)]
 
         # Track the number of rules per project.
         metrics.distribution(self._tracker, len(converted_rules))
@@ -177,6 +177,11 @@ def _now() -> int:
     return int(datetime.now(timezone.utc).timestamp())
 
 
+def _sort(rules: RuleSet) -> list[tuple[ReplacementRule, int]]:
+    """Sort rules by number of slashes, i.e. depth of the rule"""
+    return sorted(rules.items(), key=lambda p: p[0].count("/"), reverse=True)
+
+
 def get_rules(namespace: ClustererNamespace, project: Project) -> RuleSet:
     """Get rules from project options."""
     return ProjectOptionRuleStore(namespace).read(project)
@@ -185,6 +190,20 @@ def get_rules(namespace: ClustererNamespace, project: Project) -> RuleSet:
 def get_redis_rules(namespace: ClustererNamespace, project: Project) -> RuleSet:
     """Get rules from Redis."""
     return RedisRuleStore(namespace).read(project)
+
+
+def get_sorted_rules_from_redis(
+    namespace: ClustererNamespace, project: Project
+) -> list[tuple[ReplacementRule, int]]:
+    """Public interface for fetching rules for a project from Redis.
+
+    Typically `get_sorted_rules` is preferred, but for high throughput scenarios
+    it may be appropriate to use Redis instead.
+
+    The rules are ordered by specifity, meaning that rules that go deeper
+    into the URL tree occur first.
+    """
+    return RedisRuleStore(namespace).read_sorted(project)
 
 
 def get_sorted_rules(

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -200,7 +200,7 @@ def get_sorted_rules_from_redis(
     Typically `get_sorted_rules` is preferred, but for high throughput scenarios
     it may be appropriate to use Redis instead.
 
-    The rules are ordered by specifity, meaning that rules that go deeper
+    The rules are ordered by specificity, meaning that rules that go deeper
     into the URL tree occur first.
     """
     return RedisRuleStore(namespace).read_sorted(project)
@@ -214,7 +214,7 @@ def get_sorted_rules(
     The rules are fetched from project options rather than redis, because
     project options is the more persistent store.
 
-    The rules are ordered by specifity, meaning that rules that go deeper
+    The rules are ordered by specificity, meaning that rules that go deeper
     into the URL tree occur first.
     """
     return ProjectOptionRuleStore(namespace).read_sorted(project)

--- a/tests/sentry/ingest/transaction_clusterer/test_normalization.py
+++ b/tests/sentry/ingest/transaction_clusterer/test_normalization.py
@@ -101,7 +101,7 @@ def test_no_meta_changes_if_no_name_changes(default_project: mock.MagicMock):
 
 @django_db_all
 @mock.patch(
-    "sentry.ingest.transaction_clusterer.normalization.get_sorted_rules",
+    "sentry.ingest.transaction_clusterer.normalization.get_sorted_rules_from_redis",
     return_value=[("/users/*/posts/*/**", 0), ("/users/*/**", 0), ("GET /users/*/**", 0)],
 )
 @pytest.mark.parametrize(
@@ -248,7 +248,7 @@ def test_clusterer_applies_rules(
 
 @django_db_all
 @mock.patch(
-    "sentry.ingest.transaction_clusterer.normalization.get_sorted_rules",
+    "sentry.ingest.transaction_clusterer.normalization.get_sorted_rules_from_redis",
     return_value=[("/users/*/**", 0)],
 )
 def test_clusterer_works_with_scrubbing(


### PR DESCRIPTION
During segment enrichment, we get the set of segment name clustering rules in order to apply them to the incoming segment name. This is currently fetched from project options. A faster alternative would be to call redis instead, where they're also stored (at the cost of potential inconsistency due to durability issues, if the Redis data is lost).

This PR adds `get_sorted_rules_from_redis` to mirror `get_sorted_rules` and uses it in segment enrichment, refactoring the sorting code so that it can be used for both Redis and project options.