### PR TITLE
fix(trace): Set a limit on the trace query

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2002,6 +2002,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "performance.traces.pagination.query-limit",
+    type=Int,
+    default=10_000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "performance.traces.pagination.max-timeout",
     type=Float,
     default=0.0,

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -35,7 +35,6 @@ from sentry.utils import snuba_rpc
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger("sentry.snuba.spans_rpc")
-TRACE_QUERY_LIMIT_OVERRIDE: None | int = None
 
 
 class Spans(rpc_dataset_common.RPCBase):
@@ -220,7 +219,7 @@ class Spans(rpc_dataset_common.RPCBase):
             meta=meta,
             trace_id=trace_id,
             # when this is None we just get the default limit
-            limit=TRACE_QUERY_LIMIT_OVERRIDE,  # type: ignore[arg-type]
+            limit=options.get("performance.traces.pagination.query-limit"),
             items=[
                 GetTraceRequest.TraceItem(
                     item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -286,9 +286,9 @@ class OrganizationEventsTraceEndpointTest(
         {
             "performance.traces.pagination.max-iterations": 30,
             "performance.traces.pagination.max-timeout": 15,
+            "performance.traces.pagination.query-limit": 5,
         }
     )
-    @mock.patch("sentry.snuba.spans_rpc.TRACE_QUERY_LIMIT_OVERRIDE", 5)
     def test_pagination(self) -> None:
         """Test is identical to test_simple, but with the limit override, we'll need to make multiple requests to get
         all of the trace"""


### PR DESCRIPTION
- Sets the query limit to 10k by default and makes it an option so we can change it if needed