### PR TITLE
fix(dashboards): Fix an issue where widget builder preview was not using the new widget visualization component

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -15,6 +15,7 @@ import {
   type DashboardFilters,
 } from 'sentry/views/dashboards/types';
 import {isChartDisplayType} from 'sentry/views/dashboards/utils';
+import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils/widgetCanUseTimeSeriesVisualization';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
@@ -92,6 +93,8 @@ function WidgetPreview({
     setTableWidths(widths);
   }
 
+  const useTimeseriesVisualization = widgetCanUseTimeSeriesVisualization(widget);
+
   return (
     <WidgetCard
       disableFullscreen
@@ -137,6 +140,7 @@ function WidgetPreview({
       onWidgetTableSort={handleWidgetTableSort}
       onWidgetTableResizeColumn={handleWidgetTableResizeColumn}
       disableTableActions
+      useTimeseriesVisualization={useTimeseriesVisualization}
     />
   );
 }


### PR DESCRIPTION
Update widget builder preview to use new timeseries visualization when applicable.