### PR TITLE
feat(cells): make email capture demo mode control-silo only

### DIFF
--- a/src/sentry/api/endpoints/email_capture.py
+++ b/src/sentry/api/endpoints/email_capture.py
@@ -17,7 +17,6 @@ class EmailCaptureSerializer(CamelSnakeSerializer):
     email = serializers.EmailField(required=True)
 
 
-# TODO(cells): This endpoint is moving to control
 @control_silo_endpoint
 class EmailCaptureEndpoint(Endpoint):
     publish_status = {

--- a/src/sentry/api/endpoints/email_capture.py
+++ b/src/sentry/api/endpoints/email_capture.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, all_silo_endpoint
+from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.demo_mode.utils import is_demo_mode_enabled
 from sentry.utils.marketo_client import MarketoClient
@@ -18,7 +18,7 @@ class EmailCaptureSerializer(CamelSnakeSerializer):
 
 
 # TODO(cells): This endpoint is moving to control
-@all_silo_endpoint
+@control_silo_endpoint
 class EmailCaptureEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -153,6 +153,7 @@ const patterns: RegExp[] = [
   new RegExp('^api/0/wizard/[^/]+/$'),
   new RegExp('^api/0/internal/beacon/$'),
   new RegExp('^api/0/internal/integration-proxy/$'),
+  new RegExp('^api/0/internal/demo/email-capture/$'),
   new RegExp('^api/0/internal/notifications/registered-templates/$'),
   new RegExp('^api/0/uptime-ips/$'),
   new RegExp('^api/0/tempest-ips/$'),

--- a/tests/sentry/api/endpoints/test_email_capture.py
+++ b/tests/sentry/api/endpoints/test_email_capture.py
@@ -4,9 +4,11 @@ from django.urls import reverse
 
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.silo import control_silo_test
 from sentry.utils.marketo_client import MarketoClient
 
 
+@control_silo_test
 class EmailCaptureTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
note: it is safe to ship frontend + backend together in this case as backend currently works in both silos
