### PR TITLE
ref(explorer): accept pydantic model for custom tools

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -73,31 +73,23 @@ class SeerExplorerClient:
         solution = state.get_artifact("solution", Solution)
 
         # WITH CUSTOM TOOLS
-        from sentry.seer.explorer.custom_tool_utils import ExplorerTool, ExplorerToolParam, StringType
+        from pydantic import BaseModel, Field
+        from sentry.seer.explorer.custom_tool_utils import ExplorerTool
 
-        class DeploymentStatusTool(ExplorerTool):
+        class DeploymentStatusParams(BaseModel):
+            environment: str = Field(description="Environment name (e.g., 'production', 'staging')")
+            service: str = Field(description="Service name")
+
+        class DeploymentStatusTool(ExplorerTool[DeploymentStatusParams]):
+            params_model = DeploymentStatusParams
+
             @classmethod
-            def get_description(cls):
+            def get_description(cls) -> str:
                 return "Check if a service is deployed in an environment"
 
             @classmethod
-            def get_params(cls):
-                return [
-                    ExplorerToolParam(
-                        name="environment",
-                        description="Environment name (e.g., 'production', 'staging')",
-                        type=StringType(),
-                    ),
-                    ExplorerToolParam(
-                        name="service",
-                        description="Service name",
-                        type=StringType(),
-                    ),
-                ]
-
-            @classmethod
-            def execute(cls, organization, **kwargs):
-                return "deployed" if check_deployment(organization, kwargs["environment"], kwargs["service"]) else "not deployed"
+            def execute(cls, organization, params: DeploymentStatusParams) -> str:
+                return "deployed" if check_deployment(organization, params.environment, params.service) else "not deployed"
 
         client = SeerExplorerClient(
             organization,
@@ -112,7 +104,7 @@ class SeerExplorerClient:
             user: User for permission checks and user-specific context (can be User, AnonymousUser, or None)
             category_key: Optional category key for filtering/grouping runs (e.g., "bug-fixer", "trace-analyzer"). Must be provided together with category_value. Makes it easy to retrieve runs for your feature later.
             category_value: Optional category value for filtering/grouping runs (e.g., issue ID, trace ID). Must be provided together with category_key. Makes it easy to retrieve a specific run for your feature later.
-            custom_tools: Optional list of `ExplorerTool` objects to make available as tools to the agent. Each tool must inherit from ExplorerTool and implement get_params() and execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).
+            custom_tools: Optional list of `ExplorerTool` classes to make available as tools to the agent. Each tool must inherit from ExplorerTool, define a params_model (Pydantic BaseModel), and implement execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).
             intelligence_level: Optionally set the intelligence level of the agent. Higher intelligence gives better result quality at the cost of significantly higher latency and cost.
             is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer. An example use of this is the explorer chat in Sentry UI.
     """
@@ -123,7 +115,7 @@ class SeerExplorerClient:
         user: User | AnonymousUser | None = None,
         category_key: str | None = None,
         category_value: str | None = None,
-        custom_tools: list[type[ExplorerTool]] | None = None,
+        custom_tools: list[type[ExplorerTool[Any]]] | None = None,
         intelligence_level: Literal["low", "medium", "high"] = "medium",
         is_interactive: bool = False,
     ):

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -117,8 +117,7 @@ class CustomToolDefinition(BaseModel):
     name: str
     module_path: str
     description: str
-    parameters: list[dict[str, Any]]
-    required: list[str]
+    param_schema: dict[str, Any]  # JSON schema from Pydantic model
 
 
 class ExplorerRun(BaseModel):

--- a/src/sentry/seer/explorer/custom_tool_utils.py
+++ b/src/sentry/seer/explorer/custom_tool_utils.py
@@ -97,7 +97,7 @@ def extract_tool_schema(tool_class: type[ExplorerTool[Any]]) -> CustomToolDefini
         name=tool_class.__name__,
         module_path=tool_class.get_module_path(),
         description=tool_class.get_description(),
-        param_schema=tool_class.params_model.model_json_schema(),
+        param_schema=tool_class.params_model.schema(),
     )
 
 

--- a/src/sentry/seer/explorer/custom_tool_utils.py
+++ b/src/sentry/seer/explorer/custom_tool_utils.py
@@ -2,127 +2,58 @@ from __future__ import annotations
 
 import importlib
 from abc import ABC, abstractmethod
-from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
 from sentry.models.organization import Organization
 from sentry.seer.explorer.client_models import CustomToolDefinition
 
-
-class ExplorerParamType(StrEnum):
-    """Allowed parameter types for Explorer tools."""
-
-    STRING = "string"
-    INTEGER = "integer"
-    NUMBER = "number"
-    BOOLEAN = "boolean"
-    ARRAY = "array"
+ParamsT = TypeVar("ParamsT", bound=BaseModel)
 
 
-# Type specifications for different parameter types
-class StringType(BaseModel):
-    """Simple string type."""
-
-    kind: Literal["string"] = "string"
-
-
-class IntegerType(BaseModel):
-    """Simple integer type."""
-
-    kind: Literal["integer"] = "integer"
-
-
-class NumberType(BaseModel):
-    """Simple number (float) type."""
-
-    kind: Literal["number"] = "number"
-
-
-class BooleanType(BaseModel):
-    """Simple boolean type."""
-
-    kind: Literal["boolean"] = "boolean"
-
-
-class EnumType(BaseModel):
-    """String restricted to specific values."""
-
-    kind: Literal["enum"] = "enum"
-    values: list[str]
-
-
-class ArrayType(BaseModel):
-    """Array with typed elements."""
-
-    kind: Literal["array"] = "array"
-    item_type: ExplorerParamType
-
-
-ParamTypeSpec = StringType | IntegerType | NumberType | BooleanType | EnumType | ArrayType
-
-
-class ExplorerToolParam(BaseModel):
-    """Parameter definition for an Explorer tool.
-
-    Examples:
-        # String parameter
-        ExplorerToolParam(
-            name="query",
-            description="Search query",
-            type=StringType()
-        )
-
-        # Array of strings
-        ExplorerToolParam(
-            name="tags",
-            description="List of tags",
-            type=ArrayType(item_type=ExplorerParamType.STRING)
-        )
-
-        # Enum parameter
-        ExplorerToolParam(
-            name="status",
-            description="Status",
-            type=EnumType(values=["active", "inactive"])
-        )
-    """
-
-    name: str
-    description: str
-    type: ParamTypeSpec
-    required: bool = True
-
-
-class ExplorerTool(ABC):
+class ExplorerTool(ABC, Generic[ParamsT]):
     """Base class for custom Explorer tools.
 
