### PR TITLE
fix(ai-insights): disable extrapolation in traces table

### DIFF
--- a/static/app/views/insights/common/queries/types.ts
+++ b/static/app/views/insights/common/queries/types.ts
@@ -4,3 +4,5 @@ import {type EventsMetaType} from 'sentry/utils/discover/eventView';
 export type DiscoverSeries = Series & {
   meta: EventsMetaType;
 };
+
+export type ExtrapolationMode = 'sampleWeighted' | 'serverOnly' | 'unspecified' | 'none';

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -5,6 +5,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import type {ExtrapolationMode} from 'sentry/views/insights/common/queries/types';
 import {
   useWrappedDiscoverQuery,
   useWrappedDiscoverQueryWithoutPageFilters,
@@ -24,6 +25,7 @@ interface UseDiscoverQueryOptions {
 interface UseDiscoverOptions<Fields> {
   cursor?: string;
   enabled?: boolean;
+  extrapolationMode?: ExtrapolationMode;
   fields?: Fields;
   keepPreviousData?: boolean;
   limit?: number;
@@ -78,6 +80,7 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     projectIds,
     orderby,
     samplingMode = DEFAULT_SAMPLING_MODE,
+    extrapolationMode,
     useQueryOptions,
   } = options;
 
@@ -106,6 +109,7 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     cursor,
     noPagination,
     samplingMode,
+    extrapolationMode,
     additionalQueryKey: useQueryOptions?.additonalQueryKey,
     refetchInterval: useQueryOptions?.refetchInterval,
     keepPreviousData: options.keepPreviousData,

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -19,6 +19,7 @@ import type {
   RPCQueryExtras,
   SamplingMode,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
+import type {ExtrapolationMode} from 'sentry/views/insights/common/queries/types';
 import {
   getRetryDelay,
   shouldRetryHandler,
@@ -248,6 +249,7 @@ type WrappedDiscoverQueryProps<T> = {
   cursor?: string;
   disableAggregateExtrapolation?: string;
   enabled?: boolean;
+  extrapolationMode?: ExtrapolationMode;
   initialData?: T;
   keepPreviousData?: boolean;
   limit?: number;
@@ -279,6 +281,7 @@ function useWrappedDiscoverQueryBase<T>({
   logQuery,
   metricQuery,
   spanQuery,
+  extrapolationMode,
 }: WrappedDiscoverQueryProps<T> & {
   pageFiltersReady: boolean;
 }) {
@@ -293,6 +296,9 @@ function useWrappedDiscoverQueryBase<T>({
   ) {
     if (samplingMode) {
       queryExtras.sampling = samplingMode;
+    }
+    if (extrapolationMode) {
+      queryExtras.extrapolationMode = extrapolationMode;
     }
 
     if (disableAggregateExtrapolation) {

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -118,6 +118,7 @@ export function TracesTable() {
       limit: tracesRequest.data?.data.length ?? 0,
       enabled: Boolean(tracesRequest.data && tracesRequest.data.data.length > 0),
       samplingMode: SAMPLING_MODE.HIGH_ACCURACY,
+      extrapolationMode: 'none',
     },
     Referrer.TRACES_TABLE
   );


### PR DESCRIPTION
Exposes `extrapolationMode` parameter to `useSpans` hook.
Fixes [TET-1581: User Feedback: Price display incorrect](https://linear.app/getsentry/issue/TET-1581/user-feedback-price-display-incorrect)