### PR TITLE
fix(grouping): Fix grouphash caching metric cache expiry tagging

### DIFF
--- a/src/sentry/grouping/ingest/caching.py
+++ b/src/sentry/grouping/ingest/caching.py
@@ -42,7 +42,8 @@ def invalidate_grouphash_cache_on_save(instance: GroupHash, **kwargs: Any) -> No
         return
 
     cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
-    cache.delete(cache_key)
+    # TODO: We can remove the version once we've settled on a good retention period
+    cache.delete(cache_key, version=get_grouphash_cache_version("object"))
 
 
 def invalidate_grouphash_caches_on_delete(instance: GroupHash, **kwargs: Any) -> None:
@@ -57,4 +58,8 @@ def invalidate_grouphash_caches_on_delete(instance: GroupHash, **kwargs: Any) ->
     object_cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
     existence_cache_key = get_grouphash_existence_cache_key(instance.hash, instance.project.id)
 
-    cache.delete_many([object_cache_key, existence_cache_key])
+    # TODO: This can go back to being just
+    #     cache.delete_many([object_cache_key, existence_cache_key])
+    # once we've settled on a good retention period
+    cache.delete(object_cache_key, version=get_grouphash_cache_version("object"))
+    cache.delete(existence_cache_key, version=get_grouphash_cache_version("existence"))

--- a/src/sentry/grouping/ingest/caching.py
+++ b/src/sentry/grouping/ingest/caching.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from django.core.cache import cache
 
@@ -19,6 +19,13 @@ def get_grouphash_existence_cache_key(hash_value: str, project_id: int) -> str:
 
 def get_grouphash_object_cache_key(hash_value: str, project_id: int) -> str:
     return f"grouphash_with_assigned_group:{project_id}:{hash_value}"
+
+
+# TODO: Once we settle on a good expiry time for both caches, this can go
+def get_grouphash_cache_version(cache_type: Literal["existence", "object"]) -> int:
+    option_name = f"grouping.ingest_grouphash_{cache_type}_cache_expiry.trial_values"
+    possible_cache_expiries = options.get(option_name)
+    return abs(hash(tuple(possible_cache_expiries)))
 
 
 def invalidate_grouphash_cache_on_save(instance: GroupHash, **kwargs: Any) -> None:

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -247,12 +247,11 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             grouphash_exists = cache.get(cache_key)
             got_cache_hit = grouphash_exists is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
+            # TODO: Temporary tag to let us compare hit rates across different retention periods
+            metrics_tags["expiry_seconds"] = cache_expiry
 
             if got_cache_hit:
                 metrics_tags["grouphash_exists"] = grouphash_exists
-                # TODO: Temporary tag to let us compare hit rates across different retention periods
-                metrics_tags["expiry_seconds"] = cache_expiry
-
                 return grouphash_exists
 
         grouphash_exists = GroupHash.objects.filter(project=project, hash=hash_value).exists()
