### PR TITLE
feat(triage signals): Add billing flag to all triage signals check

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict, TypeVar
 import sentry_sdk
 from tokenizers import Tokenizer
 
-from sentry import features, options
+from sentry import options
 from sentry.constants import DATA_ROOT
 from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
@@ -17,6 +17,7 @@ from sentry.killswitches import killswitch_matches_context
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
@@ -509,7 +510,7 @@ def set_default_project_autofix_automation_tuning(
     if org_default == "off":
         # Explicit "off" is always respected, regardless of feature flag
         project.update_option("sentry:autofix_automation_tuning", "off")
-    elif features.has("organizations:triage-signals-v0-org", organization):
+    elif is_seer_seat_based_tier_enabled(organization):
         # Feature flag ON overrides everything except explicit "off"
         project.update_option(
             "sentry:autofix_automation_tuning",
@@ -524,7 +525,7 @@ def set_default_project_seer_scanner_automation(
     organization: Organization, project: Project
 ) -> None:
     """Called once at project creation time to set the initial seer scanner automation."""
-    if features.has("organizations:triage-signals-v0-org", organization):
+    if is_seer_seat_based_tier_enabled(organization):
         # Feature flag ON always sets scanner to True
         project.update_option("sentry:seer_scanner_automation", True)
     else:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1608,6 +1608,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     from sentry.seer.autofix.utils import (
         is_issue_eligible_for_seer_automation,
         is_seer_scanner_rate_limited,
+        is_seer_seat_based_tier_enabled,
     )
     from sentry.tasks.autofix import (
         generate_issue_summary_only,
@@ -1619,7 +1620,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     group = event.group
 
     # Default behaviour
-    if not features.has("organizations:triage-signals-v0-org", group.organization):
+    if not is_seer_seat_based_tier_enabled(group.organization):
         # Only run on issues with no existing scan
         if group.seer_fixability_score is not None:
             return


### PR DESCRIPTION
## PR Details
+ Replace direct `features.has("organizations:triage-signals-v0-org")` checks with `is_seer_seat_based_tier_enabled()` across all triage signals code paths.
+ Already tested it out on s amller scale with this PR that just added it in 1 place: https://github.com/getsentry/sentry/pull/104528. Logs are [here](https://sentry.sentry.io/explore/logs/?logsFields=timestamp&logsFields=message&logsFields=server.address&logsFields=group_id&logsFields=project&logsQuery=message%3A%EF%80%8DContains%EF%80%8D%5B%22Error%20checking%20if%20seat-based%20Seer%20tier%20is%20enabled%22%2C%22Checking%20if%20seat-based%20Seer%20tier%20is%20enabled%20for%20organization%22%5D&logsSortBys=-timestamp&mode=samples&project=1&statsPeriod=2h). No failure logs yet.

### Changes
+ **`issue_summary.py`**: Updated `run_automation()` to use `is_seer_seat_based_tier_enabled()` for both the ALERT event count check and the stopping point logic
+ **`similarity/utils.py`**: Updated `set_default_project_autofix_automation_tuning()` and `set_default_project_seer_scanner_automation()` to use `is_seer_seat_based_tier_enabled()`
+ **`post_process.py`**: Updated `kick_off_seer_automation()` to use `is_seer_seat_based_tier_enabled()`

### Why
The `is_seer_seat_based_tier_enabled()` function checks both:
1. The existing `organizations:triage-signals-v0-org` feature flag
2. The new `organizations:seat-based-seer-enabled` billing flag (with caching)

This allows triage signals features to work for organizations with either the feature flag OR the seat-based billing tier enabled.
