### PR TITLE
ref(top-issues): ui touchup for aggregate stats

### DIFF
--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -26,7 +26,9 @@ import Redirect from 'sentry/components/redirect';
 import TimeSince from 'sentry/components/timeSince';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {
+  IconCalendar,
   IconChevron,
+  IconClock,
   IconClose,
   IconCopy,
   IconFire,
@@ -394,51 +396,45 @@ function ClusterCard({
       </CardHeader>
 
       {/* Zone 2: Stats (Secondary Context) */}
-      <StatsSection>
-        <PrimaryStats>
-          <EventsMetric>
-            <IconFire size="sm" />
-            {clusterStats.isPending ? (
-              <Text size="md" variant="muted">
-                –
-              </Text>
-            ) : (
-              <EventsCount>{clusterStats.totalEvents.toLocaleString()}</EventsCount>
-            )}
-            <Text size="sm" variant="muted">
+      <ClusterStatsBar>
+        <StatItem>
+          <IconFire size="xs" color="gray300" />
+          {clusterStats.isPending ? (
+            <Text size="xs" variant="muted">
+              –
+            </Text>
+          ) : (
+            <Text size="xs">
+              <Text size="xs" bold as="span">
+                {clusterStats.totalEvents.toLocaleString()}
+              </Text>{' '}
               {tn('event', 'events', clusterStats.totalEvents)}
             </Text>
-          </EventsMetric>
-        </PrimaryStats>
-        <SecondaryStats>
-          {!clusterStats.isPending && clusterStats.lastSeen && (
-            <SecondaryStatItem>
-              <Text size="xs" variant="muted">
-                {t('Last seen')}
-              </Text>
-              <TimeSince
-                tooltipPrefix={t('Last Seen')}
-                date={clusterStats.lastSeen}
-                suffix={t('ago')}
-                unitStyle="short"
-              />
-            </SecondaryStatItem>
           )}
-          {!clusterStats.isPending && clusterStats.firstSeen && (
-            <SecondaryStatItem>
-              <Text size="xs" variant="muted">
-                {t('Age')}
-              </Text>
-              <TimeSince
-                tooltipPrefix={t('First Seen')}
-                date={clusterStats.firstSeen}
-                suffix={t('old')}
-                unitStyle="short"
-              />
-            </SecondaryStatItem>
-          )}
-        </SecondaryStats>
-      </StatsSection>
+        </StatItem>
+        {!clusterStats.isPending && clusterStats.lastSeen && (
+          <StatItem>
+            <IconClock size="xs" color="gray300" />
+            <TimeSince
+              tooltipPrefix={t('Last Seen')}
+              date={clusterStats.lastSeen}
+              suffix={t('ago')}
+              unitStyle="short"
+            />
+          </StatItem>
+        )}
+        {!clusterStats.isPending && clusterStats.firstSeen && (
+          <StatItem>
+            <IconCalendar size="xs" color="gray300" />
+            <TimeSince
+              tooltipPrefix={t('First Seen')}
+              date={clusterStats.firstSeen}
+              suffix={t('old')}
+              unitStyle="short"
+            />
+          </StatItem>
+        )}
+      </ClusterStatsBar>
 
       {/* Zone 3: Nested Issues (Detail Content) */}
       <IssuesSection>
@@ -1023,50 +1019,23 @@ const ClusterTitle = styled('h3')`
   word-break: break-word;
 `;
 
-// Zone 2: Stats section with visual hierarchy
-const StatsSection = styled('div')`
-  padding: ${space(2)} ${space(3)};
-  background: ${p => p.theme.backgroundSecondary};
-  border-top: 1px solid ${p => p.theme.innerBorder};
-  border-bottom: 1px solid ${p => p.theme.innerBorder};
+// Horizontal stats bar below header
+const ClusterStatsBar = styled('div')`
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
   align-items: center;
   gap: ${space(2)};
-  flex-wrap: wrap;
-`;
-
-const PrimaryStats = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(3)};
-`;
-
-const EventsMetric = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(1)};
-  color: ${p => p.theme.red300};
-`;
-
-const EventsCount = styled('span')`
-  font-size: ${p => p.theme.fontSize.xl};
-  font-weight: 700;
-  color: ${p => p.theme.textColor};
-  font-variant-numeric: tabular-nums;
-`;
-
-const SecondaryStats = styled('div')`
-  display: flex;
-  gap: ${space(3)};
-`;
-
-const SecondaryStatItem = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(0.25)};
+  padding: ${space(1.5)} ${space(3)};
+  border-top: 1px solid ${p => p.theme.innerBorder};
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
   font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.subText};
+`;
+
+const StatItem = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;
 
 // Zone 3: Issues list with clear containment


### PR DESCRIPTION
Back to the chips for aggregate stats
<img width="506" height="41" alt="Screenshot 2025-12-04 at 1 40 27 PM" src="https://github.com/user-attachments/assets/86722108-bf9c-45e9-a4c6-c2c12302412d" />
