### PR TITLE
feat(dashboards): apply base filters 

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
@@ -11,7 +11,7 @@ import {
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
-const BASE_FILTERS = {
+export const BASE_FILTERS = {
   [SpanFields.SPAN_CATEGORY]: ModuleName.DB,
   has: SpanFields.NORMALIZED_DESCRIPTION,
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
@@ -1,12 +1,16 @@
 import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {
   AVERAGE_DURATION_TEXT,
   QUERIES_PER_MINUTE_TEXT,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/constants';
+import {BASE_FILTERS} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/queries';
 import {SpanFields} from 'sentry/views/insights/types';
+
+const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString();
 
 export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
@@ -39,7 +43,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           fields: ['epm()'],
           aggregates: ['epm()'],
           columns: [],
-          conditions: '',
+          conditions: FILTER_STRING,
           orderby: '',
           isHidden: false,
         },
@@ -60,7 +64,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           columns: [],
-          conditions: '',
+          conditions: FILTER_STRING,
           orderby: '',
           isHidden: false,
         },
@@ -81,7 +85,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           fields: [`sum(${SpanFields.SPAN_SELF_TIME})`],
           aggregates: [`sum(${SpanFields.SPAN_SELF_TIME})`],
           columns: [],
-          conditions: '',
+          conditions: FILTER_STRING,
           orderby: '',
           isHidden: false,
         },
@@ -103,7 +107,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           aggregates: [],
           columns: ['id', 'span.op', 'span.group', 'span.description', 'span.category'],
           fieldAliases: [],
-          conditions: '',
+          conditions: FILTER_STRING,
           orderby: 'id',
           onDemand: [],
           linkedDashboards: [],
@@ -127,7 +131,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           aggregates: ['epm()', `sum(${SpanFields.SPAN_SELF_TIME})`],
           columns: [SpanFields.TRANSACTION],
           fieldAliases: [t('Found In'), t('Queries Per Minute'), t('Time Spent')],
-          conditions: '',
+          conditions: FILTER_STRING,
           orderby: `-sum(${SpanFields.SPAN_SELF_TIME})`,
           onDemand: [],
           isHidden: false,
@@ -151,7 +155,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           aggregates: ['epm()'],
           columns: [],
           fieldAliases: [],
-          conditions: '',
+          conditions: FILTER_STRING,
           orderby: 'epm()',
           onDemand: [],
           isHidden: false,
@@ -176,7 +180,7 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           columns: [],
           fieldAliases: [],
-          conditions: '',
+          conditions: FILTER_STRING,
           orderby: `avg(${SpanFields.SPAN_SELF_TIME})`,
           onDemand: [],
           isHidden: false,


### PR DESCRIPTION
Apply these filters under the hood for the query summary page so it looks better when `ALL` is selected for normalized description