### PR TITLE
feat(explore-attr-breakdowns): Consuming pagination from BE

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -108,8 +108,8 @@ export function Chart({
 
   const actionsHtmlRenderer = useCallback(
     (value: string) =>
-      tooltipActionsHtmlRenderer(value, attributeDistribution.name, theme),
-    [attributeDistribution.name, theme]
+      tooltipActionsHtmlRenderer(value, attributeDistribution.attributeName, theme),
+    [attributeDistribution.attributeName, theme]
   );
 
   const tooltipConfig = useAttributeBreakdownsTooltip({
@@ -136,9 +136,13 @@ export function Chart({
         align="center"
         gap="lg"
       >
-        <Tooltip title={attributeDistribution.name} showOnlyOnOverflow skipWrapper>
+        <Tooltip
+          title={attributeDistribution.attributeName}
+          showOnlyOnOverflow
+          skipWrapper
+        >
           <AttributeBreakdownsComponent.ChartTitle>
-            {attributeDistribution.name}
+            {attributeDistribution.attributeName}
           </AttributeBreakdownsComponent.ChartTitle>
         </Tooltip>
         <Flex gap="sm">

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -116,7 +116,6 @@ export function AttributeDistribution() {
   // Reset pagination on any query change
   useEffect(() => {
     setPagination({cursor: undefined, page: 0});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery, selection, query]);
 
   const parsedLinks = parseLinkHeader(

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -116,7 +116,7 @@ export function AttributeDistribution() {
   // Reset pagination on any query change
   useEffect(() => {
     setPagination({cursor: undefined, page: 0});
-  }, [searchQuery, selection, query]);
+  }, [debouncedSearchQuery, selection, query]);
 
   const parsedLinks = parseLinkHeader(
     getAttributeBreakdownsResponseHeader?.('Link') ?? null

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -152,9 +152,17 @@ export function CohortComparison({
                     ))}
                 </AttributeBreakdownsComponent.ChartsGrid>
                 <AttributeBreakdownsComponent.Pagination
-                  currentPage={page}
-                  onPageChange={setPage}
-                  totalItems={filteredRankedAttributes.length}
+                  isNextDisabled={
+                    page ===
+                    Math.ceil(filteredRankedAttributes.length / CHARTS_PER_PAGE) - 1
+                  }
+                  isPrevDisabled={page === 0}
+                  onNextClick={() => {
+                    setPage(page + 1);
+                  }}
+                  onPrevClick={() => {
+                    setPage(page - 1);
+                  }}
                 />
               </Fragment>
             ) : (

--- a/static/app/views/explore/components/attributeBreakdowns/styles.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/styles.tsx
@@ -21,11 +21,7 @@ import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 
-import {
-  CHART_AXIS_LABEL_FONT_SIZE,
-  CHARTS_COLUMN_COUNT,
-  CHARTS_PER_PAGE,
-} from './constants';
+import {CHART_AXIS_LABEL_FONT_SIZE, CHARTS_COLUMN_COUNT} from './constants';
 import {formatChartXAxisLabel, percentageFormatter} from './utils';
 
 function FeedbackButton() {
@@ -318,15 +314,19 @@ const PaginationContainer = styled(Flex)`
   justify-content: end;
 `;
 
-interface PaginationProps {
-  currentPage: number;
-  onPageChange: (page: number) => void;
-  totalItems: number;
-}
+type PaginationProps = {
+  isNextDisabled: boolean;
+  isPrevDisabled: boolean;
+  onNextClick: () => void;
+  onPrevClick: () => void;
+};
 
-function Pagination({currentPage, onPageChange, totalItems}: PaginationProps) {
-  const totalPages = Math.ceil(totalItems / CHARTS_PER_PAGE);
-
+function Pagination({
+  isPrevDisabled,
+  isNextDisabled,
+  onPrevClick,
+  onNextClick,
+}: PaginationProps) {
   return (
     <PaginationContainer>
       <ButtonBar merged gap="0">
@@ -334,19 +334,15 @@ function Pagination({currentPage, onPageChange, totalItems}: PaginationProps) {
           icon={<IconChevron direction="left" />}
           aria-label={t('Previous')}
           size="sm"
-          disabled={currentPage === 0}
-          onClick={() => {
-            onPageChange(currentPage - 1);
-          }}
+          disabled={isPrevDisabled}
+          onClick={onPrevClick}
         />
         <Button
           icon={<IconChevron direction="right" />}
           aria-label={t('Next')}
           size="sm"
-          disabled={currentPage === totalPages - 1}
-          onClick={() => {
-            onPageChange(currentPage + 1);
-          }}
+          disabled={isNextDisabled}
+          onClick={onNextClick}
         />
       </ButtonBar>
     </PaginationContainer>

--- a/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef} from 'react';
+import {useMemo, useRef} from 'react';
 
 import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -75,7 +75,7 @@ function useAttributeBreakdowns({
     }
   );
 
-  useEffect(() => {
+  const data = useMemo((): AttributeDistributionData | undefined => {
     const newData = result.data?.data[0]?.attribute_distributions?.data;
     if (newData) {
       accumulatedDataRef.current = {
@@ -83,13 +83,9 @@ function useAttributeBreakdowns({
         ...newData,
       };
     }
-  }, [result.data]);
-
-  const data = useMemo((): AttributeDistributionData | undefined => {
-    if (Object.keys(accumulatedDataRef.current).length === 0) {
-      return result.data?.data[0]?.attribute_distributions?.data;
-    }
-    return accumulatedDataRef.current;
+    return Object.keys(accumulatedDataRef.current).length > 0
+      ? accumulatedDataRef.current
+      : newData;
   }, [result.data]);
 
   return {

--- a/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
@@ -1,40 +1,91 @@
-import {useMemo} from 'react';
+import {useMemo, useRef} from 'react';
 
 import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {CHARTS_PER_PAGE} from 'sentry/views/explore/components/attributeBreakdowns/constants';
+
+type AttributeDistributionData = Record<string, Array<{label: string; value: number}>>;
 
 type AttributeBreakdowns = {
   data: Array<{
     attribute_distributions: {
-      data: Record<string, Array<{label: string; value: number}>>;
+      data: AttributeDistributionData;
     };
   }>;
 };
 
-function useAttributeBreakdowns() {
+function useAttributeBreakdowns({
+  cursor,
+  substringMatch,
+}: {
+  cursor: string | undefined;
+  substringMatch: string;
+}) {
   const organization = useOrganization();
   const location = useLocation();
   const {selection: pageFilters, isReady: pageFiltersReady} = usePageFilters();
   const queryString = location.query.query?.toString() ?? '';
 
+  // Ref to accumulate data across paginated requests
+  const accumulatedDataRef = useRef<AttributeDistributionData>({});
+
   const queryParams = useMemo(() => {
-    return {
+    const params = {
       ...pageFiltersToQueryParams(pageFilters),
       query: queryString,
       statsType: 'attributeDistributions',
-    };
-  }, [pageFilters, queryString]);
+      limit: CHARTS_PER_PAGE * 2,
+    } as Record<string, any>;
 
-  return useApiQuery<AttributeBreakdowns>(
+    if (cursor !== undefined) {
+      params.cursor = cursor;
+    }
+
+    if (substringMatch) {
+      params.substringMatch = substringMatch;
+    }
+
+    return params;
+  }, [pageFilters, queryString, cursor, substringMatch]);
+
+  const result = useApiQuery<AttributeBreakdowns>(
     [`/organizations/${organization.slug}/trace-items/stats/`, {query: queryParams}],
     {
       staleTime: Infinity,
       enabled: pageFiltersReady,
     }
   );
+
+  if (result.data?.data[0]?.attribute_distributions?.data) {
+    const newData = result.data.data[0].attribute_distributions.data;
+    accumulatedDataRef.current = {
+      ...accumulatedDataRef.current,
+      ...newData,
+    };
+  }
+
+  const accumulatedData = useMemo((): AttributeBreakdowns | undefined => {
+    if (Object.keys(accumulatedDataRef.current).length === 0) {
+      return result.data;
+    }
+    return {
+      data: [
+        {
+          attribute_distributions: {
+            data: accumulatedDataRef.current,
+          },
+        },
+      ],
+    };
+  }, [result.data]);
+
+  return {
+    ...result,
+    data: accumulatedData,
+  };
 }
 
 export default useAttributeBreakdowns;


### PR DESCRIPTION
Behaviour ([check out the comment on the endpoint](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/organization_trace_item_stats.py#L139-L144)):
- We fetch 24 rows and accumulate the data across pages
-  Display 12 charts per page from the accumulated data

We maintain both a `cursor` and a `page` number state to achieve this 

