### PR TITLE
feat(preprod): add compare deltas to metric cards (EME-568)

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -106,6 +106,7 @@ class SizeInfoCompleted(BaseModel):
     # Deprecated, use size_metrics instead
     download_size_bytes: int
     size_metrics: list[SizeInfoSizeMetric]
+    base_size_metrics: list[SizeInfoSizeMetric]
 
 
 class SizeInfoFailed(BaseModel):
@@ -129,6 +130,7 @@ class BuildDetailsApiResponse(BaseModel):
     vcs_info: BuildDetailsVcsInfo
     size_info: SizeInfo | None = None
     posted_status_checks: PostedStatusChecks | None = None
+    base_artifact_id: str | None = None
 
 
 def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType) -> Platform:
@@ -143,7 +145,10 @@ def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType) -> 
             raise ValueError(f"Unknown artifact type: {artifact_type}")
 
 
-def to_size_info(size_metrics: list[PreprodArtifactSizeMetrics]) -> None | SizeInfo:
+def to_size_info(
+    size_metrics: list[PreprodArtifactSizeMetrics],
+    base_size_metrics: list[PreprodArtifactSizeMetrics] | None = None,
+) -> None | SizeInfo:
     if len(size_metrics) == 0:
         return None
 
@@ -182,6 +187,15 @@ def to_size_info(size_metrics: list[PreprodArtifactSizeMetrics]) -> None | SizeI
                     )
                     for metric in size_metrics
                 ],
+                base_size_metrics=[
+                    SizeInfoSizeMetric(
+                        metrics_artifact_type=metric.metrics_artifact_type,
+                        install_size_bytes=metric.max_install_size,
+                        download_size_bytes=metric.max_download_size,
+                    )
+                    for metric in (base_size_metrics or [])
+                    if metric.max_install_size is not None and metric.max_download_size is not None
+                ],
             )
         case PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED:
             error_code = main_metric.error_code
@@ -201,7 +215,15 @@ def transform_preprod_artifact_to_build_details(
         preprod_artifact=artifact,
     )
 
-    size_info = to_size_info(list(size_metrics_qs))
+    base_size_metrics_qs: list[PreprodArtifactSizeMetrics] = []
+    base_artifact = artifact.get_base_artifact_for_commit().first()
+    if base_artifact:
+        base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact=base_artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+    size_info = to_size_info(list(size_metrics_qs), list(base_size_metrics_qs))
 
     platform = None
     # artifact_type can be null before preprocessing has completed
@@ -274,6 +296,7 @@ def transform_preprod_artifact_to_build_details(
         vcs_info=vcs_info,
         size_info=size_info,
         posted_status_checks=posted_status_checks,
+        base_artifact_id=base_artifact.id if base_artifact else None,
     )
 
 

--- a/static/app/views/preprod/buildComparison/main/buildComparisonMetricCards.tsx
+++ b/static/app/views/preprod/buildComparison/main/buildComparisonMetricCards.tsx
@@ -4,7 +4,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {PercentChange} from 'sentry/components/percentChange';
-import {IconArrow, IconCode, IconDownload} from 'sentry/icons';
+import {IconCode, IconDownload} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {MetricCard} from 'sentry/views/preprod/components/metricCard';
@@ -12,7 +12,7 @@ import type {
   SizeAnalysisComparisonResults,
   SizeComparisonApiResponse,
 } from 'sentry/views/preprod/types/appSizeTypes';
-import {getLabels} from 'sentry/views/preprod/utils/labelUtils';
+import {getLabels, getTrend} from 'sentry/views/preprod/utils/labelUtils';
 
 interface BuildComparisonMetricCardsProps {
   comparisonResponse: SizeComparisonApiResponse | undefined;
@@ -152,25 +152,4 @@ export function BuildComparisonMetricCards(props: BuildComparisonMetricCardsProp
       })}
     </Flex>
   );
-}
-
-function getTrend(diff: number): {
-  variant: 'danger' | 'success' | 'muted';
-  icon?: React.ReactNode;
-} {
-  if (diff > 0) {
-    return {
-      variant: 'danger',
-      icon: <IconArrow direction="up" size="xs" />,
-    };
-  }
-
-  if (diff < 0) {
-    return {
-      variant: 'success',
-      icon: <IconArrow direction="down" size="xs" />,
-    };
-  }
-
-  return {variant: 'muted'};
 }

--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -106,6 +106,7 @@ describe('BuildDetails', () => {
               download_size_bytes: 512000,
             },
           ],