+    Define parameters via a Pydantic model.
+
     Example:
-        class DeploymentStatusTool(ExplorerTool):
+        from pydantic import BaseModel, Field
+
+        class DeploymentStatusParams(BaseModel):
+            environment: str = Field(description="Environment name (e.g., 'production', 'staging')")
+            service: str = Field(description="Service name")
+
+        class DeploymentStatusTool(ExplorerTool[DeploymentStatusParams]):
+            params_model = DeploymentStatusParams
+
             @classmethod
             def get_description(cls) -> str:
                 return "Check if a service is deployed in an environment"
 
             @classmethod
-            def get_params(cls) -> list[ExplorerToolParam]:
-                return [
-                    ExplorerToolParam(
-                        name="environment",
-                        description="Environment name",
-                        type=StringType(),
-                    ),
-                    ExplorerToolParam(
-                        name="service",
-                        description="Service name",
-                        type=StringType(),
-                    ),
-                ]
-
-            @classmethod
-            def execute(cls, organization: Organization, **kwargs) -> str:
-                return check_deployment(organization, kwargs["environment"], kwargs["service"])
+            def execute(cls, organization: Organization, params: DeploymentStatusParams) -> str:
+                return check_deployment(organization, params.environment, params.service)
     """
+
+    # Define a Pydantic model for parameters
+    params_model: type[ParamsT]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Skip validation for abstract subclasses
+        if ABC in cls.__bases__:
+            return
+        if not hasattr(cls, "params_model") or cls.params_model is None:
+            raise TypeError(
+                f"{cls.__name__} must define a params_model class attribute. "
+                "Use an empty BaseModel if no parameters are needed."
+            )
+        if not isinstance(cls.params_model, type) or not issubclass(cls.params_model, BaseModel):
+            raise TypeError(
+                f"{cls.__name__}.params_model must be a Pydantic BaseModel subclass, "
+                f"got {type(cls.params_model)}"
+            )
 
     @classmethod
     @abstractmethod
@@ -132,14 +63,8 @@ class ExplorerTool(ABC):
 
     @classmethod
     @abstractmethod
-    def get_params(cls) -> list[ExplorerToolParam]:
-        """Return the list of parameter definitions for this tool."""
-        ...
-
-    @classmethod
-    @abstractmethod
-    def execute(cls, organization: Organization, **kwargs) -> str:
-        """Execute the tool with the given organization and parameters."""
+    def execute(cls, organization: Organization, params: ParamsT) -> str:
+        """Execute the tool with the given organization and validated parameters."""
         ...
 
     @classmethod
@@ -152,14 +77,14 @@ class ExplorerTool(ABC):
         return f"{cls.__module__}.{cls.__name__}"
 
 
-def extract_tool_schema(tool_class: type[ExplorerTool]) -> CustomToolDefinition:
+def extract_tool_schema(tool_class: type[ExplorerTool[Any]]) -> CustomToolDefinition:
     """Extract tool schema from an ExplorerTool class.
 
     Args:
         tool_class: A class that inherits from ExplorerTool
 
     Returns:
