### PR TITLE
feat(aci): Add error DetectorGroup chunked backfill task and method

### DIFF
--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -255,6 +255,11 @@ workflow_engine_tasks = app.taskregistry.create_namespace(
     app_feature="workflow_engine",
 )
 
+bulk_backfill_tasks = app.taskregistry.create_namespace(
+    "bulk_backfill",
+    app_feature="shared",
+)
+
 
 # Namespaces for testing taskworker tasks
 exampletasks = app.taskregistry.create_namespace(name="examples")

--- a/src/sentry/workflow_engine/processors/backfill.py
+++ b/src/sentry/workflow_engine/processors/backfill.py
@@ -1,0 +1,120 @@
+"""Backfill DetectorGroup associations for error detectors."""
+
+import logging
+from collections.abc import Iterator
+
+from django.db import connection
+from django.db.models import Exists, OuterRef
+
+from sentry.constants import ObjectStatus
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.group import Group, GroupStatus
+from sentry.models.project import Project
+from sentry.utils import metrics
+from sentry.utils.query import RangeQuerySetWrapper
+from sentry.workflow_engine.models import Detector, DetectorGroup
+
+logger = logging.getLogger(__name__)
+
+
+@metrics.timer("workflow_engine.error_backfill.duration")
+def backfill_detector_groups(detector_id: int) -> None:
+    """Create DetectorGroup associations for unresolved error groups in a detector's project."""
+    try:
+        detector = Detector.objects.get(id=detector_id)
+    except Detector.DoesNotExist:
+        logger.info(
+            "error_backfill.detector_not_found",
+            extra={"detector_id": detector_id},
+        )
+        return
+
+    project_id = detector.project_id
+
+    all_unresolved_groups = Group.objects.filter(
+        project_id=project_id,
+        status=GroupStatus.UNRESOLVED,
+        type=ErrorGroupType.type_id,
+    )
+
+    existing_detector_groups_subquery = DetectorGroup.objects.filter(
+        detector_id=detector_id, group_id=OuterRef("id")
+    )
+
+    groups_needing_detector_groups = all_unresolved_groups.exclude(
+        Exists(existing_detector_groups_subquery)
+    )
+
+    created_count = 0
+
+    for group in RangeQuerySetWrapper(groups_needing_detector_groups):
+        detector_group, created = DetectorGroup.objects.get_or_create(
+            detector_id=detector_id,
+            group_id=group.id,
+        )
+        if created:
+            detector_group.date_added = group.first_seen
+            detector_group.save(update_fields=["date_added"])
+            created_count += 1
+
+    metrics.incr("workflow_engine.error_backfill.groups_created", amount=created_count)
+
+    logger.info(
+        "error_backfill.completed",
+        extra={
+            "detector_id": detector_id,
+            "project_id": project_id,
+            "groups_created": created_count,
+        },
+    )
+
+
+def backfill_project_range(min_project_id: int, max_project_id: int) -> None:
+    """Backfill DetectorGroups for all active projects in the given ID range."""
+    projects = Project.objects.filter(
+        id__gte=min_project_id, id__lte=max_project_id, status=ObjectStatus.ACTIVE
+    )
+
+    for project in projects:
+        try:
+            detector = Detector.get_error_detector_for_project(project.id)
+        except Detector.DoesNotExist:
+            logger.warning(
+                "error_backfill.detector_not_found",
+                extra={"project_id": project.id},
+            )
+            metrics.incr("workflow_engine.error_backfill.detector_not_found")
+            continue
+
+        backfill_detector_groups(detector.id)
+        metrics.incr("workflow_engine.error_backfill.projects_processed", sample_rate=1.0)
+
+    logger.info(
+        "error_backfill.chunk_completed",
+        extra={
+            "min_project_id": min_project_id,
+            "max_project_id": max_project_id,
+        },
+    )
+
+
+def get_project_id_ranges_for_backfill(num_chunks: int) -> Iterator[tuple[int, int]]:
+    """Split active projects into roughly-equal ID ranges using NTILE for parallel processing."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            SELECT MIN(id) as min_id, MAX(id) as max_id
+            FROM (
+                SELECT id, NTILE(%s) OVER (ORDER BY id) as bucket
+                FROM {Project._meta.db_table}
+                WHERE status = %s
+            ) as projects_with_buckets
+            GROUP BY bucket
+            ORDER BY bucket
+            """,
+            [num_chunks, ObjectStatus.ACTIVE],
+        )
+
+        for row in cursor.fetchall():
+            min_id, max_id = row
+            yield (min_id, max_id)

