### PR TITLE
feat(issues): Remove ability to access issue share page w/o org slug

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -192,10 +192,18 @@ function buildRoutes(): RouteObject[] {
       path: '/account/',
       redirectTo: '/settings/account/details/',
     },
+    {
+      path: '/share/group/:shareId/',
+      redirectTo: '/share/issue/:shareId/',
+    },
     // Add redirect from old user feedback to new feedback
     {
       path: '/user-feedback/',
       redirectTo: '/feedback/',
+    },
+    {
+      path: '/share/issue/:shareId/',
+      component: make(() => import('sentry/views/sharedGroupDetails')),
     },
     {
       path: '/organizations/:orgId/share/issue/:shareId/',

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -201,11 +201,6 @@ function buildRoutes(): RouteObject[] {
       path: '/user-feedback/',
       redirectTo: '/feedback/',
     },
-    // TODO: remove share/issue orgless url
-    {
-      path: '/share/issue/:shareId/',
-      component: make(() => import('sentry/views/sharedGroupDetails')),
-    },
     {
       path: '/organizations/:orgId/share/issue/:shareId/',
       component: make(() => import('sentry/views/sharedGroupDetails')),

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -192,10 +192,6 @@ function buildRoutes(): RouteObject[] {
       path: '/account/',
       redirectTo: '/settings/account/details/',
     },
-    {
-      path: '/share/group/:shareId/',
-      redirectTo: '/share/issue/:shareId/',
-    },
     // Add redirect from old user feedback to new feedback
     {
       path: '/user-feedback/',

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -37,10 +37,9 @@ interface ShareIssueModalProps extends ModalRenderProps {
 
 type UrlRef = React.ElementRef<typeof AutoSelectText>;
 
-export function getShareUrl(group: Group) {
-  const path = `/share/issue/${group.shareId}/`;
-  const {host, protocol} = window.location;
-  return `${protocol}//${host}${path}`;
+export function getShareUrl(organization: Organization, group: Group) {
+  const path = `/organizations/${organization.slug}/share/issue/${group.shareId}/`;
+  return `${window.location.origin}${normalizeUrl(path)}`;
 }
 
 export default function ShareIssueModal({
@@ -122,7 +121,7 @@ export default function ShareIssueModal({
     [api, setLoading, onToggle, isPublished, organization.slug, projectSlug, groupId]
   );
 
-  const shareUrl = group?.shareId ? getShareUrl(group) : null;
+  const shareUrl = group?.shareId ? getShareUrl(organization, group) : null;
 
   return (
     <Fragment>

--- a/static/app/views/issueDetails/streamline/header/issueIdBreadcrumb.tsx
+++ b/static/app/views/issueDetails/streamline/header/issueIdBreadcrumb.tsx
@@ -27,7 +27,7 @@ interface ShortIdBreadcrumbProps {
 export function IssueIdBreadcrumb({project, group}: ShortIdBreadcrumbProps) {
   const organization = useOrganization();
   const [isHovered, setIsHovered] = useState(false);
-  const shareUrl = group?.shareId ? getShareUrl(group) : null;
+  const shareUrl = group?.shareId ? getShareUrl(organization, group) : null;
   const {copy} = useCopyToClipboard();
 
   const handleCopyShortId = useCallback(() => {

--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -62,24 +62,12 @@ describe('SharedGroupDetails', () => {
     render(<SharedGroupDetails />, {
       initialRouterConfig: {
         location: {
-          pathname: '/share/issue/a/',
-        },
-        route: '/share/issue/:shareId/',
-      },
-    });
-    await screen.findByText('Details');
-  });
-
-  it('renders with org slug in path', async () => {
-    render(<SharedGroupDetails />, {
-      initialRouterConfig: {
-        location: {
           pathname: `/organizations/${organization.slug}/share/issue/a/`,
         },
         route: '/organizations/:orgId/share/issue/:shareId/',
       },
     });
-    await screen.findByText('Details');
-    await screen.findByTestId('sgh-timestamp');
+    expect(await screen.findByText('Details')).toBeInTheDocument();
+    expect(await screen.findByTestId('sgh-timestamp')).toBeInTheDocument();
   });
 });

--- a/static/app/views/sharedGroupDetails/index.tsx
+++ b/static/app/views/sharedGroupDetails/index.tsx
@@ -39,30 +39,24 @@ function SharedGroupDetails() {
 
   const {
     data: group,
-    isPending,
+    isLoading,
     isError,
     refetch,
-  } = useApiQuery<Group>(
-    [
-      orgSlug
-        ? `/organizations/${orgSlug}/shared/issues/${shareId}/`
-        : `/shared/issues/${shareId}/`,
-    ],
-    {
-      staleTime: 0,
-    }
-  );
+  } = useApiQuery<Group>([`/organizations/${orgSlug}/shared/issues/${shareId}/`], {
+    staleTime: 0,
+    enabled: !!orgSlug,
+  });
 
-  if (isPending) {
+  if (isLoading) {
     return <LoadingIndicator />;
-  }
-
-  if (!group) {
-    return <NotFound />;
   }
 
   if (isError) {
     return <LoadingError onRetry={refetch} />;
+  }
+
+  if (!group || !orgSlug) {
+    return <NotFound />;
   }
 
   // project.organization is not a real organization, it's just the slug and name


### PR DESCRIPTION
We'll no longer attempt to access the route without the org slug. We've had the org slug in the share url for a while.

Edit: we're keeping the route and just the backend api portion is changing and we'll display a message if org id is not available. Part of https://www.notion.so/sentry/Cell-safe-API-endpoints-2a38b10e4b5d8036931fd6781e01eb23