+          base_size_metrics: [],
         },
         {
           vcs_info: PreprodVcsInfoFullFixture(),
@@ -181,6 +182,7 @@ describe('BuildDetails', () => {
               download_size_bytes: 512000,
             },
           ],
+          base_size_metrics: [],
         });
       },
     });
@@ -233,6 +235,7 @@ describe('BuildDetails', () => {
             download_size_bytes: 512000,
           },
         ],
+        base_size_metrics: [],
       }),
     });
 

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -323,6 +323,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
         sizeInfo={sizeInfo}
         processedInsights={processedInsights}
         totalSize={totalSize}
+        baseArtifactId={buildDetailsData?.base_artifact_id ?? null}
         platform={buildDetailsData?.app_info?.platform ?? null}
         projectType={projectType}
         onOpenInsightsSidebar={openInsightsSidebar}

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -1,16 +1,19 @@
 import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
+import {LinkButton} from '@sentry/scraps/button/linkButton';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {PercentChange} from 'sentry/components/percentChange';
 import {IconCode, IconDownload, IconLightning, IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import {MetricCard} from 'sentry/views/preprod/components/metricCard';
 import {MetricsArtifactType} from 'sentry/views/preprod/types/appSizeTypes';
 import {
@@ -27,6 +30,7 @@ import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
   getLabels,
+  getTrend,
 } from 'sentry/views/preprod/utils/labelUtils';
 
 interface BuildDetailsMetricCardsProps {
@@ -34,6 +38,7 @@ interface BuildDetailsMetricCardsProps {
   processedInsights: ProcessedInsight[];
   sizeInfo: BuildDetailsSizeInfo | undefined;
   totalSize: number;
+  baseArtifactId?: string | null;
   platform?: Platform | null;
   projectType?: string | null;
 }
@@ -43,10 +48,17 @@ interface MetricCardConfig {
   key: string;
   title: string;
   value: string;
+  comparisonUrl?: string;
+  delta?: MetricDelta;
   labelTooltip?: string;
   percentageText?: string;
   showInsightsButton?: boolean;
   watchBreakdown?: WatchBreakdown;
+}
+interface MetricDelta {
+  baseValue: number;
+  diff: number;
+  percentageChange: number;
 }
 
 interface WatchBreakdown {
@@ -59,12 +71,14 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
     sizeInfo,
     processedInsights,
     totalSize,
+    baseArtifactId,
     platform: platformProp,
     projectType,
     onOpenInsightsSidebar,
   } = props;
 
   const organization = useOrganization();
+  const params = useParams<{artifactId: string; projectId: string}>();
 
   if (!isSizeInfoCompleted(sizeInfo)) {
     return null;
@@ -77,6 +91,27 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
   );
   const installMetricValue = formattedPrimaryMetricInstallSize(sizeInfo);
   const downloadMetricValue = formattedPrimaryMetricDownloadSize(sizeInfo);
+
+  // Find matching base metrics for comparison
+  const basePrimarySizeMetric = sizeInfo.base_size_metrics.find(
+    metric => metric.metrics_artifact_type === MetricsArtifactType.MAIN_ARTIFACT
+  );
+
+  // Calculate deltas for install and download sizes
+  const installDelta: MetricDelta | undefined = calculateDelta(
+    primarySizeMetric?.install_size_bytes,
+    basePrimarySizeMetric?.install_size_bytes
+  );
+  const downloadDelta: MetricDelta | undefined = calculateDelta(
+    primarySizeMetric?.download_size_bytes,
+    basePrimarySizeMetric?.download_size_bytes
+  );
+
+  // Build comparison URL using route params
+  const comparisonUrl = baseArtifactId
+    ? `/organizations/${organization.slug}/preprod/${params.projectId}/compare/${params.artifactId}/${baseArtifactId}/`
+    : undefined;
+
   const totalPotentialSavings = processedInsights.reduce(
     (sum, insight) => sum + (insight.totalSavings ?? 0),
     0
@@ -97,11 +132,13 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
       icon: <IconCode size="sm" />,
       labelTooltip: labels.installSizeDescription,
       value: installMetricValue,
+      comparisonUrl,
       watchBreakdown: getWatchBreakdown(
         primarySizeMetric,
         watchArtifactMetric,
         'install_size_bytes'
       ),
+      delta: installDelta,
     },
     {
       key: 'download',
@@ -109,11 +146,13 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
       icon: <IconDownload size="sm" />,
       labelTooltip: labels.downloadSizeDescription,
       value: downloadMetricValue,
+      comparisonUrl,
       watchBreakdown: getWatchBreakdown(
         primarySizeMetric,
         watchArtifactMetric,
         'download_size_bytes'
       ),
+      delta: downloadDelta,
     },
     {
       key: 'savings',
@@ -121,6 +160,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
       icon: <IconLightning size="sm" />,
       labelTooltip: t('Total savings from insights'),
       value: formatBytesBase10(totalPotentialSavings),
+      comparisonUrl: undefined,
       percentageText: potentialSavingsPercentageText,
       showInsightsButton: totalPotentialSavings > 0,
     },
@@ -153,24 +193,95 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
               : undefined
           }
         >
-          <Heading as="h3">
-            {card.watchBreakdown ? (
-              <Tooltip
-                title={
-                  <WatchBreakdownTooltip
-                    appValue={card.watchBreakdown.appValue}
-                    watchValue={card.watchBreakdown.watchValue}
-                  />
-                }
-                position="bottom"
-              >
-                <MetricValue $interactive>{card.value}</MetricValue>
-              </Tooltip>
-            ) : (
-              <MetricValue>{card.value}</MetricValue>
+          <Stack gap="xs">
+            <Flex align="end" gap="sm" wrap="wrap">
+              <Heading as="h3">
+                {card.watchBreakdown ? (
+                  <Tooltip
+                    title={
+                      <WatchBreakdownTooltip
+                        appValue={card.watchBreakdown.appValue}
+                        watchValue={card.watchBreakdown.watchValue}
+                      />
+                    }
+                    position="bottom"
+                  >
+                    <MetricValue $interactive>{card.value}</MetricValue>
+                  </Tooltip>
+                ) : (
+                  <MetricValue>{card.value}</MetricValue>
+                )}
+                {card.percentageText ?? ''}
+              </Heading>
+
+              {card.delta &&
+                card.comparisonUrl &&
+                (() => {
+                  const {variant, icon} = getTrend(card.delta.diff);
+
+                  return (
+                    <LinkButton
+                      to={card.comparisonUrl}
+                      size="xs"
+                      priority="link"
+                      aria-label={t('Compare builds')}
+                    >
+                      <Flex align="center" gap="xs">
+                        {icon}
+                        <Text
+                          as="span"
+                          variant={variant}
+                          size="sm"
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            flexWrap: 'wrap',
+                            gap: '0.25em',
+                            fontWeight: 'normal',
+                          }}
+                        >
+                          {card.delta.diff > 0 ? '+' : card.delta.diff < 0 ? '-' : ''}
+                          {formatBytesBase10(Math.abs(card.delta.diff))}
+                          {card.delta.percentageChange !== 0 && (
+                            <Text
+                              as="span"
+                              variant={variant}
+                              style={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {' ('}
+                              <PercentChange
+                                value={card.delta.percentageChange}
+                                minimumValue={0.001}
+                                preferredPolarity="-"
+                                colorize
+                              />
+                              {')'}
+                            </Text>
+                          )}
+                        </Text>
+                      </Flex>
+                    </LinkButton>
+                  );
+                })()}
+            </Flex>
+
+            {card.delta && (
+              <Flex gap="xs" wrap="wrap">
+                <Text variant="muted" size="sm">
+                  {t('Base Build Size:')}
+                </Text>
+                <Text variant="muted" size="sm" bold>
+                  {card.delta.baseValue === 0
+                    ? t('Not present')
+                    : formatBytesBase10(card.delta.baseValue)}
+                </Text>
+              </Flex>
             )}
-            {card.percentageText ?? ''}
-          </Heading>
+          </Stack>
         </MetricCard>
       ))}
     </Flex>
