### PR TITLE
chore(aci): add alert creation + success analytics

### DIFF
--- a/static/app/utils/analytics/alertsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/alertsAnalyticsEvents.tsx
@@ -1,7 +1,22 @@
+import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import type {UptimeMonitorMode} from 'sentry/views/alerts/rules/uptime/types';
+import type {MonitorConfig} from 'sentry/views/insights/crons/types';
+
 export type AlertsEventParameters = {
   'anomaly-detection.feedback-submitted': {
     choice_selected: boolean;
     incident_id: string;
+  };
+  'cron_monitor.created': {
+    cron_schedule_type: MonitorConfig['schedule_type'];
+  };
+  'issue_alert_rule.created': Record<string, unknown>;
+  'metric_alert_rule.created': {
+    aggregate: MetricRule['aggregate'];
+    dataset: MetricRule['dataset'];
+  };
+  'uptime_monitor.created': {
+    uptime_mode: UptimeMonitorMode;
   };
 };
 
@@ -9,4 +24,8 @@ type AlertsEventKey = keyof AlertsEventParameters;
 
 export const alertsEventMap: Record<AlertsEventKey, string | null> = {
   'anomaly-detection.feedback-submitted': 'Anomaly Detection Feedback Submitted',
+  'issue_alert_rule.created': 'Issue Alert Rule Created',
+  'metric_alert_rule.created': 'Metric Alert Rule Created',
+  'cron_monitor.created': 'Cron Monitor Created',
+  'uptime_monitor.created': 'Uptime Monitor Created',
 };

--- a/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
@@ -6,9 +6,16 @@ type DetectorAnalyticsEventPayload = ReturnType<typeof getDetectorAnalyticsPaylo
 
 type AutomationAnalyticsEventPayload = ReturnType<typeof getAutomationAnalyticsPayload>;
 
