### PR TITLE
ref(ui): remove usages of DO_NOT_USE_ChonkTheme

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -12,7 +12,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types/core';
 import type {SuggestedOwnerReason} from 'sentry/types/group';
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 
 type AssigneeBadgeProps = {
@@ -161,7 +161,7 @@ const UnassignedTag = withChonk(
   styled(StyledTag)`
     border-style: dashed;
   `,
-  styled(StyledTag)<{theme: DO_NOT_USE_ChonkTheme}>`
+  styled(StyledTag)<{theme: Theme}>`
     border: 1px dashed ${p => p.theme.border};
     background-color: transparent;
   `

--- a/static/app/components/core/avatar/letterAvatar.tsx
+++ b/static/app/components/core/avatar/letterAvatar.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import color from 'color';
 
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 import {isChonkTheme} from 'sentry/utils/theme/withChonk';
 
 import {baseAvatarStyles, type BaseAvatarStyleProps} from './baseAvatarComponentStyles';
@@ -103,7 +103,7 @@ function getColor(identifier: string | undefined): Color {
 
 function getChonkColor(
   identifier: string | undefined,
-  theme: DO_NOT_USE_ChonkTheme
+  theme: Theme
 ): {
   background: string;
   content: string;
@@ -131,7 +131,7 @@ function getInitials(displayName: string | undefined) {
   return initials.toUpperCase();
 }
 
-function makeChonkLetterAvatarColors(theme: DO_NOT_USE_ChonkTheme) {
+function makeChonkLetterAvatarColors(theme: Theme) {
   return theme.chart.getColorPalette(9).map(c => ({
     background: c,
     content: color(c).isDark() ? theme.colors.white : theme.colors.black,

--- a/static/app/components/core/badge/alertBadge.chonk.tsx
+++ b/static/app/components/core/badge/alertBadge.chonk.tsx
@@ -1,5 +1,5 @@
 import type {AlertBadgeProps} from 'sentry/components/core/badge/alertBadge';
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme';
 import {IncidentStatus} from 'sentry/views/alerts/types';
 
@@ -7,7 +7,7 @@ function makeChonkAlertBadgeDiamondBackgroundTheme(
   status: AlertBadgeProps['status'],
   isIssue: AlertBadgeProps['isIssue'],
   isDisabled: AlertBadgeProps['isDisabled'],
-  theme: DO_NOT_USE_ChonkTheme
+  theme: Theme
 ): React.CSSProperties {
   if (isDisabled) {
     return {

--- a/static/app/components/core/badge/tag.chonk.tsx
+++ b/static/app/components/core/badge/tag.chonk.tsx
@@ -1,6 +1,6 @@
 import type {TagProps} from 'sentry/components/core/badge/tag';
 import {space} from 'sentry/styles/space';
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme';
 import {unreachable} from 'sentry/utils/unreachable';
 
@@ -43,10 +43,7 @@ export const TagPill = chonkStyled('div')<{
   }
 `;
 
-function makeTagPillTheme(
-  type: TagType | undefined,
-  theme: DO_NOT_USE_ChonkTheme
-): React.CSSProperties {
+function makeTagPillTheme(type: TagType | undefined, theme: Theme): React.CSSProperties {
   switch (type) {
     case undefined:
     case 'default':

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -1,7 +1,7 @@
 import type {DO_NOT_USE_ButtonProps as ButtonProps} from 'sentry/components/core/button/types';
 import {chonkFor} from 'sentry/components/core/chonk';
 // eslint-disable-next-line boundaries/element-types
-import type {DO_NOT_USE_ChonkTheme, StrictCSSObject} from 'sentry/utils/theme';
+import type {StrictCSSObject, Theme} from 'sentry/utils/theme';
 
 // @TODO: remove Link type in the future
 type ChonkButtonType =
@@ -43,7 +43,7 @@ const chonkHoverElevation = '1px';
 export function DO_NOT_USE_getChonkButtonStyles(
   p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled' | 'borderless'> & {
     size: NonNullable<ButtonProps['size']>;
-    theme: DO_NOT_USE_ChonkTheme;
+    theme: Theme;
   }
 ): StrictCSSObject {
   const type = chonkPriorityToType(p.priority);
@@ -254,7 +254,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
   };
 }
 
-function getChonkButtonTheme(type: ChonkButtonType, theme: DO_NOT_USE_ChonkTheme) {
+function getChonkButtonTheme(type: ChonkButtonType, theme: Theme) {
   switch (type) {
     case 'default':
       return {
@@ -299,7 +299,7 @@ function getChonkButtonTheme(type: ChonkButtonType, theme: DO_NOT_USE_ChonkTheme
 
 function getChonkButtonSizeTheme(
   size: ButtonProps['size'],
-  theme: DO_NOT_USE_ChonkTheme
+  theme: Theme
 ): StrictCSSObject {
   switch (size) {
     case 'md':

--- a/static/app/components/core/chonk.ts
+++ b/static/app/components/core/chonk.ts
@@ -1,10 +1,10 @@
 import color from 'color';
 
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 
 const chonkCache = new Map<{baseColor: string; type: 'light' | 'dark'}, string>();
 
-export function chonkFor(theme: DO_NOT_USE_ChonkTheme, baseColor: string) {
+export function chonkFor(theme: Theme, baseColor: string) {
   const cacheKey = {baseColor, type: theme.type};
   if (chonkCache.has(cacheKey)) {
     return chonkCache.get(cacheKey)!;
@@ -23,7 +23,7 @@ export function chonkFor(theme: DO_NOT_USE_ChonkTheme, baseColor: string) {
   return result;
 }
 
-export function debossedBackground(theme: DO_NOT_USE_ChonkTheme) {
+export function debossedBackground(theme: Theme) {
   return {
     backgroundColor: theme.type === 'dark' ? 'rgba(8,0,24,0.28)' : 'rgba(0,0,112,0.03)',
   };

--- a/static/app/components/core/code/codeBlock.tsx
+++ b/static/app/components/core/code/codeBlock.tsx
@@ -8,7 +8,8 @@ import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {loadPrismLanguage} from 'sentry/utils/prism';
-import {DO_NOT_USE_darkChonkTheme} from 'sentry/utils/theme/theme';
+// eslint-disable-next-line no-restricted-imports
+import {darkTheme} from 'sentry/utils/theme/theme';
 
 interface CodeBlockProps {
   children: string;
@@ -209,11 +210,7 @@ export function CodeBlock({
 
   // Override theme provider when in dark mode to provider dark theme to
   // components
-  return (
-    <ThemeProvider theme={dark ? (DO_NOT_USE_darkChonkTheme as any) : theme}>
-      {snippet}
-    </ThemeProvider>
-  );
+  return <ThemeProvider theme={dark ? darkTheme : theme}>{snippet}</ThemeProvider>;
 }
 
 const FlexSpacer = styled('div')`

--- a/static/app/components/core/input/input.chonk.tsx
+++ b/static/app/components/core/input/input.chonk.tsx
@@ -1,5 +1,5 @@
 import {debossedBackground} from 'sentry/components/core/chonk';
-import type {DO_NOT_USE_ChonkTheme, StrictCSSObject} from 'sentry/utils/theme';
+import type {StrictCSSObject, Theme} from 'sentry/utils/theme';
 
 import type {InputStylesProps} from './input';
 
@@ -8,7 +8,7 @@ export const chonkInputStyles = ({
   monospace,
   readOnly,
   size = 'md',
-}: InputStylesProps & {theme: DO_NOT_USE_ChonkTheme}): StrictCSSObject => {
+}: InputStylesProps & {theme: Theme}): StrictCSSObject => {
   const boxShadow = `0px 1px 0px 0px ${theme.tokens.border.primary} inset`;
 
   return {

--- a/static/app/components/core/input/inputGroup.chonk.tsx
+++ b/static/app/components/core/input/inputGroup.chonk.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {Input} from 'sentry/components/core/input/index';
 import {TextArea} from 'sentry/components/core/textarea';
 import {space} from 'sentry/styles/space';
-import type {DO_NOT_USE_ChonkTheme, FormSize, StrictCSSObject} from 'sentry/utils/theme';
+import type {FormSize, StrictCSSObject, Theme} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme';
 
 export interface InputStyleProps {
@@ -35,7 +35,7 @@ const chonkInputStyles = ({
   trailingWidth,
   size = 'md',
   theme,
-}: InputStyleProps & {theme: DO_NOT_USE_ChonkTheme}): StrictCSSObject => css`
+}: InputStyleProps & {theme: Theme}): StrictCSSObject => css`
   ${leadingWidth &&
   css`
     padding-left: calc(

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useMemo, useSyncExternalStore} from 'react';
 import {css, useTheme, type SerializedStyles} from '@emotion/react';
 
-import type {DO_NOT_USE_ChonkTheme, Theme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 import {isChonkTheme} from 'sentry/utils/theme/withChonk';
 
 // It is unfortunate, but Emotion seems to use the fn callback name in the classname, so lets keep it short.
@@ -65,7 +65,7 @@ const BREAKPOINT_ORDER: readonly Breakpoint[] = [
 ];
 
 // We alias None -> 0 to make it slighly more terse and easier to read.
-export type RadiusSize = keyof DO_NOT_USE_ChonkTheme['radius'];
+export type RadiusSize = keyof Theme['radius'];
 export type SpacingSize = keyof Theme['space'];
 export type Border = keyof Theme['tokens']['border'];
 export type Breakpoint = keyof Theme['breakpoints'];

--- a/static/app/components/core/radio/radio.chonk.tsx
+++ b/static/app/components/core/radio/radio.chonk.tsx
@@ -1,6 +1,6 @@
 import type {RadioProps} from 'sentry/components/core/radio';
 import {growIn} from 'sentry/styles/animations';
-import type {DO_NOT_USE_ChonkTheme, StrictCSSObject} from 'sentry/utils/theme';
+import type {StrictCSSObject, Theme} from 'sentry/utils/theme';
 
 const radioConfig = {
   sm: {
@@ -14,7 +14,7 @@ const radioConfig = {
 };
 
 export const chonkRadioStyles = (
-  props: RadioProps & {theme: DO_NOT_USE_ChonkTheme}
+  props: RadioProps & {theme: Theme}
 ): StrictCSSObject => ({
   width: radioConfig[props.size ?? 'md'].outerSize,
   height: radioConfig[props.size ?? 'md'].outerSize,

--- a/static/app/components/core/segmentedControl/segmentedControl.chonk.tsx
+++ b/static/app/components/core/segmentedControl/segmentedControl.chonk.tsx
@@ -2,7 +2,7 @@ import {css} from '@emotion/react';
 
 import {DO_NOT_USE_getChonkButtonStyles} from 'sentry/components/core/button/styles.chonk';
 import {space} from 'sentry/styles/space';
-import type {DO_NOT_USE_ChonkTheme, FormSize} from 'sentry/utils/theme';
+import type {FormSize, Theme} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme';
 
 export type Priority = 'default' | 'primary';
@@ -102,7 +102,7 @@ function getTextColor({
 }: {
   isSelected: boolean;
   priority: Priority;
-  theme: DO_NOT_USE_ChonkTheme;
+  theme: Theme;
   isDisabled?: boolean;
 }) {
   if (isSelected) {

--- a/static/app/components/core/select/select.chonk.tsx
+++ b/static/app/components/core/select/select.chonk.tsx
@@ -8,7 +8,7 @@ import {components as selectComponents} from 'sentry/components/forms/controls/r
 import {IconChevron, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {DO_NOT_USE_ChonkTheme, FormSize} from 'sentry/utils/theme';
+import type {FormSize, Theme} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme';
 
 // We don't care about any options for the styles config
@@ -42,7 +42,7 @@ export const getChonkStylesConfig = ({
   isSearchable: boolean | undefined;
   maxMenuWidth: string | number | undefined;
   size: FormSize | undefined;
-  theme: DO_NOT_USE_ChonkTheme;
+  theme: Theme;
 }) => {
   // TODO(epurkhiser): The loading indicator should probably also be our loading
   // indicator.

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -372,7 +372,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   const defaultStyles = useMemo(() => {
     return theme.isChonk
       ? getChonkStylesConfig({
-          theme: theme as any,
+          theme,
           size,
           maxMenuWidth,
           isInsideModal,

--- a/static/app/components/core/tabs/tab.chonk.tsx
+++ b/static/app/components/core/tabs/tab.chonk.tsx
@@ -1,7 +1,7 @@
 import {css} from '@emotion/react';
 import type {DOMAttributes, Orientation} from '@react-types/shared';
 
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme';
 
 import {tabsShouldForwardProp} from './utils';
@@ -48,7 +48,7 @@ export const ChonkStyledTabWrap = chonkStyled('li', {
     `}
 `;
 
-const paddingPerSize = (theme: DO_NOT_USE_ChonkTheme, orientation: Orientation) => ({
+const paddingPerSize = (theme: Theme, orientation: Orientation) => ({
   md: orientation === 'horizontal' ? `10px ${theme.space.xl}` : `10px ${theme.space.md}`,
   sm:
     orientation === 'horizontal'
@@ -72,7 +72,7 @@ export const chonkInnerWrapStyles = ({
   orientation: Orientation;
   selected: boolean;
   size: BaseTabProps['size'];
-  theme: DO_NOT_USE_ChonkTheme;
+  theme: Theme;
   variant: BaseTabProps['variant'];
 }) => css`
   display: flex;

--- a/static/app/components/core/toast/toast.tsx
+++ b/static/app/components/core/toast/toast.tsx
@@ -12,7 +12,7 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {IconCheckmark, IconRefresh, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import testableTransition from 'sentry/utils/testableTransition';
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme';
 
 export interface ToastProps {
@@ -93,10 +93,7 @@ function ToastIcon({type}: {type: Indicator['type']}) {
   }
 }
 
-function getContainerTheme(
-  theme: DO_NOT_USE_ChonkTheme,
-  type: Indicator['type']
-): React.CSSProperties {
+function getContainerTheme(theme: Theme, type: Indicator['type']): React.CSSProperties {
   switch (type) {
     case 'success':
       return {
@@ -155,7 +152,7 @@ const ToastInnerContainer = chonkStyled('div')<{type: Indicator['type']}>`
 `;
 
 function getToastIconContainerTheme(
-  theme: DO_NOT_USE_ChonkTheme,
+  theme: Theme,
   type: Indicator['type']
 ): React.CSSProperties {
   switch (type) {

--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -3,7 +3,6 @@ import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
 
 // Note: This component is also used in Explore multi-query mode
 // static/app/views/explore/multiQueryMode/queryConstructors/sortBy.tsx
@@ -124,7 +123,7 @@ const getChildTransforms = (count: number) => {
 
 const chonkPageFilterBarStyles = (p: {
   listSize: number;
-  theme: DO_NOT_USE_ChonkTheme;
+  theme: Theme;
   condensed?: boolean;
 }) => css`
   /* No idea what this is supposed to style, but I am afraid to remove it */

--- a/static/app/components/themeAndStyleProvider.tsx
+++ b/static/app/components/themeAndStyleProvider.tsx
@@ -1,7 +1,6 @@
 import {Fragment, lazy, useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import createCache from '@emotion/cache';
-import type {Theme} from '@emotion/react';
 import {CacheProvider, ThemeProvider} from '@emotion/react';
 
 import {NODE_ENV} from 'sentry/constants';
@@ -9,10 +8,8 @@ import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import GlobalStyles from 'sentry/styles/global';
 import {removeBodyTheme} from 'sentry/utils/removeBodyTheme';
-import {
-  DO_NOT_USE_darkChonkTheme,
-  DO_NOT_USE_lightChonkTheme,
-} from 'sentry/utils/theme/theme';
+// eslint-disable-next-line no-restricted-imports
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import {useHotkeys} from 'sentry/utils/useHotkeys';
 
 const SentryComponentInspector =
@@ -62,9 +59,7 @@ export function ThemeAndStyleProvider({children}: Props) {
 
   useHotkeys(themeToggleHotkey);
 
-  const theme = (config.theme === 'dark'
-    ? DO_NOT_USE_darkChonkTheme
-    : DO_NOT_USE_lightChonkTheme) as unknown as Theme;
+  const theme = config.theme === 'dark' ? darkTheme : lightTheme;
 
   return (
     <ThemeProvider theme={theme}>

--- a/static/app/debug/notifications/components/debugNotificationsLanding.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsLanding.tsx
@@ -8,14 +8,11 @@ import heroImg from 'sentry-images/debug/notifications/hero.png';
 import {Flex} from 'sentry/components/core/layout/flex';
 import {Heading, Text} from 'sentry/components/core/text';
 // Mimicking useStoriesDarkMode -> Don't use these elsewhere please 🙏
-import {DO_NOT_USE_darkChonkTheme} from 'sentry/utils/theme/theme';
+// eslint-disable-next-line no-restricted-imports
+import {darkTheme} from 'sentry/utils/theme/theme';
 
 function DarkModeProvider(props: PropsWithChildren) {
-  return (
-    <ThemeProvider theme={DO_NOT_USE_darkChonkTheme as any}>
-      {props.children}
-    </ThemeProvider>
-  );
+  return <ThemeProvider theme={darkTheme}>{props.children}</ThemeProvider>;
 }
 
 export function DebugNotificationsLanding() {

--- a/static/app/stories/theme.tsx
+++ b/static/app/stories/theme.tsx
@@ -8,10 +8,8 @@ import {IconMoon} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import {
-  DO_NOT_USE_darkChonkTheme,
-  DO_NOT_USE_lightChonkTheme,
-} from 'sentry/utils/theme/theme';
+// eslint-disable-next-line no-restricted-imports
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 interface ThemeToggleProps {
   children: React.ReactNode;
@@ -22,8 +20,7 @@ export function ThemeToggle({children}: ThemeToggleProps) {
 
   const [localThemeName, setLocalThemeName] = useState(config.theme);
 
-  const localThemeValue =
-    localThemeName === 'dark' ? DO_NOT_USE_darkChonkTheme : DO_NOT_USE_lightChonkTheme;
+  const localThemeValue = localThemeName === 'dark' ? darkTheme : lightTheme;
 
   return (
     <Fragment>

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -643,8 +643,7 @@ const FolderLink = styled(Link, {
   transition: none;
 
   &:before {
-    background: ${p =>
-      p.theme.isChonk ? (p.theme as any).colors.blue100 : p.theme.blue100};
+    background: ${p => (p.theme.isChonk ? p.theme.colors.blue100 : p.theme.blue100)};
     content: '';
     inset: 0 ${p => p.theme.space.md} 0 -${p => p.theme.space['2xs']};
     position: absolute;

--- a/static/app/stories/view/useStoriesDarkMode.tsx
+++ b/static/app/stories/view/useStoriesDarkMode.tsx
@@ -3,7 +3,8 @@ import {ThemeProvider, type Theme} from '@emotion/react';
 
 // these utils are for stories that have forced dark mode
 // which is a very specific sanctioned use case
-import {DO_NOT_USE_darkChonkTheme} from 'sentry/utils/theme/theme';
+// eslint-disable-next-line no-restricted-imports
+import {darkTheme} from 'sentry/utils/theme/theme';
 
 /**
  * Access the raw values from the dark theme
@@ -11,7 +12,7 @@ import {DO_NOT_USE_darkChonkTheme} from 'sentry/utils/theme/theme';
  * ⚠️ DO NOT USE OUTSIDE OF STORIES
  */
 export const useStoryDarkModeTheme = (): Theme => {
-  return DO_NOT_USE_darkChonkTheme as any;
+  return darkTheme;
 };
 
 /**

--- a/static/app/utils/theme/index.tsx
+++ b/static/app/utils/theme/index.tsx
@@ -5,5 +5,4 @@ export type {
   IconSize,
   StrictCSSObject,
   SentryTheme as Theme,
-  SentryTheme as DO_NOT_USE_ChonkTheme,
 } from './theme';

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -644,7 +644,7 @@ export type Color = keyof ReturnType<typeof deprecatedColorMappings>;
 export type IconSize = keyof typeof iconSizes;
 type Aliases = typeof lightAliases;
 export type ColorOrAlias = keyof Aliases | Color;
-export interface SentryTheme extends Omit<typeof lightTheme, 'chart'> {
+export interface SentryTheme extends Omit<typeof lightThemeDefinition, 'chart'> {
   chart: {
     colors: typeof CHART_PALETTE_LIGHT | typeof CHART_PALETTE_DARK;
     getColorPalette: ReturnType<typeof makeChartColorPalette>;
@@ -1775,10 +1775,7 @@ const deprecatedColorMappings = (colors: Colors) => ({
   },
 });
 
-/**
- * @deprecated use useTheme hook instead of directly importing the theme. If you require a theme for your tests, use ThemeFixture.
- */
-export const lightTheme = {
+const lightThemeDefinition = {
   isChonk: true,
   type: 'light' as 'light' | 'dark',
   // @TODO: color theme contains some colors (like chart color palette, diff, tag and level)
@@ -1834,6 +1831,11 @@ export const lightTheme = {
     superuser: '#880808',
   },
 };
+
+/**
+ * @deprecated use useTheme hook instead of directly importing the theme. If you require a theme for your tests, use ThemeFixture.
+ */
+export const lightTheme: SentryTheme = lightThemeDefinition;
 
 /**
  * @deprecated use useTheme hook instead of directly importing the theme. If you require a theme for your tests, use ThemeFixture.
@@ -1911,7 +1913,3 @@ export type StrictCSSObject = {
 
 export const chonkStyled = styled;
 export const useChonkTheme = useTheme;
-/** @alias */
-export const DO_NOT_USE_lightChonkTheme = lightTheme;
-/** @alias */
-export const DO_NOT_USE_darkChonkTheme = darkTheme;

--- a/static/app/utils/theme/withChonk.spec.tsx
+++ b/static/app/utils/theme/withChonk.spec.tsx
@@ -9,7 +9,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 
 import {withChonk} from './withChonk';
 
@@ -17,7 +17,7 @@ function LegacyComponent() {
   const theme = useTheme();
   return <div>Legacy: {theme.isChonk ? 'true' : 'false'}</div>;
 }
-function ChonkComponent({theme}: {theme: DO_NOT_USE_ChonkTheme}) {
+function ChonkComponent({theme}: {theme: Theme}) {
   return <div>Chonk: {theme.isChonk ? 'true' : 'false'}</div>;
 }
 
@@ -26,12 +26,7 @@ function LegacyComponentWithRef({ref}: {ref?: React.Ref<HTMLDivElement>}) {
   return <div ref={ref}>Legacy: {theme.isChonk ? 'true' : 'false'}</div>;
 }
 
-function ChonkComponentWithRef({
-  ref,
-}: {
-  theme: DO_NOT_USE_ChonkTheme;
-  ref?: React.Ref<HTMLDivElement>;
-}) {
+function ChonkComponentWithRef({ref}: {theme: Theme; ref?: React.Ref<HTMLDivElement>}) {
   const theme = useTheme();
   return <div ref={ref}>Chonk: {theme.isChonk ? 'true' : 'false'}</div>;
 }

--- a/static/app/utils/theme/withChonk.tsx
+++ b/static/app/utils/theme/withChonk.tsx
@@ -2,8 +2,6 @@ import type {Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
-
 export type ChonkPropMapping<LegacyProps, ChonkProps> = (
   props: Omit<LegacyProps, 'theme' | 'ref'>
 ) => Omit<ChonkProps, 'theme' | 'ref'>;
@@ -22,7 +20,7 @@ export function withChonk<
   LegacyProps extends {children?: React.ReactNode} & React.RefAttributes<any>,
   ChonkProps extends {
     children?: React.ReactNode;
-    theme?: DO_NOT_USE_ChonkTheme;
+    theme?: Theme;
   } & React.RefAttributes<any>,
 >(
   legacyComponent: React.ComponentType<LegacyProps>,

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react';
-import {ThemeProvider, type Theme} from '@emotion/react';
+import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -11,17 +11,15 @@ import {IconSentry, IconSliders} from 'sentry/icons';
 import {ScrapsProviders} from 'sentry/scrapsProviders';
 import {space} from 'sentry/styles/space';
 import localStorage from 'sentry/utils/localStorage';
-import {
-  DO_NOT_USE_darkChonkTheme,
-  DO_NOT_USE_lightChonkTheme,
-} from 'sentry/utils/theme/theme';
+// eslint-disable-next-line no-restricted-imports
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import SystemAlerts from 'sentry/views/app/systemAlerts';
 
 import GlobalStyles from 'admin/globalStyles';
 
 const themes = {
-  darkTheme: DO_NOT_USE_darkChonkTheme as unknown as Theme,
-  lightTheme: DO_NOT_USE_lightChonkTheme as unknown as Theme,
+  darkTheme,
+  lightTheme,
 };
 
 type ThemeName = keyof typeof themes;

--- a/static/gsApp/components/stripeWrapper.tsx
+++ b/static/gsApp/components/stripeWrapper.tsx
@@ -54,7 +54,7 @@ function StripeWrapper({
             '.Input': {
               fontSize: theme.fontSize.md,
               boxShadow: `0px 2px 0px 0px ${theme.tokens.border.primary} inset`,
-              backgroundColor: debossedBackground(theme as any).backgroundColor,
+              backgroundColor: debossedBackground(theme).backgroundColor,
               padding: `${theme.space.lg} ${theme.space.xl}`,
             },
             '.Label': {

--- a/static/gsApp/components/superuser/superuserWarning.tsx
+++ b/static/gsApp/components/superuser/superuserWarning.tsx
@@ -104,8 +104,7 @@ function SuperuserWarning({organization, className}: Props) {
 
 const StyledBadge = styled(Badge)`
   color: ${p => (p.theme.isChonk ? p.theme.white : undefined)};
-  background: ${p =>
-    p.theme.isChonk ? (p.theme as any).colors.chonk.red400 : undefined};
+  background: ${p => (p.theme.isChonk ? p.theme.colors.chonk.red400 : undefined)};
 `;
 
 const TooltipContent = styled('div')`

--- a/tests/js/fixtures/theme.tsx
+++ b/tests/js/fixtures/theme.tsx
@@ -1,7 +1,6 @@
-import type {DO_NOT_USE_ChonkTheme} from 'sentry/utils/theme';
-import {type Theme} from 'sentry/utils/theme';
-import {DO_NOT_USE_lightChonkTheme} from 'sentry/utils/theme/theme';
+// eslint-disable-next-line no-restricted-imports
+import {lightTheme} from 'sentry/utils/theme/theme';
 
-export const ThemeFixture = (): Theme & DO_NOT_USE_ChonkTheme => {
-  return DO_NOT_USE_lightChonkTheme as Theme & DO_NOT_USE_ChonkTheme;
+export const ThemeFixture = () => {
+  return lightTheme;
 };


### PR DESCRIPTION
There is now only one `Theme`, and we can use `darkTheme` and `lightTheme` directly (even though we need to eslint-disable the import, as they are discouraged, but there are a few places where we need direct theme access).