### PR TITLE
fix(spans-migration): commit changes once everything passes

### DIFF
--- a/tests/sentry/explore/translation/test_alerts_translation.py
+++ b/tests/sentry/explore/translation/test_alerts_translation.py
@@ -35,6 +35,7 @@ from sentry.snuba.models import (
     SnubaQueryEventType,
 )
 from sentry.snuba.subscriptions import create_snuba_query
+from sentry.snuba.tasks import SubscriptionError
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -348,6 +349,64 @@ class AlertsTranslationTestCase(TestCase, SnubaTestCase):
 
     @with_feature("organizations:migrate-transaction-alerts-to-spans")
     @patch("sentry.snuba.tasks._create_rpc_in_snuba")
+    def test_translate_alert_rule_apdex(self, mock_create_rpc) -> None:
+        mock_create_rpc.return_value = "test-subscription-id"
+
+        snuba_query = create_snuba_query(
+            query_type=SnubaQuery.Type.PERFORMANCE,
+            dataset=Dataset.Transactions,
+            query="",
+            aggregate="apdex(300)",
+            time_window=timedelta(minutes=10),
+            environment=None,
+            event_types=[SnubaQueryEventType.EventType.TRANSACTION],
+            resolution=timedelta(minutes=1),
+        )
+
+        query_subscription = QuerySubscription.objects.create(
+            project=self.project,
+            type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
+            snuba_query=snuba_query,
+            status=QuerySubscription.Status.ACTIVE.value,
+        )
+
+        data_source = self.create_data_source(
+            organization=self.org,
+            source_id=str(query_subscription.id),
+            type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+        )
+
+        detector_data_condition_group = self.create_data_condition_group(
+            organization=self.org,
+        )
+
+        detector = self.create_detector(
+            name="Test Detector",
+            type=MetricIssue.slug,
+            project=self.project,
+            config={"detection_type": AlertRuleDetectionType.STATIC.value},
+            workflow_condition_group=detector_data_condition_group,
+        )
+
+        data_source.detectors.add(detector)
+
+        with self.tasks():
+            translate_detector_and_update_subscription_in_snuba(snuba_query)
+        snuba_query.refresh_from_db()
+
+        assert snuba_query.dataset == Dataset.EventsAnalyticsPlatform.value
+        assert snuba_query.aggregate == "apdex(span.duration,300)"
+        assert snuba_query.query == "is_transaction:1"
+        assert snuba_query.extrapolation_mode == ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED.value
+
+        assert mock_create_rpc.called
+        call_args = mock_create_rpc.call_args
+        rpc_time_series_request = call_args[0][2]
+        assert rpc_time_series_request is not None
+        assert len(rpc_time_series_request.expressions) > 0
+
+    @with_feature("organizations:migrate-transaction-alerts-to-spans")
+    @patch("sentry.snuba.tasks._create_rpc_in_snuba")
     def test_translate_alert_rule_empty_query(self, mock_create_rpc) -> None:
         mock_create_rpc.return_value = "test-subscription-id"
 
@@ -468,7 +527,8 @@ class AlertsTranslationTestCase(TestCase, SnubaTestCase):
         assert mock_create_rpc.called
         assert mock_create_rpc.call_count == 1
 
-        rollback_detector_query_and_update_subscription_in_snuba(snuba_query)
+        with self.tasks():
+            rollback_detector_query_and_update_subscription_in_snuba(snuba_query)
         snuba_query.refresh_from_db()
 
         assert snuba_query.type == original_type
@@ -1002,6 +1062,141 @@ class AlertsTranslationTestCase(TestCase, SnubaTestCase):
         snuba_query.refresh_from_db()
 
         assert snuba_query.extrapolation_mode == ExtrapolationMode.CLIENT_AND_SERVER_WEIGHTED.value
