### PR TITLE
fix(aci): Extend taint tracking to delayed workflow condition evaluation

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -576,7 +576,9 @@ def get_groups_to_fire(
             if not when_result.triggered:
                 # If we're not triggering, all action-y if conditions need to be treated
                 # as tainted or not based on the when condition result.
-                if_cond_count = len(event_key.if_dcg_ids) + len(event_key.passing_dcg_ids)
+                if_conds = event_key.if_dcg_ids | event_key.passing_dcg_ids
+                # Limit to those we can access to be consistent with the if conditions evaluation.
+                if_cond_count = len(if_conds & data_condition_group_mapping.keys())
                 if when_result.is_tainted():
                     tainted += if_cond_count
                 else:

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -541,20 +541,6 @@ class _ConditionEvaluationStats:
     tainted: int
     untainted: int
 
-    def report(self) -> None:
-        metrics.incr(
-            "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
-            amount=self.tainted,
-            tags={"tainted": True},
-            sample_rate=1.0,
-        )
-        metrics.incr(
-            "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
-            amount=self.untainted,
-            tags={"tainted": False},
-            sample_rate=1.0,
-        )
-
 
 @sentry_sdk.trace
 def get_groups_to_fire(
@@ -890,7 +876,18 @@ def process_delayed_workflows(
         condition_group_results,
         dcg_to_slow_conditions,
     )
-    trigger_stats.report()
+    metrics.incr(
+        "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
+        amount=trigger_stats.tainted,
+        tags={"tainted": True},
+        sample_rate=1.0,
+    )
+    metrics.incr(
+        "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
+        amount=trigger_stats.untainted,
+        tags={"tainted": False},
+        sample_rate=1.0,
+    )
     logger.debug(
         "delayed_workflow.groups_to_fire",
         extra={

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -44,12 +44,13 @@ from sentry.workflow_engine.models.data_condition import (
     Condition,
 )
 from sentry.workflow_engine.processors.data_condition_group import (
+    TriggerResult,
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
 )
 from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
 logger = log_context.get_logger("sentry.workflow_engine.processors.delayed_workflow")
@@ -495,7 +496,7 @@ def _evaluate_group_result_for_dcg(
     group_id: GroupId,
     workflow_env: int | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
-) -> bool:
+) -> TriggerResult:
     slow_conditions = dcg_to_slow_conditions[dcg.id]
     try:
         return _group_result_for_dcg(
@@ -509,7 +510,7 @@ def _evaluate_group_result_for_dcg(
             sample_rate=1.0,
         )
         logger.warning("workflow_engine.delayed_workflow.missing_query_result", exc_info=True)
-        return False
+        return TriggerResult(triggered=False, error=ConditionError(msg="Missing query result"))
 
 
 def _group_result_for_dcg(
@@ -518,7 +519,7 @@ def _group_result_for_dcg(
     workflow_env: int | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     slow_conditions: list[DataCondition],
-) -> bool:
+) -> TriggerResult:
     conditions_to_evaluate: list[tuple[DataCondition, list[int | float]]] = []
     for condition in slow_conditions:
         query_values = []
@@ -532,7 +533,27 @@ def _group_result_for_dcg(
 
     return evaluate_data_conditions(
         conditions_to_evaluate, DataConditionGroup.Type(dcg.logic_type)
-    ).logic_result.triggered
+    ).logic_result
+
+
+@dataclass(frozen=True)
+class _ConditionEvaluationStats:
+    tainted: int
+    untainted: int
+
+    def report(self) -> None:
+        metrics.incr(
+            "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
+            amount=self.tainted,
+            tags={"tainted": True},
+            sample_rate=1.0,
+        )
+        metrics.incr(
+            "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
+            amount=self.untainted,
+            tags={"tainted": False},
+            sample_rate=1.0,
+        )
 
 
 @sentry_sdk.trace
@@ -542,10 +563,11 @@ def get_groups_to_fire(
     event_data: EventRedisData,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],
-) -> dict[GroupId, set[DataConditionGroup]]:
+) -> tuple[dict[GroupId, set[DataConditionGroup]], _ConditionEvaluationStats]:
     data_condition_group_mapping = {dcg.id: dcg for dcg in data_condition_groups}
     groups_to_fire: dict[GroupId, set[DataConditionGroup]] = defaultdict(set)
 
+    tainted, untainted = 0, 0
     for event_key in event_data.events:
         group_id = event_key.group_id
         if event_key.workflow_id not in workflows_to_envs:
@@ -553,36 +575,55 @@ def get_groups_to_fire(
             continue
 
         workflow_env = workflows_to_envs[event_key.workflow_id]
+        when_result = TriggerResult.TRUE
         if when_dcg_id := event_key.when_dcg_id:
-            if not (
-                dcg := data_condition_group_mapping.get(when_dcg_id)
-            ) or not _evaluate_group_result_for_dcg(
-                dcg,
+            when_dcg = data_condition_group_mapping.get(when_dcg_id)
+            if not when_dcg:
+                continue
+            when_result = _evaluate_group_result_for_dcg(
+                when_dcg,
                 dcg_to_slow_conditions,
                 group_id,
                 workflow_env,
                 condition_group_results,
-            ):
+            )
+            if not when_result.triggered:
+                # If we're not triggering, all action-y if conditions need to be treated
+                # as tainted or not based on the when condition result.
+                if_cond_count = len(event_key.if_dcg_ids) + len(event_key.passing_dcg_ids)
+                if when_result.is_tainted():
+                    tainted += if_cond_count
+                else:
+                    untainted += if_cond_count
                 continue
 
         # the WHEN condition passed / was not evaluated, so we can now check the IF conditions
         for if_dcg_id in event_key.if_dcg_ids:
-            if (
-                dcg := data_condition_group_mapping.get(if_dcg_id)
-            ) and _evaluate_group_result_for_dcg(
-                dcg,
-                dcg_to_slow_conditions,
-                group_id,
-                workflow_env,
-                condition_group_results,
-            ):
-                groups_to_fire[group_id].add(dcg)
+            if dcg := data_condition_group_mapping.get(if_dcg_id):
+                if_result = when_result & _evaluate_group_result_for_dcg(
+                    dcg,
+                    dcg_to_slow_conditions,
+                    group_id,
+                    workflow_env,
+                    condition_group_results,
+                )
+                if if_result.is_tainted():
+                    tainted += 1
+                else:
+                    untainted += 1
+                if if_result.triggered:
+                    groups_to_fire[group_id].add(dcg)
 
         for if_dcg_id in event_key.passing_dcg_ids:
             if dcg := data_condition_group_mapping.get(if_dcg_id):
+                # TODO: Propagate taint with passing conditions.
+                if when_result.is_tainted():
+                    tainted += 1
+                else:
+                    untainted += 1
                 groups_to_fire[group_id].add(dcg)
 
-    return groups_to_fire
+    return groups_to_fire, _ConditionEvaluationStats(tainted=tainted, untainted=untainted)
 
 
 @sentry_sdk.trace
@@ -842,13 +883,14 @@ def process_delayed_workflows(
     )
 
     # Evaluate DCGs
-    groups_to_dcgs = get_groups_to_fire(
+    groups_to_dcgs, trigger_stats = get_groups_to_fire(
         data_condition_groups,
         workflows_to_envs,
         event_data,
         condition_group_results,
         dcg_to_slow_conditions,
     )
+    trigger_stats.report()
     logger.debug(
         "delayed_workflow.groups_to_fire",
         extra={

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -723,7 +723,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         self.dcg_to_slow_conditions = get_slow_conditions_for_groups(list(self.event_data.dcg_ids))
 
     def test_simple(self) -> None:
-        result = get_groups_to_fire(
+        result, _ = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -749,7 +749,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.group1.id: existing_result[self.group1.id]
         }
 
-        result = get_groups_to_fire(
+        result, _ = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -773,7 +773,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             }
         )
 
-        result = get_groups_to_fire(
+        result, _ = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -795,7 +795,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             }
         )
 
-        result = get_groups_to_fire(
+        result, _ = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -823,7 +823,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             + [self.workflow2_if_dcgs[0]]
         )
 
-        result = get_groups_to_fire(
+        result, _ = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -841,7 +841,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
 
         self.workflows_to_envs = {self.workflow2.id: None}
 
-        result = get_groups_to_fire(
+        result, _ = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
             self.event_data,
@@ -851,6 +851,73 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
 
         # NOTE: same result as test_simple but without the deleted workflow
         assert result == {self.group2.id: {self.workflow2_if_dcgs[1]}}
+
+    def test_tainted_when_condition_doesnt_trigger(self) -> None:
+        query_for_when = UniqueConditionQuery(
+            handler=EventFrequencyQueryHandler,
+            interval="1h",
+            environment_id=self.environment.id,
+        )
+        self.condition_group_results[query_for_when] = {self.group2.id: 101}
+
+        result, stats = get_groups_to_fire(
+            self.data_condition_groups,
+            self.workflows_to_envs,
+            self.event_data,
+            self.condition_group_results,
+            self.dcg_to_slow_conditions,
+        )
+
+        assert result == {
+            self.group2.id: {self.workflow2_if_dcgs[1]},
+        }
+        assert stats.tainted == 2
+        assert stats.untainted == 2
+
+    def test_when_untainted_doesnt_trigger(self) -> None:
+        query_for_when = UniqueConditionQuery(
+            handler=EventFrequencyQueryHandler,
+            interval="1h",
+            environment_id=self.environment.id,
+        )
+        self.condition_group_results[query_for_when] = {self.group1.id: 99, self.group2.id: 101}
+
+        result, stats = get_groups_to_fire(
+            self.data_condition_groups,
+            self.workflows_to_envs,
+            self.event_data,
+            self.condition_group_results,
+            self.dcg_to_slow_conditions,
+        )
+
+        assert result == {
+            self.group2.id: {self.workflow2_if_dcgs[1]},
+        }
+        assert stats.tainted == 0
+        assert stats.untainted == 4
+
+    def test_tainted_if_condition_counts(self) -> None:
+        query_for_if = UniqueConditionQuery(
+            handler=EventUniqueUserFrequencyQueryHandler,
+            interval="1h",
+            environment_id=self.environment.id,
+        )
+        self.condition_group_results[query_for_if] = {self.group2.id: 101}
+
+        result, stats = get_groups_to_fire(
+            self.data_condition_groups,
+            self.workflows_to_envs,
+            self.event_data,
+            self.condition_group_results,
+            self.dcg_to_slow_conditions,
+        )
+
+        assert result == {
+            self.group1.id: {self.workflow1_if_dcgs[1]},
+            self.group2.id: {self.workflow2_if_dcgs[1]},
+        }
+        assert stats.tainted == 1
+        assert stats.untainted == 3
 
 
 class TestFireActionsForGroups(TestDelayedWorkflowBase):


### PR DESCRIPTION
delayed_workflow can fail to evaluate snuba queries and as a result potentially trigger incorrectly.
We already report this case, but only locally and without any reasonable way to assess the impact.

Extending the TriggerResult taint-tracking approach to delayed workflow condition evaluation allows us to start
tracking at least in terms of if-condition evaluations how many results are tainted vs not, giving us something much more user-relevant to alert on.

This should be refined further to be reported in terms of workflows and/or actions, but that's a follow-up.

Updates ACI-563.