--- a/src/sentry/workflow_engine/tasks/backfill.py
+++ b/src/sentry/workflow_engine/tasks/backfill.py
@@ -1,0 +1,23 @@
+"""Tasks for backfilling DetectorGroup associations for error detectors."""
+
+from typing import Any
+
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task, retry
+from sentry.taskworker.namespaces import bulk_backfill_tasks
+from sentry.taskworker.retry import Retry
+
+
+@instrumented_task(
+    name="sentry.workflow_engine.tasks.backfill_error_detector_groups",
+    namespace=bulk_backfill_tasks,
+    processing_deadline_duration=300,
+    silo_mode=SiloMode.REGION,
+    retry=Retry(times=3, delay=6),
+)
+@retry(timeouts=True)
+def backfill_error_detector_groups(min_project_id: int, max_project_id: int, **kwargs: Any) -> None:
+    """Backfill DetectorGroups for all active projects in the given ID range."""
+    from sentry.workflow_engine.processors.backfill import backfill_project_range
+
+    backfill_project_range(min_project_id, max_project_id)

--- a/tests/sentry/workflow_engine/processors/test_backfill.py
+++ b/tests/sentry/workflow_engine/processors/test_backfill.py
@@ -1,0 +1,259 @@
+from sentry.constants import ObjectStatus
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.issues.grouptype import PerformanceNPlusOneAPICallsGroupType
+from sentry.models.group import GroupStatus
+from sentry.models.project import Project
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.workflow_engine.models import Detector, DetectorGroup
+from sentry.workflow_engine.processors.backfill import (
+    backfill_detector_groups,
+    backfill_project_range,
+    get_project_id_ranges_for_backfill,
+)
+
+
+class BackfillDetectorGroupsTest(TestCase):
+    def test_backfills_unresolved_error_groups(self) -> None:
+
+        detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
+        group1 = self.create_group(project=self.project, type=ErrorGroupType.type_id)
+        group2 = self.create_group(project=self.project, type=ErrorGroupType.type_id)
+
+        # No DetectorGroups should exist yet
+        assert not DetectorGroup.objects.filter(detector=detector).exists()
+
+        backfill_detector_groups(detector.id)
+
+        # DetectorGroups should now exist for both groups
+        assert DetectorGroup.objects.filter(detector=detector, group=group1).exists()
+        assert DetectorGroup.objects.filter(detector=detector, group=group2).exists()
+        assert DetectorGroup.objects.filter(detector=detector).count() == 2
+
+    def test_skips_resolved_groups(self) -> None:
+
+        detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
+        unresolved_group = self.create_group(
+            project=self.project, type=ErrorGroupType.type_id, status=GroupStatus.UNRESOLVED
+        )
+        resolved_group = self.create_group(
+            project=self.project, type=ErrorGroupType.type_id, status=GroupStatus.RESOLVED
+        )
+
+        backfill_detector_groups(detector.id)
+
+        # Only unresolved group should have a DetectorGroup
+        assert DetectorGroup.objects.filter(detector=detector, group=unresolved_group).exists()
+        assert not DetectorGroup.objects.filter(detector=detector, group=resolved_group).exists()
+
+    def test_skips_non_error_groups(self) -> None:
+        detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
+        error_group = self.create_group(project=self.project, type=ErrorGroupType.type_id)
+        perf_group = self.create_group(
+            project=self.project, type=PerformanceNPlusOneAPICallsGroupType.type_id
+        )
+
+        backfill_detector_groups(detector.id)
+
+        # Only error group should have a DetectorGroup
+        assert DetectorGroup.objects.filter(detector=detector, group=error_group).exists()
+        assert not DetectorGroup.objects.filter(detector=detector, group=perf_group).exists()
+
+    def test_skips_existing_detector_groups(self) -> None:
+
+        detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
+        group = self.create_group(project=self.project, type=ErrorGroupType.type_id)
+
+        # Create existing DetectorGroup
+        DetectorGroup.objects.create(detector=detector, group=group)
+
+        backfill_detector_groups(detector.id)
+
+        # Should still only have one DetectorGroup
+        assert DetectorGroup.objects.filter(detector=detector, group=group).count() == 1
+
+    def test_sets_date_added_to_group_first_seen(self) -> None:
+
+        detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
+        first_seen = before_now(days=7)
+        group = self.create_group(
+            project=self.project, type=ErrorGroupType.type_id, first_seen=first_seen
+        )
+
+        backfill_detector_groups(detector.id)
+
+        detector_group = DetectorGroup.objects.get(detector=detector, group=group)
+        assert detector_group.date_added == first_seen
+
+    def test_handles_missing_detector(self) -> None:
+
+        # Should not raise an exception
+        backfill_detector_groups(999999)
+
+    def test_processes_multiple_groups(self) -> None:
+
+        detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
+
+        # Create multiple groups to ensure iteration works correctly
+        num_groups = 50
+        for _ in range(num_groups):
+            self.create_group(project=self.project, type=ErrorGroupType.type_id)
+
+        backfill_detector_groups(detector.id)
+
+        # All groups should have DetectorGroups
+        assert DetectorGroup.objects.filter(detector=detector).count() == num_groups
+
+
+class BackfillProjectRangeTest(TestCase):
+    def test_processes_projects_in_range(self) -> None:
+
+        # Create multiple projects with detectors
+        project1 = self.create_project()
+        project2 = self.create_project()
+        project3 = self.create_project()
+
+        # Create detectors for each project
+        detector1 = self.create_detector(project=project1, type=ErrorGroupType.slug)
+        detector2 = self.create_detector(project=project2, type=ErrorGroupType.slug)
+        detector3 = self.create_detector(project=project3, type=ErrorGroupType.slug)
+
+        # Create unresolved error groups for each
+        self.create_group(project=project1, type=ErrorGroupType.type_id)
+        self.create_group(project=project2, type=ErrorGroupType.type_id)
+        self.create_group(project=project3, type=ErrorGroupType.type_id)
+
+        min_id = min(project1.id, project2.id, project3.id)
+        max_id = max(project1.id, project2.id, project3.id)
+
+        backfill_project_range(min_id, max_id)
+
+        # Each project should have DetectorGroups
+        assert DetectorGroup.objects.filter(detector=detector1).exists()
+        assert DetectorGroup.objects.filter(detector=detector2).exists()
+        assert DetectorGroup.objects.filter(detector=detector3).exists()
+
+    def test_skips_projects_without_unresolved_groups(self) -> None:
+
+        project_with_groups = self.create_project()
+        project_without_groups = self.create_project()
+
+        # Create detector for project with groups
+        detector_with_groups = self.create_detector(
+            project=project_with_groups, type=ErrorGroupType.slug
+        )
+
+        # Only create groups for one project
+        self.create_group(project=project_with_groups, type=ErrorGroupType.type_id)
+
+        min_id = min(project_with_groups.id, project_without_groups.id)
+        max_id = max(project_with_groups.id, project_without_groups.id)
+
+        backfill_project_range(min_id, max_id)
+
+        # Only the project with groups should have DetectorGroups
+        assert DetectorGroup.objects.filter(detector=detector_with_groups).exists()
+
+    def test_skips_inactive_projects(self) -> None:
+
+        active_project = self.create_project()
+        inactive_project = self.create_project()
+        inactive_project.status = ObjectStatus.PENDING_DELETION
+        inactive_project.save()
+
+        # Create detector for active project
+        detector = self.create_detector(project=active_project, type=ErrorGroupType.slug)
+
+        # Create groups for both
+        self.create_group(project=active_project, type=ErrorGroupType.type_id)
+        self.create_group(project=inactive_project, type=ErrorGroupType.type_id)
+
+        min_id = min(active_project.id, inactive_project.id)
+        max_id = max(active_project.id, inactive_project.id)
+
+        backfill_project_range(min_id, max_id)
+
+        # Only active project should be processed
+        assert DetectorGroup.objects.filter(detector=detector).exists()
+
+    def test_skips_project_without_detector(self) -> None:
+
+        project = self.create_project()
+        self.create_group(project=project, type=ErrorGroupType.type_id)
+
+        # No detector should exist yet
+        assert not Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
+
+        backfill_project_range(project.id, project.id)
+
+        # Detector should still not exist (we don't create it)
+        assert not Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
+
+
+class GetProjectIdRangesForBackfillTest(TestCase):
+    def test_splits_projects_into_chunks(self) -> None:
+
+        # Create 10 active projects
+        for _ in range(10):
+            self.create_project()
+
+        num_chunks = 3
+        ranges = list(get_project_id_ranges_for_backfill(num_chunks))
+
+        # Should return 3 ranges
+        assert len(ranges) == num_chunks
+
+        # Each range should be a tuple of (min_id, max_id)
+        for min_id, max_id in ranges:
+            assert isinstance(min_id, int)
+            assert isinstance(max_id, int)
+            assert min_id <= max_id
+
+    def test_covers_all_active_projects(self) -> None:
+
+        # Create projects with varying statuses
+        active_projects = [self.create_project() for _ in range(5)]
+        inactive_project = self.create_project()
+        inactive_project.status = ObjectStatus.PENDING_DELETION
+        inactive_project.save()
+
+        ranges = list(get_project_id_ranges_for_backfill(num_chunks=2))
+
+        # Get all project IDs covered by ranges
+        covered_ids = set[int]()
+        for min_id, max_id in ranges:
+            covered_ids.update(range(min_id, max_id + 1))
+
+        # All active projects should be covered
+        for project in active_projects:
+            assert project.id in covered_ids
+
+        # Inactive project should not be covered
+        assert inactive_project.id not in covered_ids
+
+    def test_single_chunk_returns_one_range(self) -> None:
+
+        all_project_ids = [self.create_project().id for _ in range(5)]
+
+        ranges = list(get_project_id_ranges_for_backfill(num_chunks=1))
+
+        assert len(ranges) == 1
+        min_id, max_id = ranges[0]
+
+        # Should cover all project IDs
+        assert min_id == min(all_project_ids)
+        assert max_id == max(all_project_ids)
+
+    def test_handles_no_projects(self) -> None:
+        Project.objects.all().delete()
+
+        ranges = list(get_project_id_ranges_for_backfill(num_chunks=5))
+
+        assert len(ranges) == 0
+
+    def test_more_chunks_than_projects(self) -> None:
+        for _ in range(3):
+            self.create_project()
+
+        ranges = list(get_project_id_ranges_for_backfill(num_chunks=10))
+        assert len(ranges) == 3

