### PR TITLE
feat(analytics): Add Seer feature tracking to issue_details.seer_opened event

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -134,6 +134,16 @@ export type TeamInsightsEventParameters = {
     group_id: string | undefined;
     resource: string;
   };
+  'issue_details.seer_opened': {
+    autofix_exists: boolean;
+    autofix_step_type: string | null;
+    has_coded_solution: boolean;
+    has_pr: boolean;
+    has_root_cause: boolean;
+    has_solution: boolean;
+    has_streamlined_ui: boolean;
+    has_summary: boolean;
+  };
   'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
     has_pull_request: boolean;
     suspect_commit_calculation: string;
@@ -233,6 +243,7 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'issue_details.issue_tab.trace_timeline_more_events_clicked':
     'Issue Details: Trace Timeline More Events Clicked',
   'issue_details.resources_link_clicked': 'Issue Details: Resources Link Clicked',
+  'issue_details.seer_opened': 'Issue Details: Seer Opened',
   'issue_details.suspect_commits.commit_clicked': 'Issue Details: Suspect Commit Clicked',
   'issue_details.suspect_commits.pull_request_clicked':
     'Issue Details: Suspect Pull Request Clicked',

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -10,7 +10,14 @@ import {
   type AutofixStep,
 } from 'sentry/components/events/autofix/types';
 import {useAiAutofix, useAutofixData} from 'sentry/components/events/autofix/useAutofix';
-import {getAutofixRunExists} from 'sentry/components/events/autofix/utils';
+import {
+  getAutofixRunExists,
+  getCodeChangesDescription,
+  getRootCauseDescription,
+  getSolutionDescription,
+  hasPullRequest,
+} from 'sentry/components/events/autofix/utils';
+import {useGroupSummaryData} from 'sentry/components/group/groupSummary';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import {IconChevron} from 'sentry/icons';
@@ -55,6 +62,8 @@ export function SeerSectionCtaButton({
     isSidebar: !isDrawerOpenRef.current,
     pollInterval: 1500,
   });
+
+  const {data: summaryData, isPending: isSummaryPending} = useGroupSummaryData(group);
 
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
@@ -143,6 +152,13 @@ export function SeerSectionCtaButton({
   const hasStepType = (type: AutofixStepType) =>
     autofixData?.steps?.some(step => step.type === type);
 
+  const rootCauseDescription = autofixData ? getRootCauseDescription(autofixData) : null;
+  const solutionDescription = autofixData ? getSolutionDescription(autofixData) : null;
+  const codeChangesDescription = autofixData
+    ? getCodeChangesDescription(autofixData)
+    : null;
+  const hasPr = hasPullRequest(autofixData);
+
   const getButtonText = () => {
     if (!aiConfig.hasAutofix) {
       return t('Open Resources');
@@ -205,6 +221,11 @@ export function SeerSectionCtaButton({
         has_streamlined_ui: hasStreamlinedUI,
         autofix_exists: Boolean(autofixData?.steps?.length),
         autofix_step_type: lastStep?.type ?? null,
+        has_summary: Boolean(summaryData && !isSummaryPending),
+        has_root_cause: Boolean(rootCauseDescription),
+        has_solution: Boolean(solutionDescription),
+        has_coded_solution: Boolean(codeChangesDescription),
+        has_pr: hasPr,
       }}
       priority="primary"
     >


### PR DESCRIPTION
add `has_summary`, `has_root_cause`, `has_solution`, `has_coded_solution`, and `has_pr` properties to the "Issue Details: Seer Opened" analytics event to track which Seer features are available when users open the panel.

This PR was created with claude code, given the linear ticket as a prompt via Linear-MCP.

Fixes https://linear.app/getsentry/issue/AIML-1994/track-seer-panel-fields-in-seer-opened-event
