### PR TITLE
fix(api): edit watch script so dirname is defined

### DIFF
--- a/api-docs/watch.ts
+++ b/api-docs/watch.ts
@@ -1,9 +1,11 @@
 import {spawn} from 'node:child_process';
-import {join} from 'node:path';
+import {dirname, join} from 'node:path';
 import {stderr, stdout} from 'node:process';
+import {fileURLToPath} from 'node:url';
 
 import sane from 'sane';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const watcherPy = sane(join(__dirname, '../src/sentry'));
 const watcherJson = sane(join(__dirname, '../api-docs'));
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Was unable to test endpoint changes as watch script was failing. Fixed by defining dirname
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