+type DetectorCreateAnalyticsEventPayload =
+  | (DetectorAnalyticsEventPayload & {
+      success: true;
+    })
+  | {detector_type: string; success: false};
+
 export type MonitorsEventParameters = {
   'automation.created': AutomationAnalyticsEventPayload & {
     organization: Organization;
+    success: boolean;
   };
   'automation.updated': AutomationAnalyticsEventPayload & {
     organization: Organization;
@@ -17,7 +24,7 @@ export type MonitorsEventParameters = {
     guide: string;
     platform: string;
   };
-  'monitor.created': DetectorAnalyticsEventPayload;
+  'monitor.created': DetectorCreateAnalyticsEventPayload;
   'monitor.updated': DetectorAnalyticsEventPayload;
 };
 

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Member, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import {uniqueId} from 'sentry/utils/guid';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -166,14 +167,18 @@ function Create(props: Props) {
               <MonitorForm
                 apiMethod="POST"
                 apiEndpoint={`/organizations/${organization.slug}/monitors/`}
-                onSubmitSuccess={(data: Monitor) =>
+                onSubmitSuccess={(data: Monitor) => {
+                  trackAnalytics('cron_monitor.created', {
+                    organization,
+                    cron_schedule_type: data.config.schedule_type,
+                  });
                   navigate(
                     makeAlertsPathname({
                       path: `/rules/crons/${data.project.slug}/${data.slug}/details/`,
                       organization,
                     })
-                  )
-                }
+                  );
+                }}
                 submitLabel={t('Create')}
               />
             ) : !hasMetricAlerts || alertType === AlertRuleType.ISSUE ? (

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -457,6 +457,12 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
 
     metric.endSpan({name: 'saveAlertRule'});
 
+    if (isNew) {
+      trackAnalytics('issue_alert_rule.created', {
+        organization,
+      });
+    }
+
     router.push(
       makeAlertsPathname({
         path: `/rules/${project.slug}/${rule.id}/details/`,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -370,6 +370,15 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       }
       if (alertRule) {
         addSuccessMessage(ruleId ? t('Updated alert rule') : t('Created alert rule'));
+
+        if (!ruleId) {
+          trackAnalytics('metric_alert_rule.created', {
+            organization,
+            aggregate: alertRule.aggregate,
+            dataset: alertRule.dataset,
+          });
+        }
+
         if (onSubmitSuccess) {
           onSubmitSuccess(alertRule, model);
         }
@@ -849,6 +858,15 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
           IndicatorStore.remove(loadingIndicator);
           this.setState({loading: false});
           addSuccessMessage(ruleId ? t('Updated alert rule') : t('Created alert rule'));
+
+          if (!ruleId) {
+            trackAnalytics('metric_alert_rule.created', {
+              organization,
+              aggregate: data.aggregate,
+              dataset: data.dataset,
+            });
+          }
+
           if (onSubmitSuccess) {
             onSubmitSuccess(data, model);
           }

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -26,6 +26,7 @@ import ListItem from 'sentry/components/list/listItem';
 import Panel from 'sentry/components/panels/panel';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -129,6 +130,14 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
               exact: true,
             });
           }
+
+          if (!rule) {
+            trackAnalytics('uptime_monitor.created', {
+              organization,
+              uptime_mode: response.mode,
+            });
+          }
+
           navigate(
             makeAlertsPathname({
               path: `/rules/uptime/${projectSlug}/${response.id}/details/`,

--- a/static/app/views/automations/components/forms/common/getAutomationAnalyticsPayload.ts
+++ b/static/app/views/automations/components/forms/common/getAutomationAnalyticsPayload.ts
@@ -1,6 +1,6 @@
-import type {Automation} from 'sentry/types/workflowEngine/automations';
+import type {NewAutomation} from 'sentry/types/workflowEngine/automations';
 
-export function getAutomationAnalyticsPayload(automation: Automation): {
+export function getAutomationAnalyticsPayload(automation: NewAutomation): {
   actions_count: number;
   detectors_count: number;
   environment: string | null;

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -28,6 +28,7 @@ describe('AutomationNewSettings', () => {
   });
 
   beforeEach(() => {
+    jest.clearAllMocks();
     MockApiClient.clearMockResponses();
 
     // Available actions (include Slack with a default integration)
@@ -205,16 +206,14 @@ describe('AutomationNewSettings', () => {
     );
 
     // Verify analytics was called with correct event and payload structure
-    await waitFor(() => {
-      expect(trackAnalytics).toHaveBeenCalledWith('automation.created', {
-        organization,
-        frequency_minutes: expect.any(Number),
-        environment: expect.anything(),
-        detectors_count: expect.any(Number),
-        trigger_conditions_count: expect.any(Number),
-        success: true,
-        actions_count: expect.any(Number),
-      });
+    expect(trackAnalytics).toHaveBeenCalledWith('automation.created', {
+      organization,
+      frequency_minutes: expect.any(Number),
+      environment: null,
+      detectors_count: expect.any(Number),
+      trigger_conditions_count: expect.any(Number),
+      success: true,
+      actions_count: expect.any(Number),
     });
   });
 });

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -212,6 +212,7 @@ describe('AutomationNewSettings', () => {
         environment: expect.anything(),
         detectors_count: expect.any(Number),
         trigger_conditions_count: expect.any(Number),
+        success: true,
         actions_count: expect.any(Number),
       });
     });

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -108,16 +108,24 @@ export default function AutomationNewSettings() {
     async (data, _, __, ___, ____) => {
       const errors = validateAutomationBuilderState(state);
       setAutomationBuilderErrors(errors);
+      const newAutomationData = getNewAutomationData(data as AutomationFormData, state);
 
       if (Object.keys(errors).length === 0) {
-        const automation = await createAutomation(
-          getNewAutomationData(data as AutomationFormData, state)
-        );
-        trackAnalytics('automation.created', {
-          organization,
-          ...getAutomationAnalyticsPayload(automation),
-        });
-        navigate(makeAutomationDetailsPathname(organization.slug, automation.id));
+        try {
+          const automation = await createAutomation(newAutomationData);
+          trackAnalytics('automation.created', {
+            organization,
+            ...getAutomationAnalyticsPayload(newAutomationData),
+            success: true,
+          });
+          navigate(makeAutomationDetailsPathname(organization.slug, automation.id));
+        } catch {
+          trackAnalytics('automation.created', {
+            organization,
+            ...getAutomationAnalyticsPayload(newAutomationData),
+            success: false,
+          });
+        }
       }
     },
     [createAutomation, state, navigate, organization]

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -126,6 +126,12 @@ export default function AutomationNewSettings() {
             success: false,
           });
         }
+      } else {
+        trackAnalytics('automation.created', {
+          organization,
+          ...getAutomationAnalyticsPayload(newAutomationData),
+          success: false,
+        });
       }
     },
     [createAutomation, state, navigate, organization]

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -44,6 +44,7 @@ export function NewDetectorLayout<
   const maxWidth = theme.breakpoints.xl;
 
   const formSubmitHandler = useCreateDetectorFormSubmit({
+    detectorType,
     formDataToEndpointPayload,
   });
 

--- a/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
+++ b/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
@@ -6,6 +6,7 @@ import {t} from 'sentry/locale';
 import type {
   BaseDetectorUpdatePayload,
   Detector,
+  DetectorType,
 } from 'sentry/types/workflowEngine/detectors';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -15,6 +16,10 @@ import {useCreateDetector} from 'sentry/views/detectors/hooks';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 interface UseCreateDetectorFormSubmitOptions<TFormData, TUpdatePayload> {
+  /**
+   * Detector type for analytics tracking when validation fails
+   */
+  detectorType: DetectorType;
   /**
    * Function to transform form data to API payload
    */
@@ -27,6 +32,7 @@ export function useCreateDetectorFormSubmit<
   TFormData extends Data,
   TUpdatePayload extends BaseDetectorUpdatePayload,
 >({
+  detectorType,
   formDataToEndpointPayload,
   onError,
   onSuccess,
@@ -39,6 +45,11 @@ export function useCreateDetectorFormSubmit<
     async (data, onSubmitSuccess, onSubmitError, _, formModel) => {
       const isValid = formModel.validateForm();
       if (!isValid) {
+        trackAnalytics('monitor.created', {
+          organization,
+          detector_type: detectorType,
+          success: false,
+        });
         return;
       }
 
@@ -79,6 +90,7 @@ export function useCreateDetectorFormSubmit<
       }
     },
     [
+      detectorType,
       formDataToEndpointPayload,
       createDetector,
       organization,

--- a/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
+++ b/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
@@ -42,13 +42,15 @@ export function useCreateDetectorFormSubmit<
         return;
       }
 
+      const payload = formDataToEndpointPayload(data as TFormData);
+
       try {
-        const payload = formDataToEndpointPayload(data as TFormData);
         const resultDetector = await createDetector(payload);
 
         trackAnalytics('monitor.created', {
           organization,
           ...getDetectorAnalyticsPayload(resultDetector),
+          success: true,
         });
 
         addSuccessMessage(t('Monitor created successfully'));
@@ -61,6 +63,12 @@ export function useCreateDetectorFormSubmit<
 
         onSubmitSuccess?.(resultDetector);
       } catch (error) {
+        trackAnalytics('monitor.created', {
+          organization,
+          detector_type: payload.type,
+          success: false,
+        });
+
         addErrorMessage(t('Unable to create monitor'));
 
         if (onError) {


### PR DESCRIPTION
Adding analytics for creating old alert rules, cron monitors, and uptime monitors in the old UI so that we can compare these numbers to the new UI. Also added a `success: boolean` field to the monitor/automation creation analytics so we can see if the new UI is intuitive or if users are running into lots of errors.