### PR TITLE
chore(cells) Add deprecation notices for a few issue endpoints

### DIFF
--- a/src/sentry/api/helpers/deprecation.py
+++ b/src/sentry/api/helpers/deprecation.py
@@ -132,6 +132,8 @@ def deprecated(
     :param key: The key prefix for an option use for the brownout schedule and duration
                 If not set 'api.deprecation.brownout' will be used, which currently
                 is using schedule of a 1 minute blackout at noon UTC.
+    :param url_names: A list of URL names that are deprecated if an endpoint has multiple URLs
+                      and you need to deprecate one of the URLs.
     """
 
     def decorator(func: EndpointT[SelfT, P]) -> EndpointT[SelfT, P]:

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -7,7 +7,7 @@ import logging
 import os.path
 from collections import namedtuple
 from collections.abc import Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import cast
 
@@ -1053,3 +1053,7 @@ EXTENSION_LANGUAGE_MAP = {
     "dsr": "visual basic 6.0",
     "frm": "visual basic 6.0",
 }
+
+# After this date APIs that are incompatible with cell routing
+# will begin periodic brownouts.
+CELL_API_DEPRECATION_DATE = datetime(2025, 5, 15)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -7,7 +7,7 @@ import logging
 import os.path
 from collections import namedtuple
 from collections.abc import Sequence
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import cast
 
@@ -1056,4 +1056,4 @@ EXTENSION_LANGUAGE_MAP = {
 
 # After this date APIs that are incompatible with cell routing
 # will begin periodic brownouts.
-CELL_API_DEPRECATION_DATE = datetime(2025, 5, 15)
+CELL_API_DEPRECATION_DATE = datetime(2025, 5, 15, 0, 0, 0, tzinfo=UTC)

--- a/src/sentry/issues/endpoints/organization_group_suspect_flags.py
+++ b/src/sentry/issues/endpoints/organization_group_suspect_flags.py
@@ -8,8 +8,10 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.utils import get_date_range_from_params
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.suspect_flags import Distribution, get_suspect_flag_scores
 from sentry.models.group import Group
@@ -32,6 +34,7 @@ class ResponseData(TypedDict):
 class OrganizationGroupSuspectFlagsEndpoint(GroupEndpoint):
     publish_status = {"GET": ApiPublishStatus.PRIVATE}
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-suspect-flags"])
     def get(self, request: Request, group: Group) -> Response:
         """Stats bucketed by time."""
         if not features.has(

--- a/src/sentry/issues/endpoints/organization_group_suspect_tags.py
+++ b/src/sentry/issues/endpoints/organization_group_suspect_tags.py
@@ -6,8 +6,10 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.utils import get_date_range_from_params
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.suspect_tags import get_suspect_tag_scores
 from sentry.models.group import Group
@@ -17,6 +19,7 @@ from sentry.models.group import Group
 class OrganizationGroupSuspectTagsEndpoint(GroupEndpoint):
     publish_status = {"GET": ApiPublishStatus.PRIVATE}
 
+    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-suspect-tags"])
     def get(self, request: Request, group: Group) -> Response:
         """Stats bucketed by time."""
         if not features.has(


### PR DESCRIPTION
As part of the cells project we need to deprecate URLs that don't have organization_slug_or_id in them. This change adds deprecations to a few issues endpoints for the org-less URL.

I've only updated a couple endpoints to start with so that I can validate behavior before updating the remaining issue endpoints.

Refs INFRENG-208