### PR TITLE
chore(search): Use fuzzy search on raw text values with spaces

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -123,7 +123,7 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: 'test test',
         },
         expected: {
-          query: `span.description:${WildcardOperators.CONTAINS}"test test"`,
+          query: `span.description:"*test * test*"`,
           focusOverride: {itemKey: 'freeText:1'},
         },
       },
@@ -159,7 +159,7 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: `span.description:${WildcardOperators.CONTAINS}test other value`,
         },
         expected: {
-          query: `span.description:${WildcardOperators.CONTAINS}test span.description:${WildcardOperators.CONTAINS}"other value"`,
+          query: `span.description:${WildcardOperators.CONTAINS}test span.description:"*other * value*"`,
           focusOverride: {itemKey: 'freeText:2'},
         },
       },
@@ -172,7 +172,7 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: `span.description:test other value`,
         },
         expected: {
-          query: `span.description:test span.description:${WildcardOperators.CONTAINS}"other value"`,
+          query: `span.description:test span.description:"*other * value*"`,
           focusOverride: {itemKey: 'freeText:2'},
         },
       },

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -188,6 +188,18 @@ describe('replaceFreeTextTokens', () => {
           focusOverride: {itemKey: 'freeText:2'},
         },
       },
+      {
+        description: 'when the value contains a space and asterisks, it sets to is',
+        input: {
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `te*st test`,
+        },
+        expected: {
+          query: `span.description:"te*st test"`,
+          focusOverride: {itemKey: 'freeText:1'},
+        },
+      },
     ];
 
     it.each(testCases)('$description', ({input, expected}) => {

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -123,7 +123,7 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: 'test test',
         },
         expected: {
-          query: `span.description:"*test * test*"`,
+          query: `span.description:"*test*test*"`,
           focusOverride: {itemKey: 'freeText:1'},
         },
       },
@@ -159,7 +159,7 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: `span.description:${WildcardOperators.CONTAINS}test other value`,
         },
         expected: {
-          query: `span.description:${WildcardOperators.CONTAINS}test span.description:"*other * value*"`,
+          query: `span.description:${WildcardOperators.CONTAINS}test span.description:"*other*value*"`,
           focusOverride: {itemKey: 'freeText:2'},
         },
       },
@@ -172,7 +172,7 @@ describe('replaceFreeTextTokens', () => {
           currentQuery: `span.description:test other value`,
         },
         expected: {
-          query: `span.description:test span.description:"*other * value*"`,
+          query: `span.description:test span.description:"*other*value*"`,
           focusOverride: {itemKey: 'freeText:2'},
         },
       },
@@ -197,6 +197,19 @@ describe('replaceFreeTextTokens', () => {
         },
         expected: {
           query: `span.description:"te*st test"`,
+          focusOverride: {itemKey: 'freeText:1'},
+        },
+      },
+      {
+        description:
+          'when the value contains multiple spaces, it removes them and will replace them with a single space, and apply fuzzy matching',
+        input: {
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `test  test`,
+        },
+        expected: {
+          query: `span.description:"*test*test*"`,
           focusOverride: {itemKey: 'freeText:1'},
         },
       },

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -732,13 +732,22 @@ export function replaceFreeTextTokens(
     }
 
     const value = escapeTagValue(token.text.trim());
