### PR TITLE
feat: Add pagination to trace item stats endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -111,6 +111,11 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                 )
 
         def data_fn(offset: int, limit: int):
+            # Intersecting attributes filter is a best effort operation, and if is not
+            # possible in under 1 second, returns all attributes. This might result in a
+            # negative user experience if the results in the query filter do not actually
+            # contain these attributes. One suggestion would be to request more in the limit
+            # than actually what's visualized in the page.
             with handle_query_errors():
                 attrs_request = TraceItemAttributeNamesRequest(
                     meta=attrs_meta,

--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import TraceItemAttributeNamesRequest
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from sentry import options
@@ -14,7 +14,12 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.endpoints.organization_trace_item_attributes import adjust_start_end_window
+from sentry.api.endpoints.organization_trace_item_attributes import (
+    TraceItemAttributesNamesPaginator,
+    adjust_start_end_window,
+)
+from sentry.api.event_search import translate_escape_sequences
+from sentry.api.serializers import serialize
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.eap.constants import SUPPORTED_STATS_TYPES
@@ -36,6 +41,13 @@ class OrganizationTraceItemsStatsSerializer(serializers.Serializer):
     query = serializers.CharField(required=False)
     statsType = serializers.ListField(
         child=serializers.ChoiceField(list(SUPPORTED_STATS_TYPES)), required=True
+    )
+    substringMatch = serializers.CharField(
+        required=False,
+        help_text="Match substring on attribute name.",
+    )
+    limit = serializers.IntegerField(
+        required=False,
     )
 
 
@@ -65,6 +77,9 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
         query_string = serialized.get("query")
         query_filter, _, _ = resolver.resolve_query(query_string)
 
+        substring_match = serialized.get("substringMatch", "")
+        value_substring_match = translate_escape_sequences(substring_match)
+
         # Fetch attribute names
         adjusted_start_date, adjusted_end_date = adjust_start_end_window(
             snuba_params.start_date, snuba_params.end_date
@@ -83,26 +98,6 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
         attr_type = AttributeKey.Type.TYPE_STRING
         max_attributes = options.get("explore.trace-items.keys.max")
 
-        with handle_query_errors():
-            attrs_request = TraceItemAttributeNamesRequest(
-                meta=attrs_meta,
-                limit=max_attributes,
-                type=attr_type,
-                intersecting_attributes_filter=query_filter,
-            )
-
-            attrs_response = snuba_rpc.attribute_names_rpc(attrs_request)
-
-        # Chunk attributes and run stats query in parallel
-        chunked_attributes: defaultdict[int, list[AttributeKey]] = defaultdict(list)
-        for i, attr in enumerate(attrs_response.attributes):
-            if attr.name in SPANS_STATS_EXCLUDED_ATTRIBUTES:
-                continue
-
-            chunked_attributes[i % MAX_THREADS].append(
-                AttributeKey(name=attr.name, type=AttributeKey.TYPE_STRING)
-            )
-
         def run_stats_query_with_error_handling(attributes):
             with handle_query_errors():
                 return Spans.run_stats_query(
@@ -115,21 +110,52 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                     attributes=attributes,
                 )
 
-        stats_results: dict[str, dict[str, dict]] = defaultdict(lambda: {"data": {}})
-        with ThreadPoolExecutor(
-            thread_name_prefix=__name__,
-            max_workers=MAX_THREADS,
-        ) as query_thread_pool:
+        def data_fn(offset: int, limit: int):
+            with handle_query_errors():
+                attrs_request = TraceItemAttributeNamesRequest(
+                    meta=attrs_meta,
+                    limit=limit,
+                    page_token=PageToken(offset=offset),
+                    type=attr_type,
+                    intersecting_attributes_filter=query_filter,
+                    value_substring_match=value_substring_match,
+                )
 
-            futures = [
-                query_thread_pool.submit(run_stats_query_with_error_handling, attributes)
-                for attributes in chunked_attributes.values()
-            ]
+                attrs_response = snuba_rpc.attribute_names_rpc(attrs_request)
 
-            for future in as_completed(futures):
-                result = future.result()
-                for stats in result:
-                    for stats_type, data in stats.items():
-                        stats_results[stats_type]["data"].update(data["data"])
+            # Chunk attributes and run stats query in parallel
+            chunked_attributes: defaultdict[int, list[AttributeKey]] = defaultdict(list)
+            for i, attr in enumerate(attrs_response.attributes):
+                if attr.name in SPANS_STATS_EXCLUDED_ATTRIBUTES:
+                    continue
 
-        return Response({"data": [{k: v} for k, v in stats_results.items()]})
+                chunked_attributes[i % MAX_THREADS].append(
+                    AttributeKey(name=attr.name, type=AttributeKey.TYPE_STRING)
+                )
+
+            stats_results: dict[str, dict[str, dict]] = defaultdict(lambda: {"data": {}})
+            with ThreadPoolExecutor(
+                thread_name_prefix=__name__,
+                max_workers=MAX_THREADS,
+            ) as query_thread_pool:
+
+                futures = [
+                    query_thread_pool.submit(run_stats_query_with_error_handling, attributes)
+                    for attributes in chunked_attributes.values()
+                ]
+
+                for future in as_completed(futures):
+                    result = future.result()
+                    for stats in result:
+                        for stats_type, data in stats.items():
+                            stats_results[stats_type]["data"].update(data["data"])
+
+            return [{k: v} for k, v in stats_results.items()]
+
+        return self.paginate(
+            request=request,
+            paginator=TraceItemAttributesNamesPaginator(data_fn=data_fn),
+            on_results=lambda results: {"data": serialize(results, request.user)},
+            default_per_page=serialized.get("limit") or max_attributes,
+            max_per_page=max_attributes,
+        )

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -1,7 +1,9 @@
 from django.urls import reverse
 
 from sentry.testutils.cases import APITransactionTestCase, SnubaTestCase, SpanTestCase
+from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.options import override_options
 
 
 class OrganizationTraceItemsStatsEndpointTest(
@@ -51,6 +53,17 @@ class OrganizationTraceItemsStatsEndpointTest(
         assert response.status_code == 200, response.data
         assert response.data == {"data": []}
 
+    def test_missing_stats_type(self) -> None:
+        self._store_span()
+        response = self.do_request(query={})
+        assert response.status_code == 400, response.data
+        assert "statsType" in response.data
+
+    def test_invalid_stats_type(self) -> None:
+        self._store_span()
+        response = self.do_request(query={"statsType": ["invalid_type"]})
+        assert response.status_code == 400, response.data
+
     def test_distribution_values(self) -> None:
         tags = [
             ({"browser": "chrome", "device": "desktop"}, 500),
@@ -76,3 +89,115 @@ class OrganizationTraceItemsStatsEndpointTest(
         assert {"label": "desktop", "value": 1.0} in device_data
 
         assert response.data
+
+    def test_substring_match_filters_attributes(self) -> None:
+        tags = [
+            ({"browser.name": "chrome", "browser.version": "120", "device": "desktop"}, 100),
+            ({"browser.name": "firefox", "device": "mobile"}, 100),
+        ]
+
+        for tag, duration in tags:
+            self._store_span(tags=tag, duration=duration)
+
+        response = self.do_request(
+            query={
+                "statsType": ["attributeDistributions"],
+                "substringMatch": "browser",
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert len(response.data["data"]) == 1
+        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+
+        assert "browser.name" in attribute_distribution
+        assert "device" not in attribute_distribution
+
+    def test_query_filters_spans_before_stats(self) -> None:
+        tags = [
+            ({"browser": "chrome", "device": "desktop"}, 100),
+            ({"browser": "firefox", "device": "mobile"}, 100),
+            ({"browser": "safari", "device": "tablet"}, 500),
+        ]
+
+        for tag, duration in tags:
+            self._store_span(tags=tag, duration=duration)
+
+        response = self.do_request(
+            query={
+                "query": "browser:chrome",
+                "statsType": ["attributeDistributions"],
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert len(response.data["data"]) == 1
+        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+
+        device_data = attribute_distribution.get("sentry.device", [])
+        assert any(item["label"] == "desktop" for item in device_data)
+        assert not any(
+            item["label"] == "mobile" or item["label"] == "tablet" for item in device_data
+        )
+
+    @override_options({"explore.trace-items.keys.max": 3})
+    def test_pagination_with_limit(self) -> None:
+        tags = [
+            {"attr1": "value1"},
+            {"attr2": "value2"},
+            {"attr3": "value3"},
+            {"attr4": "value4"},
+        ]
+
+        for tag in tags:
+            self._store_span(tags=tag)
+
+        response = self.do_request(
+            query={
+                "statsType": ["attributeDistributions"],
+            }
+        )
+        assert response.status_code == 200, response.data
+
+        links = {}
+        if "Link" in response:
+            for url, attrs in parse_link_header(response["Link"]).items():
+                links[attrs["rel"]] = attrs
+                attrs["href"] = url
+
+            assert links["previous"]["results"] == "false"
+
+            if links.get("next", {}).get("results") == "true":
+                assert links["next"]["href"] is not None
+                next_response = self.client.get(links["next"]["href"], format="json")
+                assert next_response.status_code == 200, next_response.content
+
+    @override_options({"explore.trace-items.keys.max": 2})
+    def test_custom_limit_parameter(self) -> None:
+        tags = [
+            {"custom1": "value1"},
+            {"custom2": "value2"},
+            {"custom3": "value3"},
+        ]
+
+        for tag in tags:
+            self._store_span(tags=tag)
+
+        response = self.do_request(
+            query={
+                "statsType": ["attributeDistributions"],
+                "limit": 1,
+            }
+        )
+        assert response.status_code == 200, response.data
+
+        assert len(response.data["data"]) == 1
+        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        assert (
+            len(attribute_distribution) == 2
+        )  # We return limit + 1 to check if there is a next page
+
+        if "Link" in response:
+            links = {}
+            for url, attrs in parse_link_header(response["Link"]).items():
+                links[attrs["rel"]] = attrs
+
+            assert links["previous"]["results"] == "false"


### PR DESCRIPTION
Uses the TraceItemAttributesNamesPaginator to paginate
results on the trace item stats endpoint. Leaving in the
parallelization for now, but if we go the pagination route,
we can probably take it out.