-        CustomToolDefinition with the tool's name, description, parameters, and module path
+        CustomToolDefinition with the tool's name, description, param_schema, and module path
     """
     # Enforce module-level classes only (no nested classes)
     if "." in tool_class.__qualname__:
@@ -168,43 +93,11 @@ def extract_tool_schema(tool_class: type[ExplorerTool]) -> CustomToolDefinition:
             f"Nested classes are not supported. (qualname: {tool_class.__qualname__})"
         )
 
-    params = tool_class.get_params()
-
-    # Convert ExplorerToolParam list to parameter dicts
-    parameters: list[dict[str, Any]] = []
-    required: list[str] = []
-    for param in params:
-        param_dict: dict[str, Any] = {
-            "name": param.name,
-            "description": param.description,
-        }
-
-        # Extract type information based on the type spec
-        type_spec = param.type
-        if isinstance(type_spec, EnumType):
-            param_dict["type"] = "string"
-            param_dict["enum"] = type_spec.values
-        elif isinstance(type_spec, ArrayType):
-            param_dict["type"] = "array"
-            param_dict["items"] = {"type": type_spec.item_type.value}
-        else:
-            # Simple types: StringType, IntegerType, etc.
-            param_dict["type"] = type_spec.kind
-
-        parameters.append(param_dict)
-
-        # Track required parameters
-        if param.required:
-            required.append(param.name)
-
-    description = tool_class.get_description()
-
     return CustomToolDefinition(
         name=tool_class.__name__,
         module_path=tool_class.get_module_path(),
-        description=description,
-        parameters=parameters,
-        required=required,
+        description=tool_class.get_description(),
+        param_schema=tool_class.params_model.model_json_schema(),
     )
 
 
@@ -256,9 +149,15 @@ def call_custom_tool(
     if not isinstance(tool_class, type) or not issubclass(tool_class, ExplorerTool):
         raise ValueError(f"{module_path} must be a class that inherits from ExplorerTool")
 
+    # Validate and parse params through the model
+    try:
+        params = tool_class.params_model(**kwargs)
+    except Exception as e:
+        raise ValueError(f"Invalid parameters for {module_path}: {e}")
+
     # Execute the tool
     try:
-        result = tool_class.execute(organization, **kwargs)
+        result = tool_class.execute(organization, params)
     except Exception as e:
         raise RuntimeError(f"Error executing custom tool {module_path}: {e}")
 

--- a/tests/sentry/seer/explorer/test_custom_tool_utils.py
+++ b/tests/sentry/seer/explorer/test_custom_tool_utils.py
@@ -3,16 +3,10 @@ Tests for custom tool utilities.
 """
 
 import pytest