-    replacedQuery.push(
-      // We don't want to break user flows, so if they include an asterisk in their free
-      // text value, leave it as an `is` filter.
-      value.includes('*')
-        ? `${primarySearchKey}:${value}`
-        : `${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`
-    );
+
+    const valueIsQuoted =
+      value.startsWith('"') && value.endsWith('"') && value.includes(' ');
+
+    if (!token.quoted && valueIsQuoted) {
+      const temp = `"*${value.slice(1, -1).replaceAll(' ', ' * ')}*"`;
+      replacedQuery.push(`${primarySearchKey}:${temp}`);
+    } else {
+      replacedQuery.push(
+        // We don't want to break user flows, so if they include an asterisk in their free
+        // text value, leave it as an `is` filter.
+        value.includes('*')
+          ? `${primarySearchKey}:${value}`
+          : `${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`
+      );
+    }
   }
 
   const finalQuery = replacedQuery.join(' ').trim();

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -743,9 +743,12 @@ export function replaceFreeTextTokens(
       value.endsWith('"') &&
       value.includes(' ')
     ) {
-      replacedQuery.push(
-        `${primarySearchKey}:"*${value.slice(1, -1).replaceAll(' ', ' * ')}*"`
-      );
+      const formattedValue = value
+        .slice(1, -1)
+        .trim()
+        .replace(/\s+/g, ' ')
+        .replaceAll(' ', '*');
+      replacedQuery.push(`${primarySearchKey}:"*${formattedValue}*"`);
     } else {
       replacedQuery.push(`${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`);
     }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -732,13 +732,13 @@ export function replaceFreeTextTokens(
     }
 
     const value = escapeTagValue(token.text.trim());
-
     const valueIsQuoted =
       value.startsWith('"') && value.endsWith('"') && value.includes(' ');
 
     if (!token.quoted && valueIsQuoted) {
-      const temp = `"*${value.slice(1, -1).replaceAll(' ', ' * ')}*"`;
-      replacedQuery.push(`${primarySearchKey}:${temp}`);
+      replacedQuery.push(
+        `${primarySearchKey}:"*${value.slice(1, -1).replaceAll(' ', ' * ')}*"`
+      );
     } else {
       replacedQuery.push(
         // We don't want to break user flows, so if they include an asterisk in their free

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -732,21 +732,22 @@ export function replaceFreeTextTokens(
     }
 
     const value = escapeTagValue(token.text.trim());
-    const valueIsQuoted =
-      value.startsWith('"') && value.endsWith('"') && value.includes(' ');
 
-    if (!token.quoted && valueIsQuoted) {
+    // We don't want to break user flows, so if they include an asterisk in their free
+    // text value, leave it as an `is` filter.
+    if (value.includes('*')) {
+      replacedQuery.push(`${primarySearchKey}:${value}`);
+    } else if (
+      !token.quoted &&
+      value.startsWith('"') &&
+      value.endsWith('"') &&
+      value.includes(' ')
+    ) {
       replacedQuery.push(
         `${primarySearchKey}:"*${value.slice(1, -1).replaceAll(' ', ' * ')}*"`
       );
     } else {
-      replacedQuery.push(
-        // We don't want to break user flows, so if they include an asterisk in their free
-        // text value, leave it as an `is` filter.
-        value.includes('*')
-          ? `${primarySearchKey}:${value}`
-          : `${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`
-      );
+      replacedQuery.push(`${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`);
     }
   }
 

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {TagCollection} from 'sentry/types/group';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
 import {
   useSearchQueryBuilderProps,
@@ -32,6 +33,11 @@ export function useLogsSearchQueryBuilderProps({
   const fields = useQueryParamsFields();
   const setQueryParams = useSetQueryParams();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
+  const organization = useOrganization();
+  const hasRawSearchReplacement = organization.features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
+
   const onSearch = useCallback(
     (newQuery: string) => {
       const newSearch = new MutableSearch(newQuery);
@@ -62,6 +68,7 @@ export function useLogsSearchQueryBuilderProps({
     stringSecondaryAliases,
     caseInsensitive,
     onCaseInsensitiveClick: setCaseInsensitive,
+    replaceRawSearchKeys: hasRawSearchReplacement ? ['message'] : undefined,
   };
 
   const searchQueryBuilderProviderProps = useSearchQueryBuilderProps(


### PR DESCRIPTION
This PR tweaks the replacement logic in `useQueryBuilderState` to handle unquoted values with spaces slightly differently. Instead of using the `contains` operator we will instead do a fuzzy search on the value: 
  i.e. `test value` -> `*test * value*`

This PR also conditionally adds the `message` filter key as the auto replace key for the logs search bar based off of the `search-query-builder-raw-search-replacement` flag.

Ticket: LOGS-521