### PR TITLE
fix(aci): fix resolution shading on metric charts

### DIFF
--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
@@ -255,7 +255,7 @@ export function useMetricDetectorThresholdSeries({
           markArea: createThresholdMarkArea(
             theme.green300,
             displayResolution,
-            resolution.type === DataConditionType.GREATER
+            resolution.type !== DataConditionType.GREATER
           ),
           data: [],
         };


### PR DESCRIPTION
shading direction was backwards

before
<img width="2404" height="560" alt="image" src="https://github.com/user-attachments/assets/c0e139c3-8477-4a89-826f-1c3a5801f8a6" />

after
<img width="1198" height="269" alt="Screenshot 2025-12-08 at 3 48 42 PM" src="https://github.com/user-attachments/assets/119044d1-ee29-4568-9196-631d7545d491" />
