### PR TITLE
ref(grouping): Clean up grouphash caching metrics

### DIFF
--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -221,7 +221,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
     ) as metrics_tags:
         if use_caching:
             cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
-            cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+            cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
             grouphash_exists = cache.get(cache_key)
             got_cache_hit = grouphash_exists is not None
@@ -230,7 +230,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             if got_cache_hit:
                 metrics_tags["grouphash_exists"] = grouphash_exists
                 # TODO: Temporary tag to let us compare hit rates across different retention periods
-                metrics_tags["expiry_seconds"] = cache_expiry_seconds
+                metrics_tags["expiry_seconds"] = cache_expiry
 
                 return grouphash_exists
 
@@ -240,7 +240,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             metrics_tags["grouphash_exists"] = grouphash_exists
             metrics_tags["cache_set"] = True
 
-            cache.set(cache_key, grouphash_exists, cache_expiry_seconds)
+            cache.set(cache_key, grouphash_exists, cache_expiry)
 
         return grouphash_exists
 
@@ -261,7 +261,7 @@ def _get_or_create_single_grouphash(
     ) as metrics_tags:
         if use_caching:
             cache_key = get_grouphash_object_cache_key(hash_value, project.id)
-            cache_expiry_seconds = options.get("grouping.ingest_grouphash_object_cache_expiry")
+            cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
 
             grouphash = cache.get(cache_key)
             got_cache_hit = grouphash is not None
@@ -269,7 +269,7 @@ def _get_or_create_single_grouphash(
 
             if got_cache_hit:
                 # TODO: Temporary tag to let us compare hit rates across different retention periods
-                metrics_tags["expiry_seconds"] = cache_expiry_seconds
+                metrics_tags["expiry_seconds"] = cache_expiry
 
                 return (grouphash, False)
 
@@ -281,7 +281,7 @@ def _get_or_create_single_grouphash(
         if use_caching and grouphash.group_id is not None:
             metrics_tags["cache_set"] = True
 
-            cache.set(cache_key, grouphash, cache_expiry_seconds)
+            cache.set(cache_key, grouphash, cache_expiry)
 
         return (grouphash, created)
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -228,7 +228,6 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
 
             metrics_tags.update(
                 {
-                    "cache_get": True,
                     "cache_result": "hit" if got_cache_hit else "miss",
                     "expiry_seconds": cache_expiry_seconds,
                     # If there's a cache miss this will be overridden below
@@ -272,11 +271,8 @@ def _get_or_create_single_grouphash(
 
             metrics_tags.update(
                 {
-                    "cache_get": True,
                     "cache_result": "hit" if got_cache_hit else "miss",
                     "expiry_seconds": cache_expiry_seconds,
-                    # If there's a cache miss this will be overridden below
-                    "created": False,
                 }
             )
 
@@ -284,7 +280,6 @@ def _get_or_create_single_grouphash(
                 return (grouphash, False)
 
         grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)
-        metrics_tags["created"] = created
 
         # We only want to cache grouphashes which already have a group assigned, because we know any
         # without a group will only stay current in the cache for a few milliseconds (until they get

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -225,16 +225,13 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
 
             grouphash_exists = cache.get(cache_key)
             got_cache_hit = grouphash_exists is not None
-
-            metrics_tags.update(
-                {
-                    "cache_result": "hit" if got_cache_hit else "miss",
-                    "expiry_seconds": cache_expiry_seconds,
-                }
-            )
+            metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
 
             if got_cache_hit:
                 metrics_tags["grouphash_exists"] = grouphash_exists
+                # TODO: Temporary tag to let us compare hit rates across different retention periods
+                metrics_tags["expiry_seconds"] = cache_expiry_seconds
+
                 return grouphash_exists
 
         grouphash_exists = GroupHash.objects.filter(project=project, hash=hash_value).exists()
@@ -267,15 +264,12 @@ def _get_or_create_single_grouphash(
 
             grouphash = cache.get(cache_key)
             got_cache_hit = grouphash is not None
-
-            metrics_tags.update(
-                {
-                    "cache_result": "hit" if got_cache_hit else "miss",
-                    "expiry_seconds": cache_expiry_seconds,
-                }
-            )
+            metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
 
             if got_cache_hit:
+                # TODO: Temporary tag to let us compare hit rates across different retention periods
+                metrics_tags["expiry_seconds"] = cache_expiry_seconds
+
                 return (grouphash, False)
 
         grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -230,12 +230,11 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
                 {
                     "cache_result": "hit" if got_cache_hit else "miss",
                     "expiry_seconds": cache_expiry_seconds,
-                    # If there's a cache miss this will be overridden below
-                    "grouphash_exists": grouphash_exists,
                 }
             )
 
             if got_cache_hit:
+                metrics_tags["grouphash_exists"] = grouphash_exists
                 return grouphash_exists
 
         grouphash_exists = GroupHash.objects.filter(project=project, hash=hash_value).exists()

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -238,8 +238,9 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
 
         if use_caching:
             metrics_tags["grouphash_exists"] = grouphash_exists
-            cache.set(cache_key, grouphash_exists, cache_expiry_seconds)
             metrics_tags["cache_set"] = True
+
+            cache.set(cache_key, grouphash_exists, cache_expiry_seconds)
 
         return grouphash_exists
 
@@ -278,8 +279,9 @@ def _get_or_create_single_grouphash(
         # without a group will only stay current in the cache for a few milliseconds (until they get
         # their own group), so there's no point in bothering to cache them.
         if use_caching and grouphash.group_id is not None:
-            cache.set(cache_key, grouphash, cache_expiry_seconds)
             metrics_tags["cache_set"] = True
+
+            cache.set(cache_key, grouphash, cache_expiry_seconds)
 
         return (grouphash, created)
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -219,9 +219,6 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
     with metrics.timer(
         "grouping.get_or_create_grouphashes.check_secondary_hash_existence"
     ) as metrics_tags:
-        # If caching is used, these will get overridden below
-        metrics_tags.update({"cache_get": False, "cache_set": False})
-
         if use_caching:
             cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
             cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
@@ -243,9 +240,9 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
                 return grouphash_exists
 
         grouphash_exists = GroupHash.objects.filter(project=project, hash=hash_value).exists()
-        metrics_tags["grouphash_exists"] = grouphash_exists
 
         if use_caching:
+            metrics_tags["grouphash_exists"] = grouphash_exists
             cache.set(cache_key, grouphash_exists, cache_expiry_seconds)
             metrics_tags["cache_set"] = True
 
@@ -266,9 +263,6 @@ def _get_or_create_single_grouphash(
     with metrics.timer(
         "grouping.get_or_create_grouphashes.get_or_create_grouphash"
     ) as metrics_tags:
-        # If caching is used, these will get overridden below
-        metrics_tags.update({"cache_get": False, "cache_set": False})
-
         if use_caching:
             cache_key = get_grouphash_object_cache_key(hash_value, project.id)
             cache_expiry_seconds = options.get("grouping.ingest_grouphash_object_cache_expiry")


### PR DESCRIPTION
This is a small amount of cleanup of the metrics we recently added to track grouphash caching during ingest, mostly getting rid of tags which turn out not to be that useful and only attaching others in cases where we really need them.