### PR TITLE
fix: make sentry-feedback widget look more like UI2

### DIFF
--- a/static/gsApp/utils/useFeedbackInit.tsx
+++ b/static/gsApp/utils/useFeedbackInit.tsx
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+import {useTheme} from '@emotion/react';
 import {addIntegration, getClient} from '@sentry/react';
 
 import useAsyncSDKIntegrationStore from 'sentry/views/app/asyncSDKIntegrationProvider';
@@ -9,6 +10,7 @@ import useAsyncSDKIntegrationStore from 'sentry/views/app/asyncSDKIntegrationPro
  */
 export default function useFeedbackInit() {
   const {setState} = useAsyncSDKIntegrationStore();
+  const theme = useTheme();
 
   useEffect(() => {
     async function init() {
@@ -33,4 +35,29 @@ export default function useFeedbackInit() {
 
     init();
   }, [setState]);
+
+  useEffect(() => {
+    const styleElement = document.createElement('style');
+    styleElement.textContent = `
+      #sentry-feedback {
+        --foreground: ${theme.tokens.content.primary};
+        --background: ${theme.tokens.background.primary};
+        --accent-foreground: ${theme.colors.white};
+        --accent-background: ${theme.colors.chonk.blue400};
+        --success-color: ${theme.tokens.content.success};
+        --error-color: ${theme.tokens.content.danger};
+        --outline: 1px auto ${theme.tokens.border.accent};
+        --interactive-filter: brightness(${theme.type === 'dark' ? '110%' : '95%'});
+        --border: 1px solid ${theme.tokens.border.primary};
+        --button-border-radius: ${theme.formRadius.md.borderRadius};
+        --button-primary-border-radius: ${theme.formRadius.md.borderRadius};
+        --input-border-radius: ${theme.formRadius.md.borderRadius};
+      }
+    `;
+    document.head.appendChild(styleElement);
+
+    return () => {
+      document.head.removeChild(styleElement);
+    };
+  }, [theme]);
 }


### PR DESCRIPTION
This PR makes our feedback widget align more with UI2. Note that we can’t easily do chonky buttons, as we only have a limited amount of styling possibilities with the default widget, but I tried to align colors and borders.

| before | after |
|--------|--------|
| <img width="397" height="452" alt="Screenshot 2025-12-04 at 18 44 19" src="https://github.com/user-attachments/assets/e68993f2-e8ca-4707-9ecf-6bb6e70a5cac" /> | <img width="395" height="451" alt="Screenshot 2025-12-04 at 18 43 27" src="https://github.com/user-attachments/assets/dd5f6825-ad14-491d-b521-799bbab330d2" /> |
| <img width="416" height="455" alt="Screenshot 2025-12-04 at 18 45 08" src="https://github.com/user-attachments/assets/a7672c17-82bc-4901-9c90-df51a4f43755" /> | <img width="400" height="448" alt="Screenshot 2025-12-04 at 18 43 47" src="https://github.com/user-attachments/assets/99183169-6249-4539-86c4-fd12a04d43ec" /> | 

There is currently an issue that focus borders are broken in dark mode, this needs to be fixed in the SDK (I’m investigating a potential fix with @ryan953). This is also in master so it’s the same right now. I faked it for the screenshot with the potential fix so that we can see how it will look.

Also, this PR fixes an issue where the styles were only injected on a full page reload, so if you switched themes with `cmd-1`, the styles wouldn’t update. This is fixed by injecting css variables for styling, which always overrides everything else, and swapping them on a theme switch.