### PR TITLE
fix(dashboards): Hide group by option for series display Issue widgets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -656,4 +656,36 @@ describe('WidgetBuilderSlideout', () => {
 
     expect(screen.queryByLabelText('Add a search term')).not.toBeInTheDocument();
   });
+
+  it('should not show the group by selector if the widget is an issue and a chart display type', () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid={false}
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.SPANS,
+              displayType: DisplayType.LINE,
+            },
+          }),
+        }),
+        deprecatedRouterMocks: true,
+      }
+    );
+
+    expect(screen.queryByText('Group by')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -677,7 +677,7 @@ describe('WidgetBuilderSlideout', () => {
         router: RouterFixture({
           location: LocationFixture({
             query: {
-              dataset: WidgetType.SPANS,
+              dataset: WidgetType.ISSUE,
               displayType: DisplayType.LINE,
             },
           }),

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -129,6 +129,7 @@ function WidgetBuilderSlideout({
   const showQueryFilterBuilder = !(
     state.dataset === WidgetType.ISSUE && isChartDisplayType(state.displayType)
   );
+  const showGroupBySelector = isChartWidget && !(state.dataset === WidgetType.ISSUE);
 
   const customPreviewRef = useRef<HTMLDivElement>(null);
   const templatesPreviewRef = useRef<HTMLDivElement>(null);
@@ -368,7 +369,7 @@ function WidgetBuilderSlideout({
                   />
                 </Section>
               )}
-              {isChartWidget && (
+              {showGroupBySelector && (
                 <Section>
                   <WidgetBuilderGroupBySelector
                     validatedWidgetResponse={validatedWidgetResponse}


### PR DESCRIPTION
Timeseries Issue widgets don't support groupbys at the moment, so hide the selector from the widget builder.