### PR TITLE
deps(ui): upgrade to react 19.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
     "@types/lodash": "^4.14.182",
     "@types/papaparse": "^5.3.5",
     "@types/prismjs": "^1.26.0",
-    "@types/react": "19.2.0",
+    "@types/react": "19.2.1",
     "@types/react-date-range": "^1.4.4",
-    "@types/react-dom": "19.2.0",
+    "@types/react-dom": "19.2.1",
     "@types/react-grid-layout": "^1.3.2",
     "@types/react-lazyload": "3.2.3",
     "@types/react-mentions": "4.1.13",
@@ -153,10 +153,10 @@
     "process": "^0.11.10",
     "qrcode.react": "^3.1.0",
     "query-string": "7.0.1",
-    "react": "19.2.0",
+    "react": "19.2.1",
     "react-date-range": "^1.4.0",
     "react-docgen-typescript": "^2.2.2",
-    "react-dom": "19.2.0",
+    "react-dom": "19.2.1",
     "react-grid-layout": "^1.3.4",
     "react-lazyload": "^3.2.1",
     "react-mentions": "4.4.10",
@@ -234,7 +234,7 @@
   "pnpm": {
     "overrides": {
       "react-mentions>@babel/runtime": "7.26.10",
-      "react-is": "19.2.0"
+      "react-is": "19.2.1"
     },
     "onlyBuiltDependencies": [
       "@sentry-internal/node-cpu-profiler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   react-mentions>@babel/runtime: 7.26.10
-  react-is: 19.2.0
+  react-is: 19.2.1
 
 importers:
 
@@ -29,13 +29,13 @@ importers:
         version: 7.27.1(@babel/core@7.28.0)
       '@dnd-kit/core':
         specifier: ^6.1.0
-        version: 6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 6.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@dnd-kit/sortable':
         specifier: ^8.0.0
-        version: 8.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 8.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@dnd-kit/utilities':
         specifier: ^3.2.2
-        version: 3.2.2(react@19.2.0)
+        version: 3.2.2(react@19.2.1)
       '@emotion/babel-plugin':
         specifier: ^11.13.5
         version: 11.13.5
@@ -50,10 +50,10 @@ importers:
         version: 1.3.1
       '@emotion/react':
         specifier: ^11.14.0
-        version: 11.14.0(@types/react@19.2.0)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.1)(react@19.2.1)
       '@emotion/styled':
         specifier: ^11.14.0
-        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.2.0)(react@19.2.0))(@types/react@19.2.0)(react@19.2.0)
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.2.1)(react@19.2.1))(@types/react@19.2.1)(react@19.2.1)
       '@mdx-js/loader':
         specifier: ^3.1.0
         version: 3.1.0(acorn@8.15.0)(webpack@5.99.6(esbuild@0.25.10))
@@ -68,103 +68,103 @@ importers:
         version: 0.6.2
       '@react-aria/button':
         specifier: 3.14.0
-        version: 3.14.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.14.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/combobox':
         specifier: 3.13.0
-        version: 3.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.13.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/disclosure':
         specifier: 3.0.7
-        version: 3.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/focus':
         specifier: 3.21.0
-        version: 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/gridlist':
         specifier: 3.13.3
-        version: 3.13.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.13.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/i18n':
         specifier: 3.12.11
-        version: 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/interactions':
         specifier: 3.25.4
-        version: 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/listbox':
         specifier: 3.14.7
-        version: 3.14.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.14.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/live-announcer':
         specifier: 3.4.4
         version: 3.4.4
       '@react-aria/menu':
         specifier: 3.19.0
-        version: 3.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.19.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/numberfield':
         specifier: 3.12.0
-        version: 3.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/overlays':
         specifier: 3.28.0
-        version: 3.28.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.28.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/radio':
         specifier: 3.12.0
-        version: 3.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/selection':
         specifier: 3.25.0
-        version: 3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/separator':
         specifier: 3.4.11
-        version: 3.4.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.4.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/slider':
         specifier: 3.8.0
-        version: 3.8.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.8.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/tabs':
         specifier: 3.10.6
-        version: 3.10.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.10.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/textfield':
         specifier: 3.18.0
-        version: 3.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.18.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/utils':
         specifier: 3.30.0
-        version: 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/visually-hidden':
         specifier: 3.8.26
