### PR TITLE
chore(cells): Fix cell deprecation date

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -1056,4 +1056,4 @@ EXTENSION_LANGUAGE_MAP = {
 
 # After this date APIs that are incompatible with cell routing
 # will begin periodic brownouts.
-CELL_API_DEPRECATION_DATE = datetime(2025, 5, 15, 0, 0, 0, tzinfo=UTC)
+CELL_API_DEPRECATION_DATE = datetime(2026, 5, 15, 0, 0, 0, tzinfo=UTC)


### PR DESCRIPTION
We want the date in the 2026, not already past.