@@ -297,11 +296,10 @@ def _get_or_create_single_grouphash(
             grouphash = cache.get(cache_key)
             got_cache_hit = grouphash is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
+            # TODO: Temporary tag to let us compare hit rates across different retention periods
+            metrics_tags["expiry_seconds"] = cache_expiry
 
             if got_cache_hit:
-                # TODO: Temporary tag to let us compare hit rates across different retention periods
-                metrics_tags["expiry_seconds"] = cache_expiry
-
                 return (grouphash, False)
 
         grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -264,7 +264,6 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             #     cache.set(cache_key, grouphash_exists, cache_expiry)
             # once we've settled on a good retention period
             cache.set(cache_key, grouphash_exists, cache_expiry)
-            cache.set(cache_key + "_expiry", cache_expiry, cache_expiry)
 
         return grouphash_exists
 
@@ -314,7 +313,6 @@ def _get_or_create_single_grouphash(
             #     cache.set(cache_key, grouphash, cache_expiry)
             # once we've settled on a good retention period
             cache.set(cache_key, grouphash, cache_expiry)
-            cache.set(cache_key + "_expiry", cache_expiry, cache_expiry)
 
         return (grouphash, created)
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -239,6 +239,10 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
     ) as metrics_tags:
         if use_caching:
             cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
+            # TODO: This can go back to being just
+            #     cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+            # once we've settled on a good retention period
+            cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="existence")
 
             grouphash_exists = cache.get(cache_key)
             cache_expiry_used_when_setting = cache.get(
@@ -262,10 +266,8 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             metrics_tags["cache_set"] = True
 
             # TODO: This can go back to being just
-            #     cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
             #     cache.set(cache_key, grouphash_exists, cache_expiry)
             # once we've settled on a good retention period
-            cache_expiry = _get_cache_expiry(cache_key, cache_type="existence")
             cache.set(cache_key, grouphash_exists, cache_expiry)
             cache.set(cache_key + "_expiry", cache_expiry, cache_expiry)
 
@@ -291,6 +293,10 @@ def _get_or_create_single_grouphash(
     ) as metrics_tags:
         if use_caching:
             cache_key = get_grouphash_object_cache_key(hash_value, project.id)
+            # TODO: This can go back to being just
+            #     cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
+            # once we've settled on a good retention period
+            cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="object")
 
             grouphash = cache.get(cache_key)
             cache_expiry_used_when_setting = cache.get(
@@ -315,10 +321,8 @@ def _get_or_create_single_grouphash(
             metrics_tags["cache_set"] = True
 
             # TODO: This can go back to being just
-            #     cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
             #     cache.set(cache_key, grouphash, cache_expiry)
             # once we've settled on a good retention period
-            cache_expiry = _get_cache_expiry(cache_key, cache_type="object")
             cache.set(cache_key, grouphash, cache_expiry)
             cache.set(cache_key + "_expiry", cache_expiry, cache_expiry)
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -244,6 +244,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             # once we've settled on a good retention period
             cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="existence")
 
+            # TODO: We can remove the version once we've settled on a good retention period
             grouphash_exists = cache.get(cache_key, version=option_version)
             got_cache_hit = grouphash_exists is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
@@ -260,9 +261,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             metrics_tags["grouphash_exists"] = grouphash_exists
             metrics_tags["cache_set"] = True
 
-            # TODO: This can go back to being just
-            #     cache.set(cache_key, grouphash_exists, cache_expiry)
-            # once we've settled on a good retention period
+            # TODO: We can remove the version once we've settled on a good retention period
             cache.set(cache_key, grouphash_exists, cache_expiry, version=option_version)
 
         return grouphash_exists
@@ -292,6 +291,7 @@ def _get_or_create_single_grouphash(
             # once we've settled on a good retention period
             cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="object")
 
+            # TODO: We can remove the version once we've settled on a good retention period
             grouphash = cache.get(cache_key, version=option_version)
             got_cache_hit = grouphash is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
@@ -309,9 +309,7 @@ def _get_or_create_single_grouphash(
         if use_caching and grouphash.group_id is not None:
             metrics_tags["cache_set"] = True
 
-            # TODO: This can go back to being just
-            #     cache.set(cache_key, grouphash, cache_expiry)
-            # once we've settled on a good retention period
+            # TODO: We can remove the version once we've settled on a good retention period
             cache.set(cache_key, grouphash, cache_expiry, version=option_version)
 
         return (grouphash, created)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -244,7 +244,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             # once we've settled on a good retention period
             cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="existence")
 
-            grouphash_exists = cache.get(cache_key)
+            grouphash_exists = cache.get(cache_key, version=option_version)
             got_cache_hit = grouphash_exists is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
             # TODO: Temporary tag to let us compare hit rates across different retention periods
@@ -263,7 +263,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             # TODO: This can go back to being just
             #     cache.set(cache_key, grouphash_exists, cache_expiry)
             # once we've settled on a good retention period
-            cache.set(cache_key, grouphash_exists, cache_expiry)
+            cache.set(cache_key, grouphash_exists, cache_expiry, version=option_version)
 
         return grouphash_exists
 
@@ -292,7 +292,7 @@ def _get_or_create_single_grouphash(
             # once we've settled on a good retention period
             cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="object")
 
-            grouphash = cache.get(cache_key)
+            grouphash = cache.get(cache_key, version=option_version)
             got_cache_hit = grouphash is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
             # TODO: Temporary tag to let us compare hit rates across different retention periods
@@ -312,7 +312,7 @@ def _get_or_create_single_grouphash(
             # TODO: This can go back to being just
             #     cache.set(cache_key, grouphash, cache_expiry)
             # once we've settled on a good retention period
-            cache.set(cache_key, grouphash, cache_expiry)
+            cache.set(cache_key, grouphash, cache_expiry, version=option_version)
 
         return (grouphash, created)
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -245,17 +245,13 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="existence")
 
             grouphash_exists = cache.get(cache_key)
-            cache_expiry_used_when_setting = cache.get(
-                cache_key + "_expiry",
-                default=options.get("grouping.ingest_grouphash_existence_cache_expiry"),
-            )
             got_cache_hit = grouphash_exists is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
 
             if got_cache_hit:
                 metrics_tags["grouphash_exists"] = grouphash_exists
                 # TODO: Temporary tag to let us compare hit rates across different retention periods
-                metrics_tags["expiry_seconds"] = cache_expiry_used_when_setting
+                metrics_tags["expiry_seconds"] = cache_expiry
 
                 return grouphash_exists
 
@@ -299,16 +295,12 @@ def _get_or_create_single_grouphash(
             cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="object")
 
             grouphash = cache.get(cache_key)
-            cache_expiry_used_when_setting = cache.get(
-                cache_key + "_expiry",
-                default=options.get("grouping.ingest_grouphash_object_cache_expiry"),
-            )
             got_cache_hit = grouphash is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
 
             if got_cache_hit:
                 # TODO: Temporary tag to let us compare hit rates across different retention periods
-                metrics_tags["expiry_seconds"] = cache_expiry_used_when_setting
+                metrics_tags["expiry_seconds"] = cache_expiry
 
                 return (grouphash, False)
 

--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -20,6 +20,7 @@ from sentry.db.models.base import sane_repr
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.grouping.ingest.caching import (
+    get_grouphash_cache_version,
     get_grouphash_object_cache_key,
     invalidate_grouphash_cache_on_save,
     invalidate_grouphash_caches_on_delete,
@@ -51,7 +52,8 @@ class GroupHashQuerySet(BaseQuerySet):
             )
         ]
 
-        cache.delete_many(cache_keys)
+        # TODO: We can remove the version once we've settled on a good retention period
+        cache.delete_many(cache_keys, version=get_grouphash_cache_version("object"))
 
         return len(cache_keys)
 


### PR DESCRIPTION
Currently, we only tag our `grouping.get_or_create_grouphashes.check_secondary_hash_existence` and `grouping.get_or_create_grouphashes.get_or_create_grouphash` metrics with the cache expiry time in cases where there's a cache hit. When there was only one possible expiry time, that worked fine, because anything that was a cache miss also can be assumed to have used that same expiry period. However, now that we're [testing multiple expiry times at once](https://github.com/getsentry/sentry/pull/104460), it's impossible to know which expiry time led to a given miss, which in turn throws off our hit-rate calculations.

To fix that problem, this PR adds the `expiry_seconds` tag to misses as well. Since by definition misses don't find anything in the cache, this also switches from using a cached expiry value to using the current expiry value. Finally, so that using the current value doesn't pollute results based on hits stored with an old value, it also introduces the use of cache versioning. That way, any time the list of potential cache times changes, no previously-stored values will be found.