### PR TITLE
Make environment field required on uptime detector form

### DIFF
--- a/static/app/views/detectors/components/forms/detectorBaseFields.tsx
+++ b/static/app/views/detectors/components/forms/detectorBaseFields.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
@@ -13,10 +14,14 @@ import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/co
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 interface DetectorBaseFieldsProps {
+  envFieldProps?: Partial<ComponentProps<typeof SelectField>>;
   noEnvironment?: boolean;
 }
 
-export function DetectorBaseFields({noEnvironment}: DetectorBaseFieldsProps) {
+export function DetectorBaseFields({
+  noEnvironment,
+  envFieldProps,
+}: DetectorBaseFieldsProps) {
   const {setHasSetDetectorName} = useDetectorFormContext();
 
   return (
@@ -43,7 +48,7 @@ export function DetectorBaseFields({noEnvironment}: DetectorBaseFieldsProps) {
       </Layout.Title>
       <Flex gap="md">
         <ProjectField />
-        {!noEnvironment && <EnvironmentField />}
+        {!noEnvironment && <EnvironmentField {...envFieldProps} />}
       </Flex>
     </Flex>
   );
@@ -85,7 +90,7 @@ function ProjectField() {
   );
 }
 
-function EnvironmentField() {
+function EnvironmentField(props: Partial<ComponentProps<typeof SelectField>>) {
   const {projects} = useProjects();
   const projectId = useFormField<string>('projectId')!;
 
@@ -104,6 +109,7 @@ function EnvironmentField() {
       placeholder={t('Environment')}
       aria-label={t('Select Environment')}
       size="sm"
+      {...props}
     />
   );
 }

--- a/static/app/views/detectors/components/forms/detectorBaseFields.tsx
+++ b/static/app/views/detectors/components/forms/detectorBaseFields.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
@@ -14,7 +13,7 @@ import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/co
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 interface DetectorBaseFieldsProps {
-  envFieldProps?: Partial<ComponentProps<typeof SelectField>>;
+  envFieldProps?: Partial<React.ComponentProps<typeof SelectField>>;
   noEnvironment?: boolean;
 }
 
@@ -90,7 +89,7 @@ function ProjectField() {
   );
 }
 
-function EnvironmentField(props: Partial<ComponentProps<typeof SelectField>>) {
+function EnvironmentField(props: Partial<React.ComponentProps<typeof SelectField>>) {
   const {projects} = useProjects();
   const projectId = useFormField<string>('projectId')!;
 

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
@@ -25,7 +24,7 @@ type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
   detector: TDetector;
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   savedDetectorToFormData: (detector: TDetector) => TFormData;
-  envFieldProps?: ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
+  envFieldProps?: React.ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
   mapFormErrors?: (error: any) => any;
   noEnvironment?: boolean;
   previewChart?: React.ReactNode;

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
@@ -14,7 +15,8 @@ import {
   DisableDetectorAction,
 } from 'sentry/views/detectors/components/details/common/actions';
 import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
-import {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
+import type {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
+import {DetectorBaseFields as DetectorBaseFieldsComponent} from 'sentry/views/detectors/components/forms/detectorBaseFields';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
 
@@ -23,6 +25,7 @@ type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
   detector: TDetector;
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   savedDetectorToFormData: (detector: TDetector) => TFormData;
+  envFieldProps?: ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
   mapFormErrors?: (error: any) => any;
   noEnvironment?: boolean;
   previewChart?: React.ReactNode;
@@ -40,6 +43,7 @@ export function EditDetectorLayout<
   savedDetectorToFormData,
   mapFormErrors,
   noEnvironment,
+  envFieldProps,
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
@@ -73,7 +77,10 @@ export function EditDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields noEnvironment={noEnvironment} />
+          <DetectorBaseFieldsComponent
+            noEnvironment={noEnvironment}
+            envFieldProps={envFieldProps}
+          />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
@@ -24,7 +23,7 @@ type NewDetectorLayoutProps<TFormData, TUpdatePayload> = {
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   initialFormData: Partial<TFormData>;
   disabledCreate?: string;
-  envFieldProps?: ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
+  envFieldProps?: React.ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
   mapFormErrors?: (error: any) => any;
   noEnvironment?: boolean;
   previewChart?: React.ReactNode;

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
@@ -12,7 +13,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 import {NewDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {NewDetectorFooter} from 'sentry/views/detectors/components/forms/common/footer';
-import {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
+import type {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
+import {DetectorBaseFields as DetectorBaseFieldsComponent} from 'sentry/views/detectors/components/forms/detectorBaseFields';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {useCreateDetectorFormSubmit} from 'sentry/views/detectors/hooks/useCreateDetectorFormSubmit';
 
@@ -22,6 +24,7 @@ type NewDetectorLayoutProps<TFormData, TUpdatePayload> = {
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   initialFormData: Partial<TFormData>;
   disabledCreate?: string;
+  envFieldProps?: ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
   mapFormErrors?: (error: any) => any;
   noEnvironment?: boolean;
   previewChart?: React.ReactNode;
@@ -37,6 +40,7 @@ export function NewDetectorLayout<
   disabledCreate,
   mapFormErrors,
   noEnvironment,
+  envFieldProps,
   previewChart,
   detectorType,
 }: NewDetectorLayoutProps<TFormData, TUpdatePayload>) {
@@ -87,7 +91,10 @@ export function NewDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields noEnvironment={noEnvironment} />
+          <DetectorBaseFieldsComponent
+            noEnvironment={noEnvironment}
+            envFieldProps={envFieldProps}
+          />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -56,6 +56,7 @@ export function NewUptimeDetectorForm() {
       detectorType="uptime_domain_failure"
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       initialFormData={{}}
+      envFieldProps={{required: true}}
     >
       <UptimeDetectorForm />
     </NewDetectorLayout>
@@ -68,6 +69,7 @@ export function EditExistingUptimeDetectorForm({detector}: {detector: UptimeDete
       detector={detector}
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       savedDetectorToFormData={uptimeSavedDetectorToFormData}
+      envFieldProps={{required: true}}
     >
       <UptimeDetectorForm />
     </EditDetectorLayout>


### PR DESCRIPTION
<!-- Describe your PR here. -->
Makes the environment field a required input in the UI for uptime detector creation and edit forms.

This ensures that an environment is always specified for uptime detectors, improving data consistency and reliability. The change is implemented by passing `envFieldProps={{required: true}}` to the uptime detector forms, which then propagates to the `EnvironmentField` component.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C09TNBD91T8/p1764879957870089?thread_ts=1764879957.870089&cid=C09TNBD91T8)

<a href="https://cursor.com/background-agent?bcId=bc-b714379f-61ed-463f-b196-b8fa1836da9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b714379f-61ed-463f-b196-b8fa1836da9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

