### PR TITLE
fix(aci): Use detector config in issue details

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -18,6 +18,7 @@ import {space} from 'sentry/styles/space';
 import type {Event, EventOccurrence} from 'sentry/types/event';
 import type {
   MetricCondition,
+  MetricDetectorConfig,
   SnubaQueryDataSource,
 } from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
@@ -36,6 +37,10 @@ interface MetricDetectorEvidenceData {
    * The triggered conditions that caused the occurrence to be created
    */
   conditions: MetricCondition[];
+  /**
+   * The detector configuration at the time that the occurrence was created
+   */
+  config: MetricDetectorConfig;
   /**
    * The data source at the time that the occurrence was created
    */
@@ -247,8 +252,7 @@ function TriggeredConditionDetails({
                   {getConditionDescription({
                     aggregate: snubaQuery.aggregate,
                     condition: triggeredCondition,
-                    // TODO: Record detector config in issue occurrence and use that here
-                    config: {
+                    config: evidenceData.config ?? {
                       detectionType: 'static',
                     },
                   })}


### PR DESCRIPTION
Now that we are getting config info, use it to display the condition correctly:

<img width="1068" height="622" alt="CleanShot 2025-12-09 at 09 42 41@2x" src="https://github.com/user-attachments/assets/84c18cd3-e02d-470b-a81d-7e07cb3abc2a" />
