### PR TITLE
fix(aci): prevent invalid custom resolve thresholds

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -255,13 +255,13 @@ function PriorityRow({
     />
   ) : (
     <DirectionField
+      key={conditionType}
       aria-label={t('Threshold direction')}
       name="conditionTypeDisplay"
       hideLabel
       inline
       flexibleControlStateSize
       choices={conditionChoices}
-      value={conditionType}
       defaultValue={conditionType}
       disabled
     />

--- a/static/app/views/detectors/components/forms/metric/resolveSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/resolveSection.tsx
@@ -31,13 +31,23 @@ function validateResolutionThreshold({
   form: MetricDetectorFormData;
   id: string;
 }): Array<[string, string]> {
-  const {conditionType, highThreshold, detectionType, resolutionStrategy} = form;
-  if (!conditionType || detectionType !== 'static' || resolutionStrategy !== 'custom') {
+  const {
+    conditionType,
+    highThreshold,
+    mediumThreshold,
+    detectionType,
+    resolutionStrategy,
+  } = form;
+  if (
+    !conditionType ||
+    (detectionType !== 'static' && detectionType !== 'percent') ||
+    resolutionStrategy !== 'custom'
+  ) {
     return [];
   }
 
   const resolutionNum = Number(form.resolutionValue);
-  const conditionNum = Number(highThreshold);
+  const conditionNum = Number(mediumThreshold || highThreshold);
 
   if (
     Number.isFinite(resolutionNum) &&


### PR DESCRIPTION
Fixed resolution validation so that we compare against the medium threshold number if it exists, and the high threshold if not. Previously we were only checking against the high threshold.

New:
<img width="723" height="395" alt="Screenshot 2025-12-08 at 3 20 00 PM" src="https://github.com/user-attachments/assets/ea8c4382-22b4-4822-95b0-838a3d1dcd74" />

Also fixed a bug where the medium threshold direction was not changing when the high direction was changed by adding a `key` to the DirectionField to force a rerender (lmk if there are better solutions)

Bug:
<img width="519" height="162" alt="Screenshot 2025-12-08 at 3 23 49 PM" src="https://github.com/user-attachments/assets/66c6b4e4-c855-47fd-8ad1-9ac5c99ab0d4" />