+
+    @with_feature("organizations:migrate-transaction-alerts-to-spans")
+    @patch("sentry.snuba.tasks._create_rpc_in_snuba")
+    def test_translate_multiple_subscriptions_updates_each_correctly(self, mock_create_rpc) -> None:
+        """
+        Test that when there are multiple subscriptions for a snuba_query,
+        each subscription gets its own ID passed to update_subscription_in_snuba.
+        This verifies the closure bug fix where lambda captures subscription.id by value.
+        """
+        # Return unique subscription IDs to avoid unique constraint violation
+        mock_create_rpc.side_effect = [
+            "test-subscription-id-1",
+            "test-subscription-id-2",
+            "test-subscription-id-3",
+        ]
+
+        snuba_query = create_snuba_query(
+            query_type=SnubaQuery.Type.PERFORMANCE,
+            dataset=Dataset.PerformanceMetrics,
+            query="transaction.duration:>100",
+            aggregate="count()",
+            time_window=timedelta(minutes=10),
+            environment=None,
+            event_types=[SnubaQueryEventType.EventType.TRANSACTION],
+            resolution=timedelta(minutes=1),
+        )
+
+        project2 = self.create_project(organization=self.org)
+        project3 = self.create_project(organization=self.org)
+
+        subscription1 = QuerySubscription.objects.create(
+            project=self.project,
+            type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
+            snuba_query=snuba_query,
+            status=QuerySubscription.Status.ACTIVE.value,
+        )
+        subscription2 = QuerySubscription.objects.create(
+            project=project2,
+            type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
+            snuba_query=snuba_query,
+            status=QuerySubscription.Status.ACTIVE.value,
+        )
+        subscription3 = QuerySubscription.objects.create(
+            project=project3,
+            type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
+            snuba_query=snuba_query,
+            status=QuerySubscription.Status.ACTIVE.value,
+        )
+
+        data_source = self.create_data_source(
+            organization=self.org,
+            source_id=str(subscription1.id),
+            type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+        )
+
+        detector_data_condition_group = self.create_data_condition_group(
+            organization=self.org,
+        )
+
+        detector = self.create_detector(
+            name="Test Detector",
+            type=MetricIssue.slug,
+            project=self.project,
+            config={"detection_type": AlertRuleDetectionType.STATIC.value},
+            workflow_condition_group=detector_data_condition_group,
+        )
+
+        data_source.detectors.add(detector)
+
+        with self.tasks():
+            translate_detector_and_update_subscription_in_snuba(snuba_query)
+
+        assert mock_create_rpc.call_count == 3
+
+        # _create_rpc_in_snuba receives the subscription object as the first argument
+        called_subscription_ids = {
+            call_args[0][0].id for call_args in mock_create_rpc.call_args_list
+        }
+        expected_subscription_ids = {subscription1.id, subscription2.id, subscription3.id}
+        assert called_subscription_ids == expected_subscription_ids
+
+    @with_feature("organizations:migrate-transaction-alerts-to-spans")
+    @patch("sentry.explore.translation.alerts_translation.bulk_update_snuba_subscriptions")
+    def test_update_snuba_subscription_fails(self, mock_update_subscription_in_snuba) -> None:
+        mock_update_subscription_in_snuba.side_effect = SubscriptionError()
+
+        snuba_query = create_snuba_query(
+            query_type=SnubaQuery.Type.PERFORMANCE,
+            dataset=Dataset.PerformanceMetrics,
+            query="transaction.duration:>100",
+            aggregate="count(d:spans/webvital.score.total@ratio)",
+            time_window=timedelta(minutes=10),
+            environment=None,
+            event_types=[SnubaQueryEventType.EventType.TRANSACTION],
+            resolution=timedelta(minutes=1),
+        )
+
+        subscription1 = QuerySubscription.objects.create(
+            project=self.project,
+            type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
+            snuba_query=snuba_query,
+            status=QuerySubscription.Status.ACTIVE.value,
+        )
+
+        data_source = self.create_data_source(
+            organization=self.org,
+            source_id=str(subscription1.id),
+            type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+        )
+
+        detector_data_condition_group = self.create_data_condition_group(
+            organization=self.org,
+        )
+
+        detector = self.create_detector(
+            name="Test Detector",
+            type=MetricIssue.slug,
+            project=self.project,
+            config={"detection_type": AlertRuleDetectionType.STATIC.value},
+            workflow_condition_group=detector_data_condition_group,
+        )
+
+        data_source.detectors.add(detector)
+
+        with self.tasks(), pytest.raises(SubscriptionError):
+            translate_detector_and_update_subscription_in_snuba(snuba_query)
+
+        assert mock_update_subscription_in_snuba.call_count == 1
+
+        snuba_query.refresh_from_db()
+        subscription1.refresh_from_db()
+
+        assert snuba_query.dataset == Dataset.PerformanceMetrics.value
+        assert snuba_query.extrapolation_mode == ExtrapolationMode.UNKNOWN.value
+        assert subscription1.status == QuerySubscription.Status.ACTIVE.value
 
     @with_feature("organizations:migrate-transaction-alerts-to-spans")
     @patch("sentry.snuba.tasks._create_rpc_in_snuba")


### PR DESCRIPTION
made a bunch of changes to the alerts migration scripts to make sure it works the way we want to
1. Ensure that on translation and rollback that all the changes in the db get made only after all actions are successful
2. For all `count(...)` functions with parameters, we're going to default them to the regular count so they get translated properly
3. Some functions get translated with the `equation|` prefix because we needed that in dashboards and explore but it's not needed for alerts so I've stripped out the equation prefix for these functions
4. Added a BUNCH of logs so that we know where things are failing if they fail during the migration