### PR TITLE
chore(billing): remove grace period from user-facing frontend components

### DIFF
--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -69,7 +69,6 @@ function setUpTests() {
     'promotion-platform',
     'forced-trial',
     'soft-cap',
-    'grace-period',
     'trial-ending',
     'partner-plan-ending',
     'suspended',
@@ -148,24 +147,6 @@ describe('GSBanner', () => {
     renderGlobalModal();
 
     expect(await screen.findByTestId('modal-usage-exceeded')).toBeInTheDocument();
-  });
-
-  it('renders grace period modal with billing access', async () => {
-    const organization = OrganizationFixture({
-      slug: 'grace-period',
-      access: ['org:billing'],
-    });
-    SubscriptionStore.set(
-      organization.slug,
-      SubscriptionFixture({organization, isGracePeriod: true})
-    );
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-    });
-    renderGlobalModal();
-
-    expect(await screen.findByTestId('modal-grace-period')).toBeInTheDocument();
   });
 
   it('opens the trialEndingModal within 3 days of ending', async () => {

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -74,7 +74,6 @@ import withPromotions from 'getsentry/utils/withPromotions';
 
 enum ModalType {
   USAGE_EXCEEDED = 'usage-exceeded',
-  GRACE_PERIOD = 'grace-period',
   PAST_DUE = 'past-due',
   MEMBER_LIMIT = 'member-limit',
 }
@@ -190,17 +189,6 @@ function NoticeModal({
   let primaryButtonMessage: React.ReactNode;
 
   switch (whichModal) {
-    case ModalType.GRACE_PERIOD:
-      title = t('Grace period started');
-      body = tct(
-        `Your organization has depleted its error capacity for the current usage period.
-          We've put your account into a one time grace period, which will continue to accept errors at a limited rate.
-          This grace period ends on [gracePeriodEnd].`,
-        {gracePeriodEnd: moment(subscription.gracePeriodEnd).format('ll')}
-      );
-      link = normalizeUrl(`/settings/${organization.slug}/billing/overview/`);
-      primaryButtonMessage = t('Continue');
-      break;
     case ModalType.USAGE_EXCEEDED:
       title = t('Usage exceeded');
       body = t(
@@ -240,7 +228,7 @@ function NoticeModal({
     default:
   }
 
-  if (subscription.usageExceeded || subscription.isGracePeriod) {
+  if (subscription.usageExceeded) {
     if (subscription.isFree) {
       subText = subscription.canTrial
         ? t(
@@ -496,13 +484,11 @@ class GSBanner extends Component<Props, State> {
   tryTriggerNoticeModal() {
     const {organization, subscription} = this.props;
 
-    const whichModal = subscription.isGracePeriod
-      ? ModalType.GRACE_PERIOD
-      : subscription.usageExceeded
-        ? ModalType.USAGE_EXCEEDED
-        : subscription.isPastDue && subscription.canSelfServe
-          ? ModalType.PAST_DUE
-          : null;
+    const whichModal = subscription.usageExceeded
+      ? ModalType.USAGE_EXCEEDED
+      : subscription.isPastDue && subscription.canSelfServe
+        ? ModalType.PAST_DUE
+        : null;
 
     if (whichModal === null) {
       return;
@@ -523,7 +509,6 @@ class GSBanner extends Component<Props, State> {
     }
 
     const modalAnalytics = {
-      [ModalType.GRACE_PERIOD]: 'grace_period_modal.seen',
       [ModalType.USAGE_EXCEEDED]: 'usage_exceeded_modal.seen',
       [ModalType.PAST_DUE]: 'past_due_modal.seen',
     } as const;

--- a/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
@@ -67,7 +67,6 @@ describe('Subscription > UsageAlert', () => {
     expect(screen.queryByText('grace period')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
@@ -96,7 +95,6 @@ describe('Subscription > UsageAlert', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Start Trial')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
@@ -131,7 +129,6 @@ describe('Subscription > UsageAlert', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Request Additional Quota')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
@@ -166,7 +163,6 @@ describe('Subscription > UsageAlert', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Request Additional Quota')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
@@ -205,7 +201,6 @@ describe('Subscription > UsageAlert', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Setup On-Demand')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
@@ -248,7 +243,6 @@ describe('Subscription > UsageAlert', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Request Upgrade')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
@@ -291,7 +285,6 @@ describe('Subscription > UsageAlert', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Request Upgrade')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
@@ -334,122 +327,35 @@ describe('Subscription > UsageAlert', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Request Upgrade')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
   });
 
-  describe('grace period', () => {
-    it('renders for grace period', () => {
-      const organization = OrganizationFixture({access: ['org:billing']});
-      const subscription = SubscriptionFixture({organization, canTrial: false});
+  it('does not render upgrade buttons if cannot self-serve', () => {
+    const organization = OrganizationFixture({access: ['org:billing']});
+    const subscription = SubscriptionFixture({organization, canTrial: false});
 
-      render(
-        <UsageAlert
-          subscription={{...subscription, isGracePeriod: true}}
-          usage={emptyUsage}
-        />,
-        {organization}
-      );
+    render(
+      <UsageAlert
+        subscription={{
+          ...subscription,
+          canSelfServe: false,
+          categories: {
+            errors: MetricHistoryFixture({usageExceeded: true}),
+            transactions: MetricHistoryFixture({
+              category: DataCategory.TRANSACTIONS,
+            }),
+            attachments: MetricHistoryFixture({
+              category: DataCategory.ATTACHMENTS,
+            }),
+          },
+        }}
+        usage={emptyUsage}
+      />,
+      {organization}
+    );
 
-      expect(screen.getByTestId('grace-period-alert')).toBeInTheDocument();
-      expect(screen.getByText('Grace Period')).toBeInTheDocument();
-      expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
-
-      expect(screen.queryByTestId('usage-exceeded-alert')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
-    });
-
-    it('renders for grace period and transactions exceeded', () => {
-      const organization = OrganizationFixture({access: ['org:billing']});
-      const subscription = SubscriptionFixture({organization, canTrial: false});
-
-      render(
-        <UsageAlert
-          subscription={{
-            ...subscription,
-            isGracePeriod: true,
-            categories: {
-              transactions: MetricHistoryFixture({usageExceeded: true}),
-            },
-          }}
-          usage={emptyUsage}
-        />,
-        {organization}
-      );
-
-      expect(screen.getByTestId('grace-period-alert')).toBeInTheDocument();
-      expect(screen.getByText('Grace Period')).toBeInTheDocument();
-      expect(screen.getAllByLabelText('Upgrade Plan')).toHaveLength(2);
-
-      expect(screen.getByTestId('usage-exceeded-alert')).toBeInTheDocument();
-      expect(
-        screen.getByText(textWithMarkupMatcher(/transactions capacity/))
-      ).toBeInTheDocument();
-
-      expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
-    });
-
-    it('renders for am2 grace period and transactions exceeded', () => {
-      const organization = OrganizationFixture({access: ['org:billing']});
-      const subscription = SubscriptionFixture({
-        plan: 'am2_f',
-        organization,
-        canTrial: false,
-      });
-
-      render(
-        <UsageAlert
-          subscription={{
-            ...subscription,
-            isGracePeriod: true,
-            categories: {
-              transactions: MetricHistoryFixture({usageExceeded: true}),
-            },
-          }}
-          usage={emptyUsage}
-        />,
-        {organization}
-      );
-
-      expect(screen.getByTestId('grace-period-alert')).toBeInTheDocument();
-      expect(screen.getByText('Grace Period')).toBeInTheDocument();
-      expect(screen.getAllByLabelText('Upgrade Plan')).toHaveLength(2);
-
-      expect(screen.getByTestId('usage-exceeded-alert')).toBeInTheDocument();
-      expect(
-        screen.getByText(textWithMarkupMatcher(/performance units capacity/))
-      ).toBeInTheDocument();
-
-      expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
-    });
-
-    it('does not render upgrade buttons if cannot self-serve', () => {
-      const organization = OrganizationFixture({access: ['org:billing']});
-      const subscription = SubscriptionFixture({organization, canTrial: false});
-
-      render(
-        <UsageAlert
-          subscription={{
-            ...subscription,
-            canSelfServe: false,
-            categories: {
-              errors: MetricHistoryFixture({usageExceeded: true}),
-              transactions: MetricHistoryFixture({
-                category: DataCategory.TRANSACTIONS,
-              }),
-              attachments: MetricHistoryFixture({
-                category: DataCategory.ATTACHMENTS,
-              }),
-            },
-          }}
-          usage={emptyUsage}
-        />,
-        {organization}
-      );
-
-      expect(screen.getByTestId('usage-exceeded-alert')).toBeInTheDocument();
-      expect(screen.queryByLabelText('Upgrade Plan')).not.toBeInTheDocument();
-    });
+    expect(screen.getByTestId('usage-exceeded-alert')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Upgrade Plan')).not.toBeInTheDocument();
   });
 
   describe('projected overage', () => {
@@ -488,7 +394,6 @@ describe('Subscription > UsageAlert', () => {
 
       expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
 
-      expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
       expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
     });
 
@@ -520,7 +425,6 @@ describe('Subscription > UsageAlert', () => {
       expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
 
       expect(screen.queryByTestId('usage-exceeded-alert')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     });
 
     it('does not render without projected errors overage', () => {
@@ -590,7 +494,6 @@ describe('Subscription > UsageAlert', () => {
       expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
 
       expect(screen.queryByTestId('usage-exceeded-alert')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     });
 
     it('renders am2 with projected errors and transactions overage', () => {
@@ -639,7 +542,6 @@ describe('Subscription > UsageAlert', () => {
       expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
 
       expect(screen.queryByTestId('usage-exceeded-alert')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     });
 
     it('renders am1 with projected attachments overage', () => {
@@ -675,7 +577,6 @@ describe('Subscription > UsageAlert', () => {
       expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
 
       expect(screen.queryByTestId('usage-exceeded-alert')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     });
 
     it('does not render without projected attachments overage', () => {
@@ -741,7 +642,6 @@ describe('Subscription > UsageAlert', () => {
       expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
 
       expect(screen.queryByTestId('usage-exceeded-alert')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('grace-period-alert')).not.toBeInTheDocument();
     });
 
     it('does not render without projected profile duration overage', () => {

--- a/static/gsApp/views/subscriptionPage/usageAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
-import moment from 'moment-timezone';
 
 import {Container, Flex} from '@sentry/scraps/layout';
 
-import {IconFire, IconStats, IconWarning} from 'sentry/icons';
+import {IconFire, IconStats} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategory} from 'sentry/types/core';
@@ -143,36 +142,6 @@ function UsageAlert({subscription, usage}: Props) {
     );
   }
 
-  function renderGracePeriodInfo() {
-    return (
-      <Container
-        background="primary"
-        border="primary"
-        radius="md"
-        data-test-id="grace-period-alert"
-      >
-        <SubscriptionBody withPadding>
-          <UsageInfo>
-            <IconWarning size="md" color="yellow300" />
-            <div>
-              <h3>{t('Grace Period')}</h3>
-              <Description>
-                {tct(
-                  `Your organization has depleted its error capacity for the current usage period.
-                  We've put your account into a one time grace period, which will continue to accept errors at a limited rate.
-                  This grace period ends on [gracePeriodEnd].`,
-                  {gracePeriodEnd: moment(subscription.gracePeriodEnd).format('ll')}
-                )}{' '}
-                {getActionSentence()}
-              </Description>
-            </div>
-          </UsageInfo>
-          {renderPrimaryCTA('grace-period')}
-        </SubscriptionBody>
-      </Container>
-    );
-  }
-
   function renderExceededInfo() {
     const exceededList = sortCategoriesWithKeys(subscription.categories)
       .filter(
@@ -280,20 +249,18 @@ function UsageAlert({subscription, usage}: Props) {
     // TODO: Remove when mmx plans have error BillingMetricHistory
     subscription.usageExceeded;
   const projectedOverages = getProjectedOverages();
-  const hasOverage =
-    subscription.isGracePeriod || hasExceeded || !!projectedOverages.length;
+  const hasOverage = hasExceeded || !!projectedOverages.length;
 
   // if no overage, we can still have a CTA
   if (!hasOverage) {
     return renderDefaultEventCTA();
   }
 
-  const showProjected = !hasExceeded && !subscription.isGracePeriod;
+  const showProjected = !hasExceeded;
 
   return (
     <Flex direction="column" gap="xl" data-test-id="usage-alert">
       {hasExceeded && renderExceededInfo()}
-      {subscription.isGracePeriod && renderGracePeriodInfo()}
       {showProjected && renderProjectedInfo(projectedOverages)}
     </Flex>
   );


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1834/remove-grace-period-from-gsapp-components-user-facing

Remove grace period modal, alerts, and related UI elements as part of the grace period deprecation initiative.

This PR:
- Removes `GRACE_PERIOD` modal type and handling from gsBanner
- Remove grace period alert section from subscription usage alerts
- Remove related test cases and assertions
