### PR TITLE
feat: Add thumbs up/down feedback to Seer cards

### DIFF
--- a/static/app/components/events/autofix/autofixStepFeedback.tsx
+++ b/static/app/components/events/autofix/autofixStepFeedback.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useState} from 'react';
 
 import {Button} from 'sentry/components/core/button';
+import type {ButtonProps} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {IconThumb} from 'sentry/icons';
@@ -15,19 +16,29 @@ interface AutofixStepFeedbackProps {
   groupId: string;
   runId: string;
   stepType: StepType;
+  buttonSize?: ButtonProps['size'];
+  compact?: boolean;
+  onFeedbackClick?: (e: React.MouseEvent) => void;
 }
 
 export function AutofixStepFeedback({
   stepType,
   groupId,
   runId,
+  buttonSize = 'xs',
+  compact = false,
+  onFeedbackClick,
 }: AutofixStepFeedbackProps) {
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const organization = useOrganization();
   const user = useUser();
 
   const handleFeedback = useCallback(
-    (positive: boolean) => {
+    (positive: boolean, e?: React.MouseEvent) => {
+      if (onFeedbackClick && e) {
+        onFeedbackClick(e);
+      }
+
       const analyticsData = {
         step_type: stepType,
         positive,
@@ -41,30 +52,42 @@ export function AutofixStepFeedback({
 
       setFeedbackSubmitted(true);
     },
-    [stepType, groupId, runId, organization, user]
+    [stepType, groupId, runId, organization, user, onFeedbackClick]
   );
 
   if (feedbackSubmitted) {
     return (
-      <Flex align="center" gap="sm">
-        <Text variant="muted">{t('Thanks!')}</Text>
+      <Flex
+        align="center"
+        gap={compact ? '0' : 'sm'}
+        onClick={onFeedbackClick}
+        style={{cursor: onFeedbackClick ? 'default' : undefined}}
+      >
+        <Text variant="muted" size={compact ? 'xs' : 'sm'}>
+          {t('Thanks!')}
+        </Text>
       </Flex>
     );
   }
 
+  const iconSize = buttonSize === 'zero' ? 'xs' : 'sm';
+  const gap = compact ? '2xs' : 'xs';
+
   return (
-    <Flex align="center" gap="xs">
+    <Flex align="center" gap={gap}>
       <Button
-        size="xs"
-        icon={<IconThumb direction="up" size="sm" />}
-        onClick={() => handleFeedback(true)}
-        aria-label={t('This step was helpful')}
+        size={buttonSize}
+        borderless={compact}
+        icon={<IconThumb direction="up" size={iconSize} />}
+        onClick={e => handleFeedback(true, e)}
+        aria-label={t('This was helpful')}
       />
       <Button
-        size="xs"
-        icon={<IconThumb direction="down" size="sm" />}
-        onClick={() => handleFeedback(false)}
-        aria-label={t('This step was not helpful')}
+        size={buttonSize}
+        borderless={compact}
+        icon={<IconThumb direction="down" size={iconSize} />}
+        onClick={e => handleFeedback(false, e)}
+        aria-label={t('This was not helpful')}
       />
     </Flex>
   );

--- a/static/app/components/group/groupSummaryWithAutofix.spec.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.spec.tsx
@@ -1,0 +1,282 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useAutofixData} from 'sentry/components/events/autofix/useAutofix';
+import {AutofixSummary} from 'sentry/components/group/groupSummaryWithAutofix';
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+jest.mock('sentry/components/events/autofix/useAutofix');
+jest.mock('sentry/utils/analytics');
+
+describe('AutofixSummary', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+  const group = GroupFixture({id: '1', shortId: 'TEST-1'});
+  const user = UserFixture();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockApiClient.clearMockResponses();
+
+    jest.mocked(useAutofixData).mockReturnValue({
+      data: {
+        run_id: 'test-run-id',
+        status: 'COMPLETED',
+        steps: [],
+      },
+      isPending: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  it('renders feedback buttons for root cause card', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription={null}
+        solutionCopyText={null}
+        solutionIsLoading={false}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization}
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'This was helpful'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'This was not helpful'})
+    ).toBeInTheDocument();
+  });
+
+  it('renders feedback buttons for solution card', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription="This is the solution"
+        solutionCopyText="Solution text"
+        solutionIsLoading={false}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization}
+    );
+
+    const helpfulButtons = screen.getAllByRole('button', {name: 'This was helpful'});
+    expect(helpfulButtons).toHaveLength(2); // One for root cause, one for solution
+  });
+
+  it('tracks analytics event when thumbs up is clicked', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription={null}
+        solutionCopyText={null}
+        solutionIsLoading={false}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization, user}
+    );
+
+    const thumbsUpButton = screen.getByRole('button', {name: 'This was helpful'});
+    await userEvent.click(thumbsUpButton);
+
+    await waitFor(() => {
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'seer.autofix.feedback_submitted',
+        expect.objectContaining({
+          step_type: 'root_cause',
+          positive: true,
+          group_id: '1',
+          autofix_run_id: 'test-run-id',
+          user_id: user.id,
+          organization,
+        })
+      );
+    });
+  });
+
+  it('tracks analytics event when thumbs down is clicked', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription={null}
+        solutionCopyText={null}
+        solutionIsLoading={false}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization, user}
+    );
+
+    const thumbsDownButton = screen.getByRole('button', {
+      name: 'This was not helpful',
+    });
+    await userEvent.click(thumbsDownButton);
+
+    await waitFor(() => {
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'seer.autofix.feedback_submitted',
+        expect.objectContaining({
+          step_type: 'root_cause',
+          positive: false,
+          group_id: '1',
+          autofix_run_id: 'test-run-id',
+          user_id: user.id,
+          organization,
+        })
+      );
+    });
+  });
+
+  it('shows "Thanks!" message after feedback is submitted', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription={null}
+        solutionCopyText={null}
+        solutionIsLoading={false}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization}
+    );
+
+    const thumbsUpButton = screen.getByRole('button', {name: 'This was helpful'});
+    await userEvent.click(thumbsUpButton);
+
+    expect(await screen.findByText('Thanks!')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'This was helpful'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render feedback buttons when loading', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription={null}
+        solutionCopyText={null}
+        solutionIsLoading={true}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization}
+    );
+
+    // Root cause should have feedback buttons
+    expect(
+      screen.getByRole('button', {name: 'This was helpful'})
+    ).toBeInTheDocument();
+
+    // Solution should not have feedback buttons because it's loading
+    const helpfulButtons = screen.getAllByRole('button', {name: 'This was helpful'});
+    expect(helpfulButtons).toHaveLength(1);
+  });
+
+  it('tracks different step_type for solution feedback', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription="This is the solution"
+        solutionCopyText="Solution text"
+        solutionIsLoading={false}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization, user}
+    );
+
+    const thumbsUpButtons = screen.getAllByRole('button', {name: 'This was helpful'});
+    // Click the second thumbs up (solution)
+    await userEvent.click(thumbsUpButtons[1]);
+
+    await waitFor(() => {
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'seer.autofix.feedback_submitted',
+        expect.objectContaining({
+          step_type: 'solution',
+          positive: true,
+        })
+      );
+    });
+  });
+
+  it('tracks changes step_type for code changes feedback', async () => {
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription="This is the solution"
+        solutionCopyText="Solution text"
+        solutionIsLoading={false}
+        codeChangesDescription="These are the code changes"
+        codeChangesIsLoading={false}
+      />,
+      {organization, user}
+    );
+
+    const thumbsUpButtons = screen.getAllByRole('button', {name: 'This was helpful'});
+    // Click the third thumbs up (code changes)
+    await userEvent.click(thumbsUpButtons[2]);
+
+    await waitFor(() => {
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'seer.autofix.feedback_submitted',
+        expect.objectContaining({
+          step_type: 'changes',
+          positive: true,
+        })
+      );
+    });
+  });
+
+  it('does not render feedback buttons when run_id is missing', async () => {
+    jest.mocked(useAutofixData).mockReturnValue({
+      data: null,
+      isPending: false,
+      isError: false,
+      error: null,
+    } as any);
+
+    render(
+      <AutofixSummary
+        group={group}
+        rootCauseDescription="This is the root cause"
+        rootCauseCopyText="Root cause text"
+        solutionDescription={null}
+        solutionCopyText={null}
+        solutionIsLoading={false}
+        codeChangesDescription={null}
+        codeChangesIsLoading={false}
+      />,
+      {organization}
+    );
+
+    expect(
+      screen.queryByRole('button', {name: 'This was helpful'})
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/group/groupSummaryWithAutofix.spec.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.spec.tsx
@@ -49,9 +49,7 @@ describe('AutofixSummary', () => {
       {organization}
     );
 
-    expect(
-      screen.getByRole('button', {name: 'This was helpful'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'This was helpful'})).toBeInTheDocument();
     expect(
       screen.getByRole('button', {name: 'This was not helpful'})
     ).toBeInTheDocument();
@@ -176,7 +174,7 @@ describe('AutofixSummary', () => {
         rootCauseCopyText="Root cause text"
         solutionDescription={null}
         solutionCopyText={null}
-        solutionIsLoading={true}
+        solutionIsLoading
         codeChangesDescription={null}
         codeChangesIsLoading={false}
       />,
@@ -184,9 +182,7 @@ describe('AutofixSummary', () => {
     );
 
     // Root cause should have feedback buttons
-    expect(
-      screen.getByRole('button', {name: 'This was helpful'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'This was helpful'})).toBeInTheDocument();
 
     // Solution should not have feedback buttons because it's loading
     const helpfulButtons = screen.getAllByRole('button', {name: 'This was helpful'});

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -2,8 +2,8 @@ import React, {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
-import {Button} from 'sentry/components/core/button';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {Button} from 'sentry/components/core/button';
 import {useAutofixData} from 'sentry/components/events/autofix/useAutofix';
 import {
   getAutofixRunExists,
@@ -91,11 +91,7 @@ function CardFeedback({feedbackType, groupId, runId}: CardFeedbackProps) {
   );
 
   if (feedbackSubmitted) {
-    return (
-      <FeedbackText onClick={e => e.stopPropagation()}>
-        {t('Thanks!')}
-      </FeedbackText>
-    );
+    return <FeedbackText onClick={e => e.stopPropagation()}>{t('Thanks!')}</FeedbackText>;
   }
 
   return (
@@ -329,15 +325,13 @@ export function AutofixSummary({
                       <CardTitleText>{card.title}</CardTitleText>
                     </CardTitleSpacer>
                     <CardActions>
-                      {!card.isLoading &&
-                        card.feedbackType &&
-                        autofixData?.run_id && (
-                          <CardFeedback
-                            feedbackType={card.feedbackType}
-                            groupId={group.id}
-                            runId={autofixData.run_id}
-                          />
-                        )}
+                      {!card.isLoading && card.feedbackType && autofixData?.run_id && (
+                        <CardFeedback
+                          feedbackType={card.feedbackType}
+                          groupId={group.id}
+                          runId={autofixData.run_id}
+                        />
+                      )}
                       {card.copyText && card.copyTitle && (
                         <CopyToClipboardButton
                           aria-label={t('Copy to clipboard')}


### PR DESCRIPTION
Implements [AIML-2003](https://linear.app/getsentry/issue/AIML-2003/add-thumbs-updown-feedback-to-seer-cards)

Adds thumbs up/down feedback buttons directly in the Seer Root Cause, Solution, and Code Changes cards to collect user feedback.

## Changes

- **Created `CardFeedback` Component**:
  - Displays thumbs up/down icons for each card
  - Tracks the existing `seer.autofix.feedback_submitted` analytics event
  - Shows "Thanks!" message after feedback is submitted
  - Prevents event propagation to avoid interfering with card navigation

- **Integrated Into Summary Cards**:
  - Feedback buttons appear in card headers between title and copy button
  - Only shown when card is fully loaded and has a valid `run_id`
  - Supports all three card types: Root Cause, Solution, and Code Changes

- **Comprehensive Test Coverage**:
  - 9 tests covering all feedback scenarios
  - Validates analytics event tracking with correct parameters
  - Tests loading states and edge cases

This reuses the existing `seer.autofix.feedback_submitted` analytics event (no backend changes needed).

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.