### PR TITLE
fix(dashboards): temporary filters broken when changing values

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1433,8 +1433,7 @@ function getDashboardUrl(
       ].filter(
         filter =>
           Boolean(filter.value) &&
-          filter.tag.key !== field &&
-          filter.dataset !== widget.widgetType
+          !(filter.tag.key === field && filter.dataset === widget.widgetType)
       );
 
       // Format the value as a proper filter condition string

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1430,7 +1430,12 @@ function getDashboardUrl(
     if (dashboardLink && dashboardLink.dashboardId !== '-1') {
       const newTemporaryFilters: GlobalFilter[] = [
         ...(dashboardFilters[DashboardFilterKeys.GLOBAL_FILTER] ?? []),
-      ].filter(filter => Boolean(filter.value));
+      ].filter(
+        filter =>
+          Boolean(filter.value) &&
+          filter.tag.key !== field &&
+          filter.dataset !== widget.widgetType
+      );
 
       // Format the value as a proper filter condition string
       const mutableSearch = new MutableSearch('');

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1440,6 +1440,7 @@ function getDashboardUrl(
         dataset: widget.widgetType,
         tag: {key: field, name: field, kind: FieldKind.TAG},
         value: formattedValue,
+        isTemporary: true,
       });
 
       // Preserve project, environment, and time range query params
