### PR TITLE
inspector: add copy llm prompt

### DIFF
--- a/static/app/components/core/inspector.spec.tsx
+++ b/static/app/components/core/inspector.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import * as constants from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
 
-import {SentryComponentInspector} from './inspector';
+import {SentryComponentInspector, serializeTraceForLLM} from './inspector';
 
 jest.mock('sentry/constants');
 
@@ -96,5 +96,47 @@ describe('SentryComponentInspector', () => {
     expect(
       await screen.findByText('.../app/components/test/parent.tsx')
     ).toBeInTheDocument();
+  });
+
+  it('serializes trace for LLM with correct hierarchy', () => {
+    // Create mock trace elements (leaf to root order)
+    const leafElement = document.createElement('div');
+    leafElement.dataset.sentryComponent = 'LeafComponent';
+    leafElement.dataset.sentrySourcePath = '/static/app/components/test/leaf.tsx';
+
+    const childElement = document.createElement('div');
+    childElement.dataset.sentryComponent = 'ChildComponent';
+    childElement.dataset.sentrySourcePath = '/static/app/components/test/child.tsx';
+
+    const parentElement = document.createElement('div');
+    parentElement.dataset.sentryComponent = 'ParentComponent';
+    parentElement.dataset.sentrySourcePath = '/static/app/components/test/parent.tsx';
+
+    // Trace is in leaf-to-root order
+    const trace = [leafElement, childElement, parentElement];
+
+    // Serialize with ChildComponent as the target
+    const result = serializeTraceForLLM(trace, childElement);
+
+    // Verify the output contains the correct structure
+    expect(result).toContain('# Component Trace');
+    expect(result).toContain('This trace represents the DOM hierarchy');
+    expect(result).toContain(
+      'The last component in the hierarchy (marked with ◄) is the target component that should be modified'
+    );
+    expect(result).toContain('## Instructions');
+    expect(result).toContain('styled()');
+    expect(result).toContain('work up the component tree');
+    expect(result).toContain('┌─ ParentComponent (file: app/components/test/parent.tsx)');
+    expect(result).toContain('└─ ChildComponent (file: app/components/test/child.tsx) ◄');
+
+    // Verify that child components after the target are NOT included
+    expect(result).not.toContain('LeafComponent');
+
+    // Verify the order (parent should come before child)
+    const parentIndex = result.indexOf('ParentComponent');
+    const childIndex = result.indexOf('ChildComponent');
+
+    expect(parentIndex).toBeLessThan(childIndex);
   });
 });

--- a/static/app/components/core/inspector.tsx
+++ b/static/app/components/core/inspector.tsx
@@ -409,6 +409,7 @@ export function SentryComponentInspector() {
                           componentName={componentName}
                           sourcePath={sourcePath}
                           el={el}
+                          fullTrace={contextMenuTrace}
                           storybook={getComponentStorybookFile(el, storybookFilesLookup)}
                           onAction={() => {
                             contextMenu.setOpen(false);
@@ -474,6 +475,7 @@ function MenuItem(props: {
   contextMenu: ReturnType<typeof useContextMenu>;
   copyToClipboard: (text: string) => void;
   el: TraceElement;
+  fullTrace: TraceElement[];
   onAction: () => void;
   sourcePath: string;
   storybook: string | null;
@@ -646,6 +648,19 @@ function MenuItem(props: {
               >
                 {t('Copy Component Path')}
               </ProfilingContextMenuItemButton>
+              <ProfilingContextMenuItemButton
+                {...props.contextMenu.getMenuItemProps({
+                  onClick: () => {
+                    const llmPrompt = serializeTraceForLLM(props.fullTrace, props.el);
+                    props.copyToClipboard(llmPrompt);
+                    addSuccessMessage(t('LLM prompt copied to clipboard'));
+                    props.onAction();
+                  },
+                })}
+                icon={<IconCopy size="xs" />}
+              >
+                {t('Copy LLM Prompt')}
+              </ProfilingContextMenuItemButton>
             </ProfilingContextMenuGroup>
           </ProfilingContextMenu>,
           props.subMenuPortalRef
@@ -782,4 +797,55 @@ function isCoreComponent(el: unknown): boolean {
 function isViewComponent(el: unknown): boolean {
   if (!isTraceElement(el)) return false;
   return el.dataset.sentrySourcePath?.includes('app/views') ?? false;
+}
+
+export function serializeTraceForLLM(
+  trace: TraceElement[],
+  targetElement: TraceElement
+): string {
+  // Reverse the trace array to show root to leaf (trace is leaf to root)
+  const reversedTrace = [...trace].reverse();
+  const targetIndex = reversedTrace.indexOf(targetElement);
+
+  // Only include components up to and including the target
+  const relevantTrace = reversedTrace.slice(0, targetIndex + 1);
+
+  const lines = relevantTrace.map((el, index) => {
+    const componentName = getComponentName(el);
+    const sourcePath = getSourcePath(el);
+    const isLast = index === relevantTrace.length - 1;
+
+    // Use tree-style box-drawing characters
+    let prefix = '';
+    if (index === 0) {
+      prefix = '┌─';
+    } else if (isLast) {
+      prefix = '└─';
+    } else {
+      prefix = '├─';
+    }
+
+    const suffix = isLast ? ' ◄' : '';
+
+    return `${prefix} ${componentName} (file: ${sourcePath})${suffix}`;
+  });
+
+  const prompt = `# Component Trace
+
+The following is a component hierarchy trace from a React application. This trace represents the DOM hierarchy, not the React component tree. The last component in the hierarchy (marked with ◄) is the target component that should be modified.
+
+${lines.join('\n')}
+
+## Instructions
+
+1. Locate the target component by searching for the component name in the specified file path
+2. If you cannot find an exact match for the component name, consider these alternatives:
+   - The component may be wrapped with \`styled()\`, such as \`styled(ComponentName)\` or \`const StyledComponent = styled(ComponentName)\`
+   - The component may be exported with a different name or wrapped in HOCs
+3. If the target component cannot be found in its file, work up the component tree (towards the root) to find the nearest component that exists
+4. Once located, make the necessary modifications to the target component
+
+Please locate the target component in the codebase and make the necessary modifications.`;
+
+  return prompt;
 }


### PR DESCRIPTION
Adds a copy button for copying component trace to LLM. This will save users time by providing a pre-crafted prompt that contains a detailed instructions on how to locate the component and work up the component stack