### PR TITLE
chore(data-forwarding): nicer icon, better error message

### DIFF
--- a/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
@@ -69,7 +69,7 @@ export function ProjectOverrideForm({
         collapsible
         renderHeader={() => (
           <Flex padding="sm lg" borderBottom="primary" gap="md" align="center">
-            <IconInfo size="sm" />
+            <IconInfo size="sm" color="subText" />
             <Text variant="muted" size="sm" bold>
               {t('Overrides set here will only affect this project')}
             </Text>

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -149,7 +149,11 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
                 tooltip={
                   key === provider
                     ? undefined
-                    : {title: t('Cannot update provider after setup.')}
+                    : {
+                        title: t(
+                          'Cannot update provider after setup, create a new forwarder instead.'
+                        ),
+                      }
                 }
               >
                 <Flex align="center" gap="sm">


### PR DESCRIPTION
Corrects an icon color, and a better error message for the edit form. Small nitpicks I found before we EA.