### PR TITLE
fix(issue-details): Always attach lineno to Java frames in 'raw' view

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
@@ -419,7 +419,7 @@ Error: an error occurred`
     it('renders java example', () => {
       expect(displayRawContent({data, platform: 'java', exception})).toBe(
         `example.application.Error: an error occurred
-    at example.application.doThing3
+    at example.application.doThing3(:12)
     at example.application.(src/application.code:1)
     at doThing1(src/application.code:5)
     at example.application.main(src/application.code:1)`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.tsx
@@ -111,6 +111,8 @@ export function getJavaFrame(frame: Frame, includeLocation: boolean): string {
       result += ':' + frame.lineNo;
     }
     result += ')';
+  } else if (defined(frame.lineNo) && frame.lineNo >= 0 && includeLocation) {
+    result += '(:' + frame.lineNo + ')';
   }
   return result;
 }


### PR DESCRIPTION
It's useful to display lineno for Java frames even if there's no filename, because retracing tools can retrace stacktrace purely relying on line numbers.

### Before
<img width="1067" height="493" alt="image" src="https://github.com/user-attachments/assets/425b4fb3-3f6d-4915-b5c9-a73beca59e24" />


## After

<img width="1091" height="469" alt="Google Chrome 2025-12-04 12 43 09" src="https://github.com/user-attachments/assets/78eab639-6527-44cf-964a-70e8fa87a28f" />

Now this output can actually be plain copy-pasted into another retrace tool and successfully remap back to the original stacktrace