+from pydantic import BaseModel, Field
 
 from sentry.seer.explorer.custom_tool_utils import (
-    ArrayType,
-    BooleanType,
-    EnumType,
-    ExplorerParamType,
     ExplorerTool,
-    ExplorerToolParam,
-    IntegerType,
-    StringType,
     call_custom_tool,
     extract_tool_schema,
 )
@@ -20,147 +14,107 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import create_test_regions, region_silo_test
 
 
+# Pydantic models for tool parameters
+class TestCustomToolParams(BaseModel):
+    message: str = Field(description="Message to repeat")
+    count: int = Field(default=1, description="Number of times")
+
+
+class TestToolWithDefaultParams(BaseModel):
+    value: str = Field(description="Value")
+    suffix: str = Field(default="!", description="Suffix")
+
+
+class EmptyParams(BaseModel):
+    pass
+
+
+class GetUserInfoParams(BaseModel):
+    user_id: int = Field(description="User ID")
+
+
+class SearchLogsParams(BaseModel):
+    query: str = Field(description="Search query")
+    limit: int | None = Field(default=None, description="Result limit")
+    include_archived: bool | None = Field(default=None, description="Include archived")
+
+
+class ProcessItemsParams(BaseModel):
+    items: list[str] = Field(description="Items to process")
+    priorities: list[int] = Field(description="Priorities")
+
+
 # Test helper tool classes (defined in module scope so they can be imported by call_custom_tool)
-class TestCustomTool(ExplorerTool):
+class TestCustomTool(ExplorerTool[TestCustomToolParams]):
+    params_model = TestCustomToolParams
+
     @classmethod
-    def get_description(cls):
+    def get_description(cls) -> str:
         return "A test tool"
 
     @classmethod
-    def get_params(cls):
-        return [
-            ExplorerToolParam(name="message", description="Message to repeat", type=StringType()),
-            ExplorerToolParam(
-                name="count", description="Number of times", type=IntegerType(), required=False
-            ),
-        ]
+    def execute(cls, organization, params: TestCustomToolParams) -> str:
+        return params.message * params.count
+
+
+class TestToolWithDefault(ExplorerTool[TestToolWithDefaultParams]):
+    params_model = TestToolWithDefaultParams
 
     @classmethod
-    def execute(cls, organization, **kwargs):
-        message = kwargs["message"]
-        count = kwargs.get("count", 1)
-        return message * count
-
-
-class TestToolWithDefault(ExplorerTool):
-    @classmethod
-    def get_description(cls):
+    def get_description(cls) -> str:
         return "Test tool with default parameter"
 
     @classmethod
-    def get_params(cls):
-        return [
-            ExplorerToolParam(name="value", description="Value", type=StringType()),
-            ExplorerToolParam(
-                name="suffix", description="Suffix", type=StringType(), required=False
-            ),
-        ]
+    def execute(cls, organization, params: TestToolWithDefaultParams) -> str:
+        return params.value + params.suffix
+
+
+class BadTool(ExplorerTool[EmptyParams]):
+    params_model = EmptyParams
 
     @classmethod
