### PR TITLE
fix(api): Update List Seer AI Models to reflect that it is regional

### DIFF
--- a/api-docs/watch.ts
+++ b/api-docs/watch.ts
@@ -1,11 +1,8 @@
 import {spawn} from 'node:child_process';
-import {dirname, join} from 'node:path';
+import {join} from 'node:path';
 import {stderr, stdout} from 'node:process';
-import {fileURLToPath} from 'node:url';
 
 import sane from 'sane';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const watcherPy = sane(join(__dirname, '../src/sentry'));
 const watcherJson = sane(join(__dirname, '../api-docs'));

--- a/api-docs/watch.ts
+++ b/api-docs/watch.ts
@@ -1,8 +1,11 @@
 import {spawn} from 'node:child_process';
-import {join} from 'node:path';
+import {dirname, join} from 'node:path';
 import {stderr, stdout} from 'node:process';
+import {fileURLToPath} from 'node:url';
 
 import sane from 'sane';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const watcherPy = sane(join(__dirname, '../src/sentry'));
 const watcherJson = sane(join(__dirname, '../api-docs'));

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -227,6 +227,7 @@ class Endpoint(APIView):
     publish_status: dict[HTTP_METHOD_NAME, ApiPublishStatus] = {}
     rate_limits: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG
     enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
+    servers: list[dict[str, Any]] | None = None
 
     def build_cursor_link(self, request: HttpRequest, name: str, cursor: Cursor) -> str:
         if request.GET.get("cursor") is None:

--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -50,6 +50,7 @@ class SeerModelsEndpoint(Endpoint):
     }
     owner = ApiOwner.ML_AI
     permission_classes = ()
+    servers = [{"url": "https://{region}.sentry.io"}]
 
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
@@ -72,6 +73,9 @@ class SeerModelsEndpoint(Endpoint):
 
         Returns the list of AI models that are currently used in production in Seer.
         This endpoint does not require authentication and can be used to discover which models Seer uses.
+
+        Requests to this endpoint should use the region-specific domain
+        eg. `us.sentry.io` or `de.sentry.io`
         """
         cached_data = cache.get(SEER_MODELS_CACHE_KEY)
         if cached_data is not None:

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -103,10 +103,21 @@ class CustomGenerator(SchemaGenerator):
     endpoint_inspector_cls = CustomEndpointEnumerator
 
 
+# Collected during preprocessing, used in postprocessing
+_ENDPOINT_SERVERS: dict[str, list[dict[str, Any]]] = {}
+
+
 def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, rename
+    _ENDPOINT_SERVERS.clear()
+
     filtered = []
     ownership_data: dict[ApiOwner, dict] = {}
     for path, path_regex, method, callback in endpoints:
+        # Collect servers from endpoint class for postprocessing
+        endpoint_servers = getattr(callback.view_class, "servers", None)
+        if endpoint_servers is not None:
+            _ENDPOINT_SERVERS[path] = endpoint_servers
+
         owner_team = callback.view_class.owner
         if owner_team not in ownership_data:
             ownership_data[owner_team] = {
@@ -223,6 +234,12 @@ def _validate_request_body(
 
 def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> Any:
     _fix_issue_paths(result)
+
+    # Add servers override from endpoint class definitions
+    for path, servers in _ENDPOINT_SERVERS.items():
+        if path in result["paths"]:
+            for method_info in result["paths"][path].values():
+                method_info["servers"] = servers
 
     # Fetch schema component references
     schema_components = result["components"]["schemas"]

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -233,13 +233,13 @@ def _validate_request_body(
 
 
 def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> Any:
-    _fix_issue_paths(result)
-
     # Add servers override from endpoint class definitions
     for path, servers in _ENDPOINT_SERVERS.items():
         if path in result["paths"]:
             for method_info in result["paths"][path].values():
                 method_info["servers"] = servers
+
+    _fix_issue_paths(result)
 
     # Fetch schema component references
     schema_components = result["components"]["schemas"]


### PR DESCRIPTION
<!-- Describe your PR here. -->
The "List Seer AI Models" api reference did not specify a regional url. Historically, these were added in manually, but we have since switched to spectacular to create our json. I have added a servers attribute to the base api and a catch that will add the attribute to the method info if servers are specified. 

The watch command to test also had a legacy error that I fixed to properly see the changes. (This was moved to a separate PR as a frontend change) 

To test follow these instructions: https://develop.sentry.dev/backend/api/public/#building-and-testing-locally


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
