### PR TITLE
fix(spans-migration): add fixes for alerts rollback migration

### DIFF
--- a/src/sentry/explore/translation/alerts_translation.py
+++ b/src/sentry/explore/translation/alerts_translation.py
@@ -216,7 +216,6 @@ def rollback_detector_query_and_update_subscription_in_snuba(snuba_query: SnubaQ
 
     old_query_type, old_dataset, old_query, old_aggregate = _get_old_query_info(snuba_query)
 
-    # wrap everything with atomic transaction to ensure queries don't get 'half updated'
     with atomic_transaction(
         using=(
             router.db_for_write(SnubaQuery),


### PR DESCRIPTION
to make sure we roll back all alerts (even failed ones) we're checking for the updating subscription state as well. I've also put everything in an atomic transaction so that there won't be any half updated alerts 😢 