### PR TITLE
fix(preprod): Handle missing date_built in UI and backend (EME-671)

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -60,6 +60,7 @@ def validate_preprod_artifact_update_schema(
                     "is_code_signature_valid": {"type": "boolean"},
                     "code_signature_errors": {"type": "array", "items": {"type": "string"}},
                     "missing_dsym_binaries": {"type": "array", "items": {"type": "string"}},
+                    "build_date": {"type": "string"},
                 },
             },
             "android_app_info": {
@@ -90,6 +91,7 @@ def validate_preprod_artifact_update_schema(
         "apple_app_info.is_code_signature_valid": "The is_code_signature_valid field must be a boolean.",
         "apple_app_info.code_signature_errors": "The code_signature_errors field must be an array of strings.",
         "apple_app_info.missing_dsym_binaries": "The missing_dsym_binaries field must be an array of strings.",
+        "apple_app_info.build_date": "The build_date field must be a string.",
         "android_app_info": "The android_app_info field must be an object.",
         "android_app_info.has_proguard_mapping": "The has_proguard_mapping field must be a boolean.",
         "dequeued_at": "The dequeued_at field must be a string.",
@@ -292,6 +294,10 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 binaries = apple_info["missing_dsym_binaries"]
                 if isinstance(binaries, list):
                     extras_updates["has_missing_dsym_binaries"] = len(binaries) > 0
+
+            if "build_date" in apple_info:
+                head_artifact.date_built = apple_info["build_date"]
+                updated_fields.append("date_built")
 
             for field in [
                 "is_simulator",

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -68,15 +68,17 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
             </Flex>
           </Tooltip>
         )}
-        {props.appInfo.date_added && (
-          <Tooltip title={t('App upload time')}>
+        {(props.appInfo.date_built || props.appInfo.date_added) && (
+          <Tooltip
+            title={props.appInfo.date_built ? t('App build time') : t('App upload time')}
+          >
             <Flex gap="2xs" align="center">
               <InfoIcon>
                 <IconClock />
               </InfoIcon>
               <Text>
                 {getFormattedDate(
-                  getUtcToSystem(props.appInfo.date_added),
+                  getUtcToSystem(props.appInfo.date_built || props.appInfo.date_added),
                   datetimeFormat,
                   {local: true}
                 )}


### PR DESCRIPTION
Frontend: Update the build details sidebar to display a timestamp even when
`date_built` is not available by falling back to `date_added`. The tooltip now
shows "App build time" when displaying `date_built`, or "App upload time" when
displaying date_added.

Backend: Extract `build_date` from `apple_app_info` and set it as `date_built`.
Previously, Launchpad was sending `build_date` in `apple_app_info`, but the Sentry
endpoint was not extracting it. This fix ensures that the build date from the
XCArchive metadata is properly stored in the `date_built` field.

Before:
<img width="321" height="133" alt="Screenshot 2025-12-05 at 11 29 39" src="https://github.com/user-attachments/assets/e2ee1df3-09ba-4b90-b453-569412f78a11" />
After:
<img width="307" height="125" alt="Screenshot 2025-12-05 at 11 29 30" src="https://github.com/user-attachments/assets/4dceb788-d440-43da-92df-ce236df98572" />



This ensures users always see a relevant timestamp for their builds.
