### PR TITLE
fix(options): Fix and improve type coverage

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -5,15 +5,16 @@ import sys
 from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING
+from typing import Any as TAny
 
 from django.conf import settings
 
 from sentry.utils.flag import record_option
 from sentry.utils.hashlib import md5_text
-from sentry.utils.types import Any, type_from_value
+from sentry.utils.types import Any, Type, type_from_value
 
 if TYPE_CHECKING:
-    from sentry.options.store import Key, OptionsStore
+    from sentry.options.store import GroupingInfo, Key, OptionsStore
 
 # Prevent ourselves from clobbering the builtin
 _type = type
@@ -155,7 +156,7 @@ WRITE_REQUIRED_FLAGS = {
 }
 
 
-def _make_cache_key(key):
+def _make_cache_key(key: str) -> str:
     return "o:%s" % md5_text(key).hexdigest()
 
 
@@ -236,13 +237,13 @@ class OptionsManager:
     def make_key(
         self,
         name: str,
-        default,
-        type,
+        default: TAny,
+        type: Type[TAny],
         flags: int,
         ttl: int,
         grace: int,
-        grouping_info,
-    ):
+        grouping_info: GroupingInfo | None,
+    ) -> Key:
         from sentry.options.store import Key
 
         return Key(

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -13,6 +13,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.options.manager import UpdateChannel
+from sentry.utils.types import Type
 
 CACHE_FETCH_ERR = "Unable to fetch option cache for %s"
 CACHE_UPDATE_ERR = "Unable to update option cache for %s"
@@ -37,7 +38,7 @@ class GroupingInfo:
 class Key:
     name: str
     default: Any
-    type: type
+    type: Type[Any]
     flags: int
     ttl: int
     grace: int

--- a/src/sentry/testutils/helpers/options.py
+++ b/src/sentry/testutils/helpers/options.py
@@ -28,7 +28,7 @@ def override_options(options):
         except KeyError:
             return wrapped(key, **kwargs)
 
-    def new_lookup(self: OptionsManager, key):
+    def new_lookup(self: OptionsManager, key: str):
         # use the default key definition if available
         if key not in options or key in self.registry:
             return original_lookup(self, key)

--- a/src/sentry/utils/types.py
+++ b/src/sentry/utils/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from typing import Any as TAny
 from typing import TypeGuard
 
 from yaml.parser import ParserError
@@ -41,7 +42,7 @@ class Type(typing.Generic[T]):
                 return rv
         raise InvalidTypeError(f"{value!r} is not a valid {self!r}")
 
-    def convert(self, value):
+    def convert(self, value: TAny) -> T | None:
         return value
 
     def _default(self) -> T:
@@ -72,7 +73,7 @@ class BoolType(Type[bool]):
     expected_types = (bool,)
     compatible_types = (str, int)
 
-    def convert(self, value):
+    def convert(self, value: TAny) -> bool | None:
         if isinstance(value, int):
             return bool(value)
         value = value.lower()
@@ -91,7 +92,7 @@ class IntType(Type[int]):
     default = 0
     expected_types = (int,)
 
-    def convert(self, value):
+    def convert(self, value: TAny) -> int | None:
         try:
             return int(value)
         except ValueError:
@@ -106,7 +107,7 @@ class FloatType(Type[float]):
     expected_types = (float,)
     compatible_types = (str, int, float)
 
-    def convert(self, value):
+    def convert(self, value: TAny) -> float | None:
         try:
             return float(value)
         except ValueError:
@@ -128,11 +129,11 @@ class DictType(Type[dict]):
     name = "dictionary"
     expected_types = (dict,)
 
-    def _default(self) -> dict[str, typing.Any]:
+    def _default(self) -> dict[str, TAny]:
         # make sure we create a fresh dict each time
         return {}
 
-    def convert(self, value):
+    def convert(self, value: TAny) -> dict[str, TAny] | None:
         try:
             return safe_load(value)
         except (AttributeError, ParserError, ScannerError):
@@ -146,11 +147,11 @@ class SequenceType(Type[list]):
     expected_types = (list,)
     compatible_types = (str, tuple, list)
 
-    def _default(self) -> list[typing.Any]:
+    def _default(self) -> list[TAny]:
         # make sure we create a fresh list each time
         return []
 
-    def convert(self, value):
+    def convert(self, value: TAny) -> list[TAny] | None:
         if isinstance(value, str):
             try:
                 value = safe_load(value)


### PR DESCRIPTION
This fixes a case where we had 'type' rather than 'Type', refines a few untyped things while we're there.
This was mostly motivated by wanting to ensure 'Find All References' actually finds the relevant references after I noticed it wasn't when trying to adjust the type checking semantics.
