### PR TITLE
feat(explorer): allow client to pass in metadata

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -193,6 +193,7 @@ class SeerExplorerClient:
         on_page_context: str | None = None,
         artifact_key: str | None = None,
         artifact_schema: type[BaseModel] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> int:
         """
         Start a new Seer Explorer session.
@@ -202,6 +203,7 @@ class SeerExplorerClient:
             on_page_context: Optional context from the user's screen
             artifact_key: Optional key to identify this artifact (required if artifact_schema is provided)
             artifact_schema: Optional Pydantic model to generate a structured artifact
+            metadata: Optional metadata to store with the run (e.g., stopping_point, group_id)
 
         Returns:
             int: The run ID that can be used to fetch results or continue the conversation
@@ -245,6 +247,9 @@ class SeerExplorerClient:
         if self.category_key and self.category_value:
             payload["category_key"] = self.category_key
             payload["category_value"] = self.category_value
+
+        if metadata:
+            payload["metadata"] = metadata
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -121,6 +121,7 @@ class SeerRunState(BaseModel):
     updated_at: str
     pending_user_input: PendingUserInput | None = None
     repo_pr_states: dict[str, RepoPRState] = {}
+    metadata: dict[str, Any] | None = None
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
Allows client to pass in arbitrary metadata when starting a new run and allow it to retrieve it later