### PR TITLE
fix(Replay): Normalize Project ID Typing To Int For Frontend

### DIFF
--- a/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
+++ b/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
@@ -3,7 +3,7 @@ from typing import Any
 from uuid import uuid4
 
 from sentry.replays.endpoints.organization_replay_details import (
-    _format_eap_timestamps,
+    _normalize_eap_response,
     query_replay_instance_eap,
 )
 from sentry.testutils.cases import ReplayBreadcrumbType, ReplayEAPTestCase, TestCase
@@ -112,6 +112,14 @@ class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
 
         replay1_data = res1["data"][0]
         assert "count_segments" in replay1_data
+        assert "agg_project_id" in replay1_data
+
+        assert isinstance(
+            replay1_data["agg_project_id"], int
+        ), f"agg_project_id should be int after normalization, got {type(replay1_data['agg_project_id'])}"
+        assert (
+            replay1_data["agg_project_id"] == self.project.id
+        ), f"project_id mismatch: got {replay1_data['agg_project_id']}, expected {self.project.id}"
         assert "count_errors" in replay1_data
         assert "count_warnings" in replay1_data
         assert "count_dead_clicks" in replay1_data
@@ -130,36 +138,47 @@ class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
         assert replay2_data["count_dead_clicks"] == 3, "1 DEAD_CLICK + 2 RAGE_CLICK = 3 dead"
         assert replay2_data["count_rage_clicks"] == 2, "2 RAGE_CLICK = 2 rage"
 
-    def test_format_eap_timestamps(self) -> None:
-        """Test that float timestamps are correctly converted to ISO strings."""
+    def test_normalize_eap_response(self) -> None:
+        """Test that EAP response data is correctly normalized.
+
+        - Float timestamps should be converted to ISO strings
+        - Float project IDs should be converted to integers
+        """
         start_ts = 1690182000.0
         end_ts = 1690185600.0
+        project_id_float = 4557221366136832.0
 
         data: list[dict[str, Any]] = [
             {
                 "replay_id": "test123",
                 "started_at": start_ts,
                 "finished_at": end_ts,
+                "agg_project_id": project_id_float,
             },
             {
                 "replay_id": "test456",
                 "started_at": None,
                 "finished_at": None,
+                "agg_project_id": None,
             },
         ]
 
-        formatted = _format_eap_timestamps(data)
+        normalized = _normalize_eap_response(data)
 
-        assert isinstance(formatted[0]["started_at"], str)
-        assert isinstance(formatted[0]["finished_at"], str)
+        # Test timestamp conversion
+        assert isinstance(normalized[0]["started_at"], str)
+        assert isinstance(normalized[0]["finished_at"], str)
+        assert normalized[1]["started_at"] is None
+        assert normalized[1]["finished_at"] is None
 
-        assert formatted[1]["started_at"] is None
-        assert formatted[1]["finished_at"] is None
-
-        parsed_start = datetime.datetime.fromisoformat(formatted[0]["started_at"])
-        parsed_end = datetime.datetime.fromisoformat(formatted[0]["finished_at"])
-
+        parsed_start = datetime.datetime.fromisoformat(normalized[0]["started_at"])
+        parsed_end = datetime.datetime.fromisoformat(normalized[0]["finished_at"])
         assert parsed_start.timestamp() == start_ts
         assert parsed_end.timestamp() == end_ts
-
         assert (parsed_end - parsed_start).total_seconds() == 3600
+
+        assert isinstance(normalized[0]["agg_project_id"], int)
+        assert normalized[0]["agg_project_id"] == int(project_id_float)
+
+        assert ".0" not in str(normalized[0]["agg_project_id"])
+        assert normalized[1]["agg_project_id"] is None


### PR DESCRIPTION
EAP returns `agg_project_id` column as a float, which we eventually convert to a string in `post_process.py`:

```
ret_item["project_id"] = str(item["agg_project_id"])
```

Since `agg_project_id` is a float, the conversion to a string results in a ".0" trailling the ID, which results in an unknown project when passed to the frontend.

After asserting that the `agg_project_id` is indeed a float, this PR updates the normalization function to also convert the `agg_project_id` to an int first (to truncate the decimals) to account for the above issue.


Relates to: https://linear.app/getsentry/issue/REPLAY-824/create-query-function-for-replay-details