-    def execute(cls, organization, **kwargs):
-        value = kwargs["value"]
-        suffix = kwargs.get("suffix", "!")
-        return value + suffix
-
-
-class BadTool(ExplorerTool):
-    @classmethod
-    def get_description(cls):
+    def get_description(cls) -> str:
         return "Tool that returns wrong type"
 
     @classmethod
-    def get_params(cls):
-        return []
+    def execute(cls, organization, params: EmptyParams) -> str:
+        return 123  # type: ignore[return-value]  # Returns wrong type to test runtime validation
+
+
+class GetUserInfoTool(ExplorerTool[GetUserInfoParams]):
+    params_model = GetUserInfoParams
 
     @classmethod
-    def execute(cls, organization, **kwargs):
-        return 123  # Returns wrong type to test runtime validation
-
-
-class GetUserInfoTool(ExplorerTool):
-    @classmethod
-    def get_description(cls):
+    def get_description(cls) -> str:
         return "Fetches user information"
 
     @classmethod
-    def get_params(cls):
-        return [
-            ExplorerToolParam(name="user_id", description="User ID", type=IntegerType()),
-        ]
+    def execute(cls, organization, params: GetUserInfoParams) -> str:
+        return f"User {params.user_id}"
+
+
+class SearchLogsTool(ExplorerTool[SearchLogsParams]):
+    params_model = SearchLogsParams
 
     @classmethod
-    def execute(cls, organization, **kwargs):
-        return f"User {kwargs['user_id']}"
-
-
-class SearchLogsTool(ExplorerTool):
-    @classmethod
-    def get_description(cls):
+    def get_description(cls) -> str:
         return "Search application logs"
 
     @classmethod
-    def get_params(cls):
-        return [
-            ExplorerToolParam(name="query", description="Search query", type=StringType()),
-            ExplorerToolParam(
-                name="limit", description="Result limit", type=IntegerType(), required=False
-            ),
-            ExplorerToolParam(
-                name="include_archived",
-                description="Include archived",
-                type=BooleanType(),
-                required=False,
-            ),
-        ]
+    def execute(cls, organization, params: SearchLogsParams) -> str:
+        return f"Found logs for: {params.query}"
+
+
+class ProcessItemsTool(ExplorerTool[ProcessItemsParams]):
+    params_model = ProcessItemsParams
 
     @classmethod
-    def execute(cls, organization, **kwargs):
-        return f"Found logs for: {kwargs['query']}"
-
-
-class ProcessItemsTool(ExplorerTool):
-    @classmethod
-    def get_description(cls):
+    def get_description(cls) -> str:
         return "Process a list of items"
 
     @classmethod
-    def get_params(cls):
-        return [
-            ExplorerToolParam(
-                name="items",
-                description="Items to process",
-                type=ArrayType(item_type=ExplorerParamType.STRING),
-            ),
-            ExplorerToolParam(
-                name="priorities",
-                description="Priorities",
-                type=ArrayType(item_type=ExplorerParamType.INTEGER),
-            ),
-        ]
-
-    @classmethod
-    def execute(cls, organization, **kwargs):
+    def execute(cls, organization, params: ProcessItemsParams) -> str:
         return "Processed"
-
-
-class ToolWithEnum(ExplorerTool):
-    @classmethod
-    def get_description(cls):
-        return "Tool with enum parameter"
-
-    @classmethod
-    def get_params(cls):
-        return [
-            ExplorerToolParam(
-                name="unit",
-                description="Temperature unit",
-                type=EnumType(values=["celsius", "fahrenheit"]),
-            ),
-        ]
-
-    @classmethod
-    def execute(cls, organization, **kwargs):
-        return kwargs["unit"]
 
 
 @region_silo_test
@@ -174,17 +128,15 @@ class CustomToolUtilsTest(TestCase):
         """Test validation fails for nested classes."""
 
         class OuterClass:
-            class NestedTool(ExplorerTool):
+            class NestedTool(ExplorerTool[EmptyParams]):
+                params_model = EmptyParams
+
                 @classmethod