-        version: 3.8.26(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.8.26(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-google-maps/api':
         specifier: ^2.12.0
-        version: 2.20.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 2.20.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-stately/collections':
         specifier: 3.12.6
-        version: 3.12.6(react@19.2.0)
+        version: 3.12.6(react@19.2.1)
       '@react-stately/combobox':
         specifier: 3.11.0
-        version: 3.11.0(react@19.2.0)
+        version: 3.11.0(react@19.2.1)
       '@react-stately/disclosure':
         specifier: 3.0.6
-        version: 3.0.6(react@19.2.0)
+        version: 3.0.6(react@19.2.1)
       '@react-stately/form':
         specifier: 3.2.0
-        version: 3.2.0(react@19.2.0)
+        version: 3.2.0(react@19.2.1)
       '@react-stately/list':
         specifier: 3.12.4
-        version: 3.12.4(react@19.2.0)
+        version: 3.12.4(react@19.2.1)
       '@react-stately/numberfield':
         specifier: 3.10.0
-        version: 3.10.0(react@19.2.0)
+        version: 3.10.0(react@19.2.1)
       '@react-stately/overlays':
         specifier: 3.6.18
-        version: 3.6.18(react@19.2.0)
+        version: 3.6.18(react@19.2.1)
       '@react-stately/radio':
         specifier: 3.11.0
-        version: 3.11.0(react@19.2.0)
+        version: 3.11.0(react@19.2.1)
       '@react-stately/slider':
         specifier: 3.7.0
-        version: 3.7.0(react@19.2.0)
+        version: 3.7.0(react@19.2.1)
       '@react-stately/tabs':
         specifier: 3.8.4
-        version: 3.8.4(react@19.2.0)
+        version: 3.8.4(react@19.2.1)
       '@react-stately/tree':
         specifier: 3.9.1
-        version: 3.9.1(react@19.2.0)
+        version: 3.9.1(react@19.2.1)
       '@react-types/shared':
         specifier: 3.31.0
-        version: 3.31.0(react@19.2.0)
+        version: 3.31.0(react@19.2.1)
       '@remix-run/router':
         specifier: 1.23.0
         version: 1.23.0
@@ -182,7 +182,7 @@ importers:
         version: 1.5.1(react-refresh@0.18.0)
       '@sentry-internal/global-search':
         specifier: ^1.0.0
-        version: 1.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@sentry-internal/rrweb':
         specifier: 2.40.0
         version: 2.40.0
@@ -200,7 +200,7 @@ importers:
         version: 10.27.0
       '@sentry/react':
         specifier: 10.27.0
-        version: 10.27.0(react@19.2.0)
+        version: 10.27.0(react@19.2.1)
       '@sentry/release-parser':
         specifier: ^1.3.1
         version: 1.3.1
@@ -209,13 +209,13 @@ importers:
         version: 0.6.1
       '@sentry/toolbar':
         specifier: 1.0.0-beta.16
-        version: 1.0.0-beta.16(react@19.2.0)
+        version: 1.0.0-beta.16(react@19.2.1)
       '@sentry/webpack-plugin':
         specifier: 4.6.1
         version: 4.6.1(encoding@0.1.13)(webpack@5.99.6(esbuild@0.25.10))
       '@stripe/react-stripe-js':
         specifier: ^3.9.2
-        version: 3.9.2(@stripe/stripe-js@5.10.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.9.2(@stripe/stripe-js@5.10.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@stripe/stripe-js':
         specifier: ^5.10.0
         version: 5.10.0
@@ -227,19 +227,19 @@ importers:
         version: 5.83.1
       '@tanstack/react-pacer':
         specifier: ^0.17.0
-        version: 0.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 0.17.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query':
         specifier: 5.85.0
-        version: 5.85.0(react@19.2.0)
+        version: 5.85.0(react@19.2.1)
       '@tanstack/react-query-devtools':
         specifier: 5.85.0
-        version: 5.85.0(@tanstack/react-query@5.85.0(react@19.2.0))(react@19.2.0)
+        version: 5.85.0(@tanstack/react-query@5.85.0(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query-persist-client':
         specifier: 5.85.0
-        version: 5.85.0(@tanstack/react-query@5.85.0(react@19.2.0))(react@19.2.0)
+        version: 5.85.0(@tanstack/react-query@5.85.0(react@19.2.1))(react@19.2.1)
       '@tanstack/react-virtual':
         specifier: ^3.13.6
-        version: 3.13.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.13.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/gtag.js':
         specifier: ^0.0.12
         version: 0.0.12
@@ -268,14 +268,14 @@ importers:
         specifier: ^1.26.0
         version: 1.26.0
       '@types/react':
-        specifier: 19.2.0
-        version: 19.2.0
+        specifier: 19.2.1
+        version: 19.2.1
       '@types/react-date-range':
         specifier: ^1.4.4
         version: 1.4.4
       '@types/react-dom':
-        specifier: 19.2.0
-        version: 19.2.0(@types/react@19.2.0)
+        specifier: 19.2.1
+        version: 19.2.1(@types/react@19.2.1)
       '@types/react-grid-layout':
         specifier: ^1.3.2
         version: 1.3.2
@@ -302,7 +302,7 @@ importers:
         version: 1.18.8
       ansi-to-react:
         specifier: ^6.1.6
-        version: 6.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 6.1.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       base64-arraybuffer:
         specifier: ^1.0.1
         version: 1.0.2
@@ -323,7 +323,7 @@ importers:
         version: 11.1.0(webpack@5.99.6(esbuild@0.25.10))
       conduit-client:
         specifier: ^1.0.0
-        version: 1.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       core-js:
         specifier: 3.45.0
         version: 3.45.0
@@ -347,7 +347,7 @@ importers:
         version: 6.0.0
       echarts-for-react:
         specifier: 3.0.5
-        version: 3.0.5(echarts@6.0.0)(react@19.2.0)
+        version: 3.0.5(echarts@6.0.0)(react@19.2.1)
       esbuild:
         specifier: 0.25.10
         version: 0.25.10
@@ -356,7 +356,7 @@ importers:
         version: 7.6.5
       framer-motion:
         specifier: 12.23.12
-        version: 12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       fuse.js:
         specifier: ^6.6.2
         version: 6.6.2
@@ -410,7 +410,7 @@ importers:
         version: 6.13.7
       mobx-react-lite:
         specifier: 4.1.0
-        version: 4.1.0(mobx@6.13.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.1.0(mobx@6.13.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       mockdate:
         specifier: 3.0.5
         version: 3.0.5
@@ -419,7 +419,7 @@ importers:
         version: 0.6.0
       nuqs:
         specifier: 2.7.1
-        version: 2.7.1(react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-router@6.30.1(react@19.2.0))(react@19.2.0)
+        version: 2.7.1(react-router-dom@6.30.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@6.30.1(react@19.2.1))(react@19.2.1)
       papaparse:
         specifier: ^5.3.2
         version: 5.3.2
@@ -428,7 +428,7 @@ importers:
         version: 4.1.1
       platformicons:
         specifier: ^8.0.9
-        version: 8.0.9(react@19.2.0)
+        version: 8.0.9(react@19.2.1)
       po-catalog-loader:
         specifier: 2.1.0
         version: 2.1.0(gettext-parser@7.0.1)
@@ -443,49 +443,49 @@ importers:
         version: 0.11.10
       qrcode.react:
         specifier: ^3.1.0
-        version: 3.1.0(react@19.2.0)
+        version: 3.1.0(react@19.2.1)
       query-string:
         specifier: 7.0.1
         version: 7.0.1
       react:
-        specifier: 19.2.0
-        version: 19.2.0
+        specifier: 19.2.1
+        version: 19.2.1
       react-date-range:
         specifier: ^1.4.0
-        version: 1.4.0(date-fns@2.17.0)(react@19.2.0)
+        version: 1.4.0(date-fns@2.17.0)(react@19.2.1)
       react-docgen-typescript:
         specifier: ^2.2.2
         version: 2.2.2(typescript@5.9.2)
       react-dom:
-        specifier: 19.2.0
-        version: 19.2.0(react@19.2.0)
+        specifier: 19.2.1
+        version: 19.2.1(react@19.2.1)
       react-grid-layout:
         specifier: ^1.3.4
-        version: 1.3.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.3.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-lazyload:
         specifier: ^3.2.1
-        version: 3.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.2.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-mentions:
         specifier: 4.4.10
-        version: 4.4.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.4.10(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-popper:
         specifier: ^2.3.0
-        version: 2.3.0(@popperjs/core@2.11.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 2.3.0(@popperjs/core@2.11.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-router-dom:
         specifier: 6.30.1
-        version: 6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 6.30.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-select:
         specifier: 4.3.1
-        version: 4.3.1(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.3.1(@types/react@19.2.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-textarea-autosize:
         specifier: 8.5.7
-        version: 8.5.7(@types/react@19.2.0)(react@19.2.0)
+        version: 8.5.7(@types/react@19.2.1)(react@19.2.1)
       react-virtualized:
         specifier: ^9.22.6
-        version: 9.22.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 9.22.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       reflux:
         specifier: 0.4.1
-        version: 0.4.1(react@19.2.0)
+        version: 0.4.1(react@19.2.1)
       rehype-expressive-code:
         specifier: ^0.41.2
         version: 0.41.2
@@ -570,7 +570,7 @@ importers:
         version: 6.6.3
       '@testing-library/react':
         specifier: 16.2.0
-        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.1(@types/react@19.2.1))(@types/react@19.2.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -3631,8 +3631,8 @@ packages:
   '@types/react-date-range@1.4.4':
     resolution: {integrity: sha512-9Y9NyNgaCsEVN/+O4HKuxzPbVjRVBGdOKRxMDcsTRWVG62lpYgnxefNckTXDWup8FvczoqPW0+ESZR6R1yymDg==}
 
-  '@types/react-dom@19.2.0':
-    resolution: {integrity: sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==}
+  '@types/react-dom@19.2.1':
+    resolution: {integrity: sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==}
     peerDependencies:
       '@types/react': ^19.2.0
 
@@ -3654,8 +3654,8 @@ packages:
   '@types/react-virtualized@9.22.0':
     resolution: {integrity: sha512-JL/YCCFZ123za//cj10Apk54F0UGFMrjOE0QHTuXt1KBMFrzLOGv9/x6Uc/pZ0Gaf4o6w61Fostvlw0DwuPXig==}
 
-  '@types/react@19.2.0':
-    resolution: {integrity: sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==}
+  '@types/react@19.2.1':
+    resolution: {integrity: sha512-1U5NQWh/GylZQ50ZMnnPjkYHEaGhg6t5i/KI0LDDh3t4E3h3T3vzm+GLY2BRzMfIjSBwzm6tginoZl5z0O/qsA==}
 
   '@types/readable-stream@4.0.18':
     resolution: {integrity: sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==}
@@ -7440,10 +7440,10 @@ packages:
     peerDependencies:
       typescript: '>= 4.3.x'
 
-  react-dom@19.2.0:
-    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+  react-dom@19.2.1:
+    resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
     peerDependencies:
-      react: ^19.2.0
+      react: ^19.2.1
 
   react-draggable@4.4.4:
     resolution: {integrity: sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==}
@@ -7465,8 +7465,8 @@ packages:
     peerDependencies:
       react: ^16.3.0 || ^17.0.0
 
-  react-is@19.2.0:
-    resolution: {integrity: sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==}
+  react-is@19.2.1:
+    resolution: {integrity: sha512-L7BnWgRbMwzMAubQcS7sXdPdNLmKlucPlopgAzx7FtYbksWZgEWiuYM5x9T6UqS2Ne0rsgQTq5kY2SGqpzUkYA==}
 
   react-lazyload@3.2.1:
     resolution: {integrity: sha512-oDLlLOI/rRLY0fUh/HYFCy4CqCe7zdJXv6oTl2pC30tN3ezWxvwcdHYfD/ZkrGOMOOT5pO7hNLSvg7WsmAij1w==}
@@ -7541,8 +7541,8 @@ packages:
       react: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react@19.2.0:
-    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+  react@19.2.1:
+    resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
 
   read-package-json-fast@3.0.2:
@@ -9918,29 +9918,29 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@dnd-kit/accessibility@3.1.0(react@19.2.0)':
+  '@dnd-kit/accessibility@3.1.0(react@19.2.1)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
       tslib: 2.8.1
 
-  '@dnd-kit/core@6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@dnd-kit/core@6.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@dnd-kit/accessibility': 3.1.0(react@19.2.0)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@dnd-kit/accessibility': 3.1.0(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
       tslib: 2.8.1
 
-  '@dnd-kit/sortable@8.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@dnd-kit/sortable@8.0.0(@dnd-kit/core@6.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@dnd-kit/core': 6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.0)
-      react: 19.2.0
+      '@dnd-kit/core': 6.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
       tslib: 2.8.1
 
-  '@dnd-kit/utilities@3.2.2(react@19.2.0)':
+  '@dnd-kit/utilities@3.2.2(react@19.2.1)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
       tslib: 2.8.1
 
   '@dual-bundle/import-meta-resolve@4.1.0': {}
@@ -10053,19 +10053,19 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.0)(react@19.2.0)':
+  '@emotion/react@11.14.0(@types/react@19.2.1)(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.1)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
-      react: 19.2.0
+      react: 19.2.1
     optionalDependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10079,26 +10079,26 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.0)(react@19.2.0))(@types/react@19.2.0)(react@19.2.0)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.1)(react@19.2.1))(@types/react@19.2.1)(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
-      '@emotion/react': 11.14.0(@types/react@19.2.0)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.1)(react@19.2.1)
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.1)
       '@emotion/utils': 1.4.2
-      react: 19.2.0
+      react: 19.2.1
     optionalDependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
     transitivePeerDependencies:
       - supports-color
 
   '@emotion/unitless@0.10.0': {}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.0)':
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.1)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
 
   '@emotion/utils@1.4.2': {}
 
@@ -11234,324 +11234,324 @@ snapshots:
       defu: 6.1.4
       unist-util-visit: 5.0.0
 
-  '@react-aria/button@3.14.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/button@3.14.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/toolbar': 3.0.0-beta.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/toggle': 3.9.0(react@19.2.0)
-      '@react-types/button': 3.13.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/toolbar': 3.0.0-beta.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/toggle': 3.9.0(react@19.2.1)
+      '@react-types/button': 3.13.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/combobox@3.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/combobox@3.13.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/listbox': 3.14.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/listbox': 3.14.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/live-announcer': 3.4.4
-      '@react-aria/menu': 3.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/overlays': 3.28.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/selection': 3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/textfield': 3.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/combobox': 3.11.0(react@19.2.0)
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-types/button': 3.13.0(react@19.2.0)
-      '@react-types/combobox': 3.13.7(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/menu': 3.19.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/overlays': 3.28.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/selection': 3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/textfield': 3.18.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/combobox': 3.11.0(react@19.2.1)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-types/button': 3.13.0(react@19.2.1)
+      '@react-types/combobox': 3.13.7(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/disclosure@3.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/disclosure@3.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/ssr': 3.9.10(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/disclosure': 3.0.6(react@19.2.0)
-      '@react-types/button': 3.13.0(react@19.2.0)
+      '@react-aria/ssr': 3.9.10(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/disclosure': 3.0.6(react@19.2.1)
+      '@react-types/button': 3.13.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/focus@3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/focus@3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
       clsx: 2.1.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/form@3.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/form@3.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/grid@3.14.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/grid@3.14.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/live-announcer': 3.4.4
-      '@react-aria/selection': 3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/grid': 3.11.4(react@19.2.0)
-      '@react-stately/selection': 3.20.4(react@19.2.0)
-      '@react-types/checkbox': 3.10.0(react@19.2.0)
-      '@react-types/grid': 3.3.4(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/selection': 3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/grid': 3.11.4(react@19.2.1)
+      '@react-stately/selection': 3.20.4(react@19.2.1)
+      '@react-types/checkbox': 3.10.0(react@19.2.1)
+      '@react-types/grid': 3.3.4(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/gridlist@3.13.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/gridlist@3.13.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/grid': 3.14.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/selection': 3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/list': 3.12.4(react@19.2.0)
-      '@react-stately/tree': 3.9.1(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/grid': 3.14.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/selection': 3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/list': 3.12.4(react@19.2.1)
+      '@react-stately/tree': 3.9.1(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/i18n@3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/i18n@3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@internationalized/date': 3.8.2
       '@internationalized/message': 3.1.8
       '@internationalized/number': 3.6.4
       '@internationalized/string': 3.2.7
-      '@react-aria/ssr': 3.9.10(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/ssr': 3.9.10(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/interactions@3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/interactions@3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/ssr': 3.9.10(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-aria/ssr': 3.9.10(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-stately/flags': 3.1.2
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/label@3.7.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/label@3.7.20(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/listbox@3.14.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/listbox@3.14.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/label': 3.7.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/selection': 3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/list': 3.12.4(react@19.2.0)
-      '@react-types/listbox': 3.7.2(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/label': 3.7.20(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/selection': 3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/list': 3.12.4(react@19.2.1)
+      '@react-types/listbox': 3.7.2(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   '@react-aria/live-announcer@3.4.4':
     dependencies:
       '@swc/helpers': 0.5.15
 
-  '@react-aria/menu@3.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/menu@3.19.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/overlays': 3.28.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/selection': 3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/menu': 3.9.6(react@19.2.0)
-      '@react-stately/selection': 3.20.4(react@19.2.0)
-      '@react-stately/tree': 3.9.1(react@19.2.0)
-      '@react-types/button': 3.13.0(react@19.2.0)
-      '@react-types/menu': 3.10.3(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/overlays': 3.28.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/selection': 3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/menu': 3.9.6(react@19.2.1)
+      '@react-stately/selection': 3.20.4(react@19.2.1)
+      '@react-stately/tree': 3.9.1(react@19.2.1)
+      '@react-types/button': 3.13.0(react@19.2.1)
+      '@react-types/menu': 3.10.3(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/numberfield@3.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/numberfield@3.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/spinbutton': 3.6.17(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/textfield': 3.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-stately/numberfield': 3.10.0(react@19.2.0)
-      '@react-types/button': 3.13.0(react@19.2.0)
-      '@react-types/numberfield': 3.8.13(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/spinbutton': 3.6.17(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/textfield': 3.18.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-stately/numberfield': 3.10.0(react@19.2.1)
+      '@react-types/button': 3.13.0(react@19.2.1)
+      '@react-types/numberfield': 3.8.13(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/overlays@3.28.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/overlays@3.28.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/ssr': 3.9.10(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/visually-hidden': 3.8.26(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/overlays': 3.6.18(react@19.2.0)
-      '@react-types/button': 3.13.0(react@19.2.0)
-      '@react-types/overlays': 3.9.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/ssr': 3.9.10(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/visually-hidden': 3.8.26(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/overlays': 3.6.18(react@19.2.1)
+      '@react-types/button': 3.13.0(react@19.2.1)
+      '@react-types/overlays': 3.9.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/radio@3.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/radio@3.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/form': 3.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/label': 3.7.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/radio': 3.11.0(react@19.2.0)
-      '@react-types/radio': 3.9.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/form': 3.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/label': 3.7.20(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/radio': 3.11.0(react@19.2.1)
+      '@react-types/radio': 3.9.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/selection@3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/selection@3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/selection': 3.20.4(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/selection': 3.20.4(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/separator@3.4.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/separator@3.4.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/slider@3.8.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/slider@3.8.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/label': 3.7.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/slider': 3.7.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      '@react-types/slider': 3.8.0(react@19.2.0)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/label': 3.7.20(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/slider': 3.7.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      '@react-types/slider': 3.8.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/spinbutton@3.6.17(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/spinbutton@3.6.17(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-aria/live-announcer': 3.4.4
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-types/button': 3.13.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-types/button': 3.13.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/ssr@3.9.10(react@19.2.0)':
+  '@react-aria/ssr@3.9.10(react@19.2.1)':
     dependencies:
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-aria/tabs@3.10.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/tabs@3.10.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/selection': 3.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/tabs': 3.8.4(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      '@react-types/tabs': 3.3.17(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/selection': 3.25.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/tabs': 3.8.4(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      '@react-types/tabs': 3.3.17(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/textfield@3.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/textfield@3.18.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/form': 3.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/label': 3.7.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      '@react-types/textfield': 3.12.4(react@19.2.0)
+      '@react-aria/form': 3.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/label': 3.7.20(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      '@react-types/textfield': 3.12.4(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/toolbar@3.0.0-beta.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/toolbar@3.0.0-beta.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/focus': 3.21.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/i18n': 3.12.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/focus': 3.21.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/i18n': 3.12.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/utils@3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/utils@3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/ssr': 3.9.10(react@19.2.0)
+      '@react-aria/ssr': 3.9.10(react@19.2.1)
       '@react-stately/flags': 3.1.2
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
       clsx: 2.1.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-aria/visually-hidden@3.8.26(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-aria/visually-hidden@3.8.26(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-aria/utils': 3.30.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-aria/interactions': 3.25.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-aria/utils': 3.30.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@react-google-maps/api@2.20.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-google-maps/api@2.20.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@googlemaps/js-api-loader': 1.16.8
       '@googlemaps/markerclusterer': 2.5.3
@@ -11559,225 +11559,225 @@ snapshots:
       '@react-google-maps/marker-clusterer': 2.20.0
       '@types/google.maps': 3.58.1
       invariant: 2.2.4
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   '@react-google-maps/infobox@2.20.0': {}
 
   '@react-google-maps/marker-clusterer@2.20.0': {}
 
-  '@react-stately/collections@3.12.6(react@19.2.0)':
+  '@react-stately/collections@3.12.6(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/combobox@3.11.0(react@19.2.0)':
+  '@react-stately/combobox@3.11.0(react@19.2.1)':
     dependencies:
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-stately/list': 3.12.4(react@19.2.0)
-      '@react-stately/overlays': 3.6.18(react@19.2.0)
-      '@react-stately/select': 3.7.0(react@19.2.0)
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/combobox': 3.13.7(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-stately/list': 3.12.4(react@19.2.1)
+      '@react-stately/overlays': 3.6.18(react@19.2.1)
+      '@react-stately/select': 3.7.0(react@19.2.1)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/combobox': 3.13.7(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/disclosure@3.0.6(react@19.2.0)':
+  '@react-stately/disclosure@3.0.6(react@19.2.1)':
     dependencies:
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
   '@react-stately/flags@3.1.2':
     dependencies:
       '@swc/helpers': 0.5.15
 
-  '@react-stately/form@3.2.0(react@19.2.0)':
+  '@react-stately/form@3.2.0(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/grid@3.11.4(react@19.2.0)':
+  '@react-stately/grid@3.11.4(react@19.2.1)':
     dependencies:
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/selection': 3.20.4(react@19.2.0)
-      '@react-types/grid': 3.3.4(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/selection': 3.20.4(react@19.2.1)
+      '@react-types/grid': 3.3.4(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/list@3.12.4(react@19.2.0)':
+  '@react-stately/list@3.12.4(react@19.2.1)':
     dependencies:
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/selection': 3.20.4(react@19.2.0)
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/selection': 3.20.4(react@19.2.1)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/menu@3.9.6(react@19.2.0)':
+  '@react-stately/menu@3.9.6(react@19.2.1)':
     dependencies:
-      '@react-stately/overlays': 3.6.18(react@19.2.0)
-      '@react-types/menu': 3.10.3(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/overlays': 3.6.18(react@19.2.1)
+      '@react-types/menu': 3.10.3(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/numberfield@3.10.0(react@19.2.0)':
+  '@react-stately/numberfield@3.10.0(react@19.2.1)':
     dependencies:
       '@internationalized/number': 3.6.4
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/numberfield': 3.8.13(react@19.2.0)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/numberfield': 3.8.13(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/overlays@3.6.18(react@19.2.0)':
+  '@react-stately/overlays@3.6.18(react@19.2.1)':
     dependencies:
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/overlays': 3.9.0(react@19.2.0)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/overlays': 3.9.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/radio@3.11.0(react@19.2.0)':
+  '@react-stately/radio@3.11.0(react@19.2.1)':
     dependencies:
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/radio': 3.9.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/radio': 3.9.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/select@3.7.0(react@19.2.0)':
+  '@react-stately/select@3.7.0(react@19.2.1)':
     dependencies:
-      '@react-stately/form': 3.2.0(react@19.2.0)
-      '@react-stately/list': 3.12.4(react@19.2.0)
-      '@react-stately/overlays': 3.6.18(react@19.2.0)
-      '@react-types/select': 3.10.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/form': 3.2.0(react@19.2.1)
+      '@react-stately/list': 3.12.4(react@19.2.1)
+      '@react-stately/overlays': 3.6.18(react@19.2.1)
+      '@react-types/select': 3.10.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/selection@3.20.4(react@19.2.0)':
+  '@react-stately/selection@3.20.4(react@19.2.1)':
     dependencies:
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/slider@3.7.0(react@19.2.0)':
+  '@react-stately/slider@3.7.0(react@19.2.1)':
     dependencies:
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      '@react-types/slider': 3.8.0(react@19.2.0)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      '@react-types/slider': 3.8.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/tabs@3.8.4(react@19.2.0)':
+  '@react-stately/tabs@3.8.4(react@19.2.1)':
     dependencies:
-      '@react-stately/list': 3.12.4(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      '@react-types/tabs': 3.3.17(react@19.2.0)
+      '@react-stately/list': 3.12.4(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      '@react-types/tabs': 3.3.17(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/toggle@3.9.0(react@19.2.0)':
+  '@react-stately/toggle@3.9.0(react@19.2.1)':
     dependencies:
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/checkbox': 3.10.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/checkbox': 3.10.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/tree@3.9.1(react@19.2.0)':
+  '@react-stately/tree@3.9.1(react@19.2.1)':
     dependencies:
-      '@react-stately/collections': 3.12.6(react@19.2.0)
-      '@react-stately/selection': 3.20.4(react@19.2.0)
-      '@react-stately/utils': 3.10.8(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
+      '@react-stately/collections': 3.12.6(react@19.2.1)
+      '@react-stately/selection': 3.20.4(react@19.2.1)
+      '@react-stately/utils': 3.10.8(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-stately/utils@3.10.8(react@19.2.0)':
+  '@react-stately/utils@3.10.8(react@19.2.1)':
     dependencies:
       '@swc/helpers': 0.5.15
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-types/button@3.13.0(react@19.2.0)':
+  '@react-types/button@3.13.0(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/checkbox@3.10.0(react@19.2.0)':
+  '@react-types/checkbox@3.10.0(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/combobox@3.13.7(react@19.2.0)':
+  '@react-types/combobox@3.13.7(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/grid@3.3.4(react@19.2.0)':
+  '@react-types/grid@3.3.4(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/listbox@3.7.2(react@19.2.0)':
+  '@react-types/listbox@3.7.2(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/menu@3.10.3(react@19.2.0)':
+  '@react-types/menu@3.10.3(react@19.2.1)':
     dependencies:
-      '@react-types/overlays': 3.9.0(react@19.2.0)
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/overlays': 3.9.0(react@19.2.1)
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/numberfield@3.8.13(react@19.2.0)':
+  '@react-types/numberfield@3.8.13(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/overlays@3.9.0(react@19.2.0)':
+  '@react-types/overlays@3.9.0(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/radio@3.9.0(react@19.2.0)':
+  '@react-types/radio@3.9.0(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/select@3.10.0(react@19.2.0)':
+  '@react-types/select@3.10.0(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/shared@3.31.0(react@19.2.0)':
+  '@react-types/shared@3.31.0(react@19.2.1)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
 
-  '@react-types/slider@3.8.0(react@19.2.0)':
+  '@react-types/slider@3.8.0(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/tabs@3.3.17(react@19.2.0)':
+  '@react-types/tabs@3.3.17(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
-  '@react-types/textfield@3.12.4(react@19.2.0)':
+  '@react-types/textfield@3.12.4(react@19.2.1)':
     dependencies:
-      '@react-types/shared': 3.31.0(react@19.2.0)
-      react: 19.2.0
+      '@react-types/shared': 3.31.0(react@19.2.1)
+      react: 19.2.1
 
   '@remix-run/router@1.23.0': {}
 
@@ -11984,17 +11984,17 @@ snapshots:
     dependencies:
       '@sentry/core': 10.27.0
 
-  '@sentry-internal/global-search@1.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@sentry-internal/global-search@1.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@types/react': 19.2.0
-      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+      '@types/react': 19.2.1
+      '@types/react-dom': 19.2.1(@types/react@19.2.1)
       algoliasearch: 4.13.1
       css-select: 4.1.3
       domhandler: 4.2.0
       dompurify: 3.2.5
       htmlparser2: 4.1.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
       title-case: 3.0.2
 
   '@sentry-internal/node-cpu-profiler@2.2.0':
@@ -12194,20 +12194,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/react@10.27.0(react@19.2.0)':
+  '@sentry/react@10.27.0(react@19.2.1)':
     dependencies:
       '@sentry/browser': 10.27.0
       '@sentry/core': 10.27.0
       hoist-non-react-statics: 3.3.2
-      react: 19.2.0
+      react: 19.2.1
 
   '@sentry/release-parser@1.3.1': {}
 
   '@sentry/status-page-list@0.6.1': {}
 
-  '@sentry/toolbar@1.0.0-beta.16(react@19.2.0)':
+  '@sentry/toolbar@1.0.0-beta.16(react@19.2.1)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
 
   '@sentry/webpack-plugin@4.6.1(encoding@0.1.13)(webpack@5.99.6(esbuild@0.25.10))':
     dependencies:
@@ -12266,12 +12266,12 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@stripe/react-stripe-js@3.9.2(@stripe/stripe-js@5.10.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@stripe/react-stripe-js@3.9.2(@stripe/stripe-js@5.10.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@stripe/stripe-js': 5.10.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   '@stripe/stripe-js@5.10.0': {}
 
@@ -12320,42 +12320,42 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.83.1
 
-  '@tanstack/react-pacer@0.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@tanstack/react-pacer@0.17.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@tanstack/pacer': 0.16.0
-      '@tanstack/react-store': 0.7.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@tanstack/react-store': 0.7.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  '@tanstack/react-query-devtools@5.85.0(@tanstack/react-query@5.85.0(react@19.2.0))(react@19.2.0)':
+  '@tanstack/react-query-devtools@5.85.0(@tanstack/react-query@5.85.0(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@tanstack/query-devtools': 5.84.0
-      '@tanstack/react-query': 5.85.0(react@19.2.0)
-      react: 19.2.0
+      '@tanstack/react-query': 5.85.0(react@19.2.1)
+      react: 19.2.1
 
-  '@tanstack/react-query-persist-client@5.85.0(@tanstack/react-query@5.85.0(react@19.2.0))(react@19.2.0)':
+  '@tanstack/react-query-persist-client@5.85.0(@tanstack/react-query@5.85.0(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@tanstack/query-persist-client-core': 5.83.1
-      '@tanstack/react-query': 5.85.0(react@19.2.0)
-      react: 19.2.0
+      '@tanstack/react-query': 5.85.0(react@19.2.1)
+      react: 19.2.1
 
-  '@tanstack/react-query@5.85.0(react@19.2.0)':
+  '@tanstack/react-query@5.85.0(react@19.2.1)':
     dependencies:
       '@tanstack/query-core': 5.83.1
-      react: 19.2.0
+      react: 19.2.1
 
-  '@tanstack/react-store@0.7.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@tanstack/react-store@0.7.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@tanstack/store': 0.7.7
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      use-sync-external-store: 1.5.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      use-sync-external-store: 1.5.0(react@19.2.1)
 
-  '@tanstack/react-virtual@3.13.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@tanstack/react-virtual@3.13.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@tanstack/virtual-core': 3.13.6
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   '@tanstack/store@0.7.7': {}
 
@@ -12382,15 +12382,15 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.1(@types/react@19.2.1))(@types/react@19.2.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@testing-library/dom': 10.4.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:
-      '@types/react': 19.2.0
-      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+      '@types/react': 19.2.1
+      '@types/react-dom': 19.2.1(@types/react@19.2.1)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
@@ -12644,42 +12644,42 @@ snapshots:
 
   '@types/react-date-range@1.4.4':
     dependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
       date-fns: 2.17.0
 
-  '@types/react-dom@19.2.0(@types/react@19.2.0)':
+  '@types/react-dom@19.2.1(@types/react@19.2.1)':
     dependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
   '@types/react-grid-layout@1.3.2':
     dependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
   '@types/react-lazyload@3.2.3':
     dependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
   '@types/react-mentions@4.1.13':
     dependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
   '@types/react-select@4.0.18':
     dependencies:
       '@emotion/serialize': 1.3.3
-      '@types/react': 19.2.0
-      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+      '@types/react': 19.2.1
+      '@types/react-dom': 19.2.1(@types/react@19.2.1)
       '@types/react-transition-group': 4.2.4
 
   '@types/react-transition-group@4.2.4':
     dependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
   '@types/react-virtualized@9.22.0':
     dependencies:
       '@types/prop-types': 15.7.4
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
-  '@types/react@19.2.0':
+  '@types/react@19.2.1':
     dependencies:
       csstype: 3.0.8
 
@@ -13169,12 +13169,12 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  ansi-to-react@6.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  ansi-to-react@6.1.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       anser: 1.4.10
       escape-carriage: 1.3.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   anymatch@3.1.2:
     dependencies:
@@ -13638,10 +13638,10 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
-  conduit-client@1.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  conduit-client@1.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   config-chain@1.1.13:
     dependencies:
@@ -13954,11 +13954,11 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  echarts-for-react@3.0.5(echarts@6.0.0)(react@19.2.0):
+  echarts-for-react@3.0.5(echarts@6.0.0)(react@19.2.1):
     dependencies:
       echarts: 6.0.0
       fast-deep-equal: 3.1.3
-      react: 19.2.0
+      react: 19.2.1
       size-sensor: 1.0.1
 
   echarts@6.0.0:
@@ -14856,15 +14856,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  framer-motion@12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       motion-dom: 12.23.12
       motion-utils: 12.23.6
       tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.3.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   fresh@0.5.2: {}
 
@@ -15181,7 +15181,7 @@ snapshots:
 
   hoist-non-react-statics@3.3.2:
     dependencies:
-      react-is: 19.2.0
+      react-is: 19.2.1
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -16803,13 +16803,13 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mobx-react-lite@4.1.0(mobx@6.13.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  mobx-react-lite@4.1.0(mobx@6.13.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       mobx: 6.13.7
-      react: 19.2.0
-      use-sync-external-store: 1.5.0(react@19.2.0)
+      react: 19.2.1
+      use-sync-external-store: 1.5.0(react@19.2.1)
     optionalDependencies:
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.1(react@19.2.1)
 
   mobx@6.13.7: {}
 
@@ -16930,13 +16930,13 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.7.1(react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-router@6.30.1(react@19.2.0))(react@19.2.0):
+  nuqs@2.7.1(react-router-dom@6.30.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@6.30.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@standard-schema/spec': 1.0.0
-      react: 19.2.0
+      react: 19.2.1
     optionalDependencies:
-      react-router: 6.30.1(react@19.2.0)
-      react-router-dom: 6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router: 6.30.1(react@19.2.1)
+      react-router-dom: 6.30.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   nwsapi@2.2.20: {}
 
@@ -17209,11 +17209,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  platformicons@8.0.9(react@19.2.0):
+  platformicons@8.0.9(react@19.2.1):
     dependencies:
       '@types/node': 22.15.21
-      '@types/react': 19.2.0
-      react: 19.2.0
+      '@types/react': 19.2.1
+      react: 19.2.1
 
   pluralize@8.0.0: {}
 
@@ -17297,19 +17297,19 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
-      react-is: 19.2.0
+      react-is: 19.2.1
 
   pretty-format@30.0.0:
     dependencies:
       '@jest/schemas': 30.0.0
       ansi-styles: 5.2.0
-      react-is: 19.2.0
+      react-is: 19.2.1
 
   pretty-format@30.0.2:
     dependencies:
       '@jest/schemas': 30.0.1
       ansi-styles: 5.2.0
-      react-is: 19.2.0
+      react-is: 19.2.1
 
   prismjs@1.30.0: {}
 
@@ -17334,7 +17334,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 19.2.0
+      react-is: 19.2.1
 
   property-information@7.1.0: {}
 
@@ -17354,9 +17354,9 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qrcode.react@3.1.0(react@19.2.0):
+  qrcode.react@3.1.0(react@19.2.1):
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
 
   qs@6.13.0:
     dependencies:
@@ -17386,146 +17386,146 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  react-date-range@1.4.0(date-fns@2.17.0)(react@19.2.0):
+  react-date-range@1.4.0(date-fns@2.17.0)(react@19.2.1):
     dependencies:
       classnames: 2.3.1
       date-fns: 2.17.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-list: 0.8.16(react@19.2.0)
+      react: 19.2.1
+      react-list: 0.8.16(react@19.2.1)
       shallow-equal: 1.2.1
 
   react-docgen-typescript@2.2.2(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
 
-  react-dom@19.2.0(react@19.2.0):
+  react-dom@19.2.1(react@19.2.1):
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
       scheduler: 0.27.0
 
-  react-draggable@4.4.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-draggable@4.4.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       clsx: 1.2.1
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   react-fast-compare@3.2.0: {}
 
-  react-grid-layout@1.3.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-grid-layout@1.3.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       clsx: 1.2.1
       lodash.isequal: 4.5.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-draggable: 4.4.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react-resizable: 3.0.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-draggable: 4.4.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react-resizable: 3.0.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  react-input-autosize@3.0.0(react@19.2.0):
+  react-input-autosize@3.0.0(react@19.2.1):
     dependencies:
       prop-types: 15.8.1
-      react: 19.2.0
+      react: 19.2.1
 
-  react-is@19.2.0: {}
+  react-is@19.2.1: {}
 
-  react-lazyload@3.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-lazyload@3.2.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   react-lifecycles-compat@3.0.4: {}
 
-  react-list@0.8.16(react@19.2.0):
+  react-list@0.8.16(react@19.2.1):
     dependencies:
       prop-types: 15.8.1
-      react: 19.2.0
+      react: 19.2.1
 
-  react-mentions@4.4.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-mentions@4.4.10(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.26.10
       invariant: 2.2.4
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      substyle: 9.4.1(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      substyle: 9.4.1(react@19.2.1)
 
-  react-popper@2.3.0(@popperjs/core@2.11.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-popper@2.3.0(@popperjs/core@2.11.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@popperjs/core': 2.11.5
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
       react-fast-compare: 3.2.0
       warning: 4.0.3
 
   react-refresh@0.18.0: {}
 
-  react-resizable@3.0.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-resizable@3.0.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       prop-types: 15.8.1
-      react: 19.2.0
-      react-draggable: 4.4.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.1
+      react-draggable: 4.4.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     transitivePeerDependencies:
       - react-dom
 
-  react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router-dom@6.30.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@remix-run/router': 1.23.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-router: 6.30.1(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-router: 6.30.1(react@19.2.1)
 
-  react-router@6.30.1(react@19.2.0):
+  react-router@6.30.1(react@19.2.1):
     dependencies:
       '@remix-run/router': 1.23.0
-      react: 19.2.0
+      react: 19.2.1
 
-  react-select@4.3.1(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-select@4.3.1(@types/react@19.2.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.27.6
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.0)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.1)(react@19.2.1)
       memoize-one: 5.1.1
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-input-autosize: 3.0.0(react@19.2.0)
-      react-transition-group: 4.4.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-input-autosize: 3.0.0(react@19.2.1)
+      react-transition-group: 4.4.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  react-textarea-autosize@8.5.7(@types/react@19.2.0)(react@19.2.0):
+  react-textarea-autosize@8.5.7(@types/react@19.2.1)(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.27.6
-      react: 19.2.0
-      use-composed-ref: 1.4.0(@types/react@19.2.0)(react@19.2.0)
-      use-latest: 1.3.0(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.1
+      use-composed-ref: 1.4.0(@types/react@19.2.1)(react@19.2.1)
+      use-latest: 1.3.0(@types/react@19.2.1)(react@19.2.1)
     transitivePeerDependencies:
       - '@types/react'
 
-  react-transition-group@4.4.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-transition-group@4.4.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.27.6
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
-  react-virtualized@9.22.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-virtualized@9.22.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.27.6
       clsx: 1.2.1
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
       react-lifecycles-compat: 3.0.4
 
-  react@19.2.0: {}
+  react@19.2.1: {}
 
   read-package-json-fast@3.0.2:
     dependencies:
@@ -17624,10 +17624,10 @@ snapshots:
     dependencies:
       eventemitter3: 1.2.0
 
-  reflux@0.4.1(react@19.2.0):
+  reflux@0.4.1(react@19.2.1):
     dependencies:
       eventemitter3: 1.2.0
-      react: 19.2.0
+      react: 19.2.1
       reflux-core: 0.3.0
 
   regenerate-unicode-properties@10.2.0:
@@ -18306,11 +18306,11 @@ snapshots:
 
   stylis@4.2.0: {}
 
-  substyle@9.4.1(react@19.2.0):
+  substyle@9.4.1(react@19.2.1):
     dependencies:
       '@babel/runtime': 7.27.6
       invariant: 2.2.4
-      react: 19.2.0
+      react: 19.2.1
 
   supercluster@8.0.1:
     dependencies:
@@ -18736,28 +18736,28 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-composed-ref@1.4.0(@types/react@19.2.0)(react@19.2.0):
+  use-composed-ref@1.4.0(@types/react@19.2.1)(react@19.2.1):
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
     optionalDependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
-  use-isomorphic-layout-effect@1.2.0(@types/react@19.2.0)(react@19.2.0):
+  use-isomorphic-layout-effect@1.2.0(@types/react@19.2.1)(react@19.2.1):
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
     optionalDependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
-  use-latest@1.3.0(@types/react@19.2.0)(react@19.2.0):
+  use-latest@1.3.0(@types/react@19.2.1)(react@19.2.1):
     dependencies:
-      react: 19.2.0
-      use-isomorphic-layout-effect: 1.2.0(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.1
+      use-isomorphic-layout-effect: 1.2.0(@types/react@19.2.1)(react@19.2.1)
     optionalDependencies:
-      '@types/react': 19.2.0
+      '@types/react': 19.2.1
 
-  use-sync-external-store@1.5.0(react@19.2.0):
+  use-sync-external-store@1.5.0(react@19.2.1):
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
Even though we are not affected (no RSC usage) but let's upgrade to avoid noise
https://github.com/facebook/react/releases/tag/v19.2.1
https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components