### PR TITLE
fix(seer): Fix simple organization seer rpcs

### DIFF
--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -13,7 +13,8 @@ def map_org_id_param(func: Callable) -> Callable:
     """
 
     def wrapper(*, organization_id: int, **kwargs: Any) -> Any:
-        return func(org_id=organization_id, **kwargs)
+        kwargs["org_id"] = organization_id
+        return func(**kwargs)
 
     return wrapper
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -157,3 +157,12 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
 
             assert response.status_code == 200
             assert response.data == {"slug": self.organization.slug}
+
+    @with_feature("organizations:seer-public-rpc")
+    def test_org_level_method_duplicate_org_id(self) -> None:
+        """Test that organization-level methods work and return correct data"""
+        path = self._get_path("get_organization_slug")
+        response = self.client.post(path, data={"args": {"org_id": 1}}, format="json")
+
+        assert response.status_code == 200
+        assert response.data == {"slug": self.organization.slug}


### PR DESCRIPTION
Seer passes `org_id` as an arg so this wrapper actually results in the same keyword arg being specified twice which is an error.