### PR TITLE
fix(ai-code-review): Add on_new_commit flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -78,6 +78,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:chonk-ui-feedback", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Codecov UI
     manager.add("organizations:codecov-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Prevent AI code review to run per commit
+    manager.add("organizations:code-review-run-per-commit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables Prevent Test Analytics
     manager.add("organizations:prevent-test-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the improved command menu (Cmd+K)

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -25,7 +25,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.prevent.models import PreventAIConfiguration
-from sentry.prevent.types.config import PREVENT_AI_CONFIG_DEFAULT
+from sentry.prevent.types.config import PREVENT_AI_CONFIG_DEFAULT, PREVENT_AI_CONFIG_DEFAULT_V1
 from sentry.silo.base import SiloMode
 
 logger = logging.getLogger(__name__)
@@ -154,7 +154,13 @@ class PreventPrReviewResolvedConfigsEndpoint(Endpoint):
             integration_id=github_org_integrations[0].integration_id,
         ).first()
 
-        response_data: dict[str, Any] = deepcopy(PREVENT_AI_CONFIG_DEFAULT)
+        organization = Organization.objects.filter(id=sentry_org_id).first()
+
+        default_config = PREVENT_AI_CONFIG_DEFAULT
+        if features.has("organizations:code-review-run-per-commit", organization):
+            default_config = PREVENT_AI_CONFIG_DEFAULT_V1
+
+        response_data: dict[str, Any] = deepcopy(default_config)
         if config:
             response_data["organization"] = config.data
 

--- a/src/sentry/prevent/types/config.py
+++ b/src/sentry/prevent/types/config.py
@@ -125,3 +125,40 @@ PREVENT_AI_CONFIG_DEFAULT = {
     },
     "organization": {},
 }
+
+PREVENT_AI_CONFIG_DEFAULT_V1 = {
+    "schema_version": "v1",
+    "default_org_config": {
+        "org_defaults": {
+            "bug_prediction": {
+                "enabled": True,
+                "sensitivity": "medium",
+                "triggers": {
+                    "on_command_phrase": True,
+                    "on_ready_for_review": True,
+                    # v1 default enables on_new_commit
+                    "on_new_commit": True,
+                },
+            },
+            "test_generation": {
+                "enabled": True,
+                "triggers": {
+                    "on_command_phrase": True,
+                    "on_ready_for_review": False,
+                    "on_new_commit": False,
+                },
+            },
+            "vanilla": {
+                "enabled": True,
+                "sensitivity": "medium",
+                "triggers": {
+                    "on_command_phrase": True,
+                    "on_ready_for_review": False,
+                    "on_new_commit": False,
+                },
+            },
+        },
+        "repo_overrides": {},
+    },
+    "organization": {},
+}


### PR DESCRIPTION
Use new feature flag to gate rollout of `on_new_commit`=True so we run code review on every commit (instead of just when PR opened).
We'll roll this out to batches of orgs at a time

PREVENT-472