### PR TITLE
chore(logs): Expand logs field definitions

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2505,7 +2505,9 @@ const LOG_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   },
   [OurLogKnownFieldKey.CODE_LINE_NUMBER]: {
     desc: t(
-      'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function'
+      'The line number in %s best representing the operation. It SHOULD point within the code unit named in %s.',
+      OurLogKnownFieldKey.CODE_FILE_PATH,
+      OurLogKnownFieldKey.CODE_FUNCTION_NAME
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2460,6 +2460,7 @@ const SPAN_HTTP_FIELD_DEFINITIONS: Record<SpanHttpField, FieldDefinition> = {
     valueType: FieldValueType.SIZE,
   },
 };
+
 const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   ...EVENT_FIELD_DEFINITIONS,
   ...SPAN_AGGREGATION_FIELDS,
@@ -2494,6 +2495,80 @@ const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
 
 const LOG_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   ...LOG_AGGREGATION_FIELDS,
+  ...EVENT_FIELD_DEFINITIONS,
+  [OurLogKnownFieldKey.CODE_FILE_PATH]: {
+    desc: t(
+      'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [OurLogKnownFieldKey.CODE_LINE_NUMBER]: {
+    desc: t(
+      'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.INTEGER,
+  },
+  [OurLogKnownFieldKey.CODE_FUNCTION_NAME]: {
+    desc: t(
+      'The method or function name, or equivalent (usually rightmost part of the code unit’s name).'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [OurLogKnownFieldKey.LOGGER]: {
+    desc: t('The name of the logger that generated this event.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [OurLogKnownFieldKey.MESSAGE]: {
+    desc: t('Log message'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [OurLogKnownFieldKey.PARENT_SPAN_ID]: {
+    desc: t(
+      'The span id of the span that was active when the log was collected. This should not be set if there was no active span.'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [OurLogKnownFieldKey.PAYLOAD_SIZE]: {
+    desc: t('The size of the log payload in bytes.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.SIZE,
+  },
+  [OurLogKnownFieldKey.REPLAY_ID]: {
+    desc: t('The ID of an associated sentry replay.'),
+    kind: FieldKind.TAG,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [OurLogKnownFieldKey.SERVER_ADDRESS]: {
+    desc: t(
+      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [OurLogKnownFieldKey.SEVERITY]: {
+    desc: t('The severity level of the log.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [OurLogKnownFieldKey.SPAN_ID]: {
+    desc: t('The associated span ID of the log.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
+  [OurLogKnownFieldKey.TEMPLATE]: {
+    desc: t('The parameterized template string.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
 };
 
 const TRACEMETRIC_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -26,6 +26,7 @@ export enum OurLogKnownFieldKey {
   TIMESTAMP = 'timestamp',
   TIMESTAMP_PRECISE = 'timestamp_precise',
   OBSERVED_TIMESTAMP_PRECISE = 'observed_timestamp',
+  LOGGER = 'logger.name',
 
   PAYLOAD_SIZE = 'payload_size',
 


### PR DESCRIPTION
This PR adds in additional field definitions to bring in descriptions, and better search experiences by limiting search capabilities such as removing wildcards for id fields, or using the date selection experience for timestamps.