### PR TITLE
feat(admin): Add cell routing to spike protection batch

### DIFF
--- a/static/gsAdmin/views/generateSpikeProjectionsForBatch.spec.tsx
+++ b/static/gsAdmin/views/generateSpikeProjectionsForBatch.spec.tsx
@@ -1,0 +1,45 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+
+import GenerateSpikeProjectionsForBatch from 'admin/views/generateSpikeProjectionsForBatch';
+
+describe('GenerateSpikeProjectionsForBatch', () => {
+  beforeEach(() => {
+    ConfigStore.set('regions', [
+      {name: 'us', url: 'https://us.test/api/0/'},
+      {name: 'eu', url: 'https://eu.test/api/0/'},
+    ]);
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('submits batch id to selected region', async () => {
+    const requestMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/queue-spike-projection-batch/',
+      method: 'POST',
+      body: {},
+    });
+
+    render(<GenerateSpikeProjectionsForBatch />);
+
+    const batchInput = await screen.findByLabelText('Batch ID:');
+    await userEvent.clear(batchInput);
+    await userEvent.type(batchInput, '13');
+    expect(await screen.findByText('(Batch Run Time: 2:10 AM UTC)')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+    await waitFor(() => expect(requestMock).toHaveBeenCalled());
+    expect(requestMock).toHaveBeenCalledWith(
+      '/_admin/cells/us/queue-spike-projection-batch/',
+      expect.objectContaining({
+        method: 'POST',
+        data: {batch_id: 13},
+        host: 'https://us.test/api/0/',
+      })
+    );
+  });
+});

--- a/static/gsAdmin/views/generateSpikeProjectionsForBatch.tsx
+++ b/static/gsAdmin/views/generateSpikeProjectionsForBatch.tsx
@@ -21,7 +21,8 @@ function GenerateSpikeProjectionsForBatch() {
   const {mutate} = useMutation({
     mutationFn: () => {
       return fetchMutation({
-        url: `/_admin/queue-spike-projection-batch/`,
+        // TODO(cells): Switch from region name to cell
+        url: `/_admin/cells/${region?.name}/queue-spike-projection-batch/`,
         method: 'POST',
         data: {
           batch_id: batchId,
@@ -86,6 +87,7 @@ function GenerateSpikeProjectionsForBatch() {
         <label htmlFor="batchId">Batch ID:</label>
         <BatchInput
           type="number"
+          id="batchId"
           name="batchId"
           value={batchId === null ? '' : batchId}
           onChange={e => {


### PR DESCRIPTION
in https://github.com/getsentry/getsentry/pull/18975 we added cell based routes for admin urls that will later be used to route to the correct region + cell.

part of https://www.notion.so/sentry/Cell-safe-API-endpoints-2a38b10e4b5d8036931fd6781e01eb23
