### PR TITLE
feat(top-issues): increase visual contrast between clusters

### DIFF
--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -1079,6 +1079,7 @@ const PageWrapper = styled('div')`
 
 const HeaderSection = styled('div')`
   padding: ${space(4)} ${space(4)} ${space(3)};
+  background: ${p => p.theme.backgroundSecondary};
 `;
 
 const ClickableHeading = styled(Heading)`
@@ -1089,6 +1090,7 @@ const ClickableHeading = styled(Heading)`
 const CardsSection = styled('div')`
   flex: 1;
   padding: ${space(2)} ${space(4)} ${space(4)};
+  background: ${p => p.theme.backgroundSecondary};
 `;
 
 const CardsGrid = styled('div')`
@@ -1190,7 +1192,6 @@ const CardFooter = styled('div')`
   display: flex;
   justify-content: flex-end;
   gap: ${space(1)};
-  background: ${p => p.theme.backgroundSecondary};
 `;
 
 // Split button for Send to Seer action


### PR DESCRIPTION
Adds a background behind the clusters section so clusters are more visually distinct.
Before:
<img width="626" height="791" alt="Screenshot 2025-12-08 at 10 33 13 AM" src="https://github.com/user-attachments/assets/f4e1e047-d09c-444e-92e0-65d907d63fdd" />

After:
<img width="633" height="756" alt="Screenshot 2025-12-08 at 10 32 59 AM" src="https://github.com/user-attachments/assets/06472f77-bdf7-4aec-b881-f5f186c78d31" />
