### PR TITLE
chore(eap): increase max rollup points to match snuba buckets

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -115,9 +115,9 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
 }
 
 # https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py
-# The RPC limits us to 2689 points per timeseries
-# MAX 15 minute granularity over 28 days (2688 buckets) + 1 bucket to allow for partial time buckets on
-MAX_ROLLUP_POINTS = 2689
+# The RPC limits us to 10081 points per timeseries
+# MAX 1 minute granularity over 7 days (10080 buckets) + 1 bucket to allow for partial time buckets on
+MAX_ROLLUP_POINTS = 10081
 # Copied from snuba, a number of total seconds
 VALID_GRANULARITIES = frozenset(
     {


### PR DESCRIPTION
needs to be updated here after being updated in snuba. the events requests are returning errors because of this.
