### PR TITLE
fix(aci): Error metric detectors should include error types in query

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -173,7 +173,7 @@ export function useMetricDetectorChart({
     extrapolationMode: snubaQuery.extrapolationMode,
     aggregate,
     interval: snubaQuery.timeWindow,
-    query: snubaQuery.query,
+    query: datasetConfig.toSnubaQueryString(snubaQuery),
     environment: snubaQuery.environment,
     projectId: detector.projectId,
     eventTypes: snubaQuery.eventTypes,


### PR DESCRIPTION
We need this transformation to chart the correct series with `event.type:error` or `event.type:default` if they exist. 