### PR TITLE
fix(aci): camelCase action data fields in serializer

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
@@ -32,7 +32,7 @@ class ActionSerializer(Serializer):
             "id": str(obj.id),
             "type": obj.type,
             "integrationId": str(obj.integration_id) if obj.integration_id else None,
-            "data": obj.data,
+            "data": convert_dict_key_case(obj.data, snake_to_camel_case),
             "config": convert_dict_key_case(config, snake_to_camel_case),
             "status": obj.get_status_display(),
         }

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
@@ -1,6 +1,7 @@
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.models import Action
@@ -100,6 +101,28 @@ class TestActionSerializer(TestCase):
                 "targetType": "specific",
                 "targetDisplay": "freddy frog",
                 "targetIdentifier": "123-id",
+            },
+            "status": "active",
+        }
+
+    def test_serialize_with_data(self) -> None:
+        action = self.create_action(
+            type=Action.Type.EMAIL,
+            data={"fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS},
+            config={
+                "target_type": ActionTarget.ISSUE_OWNERS,
+            },
+        )
+
+        result = serialize(action)
+
+        assert result == {
+            "id": str(action.id),
+            "type": "email",
+            "data": {"fallthroughType": "ActiveMembers"},
+            "integrationId": None,
+            "config": {
+                "targetType": "issue_owners",
             },
             "status": "active",
         }


### PR DESCRIPTION
we already made the fix to convert the action `config` fields to camelCase in the action serializer, so we should do the same for the `data` fields