### PR TITLE
feat(ai-insights): move analytics event to event timeseries

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -7,8 +7,7 @@ from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
-from sentry.analytics.events.agent_monitoring_events import AgentMonitoringQuery
+from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
@@ -156,17 +155,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
 
             if referrer in SENTRY_BACKEND_REFERRERS:
                 query_source = QuerySource.SENTRY_BACKEND
-
-            if "agent-monitoring" in referrer:
-                try:
-                    analytics.record(
-                        AgentMonitoringQuery(
-                            organization_id=organization.id,
-                            referrer=referrer,
-                        )
-                    )
-                except Exception as e:
-                    sentry_sdk.capture_exception(e)
 
             batch_features = self.get_features(organization, request)
             use_metrics = (


### PR DESCRIPTION
Moved the analytics even from /events-stats/ to /events-timeseries/ since the AI insights dashboard uses the new endpoint now