### PR TITLE
fix(seer): Allow org read permissions on seer public rpc

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -12,7 +12,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.constants import ObjectStatus
 from sentry.hybridcloud.rpc.service import RpcResolutionException
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
@@ -95,6 +95,14 @@ public_project_seer_method_registry: dict[str, Callable] = {
 }
 
 
+class SeerRpcPermission(OrganizationPermission):
+    # Seer RPCs uses POST requests but is actually read only
+    # So relax the permissions here.
+    scope_map = {
+        "POST": ["org:read"],
+    }
+
+
 @region_silo_endpoint
 class OrganizationSeerRpcEndpoint(OrganizationEndpoint):
     """
@@ -114,6 +122,7 @@ class OrganizationSeerRpcEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ML_AI
     enforce_rate_limit = False
+    permission_classes = (SeerRpcPermission,)
 
     def _is_allowed(self, organization: Organization) -> bool:
         """Check if the organization is allowed to use this endpoint."""

--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -99,7 +99,7 @@ class SeerRpcPermission(OrganizationPermission):
     # Seer RPCs uses POST requests but is actually read only
     # So relax the permissions here.
     scope_map = {
-        "POST": ["org:read"],
+        "POST": ["org:read", "org:write", "org:admin"],
     }
 
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -1,7 +1,10 @@
 from django.urls import reverse
 
+from sentry.models.apitoken import ApiToken
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 class TestOrganizationSeerRpcEndpoint(APITestCase):
@@ -137,3 +140,18 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         path = self._get_path("definitely_not_a_real_method")
         response = self.client.post(path, data={"args": {}}, format="json")
         assert response.status_code == 404
+
+    @with_feature("organizations:seer-public-rpc")
+    def test_org_read_permission(self) -> None:
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["org:read"])
+
+        path = self._get_path("get_organization_slug")
+        response = self.client.post(
+            path, data={"args": {}}, format="json", HTTP_AUTHORIZATION=f"Bearer {token.token}"
+        )
+
+        assert response.status_code == 200
+        assert response.data == {"slug": self.organization.slug}

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -145,13 +145,15 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
     def test_org_read_permission(self) -> None:
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            token = ApiToken.objects.create(user=self.user, scope_list=["org:read"])
 
-        path = self._get_path("get_organization_slug")
-        response = self.client.post(
-            path, data={"args": {}}, format="json", HTTP_AUTHORIZATION=f"Bearer {token.token}"
-        )
+        for scope in ["org:read", "org:write", "org:admin"]:
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                token = ApiToken.objects.create(user=self.user, scope_list=[scope])
 
-        assert response.status_code == 200
-        assert response.data == {"slug": self.organization.slug}
+            path = self._get_path("get_organization_slug")
+            response = self.client.post(
+                path, data={"args": {}}, format="json", HTTP_AUTHORIZATION=f"Bearer {token.token}"
+            )
+
+            assert response.status_code == 200
+            assert response.data == {"slug": self.organization.slug}


### PR DESCRIPTION
Seer rpcs use POST request for a bunch of read operations. Relax the permissions on this endpoint so we only need `org:read`.