### PR TITLE
fix(dashboards): Fix duplicate prebuilt dashboard from table manage view producing empty dashboard

### DIFF
--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -24,11 +24,10 @@ export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
   const duplicateDashboard = useCallback(
     async (dashboard: DashboardListItem, viewType: 'table' | 'grid') => {
       try {
-        const dashboardDetail = await fetchDashboard(
-          api,
-          organization.slug,
-          dashboard.id
-        );
+        const dashboardDetail = dashboard.prebuiltId
+          ? {id: '-1', ...PREBUILT_DASHBOARDS[dashboard.prebuiltId]}
+          : await fetchDashboard(api, organization.slug, dashboard.id);
+
         const newDashboard = cloneDashboard(dashboardDetail);
         newDashboard.widgets.map(widget => (widget.id = undefined));
         const copiedDashboard = await createDashboard(


### PR DESCRIPTION
Update to use prebuilt config when duplicating a prebuilt dashboard in the manage table view