### PR TITLE
feat(explorer): allow client to control and inspect coding state

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -112,7 +112,12 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         on_page_context = validated_data.get("on_page_context")
 
         try:
-            client = SeerExplorerClient(organization, request.user, is_interactive=True)
+            client = SeerExplorerClient(
+                organization,
+                request.user,
+                is_interactive=True,
+                enable_coding=True,
+            )
             if run_id:
                 # Continue existing conversation
                 result_run_id = client.continue_run(

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -93,7 +93,9 @@ class MemoryBlock(BaseModel):
     loading: bool = False
     artifacts: list[Artifact] = []
     file_patches: list[ExplorerFilePatch] = []
-    pr_commit_shas: dict[str, str] | None = None
+    pr_commit_shas: dict[str, str] | None = (
+        None  # repository name -> commit SHA. Used to track which commit was associated with each repo's PR at the time this block was created.
+    )
 
     class Config:
         extra = "allow"

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -44,6 +44,46 @@ class Artifact(BaseModel):
         extra = "allow"
 
 
+class FilePatch(BaseModel):
+    """A file patch from code editing."""
+
+    path: str
+    type: Literal["A", "M", "D"]  # A=add, M=modify, D=delete
+    added: int
+    removed: int
+
+    class Config:
+        extra = "allow"
+
+
+class ExplorerFilePatch(BaseModel):
+    """A file patch associated with a repository."""
+
+    repo_name: str
+    patch: FilePatch
+
+    class Config:
+        extra = "allow"
+
+
+class RepoPRState(BaseModel):
+    """PR state for a single repository."""
+
+    repo_name: str
+    branch_name: str | None = None
+    pr_number: int | None = None
+    pr_url: str | None = None
+    pr_id: int | None = None
+    commit_sha: str | None = None
+    pr_creation_status: Literal["creating", "completed", "error"] | None = None
+    pr_creation_error: str | None = None
+    title: str | None = None
+    description: str | None = None
+
+    class Config:
+        extra = "allow"
+
+
 class MemoryBlock(BaseModel):
     """A block in the Explorer agent's conversation/memory."""
 
@@ -52,6 +92,8 @@ class MemoryBlock(BaseModel):
     timestamp: str
     loading: bool = False
     artifacts: list[Artifact] = []
+    file_patches: list[ExplorerFilePatch] = []
+    pr_commit_shas: dict[str, str] | None = None
 
     class Config:
         extra = "allow"
@@ -76,6 +118,7 @@ class SeerRunState(BaseModel):
     status: Literal["processing", "completed", "error", "awaiting_user_input"]
     updated_at: str
     pending_user_input: PendingUserInput | None = None
+    repo_pr_states: dict[str, RepoPRState] = {}
 
     class Config:
         extra = "allow"
@@ -109,6 +152,52 @@ class SeerRunState(BaseModel):
         if artifact is None or artifact.data is None:
             return None
         return schema.parse_obj(artifact.data)
+
+    def get_file_patches_by_repo(self) -> dict[str, list[ExplorerFilePatch]]:
+        """Get file patches grouped by repository."""
+        by_repo: dict[str, list[ExplorerFilePatch]] = {}
+        for block in self.blocks:
+            for fp in block.file_patches:
+                if fp.repo_name not in by_repo:
+                    by_repo[fp.repo_name] = []
+                by_repo[fp.repo_name].append(fp)
+        return by_repo
+
+    def get_pr_state(self, repo_name: str) -> RepoPRState | None:
+        """Get PR state for a specific repository."""
+        return self.repo_pr_states.get(repo_name)
+
+    def _is_repo_synced(self, repo_name: str) -> bool:
+        """Check if PR for a repo is in sync with latest changes."""
+        pr_state = self.repo_pr_states.get(repo_name)
+        if not pr_state or not pr_state.commit_sha:
+            return False  # No PR yet = not synced
+
+        # Find last block with patches for this repo
+        for block in reversed(self.blocks):
+            if any(fp.repo_name == repo_name for fp in block.file_patches):
+                block_sha = (block.pr_commit_shas or {}).get(repo_name)
+                return block_sha == pr_state.commit_sha
+        return True  # No patches found = synced
+
+    def has_code_changes(self) -> tuple[bool, bool]:
+        """
+        Check if there are code changes and if all have been pushed to PRs.
+
+        Returns:
+            (has_changes, all_changes_pushed):
+            - has_changes: True if any file patches exist
+            - all_changes_pushed: True if the current state of changes across all repos have all been pushed to PRs.
+        """
+        patches_by_repo = self.get_file_patches_by_repo()
+        has_changes = len(patches_by_repo) > 0
+
+        if not has_changes:
+            return (False, True)
+
+        # Check if all repos with changes are synced
+        all_changes_pushed = all(self._is_repo_synced(repo) for repo in patches_by_repo.keys())
+        return (has_changes, all_changes_pushed)
 
 
 class CustomToolDefinition(BaseModel):

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -69,7 +69,9 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.data == {"run_id": 456}
 
         # Verify client was called correctly
-        mock_client_class.assert_called_once_with(self.organization, ANY, is_interactive=True)
+        mock_client_class.assert_called_once_with(
+            self.organization, ANY, is_interactive=True, enable_coding=True
+        )
         mock_client.start_run.assert_called_once_with(
             prompt="What is this error about?", on_page_context=None
         )
@@ -90,7 +92,9 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.data == {"run_id": 789}
 
         # Verify client was called correctly
-        mock_client_class.assert_called_once_with(self.organization, ANY, is_interactive=True)
+        mock_client_class.assert_called_once_with(
+            self.organization, ANY, is_interactive=True, enable_coding=True
+        )
         mock_client.continue_run.assert_called_once_with(
             run_id=789, prompt="Follow up question", insert_index=2, on_page_context=None
         )

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -6,7 +6,14 @@ import requests
 from pydantic import BaseModel
 
 from sentry.seer.explorer.client import SeerExplorerClient
-from sentry.seer.explorer.client_models import SeerRunState
+from sentry.seer.explorer.client_models import (
+    ExplorerFilePatch,
+    FilePatch,
+    MemoryBlock,
+    Message,
+    RepoPRState,
+    SeerRunState,
+)
 from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import TestCase
 
@@ -582,3 +589,218 @@ class TestSeerExplorerClientArtifacts(TestCase):
         root_cause = result.get_artifact("root_cause", RootCause)
         assert root_cause is not None
         assert root_cause.cause == "New cause"
+
+
+class TestSeerExplorerClientPushChanges(TestCase):
+    """Test push_changes method"""
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.fetch_run_status")
+    @patch("sentry.seer.explorer.client.requests.post")
+    def test_push_changes_sends_correct_payload(self, mock_post, mock_fetch, mock_access):
+        """Test that push_changes sends correct payload"""
+        mock_access.return_value = (True, None)
+        mock_post.return_value = MagicMock()
+        mock_fetch.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo",
+                    pr_creation_status="completed",
+                    pr_url="https://github.com/owner/repo/pull/1",
+                )
+            },
+        )
+
+        client = SeerExplorerClient(self.organization, self.user, enable_coding=True)
+        result = client.push_changes(123, repo_name="owner/repo")
+
+        body = orjson.loads(mock_post.call_args[1]["data"])
+        assert body["run_id"] == 123
+        assert body["payload"]["type"] == "create_pr"
+        assert body["payload"]["repo_name"] == "owner/repo"
+        assert result.repo_pr_states["owner/repo"].pr_url == "https://github.com/owner/repo/pull/1"
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.fetch_run_status")
+    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.time.sleep")
+    def test_push_changes_polls_until_complete(
+        self, mock_sleep, mock_post, mock_fetch, mock_access
+    ):
+        """Test that push_changes polls until PR creation completes"""
+        mock_access.return_value = (True, None)
+        mock_post.return_value = MagicMock()
+
+        creating_state = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(repo_name="owner/repo", pr_creation_status="creating")
+            },
+        )
+        completed_state = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(repo_name="owner/repo", pr_creation_status="completed")
+            },
+        )
+        mock_fetch.side_effect = [creating_state, completed_state]
+
+        client = SeerExplorerClient(self.organization, self.user, enable_coding=True)
+        result = client.push_changes(123)
+
+        assert mock_fetch.call_count == 2
+        assert mock_sleep.call_count == 1
+        assert result.repo_pr_states["owner/repo"].pr_creation_status == "completed"
+
+    @patch("sentry.seer.explorer.client.has_seer_explorer_access_with_detail")
+    @patch("sentry.seer.explorer.client.fetch_run_status")
+    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.time.time")
+    def test_push_changes_timeout(self, mock_time, mock_post, mock_fetch, mock_access):
+        """Test that push_changes raises TimeoutError after timeout"""
+        mock_access.return_value = (True, None)
+        mock_post.return_value = MagicMock()
+        mock_fetch.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(repo_name="owner/repo", pr_creation_status="creating")
+            },
+        )
+        mock_time.side_effect = [0, 0, 200]  # Exceeds 120s timeout
+
+        client = SeerExplorerClient(self.organization, self.user, enable_coding=True)
+        with pytest.raises(TimeoutError, match="PR creation timed out"):
+            client.push_changes(123, poll_timeout=120.0)
+
+
+class TestSeerRunStateCodeChanges(TestCase):
+    """Test SeerRunState helper methods for code changes"""
+
+    def test_has_code_changes_no_patches(self):
+        """Test has_code_changes with no patches returns (False, True)"""
+        state = SeerRunState(
+            run_id=123,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="Hello"),
+                    timestamp="2024-01-01T00:00:00Z",
+                )
+            ],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        has_changes, is_synced = state.has_code_changes()
+        assert has_changes is False
+        assert is_synced is True
+
+    def test_has_code_changes_unsynced(self):
+        """Test has_code_changes with patches but no PR"""
+        state = SeerRunState(
+            run_id=123,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="Fixed"),
+                    timestamp="2024-01-01T00:00:00Z",
+                    file_patches=[
+                        ExplorerFilePatch(
+                            repo_name="owner/repo",
+                            patch=FilePatch(path="file.py", type="M", added=10, removed=5),
+                        )
+                    ],
+                )
+            ],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        has_changes, is_synced = state.has_code_changes()
+        assert has_changes is True
+        assert is_synced is False
+
+    def test_has_code_changes_synced(self):
+        """Test has_code_changes when changes are synced to PR"""
+        state = SeerRunState(
+            run_id=123,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="Fixed"),
+                    timestamp="2024-01-01T00:00:00Z",
+                    file_patches=[
+                        ExplorerFilePatch(
+                            repo_name="owner/repo",
+                            patch=FilePatch(path="file.py", type="M", added=10, removed=5),
+                        )
+                    ],
+                    pr_commit_shas={"owner/repo": "abc123"},
+                )
+            ],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo",
+                    commit_sha="abc123",
+                    pr_creation_status="completed",
+                )
+            },
+        )
+
+        has_changes, is_synced = state.has_code_changes()
+        assert has_changes is True
+        assert is_synced is True
+
+    def test_get_file_patches_by_repo(self):
+        """Test get_file_patches_by_repo groups patches correctly"""
+        state = SeerRunState(
+            run_id=123,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="Fixed"),
+                    timestamp="2024-01-01T00:00:00Z",
+                    file_patches=[
+                        ExplorerFilePatch(
+                            repo_name="owner/repo1",
+                            patch=FilePatch(path="file1.py", type="M", added=10, removed=5),
+                        ),
+                        ExplorerFilePatch(
+                            repo_name="owner/repo2",
+                            patch=FilePatch(path="file2.py", type="A", added=20, removed=0),
+                        ),
+                        ExplorerFilePatch(
+                            repo_name="owner/repo1",
+                            patch=FilePatch(path="file3.py", type="M", added=5, removed=2),
+                        ),
+                    ],
+                )
+            ],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        result = state.get_file_patches_by_repo()
+        assert len(result) == 2
+        assert len(result["owner/repo1"]) == 2
+        assert len(result["owner/repo2"]) == 1


### PR DESCRIPTION
The explorer client can now enable/disable coding tools, view returned file patches, and make and view PRs

Part of AIML-1698

Requires https://github.com/getsentry/seer/pull/4200/