### PR TITLE
chore(cross-events): Render disabled search bars and an error toast

### DIFF
--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -633,7 +633,7 @@ describe('SpansTabContent', () => {
       ).toBeInTheDocument();
     });
 
-    it('displays the cross event query limit alert', () => {
+    it('renders disabled cross event search bar when the limit is reached', () => {
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
@@ -651,9 +651,10 @@ describe('SpansTabContent', () => {
         },
       });
 
-      expect(
-        screen.getByText('You can add up to a maximum of 2 cross event queries.')
-      ).toBeInTheDocument();
+      expect(screen.getAllByTestId('search-query-builder').pop()).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
     });
   });
 });

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -1,11 +1,11 @@
-import {Fragment, memo, useMemo, type Key} from 'react';
+import {Fragment, memo, useMemo, useRef, type Key} from 'react';
 import styled from '@emotion/styled';
 
-import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Container, Grid} from '@sentry/scraps/layout';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {DatePageFilterProps} from 'sentry/components/organizations/datePageFilter';
@@ -204,6 +204,8 @@ const SpansTabCrossEventSearchBar = memo(
 );
 
 function SpansTabCrossEventSearchBars() {
+  const firedToastOnMount = useRef(false);
+
   const crossEvents = useQueryParamsCrossEvents();
   const setCrossEvents = useSetQueryParamsCrossEvents();
 
@@ -211,62 +213,122 @@ function SpansTabCrossEventSearchBars() {
     return null;
   }
 
-  return crossEvents.slice(0, MAX_CROSS_EVENT_QUERIES).map((crossEvent, index) => {
-    const traceItemType =
-      crossEvent.type === 'spans'
-        ? TraceItemDataset.SPANS
-        : crossEvent.type === 'logs'
-          ? TraceItemDataset.LOGS
-          : TraceItemDataset.TRACEMETRICS;
+  return (
+    <Fragment>
+      <Container
+        display="none"
+        ref={() => {
+          if (
+            !firedToastOnMount.current &&
+            defined(crossEvents) &&
+            crossEvents.length > MAX_CROSS_EVENT_QUERIES
+          ) {
+            firedToastOnMount.current = true;
+            addErrorMessage(
+              t(
+                'You can add up to a maximum of %s cross event queries.',
+                MAX_CROSS_EVENT_QUERIES
+              )
+            );
+          }
+        }}
+      />
+      {crossEvents.map((crossEvent, index) => {
+        const traceItemType =
+          crossEvent.type === 'spans'
+            ? TraceItemDataset.SPANS
+            : crossEvent.type === 'logs'
+              ? TraceItemDataset.LOGS
+              : TraceItemDataset.TRACEMETRICS;
 
-    return (
-      <Fragment key={`${crossEvent.type}-${index}`}>
-        <Container justifySelf="end" width={{sm: '100%', md: 'min-content'}}>
-          {props => (
-            <CompactSelect
-              {...props}
-              menuTitle={t('Dataset')}
-              aria-label={t('Modify dataset to cross reference')}
-              value={crossEvent.type}
-              triggerProps={{
-                prefix: t('with'),
-                ...props,
-              }}
-              options={[
-                {value: 'spans', label: t('Spans')},
-                {value: 'logs', label: t('Logs')},
-                {value: 'metrics', label: t('Metrics')},
-              ]}
-              onChange={({value: newValue}) => {
-                if (!isCrossEventType(newValue)) return;
+        const maxCrossEventQueriesReached = index >= MAX_CROSS_EVENT_QUERIES;
 
-                setCrossEvents(
-                  crossEvents.map((c, i) => {
-                    if (i === index) return {query: '', type: newValue};
-                    return c;
-                  })
-                );
+        return (
+          <Fragment key={`${crossEvent.type}-${index}`}>
+            <Container justifySelf="end" width={{sm: '100%', md: 'min-content'}}>
+              {props => (
+                <CompactSelect
+                  {...props}
+                  menuTitle={t('Dataset')}
+                  aria-label={t('Modify dataset to cross reference')}
+                  value={crossEvent.type}
+                  disabled={maxCrossEventQueriesReached}
+                  triggerProps={{
+                    prefix: t('with'),
+                    ...props,
+                  }}
+                  options={[
+                    {value: 'spans', label: t('Spans')},
+                    {value: 'logs', label: t('Logs')},
+                    {value: 'metrics', label: t('Metrics')},
+                  ]}
+                  onChange={({value: newValue}) => {
+                    if (!isCrossEventType(newValue)) return;
+
+                    setCrossEvents(
+                      crossEvents.map((c, i) => {
+                        if (i === index) return {query: '', type: newValue};
+                        return c;
+                      })
+                    );
+                  }}
+                />
+              )}
+            </Container>
+            {maxCrossEventQueriesReached ? (
+              <SearchQueryBuilderProvider
+                filterKeys={{}}
+                getTagValues={() => Promise.resolve([])}
+                initialQuery=""
+                searchSource="explore"
+              >
+                <TraceItemSearchQueryBuilder
+                  disabled
+                  itemType={traceItemType}
+                  initialQuery={crossEvent.query}
+                  numberAttributes={{}}
+                  stringAttributes={{}}
+                  numberSecondaryAliases={{}}
+                  stringSecondaryAliases={{}}
+                  searchSource="explore"
+                  getFilterTokenWarning={() => undefined}
+                  supportedAggregates={[]}
+                  onSearch={() => {}}
+                  onChange={() => {
+                    return;
+                  }}
+                />
+              </SearchQueryBuilderProvider>
+            ) : (
+              <TraceItemAttributeProvider traceItemType={traceItemType} enabled>
+                <SpansTabCrossEventSearchBar
+                  index={index}
+                  query={crossEvent.query}
+                  type={crossEvent.type}
+                />
+              </TraceItemAttributeProvider>
+            )}
+            <Button
+              icon={<IconDelete />}
+              aria-label={t('Remove cross event search for %s', crossEvent.type)}
+              onClick={() => {
+                // we add 1 here to the max because the current cross event is being removed
+                if (crossEvents.length > MAX_CROSS_EVENT_QUERIES + 1) {
+                  addErrorMessage(
+                    t(
+                      'You can add up to a maximum of %s cross event queries.',
+                      MAX_CROSS_EVENT_QUERIES
+                    )
+                  );
+                }
+                setCrossEvents(crossEvents.filter((_, i) => i !== index));
               }}
             />
-          )}
-        </Container>
-        <TraceItemAttributeProvider traceItemType={traceItemType} enabled>
-          <SpansTabCrossEventSearchBar
-            index={index}
-            query={crossEvent.query}
-            type={crossEvent.type}
-          />
-        </TraceItemAttributeProvider>
-        <Button
-          icon={<IconDelete />}
-          aria-label={t('Remove cross event search for %s', crossEvent.type)}
-          onClick={() => {
-            setCrossEvents(crossEvents.filter((_, i) => i !== index));
-          }}
-        />
-      </Fragment>
-    );
-  });
+          </Fragment>
+        );
+      })}
+    </Fragment>
+  );
 }
 
 function SpansSearchBar({
@@ -414,16 +476,6 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
             {hasCrossEventQueryingFlag ? <CrossEventQueryingDropdown /> : null}
             {hasCrossEvents ? <SpansTabCrossEventSearchBars /> : null}
           </Grid>
-          {hasCrossEvents && crossEvents.length > MAX_CROSS_EVENT_QUERIES ? (
-            <Container paddingTop="md">
-              <Alert type="warning">
-                {t(
-                  'You can add up to a maximum of %s cross event queries.',
-                  MAX_CROSS_EVENT_QUERIES
-                )}
-              </Alert>
-            </Container>
-          ) : null}
           {hasCrossEvents ? null : (
             <ExploreSchemaHintsSection>
               <SchemaHintsList


### PR DESCRIPTION
This PR updates error handling of extra cross event queries if users have gone in and manually adjusted the URL query param to have more than the max allowed cross event queries.

We now will render the disabled cross event search bars, so that the user can get themselves out of the error state. This PR will also render an error toast if there are too many cross event search bars present.

Ticket: EXP-636