### PR TITLE
feat(seer settings): Fix bug and change seer project level defaults if feature flag is set

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -503,6 +503,7 @@ def project_is_seer_eligible(project: Project) -> bool:
 def set_default_project_autofix_automation_tuning(
     organization: Organization, project: Project
 ) -> None:
+    """Called once at project creation time to set the initial autofix automation tuning."""
     org_default = organization.get_option("sentry:default_autofix_automation_tuning")
 
     if org_default == "off":
@@ -522,13 +523,15 @@ def set_default_project_autofix_automation_tuning(
 def set_default_project_seer_scanner_automation(
     organization: Organization, project: Project
 ) -> None:
-    org_default_seer_scanner_automation = organization.get_option(
-        "sentry:default_seer_scanner_automation"
-    )
-    if org_default_seer_scanner_automation:
-        project.update_option(
-            "sentry:default_seer_scanner_automation", org_default_seer_scanner_automation
-        )
+    """Called once at project creation time to set the initial seer scanner automation."""
+    if features.has("organizations:triage-signals-v0-org", organization):
+        # Feature flag ON always sets scanner to True
+        project.update_option("sentry:seer_scanner_automation", True)
+    else:
+        # Feature flag OFF, use org's explicit value if set
+        org_default = organization.get_option("sentry:default_seer_scanner_automation")
+        if org_default is not None:
+            project.update_option("sentry:seer_scanner_automation", org_default)
 
 
 def report_token_count_metric(

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict, TypeVar
 import sentry_sdk
 from tokenizers import Tokenizer
 
-from sentry import options
+from sentry import features, options
 from sentry.constants import DATA_ROOT
 from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
@@ -16,6 +16,7 @@ from sentry.grouping.variants import BaseVariant
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
@@ -502,13 +503,20 @@ def project_is_seer_eligible(project: Project) -> bool:
 def set_default_project_autofix_automation_tuning(
     organization: Organization, project: Project
 ) -> None:
-    org_default_autofix_automation_tuning = organization.get_option(
-        "sentry:default_autofix_automation_tuning"
-    )
-    if org_default_autofix_automation_tuning and org_default_autofix_automation_tuning != "off":
+    org_default = organization.get_option("sentry:default_autofix_automation_tuning")
+
+    if org_default == "off":
+        # Explicit "off" is always respected, regardless of feature flag
+        project.update_option("sentry:autofix_automation_tuning", "off")
+    elif features.has("organizations:triage-signals-v0-org", organization):
+        # Feature flag ON overrides everything except explicit "off"
         project.update_option(
-            "sentry:default_autofix_automation_tuning", org_default_autofix_automation_tuning
+            "sentry:autofix_automation_tuning",
+            AutofixAutomationTuningSettings.MEDIUM,
         )
+    elif org_default:
+        # Feature flag OFF, use org's explicit value
+        project.update_option("sentry:autofix_automation_tuning", org_default)
 
 
 def set_default_project_seer_scanner_automation(


### PR DESCRIPTION
## PR details
Fix project option key mismatches and add `triage-signals-v0-org` feature flag support for autofix and scanner automation defaults on new projects.

## Changes

1. **Fixed key mismatch in `set_default_project_autofix_automation_tuning`**
   - Was incorrectly setting `sentry:default_autofix_automation_tuning` on projects
   - Now correctly sets `sentry:autofix_automation_tuning` (the key used at runtime)

2. **Added feature flag support for autofix automation tuning**
   - When `triage-signals-v0-org` flag is enabled, new projects default to `medium` tuning
   - Explicit `off` at org level is always respected (not overridden by flag)
   - When flag is off, org's explicit value is used if set

3. **Fixed key mismatch in `set_default_project_seer_scanner_automation`**
   - Was incorrectly setting `sentry:default_seer_scanner_automation` on projects
   - Now correctly sets `sentry:seer_scanner_automation` (the key used at runtime)

4. **Added feature flag support for scanner automation**
   - When `triage-signals-v0-org` flag is enabled, scanner is always `True` for new projects
   - When flag is off, org's explicit value is used if set