### PR TITLE
fix(dashboards): context menu doesn't show up insights prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -24,6 +24,7 @@ export function PrebuiltDashboardRenderer({prebuiltId}: PrebuiltDashboardRendere
 
   const dashboard: DashboardDetails = {
     id: `prebuilt-dashboard-${prebuiltId}`,
+    prebuiltId,
     title,
     widgets,
     dateCreated: '',

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -127,7 +127,7 @@ function SortableWidget(props: Props) {
     onEdit,
     onDuplicate,
     onSetTransactionsDataset,
-    showContextMenu: !isEmbedded,
+    showContextMenu: !isEmbedded || isPrebuiltDashboard,
     isPreview,
     index,
     dashboardFilters,


### PR DESCRIPTION
Fixes a bug where the context menu does not show up on prebuilt dashboards that are under insights
<img width="650" height="454" alt="image" src="https://github.com/user-attachments/assets/b5d60e2a-8481-4a5b-b867-6a2a80043700" />