@@ -1455,7 +1456,7 @@ function getDashboardUrl(
       const url = `/organizations/${organization.slug}/dashboard/${dashboardLink.dashboardId}/?${qs.stringify(
         {
           ...filterParams,
-          [DashboardFilterKeys.TEMPORARY_FILTERS]: newTemporaryFilters.map(filter =>
+          [DashboardFilterKeys.GLOBAL_FILTER]: newTemporaryFilters.map(filter =>
             JSON.stringify(filter)
           ),
         }

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -516,6 +516,14 @@ class DashboardDetail extends Component<Props, State> {
         )
       : [''];
 
+    filterParams[DashboardFilterKeys.TEMPORARY_FILTERS] = activeFilters[
+      DashboardFilterKeys.TEMPORARY_FILTERS
+    ]?.length
+      ? activeFilters[DashboardFilterKeys.TEMPORARY_FILTERS].map(filter =>
+          JSON.stringify(filter)
+        )
+      : [''];
+
     if (
       !isEqualWith(activeFilters, dashboard.filters, (a, b) => {
         // This is to handle the case where dashboard filters has release:[] and the new filter is release:""

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -968,7 +968,6 @@ class DashboardDetail extends Component<Props, State> {
                   filters={{}} // Default Dashboards don't have filters set
                   location={location}
                   hasUnsavedChanges={false}
-                  hasTemporaryFilters={false}
                   isEditingDashboard={false}
                   isPreview={false}
                   onDashboardFilterChange={this.handleChangeFilter}
@@ -1050,10 +1049,6 @@ class DashboardDetail extends Component<Props, State> {
       dashboard.id !== 'default-overview' &&
       dashboardState !== DashboardState.CREATE &&
       hasUnsavedFilterChanges(dashboard, location);
-
-    const hasTemporaryFilters = defined(
-      location.query?.[DashboardFilterKeys.TEMPORARY_FILTERS]
-    );
 
     const eventView = generatePerformanceEventView(location, projects, {}, organization);
 
@@ -1187,7 +1182,6 @@ class DashboardDetail extends Component<Props, State> {
                                 dashboardCreator={dashboard.createdBy}
                                 location={location}
                                 hasUnsavedChanges={!this.isEmbedded && hasUnsavedFilters}
-                                hasTemporaryFilters={hasTemporaryFilters}
                                 isEditingDashboard={
                                   dashboardState !== DashboardState.CREATE &&
                                   this.isEditingDashboard

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -516,14 +516,6 @@ class DashboardDetail extends Component<Props, State> {
         )
       : [''];
 
-    filterParams[DashboardFilterKeys.TEMPORARY_FILTERS] = activeFilters[
-      DashboardFilterKeys.TEMPORARY_FILTERS
-    ]?.length
-      ? activeFilters[DashboardFilterKeys.TEMPORARY_FILTERS].map(filter =>
-          JSON.stringify(filter)
-        )
-      : [''];
-
     if (
       !isEqualWith(activeFilters, dashboard.filters, (a, b) => {
         // This is to handle the case where dashboard filters has release:[] and the new filter is release:""

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1195,7 +1195,7 @@ class DashboardDetail extends Component<Props, State> {
                                 isPreview={this.isPreview}
                                 onDashboardFilterChange={this.handleChangeFilter}
                                 shouldBusySaveButton={this.state.isSavingDashboardFilters}
-                                isPrebuiltDashboard={defined(dashboard.prebuiltId)}
+                                prebuiltDashboardId={dashboard.prebuiltId}
                                 onCancel={() => {
                                   resetPageFilters(dashboard, location);
                                   trackAnalytics('dashboards2.filter.cancel', {

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -1,0 +1,153 @@
+// create a basic test for filters bar
+
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ReleaseFixture} from 'sentry-fixture/release';
+import {TagsFixture} from 'sentry-fixture/tags';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+
+import type {Organization} from 'sentry/types/organization';
+import {FieldKind} from 'sentry/utils/fields';
+import FiltersBar, {type FiltersBarProps} from 'sentry/views/dashboards/filtersBar';
+import {
+  DashboardFilterKeys,
+  WidgetType,
+  type GlobalFilter,
+} from 'sentry/views/dashboards/types';
+
+describe('FiltersBar', () => {
+  let organization: Organization;
+
+  beforeEach(() => {
+    mockNetworkRequests();
+
+    organization = OrganizationFixture({
+      features: ['dashboards-basic', 'dashboards-edit', 'dashboards-global-filters'],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  const renderFilterBar = (overrides: Partial<FiltersBarProps> = {}) => {
+    const props: FiltersBarProps = {
+      filters: {},
+      hasTemporaryFilters: false,
+      hasUnsavedChanges: false,
+      isEditingDashboard: false,
+      isPreview: false,
+      location: LocationFixture(),
+      onDashboardFilterChange: () => {},
+      ...overrides,
+    };
+
+    return render(<FiltersBar {...props} />, {organization});
+  };
+
+  it('should render basic global filter', async () => {
+    const newLocation = LocationFixture({
+      query: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify({
+          dataset: WidgetType.SPANS,
+          tag: {key: 'browser.name', name: 'Browser Name', kind: FieldKind.FIELD},
+          value: `browser.name:[Chrome]`,
+        } satisfies GlobalFilter),
+      },
+    });
+    renderFilterBar({location: newLocation});
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    expect(
+      screen.getByRole('button', {name: /browser\.name.*Chrome/i})
+    ).toBeInTheDocument();
+  });
+
+  it('should render save button with unsaved changes', async () => {
+    const newLocation = LocationFixture({
+      query: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify({
+          dataset: WidgetType.SPANS,
+          tag: {key: 'browser.name', name: 'Browser Name', kind: FieldKind.FIELD},
+          value: `browser.name:[Chrome]`,
+        } satisfies GlobalFilter),
+      },
+    });
+    renderFilterBar({location: newLocation, hasUnsavedChanges: true});
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    expect(
+      screen.getByRole('button', {name: /browser\.name.*Chrome/i})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
+  });
+
+  it('should not render save button with temporary filter', async () => {
+    const newLocation = LocationFixture({
+      query: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify({
+          dataset: WidgetType.SPANS,
+          tag: {key: 'browser.name', name: 'Browser Name', kind: FieldKind.FIELD},
+          value: `browser.name:[Chrome]`,
+          isTemporary: true,
+        } satisfies GlobalFilter),
+      },
+    });
+
+    renderFilterBar({location: newLocation});
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    expect(
+      screen.getByRole('button', {name: /browser\.name.*Chrome/i})
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
+  });
+});
+
+const mockNetworkRequests = () => {
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/releases/',
+    body: [ReleaseFixture()],
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/tags/',
+    body: TagsFixture(),
+  });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/measurements-meta/`,
+    body: {
+      'measurements.custom.measurement': {
+        functions: ['p99'],
+      },
+      'measurements.another.custom.measurement': {
+        functions: ['p99'],
+      },
+    },
+  });
+
+  const mockSearchResponse = [
+    {
+      key: 'browser.name',
+      value: 'Chrome',
+      name: 'Chrome',
+      first_seen: null,
+      last_seen: null,
+      times_seen: null,
+    },
+    {
+      key: 'browser.name',
+      value: 'Firefox',
+      name: 'Firefox',
+      first_seen: null,
+      last_seen: null,
+      times_seen: null,
+    },
+  ];
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/trace-items/attributes/browser.name/values/`,
+    body: mockSearchResponse,
+    match: [MockApiClient.matchQuery({attributeType: 'string'})],
+  });
+};

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -36,7 +36,6 @@ describe('FiltersBar', () => {
   const renderFilterBar = (overrides: Partial<FiltersBarProps> = {}) => {
     const props: FiltersBarProps = {
       filters: {},
-      hasTemporaryFilters: false,
       hasUnsavedChanges: false,
       isEditingDashboard: false,
       isPreview: false,

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -15,6 +15,7 @@ import {
   WidgetType,
   type GlobalFilter,
 } from 'sentry/views/dashboards/types';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 
 describe('FiltersBar', () => {
   let organization: Organization;
@@ -76,9 +77,6 @@ describe('FiltersBar', () => {
     });
     renderFilterBar({location: newLocation, hasUnsavedChanges: true});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    expect(
-      screen.getByRole('button', {name: /browser\.name.*Chrome/i})
-    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
   });
@@ -96,6 +94,28 @@ describe('FiltersBar', () => {
     });
 
     renderFilterBar({location: newLocation});
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    expect(
+      screen.getByRole('button', {name: /browser\.name.*Chrome/i})
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
+  });
+
+  it('should not render save button on prebuilt dashboard', async () => {
+    const newLocation = LocationFixture({
+      query: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify({
+          dataset: WidgetType.SPANS,
+          tag: {key: 'browser.name', name: 'Browser Name', kind: FieldKind.FIELD},
+          value: `browser.name:[Chrome]`,
+        } satisfies GlobalFilter),
+      },
+    });
+    renderFilterBar({
+      location: newLocation,
+      prebuiltDashboardId: PrebuiltDashboardId.FRONTEND_SESSION_HEALTH,
+    });
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(
       screen.getByRole('button', {name: /browser\.name.*Chrome/i})

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -106,9 +106,12 @@ export default function FiltersBar({
 
   const updateGlobalFilters = (newGlobalFilters: GlobalFilter[]) => {
     setActiveGlobalFilters(newGlobalFilters);
+    const temporaryFilters = newGlobalFilters.filter(filter => filter.isTemporary);
+    const globalFilters = newGlobalFilters.filter(filter => !filter.isTemporary);
     onDashboardFilterChange({
       [DashboardFilterKeys.RELEASE]: selectedReleases,
-      [DashboardFilterKeys.GLOBAL_FILTER]: newGlobalFilters,
+      [DashboardFilterKeys.GLOBAL_FILTER]: globalFilters,
+      [DashboardFilterKeys.TEMPORARY_FILTERS]: temporaryFilters,
     });
   };
 
@@ -163,6 +166,7 @@ export default function FiltersBar({
         <Fragment>
           {activeGlobalFilters.map(filter => (
             <GenericFilterSelector
+              disableRemoveFilter={isPrebuiltDashboard && filter.isTemporary}
               key={filter.tag.key + filter.value}
               globalFilter={filter}
               searchBarData={getSearchBarData(filter.dataset)}

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -50,6 +50,7 @@ type FilterSelectorProps = {
   onRemoveFilter: (filter: GlobalFilter) => void;
   onUpdateFilter: (filter: GlobalFilter) => void;
   searchBarData: SearchBarData;
+  disableRemoveFilter?: boolean;
 };
 
 function FilterSelector({
@@ -57,6 +58,7 @@ function FilterSelector({
   searchBarData,
   onRemoveFilter,
   onUpdateFilter,
+  disableRemoveFilter,
 }: FilterSelectorProps) {
   const {selection} = usePageFilters();
 
@@ -275,13 +277,15 @@ function FilterSelector({
           {t('Clear')}
         </StyledButton>
       )}
-      <StyledButton
-        aria-label={t('Remove Filter')}
-        size="zero"
-        onClick={() => onRemoveFilter(globalFilter)}
-      >
-        {t('Remove Filter')}
-      </StyledButton>
+      {!disableRemoveFilter && (
+        <StyledButton
+          aria-label={t('Remove Filter')}
+          size="zero"
+          onClick={() => onRemoveFilter(globalFilter)}
+        >
+          {t('Remove Filter')}
+        </StyledButton>
+      )}
     </Flex>
   );
 

--- a/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
@@ -10,6 +10,7 @@ export type GenericFilterSelectorProps = {
   onRemoveFilter: (filter: GlobalFilter) => void;
   onUpdateFilter: (filter: GlobalFilter) => void;
   searchBarData: SearchBarData;
+  disableRemoveFilter?: boolean;
 };
 
 function getFilterSelector(

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -204,6 +204,7 @@ function NumericFilterSelector({
   globalFilter,
   onRemoveFilter,
   onUpdateFilter,
+  disableRemoveFilter,
 }: GenericFilterSelectorProps) {
   const globalFilterQueries = useMemo(
     () => globalFilter.value.split(FILTER_QUERY_SEPARATOR),
@@ -291,15 +292,19 @@ function NumericFilterSelector({
           {t('%s Filter', getDatasetLabel(globalFilter.dataset))}
         </MenuTitleWrapper>
       }
-      menuHeaderTrailingItems={() => (
-        <StyledButton
-          aria-label={t('Remove Filter')}
-          size="zero"
-          onClick={() => onRemoveFilter(globalFilter)}
-        >
-          {t('Remove Filter')}
-        </StyledButton>
-      )}
+      menuHeaderTrailingItems={
+        disableRemoveFilter
+          ? undefined
+          : () => (
+              <StyledButton
+                aria-label={t('Remove Filter')}
+                size="zero"
+                onClick={() => onRemoveFilter(globalFilter)}
+              >
+                {t('Remove Filter')}
+              </StyledButton>
+            )
+      }
       menuBody={
         <MenuBodyWrap>
           <Flex gap="xs" direction="column">

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -175,14 +175,11 @@ export type DashboardListItem = {
 export enum DashboardFilterKeys {
   RELEASE = 'release',
   GLOBAL_FILTER = 'globalFilter',
-  // temporary filters are filters that are not saved to the dashboard, they occur when you link from one dashboard to another
-  TEMPORARY_FILTERS = 'temporaryFilters',
 }
 
 export type DashboardFilters = {
   [DashboardFilterKeys.RELEASE]?: string[];
   [DashboardFilterKeys.GLOBAL_FILTER]?: GlobalFilter[];
-  [DashboardFilterKeys.TEMPORARY_FILTERS]?: GlobalFilter[];
 };
 
 export type GlobalFilter = {

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -192,6 +192,7 @@ export type GlobalFilter = {
   tag: Tag;
   // The raw filter condition string (e.g. 'tagKey:[values,...]')
   value: string;
+  isTemporary?: boolean;
 };
 
 /**

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -46,7 +46,6 @@ import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import type {
   DashboardDetails,
   DashboardFilters,
-  GlobalFilter,
   Widget,
   WidgetQuery,
 } from 'sentry/views/dashboards/types';
@@ -570,16 +569,6 @@ export function getDashboardFiltersFromURL(location: Location): DashboardFilters
             }
           })
           .filter(filter => filter !== null);
-      } else if (key === DashboardFilterKeys.TEMPORARY_FILTERS) {
-        dashboardFilters[key] = queryFilters
-          .map(filter => {
-            try {
-              return {...JSON.parse(filter), isTemporary: true};
-            } catch (error) {
-              return null;
-            }
-          })
-          .filter(filter => filter !== null);
       } else {
         dashboardFilters[key] = queryFilters;
       }
@@ -594,10 +583,7 @@ export function dashboardFiltersToString(
 ): string {
   let dashboardFilterConditions = '';
 
-  const pinnedFilters = omit(dashboardFilters, [
-    DashboardFilterKeys.GLOBAL_FILTER,
-    DashboardFilterKeys.TEMPORARY_FILTERS,
-  ]);
+  const pinnedFilters = omit(dashboardFilters, DashboardFilterKeys.GLOBAL_FILTER);
   if (pinnedFilters) {
     for (const [key, activeFilters] of Object.entries(pinnedFilters)) {
       if (activeFilters.length === 1) {
@@ -610,42 +596,18 @@ export function dashboardFiltersToString(
     }
   }
 
-  const combinedFilters = getCombinedDashboardFilters(
-    dashboardFilters?.[DashboardFilterKeys.GLOBAL_FILTER],
-    dashboardFilters?.[DashboardFilterKeys.TEMPORARY_FILTERS]
-  );
+  const globalFilters = dashboardFilters?.[DashboardFilterKeys.GLOBAL_FILTER];
+
   // If widgetType is provided, concatenate global filters that apply
-  if (widgetType && combinedFilters) {
+  if (widgetType && globalFilters) {
     dashboardFilterConditions +=
-      combinedFilters
+      globalFilters
         .filter(globalFilter => globalFilter.dataset === widgetType)
         .map(globalFilter => globalFilter.value)
         .join(' ') ?? '';
   }
 
   return dashboardFilterConditions;
-}
-
-// Combines global and temporary filters into a single array, deduplicating by dataset and key prioritizing the temporary filter.
-export function getCombinedDashboardFilters(
-  globalFilters?: GlobalFilter[],
-  temporaryFilters?: GlobalFilter[]
-): GlobalFilter[] {
-  const finalFilters = [...(globalFilters ?? [])];
-  const temporaryFiltersCopy = [...(temporaryFilters ?? [])];
-
-  finalFilters.forEach((filter, idx) => {
-    // if a temporary filter exists for the same dataset and key, override it and delete it from the temporary filters to avoid duplicates
-    const temporaryFilter = temporaryFiltersCopy.find(
-      tf => tf.dataset === filter.dataset && tf.tag.key === filter.tag.key
-    );
-    if (temporaryFilter) {
-      finalFilters[idx] = {...temporaryFilter};
-      temporaryFiltersCopy.splice(temporaryFiltersCopy.indexOf(temporaryFilter), 1);
-    }
-  });
-
-  return [...finalFilters, ...temporaryFiltersCopy];
 }
 
 export function connectDashboardCharts(groupName: string) {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -574,7 +574,7 @@ export function getDashboardFiltersFromURL(location: Location): DashboardFilters
         dashboardFilters[key] = queryFilters
           .map(filter => {
             try {
-              return JSON.parse(filter);
+              return {...JSON.parse(filter), isTemporary: true};
             } catch (error) {
               return null;
             }
@@ -633,16 +633,18 @@ export function getCombinedDashboardFilters(
 ): GlobalFilter[] {
   const finalFilters = [...(globalFilters ?? [])];
   const temporaryFiltersCopy = [...(temporaryFilters ?? [])];
+
   finalFilters.forEach((filter, idx) => {
     // if a temporary filter exists for the same dataset and key, override it and delete it from the temporary filters to avoid duplicates
     const temporaryFilter = temporaryFiltersCopy.find(
       tf => tf.dataset === filter.dataset && tf.tag.key === filter.tag.key
     );
     if (temporaryFilter) {
-      finalFilters[idx] = {...filter, value: temporaryFilter.value};
+      finalFilters[idx] = {...temporaryFilter};
       temporaryFiltersCopy.splice(temporaryFiltersCopy.indexOf(temporaryFilter), 1);
     }
   });
+
   return [...finalFilters, ...temporaryFiltersCopy];
 }
 


### PR DESCRIPTION
1. Add ability to disable removeFilter option, this is currently done when the dashboard is prebuilt, and a filter exists in it's prebuilt config.
2. remove the `temporaryFilters` query param and add `isTemporary` property to `GlobalFilters` which is easier to manage then having two separate query params
3. Add tests cases to dashboard link field renderer and filter bar