-                def get_description(cls):
+                def get_description(cls) -> str:
                     return "Nested tool"
 
                 @classmethod
-                def get_params(cls):
-                    return []
-
-                @classmethod
-                def execute(cls, organization, **kwargs):
+                def execute(cls, organization, params: EmptyParams) -> str:
                     return "test"
 
         with pytest.raises(ValueError) as cm:
@@ -198,10 +150,9 @@ class CustomToolUtilsTest(TestCase):
         assert schema.name == "GetUserInfoTool"
         assert "GetUserInfoTool" in schema.module_path
         assert schema.description == "Fetches user information"
-        assert len(schema.parameters) == 1
-        assert schema.parameters[0]["name"] == "user_id"
-        assert schema.parameters[0]["type"] == "integer"
-        assert schema.required == ["user_id"]
+        assert schema.param_schema is not None
+        assert "properties" in schema.param_schema
+        assert "user_id" in schema.param_schema["properties"]
 
     def test_extract_tool_schema_with_optional_params(self):
         """Test extracting schema with optional parameters."""
@@ -209,29 +160,24 @@ class CustomToolUtilsTest(TestCase):
 
         assert schema.name == "SearchLogsTool"
         assert schema.description == "Search application logs"
-        assert len(schema.parameters) == 3
-        assert schema.required == ["query"]  # Only required param
-
-        # Check parameter types
-        param_types = {p["name"]: p["type"] for p in schema.parameters}
-        assert param_types["query"] == "string"
-        assert param_types["limit"] == "integer"
-        assert param_types["include_archived"] == "boolean"
+        assert schema.param_schema is not None
+        properties = schema.param_schema["properties"]
+        assert "query" in properties
+        assert "limit" in properties
+        assert "include_archived" in properties
+        # Only query is required
+        assert schema.param_schema.get("required") == ["query"]
 
     def test_extract_tool_schema_with_list_params(self):
         """Test extracting schema with list parameters."""
         schema = extract_tool_schema(ProcessItemsTool)
 
-        assert len(schema.parameters) == 2
+        assert schema.param_schema is not None
+        properties = schema.param_schema["properties"]
 
         # Check list types
-        items_param = next(p for p in schema.parameters if p["name"] == "items")
-        assert items_param["type"] == "array"
-        assert items_param["items"]["type"] == "string"
-
-        priorities_param = next(p for p in schema.parameters if p["name"] == "priorities")
-        assert priorities_param["type"] == "array"
-        assert priorities_param["items"]["type"] == "integer"
+        assert properties["items"]["type"] == "array"
+        assert properties["priorities"]["type"] == "array"
 
     def test_call_custom_tool_success(self):
         """Test calling a custom tool successfully."""
@@ -290,12 +236,17 @@ class CustomToolUtilsTest(TestCase):
             )
         assert "must return str" in str(cm.value)
 
-    def test_tool_with_enum(self):
-        """Test that EnumType is converted correctly."""
-        schema = extract_tool_schema(ToolWithEnum)
+    def test_tool_without_params_model_raises(self):
+        """Test that a tool without params_model raises an error at class definition time."""
+        with pytest.raises(TypeError) as cm:
+            # This should raise when the class is defined, not when extract_tool_schema is called
+            class NoParamsTool(ExplorerTool[BaseModel]):  # type: ignore[type-arg]
+                @classmethod
+                def get_description(cls) -> str:
+                    return "Tool without params_model"
 
-        assert len(schema.parameters) == 1
-        unit_param = schema.parameters[0]
-        assert unit_param["name"] == "unit"
-        assert unit_param["type"] == "string"
-        assert unit_param["enum"] == ["celsius", "fahrenheit"]
+                @classmethod
+                def execute(cls, organization, params: BaseModel) -> str:
+                    return "test"
+
+        assert "must define a params_model" in str(cm.value)

