### PR TITLE
fix(ui): fallback selector for compactSelect boundary

### DIFF
--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -298,7 +298,10 @@ export function Control({
     preventOverflowOptions: {
       ...preventOverflowOptions,
       boundary:
-        preventOverflowOptions?.boundary ?? document.querySelector('main') ?? undefined,
+        preventOverflowOptions?.boundary ??
+        document.querySelector('main') ??
+        document.getElementById('main') ??
+        undefined,
     },
     flipOptions,
     strategy,


### PR DESCRIPTION
not all pages have a `main` section, but most have a div with id="main", which we can query as a fallback
