### PR TITLE
fix(prompts) Handle string organization id values

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -97,9 +97,8 @@ class PromptsActivityEndpoint(OrganizationEndpoint):
         else:
             fields["project_id"] = 0
 
-        if (
-            "organization_id" in required_fields
-            and fields["organization_id"] == request.organization.id
+        if "organization_id" in required_fields and str(fields["organization_id"]) == str(
+            request.organization.id
         ):
             if not Organization.objects.filter(id=fields["organization_id"]).exists():
                 return Response({"detail": "Organization no longer exists"}, status=400)

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -104,7 +104,7 @@ class PromptsActivityTest(APITestCase):
         assert resp.status_code == 200
         assert resp.data.get("data", None) is None
 
-        self.client.put(
+        resp = self.client.put(
             self.path,
             {
                 "organization_id": self.org.id,
@@ -113,9 +113,33 @@ class PromptsActivityTest(APITestCase):
                 "status": "dismissed",
             },
         )
+        assert resp.status_code == 201
 
         resp = self.client.get(self.path, data)
         assert resp.status_code == 200
+        assert "data" in resp.data
+        assert "dismissed_ts" in resp.data["data"]
+
+    def test_dismiss_str_id(self) -> None:
+        resp = self.client.put(
+            self.path,
+            {
+                "organization_id": str(self.org.id),
+                "project_id": str(self.project.id),
+                "feature": "releases",
+                "status": "dismissed",
+            },
+        )
+        assert resp.status_code == 201, resp.content
+
+        data = {
+            "organization_id": self.org.id,
+            "project_id": self.project.id,
+            "feature": "releases",
+        }
+        resp = self.client.get(self.path, data)
+        assert resp.status_code == 200
+        assert resp.data
         assert "data" in resp.data
         assert "dismissed_ts" in resp.data["data"]
 


### PR DESCRIPTION
The prompts-activity endpoint checks that organization_id is equal to the current organziation id. However, we also need to handle string ids, as JS code will have organization.id as a string.