### PR TITLE
feat(aci): Add 'open in' button to issue details

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -382,9 +382,17 @@ interface OpenInButtonProps {
 function OpenInButton({detector}: OpenInButtonProps) {
   const organization = useOrganization();
   const location = useLocation();
+  const snubaQuery = detector.dataSources[0]?.queryObj?.snubaQuery;
+
+  if (!snubaQuery) {
+    return null;
+  }
+
   const destination = getDetectorOpenInDestination({
-    detector,
+    detectorName: detector.name,
     organization,
+    projectId: detector.projectId,
+    snubaQuery,
     statsPeriod: decodeScalar(location.query.statsPeriod),
     start: decodeScalar(location.query.start),
     end: decodeScalar(location.query.end),
@@ -433,14 +441,19 @@ export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChar
   const location = useLocation();
   const organization = useOrganization();
   const dateParams = normalizeDateTimeParams(location.query);
+  const snubaQuery = detector.dataSources[0]?.queryObj?.snubaQuery;
 
-  const destination = getDetectorOpenInDestination({
-    detector,
-    organization,
-    statsPeriod: decodeScalar(location.query.statsPeriod),
-    start: decodeScalar(location.query.start),
-    end: decodeScalar(location.query.end),
-  });
+  const destination =
+    snubaQuery &&
+    getDetectorOpenInDestination({
+      detectorName: detector.name,
+      organization,
+      projectId: detector.projectId,
+      snubaQuery,
+      statsPeriod: decodeScalar(location.query.statsPeriod),
+      start: decodeScalar(location.query.start),
+      end: decodeScalar(location.query.end),
+    });
 
   const {data: openPeriods = []} = useOpenPeriods({
     detectorId: detector.id,

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
@@ -37,8 +37,10 @@ describe('getDetectorOpenInDestination', () => {
       });
 
       const result = getDetectorOpenInDestination({
-        detector,
+        detectorName: detector.name,
         organization,
+        projectId: detector.projectId,
+        snubaQuery: detector.dataSources[0].queryObj.snubaQuery,
         statsPeriod: '7d',
       });
 
@@ -83,8 +85,10 @@ describe('getDetectorOpenInDestination', () => {
       });
 
       const result = getDetectorOpenInDestination({
-        detector,
+        detectorName: detector.name,
         organization,
+        projectId: detector.projectId,
+        snubaQuery: detector.dataSources[0].queryObj.snubaQuery,
         statsPeriod: '14d',
       });
 
@@ -126,8 +130,10 @@ describe('getDetectorOpenInDestination', () => {
       });
 
       const result = getDetectorOpenInDestination({
-        detector,
+        detectorName: detector.name,
         organization,
+        projectId: detector.projectId,
+        snubaQuery: detector.dataSources[0].queryObj.snubaQuery,
         statsPeriod: '7d',
       });
 
@@ -166,8 +172,10 @@ describe('getDetectorOpenInDestination', () => {
         });
 
         const result = getDetectorOpenInDestination({
-          detector,
+          detectorName: detector.name,
           organization,
+          projectId: detector.projectId,
+          snubaQuery: detector.dataSources[0].queryObj.snubaQuery,
           statsPeriod: '24h',
         });
 
@@ -204,8 +212,10 @@ describe('getDetectorOpenInDestination', () => {
         });
 
         const result = getDetectorOpenInDestination({
-          detector,
+          detectorName: detector.name,
           organization,
+          projectId: detector.projectId,
+          snubaQuery: detector.dataSources[0].queryObj.snubaQuery,
           statsPeriod: '7d',
         });
 
@@ -236,8 +246,10 @@ describe('getDetectorOpenInDestination', () => {
         });
 
         const result = getDetectorOpenInDestination({
-          detector,
+          detectorName: detector.name,
           organization,
+          projectId: detector.projectId,
+          snubaQuery: detector.dataSources[0].queryObj.snubaQuery,
           statsPeriod: '14d',
         });
 

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -27,6 +27,10 @@ describe('MetricDetectorTriggeredSection', () => {
       url: '/organizations/org-slug/users/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/?end=2017-10-17T02%3A41%3A20.000Z&limit=5&query=issue.type%3Aerror%20event.type%3Aerror%20is%3Aunresolved&sort=freq&start=2019-05-21T17%3A59%3A00.000Z',
+      body: [],
+    });
   });
 
   it('renders nothing when event has no occurrence', () => {
@@ -87,9 +91,8 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders metric detector details with static condition', () => {
+  it('renders metric detector details with static condition', async () => {
     const event = EventFixture({
-      dateCreated: undefined,
       occurrence: {
         id: '1',
         eventId: 'event-1',
@@ -111,7 +114,7 @@ describe('MetricDetectorTriggeredSection', () => {
     render(<MetricDetectorTriggeredSection event={event} />);
 
     // Check sections exist by aria-label
-    expect(screen.getByRole('region', {name: 'Message'})).toBeInTheDocument();
+    expect(await screen.findByRole('region', {name: 'Message'})).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'Triggered Condition'})).toBeInTheDocument();
 
     // Check message content

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -19,6 +19,7 @@ import type {Event, EventOccurrence} from 'sentry/types/event';
 import type {
   MetricCondition,
   MetricDetectorConfig,
+  SnubaQuery,
   SnubaQueryDataSource,
 } from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
@@ -27,6 +28,7 @@ import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 import useOrganization from 'sentry/utils/useOrganization';
 import {RELATED_ISSUES_BOOLEAN_QUERY_ERROR} from 'sentry/views/alerts/rules/metric/details/relatedIssuesNotAvailable';
 import {getConditionDescription} from 'sentry/views/detectors/components/details/metric/detect';
+import {getDetectorOpenInDestination} from 'sentry/views/detectors/components/details/metric/getDetectorOpenInDestination';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
@@ -74,11 +76,15 @@ function isMetricDetectorEvidenceData(
 
 interface RelatedIssuesProps {
   aggregate: string;
+  end: string;
   eventDateCreated: string | undefined;
   query: string;
-  timeWindow: number;
+  start: string;
 }
 
+/**
+ * Calculates the
+ */
 function calculateStartOfInterval({
   eventDateCreated,
   timeWindow,
@@ -103,25 +109,20 @@ function calculateStartOfInterval({
 function ContributingIssues({
   query,
   eventDateCreated,
-  timeWindow,
   aggregate,
+  end,
+  start,
 }: RelatedIssuesProps) {
-  // TODO: When we can link events to open periods, use the end date from the open period
-  const [endDate] = useState(() => new Date().toISOString());
   const organization = useOrganization();
 
   if (!eventDateCreated) {
     return null;
   }
 
-  const startDate = calculateStartOfInterval({
-    eventDateCreated,
-    timeWindow,
-  }).toISOString();
   const queryParams = {
     query: `issue.type:error ${query}`,
-    start: startDate,
-    end: endDate,
+    start,
+    end,
     limit: 5,
     sort: aggregate === 'count_unique(user)' ? 'user' : 'freq',
   };
@@ -130,8 +131,8 @@ function ContributingIssues({
     {
       query,
       dataset: SavedQueryDatasets.ERRORS,
-      start: startDate,
-      end: endDate,
+      start,
+      end,
     }
   )}`;
 
@@ -188,19 +189,54 @@ function ContributingIssues({
   );
 }
 
+function OpenInDestinationButton({
+  snubaQuery,
+  projectId,
+  start,
+  end,
+}: {
+  end: string;
+  projectId: string | number;
+  snubaQuery: SnubaQuery;
+  start: string;
+}) {
+  const organization = useOrganization();
+  const destination = getDetectorOpenInDestination({
+    organization,
+    projectId,
+    snubaQuery,
+    start,
+    end,
+  });
+
+  if (!destination) {
+    return null;
+  }
+
+  return (
+    <LinkButton size="xs" to={destination.to}>
+      {destination.buttonText}
+    </LinkButton>
+  );
+}
+
 function TriggeredConditionDetails({
   evidenceData,
   eventDateCreated,
+  projectId,
 }: {
   eventDateCreated: string | undefined;
   evidenceData: MetricDetectorEvidenceData;
+  projectId: string | number;
 }) {
   const {conditions, dataSources, value} = evidenceData;
   const dataSource = dataSources[0];
   const snubaQuery = dataSource?.queryObj?.snubaQuery;
   const triggeredCondition = conditions[0];
+  // TODO: When we can link events to open periods, use the end date from the open period
+  const [endDate] = useState(() => new Date().toISOString());
 
-  if (!triggeredCondition || !snubaQuery) {
+  if (!triggeredCondition || !snubaQuery || !eventDateCreated) {
     return null;
   }
 
@@ -208,10 +244,25 @@ function TriggeredConditionDetails({
   const datasetConfig = getDatasetConfig(detectorDataset);
   const isErrorsDataset = detectorDataset === DetectorDataset.ERRORS;
   const issueSearchQuery = datasetConfig.toSnubaQueryString?.(snubaQuery) ?? '';
+  const startDate = calculateStartOfInterval({
+    eventDateCreated,
+    timeWindow: snubaQuery.timeWindow,
+  }).toISOString();
 
   return (
     <Fragment>
-      <InterimSection title="Triggered Condition" type="triggered_condition">
+      <InterimSection
+        title="Triggered Condition"
+        type="triggered_condition"
+        actions={
+          <OpenInDestinationButton
+            snubaQuery={snubaQuery}
+            projectId={projectId}
+            start={startDate}
+            end={endDate}
+          />
+        }
+      >
         <KeyValueList
           shouldSort={false}
           data={[
@@ -272,8 +323,9 @@ function TriggeredConditionDetails({
         <ContributingIssues
           query={issueSearchQuery}
           eventDateCreated={eventDateCreated}
-          timeWindow={snubaQuery.timeWindow}
           aggregate={snubaQuery.aggregate}
+          start={startDate}
+          end={endDate}
         />
       )}
     </Fragment>
@@ -305,6 +357,7 @@ export function MetricDetectorTriggeredSection({
         <TriggeredConditionDetails
           evidenceData={evidenceData}
           eventDateCreated={event.dateCreated}
+          projectId={event.projectID}
         />
       </ErrorBoundary>
     </Fragment>


### PR DESCRIPTION
This button was shown in the monitor details page but not in issue details

<img width="1566" height="474" alt="CleanShot 2025-12-09 at 10 34 57@2x" src="https://github.com/user-attachments/assets/c1db9a17-6531-4335-8694-391ac9656c7c" />
