### PR TITLE
feat(profiling): Add project id based kill switch in ingest-profiles

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -228,6 +228,17 @@ ALL_KILLSWITCH_OPTIONS = {
             "partition_id": "A kafka partition index.",
         },
     ),
+    "profiling.killswitch.ingest-profiles": KillswitchInfo(
+        description="""
+        Drop profiles in the ingest-profiles consumer.
+
+        This happens after relay produces profiles to the topic but before a task
+        is started to process/ingest to profile.
+        """,
+        fields={
+            "project_id": "A project ID.",
+        },
+    ),
 }
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2762,6 +2762,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "profiling.killswitch.ingest-profiles",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # max number of profiles to use for computing
 # the aggregated flamegraph.
 register(

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -1,62 +1,102 @@
 from __future__ import annotations
 
 from base64 import b64encode
+from collections.abc import MutableSequence
 from datetime import datetime
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import msgpack
+import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 from django.utils import timezone
 
 from sentry.profiles.consumers.process.factory import ProcessProfileStrategyFactory
 from sentry.profiles.task import _prepare_frames_from_profile
-from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
 
 
-class TestProcessProfileConsumerStrategy(TestCase):
-    @staticmethod
-    def processing_factory() -> ProcessProfileStrategyFactory:
-        return ProcessProfileStrategyFactory()
+@override_options({"profiling.killswitch.ingest-profiles": [{"project_id": "2"}]})
+@pytest.mark.parametrize("headers", [[], [("project_id", b"1")]])
+@patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
+@django_db_all
+def test_basic_profile_to_task(
+    process_profile_task: MagicMock, headers: MutableSequence[tuple[str, bytes]]
+) -> None:
+    processing_strategy = ProcessProfileStrategyFactory().create_with_partitions(
+        commit=Mock(), partitions={}
+    )
+    message_dict = {
+        "organization_id": 1,
+        "project_id": 1,
+        "key_id": 1,
+        "received": int(timezone.now().timestamp()),
+        "payload": json.dumps({"platform": "android", "profile": ""}),
+    }
+    payload = msgpack.packb(message_dict)
 
-    @patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
-    def test_basic_profile_to_task(self, process_profile_task: MagicMock) -> None:
-        processing_strategy = self.processing_factory().create_with_partitions(
-            commit=Mock(), partitions={}
-        )
-        message_dict = {
-            "organization_id": 1,
-            "project_id": 1,
-            "key_id": 1,
-            "received": int(timezone.now().timestamp()),
-            "payload": json.dumps({"platform": "android", "profile": ""}),
-        }
-        payload = msgpack.packb(message_dict)
-
-        processing_strategy.submit(
-            Message(
-                BrokerValue(
-                    KafkaPayload(
-                        b"key",
-                        payload,
-                        [],
-                    ),
-                    Partition(Topic("profiles"), 1),
-                    1,
-                    datetime.now(),
-                )
+    processing_strategy.submit(
+        Message(
+            BrokerValue(
+                KafkaPayload(
+                    b"key",
+                    payload,
+                    headers,
+                ),
+                Partition(Topic("profiles"), 1),
+                1,
+                datetime.now(),
             )
         )
-        processing_strategy.poll()
-        processing_strategy.join(1)
-        processing_strategy.terminate()
+    )
+    processing_strategy.poll()
+    processing_strategy.join(1)
+    processing_strategy.terminate()
 
-        process_profile_task.assert_called_with(
-            payload=b64encode(payload).decode("utf-8"),
-            sampled=True,
+    process_profile_task.assert_called_with(
+        payload=b64encode(payload).decode("utf-8"),
+        sampled=True,
+    )
+
+
+@patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
+@override_options({"profiling.killswitch.ingest-profiles": [{"project_id": "1"}]})
+@django_db_all
+def test_killswitch_project(process_profile_task: MagicMock) -> None:
+    processing_strategy = ProcessProfileStrategyFactory().create_with_partitions(
+        commit=Mock(), partitions={}
+    )
+    message_dict = {
+        "organization_id": 1,
+        "project_id": 1,
+        "key_id": 1,
+        "received": int(timezone.now().timestamp()),
+        "payload": json.dumps({"platform": "android", "profile": ""}),
+    }
+    payload = msgpack.packb(message_dict)
+
+    processing_strategy.submit(
+        Message(
+            BrokerValue(
+                KafkaPayload(
+                    b"key",
+                    payload,
+                    [("project_id", b"1")],
+                ),
+                Partition(Topic("profiles"), 1),
+                1,
+                datetime.now(),
+            )
         )
+    )
+    processing_strategy.poll()
+    processing_strategy.join(1)
+    processing_strategy.terminate()
+
+    process_profile_task.assert_not_called()
 
 
 def test_adjust_instruction_addr_sample_format() -> None:


### PR DESCRIPTION
This adds a project id based kill switch in ingest-profiles. Relay needs to send the project in the header for this to start working.