### PR TITLE
fix(profiling): Round continuous profile timestamps appropriately

### DIFF
--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -214,8 +214,10 @@ export function generateProfileRouteFromProfileReference({
       profilerId: reference.profiler_id,
       frameName,
       framePackage,
-      start: new Date(reference.start * 1e3).toISOString(),
-      end: new Date(reference.end * 1e3).toISOString(),
+      // when converting to a timestamp, we round the start timestamp down and round
+      // the end timestamp up to the millisecond to ensure we capture the full profile
+      start: new Date(Math.floor(reference.start * 1e3)).toISOString(),
+      end: new Date(Math.ceil(reference.end * 1e3)).toISOString(),
       query: dropUndefinedKeys({
         ...query,
         frameName,


### PR DESCRIPTION
When converting the reference epoch timestamp to iso strings, make sure we round the timestamps appropriately. Start timestamps should be rounded down and end timestamps should be rounded up so that we don't miss any samples due to bad rounding.

One example of this is if we have 2 samples in a chunk, and the end timestamp is rounded down, the 2nd sample is then lost.