### PR TITLE
feat(sdk): Enable Django SQL transaction spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "sentry-protos>=0.4.7",
     "sentry-redis-tools>=0.5.0",
     "sentry-relay>=0.9.22",
-    "sentry-sdk[http2]>=2.43.0",
+    "sentry-sdk[http2]>=2.47.0",
     "sentry-usage-accountant>=0.0.10",
     # remove once there are no unmarked transitive dependencies on setuptools
     "setuptools>=70.0.0",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -482,7 +482,12 @@ def configure_sdk():
         transport=MultiplexingTransport(),
         integrations=[
             DjangoAtomicIntegration(),
-            DjangoIntegration(signals_spans=False, cache_spans=True, middleware_spans=False),
+            DjangoIntegration(
+                signals_spans=False,
+                cache_spans=True,
+                middleware_spans=False,
+                db_transaction_spans=True,
+            ),
             # This makes it so all levels of logging are recorded as breadcrumbs,
             # but none are captured as events (that's handled by the `internal`
             # logger defined in `server.py`, which ignores the levels set

--- a/uv.lock
+++ b/uv.lock
@@ -2199,7 +2199,7 @@ requires-dist = [
     { name = "sentry-protos", specifier = ">=0.4.7" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.22" },
-    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.43.0" },
+    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.47.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "simplejson", specifier = ">=3.17.6" },
@@ -2438,14 +2438,14 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.43.0"
+version = "2.47.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.43.0-py2.py3-none-any.whl", hash = "sha256:4aacafcf1756ef066d359ae35030881917160ba7f6fc3ae11e0e58b09edc2d5d" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.47.0-py2.py3-none-any.whl", hash = "sha256:d72f8c61025b7d1d9e52510d03a6247b280094a327dd900d987717a4fce93412" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Upgrade the Python SDK version and enable new instrumentation for database transactions issued through Django's ORM.
