### PR TITLE
chore(cells): Add @deprecated to IssueGroupActionEndpoint

### DIFF
--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -14,8 +14,10 @@ from sentry import analytics
 from sentry.analytics.events.issue_tracker_used import IssueTrackerUsedEvent
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.plugin import PluginSerializer
+from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 
 # api compat
@@ -84,6 +86,14 @@ class IssueGroupActionEndpoint(PluginGroupEndpoint):
         GroupMeta.objects.populate_cache([group])
 
         return getattr(self.plugin, self.view_method_name)(request, group, *args, **kwargs)
+
+    @deprecated(CELL_API_DEPRECATION_DATE)
+    def get(self, request: Request, group, *args, **kwargs) -> Response:
+        return self._handle(request, group, *args, **kwargs)
+
+    @deprecated(CELL_API_DEPRECATION_DATE)
+    def post(self, request: Request, group, *args, **kwargs) -> Response:
+        return self._handle(request, group, *args, **kwargs)
 
 
 class IssueTrackingPlugin2(Plugin):


### PR DESCRIPTION
This is consistent with our policy on plugins, and the plans for cellularization, and gives remaining users are clearer indication and a clear timeline.