### PR TITLE
feat(search): Replace unquoted raw search spaces with wildcards

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -283,8 +283,10 @@ def wrap_free_text(string: str, autowrap: bool) -> str:
     if string.startswith("*") or string.endswith("*"):
         return string
     # Otherwise always wrap it with wildcarding
+    if string.startswith('"') and string.endswith('"'):
+        return string
     else:
-        return f"*{string}*"
+        return f"*{string.replace(" ", "*")}*"
 
 
 def translate_escape_sequences(string: str) -> str:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -366,6 +366,20 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
                 key=SearchKey(name="message"), operator="=", value=SearchValue(raw_value="*foo")
             )
         ]
+        # wrapped in quotes should only have surrounding wildcards
+        assert parse_search_query('"foo"', config=config) == [
+            SearchFilter(
+                key=SearchKey(name="message"), operator="=", value=SearchValue(raw_value='*"foo"*')
+            )
+        ]
+        # not wrapped in quotes with spaces should be wrapped and spaces replaced with wildcards
+        assert parse_search_query("foo bar", config=config) == [
+            SearchFilter(
+                key=SearchKey(name="message"),
+                operator="=",
+                value=SearchValue(raw_value="*foo*bar*"),
+            )
+        ]
 
     @patch("sentry.search.events.builder.base.BaseQueryBuilder.get_field_type")
     def test_size_filter(self, mock_type: MagicMock) -> None:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -367,9 +367,11 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             )
         ]
         # wrapped in quotes should only have surrounding wildcards
-        assert parse_search_query('"foo"', config=config) == [
+        assert parse_search_query('"foo bar"', config=config) == [
             SearchFilter(
-                key=SearchKey(name="message"), operator="=", value=SearchValue(raw_value='*"foo"*')
+                key=SearchKey(name="message"),
+                operator="=",
+                value=SearchValue(raw_value='*"foo bar"*'),
             )
         ]
         # not wrapped in quotes with spaces should be wrapped and spaces replaced with wildcards


### PR DESCRIPTION
This PR tweaks how we handle free text search values, as now if a raw text value comes in unquoted, we will replace any spaces present with asterisks.

Ticket: LOGS-521