### PR TITLE
fix(dashboards): Fix duplicating prebuilt dashboard 400 within dashboard page

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
@@ -59,7 +59,7 @@ export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Queries Per Minute'),
       displayType: DisplayType.LINE,
       widgetType: WidgetType.SPANS,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: QUERIES_PER_MINUTE_TEXT,
@@ -83,7 +83,7 @@ export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Average Duration'),
       displayType: DisplayType.LINE,
       widgetType: WidgetType.SPANS,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: AVERAGE_DURATION_TEXT,
@@ -107,7 +107,7 @@ export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Queries List'),
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.SPANS,
-      interval: '',
+      interval: '5m',
       tableWidths: [-1, -1, -1, -1],
       queries: [
         {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/sessionHealth.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/sessionHealth.ts
@@ -13,7 +13,7 @@ export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Issue Counts'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.ISSUE,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: '',
@@ -31,7 +31,7 @@ export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Issues'),
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.ISSUE,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: '',
@@ -49,7 +49,7 @@ export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Unhealthy Sessions'),
       displayType: DisplayType.LINE,
       widgetType: WidgetType.RELEASE,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: '',
@@ -67,7 +67,7 @@ export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('User Health'),
       displayType: DisplayType.AREA,
       widgetType: WidgetType.RELEASE,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: '',
@@ -95,7 +95,7 @@ export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Session Health'),
       displayType: DisplayType.AREA,
       widgetType: WidgetType.RELEASE,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: '',
@@ -123,7 +123,7 @@ export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('Session Counts'),
       displayType: DisplayType.LINE,
       widgetType: WidgetType.RELEASE,
-      interval: '',
+      interval: '5m',
       queries: [
         {
           name: '',
@@ -141,7 +141,7 @@ export const SESSION_HEALTH_PREBUILT_CONFIG: PrebuiltDashboard = {
       title: t('User Counts'),
       displayType: DisplayType.LINE,
       widgetType: WidgetType.RELEASE,
-      interval: '4h',
+      interval: '5m',
       queries: [
         {
           name: '',


### PR DESCRIPTION
The create dashboard endpoint expects a non empty `interval` for each widget. This `interval` attribute actually does not get used anywhere, but I've added `5m` to each prebuilt dashboard widget to satisfy the validation. 

There is probably some refactor work to do to get rid of `interval` from the widget serializer if its not being used at all.