### PR TITLE
fix(aci): remove targetDisplay from test notification payload

### DIFF
--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -23,7 +23,10 @@ import ActionNodeList from 'sentry/views/automations/components/actionNodeList';
 import {AutomationBuilderConflictContext} from 'sentry/views/automations/components/automationBuilderConflictContext';
 import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
-import {validateActions} from 'sentry/views/automations/components/automationFormData';
+import {
+  stripActionFields,
+  validateActions,
+} from 'sentry/views/automations/components/automationFormData';
 import DataConditionNodeList from 'sentry/views/automations/components/dataConditionNodeList';
 import {TRIGGER_MATCH_OPTIONS} from 'sentry/views/automations/components/triggers/constants';
 import {useSendTestNotification} from 'sentry/views/automations/hooks';
@@ -141,8 +144,7 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
     if (Object.keys(actionErrors).length === 0) {
       await sendTestNotification(
         actionFilterActions.map(action => {
-          const {id: _id, ...actionWithoutId} = action;
-          return actionWithoutId;
+          return stripActionFields(action);
         })
       );
     }

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -40,7 +40,7 @@ const stripSubfilterId = (subfilter: any) => {
   return subfilterWithoutId;
 };
 
-const stripActionFields = (action: Action) => {
+export const stripActionFields = (action: Action) => {
   const {id: _id, ...actionWithoutId} = action;
 
   // Strip targetDisplay from email action config


### PR DESCRIPTION
We have to strip the targetDisplay from the test notification payload because the endpoint expects this value to be null, which matches the behavior of the workflow POST endpoint.

same change as https://github.com/getsentry/sentry/pull/103679