### PR TITLE
chore(seer): Remove extra calls to invalidateQueries, useUpdateProjectSeerPreferences does it automatically

### DIFF
--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -1,6 +1,5 @@
 import {useCallback} from 'react';
 import styled from '@emotion/styled';
-import {useQueryClient} from '@tanstack/react-query';
 
 import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -8,10 +7,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {Button} from 'sentry/components/core/button/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {ExternalLink, Link} from 'sentry/components/core/link';
-import {
-  makeProjectSeerPreferencesQueryKey,
-  useProjectSeerPreferences,
-} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectAutomation} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectAutomation';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
@@ -27,7 +23,6 @@ interface CursorIntegrationCtaProps {
 
 export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
   const organization = useOrganization();
-  const queryClient = useQueryClient();
 
   const {preference, isFetching: isLoadingPreferences} =
     useProjectSeerPreferences(project);
@@ -64,37 +59,22 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
       });
     }
 
-    updateProjectSeerPreferences(
-      {
-        repositories: preference?.repositories || [],
-        automated_run_stopping_point: 'root_cause',
-        automation_handoff: {
-          handoff_point: 'root_cause',
-          target: 'cursor_background_agent',
-          integration_id: parseInt(cursorIntegration.id, 10),
-        },
+    updateProjectSeerPreferences({
+      repositories: preference?.repositories || [],
+      automated_run_stopping_point: 'root_cause',
+      automation_handoff: {
+        handoff_point: 'root_cause',
+        target: 'cursor_background_agent',
+        integration_id: parseInt(cursorIntegration.id, 10),
       },
-      {
-        onSuccess: () => {
-          // Invalidate queries to update the dropdown in the settings page
-          queryClient.invalidateQueries({
-            queryKey: [
-              makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
-            ],
-          });
-        },
-      }
-    );
+    });
   }, [
-    project.slug,
     project.seerScannerAutomation,
     project.autofixAutomationTuning,
-    organization.slug,
     updateProjectSeerPreferences,
     updateProjectAutomation,
     preference?.repositories,
     cursorIntegration,
-    queryClient,
   ]);
 
   if (!hasCursorIntegrationFeatureFlag) {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
-import {useQueryClient} from '@tanstack/react-query';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import addIntegrationProvider from 'sentry-images/spot/add-integration-provider.svg';
@@ -15,10 +14,7 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {ExternalLink, Link} from 'sentry/components/core/link';
-import {
-  makeProjectSeerPreferencesQueryKey,
-  useProjectSeerPreferences,
-} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectAutomation} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectAutomation';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import StarFixabilityViewButton from 'sentry/components/events/autofix/seerCreateViewButton';
@@ -95,7 +91,6 @@ function CustomStepButtons({
 
 export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNoticesProps) {
   const organization = useOrganization();
-  const queryClient = useQueryClient();
   const {repos} = useAutofixRepos(groupId);
   const {
     preference,
@@ -187,26 +182,15 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
       });
     }
 
-    updateProjectSeerPreferences(
-      {
-        repositories: preference?.repositories || [],
-        automated_run_stopping_point: 'root_cause',
-        automation_handoff: {
-          handoff_point: 'root_cause',
-          target: 'cursor_background_agent',
-          integration_id: parseInt(cursorIntegration.id, 10),
-        },
+    updateProjectSeerPreferences({
+      repositories: preference?.repositories || [],
+      automated_run_stopping_point: 'root_cause',
+      automation_handoff: {
+        handoff_point: 'root_cause',
+        target: 'cursor_background_agent',
+        integration_id: parseInt(cursorIntegration.id, 10),
       },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              makeProjectSeerPreferencesQueryKey(organization.slug, project.slug),
-            ],
-          });
-        },
-      }
-    );
+    });
   }, [
     cursorIntegration,
     project.seerScannerAutomation,
@@ -214,9 +198,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     updateProjectAutomation,
     updateProjectSeerPreferences,
     preference?.repositories,
-    queryClient,
-    organization.slug,
-    project.slug,
   ]);
 
   const handleSkipCursorStep = useCallback(() => {


### PR DESCRIPTION
The cache is cleared already inside `onSuccess`, no need for an extra callback:

https://github.com/getsentry/sentry/blob/master/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts#L28-L32