### PR TITLE
chore(aci): set event_id when creating open period

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1600,7 +1600,7 @@ def _create_group(
             logger.exception("Error after unsticking project counter")
             raise
 
-    create_open_period(group=group, start_time=group.first_seen)
+    create_open_period(group=group, start_time=group.first_seen, event_id=event.event_id)
 
     return group
 
@@ -1812,7 +1812,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
         kick_off_status_syncs.apply_async(
             kwargs={"project_id": group.project_id, "group_id": group.id}
         )
-        create_open_period(group, activity.datetime)
+        create_open_period(group, activity.datetime, event.event_id)
 
     return is_regression
 

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -184,7 +184,7 @@ def get_open_periods_for_group(
     return group_open_periods[:limit]
 
 
-def create_open_period(group: Group, start_time: datetime) -> None:
+def create_open_period(group: Group, start_time: datetime, event_id: str | None = None) -> None:
     # no-op if the group does not create open periods
     if not should_create_open_periods(group.type):
         return None
@@ -209,6 +209,7 @@ def create_open_period(group: Group, start_time: datetime) -> None:
             date_started=start_time,
             date_ended=None,
             resolution_activity=None,
+            event_id=event_id,
         )
 
         # If we care about this group's activity, create activity entry

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -4090,7 +4090,7 @@ class DSLatestReleaseBoostTest(TestCase):
 class TestSaveGroupHashAndGroup(TransactionTestCase):
     def test_simple(self) -> None:
         perf_data = load_data("transaction-n-plus-one", timestamp=before_now(minutes=10))
-        perf_data["event_id"] = str(uuid.uuid4())
+        perf_data["event_id"] = "a" * 32
         event = _get_event_instance(perf_data, project_id=self.project.id)
         group_hash = "some_group"
         group, created, _ = save_grouphash_and_group(self.project, event, group_hash)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -441,9 +441,11 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         open_period = open_periods[0]
         assert open_period.date_started == regression_activity.datetime
         assert open_period.date_ended is None
+        assert open_period.event_id == event2.event_id
         open_period = open_periods[1]
         assert open_period.date_started == group.first_seen
         assert open_period.date_ended == resolved_at
+        assert open_period.event_id == event.event_id
 
     @mock.patch("sentry.signals.issue_unresolved.send_robust")
     def test_unresolves_group_without_open_period(self, send_robust: mock.MagicMock) -> None:


### PR DESCRIPTION
This is necessary to link open periods and events in the UI.