### PR TITLE
chore(segment-enhancement): Add tracing to segment name normalization

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2982,6 +2982,10 @@ SENTRY_FEATURE_ADOPTION_CACHE_OPTIONS: ServiceOptions = {
     "options": {"cluster": "default"},
 }
 
+SENTRY_PROCESS_SEGMENTS_TRANSACTIONS_SAMPLE_RATE = (
+    0.1  # relative to SENTRY_PROCESS_EVENT_APM_SAMPLING
+)
+
 ADDITIONAL_BULK_QUERY_DELETES: list[tuple[str, str, str | None]] = []
 
 # Monitor limits to prevent abuse

--- a/src/sentry/ingest/transaction_clusterer/normalization.py
+++ b/src/sentry/ingest/transaction_clusterer/normalization.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 import orjson
+import sentry_sdk
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.ingest.transaction_clusterer import ClustererNamespace
@@ -82,6 +83,7 @@ class Remark:
 
 # Ported from Relay:
 # https://github.com/getsentry/relay/blob/aad4b6099d12422e88dd5df49abae11247efdd99/relay-event-normalization/src/transactions/processor.rs#L350
+@sentry_sdk.trace
 def _scrub_identifiers(segment_span: CompatibleSpan, segment_name: str):
     matches = TRANSACTION_NAME_NORMALIZER_REGEX.finditer(segment_name)
     remarks = []
@@ -125,6 +127,7 @@ def _scrub_identifiers(segment_span: CompatibleSpan, segment_name: str):
     segment_span["attributes"] = attributes
 
 
+@sentry_sdk.trace
 def _apply_clustering_rules(
     project: Project, segment_span: CompatibleSpan, original_segment_name: str
 ):

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import sentry_sdk
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
@@ -50,6 +51,20 @@ outcome_aggregator = OutcomeAggregator()
 def process_segment(
     unprocessed_spans: list[SpanEvent], skip_produce: bool = False
 ) -> list[CompatibleSpan]:
+    sample_rate = (
+        settings.SENTRY_PROCESS_SEGMENTS_TRANSACTIONS_SAMPLE_RATE
+        * settings.SENTRY_PROCESS_EVENT_APM_SAMPLING
+    )
+    with sentry_sdk.start_transaction(
+        name="spans.consumers.process_segments.process_segment",
+        custom_sampling_context={
+            "sample_rate": sample_rate,
+        },
+    ):
+        return _process_segment(unprocessed_spans)
+
+
+def _process_segment(unprocessed_spans: list[SpanEvent]) -> list[CompatibleSpan]:
     _verify_compatibility(unprocessed_spans)
     segment_span, spans = _enrich_spans(unprocessed_spans)
     if segment_span is None:
@@ -147,6 +162,7 @@ def _enrich_spans(
 
 
 @metrics.wraps("spans.consumers.process_segments.normalize_segment_name")
+@sentry_sdk.trace
 def _normalize_segment_name(segment_span: CompatibleSpan, project: Project) -> None:
     if not features.has(
         "organizations:normalize_segment_names_in_span_enrichment", project.organization

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -61,10 +61,12 @@ def process_segment(
             "sample_rate": sample_rate,
         },
     ):
-        return _process_segment(unprocessed_spans)
+        return _process_segment(unprocessed_spans, skip_produce)
 
 
-def _process_segment(unprocessed_spans: list[SpanEvent]) -> list[CompatibleSpan]:
+def _process_segment(
+    unprocessed_spans: list[SpanEvent], skip_produce: bool
+) -> list[CompatibleSpan]:
     _verify_compatibility(unprocessed_spans)
     segment_span, spans = _enrich_spans(unprocessed_spans)
     if segment_span is None:


### PR DESCRIPTION
This PR adds instrumentation to segment enhancement to better understand how segment name normalization performs, and to compare before and after performance improvements:
- Wrap segment enhancement's entry point (`process_message`) in a transaction with a low sample rate
- Wrap the normalize segment name step in a span, as well as its component `_scrub_identifiers` and `_apply_clustering_rules` steps.

The value of `SENTRY_PROCESS_SEGMENTS_TRANSACTIONS_SAMPLE_RATE` matches the calculation for the sample rate of [the `save_event_transaction` task](https://github.com/getsentry/sentry/blob/65fdb79de802b8a58aa62a92c4ae4d40f2bca069/src/sentry/utils/sdk.py#L57). Segment clustering should have similar volume, and therefore this should be a safe sampling rate.