### PR TITLE
feat(trace-tree-node): Fixing node matching in issues waterfall

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -368,12 +368,7 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
       occurrence => occurrence.event_id === id
     );
 
-    return (
-      this.id === id ||
-      this.transactionId === id ||
-      hasMatchingErrors ||
-      hasMatchingOccurrences
-    );
+    return this.id === id || hasMatchingErrors || hasMatchingOccurrences;
   }
 
   invalidate() {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
@@ -321,7 +321,7 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
     const superMatch = super.matchById(id);
 
     // Match by transaction_id if the node represents a transaction, otherwise use the super match.
-    return superMatch || this.value.is_transaction ? id === this.transactionId : false;
+    return superMatch || (this.value.is_transaction ? id === this.transactionId : false);
   }
 
   resolveValueFromSearchKey(key: string): any | null {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
@@ -138,13 +138,11 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
   }
 
   get transactionId(): string | undefined {
-    const transactionId = super.transactionId;
-
-    if (transactionId) {
-      return transactionId;
-    }
-
-    return this.findClosestParentTransaction()?.transactionId;
+    // If the node represents a transaction, we use the transaction_id attached to the node,
+    // otherwise we use the transaction_id of the closest parent transaction.
+    return this.value.is_transaction
+      ? this.value.transaction_id
+      : this.findClosestParentTransaction()?.transactionId;
   }
 
   get traceHeaderTitle(): {
@@ -317,6 +315,13 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
       this.value.name?.includes(query) ||
       this.id === query
     );
+  }
+
+  matchById(id: string): boolean {
+    const superMatch = super.matchById(id);
+
+    // Match by transaction_id if the node represents a transaction, otherwise use the super match.
+    return superMatch || this.value.is_transaction ? id === this.transactionId : false;
   }
 
   resolveValueFromSearchKey(key: string): any | null {


### PR DESCRIPTION
- Without this PR, we were matching with unrelated non-transation EAP spans, by their transaction IDs. Taking a slowDB query issue as an example:

Issue trace preview:
<img width="1071" height="310" alt="Screenshot 2025-12-11 at 12 33 24 PM" src="https://github.com/user-attachments/assets/062b3132-1cc9-4784-b88e-135b2c962859" />

To trace view:
<img width="1305" height="569" alt="Screenshot 2025-12-11 at 12 33 36 PM" src="https://github.com/user-attachments/assets/ea823b96-0fda-44b9-99d3-108dc9ffae5c" />