@@ -210,6 +321,24 @@ function getWatchBreakdown(
   return {
     appValue: formatBytesBase10(primaryMetric[field]),
     watchValue: formatBytesBase10(watchMetric[field]),
+  };
+}
+
+function calculateDelta(
+  headValue: number | undefined,
+  baseValue: number | undefined
+): MetricDelta | undefined {
+  if (headValue === undefined || baseValue === undefined) {
+    return undefined;
+  }
+
+  const diff = headValue - baseValue;
+  const percentageChange = baseValue === 0 ? 0 : diff / baseValue;
+
+  return {
+    baseValue,
+    diff,
+    percentageChange,
   };
 }
 

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -9,6 +9,7 @@ export interface BuildDetailsApiResponse {
   state: BuildDetailsState;
   vcs_info: BuildDetailsVcsInfo;
   size_info?: BuildDetailsSizeInfo;
+  base_artifact_id?: string | null;
 }
 
 export interface BuildDetailsAppInfo {
@@ -62,6 +63,7 @@ interface BuildDetailsSizeInfoProcessing {
 interface BuildDetailsSizeInfoCompleted {
   state: BuildDetailsSizeAnalysisState.COMPLETED;
   size_metrics: BuildDetailsSizeInfoSizeMetric[];
+  base_size_metrics: BuildDetailsSizeInfoSizeMetric[];
 }
 
 interface BuildDetailsSizeInfoFailed {

--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -1,3 +1,4 @@
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {unreachable} from 'sentry/utils/unreachable';
@@ -141,4 +142,25 @@ export function formattedPrimaryMetricDownloadSize(
     return formatBytesBase10(primarySizeMetric.download_size_bytes);
   }
   return '-';
+}
+
+export function getTrend(diff: number): {
+  variant: 'danger' | 'success' | 'muted';
+  icon?: React.ReactNode;
+} {
+  if (diff > 0) {
+    return {
+      variant: 'danger',
+      icon: <IconArrow direction="up" size="xs" />,
+    };
+  }
+
+  if (diff < 0) {
+    return {
+      variant: 'success',
+      icon: <IconArrow direction="down" size="xs" />,
+    };
+  }
+
+  return {variant: 'muted'};
 }

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -191,6 +191,58 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         assert resp_data["size_info"]["install_size_bytes"] == 1024000
         assert resp_data["size_info"]["download_size_bytes"] == 512000
 
+    def test_size_info_completed_includes_base_metrics(self) -> None:
+        """Test that completed size analysis includes base_size_metrics when base artifact exists."""
+        base_commit_comparison = self.create_commit_comparison(
+            organization=self.org,
+            head_sha=self.preprod_artifact.commit_comparison.base_sha,
+            base_sha="0000000000000000000000000000000000000000",
+        )
+        base_file = self.create_file(name="base_artifact.apk", type="application/octet-stream")
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            file_id=base_file.id,
+            artifact_type=self.preprod_artifact.artifact_type,
+            app_id=self.preprod_artifact.app_id,
+            app_name=self.preprod_artifact.app_name,
+            build_version="0.9.0",
+            build_number=41,
+            commit_comparison=base_commit_comparison,
+        )
+
+        self.create_preprod_artifact_size_metrics(
+            self.preprod_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1536000,
+            max_download_size=768000,
+        )
+        self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1024000,
+            max_download_size=512000,
+        )
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["size_info"] is not None
+        assert resp_data["size_info"]["state"] == 2
+        assert len(resp_data["size_info"]["base_size_metrics"]) == 1
+        base_metric = resp_data["size_info"]["base_size_metrics"][0]
+        assert (
+            base_metric["metrics_artifact_type"]
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+        )
+        assert base_metric["install_size_bytes"] == 1024000
+        assert base_metric["download_size_bytes"] == 512000
+
     def test_size_info_failed(self) -> None:
         """Test that failed size analysis returns SizeInfoFailed."""
         self.create_preprod_artifact_size_metrics(

--- a/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
+++ b/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
@@ -95,6 +95,37 @@ class TestToSizeInfo(TestCase):
         assert result.size_metrics[1].install_size_bytes == 512000
         assert result.size_metrics[1].download_size_bytes == 256000
 
+    def test_to_size_info_completed_state_with_base_metrics(self):
+        """Test to_size_info includes base size metrics when provided."""
+        size_metrics = [
+            PreprodArtifactSizeMetrics(
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                max_install_size=1024000,
+                max_download_size=512000,
+            ),
+        ]
+        base_size_metrics = [
+            PreprodArtifactSizeMetrics(
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                max_install_size=512000,
+                max_download_size=256000,
+            ),
+        ]
+
+        result = to_size_info(size_metrics, base_size_metrics)
+
+        assert isinstance(result, SizeInfoCompleted)
+        assert len(result.base_size_metrics) == 1
+        base_metric = result.base_size_metrics[0]
+        assert (
+            base_metric.metrics_artifact_type
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+        )
+        assert base_metric.install_size_bytes == 512000
+        assert base_metric.download_size_bytes == 256000
+
     def test_to_size_info_failed_state(self):
         """Test to_size_info returns SizeInfoFailed for FAILED state."""
         size_metrics = PreprodArtifactSizeMetrics(


### PR DESCRIPTION
## Summary
- add diff deltas to preprod build metric cards when base build data is available
- expand API/serializer wiring and types to expose base comparisons for builds
- update UI metric cards to render deltas and labels plus coverage in tests

## Why
- surface change deltas vs base build to highlight preprod regressions/improvements

## Testing
- Not run (CI will cover)

## Ticket
- EME-568

## Reviewers
- Requesting @getsentry/app-frontend @getsentry/app-backend

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->