### PR TITLE
feat(flagpole): add support for more detailed owner schema

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -88,12 +88,21 @@ def load_json_schema() -> dict[str, Any]:
 
 
 @dataclasses.dataclass(frozen=True)
+class OwnerInfo:
+    team: str
+    "The team that owns this feature."
+
+    email: str | None = None
+    "The email address of the owner."
+
+
+@dataclasses.dataclass(frozen=True)
 class Feature:
     name: str
     "The feature name."
 
-    owner: str
-    "The owner of this feature. Either an email address or team name, preferably."
+    owner: str | OwnerInfo
+    "The owner of this feature."
 
     enabled: bool = dataclasses.field(default=True)
     "Whether or not the feature is enabled."
@@ -133,9 +142,20 @@ class Feature:
             raise InvalidFeatureFlagConfiguration("Feature has no segments defined")
         try:
             segments = [Segment.from_dict(segment) for segment in segment_data]
+
+            raw_owner = config_dict.get("owner", "")
+            owner: str | OwnerInfo
+            if isinstance(raw_owner, dict):
+                owner = OwnerInfo(
+                    team=raw_owner["team"],
+                    email=raw_owner.get("email"),
+                )
+            else:
+                owner = str(raw_owner)
+
             feature = cls(
                 name=name,
-                owner=str(config_dict.get("owner", "")),
+                owner=owner,
                 enabled=bool(config_dict.get("enabled", True)),
                 created_at=str(config_dict.get("created_at")),
                 segments=segments,

--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -218,6 +218,7 @@ class Feature:
 
 __all__ = [
     "Feature",
+    "OwnerInfo",
     "InvalidFeatureFlagConfiguration",
     "ContextBuilder",
     "EvaluationContext",

--- a/src/flagpole/flagpole-schema.json
+++ b/src/flagpole/flagpole-schema.json
@@ -10,9 +10,29 @@
     },
     "owner": {
       "title": "Owner",
-      "description": "The owner of this feature. Either an email address or team name, preferably.",
-      "minLength": 1,
-      "type": "string"
+      "description": "The owner of this feature.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "properties": {
+            "team": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The team that owns this feature."
+            },
+            "email": {
+              "type": ["string", "null"],
+              "description": "The email address of the owner. Not required."
+            }
+          },
+          "required": ["team"],
+          "additionalProperties": false
+        }
+      ]
     },
     "segments": {
       "title": "Segments",


### PR DESCRIPTION
Add the option to define owner via team + email strings, rather than just a string. Supports this change in the options automator: https://github.com/getsentry/sentry-options-automator/pull/5705. This change is temporary until we can move fully to the new schema.