### PR TITLE
fix(flamegraph): Only dispatch checkpoint when finishing flamegraph i…

### DIFF
--- a/static/app/components/profiling/flamegraph/interactions/useInteractionViewCheckPoint.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useInteractionViewCheckPoint.tsx
@@ -28,11 +28,14 @@ export function useInteractionViewCheckPoint({
       return;
     }
 
-    if (
-      beforeInteractionConfigView.current &&
-      !beforeInteractionConfigView.current.equals(view.configView)
-    ) {
-      dispatch({type: 'checkpoint', payload: view.configView.clone()});
+    // Check if we are finish the current interaction
+    if (previousInteraction && lastInteraction === null) {
+      if (
+        beforeInteractionConfigView.current &&
+        !beforeInteractionConfigView.current.equals(view.configView)
+      ) {
+        dispatch({type: 'checkpoint', payload: view.configView.clone()});
+      }
     }
   }, [dispatch, lastInteraction, previousInteraction, view]);
 }


### PR DESCRIPTION
…nteraction

There seems to be some edge cases where the checkpoint action is dispatched mid interaction and can result in an infinite re-render. This ensures the checkpoint is only emitted when the interaction finishes.