### PR TITLE
fix(eventstream): Add a call to `producer.poll` prior to forwarding trace items to EAP

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -227,6 +227,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
     def _send_item(self, trace_item: TraceItem) -> None:
         producer = self.get_producer(Topic.SNUBA_ITEMS)
         real_topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
+        producer.poll(0.0)
         try:
             producer.produce(
                 topic=real_topic,


### PR DESCRIPTION
Resolves [SENTRY-FOR-SENTRY-E07](https://sentry-st.sentry.io/issues/6981257541?project=-1).

Adds a call to `producer.poll` prior to forwarding trace items to EAP. This ensures that the local buffer is properly cleared once the Kafka broker acknowledges produced messages.