### PR TITLE
fix(aci): assign condition subfilter ids on alert edit

### DIFF
--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -1,8 +1,14 @@
+import {uuid4} from '@sentry/core';
+
 import type {FieldValue} from 'sentry/components/forms/model';
 import {t} from 'sentry/locale';
 import {ActionType, type Action} from 'sentry/types/workflowEngine/actions';
 import type {Automation, NewAutomation} from 'sentry/types/workflowEngine/automations';
-import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import type {
+  DataCondition,
+  DataConditionGroup,
+  Subfilter,
+} from 'sentry/types/workflowEngine/dataConditions';
 import {actionNodesMap} from 'sentry/views/automations/components/actionNodes';
 import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
 import {dataConditionNodesMap} from 'sentry/views/automations/components/dataConditionNodes';
@@ -147,4 +153,42 @@ export function validateActions({actions}: {actions: Action[]}): Record<string, 
     }
   }
   return errors;
+}
+
+/**
+ * Subfilter IDs are stripped on form submission, so they need to be re-assigned
+ * when loading the edit form for the remove/update logic to work correctly.
+ */
+export function assignSubfilterIds(
+  actionFilters: DataConditionGroup[]
+): DataConditionGroup[] {
+  return actionFilters.map(assignConditionGroupSubfilterIds);
+}
+
+function assignConditionGroupSubfilterIds(group: DataConditionGroup): DataConditionGroup {
+  return {
+    ...group,
+    conditions: group.conditions.map(assignConditionSubfilterIds),
+  };
+}
+
+function assignConditionSubfilterIds(condition: DataCondition): DataCondition {
+  const filters = condition.comparison?.filters;
+  if (!filters) {
+    return condition;
+  }
+  return {
+    ...condition,
+    comparison: {
+      ...condition.comparison,
+      filters: filters.map(assignSubfilterId),
+    },
+  };
+}
+
+function assignSubfilterId(filter: Subfilter): Subfilter {
+  return {
+    ...filter,
+    id: filter.id ?? uuid4(),
+  };
 }

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -31,6 +31,7 @@ import {AutomationFeedbackButton} from 'sentry/views/automations/components/auto
 import AutomationForm from 'sentry/views/automations/components/automationForm';
 import type {AutomationFormData} from 'sentry/views/automations/components/automationFormData';
 import {
+  assignSubfilterIds,
   getAutomationFormData,
   getNewAutomationData,
   validateAutomationBuilderState,
@@ -117,7 +118,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
             logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
             conditions: [],
           },
-      actionFilters: automation.actionFilters,
+      actionFilters: assignSubfilterIds(automation.actionFilters),
     };
   }, [automation]);
 


### PR DESCRIPTION
We strip subfilter ids before we make the workflow POST request because these additional filters do not have ids in the backend.

However, this causes bugs when users go to edit existing workflows that contain subfilters. Since all of the subfilters don't have an ID, our logic will delete all subfilters when a user tried to delete just one (since our logic checks that the ID to delete matches the ID of the subfilter, and all ids are `null`).

To fix this, we should add ids to the subfilters when we first load the edit page.