--- a/tests/sentry/workflow_engine/tasks/test_backfill.py
+++ b/tests/sentry/workflow_engine/tasks/test_backfill.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import DetectorGroup
+from sentry.workflow_engine.tasks.backfill import backfill_error_detector_groups
+
+
+class BackfillErrorDetectorGroupsTest(TestCase):
+    @patch("sentry.workflow_engine.processors.backfill.backfill_project_range")
+    def test_calls_processor_function(self, mock_backfill: MagicMock) -> None:
+        min_id = 100
+        max_id = 200
+
+        backfill_error_detector_groups(min_id, max_id)
+
+        mock_backfill.assert_called_once_with(min_id, max_id)
+
+    def test_integration_processes_projects(self) -> None:
+        project1 = self.create_project()
+        project2 = self.create_project()
+
+        detector1 = self.create_detector(project=project1, type=ErrorGroupType.slug)
+        detector2 = self.create_detector(project=project2, type=ErrorGroupType.slug)
+
+        self.create_group(project=project1, type=ErrorGroupType.type_id)
+        self.create_group(project=project2, type=ErrorGroupType.type_id)
+
+        min_id = min(project1.id, project2.id)
+        max_id = max(project1.id, project2.id)
+
+        backfill_error_detector_groups(min_id, max_id)
+
+        assert DetectorGroup.objects.filter(detector=detector1).exists()
+        assert DetectorGroup.objects.filter(detector=detector2).exists()


### PR DESCRIPTION
The existing DetectorGroup backfill job is impractically slow.
This adds a function (intended to be triggered by a job) to produce roughly equal ranges of IDs in the Projects table, which then will be used to trigger a new task that backfills the projects in that range.

This distributes all of the slow bits into chunks we can control the size of, and the processing pool used to execute them can be gradually dialed up as we gain confidence in correctness and capacity cost.
The expectation is that this should allow backfill to finish completely in a day or so without blocking any jobs or hand-holding.