### PR TITLE
feat(Replay): Add URLs Visited to EAP Replay Query

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -32,11 +32,6 @@ def _query_replay_urls_eap(
     organization_id: int,
 ) -> list[str]:
     """Query URLs for a replay from EAP breadcrumb events."""
-    from snuba_sdk import Column, Condition, Entity, Function, Granularity, Op, Query
-
-    from sentry.replays.lib.eap import read as eap_read
-    from sentry.replays.lib.eap.snuba_transpiler import RequestMeta, Settings
-
     replay_id_no_dashes = replay_id.replace("-", "")
 
     select = [

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -47,7 +47,6 @@ def _query_replay_urls_eap(
             Condition(Column("category"), Op.EQ, "navigation"),
         ],
         groupby=[Column("to")],
-        granularity=Granularity(3600),
     )
 
     settings = Settings(


### PR DESCRIPTION
Currently when executing the EAP replay query, we see the following [error](https://sentry.sentry.io/issues/7087811918/?query=is%3Aunresolved%20user.email%3A%EF%80%8DContains%EF%80%8Dclifford.xing%40sentry.io&referrer=issue-stream):

<img width="874" height="365" alt="image" src="https://github.com/user-attachments/assets/3ae582ce-9879-46e7-bf36-efdf2e7361f9" />


This is because the frontend expects the urls visited to be passed in the data, but the EAP query previously did not query this data. Thus, this PR adds a new query to post process the URLs visited to the replay data. Specifically, the query groups by the URL column, selecting the URL itself along with the earliest time stamp. We then sort this afterwards to ensure correctness of ordering. 

Unit tests are also added to assert correctness of URL retrieval, ordering, and deduping. 