--- a/tests/sentry/seer/explorer/test_custom_tool_utils.py
+++ b/tests/sentry/seer/explorer/test_custom_tool_utils.py
@@ -15,12 +15,12 @@ from sentry.testutils.silo import create_test_regions, region_silo_test
 
 
 # Pydantic models for tool parameters
-class TestCustomToolParams(BaseModel):
+class CustomToolParams(BaseModel):
     message: str = Field(description="Message to repeat")
     count: int = Field(default=1, description="Number of times")
 
 
-class TestToolWithDefaultParams(BaseModel):
+class ToolWithDefaultParams(BaseModel):
     value: str = Field(description="Value")
     suffix: str = Field(default="!", description="Suffix")
 
@@ -45,27 +45,27 @@ class ProcessItemsParams(BaseModel):
 
 
 # Test helper tool classes (defined in module scope so they can be imported by call_custom_tool)
-class TestCustomTool(ExplorerTool[TestCustomToolParams]):
-    params_model = TestCustomToolParams
+class SampleCustomTool(ExplorerTool[CustomToolParams]):
+    params_model = CustomToolParams
 
     @classmethod
     def get_description(cls) -> str:
         return "A test tool"
 
     @classmethod
-    def execute(cls, organization, params: TestCustomToolParams) -> str:
+    def execute(cls, organization, params: CustomToolParams) -> str:
         return params.message * params.count
 
 
-class TestToolWithDefault(ExplorerTool[TestToolWithDefaultParams]):
-    params_model = TestToolWithDefaultParams
+class SampleToolWithDefault(ExplorerTool[ToolWithDefaultParams]):
+    params_model = ToolWithDefaultParams
 
     @classmethod
     def get_description(cls) -> str:
         return "Test tool with default parameter"
 
     @classmethod
-    def execute(cls, organization, params: TestToolWithDefaultParams) -> str:
+    def execute(cls, organization, params: ToolWithDefaultParams) -> str:
         return params.value + params.suffix
 
 
@@ -182,7 +182,7 @@ class CustomToolUtilsTest(TestCase):
     def test_call_custom_tool_success(self):
         """Test calling a custom tool successfully."""
         # Use test tool from this test module
-        module_path = "tests.sentry.seer.explorer.test_custom_tool_utils.TestCustomTool"
+        module_path = "tests.sentry.seer.explorer.test_custom_tool_utils.SampleCustomTool"
 
         # Call via the utility function
         result = call_custom_tool(
@@ -196,7 +196,7 @@ class CustomToolUtilsTest(TestCase):
 
     def test_call_custom_tool_with_optional_param(self):
         """Test calling a custom tool with default parameter."""
-        module_path = "tests.sentry.seer.explorer.test_custom_tool_utils.TestToolWithDefault"
+        module_path = "tests.sentry.seer.explorer.test_custom_tool_utils.SampleToolWithDefault"
         result = call_custom_tool(
             module_path=module_path,
             allowed_prefixes=("sentry.", "tests.sentry."),

--- a/tests/sentry/seer/explorer/test_custom_tool_utils.py
+++ b/tests/sentry/seer/explorer/test_custom_tool_utils.py
@@ -240,7 +240,7 @@ class CustomToolUtilsTest(TestCase):
         """Test that a tool without params_model raises an error at class definition time."""
         with pytest.raises(TypeError) as cm:
             # This should raise when the class is defined, not when extract_tool_schema is called
-            class NoParamsTool(ExplorerTool[BaseModel]):  # type: ignore[type-arg]
+            class NoParamsTool(ExplorerTool[BaseModel]):
                 @classmethod
                 def get_description(cls) -> str:
                     return "Tool without params_model"


### PR DESCRIPTION
Change custom tool definitions in explorer client to take pydantic BaseModels for simpler code and simpler dev experience. Requires https://github.com/getsentry/seer/pull/4175 to support

Part of AIML-1969