### PR TITLE
feat(crons): Add upsert guides to detector cron creation

### DIFF
--- a/static/app/components/workflowEngine/ui/section.tsx
+++ b/static/app/components/workflowEngine/ui/section.tsx
@@ -21,7 +21,7 @@ export default function Section({
 }: SectionProps) {
   return (
     <SectionContainer direction="column" gap="md" className={className}>
-      <Flex justify="between" align="end" gap="md">
+      <Flex justify="between" align="center" gap="md">
         <Heading as="h3">{title}</Heading>
         {trailingItems && <Flex gap="md">{trailingItems}</Flex>}
       </Flex>

--- a/static/app/views/detectors/components/forms/common/footer.tsx
+++ b/static/app/views/detectors/components/forms/common/footer.tsx
@@ -5,7 +5,12 @@ import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
-export function NewDetectorFooter({maxWidth}: {maxWidth?: string}) {
+interface NewDetectorFooterProps {
+  disabledCreate?: string;
+  maxWidth?: string;
+}
+
+export function NewDetectorFooter({maxWidth, disabledCreate}: NewDetectorFooterProps) {
   const organization = useOrganization();
 
   return (
@@ -16,7 +21,12 @@ export function NewDetectorFooter({maxWidth}: {maxWidth?: string}) {
       >
         {t('Back')}
       </LinkButton>
-      <Button priority="primary" type="submit">
+      <Button
+        priority="primary"
+        type="submit"
+        disabled={!!disabledCreate}
+        title={disabledCreate}
+      >
         {t('Create Monitor')}
       </Button>
     </EditLayout.Footer>

--- a/static/app/views/detectors/components/forms/cron/index.spec.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.spec.tsx
@@ -1,0 +1,102 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import OrganizationStore from 'sentry/stores/organizationStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {DetectorFormProvider} from 'sentry/views/detectors/components/forms/context';
+
+import {NewCronDetectorForm} from './index';
+
+describe('NewCronDetectorForm', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  beforeEach(() => {
+    OrganizationStore.init();
+    OrganizationStore.onUpdate(organization, {replace: true});
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      body: [],
+    });
+  });
+
+  const renderForm = (routerConfig?: any) => {
+    return render(
+      <DetectorFormProvider detectorType="monitor_check_in_failure" project={project}>
+        <NewCronDetectorForm />
+      </DetectorFormProvider>,
+      {
+        organization,
+        initialRouterConfig: routerConfig,
+      }
+    );
+  };
+
+  it('renders form sections when no guide is shown', async () => {
+    renderForm();
+
+    // Form sections should be visible
+    expect(await screen.findByText('Detect')).toBeInTheDocument();
+    expect(screen.getByText('Assign')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+
+    // Create Monitor button should be present and enabled
+    const createButton = screen.getByRole('button', {name: 'Create Monitor'});
+    expect(createButton).toBeInTheDocument();
+    expect(createButton).toBeEnabled();
+  });
+
+  it('hides form sections and disables create button when a platform guide is shown', async () => {
+    renderForm({
+      location: {
+        pathname: '/test/',
+        query: {platform: 'php', guide: 'upsert'},
+      },
+    });
+
+    // Wait for render to complete
+    await screen.findByText('Step 2 of 2');
+
+    // Form sections should be hidden
+    expect(screen.queryByText('Detect')).not.toBeInTheDocument();
+    expect(screen.queryByText('Assign')).not.toBeInTheDocument();
+    expect(screen.queryByText('Description')).not.toBeInTheDocument();
+
+    // Create Monitor button should be present but disabled
+    const createButton = screen.getByRole('button', {name: 'Create Monitor'});
+    expect(createButton).toBeInTheDocument();
+    expect(createButton).toBeDisabled();
+  });
+
+  it('shows form sections and enabled button when guide is set to "manual"', async () => {
+    renderForm({
+      location: {
+        pathname: '/test/',
+        query: {platform: 'php', guide: 'manual'},
+      },
+    });
+
+    // Form sections should be visible even with platform set, because guide is "manual"
+    expect(await screen.findByText('Detect')).toBeInTheDocument();
+    expect(screen.getByText('Assign')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+
+    // Create Monitor button should be present and enabled
+    const createButton = screen.getByRole('button', {name: 'Create Monitor'});
+    expect(createButton).toBeInTheDocument();
+    expect(createButton).toBeEnabled();
+  });
+});

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Alert} from 'sentry/components/core/alert';
@@ -13,16 +14,24 @@ import {
   cronFormDataToEndpointPayload,
   cronSavedDetectorToFormData,
 } from 'sentry/views/detectors/components/forms/cron/fields';
+import {InstrumentationGuide} from 'sentry/views/detectors/components/forms/cron/instrumentationGuide';
 import {CronDetectorFormResolveSection} from 'sentry/views/detectors/components/forms/cron/resolve';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
+import {useCronsUpsertGuideState} from 'sentry/views/insights/crons/components/useCronsUpsertGuideState';
+
+function useIsShowingPlatformGuide() {
+  const {platformKey, guideKey} = useCronsUpsertGuideState();
+  return platformKey && guideKey !== 'manual';
+}
 
 function CronDetectorForm({detector}: {detector?: CronDetector}) {
   const dataSource = detector?.dataSources[0];
   const theme = useTheme();
+  const showingPlatformGuide = useIsShowingPlatformGuide();
 
-  return (
-    <Stack gap="2xl" maxWidth={theme.breakpoints.xl}>
+  const formSections = (
+    <Fragment>
       {dataSource?.queryObj.isUpserting && (
         <Alert type="warning">
           {t(
@@ -35,11 +44,20 @@ function CronDetectorForm({detector}: {detector?: CronDetector}) {
       <AssignSection />
       <DescribeSection />
       <AutomateSection />
+    </Fragment>
+  );
+
+  return (
+    <Stack gap="2xl" maxWidth={theme.breakpoints.xl}>
+      {!detector && <InstrumentationGuide />}
+      {!showingPlatformGuide && formSections}
     </Stack>
   );
 }
 
 export function NewCronDetectorForm() {
+  const showingPlatformGuide = useIsShowingPlatformGuide();
+
   return (
     <NewDetectorLayout
       detectorType="monitor_check_in_failure"
@@ -48,6 +66,13 @@ export function NewCronDetectorForm() {
         scheduleType: CRON_DEFAULT_SCHEDULE_TYPE,
       }}
       noEnvironment
+      disabledCreate={
+        showingPlatformGuide
+          ? t(
+              'Using Auto-Instrumentation does not require you to create a monitor via the Sentry UI'
+            )
+          : undefined
+      }
     >
       <CronDetectorForm />
     </NewDetectorLayout>

--- a/static/app/views/detectors/components/forms/cron/instrumentationGuide.spec.tsx
+++ b/static/app/views/detectors/components/forms/cron/instrumentationGuide.spec.tsx
@@ -1,0 +1,237 @@
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import SentryProjectSelectorField from 'sentry/components/forms/fields/sentryProjectSelectorField';
+import Form from 'sentry/components/forms/form';
+import ProjectsStore from 'sentry/stores/projectsStore';
+
+import {InstrumentationGuide} from './instrumentationGuide';
+
+describe('InstrumentationGuide', () => {
+  beforeEach(() => {
+    ProjectsStore.reset();
+  });
+
+  it('renders the platform dropdown menu', () => {
+    render(<InstrumentationGuide />);
+
+    expect(screen.getByText('Select Instrumentation Method')).toBeInTheDocument();
+
+    const dropdown = screen.getByRole('button', {name: 'Select Platform'});
+    expect(dropdown).toBeInTheDocument();
+  });
+
+  it('hides "Manually Create a Monitor" button when no guide is selected', () => {
+    render(<InstrumentationGuide />);
+
+    expect(
+      screen.queryByRole('button', {name: 'Manually Create a Monitor'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens dropdown menu and shows platform options', async () => {
+    render(<InstrumentationGuide />);
+
+    const dropdown = screen.getByRole('button', {name: 'Select Platform'});
+    await userEvent.click(dropdown);
+
+    const menu = await screen.findByRole('menu');
+    expect(menu).toBeInTheDocument();
+
+    // Generic section should be visible
+    expect(screen.getByText('Generic')).toBeInTheDocument();
+  });
+
+  it('selects platform when clicking menu item', async () => {
+    const {router} = render(<InstrumentationGuide />);
+
+    const dropdown = screen.getByRole('button', {name: 'Select Platform'});
+    await userEvent.click(dropdown);
+
+    // Click on PHP (which has only one guide, so it should select directly)
+    const phpOption = await screen.findByRole('menuitemradio', {name: 'PHP'});
+    await userEvent.click(phpOption);
+
+    // Verify query params were updated
+    expect(router.location.query.platform).toBe('php');
+    expect(router.location.query.guide).toBe('upsert');
+
+    // Verify dropdown label updated
+    expect(await screen.findByRole('button', {name: 'PHP - Upsert'})).toBeInTheDocument();
+  });
+
+  it('shows guide content after selecting a platform', async () => {
+    render(<InstrumentationGuide />);
+
+    // Initially no guide is shown
+    expect(screen.queryByText(/Auto-Instrument with/)).not.toBeInTheDocument();
+
+    const dropdown = screen.getByRole('button', {name: 'Select Platform'});
+    await userEvent.click(dropdown);
+
+    // Click on PHP
+    const phpOption = await screen.findByRole('menuitemradio', {name: 'PHP'});
+    await userEvent.click(phpOption);
+
+    // Guide should now be visible
+    expect(await screen.findByText('Auto-Instrument with PHP')).toBeInTheDocument();
+
+    // Manual button should be visible
+    expect(
+      screen.getByRole('button', {name: 'Manually Create a Monitor'})
+    ).toBeInTheDocument();
+  });
+
+  it('clears guide when clicking "Manually Create a Monitor"', async () => {
+    render(<InstrumentationGuide />);
+
+    // Select a platform first
+    const dropdown = screen.getByRole('button', {name: 'Select Platform'});
+    await userEvent.click(dropdown);
+
+    const phpOption = await screen.findByRole('menuitemradio', {name: 'PHP'});
+    await userEvent.click(phpOption);
+
+    // Guide should be visible
+    expect(await screen.findByText('Auto-Instrument with PHP')).toBeInTheDocument();
+
+    // Click the manual button
+    const manualButton = screen.getByRole('button', {
+      name: 'Manually Create a Monitor',
+    });
+    await userEvent.click(manualButton);
+
+    // Guide should be hidden
+    expect(screen.queryByText('Auto-Instrument with PHP')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Manually Create a Monitor'})
+    ).not.toBeInTheDocument();
+  });
+
+  describe('project based auto selection', () => {
+    it('skips auto-selection when skipGuideDetection is true', () => {
+      const nodeProject = ProjectFixture({id: '7', platform: 'node'});
+      ProjectsStore.loadInitialData([nodeProject]);
+
+      render(
+        <Form initialData={{projectId: nodeProject.id}}>
+          <InstrumentationGuide />
+        </Form>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/test/',
+              query: {skipGuideDetection: 'true'},
+            },
+          },
+        }
+      );
+
+      // Verify that the guide content is NOT shown
+      expect(screen.queryByText(/Auto-Instrument with/)).not.toBeInTheDocument();
+
+      // Should still show the dropdown with default state
+      expect(screen.getByRole('button', {name: 'Select Platform'})).toBeInTheDocument();
+    });
+
+    it('does not override existing query params when project is set', async () => {
+      const pythonProject = ProjectFixture({id: '5', platform: 'python'});
+      const phpProject = ProjectFixture({id: '6', platform: 'php'});
+      ProjectsStore.loadInitialData([pythonProject, phpProject]);
+
+      // Start with PHP guide already selected in query params
+      const {router} = render(
+        <Form initialData={{projectId: pythonProject.id}}>
+          <InstrumentationGuide />
+        </Form>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/test/',
+              query: {platform: 'php', guide: 'upsert'},
+            },
+          },
+        }
+      );
+
+      // Verify router has correct query params
+      expect(router.location.query.platform).toBe('php');
+      expect(router.location.query.guide).toBe('upsert');
+
+      // Should show PHP guide, not auto-select Python based on project
+      await waitFor(() => {
+        expect(screen.getByText('Auto-Instrument with PHP')).toBeInTheDocument();
+      });
+    });
+
+    it('auto-selects platform based on selected project', async () => {
+      const pythonProject = ProjectFixture({id: '99', platform: 'python'});
+      ProjectsStore.loadInitialData([pythonProject]);
+
+      render(
+        <Form initialData={{projectId: pythonProject.id}}>
+          <InstrumentationGuide />
+        </Form>
+      );
+
+      // Should auto-select Python platform and show the guide
+      expect(await screen.findByText('Auto-Instrument with Python')).toBeInTheDocument();
+    });
+
+    it('falls back to base platform when project platform has no exact match', async () => {
+      const nodeExpressProject = ProjectFixture({id: '98', platform: 'node-express'});
+      ProjectsStore.loadInitialData([nodeExpressProject]);
+
+      render(
+        <Form initialData={{projectId: nodeExpressProject.id}}>
+          <InstrumentationGuide />
+        </Form>
+      );
+
+      // Should fall back to 'node' since 'node-express' has no guide
+      expect(await screen.findByText('Auto-Instrument with NodeJS')).toBeInTheDocument();
+    });
+
+    it('updates guide when project is changed via form field', async () => {
+      const pythonProject = ProjectFixture({
+        id: '3',
+        slug: 'python-proj',
+        platform: 'python',
+      });
+      const nodeProject = ProjectFixture({id: '4', slug: 'node-proj', platform: 'node'});
+      ProjectsStore.loadInitialData([pythonProject, nodeProject]);
+
+      // Start with PHP guide in query params and python project selected
+      render(
+        <Form initialData={{projectId: pythonProject.id}}>
+          <SentryProjectSelectorField
+            name="projectId"
+            label="Project"
+            projects={[pythonProject, nodeProject]}
+          />
+          <InstrumentationGuide />
+        </Form>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/test/',
+              query: {platform: 'php', guide: 'upsert'},
+            },
+          },
+        }
+      );
+
+      // Should initially show PHP guide (from query params)
+      expect(await screen.findByText('Auto-Instrument with PHP')).toBeInTheDocument();
+
+      // Change to node project
+      const projectSelector = screen.getByRole('textbox', {name: 'Project'});
+      await selectEvent.select(projectSelector, 'node-proj');
+
+      // Should now show NodeJS guide
+      expect(await screen.findByText('Auto-Instrument with NodeJS')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
+++ b/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
@@ -1,0 +1,200 @@
+import {Fragment, useEffect, useRef} from 'react';
+import partition from 'lodash/partition';
+import {parseAsBoolean, useQueryState} from 'nuqs';
+import {PlatformIcon} from 'platformicons';
+
+import {Button} from 'sentry/components/core/button';
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {IconGlobe, IconTerminal} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {PlatformKey} from 'sentry/types/project';
+import useProjects from 'sentry/utils/useProjects';
+import {useCronDetectorFormField} from 'sentry/views/detectors/components/forms/cron/fields';
+import {
+  platformGuides,
+  type GuideKey,
+} from 'sentry/views/insights/crons/components/upsertPlatformGuides';
+import {
+  toSupportedPlatform,
+  useCronsUpsertGuideState,
+} from 'sentry/views/insights/crons/components/useCronsUpsertGuideState';
+
+const [genericPlatforms, regularPlatforms] = partition(platformGuides, p =>
+  ['cli', 'http'].includes(p.platform)
+);
+
+const genericIcons: Record<string, React.ReactNode> = {
+  cli: <IconTerminal size="sm" />,
+  http: <IconGlobe size="sm" />,
+};
+
+export function InstrumentationGuide() {
+  const {projects} = useProjects();
+  const projectId = useCronDetectorFormField('projectId');
+  const [skipGuideDetection] = useQueryState('skipGuideDetection', parseAsBoolean);
+
+  const selectedProject = projects.find(p => p.id === projectId);
+  const projectPlatform = selectedProject?.platform;
+
+  const {platform, platformKey, guideKey, guide, setPlatformGuide} =
+    useCronsUpsertGuideState();
+
+  const startingPlatformRef = useRef(platformKey);
+  const isFirstRender = useRef(true);
+
+  // auto-select a valid upsert guide if one is available for the selected
+  // projects platform
+  useEffect(() => {
+    // Skip if skipGuideDetection param is set
+    if (skipGuideDetection) {
+      return;
+    }
+
+    if (!projectPlatform) {
+      return;
+    }
+
+    // We want to avoid overrwiting the selected platform guide when the page
+    // first loads if it was already set in the query state.
+    const skipSettingGuide =
+      isFirstRender.current && startingPlatformRef.current !== null;
+    isFirstRender.current = false;
+
+    if (skipSettingGuide) {
+      return;
+    }
+
+    // Attempt to find a supported upsert platform using th project platform.
+    // Make a second attempt if the exact project platform has no guides by
+    // extracting the 'first part' of the platform.
+    //
+    // Eg, there may be no `node-express` cron upsert guide, but there is a
+    // `node` guide.
+    const defaultPlatform =
+      toSupportedPlatform(projectPlatform) ??
+      toSupportedPlatform(projectPlatform.split('-').at(0) as PlatformKey);
+
+    if (!defaultPlatform) {
+      setPlatformGuide(null);
+      return;
+    }
+
+    setPlatformGuide(defaultPlatform);
+  }, [projectPlatform, setPlatformGuide, skipGuideDetection]);
+
+  const platformItems = regularPlatforms.map<MenuItemProps>(c => {
+    const item = {
+      key: c.platform,
+      label: c.label,
+      leadingItems: <PlatformIcon platform={c.platform} size={20} />,
+    };
+
+    // If platform has exactly one guide, select it directly
+    if (c.guides.length === 1) {
+      return {
+        ...item,
+        onAction: () => setPlatformGuide(c.platform, c.guides[0].key),
+      };
+    }
+
+    const children = c.guides.map(g => ({
+      key: g.key,
+      label: g.title,
+      onAction: () => setPlatformGuide(c.platform, g.key),
+    }));
+
+    return {...item, children, isSubmenu: true};
+  });
+
+  const genericItems: MenuItemProps = {
+    key: 'generic',
+    label: t('Generic'),
+    children: genericPlatforms.map(cronPlatform => ({
+      key: cronPlatform.platform,
+      label: cronPlatform.label,
+      leadingItems: genericIcons[cronPlatform.platform],
+      onAction: () =>
+        setPlatformGuide(cronPlatform.platform, cronPlatform.guides[0]?.key ?? 'manual'),
+    })),
+  };
+
+  const menuItems: MenuItemProps[] = [...platformItems, genericItems];
+
+  const selectedLabel =
+    platform && guide
+      ? `${platform.label} - ${guide.title}`
+      : platform
+        ? platform.label
+        : t('Select Platform');
+
+  const showAutoInstrumentationGuide = platform && guide && guideKey !== 'manual';
+
+  return (
+    <Fragment>
+      <Container>
+        <Section title={t('Select Instrumentation Method')}>
+          <Text variant="muted">
+            {t(
+              'You may not need to manually create your Cron Monitors! Configure your SDK to automatically create cron monitors.'
+            )}
+          </Text>
+          <Flex gap="lg" align="center" paddingTop="lg">
+            <DropdownMenu
+              size="sm"
+              items={menuItems}
+              triggerLabel={selectedLabel}
+              triggerProps={{
+                icon: platformKey ? (
+                  <PlatformIcon platform={platformKey} size={16} />
+                ) : undefined,
+              }}
+            />
+            {showAutoInstrumentationGuide && (
+              <Fragment>
+                <Text size="sm" variant="muted">
+                  {t('or')}
+                </Text>
+                <Button size="xs" onClick={() => setPlatformGuide(null)}>
+                  {t('Manually Create a Monitor')}
+                </Button>
+              </Fragment>
+            )}
+          </Flex>
+        </Section>
+      </Container>
+
+      {showAutoInstrumentationGuide && (
+        <Container>
+          <Section
+            title={t('Auto-Instrument with %s', platform.label)}
+            trailingItems={
+              platform.guides.length > 1 ? (
+                <CompactSelect<GuideKey>
+                  size="xs"
+                  triggerProps={{borderless: true, size: 'zero'}}
+                  value={guideKey ?? 'upsert'}
+                  onChange={option => {
+                    setPlatformGuide(platformKey, option.value);
+                  }}
+                  options={platform.guides.map(g => ({
+                    value: g.key as GuideKey,
+                    label: g.title,
+                  }))}
+                />
+              ) : undefined
+            }
+          >
+            <Flex direction="column" gap="lg">
+              <guide.Guide />
+            </Flex>
+          </Section>
+        </Container>
+      )}
+    </Fragment>
+  );
+}

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -21,6 +21,7 @@ type NewDetectorLayoutProps<TFormData, TUpdatePayload> = {
   detectorType: DetectorType;
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   initialFormData: Partial<TFormData>;
+  disabledCreate?: string;
   mapFormErrors?: (error: any) => any;
   noEnvironment?: boolean;
   previewChart?: React.ReactNode;
@@ -33,6 +34,7 @@ export function NewDetectorLayout<
   children,
   formDataToEndpointPayload,
   initialFormData,
+  disabledCreate,
   mapFormErrors,
   noEnvironment,
   previewChart,
@@ -92,7 +94,7 @@ export function NewDetectorLayout<
 
       <EditLayout.Body maxWidth={maxWidth}>{children}</EditLayout.Body>
 
-      <NewDetectorFooter maxWidth={maxWidth} />
+      <NewDetectorFooter maxWidth={maxWidth} disabledCreate={disabledCreate} />
     </EditLayout>
   );
 }

--- a/static/app/views/detectors/list/cron.spec.tsx
+++ b/static/app/views/detectors/list/cron.spec.tsx
@@ -67,6 +67,21 @@ describe('CronDetectorsList', () => {
 
     // Should show text for onboarding state
     expect(await screen.findByText('Monitor Your Cron Jobs')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "We'll tell you if your recurring jobs are running on schedule, failing, or succeeding."
+      )
+    ).toBeInTheDocument();
+
+    // Check that platform buttons exist
+    expect(screen.getByLabelText('Create python Monitor')).toBeInTheDocument();
+    expect(screen.getByLabelText('Create php Monitor')).toBeInTheDocument();
+    expect(screen.getByLabelText('Create node Monitor')).toBeInTheDocument();
+
+    // Check for the special buttons (LinkButton renders as role="button" with aria-label)
+    expect(screen.getByRole('button', {name: 'Sentry CLI'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'HTTP (cURL)'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Manual Setup'})).toBeInTheDocument();
   });
 
   it('loads cron monitors, renders timeline, and updates on time selection', async () => {

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -1,21 +1,30 @@
 import {useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
 
-import {Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {CheckInPlaceholder} from 'sentry/components/checkInTimeline/checkInPlaceholder';
 import {CheckInTimeline} from 'sentry/components/checkInTimeline/checkInTimeline';
 import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import OnboardingPanel from 'sentry/components/onboardingPanel';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import WorkflowEngineListLayout from 'sentry/components/workflowEngine/layout/list';
+import {IconGlobe, IconTerminal} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
+import {space} from 'sentry/styles/space';
 import type {CronDetector, Detector} from 'sentry/types/workflowEngine/detectors';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
 import {HeaderCell} from 'sentry/views/detectors/components/detectorListTable';
 import {DetectorListActions} from 'sentry/views/detectors/list/common/detectorListActions';
 import {DetectorListContent} from 'sentry/views/detectors/list/common/detectorListContent';
@@ -27,9 +36,13 @@ import {
   type MonitorListAdditionalColumn,
   type MonitorViewContextValue,
 } from 'sentry/views/detectors/monitorViewContext';
-import {CronsLandingPanel} from 'sentry/views/insights/crons/components/cronsLandingPanel';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 import MonitorEnvironmentLabel from 'sentry/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel';
 import {GlobalMonitorProcessingErrors} from 'sentry/views/insights/crons/components/processingErrors/globalMonitorProcessingErrors';
+import {
+  platformGuides,
+  type SupportedPlatform,
+} from 'sentry/views/insights/crons/components/upsertPlatformGuides';
 import {
   checkInStatusPrecedent,
   statusToText,
@@ -120,6 +133,80 @@ const DESCRIPTION = t(
 );
 const DOCS_URL = 'https://docs.sentry.io/product/crons/';
 
+function CronEmptyState() {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const defaultProject = projects.find(p => p.isMember) ?? projects[0];
+  const baseUrl = `${makeMonitorBasePathname(organization.slug)}new/settings/`;
+
+  const makeCreateUrl = (platform: SupportedPlatform) => {
+    const platformGuide = platformGuides.find(g => g.platform === platform);
+    const guide = platformGuide?.guides?.[0]?.key ?? 'upsert';
+
+    return {
+      pathname: baseUrl,
+      query: {
+        detectorType: 'monitor_check_in_failure',
+        project: defaultProject?.id ?? '',
+        platform,
+        guide,
+      },
+    };
+  };
+
+  return (
+    <OnboardingPanel image={<img src={onboardingImg} />}>
+      <Stack gap="2xl">
+        <Stack gap="md">
+          <Heading as="h1">{t('Monitor Your Cron Jobs')}</Heading>
+          <Text as="p">
+            {t(
+              "We'll tell you if your recurring jobs are running on schedule, failing, or succeeding."
+            )}
+          </Text>
+        </Stack>
+        <Flex gap="xl" wrap="wrap">
+          {platformGuides
+            .filter(({platform}) => !['cli', 'http'].includes(platform))
+            .map(({platform, label}) => (
+              <Flex key={platform} direction="column" gap="xs" align="center">
+                <PlatformLinkButton
+                  priority="default"
+                  to={makeCreateUrl(platform)}
+                  aria-label={t('Create %s Monitor', platform)}
+                >
+                  <PlatformIcon platform={platform} format="lg" size="100%" />
+                </PlatformLinkButton>
+                <Text variant="muted">{label}</Text>
+              </Flex>
+            ))}
+        </Flex>
+        <Flex gap="md">
+          <LinkButton size="sm" icon={<IconTerminal />} to={makeCreateUrl('cli')}>
+            Sentry CLI
+          </LinkButton>
+          <LinkButton size="sm" icon={<IconGlobe />} to={makeCreateUrl('http')}>
+            HTTP (cURL)
+          </LinkButton>
+          <LinkButton
+            size="sm"
+            to={{
+              pathname: baseUrl,
+              query: {
+                detectorType: 'monitor_check_in_failure',
+                project: defaultProject?.id ?? '',
+                skipGuideDetection: true,
+              },
+            }}
+          >
+            {t('Manual Setup')}
+          </LinkButton>
+        </Flex>
+      </Stack>
+    </OnboardingPanel>
+  );
+}
+
 export default function CronDetectorsList() {
   const {selection} = usePageFilters();
   const detectorListQuery = useDetectorListQuery({
@@ -166,10 +253,7 @@ export default function CronDetectorsList() {
           </InsightsRedirectNotice>
           <DetectorListHeader showTimeRangeSelector showTypeFilter={false} />
           <GlobalMonitorProcessingErrors project={selectedProjects} />
-          <DetectorListContent
-            {...detectorListQuery}
-            emptyState={<CronsLandingPanel />}
-          />
+          <DetectorListContent {...detectorListQuery} emptyState={<CronEmptyState />} />
         </WorkflowEngineListLayout>
       </SentryDocumentTitle>
     </MonitorViewContext.Provider>
@@ -184,4 +268,10 @@ const TimelineFadeIn = styled('div')`
   width: 100%;
   opacity: 0;
   animation: ${fadeIn} 1s ease-out forwards;
+`;
+
+const PlatformLinkButton = styled(LinkButton)`
+  width: 80px;
+  height: 80px;
+  padding: ${space(1.5)};
 `;

--- a/static/app/views/insights/crons/components/useCronsUpsertGuideState.tsx
+++ b/static/app/views/insights/crons/components/useCronsUpsertGuideState.tsx
@@ -1,6 +1,8 @@
 import {useCallback} from 'react';
 import {parseAsStringEnum, useQueryStates} from 'nuqs';
 
+import type {PlatformKey} from 'sentry/types/project';
+
 import {
   platformGuides,
   type CronsPlatform,
@@ -114,4 +116,11 @@ export function useCronsUpsertGuideState(options?: Options): PlatformGuideState 
     guideVisible,
     setPlatformGuide,
   };
+}
+
+/**
+ * Translates a `PlatformKey` to a Cron `SupportedPlatform` key.
+ */
+export function toSupportedPlatform(platform: PlatformKey) {
+  return platformParser.parse(platform) ?? undefined;
 }


### PR DESCRIPTION
Implements a two-step creation flow for cron monitors that allows users to choose between auto-instrumentation with platform-specific guides or manual monitor configuration.

When users select a platform (Python, PHP, Node, etc.) from the empty state, they see instrumentation guides with a "Back to Manual Creation" button. The standard form sections are hidden while viewing guides to reduce cognitive load and guide users through the auto-instrumentation process.

Users can also explicitly choose "Manual Setup" which bypasses platform detection and shows the full configuration form immediately. This is useful when users want direct access to all monitor settings without going through the guided flow.

The implementation uses query parameters (platform, guide, skipGuideDetection) to manage state and allow users to navigate back and forth between guided and manual creation modes.

Adds comprehensive test coverage for form visibility, footer behavior, empty state UI, and platform detection logic.

Fixes [NEW-589: Cron monitors should have 3 steps for creation, step 2 suggestions using Upsert flow](https://linear.app/getsentry/issue/NEW-589/cron-monitors-should-have-3-steps-for-creation-step-2-suggestions)