### PR TITLE
feat(triage signals): Use new seat based pricing feature flag

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -26,8 +26,8 @@ from sentry.seer.autofix.constants import (
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     get_autofix_state,
-    has_seer_seat_based_tier_enabled,
     is_seer_autotriggered_autofix_rate_limited,
+    is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
@@ -344,7 +344,7 @@ def run_automation(
 
     # Only log for orgs with seat-based Seer tier
     try:
-        if has_seer_seat_based_tier_enabled(group.organization):
+        if is_seer_seat_based_tier_enabled(group.organization):
             try:
                 times_seen = group.times_seen_with_pending
             except (AssertionError, AttributeError):

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -344,21 +344,24 @@ def run_automation(
 
     # Only log for orgs with seat-based Seer tier
     try:
-        if is_seer_seat_based_tier_enabled(group.organization):
-            try:
-                times_seen = group.times_seen_with_pending
-            except (AssertionError, AttributeError):
-                times_seen = group.times_seen
-            logger.info(
-                "Triage signals V0: %s: run_automation called: project_slug=%s, source=%s, times_seen=%s",
-                group.id,
-                group.project.slug,
-                source.value,
-                times_seen,
-            )
+        should_log = is_seer_seat_based_tier_enabled(group.organization)
     except Exception:
         logger.exception(
             "Error checking if seat-based Seer tier is enabled", extra={"group_id": group.id}
+        )
+        should_log = False
+
+    if should_log:
+        try:
+            times_seen = group.times_seen_with_pending
+        except (AssertionError, AttributeError):
+            times_seen = group.times_seen
+        logger.info(
+            "Triage signals V0: %s: run_automation called: project_slug=%s, source=%s, times_seen=%s",
+            group.id,
+            group.project.slug,
+            source.value,
+            times_seen,
         )
 
     user_id = user.id if user else None

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -365,7 +365,7 @@ def is_seer_scanner_rate_limited(project: Project, organization: Organization) -
     return is_rate_limited
 
 
-def has_seer_seat_based_tier_enabled(organization: Organization) -> bool:
+def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     """
     Check if organization has Seer seat-based tier via billing.
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -28,6 +28,7 @@ from sentry.seer.models import (
 )
 from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
 from sentry.utils import json
+from sentry.utils.cache import cache
 from sentry.utils.outcomes import Outcome, track_outcome
 
 logger = logging.getLogger(__name__)
@@ -362,6 +363,28 @@ def is_seer_scanner_rate_limited(project: Project, organization: Organization) -
             category=DataCategory.SEER_SCANNER,
         )
     return is_rate_limited
+
+
+def has_seer_seat_based_tier_enabled(organization: Organization) -> bool:
+    """
+    Check if organization has Seer seat-based tier via billing.
+
+    Returns True if the organization has either:
+    - triage-signals-v0-org feature flag enabled (org-level triage signals)
+    - seat-based-seer-enabled feature enabled (seat-based Seer subscription, cached for 24 hours)
+    """
+    if features.has("organizations:triage-signals-v0-org", organization):
+        return True
+
+    cache_key = f"seer:seat-based-tier:{organization.id}"
+    cached_value = cache.get(cache_key)
+    if cached_value is not None:
+        return cached_value
+
+    has_seat_based_seer = features.has("organizations:seat-based-seer-enabled", organization)
+    cache.set(cache_key, has_seat_based_seer, timeout=60 * 60 * 4)  # 4 hours TTL
+
+    return has_seat_based_seer
 
 
 def is_issue_eligible_for_seer_automation(group: Group) -> bool:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -367,11 +367,7 @@ def is_seer_scanner_rate_limited(project: Project, organization: Organization) -
 
 def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     """
-    Check if organization has Seer seat-based tier via billing.
-
-    Returns True if the organization has either:
-    - triage-signals-v0-org feature flag enabled (org-level triage signals)
-    - seat-based-seer-enabled feature enabled (seat-based Seer subscription, cached for 24 hours)
+    Check if organization has Seer seat-based pricing via billing.
     """
     if features.has("organizations:triage-signals-v0-org", organization):
         return True
@@ -381,6 +377,7 @@ def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     if cached_value is not None:
         return cached_value
 
+    logger.info("Checking if seat-based Seer tier is enabled for organization=%s", organization.id)
     has_seat_based_seer = features.has("organizations:seat-based-seer-enabled", organization)
     cache.set(cache_key, has_seat_based_seer, timeout=60 * 60 * 4)  # 4 hours TTL
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -365,6 +365,11 @@ def is_seer_scanner_rate_limited(project: Project, organization: Organization) -
     return is_rate_limited
 
 
+def get_seer_seat_based_tier_cache_key(organization_id: int) -> str:
+    """Get the cache key for seat-based Seer tier check."""
+    return f"seer:seat-based-tier:{organization_id}"
+
+
 def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     """
     Check if organization has Seer seat-based pricing via billing.
@@ -372,7 +377,7 @@ def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     if features.has("organizations:triage-signals-v0-org", organization):
         return True
 
-    cache_key = f"seer:seat-based-tier:{organization.id}"
+    cache_key = get_seer_seat_based_tier_cache_key(organization.id)
     cached_value = cache.get(cache_key)
     if cached_value is not None:
         return cached_value

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -125,8 +125,8 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     # Set org-level options
     organization.update_option("sentry:enable_seer_coding", True)
 
-    # If the key exists, invalidate the seat-based tier cache so new settings take effect immediately
-    cache.delete(f"seer:seat-based-tier:{organization_id}")
+    # Invalidate seat-based tier cache so new settings take effect immediately
+    cache.delete(get_seer_seat_based_tier_cache_key(organization_id))
 
     projects = list(Project.objects.filter(organization_id=organization_id, status=0))
     project_ids = [p.id for p in projects]
@@ -163,6 +163,3 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
         )
     if len(preferences_to_set) > 0:
         bulk_set_project_preferences(organization_id, preferences_to_set)
-
-    # Invalidate seat-based tier cache so new settings take effect immediately
-    cache.delete(get_seer_seat_based_tier_cache_key(organization_id))

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -9,10 +9,12 @@ from sentry.seer.autofix.utils import (
     bulk_get_project_preferences,
     bulk_set_project_preferences,
     get_autofix_state,
+    get_seer_seat_based_tier_cache_key,
 )
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ingest_errors_tasks, issues_tasks
 from sentry.taskworker.retry import Retry
+from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +125,9 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     # Set org-level options
     organization.update_option("sentry:enable_seer_coding", True)
 
+    # If the key exists, invalidate the seat-based tier cache so new settings take effect immediately
+    cache.delete(f"seer:seat-based-tier:{organization_id}")
+
     projects = list(Project.objects.filter(organization_id=organization_id, status=0))
     project_ids = [p.id for p in projects]
 
@@ -158,3 +163,6 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
         )
     if len(preferences_to_set) > 0:
         bulk_set_project_preferences(organization_id, preferences_to_set)
+
+    # Invalidate seat-based tier cache so new settings take effect immediately
+    cache.delete(get_seer_seat_based_tier_cache_key(organization_id))

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -11,8 +11,8 @@ from sentry.seer.autofix.utils import (
     CodingAgentStatus,
     get_autofix_prompt,
     get_coding_agent_prompt,
-    has_seer_seat_based_tier_enabled,
     is_issue_eligible_for_seer_automation,
+    is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.models import SeerApiError
 from sentry.testutils.cases import TestCase
@@ -351,8 +351,8 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
                 assert result is True
 
 
-class TestHasSeerSeatBasedTierEnabled(TestCase):
-    """Test the has_seer_seat_based_tier_enabled function."""
+class TestIsSeerSeatBasedTierEnabled(TestCase):
+    """Test the is_seer_seat_based_tier_enabled function."""
 
     def setUp(self):
         super().setUp()
@@ -365,7 +365,7 @@ class TestHasSeerSeatBasedTierEnabled(TestCase):
     def test_returns_true_when_triage_signals_enabled(self):
         """Test returns True when triage-signals-v0-org feature flag is enabled."""
         with self.feature("organizations:triage-signals-v0-org"):
-            result = has_seer_seat_based_tier_enabled(self.organization)
+            result = is_seer_seat_based_tier_enabled(self.organization)
             assert result is True
 
     @patch("sentry.seer.autofix.utils.features.has")
@@ -379,7 +379,7 @@ class TestHasSeerSeatBasedTierEnabled(TestCase):
 
         mock_features_has.side_effect = features_side_effect
 
-        result = has_seer_seat_based_tier_enabled(self.organization)
+        result = is_seer_seat_based_tier_enabled(self.organization)
         assert result is True
 
         # Verify it was cached
@@ -388,7 +388,7 @@ class TestHasSeerSeatBasedTierEnabled(TestCase):
 
     def test_returns_false_when_no_flags_enabled(self):
         """Test returns False when neither feature flag is enabled and caches the result."""
-        result = has_seer_seat_based_tier_enabled(self.organization)
+        result = is_seer_seat_based_tier_enabled(self.organization)
         assert result is False
 
         # Verify False was cached
@@ -401,5 +401,5 @@ class TestHasSeerSeatBasedTierEnabled(TestCase):
         cache.set(cache_key, True, timeout=60)
 
         # Even without feature flags enabled, should return cached True
-        result = has_seer_seat_based_tier_enabled(self.organization)
+        result = is_seer_seat_based_tier_enabled(self.organization)
         assert result is True


### PR DESCRIPTION
## PR Details
+ Added a new function to check for the triage-signals or the [billing feature flag in getsentry](https://github.com/getsentry/getsentry/blob/af9c348984e21886e0067ff5e8df9ad94489af1e/getsentry/features.py#L1915) to check if the org has signed up for new billing.
+ The function also caches the billing flag value since we want to reduce the number of DB reads. This function will later be used in `kick_off_seer_autoamtion` which is called for every event in every issue! 
+ Just called this function once with a try catch to check that it works as expected. If there are no issues I will remove the try-except and replace all instances of the `features.has("organizations:triage-signals-v0-org")` check with this function. 
+ Added cache invalidation when orgs sign up for the new billing. 
