### PR TITLE
feat(aci): Add option to send workflow evaluation logs directly to Sentry

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3315,6 +3315,14 @@ register(
     default=0.1,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Whether to directly log workflow evaluation logs to Sentry instead of using the stdlib
+# logger (which also logs to Sentry).
+register(
+    "workflow_engine.evaluation_logs_direct_to_sentry",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -7,6 +7,8 @@ from enum import IntEnum, StrEnum
 from logging import Logger
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
+from sentry_sdk import logger as sentry_logger
+
 from sentry import features, options
 from sentry.types.group import PriorityLevel
 
@@ -198,6 +200,7 @@ class WorkflowEvaluation:
         # Check if we should log this evaluation
         organization = self.data.organization
         should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
+        direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
 
         if not should_log:
             sample_rate = options.get("workflow_engine.evaluation_log_sample_rate")
@@ -226,21 +229,22 @@ class WorkflowEvaluation:
         triggered_workflows = data_snapshot["triggered_workflows"] or []
         action_filter_conditions = data_snapshot["action_filter_conditions"] or []
         triggered_actions = data_snapshot["triggered_actions"] or []
+        extra = {
+            "event_id": data_snapshot["event_id"],
+            "group_id": group_id,
+            "detection_type": detection_type,
+            "workflow_ids": data_snapshot["workflow_ids"],
+            "triggered_workflow_ids": [w["id"] for w in triggered_workflows],
+            "delayed_conditions": data_snapshot["delayed_conditions"],
+            "action_filter_group_ids": [afg["id"] for afg in action_filter_conditions],
+            "triggered_action_ids": [a["id"] for a in triggered_actions],
+            "debug_msg": self.msg,
+        }
 
-        logger.info(
-            log_str,
-            extra={
-                "event_id": data_snapshot["event_id"],
-                "group_id": group_id,
-                "detection_type": detection_type,
-                "workflow_ids": data_snapshot["workflow_ids"],
-                "triggered_workflow_ids": [w["id"] for w in triggered_workflows],
-                "delayed_conditions": data_snapshot["delayed_conditions"],
-                "action_filter_group_ids": [afg["id"] for afg in action_filter_conditions],
-                "triggered_action_ids": [a["id"] for a in triggered_actions],
-                "debug_msg": self.msg,
-            },
-        )
+        if direct_to_sentry:
+            sentry_logger.info(log_str, attributes=extra)
+        else:
+            logger.info(log_str, extra=extra)
         return True
 
 

--- a/tests/sentry/workflow_engine/test_types.py
+++ b/tests/sentry/workflow_engine/test_types.py
@@ -8,7 +8,7 @@ from sentry.workflow_engine.types import WorkflowEvaluation, WorkflowEvaluationD
 
 class TestWorkflowEvaluationLogTo(TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -19,38 +19,78 @@ class TestWorkflowEvaluationLogTo(TestCase):
             organization=self.organization,
         )
 
-    def test_log_to_always_logs_with_feature_enabled(self):
+    def test_log_to_always_logs_with_feature_enabled(self) -> None:
         evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
 
         mock_logger = mock.MagicMock()
 
         with Feature({"organizations:workflow-engine-log-evaluations": True}):
-            with override_options({"workflow_engine.evaluation_log_sample_rate": 0.0}):
+            with override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 0.0,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ):
                 assert evaluation.log_to(mock_logger) is True
 
-    def test_log_to_respects_sample_rate_when_feature_disabled(self):
+    def test_log_to_respects_sample_rate_when_feature_disabled(self) -> None:
         evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
         mock_logger = mock.MagicMock()
 
         with Feature({"organizations:workflow-engine-log-evaluations": False}):
-            with override_options({"workflow_engine.evaluation_log_sample_rate": 0.0}):
+            with override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 0.0,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ):
                 with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.5):
-                    assert not evaluation.log_to(mock_logger), "Should not log with 0% sample rate"
+                    assert not evaluation.log_to(mock_logger)
 
-            with override_options({"workflow_engine.evaluation_log_sample_rate": 1.0}):
+            with override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 1.0,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ):
                 with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.5):
-                    assert evaluation.log_to(mock_logger), "Should log with 100% sample rate"
+                    assert evaluation.log_to(mock_logger)
 
-    def test_log_to_samples_correctly(self):
+    def test_log_to_samples_correctly(self) -> None:
         evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
         mock_logger = mock.MagicMock()
 
         with Feature({"organizations:workflow-engine-log-evaluations": False}):
-            with override_options({"workflow_engine.evaluation_log_sample_rate": 0.1}):
+            with override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 0.1,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ):
                 with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.05):
-                    assert evaluation.log_to(mock_logger), "Should log when random < sample_rate"
+                    assert evaluation.log_to(mock_logger)
 
                 with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.15):
-                    assert not evaluation.log_to(
-                        mock_logger
-                    ), "Should not log when random >= sample_rate"
+                    assert not evaluation.log_to(mock_logger)
+
+    def test_log_to_sentry_logger_when_direct_to_sentry_enabled(self) -> None:
+        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        mock_logger = mock.MagicMock()
+
+        with Feature({"organizations:workflow-engine-log-evaluations": True}):
+            with override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}):
+                with mock.patch("sentry.workflow_engine.types.sentry_logger") as mock_sentry_logger:
+                    assert evaluation.log_to(mock_logger)
+                    mock_sentry_logger.info.assert_called_once()
+                    mock_logger.info.assert_not_called()
+
+    def test_log_to_regular_logger_when_direct_to_sentry_disabled(self) -> None:
+        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        mock_logger = mock.MagicMock()
+
+        with Feature({"organizations:workflow-engine-log-evaluations": True}):
+            with override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}):
+                with mock.patch("sentry.workflow_engine.types.sentry_logger") as mock_sentry_logger:
+                    assert evaluation.log_to(mock_logger)
+                    mock_logger.info.assert_called_once()
+                    mock_sentry_logger.info.assert_not_called()


### PR DESCRIPTION
This gives us the option to avoid paying the cost of including these in our standard log output by sending them directly to Sentry where they can be stored/queried/analyzed. 
