### PR TITLE
feat(trace): Add timeouts to the trace query

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2021,6 +2021,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )  # hours
 register(
+    "performance.traces.endpoint.query-timeout",
+    type=Float,
+    default=30.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "performance.traces.query_timestamp_projects",
     type=Bool,
     default=False,


### PR DESCRIPTION
- This adds a timeout to the queries for the trace endpoint so that the entire endpoint doesn't fail if one of the datasets takes too long to execute
- Had to switch to multiprocessing because ThreadPoolExecutor doesn't have a good way to kill running tasks when they hit timeout? afaict it will wait until all tasks finish before letting you do anything