### PR TITLE
feat(issues): Display exact release in dropdown

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -7,7 +7,6 @@ import {
   userEvent,
   within,
 } from 'sentry-test/reactTestingLibrary';
-import selectEvent from 'sentry-test/selectEvent';
 
 import ResolveActions from 'sentry/components/actions/resolve';
 
@@ -169,9 +168,10 @@ describe('ResolveActions', () => {
     await userEvent.click(screen.getByLabelText('More resolve options'));
     await userEvent.click(screen.getByText('Another existing release…'));
 
-    await selectEvent.openMenu(screen.getByText('e.g. 1.0.4'));
-    expect(await screen.findByText('1.2.0')).toBeInTheDocument();
-    await userEvent.click(screen.getByText('1.2.0'));
+    const versionTrigger = screen.getByRole('button', {name: /version/i});
+    await userEvent.click(versionTrigger);
+    const option = await screen.findByRole('option', {name: /1\.2\.0/});
+    await userEvent.click(option);
 
     const modal = screen.getByRole('dialog');
     await userEvent.click(within(modal).getByRole('button', {name: 'Resolve'}));

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -340,7 +340,6 @@ function ResolveActions({
         onSelected={(statusDetails: ResolvedStatusDetails) =>
           handleAnotherExistingReleaseResolution(statusDetails)
         }
-        organization={organization}
         projectSlug={projectSlug}
       />
     ));

--- a/static/app/components/customResolutionModal.spec.tsx
+++ b/static/app/components/customResolutionModal.spec.tsx
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
-import selectEvent from 'sentry-test/selectEvent';
 
 import CustomResolutionModal from 'sentry/components/customResolutionModal';
 import {makeCloseButton} from 'sentry/components/globalModal/components';
@@ -12,7 +10,6 @@ import ConfigStore from 'sentry/stores/configStore';
 
 describe('CustomResolutionModal', () => {
   let releasesMock: any;
-  const organization = OrganizationFixture();
   beforeEach(() => {
     ConfigStore.init();
     releasesMock = MockApiClient.addMockResponse({
@@ -34,7 +31,6 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        organization={organization}
         projectSlug="project-slug"
         onSelected={onSelected}
         closeModal={jest.fn()}
@@ -43,9 +39,10 @@ describe('CustomResolutionModal', () => {
     );
     expect(releasesMock).toHaveBeenCalled();
 
-    await selectEvent.openMenu(screen.getByText('e.g. 1.0.4'));
-    expect(await screen.findByText('1.2.0')).toBeInTheDocument();
-    await userEvent.click(screen.getByText('1.2.0'));
+    const trigger = screen.getByRole('button', {name: /version/i});
+    await userEvent.click(trigger);
+    const option = await screen.findByRole('option', {name: /1\.2\.0/i});
+    await userEvent.click(option);
 
     await userEvent.click(screen.getByText('Resolve'));
     expect(onSelected).toHaveBeenCalledWith({
@@ -61,7 +58,6 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        organization={organization}
         projectSlug="project-slug"
         onSelected={jest.fn()}
         closeModal={jest.fn()}
@@ -70,7 +66,8 @@ describe('CustomResolutionModal', () => {
     );
     expect(releasesMock).toHaveBeenCalled();
 
-    await selectEvent.openMenu(screen.getByText('e.g. 1.0.4'));
+    const trigger = screen.getByRole('button', {name: /version/i});
+    await userEvent.click(trigger);
     expect(await screen.findByText(/You committed/)).toBeInTheDocument();
   });
 
@@ -112,7 +109,6 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        organization={organization}
         projectSlug="project-slug"
         onSelected={jest.fn()}
         closeModal={jest.fn()}
@@ -120,12 +116,77 @@ describe('CustomResolutionModal', () => {
       />
     );
 
-    await selectEvent.openMenu(screen.getByText('e.g. 1.0.4'));
+    const trigger = screen.getByRole('button', {name: /version/i});
+    await userEvent.click(trigger);
     expect(
-      await screen.findByRole('menuitemradio', {name: 'abcdef (non-semver)'})
+      await screen.findByRole('option', {name: 'abcdef (non-semver)'})
     ).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: '1.2.3 (semver)'})).toBeInTheDocument();
+  });
+
+  it('shows an inline error when submitting with no selection', async () => {
+    const onSelected = jest.fn();
+    render(
+      <CustomResolutionModal
+        Header={p => <span>{p.children}</span>}
+        Body={wrapper()}
+        Footer={wrapper()}
+        projectSlug="project-slug"
+        onSelected={onSelected}
+        closeModal={jest.fn()}
+        CloseButton={makeCloseButton(() => null)}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /resolve/i}));
+    expect(await screen.findByText('Please select a release.')).toBeInTheDocument();
+    expect(onSelected).not.toHaveBeenCalled();
+
+    // selecting clears the error
+    const trigger = screen.getByRole('button', {name: /version/i});
+    await userEvent.click(trigger);
+    const option = await screen.findByRole('option', {name: /1\.2\.0/i});
+    await userEvent.click(option);
+    expect(screen.queryByText('Please select a release.')).not.toBeInTheDocument();
+  });
+
+  it('prepends exact-match release even if not in list and avoids duplicates', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      match: [MockApiClient.matchQuery({query: 'search-me@3.0.0'})],
+      body: [ReleaseFixture({version: 'other@2.0.0'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent('search-me@3.0.0')}/`,
+      body: ReleaseFixture({version: 'search-me@3.0.0'}),
+    });
+
+    render(
+      <CustomResolutionModal
+        Header={p => <span>{p.children}</span>}
+        Body={wrapper()}
+        Footer={wrapper()}
+        projectSlug="project-slug"
+        onSelected={jest.fn()}
+        closeModal={jest.fn()}
+        CloseButton={makeCloseButton(() => null)}
+      />
+    );
+
+    const trigger = screen.getByRole('button', {name: /version/i});
+    await userEvent.click(trigger);
+    const searchInput = await screen.findByRole('textbox');
+    await userEvent.click(searchInput);
+    await userEvent.paste('search-me@3.0.0');
+
     expect(
-      screen.getByRole('menuitemradio', {name: '1.2.3 (semver)'})
+      await screen.findByRole('option', {name: /sentry-android-shop.*3\.0\.0/i})
     ).toBeInTheDocument();
+
+    // Ensure no duplicates
+    const matches = screen.getAllByRole('option', {
+      name: /sentry-android-shop.*3\.0\.0/i,
+    });
+    expect(matches).toHaveLength(1);
   });
 });

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -1,76 +1,143 @@
-import {Fragment, useState} from 'react';
-import {css} from '@emotion/react';
+import {Fragment, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
-import SelectAsyncField, {
-  type SelectAsyncFieldProps,
-} from 'sentry/components/deprecatedforms/selectAsyncField';
+import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
+import {ExternalLink} from 'sentry/components/core/link';
 import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import {t} from 'sentry/locale';
 import configStore from 'sentry/stores/configStore';
-import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
 import type {Release} from 'sentry/types/release';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import useOrganization from 'sentry/utils/useOrganization';
 import {isVersionInfoSemver} from 'sentry/views/releases/utils';
+
+function makeReleaseOption(
+  release: Release,
+  currentUserEmail?: string
+): SelectOption<string> {
+  const isAuthor = release.authors?.some(
+    author => author.email && author.email === currentUserEmail
+  );
+
+  return {
+    value: release.version,
+    label: (
+      <span>
+        {release.versionInfo?.package && (
+          <Fragment>{release.versionInfo.package}@</Fragment>
+        )}
+        <Version version={release.version} anchor={false} />{' '}
+        {isVersionInfoSemver(release.versionInfo.version)
+          ? t('(semver)')
+          : t('(non-semver)')}
+      </span>
+    ),
+    textValue: release.versionInfo?.package
+      ? `${release.versionInfo.package}@${release.version}`
+      : release.version,
+    details: (
+      <span>
+        {t('Created')} <TimeSince date={release.dateCreated} />
+        {isAuthor ? <Fragment> — {t('You committed')}</Fragment> : null}
+      </span>
+    ),
+  };
+}
 
 interface CustomResolutionModalProps extends ModalRenderProps {
   onSelected: (change: {inRelease: string}) => void;
-  organization: Organization;
-  projectSlug?: string;
+  projectSlug: string | undefined;
 }
 
 function CustomResolutionModal(props: CustomResolutionModalProps) {
+  const organization = useOrganization();
   const [version, setVersion] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearch = useDebouncedValue(searchQuery);
   const currentUser = configStore.get('user');
+  const [selectionError, setSelectionError] = useState<string | null>(null);
 
-  const onChange = (selection: string | number | boolean) => {
-    setVersion(selection as string);
-  };
+  const releaseListUrl = props.projectSlug
+    ? getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/releases/', {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          projectIdOrSlug: props.projectSlug,
+        },
+      })
+    : getApiUrl('/organizations/$organizationIdOrSlug/releases/', {
+        path: {organizationIdOrSlug: organization.slug},
+      });
 
-  const onAsyncFieldResults: SelectAsyncFieldProps['onResults'] = (
-    results: Release[]
-  ) => {
-    return results.map(release => {
-      const isAuthor = release.authors.some(
-        author => author.email && author.email === currentUser?.email
+  const {data: releases = [], isFetching} = useApiQuery<Release[]>(
+    [
+      releaseListUrl,
+      {
+        query: {
+          query: debouncedSearch,
+        },
+      },
+    ],
+    {
+      staleTime: 60_000,
+      retry: false,
+    }
+  );
+
+  const shouldLookupExact = debouncedSearch.trim().length > 0;
+
+  // Attempt to find the exact release, the list is capped at the most recent 100 releases
+  const {data: exactRelease} = useApiQuery<Release>(
+    [
+      getApiUrl('/organizations/$organizationIdOrSlug/releases/$version/', {
+        path: {organizationIdOrSlug: organization.slug, version: debouncedSearch.trim()},
+      }),
+    ],
+    {
+      enabled: shouldLookupExact,
+      staleTime: 30_000,
+      retry: false,
+    }
+  );
+
+  const options = useMemo((): Array<SelectOption<string>> => {
+    const baseOptions = releases.map(release =>
+      makeReleaseOption(release, currentUser?.email)
+    );
+
+    if (exactRelease) {
+      const exactOption: (typeof baseOptions)[number] = makeReleaseOption(
+        exactRelease,
+        currentUser?.email
       );
-      return {
-        value: release.version,
-        label: (
-          <Fragment>
-            {release.versionInfo?.package && (
-              <Fragment>{release.versionInfo.package}@</Fragment>
-            )}
-            <Version version={release.version} anchor={false} />{' '}
-            {isVersionInfoSemver(release.versionInfo.version)
-              ? t('(semver)')
-              : t('(non-semver)')}
-          </Fragment>
-        ),
-        textValue: release.versionInfo.description ?? release.version,
-        details: (
-          <span>
-            {t('Created')} <TimeSince date={release.dateCreated} />
-            {isAuthor ? <Fragment> — {t('You committed')}</Fragment> : null}
-          </span>
-        ),
-        release,
-      };
-    });
-  };
 
-  const url = props.projectSlug
-    ? `/projects/${props.organization.slug}/${props.projectSlug}/releases/`
-    : `/organizations/${props.organization.slug}/releases/`;
+      const filtered = baseOptions.filter(opt => opt.value !== exactOption.value);
+      filtered.unshift(exactOption);
+      return filtered;
+    }
+
+    return baseOptions;
+  }, [currentUser?.email, exactRelease, releases]);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!version) {
+      setSelectionError(t('Please select a release.'));
+      return;
+    }
+
+    setSearchQuery('');
+    setSelectionError(null);
     props.onSelected({inRelease: version});
     props.closeModal();
   };
-
   const {Header, Body, Footer} = props;
 
   return (
@@ -79,34 +146,87 @@ function CustomResolutionModal(props: CustomResolutionModalProps) {
         <h4>{t('Resolved In')}</h4>
       </Header>
       <Body>
-        <SelectAsyncField
-          label={t('Version')}
+        <StyledCompactSelect
           id="version"
-          name="version"
-          onChange={onChange}
-          placeholder={t('e.g. 1.0.4')}
-          url={url}
-          onResults={onAsyncFieldResults}
-          onQuery={(query: any) => ({
-            query,
-          })}
+          clearable
+          searchable
+          disableSearchFilter
+          options={options}
+          value={version}
+          loading={isFetching}
+          searchPlaceholder={t('Search versions')}
+          emptyMessage={isFetching ? t('Loading releases\u2026') : t('No releases found')}
+          onSearch={setSearchQuery}
+          onChange={option => {
+            setVersion(option?.value ? String(option.value) : '');
+            setSelectionError(null);
+            setSearchQuery('');
+          }}
+          menuTitle={t('Version')}
+          menuWidth={548}
+          triggerProps={{
+            prefix: t('Version'),
+            'aria-label': t('Version'),
+            children: version
+              ? undefined
+              : isFetching
+                ? t('Loading\u2026')
+                : t('Select a version'),
+          }}
+          onClose={() => setSearchQuery('')}
         />
+        {selectionError ? <ErrorText role="alert">{selectionError}</ErrorText> : null}
+        <ReleaseLinkWrapper>
+          {version ? (
+            // Open release in new tab to avoid closing the modal
+            <ExternalLink
+              href={normalizeUrl(
+                `/organizations/${organization.slug}/releases/${encodeURIComponent(version)}/${
+                  props.projectSlug ? `?project=${props.projectSlug}` : ''
+                }`
+              )}
+              openInNewTab
+            >
+              {t('View release details')}
+            </ExternalLink>
+          ) : (
+            // Placeholder to maintain layout when no version is selected
+            <PlaceholderLink aria-hidden="true" />
+          )}
+        </ReleaseLinkWrapper>
       </Body>
       <Footer>
-        <Button
-          css={css`
-            margin-right: ${space(1.5)};
-          `}
-          onClick={props.closeModal}
-        >
-          {t('Cancel')}
-        </Button>
-        <Button type="submit" priority="primary">
-          {t('Resolve')}
-        </Button>
+        <Flex gap="sm" align="center" justify="end">
+          <Button onClick={props.closeModal}>{t('Cancel')}</Button>
+          <Button type="submit" priority="primary">
+            {t('Resolve')}
+          </Button>
+        </Flex>
       </Footer>
     </form>
   );
 }
 
 export default CustomResolutionModal;
+
+const StyledCompactSelect = styled(CompactSelect)`
+  width: 100%;
+
+  > button {
+    width: 100%;
+  }
+`;
+
+const ReleaseLinkWrapper = styled('div')`
+  margin-top: ${p => p.theme.space.md};
+`;
+
+const PlaceholderLink = styled('span')`
+  display: inline-block;
+  min-height: 1.2em;
+`;
+
+const ErrorText = styled('div')`
+  color: ${p => p.theme.errorText};
+  margin-top: ${p => p.theme.space.sm};
+`;

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -9,6 +9,7 @@ import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSe
 import {ExternalLink} from 'sentry/components/core/link';
 import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
+import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import configStore from 'sentry/stores/configStore';
 import type {Release} from 'sentry/types/release';
@@ -187,7 +188,9 @@ function CustomResolutionModal(props: CustomResolutionModalProps) {
               )}
               openInNewTab
             >
-              {t('View release details')}
+              <Flex align="center" gap="xs">
+                {t('View release')} <IconOpen size="xs" />
+              </Flex>
             </ExternalLink>
           ) : (
             // Placeholder to maintain layout when no version is selected

--- a/static/app/components/deprecatedforms/selectAsyncField.tsx
+++ b/static/app/components/deprecatedforms/selectAsyncField.tsx
@@ -8,7 +8,7 @@ import {
 } from 'sentry/components/deprecatedforms/selectField';
 import withFormContext from 'sentry/components/deprecatedforms/withFormContext';
 
-export interface SelectAsyncFieldProps
+interface SelectAsyncFieldProps
   extends SelectFieldProps,
     Omit<SelectAsyncControlProps, 'value' | 'onQuery' | 'onResults'> {
   onQuery?: SelectAsyncControlProps['onQuery'];


### PR DESCRIPTION
Refactors the resolved in release dropdown to use compact select instead of the deprecated select async component.

Pulls any exact release match to the top of the search results, this fixes a bug where if you had more than 100 releases that contained the same query it might not display the exact match.

Adds a link to open release details in a new tab.

before

<img width="625" height="491" alt="image" src="https://github.com/user-attachments/assets/288e2d68-dd18-4167-9187-3dbda47249e0" />


after

<img width="630" height="670" alt="image" src="https://github.com/user-attachments/assets/6e5fb6b5-f3a8-4921-aef6-8fb3c7979cb1" />

<img width="614" height="253" alt="image" src="https://github.com/user-attachments/assets/1891e55d-9382-4b15-949f-1f682ba40e4c" />
