### PR TITLE
ref(explorer): replace hamburger menu with top bar

### DIFF
--- a/static/app/views/seerExplorer/askUserQuestionBlock.tsx
+++ b/static/app/views/seerExplorer/askUserQuestionBlock.tsx
@@ -111,6 +111,7 @@ function AskUserQuestionBlock({
                           checked={isOtherSelected}
                           onChange={() => handleOptionClick(optionsCount)}
                           name={`question-${questionIndex}`}
+                          size="sm"
                         />
                         <CustomInputWrapper>
                           <CustomInput

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -439,7 +439,9 @@ export default BlockComponent;
 
 const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
   width: 100%;
-  border-bottom: ${p => (p.isLast ? 'none' : `1px solid ${p.theme.border}`)};
+  border-top: 1px solid transparent;
+  border-bottom: ${p =>
+    p.isLast ? '1px solid transparent' : `1px solid ${p.theme.border}`};
   position: relative;
   flex-shrink: 0; /* Prevent blocks from shrinking */
   cursor: pointer;

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -14,11 +14,7 @@ import TimeSince from 'sentry/components/timeSince';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useExplorerSessions} from 'sentry/views/seerExplorer/hooks/useExplorerSessions';
 
-type MenuMode =
-  | 'slash-commands-keyboard'
-  | 'slash-commands-manual'
-  | 'session-history'
-  | 'hidden';
+type MenuMode = 'slash-commands-keyboard' | 'session-history' | 'hidden';
 
 interface ExplorerMenuProps {
   clearInput: () => void;
@@ -85,14 +81,12 @@ export function useExplorerMenu({
     switch (menuMode) {
       case 'slash-commands-keyboard':
         return filteredSlashCommands;
-      case 'slash-commands-manual':
-        return allSlashCommands;
       case 'session-history':
         return sessionItems;
       default:
         return [];
     }
-  }, [menuMode, allSlashCommands, filteredSlashCommands, sessionItems]);
+  }, [menuMode, filteredSlashCommands, sessionItems]);
 
   const close = useCallback(() => {
     setMenuMode('hidden');
@@ -268,7 +262,6 @@ export function useExplorerMenu({
 
     const isSlashCommandMenu =
       menuMode === 'slash-commands-keyboard' ||
-      menuMode === 'slash-commands-manual' ||
       (menuMode === 'session-history' && openedViaSlashCommand);
 
     // Position relative to input for slash commands, or button for button clicks
@@ -324,15 +317,6 @@ export function useExplorerMenu({
     </Activity>
   );
 
-  // Handler for the button entrypoint.
-  const onMenuButtonClick = useCallback(() => {
-    if (menuMode === 'hidden') {
-      setMenuMode('slash-commands-manual');
-    } else {
-      close();
-    }
-  }, [menuMode, setMenuMode, close]);
-
   // Handler for opening session history from button
   const openSessionHistory = useCallback(() => {
     if (menuMode === 'session-history') {
@@ -350,7 +334,6 @@ export function useExplorerMenu({
     menuMode,
     isMenuOpen: menuMode !== 'hidden',
     closeMenu: close,
-    onMenuButtonClick,
     openSessionHistory,
   };
 }

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -210,20 +210,38 @@ export function useExplorerMenu({
     return undefined;
   }, [handleKeyDown, isVisible]);
 
-  // Helper to calculate position relative to panel
-  const calculatePosition = useCallback(
-    (anchorElement: HTMLElement, useBottom: boolean) => {
-      const rect = anchorElement.getBoundingClientRect();
-      const panelRect = anchorElement
-        .closest('[data-seer-explorer-root]')
-        ?.getBoundingClientRect();
+  // Calculate menu position based on anchor element
+  useLayoutEffect(() => {
+    if (!isVisible) {
+      setMenuPosition({});
+      return;
+    }
 
-      const spacing = 8;
-      if (panelRect) {
-        const relativeTop = rect.top - panelRect.top;
-        const relativeLeft = rect.left - panelRect.left;
+    const anchorRef =
+      menuMode === 'slash-commands-keyboard' ? inputAnchorRef : menuAnchorRef;
+    const isSlashCommand = menuMode === 'slash-commands-keyboard';
 
-        return useBottom
+    if (!anchorRef?.current) {
+      // Fallback to default bottom-left
+      setMenuPosition({
+        bottom: '100%',
+        left: '16px',
+      });
+      return;
+    }
+
+    const rect = anchorRef.current.getBoundingClientRect();
+    const panelRect = anchorRef.current
+      .closest('[data-seer-explorer-root]')
+      ?.getBoundingClientRect();
+
+    const spacing = 8;
+    if (panelRect) {
+      const relativeTop = rect.top - panelRect.top;
+      const relativeLeft = rect.left - panelRect.left;
+
+      setMenuPosition(
+        isSlashCommand
           ? {
               bottom: `${panelRect.height - relativeTop + spacing}px`,
               left: `${relativeLeft}px`,
@@ -231,46 +249,23 @@ export function useExplorerMenu({
           : {
               top: `${relativeTop + rect.height + spacing}px`,
               left: `${relativeLeft}px`,
-            };
-      }
-
-      // Fallback to viewport positioning
-      return useBottom
-        ? {
-            bottom: `${window.innerHeight - rect.top + spacing}px`,
-            left: `${rect.left}px`,
-          }
-        : {
-            top: `${rect.bottom + spacing}px`,
-            left: `${rect.left}px`,
-          };
-    },
-    []
-  );
-
-  // Calculate menu position based on anchor element or default to bottom-left
-  // Use useLayoutEffect to calculate position synchronously before paint to prevent flashing
-  useLayoutEffect(() => {
-    if (!isVisible) {
-      setMenuPosition({});
-      return;
-    }
-
-    // Position relative to input for slash commands, or button for session history
-    const anchorRef =
-      menuMode === 'slash-commands-keyboard' ? inputAnchorRef : menuAnchorRef;
-    const useBottom = menuMode === 'slash-commands-keyboard';
-
-    if (anchorRef?.current) {
-      setMenuPosition(calculatePosition(anchorRef.current, useBottom));
+            }
+      );
     } else {
-      // Fallback to default bottom-left
-      setMenuPosition({
-        bottom: '100%',
-        left: '16px',
-      });
+      // Fallback to viewport positioning
+      setMenuPosition(
+        isSlashCommand
+          ? {
+              bottom: `${window.innerHeight - rect.top + spacing}px`,
+              left: `${rect.left}px`,
+            }
+          : {
+              top: `${rect.bottom + spacing}px`,
+              left: `${rect.left}px`,
+            }
+      );
     }
-  }, [isVisible, menuMode, menuAnchorRef, inputAnchorRef, calculatePosition]);
+  }, [isVisible, menuMode, menuAnchorRef, inputAnchorRef]);
 
   const menu = (
     <Activity mode={isVisible ? 'visible' : 'hidden'}>

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -1,12 +1,4 @@
-import {
-  Activity,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {Activity, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
@@ -211,7 +203,7 @@ export function useExplorerMenu({
   }, [handleKeyDown, isVisible]);
 
   // Calculate menu position based on anchor element
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isVisible) {
       setMenuPosition({});
       return;
@@ -222,7 +214,6 @@ export function useExplorerMenu({
     const isSlashCommand = menuMode === 'slash-commands-keyboard';
 
     if (!anchorRef?.current) {
-      // Fallback to default bottom-left
       setMenuPosition({
         bottom: '100%',
         left: '16px',
@@ -235,36 +226,25 @@ export function useExplorerMenu({
       .closest('[data-seer-explorer-root]')
       ?.getBoundingClientRect();
 
-    const spacing = 8;
-    if (panelRect) {
-      const relativeTop = rect.top - panelRect.top;
-      const relativeLeft = rect.left - panelRect.left;
-
-      setMenuPosition(
-        isSlashCommand
-          ? {
-              bottom: `${panelRect.height - relativeTop + spacing}px`,
-              left: `${relativeLeft}px`,
-            }
-          : {
-              top: `${relativeTop + rect.height + spacing}px`,
-              left: `${relativeLeft}px`,
-            }
-      );
-    } else {
-      // Fallback to viewport positioning
-      setMenuPosition(
-        isSlashCommand
-          ? {
-              bottom: `${window.innerHeight - rect.top + spacing}px`,
-              left: `${rect.left}px`,
-            }
-          : {
-              top: `${rect.bottom + spacing}px`,
-              left: `${rect.left}px`,
-            }
-      );
+    if (!panelRect) {
+      return;
     }
+
+    const spacing = 8;
+    const relativeTop = rect.top - panelRect.top;
+    const relativeLeft = rect.left - panelRect.left;
+
+    setMenuPosition(
+      isSlashCommand
+        ? {
+            bottom: `${panelRect.height - relativeTop + spacing}px`,
+            left: `${relativeLeft}px`,
+          }
+        : {
+            top: `${relativeTop + rect.height + spacing}px`,
+            left: `${relativeLeft}px`,
+          }
+    );
   }, [isVisible, menuMode, menuAnchorRef, inputAnchorRef]);
 
   const menu = (

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -59,7 +59,6 @@ export function useExplorerMenu({
     right?: string | number;
     top?: string | number;
   }>({});
-  const [openedViaSlashCommand, setOpenedViaSlashCommand] = useState(false);
 
   const allSlashCommands = useSlashCommands(slashCommandHandlers);
 
@@ -90,7 +89,6 @@ export function useExplorerMenu({
 
   const close = useCallback(() => {
     setMenuMode('hidden');
-    setOpenedViaSlashCommand(false);
     if (menuMode === 'slash-commands-keyboard') {
       // Clear input and reset textarea height.
       clearInput();
@@ -120,8 +118,6 @@ export function useExplorerMenu({
 
       if (item.key === '/resume') {
         // Handle /resume command here - avoid changing menu state from item handlers.
-        // Mark that it was opened via slash command so positioning uses input anchor
-        setOpenedViaSlashCommand(true);
         setMenuMode('session-history');
         refetchSessions();
       } else {
@@ -260,13 +256,10 @@ export function useExplorerMenu({
       return;
     }
 
-    const isSlashCommandMenu =
-      menuMode === 'slash-commands-keyboard' ||
-      (menuMode === 'session-history' && openedViaSlashCommand);
-
-    // Position relative to input for slash commands, or button for button clicks
-    const anchorRef = isSlashCommandMenu ? inputAnchorRef : menuAnchorRef;
-    const useBottom = isSlashCommandMenu;
+    // Position relative to input for slash commands, or button for session history
+    const anchorRef =
+      menuMode === 'slash-commands-keyboard' ? inputAnchorRef : menuAnchorRef;
+    const useBottom = menuMode === 'slash-commands-keyboard';
 
     if (anchorRef?.current) {
       setMenuPosition(calculatePosition(anchorRef.current, useBottom));
@@ -277,14 +270,7 @@ export function useExplorerMenu({
         left: '16px',
       });
     }
-  }, [
-    isVisible,
-    menuMode,
-    menuAnchorRef,
-    inputAnchorRef,
-    openedViaSlashCommand,
-    calculatePosition,
-  ]);
+  }, [isVisible, menuMode, menuAnchorRef, inputAnchorRef, calculatePosition]);
 
   const menu = (
     <Activity mode={isVisible ? 'visible' : 'hidden'}>
@@ -322,8 +308,6 @@ export function useExplorerMenu({
     if (menuMode === 'session-history') {
       close();
     } else {
-      // Mark that it was opened via button so positioning uses button anchor
-      setOpenedViaSlashCommand(false);
       setMenuMode('session-history');
       refetchSessions();
     }

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import AskUserQuestionBlock from 'sentry/views/seerExplorer/askUserQuestionBlock';
 import BlockComponent from 'sentry/views/seerExplorer/blockComponents';
@@ -15,6 +16,7 @@ import InputSection from 'sentry/views/seerExplorer/inputSection';
 import PanelContainers, {
   BlocksContainer,
 } from 'sentry/views/seerExplorer/panelContainers';
+import TopBar from 'sentry/views/seerExplorer/topBar';
 import type {Block, ExplorerPanelProps} from 'sentry/views/seerExplorer/types';
 
 function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
@@ -33,6 +35,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
   const hoveredBlockIndex = useRef<number>(-1);
   const userScrolledUpRef = useRef<boolean>(false);
   const allowHoverFocusChange = useRef<boolean>(true);
+  const sessionHistoryButtonRef = useRef<HTMLButtonElement>(null);
 
   // Custom hooks
   const {panelSize, handleMaxSize, handleMedSize} = usePanelSizing();
@@ -204,7 +207,9 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
     setIsMinimized(false);
   }, [setFocusedBlockIndex, textareaRef, setIsMinimized]);
 
-  const {menu, isMenuOpen, closeMenu, onMenuButtonClick} = useExplorerMenu({
+  const openFeedbackForm = useFeedbackForm();
+
+  const {menu, isMenuOpen, closeMenu, openSessionHistory} = useExplorerMenu({
     clearInput: () => setInputValue(''),
     inputValue,
     focusInput,
@@ -217,12 +222,40 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
       onNew: startNewSession,
     },
     onChangeSession: setRunId,
+    menuAnchorRef: sessionHistoryButtonRef,
+    inputAnchorRef: textareaRef,
   });
 
   const handlePanelBackgroundClick = useCallback(() => {
     setIsMinimized(false);
     closeMenu();
   }, [closeMenu]);
+
+  // Close menu when clicking outside of it
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return undefined;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const menuElement = document.querySelector('[data-seer-menu-panel]');
+
+      // Don't close if clicking on the menu itself
+      if (menuElement?.contains(target)) {
+        return;
+      }
+
+      // Close menu when clicking anywhere else
+      closeMenu();
+    };
+
+    // Use capture phase to catch clicks before they bubble
+    document.addEventListener('mousedown', handleClickOutside, true);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside, true);
+    };
+  }, [isMenuOpen, closeMenu]);
 
   const handleInputClick = useCallback(() => {
     // Click handler for the input textarea.
@@ -250,6 +283,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
 
   const isAwaitingUserInput = sessionData?.status === 'awaiting_user_input';
   const pendingInput = sessionData?.pending_user_input;
+  const isEmptyState = blocks.length === 0 && !(isAwaitingUserInput && pendingInput);
 
   const {
     isFileApprovalPending,
@@ -360,6 +394,26 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
     },
   });
 
+  const handleFeedbackClick = useCallback(() => {
+    if (openFeedbackForm) {
+      openFeedbackForm({
+        formTitle: 'Seer Explorer Feedback',
+        messagePlaceholder: 'How can we make Seer Explorer better for you?',
+        tags: {
+          ['feedback.source']: 'seer_explorer',
+        },
+      });
+    }
+  }, [openFeedbackForm]);
+
+  const handleSizeToggle = useCallback(() => {
+    if (panelSize === 'max') {
+      handleMedSize();
+    } else {
+      handleMaxSize();
+    }
+  }, [panelSize, handleMaxSize, handleMedSize]);
+
   const panelContent = (
     <PanelContainers
       ref={panelRef}
@@ -368,8 +422,19 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
       panelSize={panelSize}
       onUnminimize={handleUnminimize}
     >
+      <TopBar
+        isEmptyState={isEmptyState}
+        isPolling={isPolling}
+        onFeedbackClick={handleFeedbackClick}
+        onNewChatClick={startNewSession}
+        onSessionHistoryClick={openSessionHistory}
+        onSizeToggleClick={handleSizeToggle}
+        panelSize={panelSize}
+        sessionHistoryButtonRef={sessionHistoryButtonRef}
+      />
+      {menu}
       <BlocksContainer ref={scrollContainerRef} onClick={handlePanelBackgroundClick}>
-        {blocks.length === 0 && !(isAwaitingUserInput && pendingInput) ? (
+        {isEmptyState ? (
           <EmptyState />
         ) : (
           <Fragment>
@@ -439,8 +504,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
         )}
       </BlocksContainer>
       <InputSection
-        menu={menu}
-        onMenuButtonClick={onMenuButtonClick}
         focusedBlockIndex={focusedBlockIndex}
         inputValue={inputValue}
         interruptRequested={interruptRequested}

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -209,7 +209,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
 
   const openFeedbackForm = useFeedbackForm();
 
-  const {menu, isMenuOpen, closeMenu, openSessionHistory} = useExplorerMenu({
+  const {menu, isMenuOpen, menuMode, closeMenu, openSessionHistory} = useExplorerMenu({
     clearInput: () => setInputValue(''),
     inputValue,
     focusInput,
@@ -241,8 +241,11 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
       const target = event.target as Node;
       const menuElement = document.querySelector('[data-seer-menu-panel]');
 
-      // Don't close if clicking on the menu itself
-      if (menuElement?.contains(target)) {
+      // Don't close if clicking on the menu itself or the button
+      if (
+        menuElement?.contains(target) ||
+        sessionHistoryButtonRef.current?.contains(target)
+      ) {
         return;
       }
 
@@ -425,6 +428,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
       <TopBar
         isEmptyState={isEmptyState}
         isPolling={isPolling}
+        isSessionHistoryOpen={isMenuOpen && menuMode === 'session-history'}
         onFeedbackClick={handleFeedbackClick}
         onNewChatClick={startNewSession}
         onSessionHistoryClick={openSessionHistory}

--- a/static/app/views/seerExplorer/inputSection.tsx
+++ b/static/app/views/seerExplorer/inputSection.tsx
@@ -8,7 +8,6 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea/textarea';
 
-import {IconMenu} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 interface FileApprovalActions {
@@ -33,12 +32,10 @@ interface InputSectionProps {
   inputValue: string;
   interruptRequested: boolean;
   isPolling: boolean;
-  menu: React.ReactElement;
   onClear: () => void;
   onInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onInputClick: () => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-  onMenuButtonClick: () => void;
   textAreaRef: React.RefObject<HTMLTextAreaElement | null>;
   fileApprovalActions?: FileApprovalActions;
   isMinimized?: boolean;
@@ -47,8 +44,6 @@ interface InputSectionProps {
 }
 
 function InputSection({
-  menu,
-  onMenuButtonClick,
   inputValue,
   focusedBlockIndex,
   isMinimized = false,
@@ -224,16 +219,7 @@ function InputSection({
 
   return (
     <InputBlock>
-      {menu}
       <InputRow>
-        <ButtonContainer>
-          <Button
-            priority="default"
-            aria-label="Toggle Menu"
-            onClick={onMenuButtonClick}
-            icon={<IconMenu size="md" />}
-          />
-        </ButtonContainer>
         <InputTextarea
           ref={textAreaRef}
           value={inputValue}
@@ -266,21 +252,9 @@ const InputRow = styled('div')`
   padding: 0;
 `;
 
-const ButtonContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  padding: ${p => p.theme.space.sm};
-  padding-top: ${p => p.theme.space.md};
-
-  button {
-    width: auto;
-    padding: ${p => p.theme.space.md};
-  }
-`;
-
 const InputTextarea = styled(TextArea)`
   width: 100%;
-  margin: ${p => p.theme.space.sm} ${p => p.theme.space.sm} ${p => p.theme.space.sm} 0;
+  margin: ${p => p.theme.space.sm};
   color: ${p => p.theme.textColor};
   resize: none;
   overflow-y: auto;

--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -6,7 +6,6 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {Text} from 'sentry/components/core/text';
 import {IconSeer} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
 import type {PanelSize} from 'sentry/views/seerExplorer/types';
 
 interface PanelContainersProps {
@@ -68,7 +67,7 @@ function PanelContainers({
                   transition={{duration: 0.12}}
                   onClick={onUnminimize}
                 >
-                  <Flex direction="column" align="center" gap="lg">
+                  <Flex direction="column" align="center" gap="md">
                     <IconSeer variant="waiting" size="lg" />
                     <Text>Press Tab ⇥ or click to continue with Seer</Text>
                   </Flex>
@@ -100,7 +99,7 @@ const PanelContainer = styled(motion.div)<{
   panelSize: 'max' | 'med';
 }>`
   position: fixed;
-  bottom: ${space(2)};
+  bottom: ${p => p.theme.space.md};
   left: 50%;
   z-index: 10000;
   pointer-events: auto;
@@ -108,13 +107,13 @@ const PanelContainer = styled(motion.div)<{
   ${p =>
     p.panelSize === 'max'
       ? `
-      width: calc(100vw - ${space(4)});
-      height: calc(100vh - ${space(4)});
-      margin-left: calc(-50vw + ${space(2)});
+      width: calc(100vw - ${p.theme.space.xl});
+      height: calc(100vh - ${p.theme.space.xl});
+      margin-left: calc(-50vw + ${p.theme.space.md});
     `
       : `
       width: 50vw;
-      height: 50vh;
+      height: 55vh;
       margin-left: -25vw;
     `}
 

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -17,6 +17,7 @@ import {t} from 'sentry/locale';
 interface TopBarProps {
   isEmptyState: boolean;
   isPolling: boolean;
+  isSessionHistoryOpen: boolean;
   onFeedbackClick: () => void;
   onNewChatClick: () => void;
   onSessionHistoryClick: (buttonRef: React.RefObject<HTMLElement | null>) => void;
@@ -28,6 +29,7 @@ interface TopBarProps {
 function TopBar({
   isPolling,
   isEmptyState,
+  isSessionHistoryOpen,
   onFeedbackClick,
   onNewChatClick,
   onSessionHistoryClick,
@@ -46,15 +48,18 @@ function TopBar({
           aria-label={t('Start a new chat (/new)')}
           title={t('Start a new chat (/new)')}
         />
-        <Button
-          ref={sessionHistoryButtonRef}
-          icon={<IconTimer />}
-          onClick={() => onSessionHistoryClick(sessionHistoryButtonRef)}
-          priority="transparent"
-          size="sm"
-          aria-label={t('Resume a previous chat (/resume)')}
-          title={t('Resume a previous chat (/resume)')}
-        />
+        <SessionHistoryButtonWrapper isSelected={isSessionHistoryOpen}>
+          <Button
+            ref={sessionHistoryButtonRef}
+            icon={<IconTimer />}
+            onClick={() => onSessionHistoryClick(sessionHistoryButtonRef)}
+            priority="transparent"
+            size="sm"
+            aria-label={t('Resume a previous chat (/resume)')}
+            title={t('Resume a previous chat (/resume)')}
+            aria-expanded={isSessionHistoryOpen}
+          />
+        </SessionHistoryButtonWrapper>
       </Flex>
       <AnimatePresence initial={false}>
         {!isEmptyState && (
@@ -116,4 +121,10 @@ const CenterSection = styled(motion.div)`
   align-items: center;
   justify-content: center;
   flex: 1;
+`;
+
+const SessionHistoryButtonWrapper = styled('div')<{isSelected: boolean}>`
+  button {
+    background-color: ${p => (p.isSelected ? p.theme.hover : 'transparent')};
+  }
 `;

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -1,0 +1,119 @@
+import styled from '@emotion/styled';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {
+  IconAdd,
+  IconContract,
+  IconExpand,
+  IconMegaphone,
+  IconSeer,
+  IconTimer,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+interface TopBarProps {
+  isEmptyState: boolean;
+  isPolling: boolean;
+  onFeedbackClick: () => void;
+  onNewChatClick: () => void;
+  onSessionHistoryClick: (buttonRef: React.RefObject<HTMLElement | null>) => void;
+  onSizeToggleClick: () => void;
+  panelSize: 'max' | 'med';
+  sessionHistoryButtonRef: React.RefObject<HTMLButtonElement | null>;
+}
+
+function TopBar({
+  isPolling,
+  isEmptyState,
+  onFeedbackClick,
+  onNewChatClick,
+  onSessionHistoryClick,
+  onSizeToggleClick,
+  panelSize,
+  sessionHistoryButtonRef,
+}: TopBarProps) {
+  return (
+    <TopBarContainer data-seer-top-bar="">
+      <Flex>
+        <Button
+          icon={<IconAdd />}
+          onClick={onNewChatClick}
+          priority="transparent"
+          size="sm"
+          aria-label={t('Start a new chat (/new)')}
+          title={t('Start a new chat (/new)')}
+        />
+        <Button
+          ref={sessionHistoryButtonRef}
+          icon={<IconTimer />}
+          onClick={() => onSessionHistoryClick(sessionHistoryButtonRef)}
+          priority="transparent"
+          size="sm"
+          aria-label={t('Resume a previous chat (/resume)')}
+          title={t('Resume a previous chat (/resume)')}
+        />
+      </Flex>
+      <AnimatePresence initial={false}>
+        {!isEmptyState && (
+          <CenterSection
+            key="seer-icon"
+            initial={{opacity: 0, scale: 0.8}}
+            animate={{opacity: 1, scale: 1}}
+            exit={{opacity: 0, scale: 0.8}}
+            transition={{duration: 0.12, ease: 'easeOut'}}
+          >
+            <IconSeer variant={isPolling ? 'loading' : 'waiting'} size="md" />
+          </CenterSection>
+        )}
+      </AnimatePresence>
+      <Flex>
+        <Button
+          icon={<IconMegaphone />}
+          onClick={onFeedbackClick}
+          priority="transparent"
+          size="sm"
+          aria-label={t('Give the devs feedback (/feedback)')}
+          title={t('Give the devs feedback (/feedback)')}
+        />
+        <Button
+          icon={panelSize === 'max' ? <IconContract /> : <IconExpand />}
+          onClick={onSizeToggleClick}
+          priority="transparent"
+          size="sm"
+          aria-label={
+            panelSize === 'max'
+              ? t('Shrink to medium size (/med-size)')
+              : t('Expand to full screen (/max-size)')
+          }
+          title={
+            panelSize === 'max'
+              ? t('Shrink to medium size (/med-size)')
+              : t('Expand to full screen (/max-size)')
+          }
+        />
+      </Flex>
+    </TopBarContainer>
+  );
+}
+
+export default TopBar;
+
+const TopBarContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  border-bottom: 1px solid ${p => p.theme.border};
+  background: ${p => p.theme.backgroundSecondary};
+  flex-shrink: 0;
+`;
+
+const CenterSection = styled(motion.div)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+`;


### PR DESCRIPTION
Replaces the hamburger menu with a small top bar with buttons. This addresses feedback that the actions were hard to discover. Slash commands are still supported and the position of any menus changes to match whether you used the button or the slash command

<img width="813" height="497" alt="Screenshot 2025-12-05 at 8 54 41 AM" src="https://github.com/user-attachments/assets/6391a36b-2cc8-4daf-828f-4a67f9a01f0a" />


Closes AIML-1953