### PR TITLE
ref(replay): rm seer attribute on replay analytic

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -8,9 +8,7 @@ export type ReplayEventParameters = {
   'replay.ai-summary.regenerate-requested': {
     area: string;
   };
-  'replay.ai_tab_shown': {
-    isSeerSetup: boolean;
-  };
+  'replay.ai_tab_shown': Record<string, unknown>;
   'replay.canvas-detected-banner-clicked': {
     sdk_needs_update?: boolean;
   };

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -75,7 +75,7 @@ type Props = {
 
 export default function FocusTabs({isVideoReplay}: Props) {
   const organization = useOrganization();
-  const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
   const {getActiveTab, setActiveTab} = useActiveReplayTab({isVideoReplay});
   const activeTab = getActiveTab();
   const replay = useReplayReader();
@@ -97,12 +97,7 @@ export default function FocusTabs({isVideoReplay}: Props) {
         organization,
       });
     }
-  }, [
-    organization,
-    areAiFeaturesAllowed,
-    isVideoReplay,
-    setupAcknowledgement.orgHasAcknowledged,
-  ]);
+  }, [organization, areAiFeaturesAllowed, isVideoReplay]);
 
   return (
     <TabContainer>

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -95,7 +95,6 @@ export default function FocusTabs({isVideoReplay}: Props) {
     if (isAiTabAvailable) {
       trackAnalytics('replay.ai_tab_shown', {
         organization,
-        isSeerSetup: setupAcknowledgement.orgHasAcknowledged,
       });
     }
   }, [


### PR DESCRIPTION
the `isSeerSetup` flag is no longer needed since we got rid of the consent flow (GA'd mid-November)