### PR TITLE
feat(dashboards): convert http module into dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2066,8 +2066,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
-  '@jridgewell/trace-mapping@0.3.30':
-    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -3421,8 +3421,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tsconfig/node10@1.0.11':
-    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
   '@tsconfig/node12@1.0.11':
     resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
@@ -3600,6 +3600,9 @@ packages:
 
   '@types/node@22.17.1':
     resolution: {integrity: sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==}
+
+  '@types/node@22.19.2':
+    resolution: {integrity: sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4333,11 +4336,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001717:
-    resolution: {integrity: sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==}
-
-  caniuse-lite@1.0.30001727:
-    resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
+  caniuse-lite@1.0.30001760:
+    resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
 
   cbor2@1.12.0:
     resolution: {integrity: sha512-3Cco8XQhi27DogSp9Ri6LYNZLi/TBY/JVnDe+mj06NkBjW/ZYOtekaEU4wZ4xcRMNrFkDv8KNtOAqHyDfz3lYg==}
@@ -6486,8 +6486,8 @@ packages:
   load-plugin@6.0.3:
     resolution: {integrity: sha512-kc0X2FEUZr145odl68frm+lMJuQ23+rTXYmR6TImqPtbpmXC4vVXbWKDQ9IzndA0HfyQamWfKLhzsqGSTxE63w==}
 
-  loader-runner@4.3.0:
-    resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
+  loader-runner@4.3.1:
+    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
 
   loader-utils@1.4.2:
@@ -7783,6 +7783,10 @@ packages:
     resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
     engines: {node: '>= 10.13.0'}
 
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
   screenfull@6.0.2:
     resolution: {integrity: sha512-AQdy8s4WhNvUZ6P8F6PB21tSPIYKniic+Ogx0AacBMjKP1GUHN2E9URxQHtCusiwxudnCKkdy4GrHXPPJSkCCw==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -8177,8 +8181,12 @@ packages:
     resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
     engines: {node: '>=6'}
 
-  terser-webpack-plugin@5.3.14:
-    resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  terser-webpack-plugin@5.3.15:
+    resolution: {integrity: sha512-PGkOdpRFK+rb1TzVz+msVhw4YMRT9txLF4kRqvJhGhCM324xuR3REBSHALN+l+sAhKUmz0aotnjp5D+P83mLhQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -10606,7 +10614,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
-  '@jridgewell/trace-mapping@0.3.30':
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -12396,7 +12404,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@tsconfig/node10@1.0.11':
+  '@tsconfig/node10@1.0.12':
     optional: true
 
   '@tsconfig/node12@1.0.11':
@@ -12613,6 +12621,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/node@22.17.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.19.2':
     dependencies:
       undici-types: 6.21.0
 
@@ -13427,14 +13439,14 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001717
+      caniuse-lite: 1.0.30001760
       electron-to-chromium: 1.5.113
       node-releases: 2.0.19
       update-browserslist-db: 1.1.1(browserslist@4.24.4)
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001727
+      caniuse-lite: 1.0.30001760
       electron-to-chromium: 1.5.180
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -13496,9 +13508,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001717: {}
-
-  caniuse-lite@1.0.30001727: {}
+  caniuse-lite@1.0.30001760: {}
 
   cbor2@1.12.0: {}
 
@@ -14033,7 +14043,7 @@ snapshots:
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.2.3
+      tapable: 2.3.0
 
   entities@2.0.0: {}
 
@@ -16010,7 +16020,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.17.1
+      '@types/node': 22.19.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -16209,7 +16219,7 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  loader-runner@4.3.0: {}
+  loader-runner@4.3.1: {}
 
   loader-utils@1.4.2:
     dependencies:
@@ -17858,6 +17868,13 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.17.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-keywords: 5.1.0(ajv@8.17.1)
+
   screenfull@6.0.2: {}
 
   scroll-to-element@2.0.3:
@@ -18361,11 +18378,13 @@ snapshots:
 
   tapable@2.2.3: {}
 
-  terser-webpack-plugin@5.3.14(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10)):
+  tapable@2.3.0: {}
+
+  terser-webpack-plugin@5.3.15(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
-      schema-utils: 4.3.2
+      schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.40.0
       webpack: 5.99.6(esbuild@0.25.10)
@@ -18460,7 +18479,7 @@ snapshots:
   ts-node@10.9.2(@types/node@22.15.21)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
@@ -18957,12 +18976,12 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
+      loader-runner: 4.3.1
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 4.3.2
-      tapable: 2.2.3
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10))
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.15(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2066,8 +2066,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+  '@jridgewell/trace-mapping@0.3.30':
+    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -3421,8 +3421,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
   '@tsconfig/node12@1.0.11':
     resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
@@ -3600,9 +3600,6 @@ packages:
 
   '@types/node@22.17.1':
     resolution: {integrity: sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==}
-
-  '@types/node@22.19.2':
-    resolution: {integrity: sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4336,8 +4333,11 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001760:
-    resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
+  caniuse-lite@1.0.30001717:
+    resolution: {integrity: sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==}
+
+  caniuse-lite@1.0.30001727:
+    resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
 
   cbor2@1.12.0:
     resolution: {integrity: sha512-3Cco8XQhi27DogSp9Ri6LYNZLi/TBY/JVnDe+mj06NkBjW/ZYOtekaEU4wZ4xcRMNrFkDv8KNtOAqHyDfz3lYg==}
@@ -6486,8 +6486,8 @@ packages:
   load-plugin@6.0.3:
     resolution: {integrity: sha512-kc0X2FEUZr145odl68frm+lMJuQ23+rTXYmR6TImqPtbpmXC4vVXbWKDQ9IzndA0HfyQamWfKLhzsqGSTxE63w==}
 
-  loader-runner@4.3.1:
-    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+  loader-runner@4.3.0:
+    resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
 
   loader-utils@1.4.2:
@@ -7783,10 +7783,6 @@ packages:
     resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
     engines: {node: '>= 10.13.0'}
 
-  schema-utils@4.3.3:
-    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
-    engines: {node: '>= 10.13.0'}
-
   screenfull@6.0.2:
     resolution: {integrity: sha512-AQdy8s4WhNvUZ6P8F6PB21tSPIYKniic+Ogx0AacBMjKP1GUHN2E9URxQHtCusiwxudnCKkdy4GrHXPPJSkCCw==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -8181,12 +8177,8 @@ packages:
     resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
     engines: {node: '>=6'}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
-    engines: {node: '>=6'}
-
-  terser-webpack-plugin@5.3.15:
-    resolution: {integrity: sha512-PGkOdpRFK+rb1TzVz+msVhw4YMRT9txLF4kRqvJhGhCM324xuR3REBSHALN+l+sAhKUmz0aotnjp5D+P83mLhQ==}
+  terser-webpack-plugin@5.3.14:
+    resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -10614,7 +10606,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
-  '@jridgewell/trace-mapping@0.3.31':
+  '@jridgewell/trace-mapping@0.3.30':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -12404,7 +12396,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@tsconfig/node10@1.0.12':
+  '@tsconfig/node10@1.0.11':
     optional: true
 
   '@tsconfig/node12@1.0.11':
@@ -12621,10 +12613,6 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/node@22.17.1':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.19.2':
     dependencies:
       undici-types: 6.21.0
 
@@ -13439,14 +13427,14 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001760
+      caniuse-lite: 1.0.30001717
       electron-to-chromium: 1.5.113
       node-releases: 2.0.19
       update-browserslist-db: 1.1.1(browserslist@4.24.4)
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001760
+      caniuse-lite: 1.0.30001727
       electron-to-chromium: 1.5.180
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -13508,7 +13496,9 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001760: {}
+  caniuse-lite@1.0.30001717: {}
+
+  caniuse-lite@1.0.30001727: {}
 
   cbor2@1.12.0: {}
 
@@ -14043,7 +14033,7 @@ snapshots:
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.2.3
 
   entities@2.0.0: {}
 
@@ -16020,7 +16010,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.17.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -16219,7 +16209,7 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  loader-runner@4.3.1: {}
+  loader-runner@4.3.0: {}
 
   loader-utils@1.4.2:
     dependencies:
@@ -17868,13 +17858,6 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
-  schema-utils@4.3.3:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
-
   screenfull@6.0.2: {}
 
   scroll-to-element@2.0.3:
@@ -18378,13 +18361,11 @@ snapshots:
 
   tapable@2.2.3: {}
 
-  tapable@2.3.0: {}
-
-  terser-webpack-plugin@5.3.15(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10)):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
+      '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
-      schema-utils: 4.3.3
+      schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.40.0
       webpack: 5.99.6(esbuild@0.25.10)
@@ -18479,7 +18460,7 @@ snapshots:
   ts-node@10.9.2(@types/node@22.15.21)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
@@ -18976,12 +18957,12 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
+      loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.15(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10))
+      schema-utils: 4.3.2
+      tapable: 2.2.3
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.10)(webpack@5.99.6(esbuild@0.25.10))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -1,4 +1,6 @@
 import {type DashboardDetails} from 'sentry/views/dashboards/types';
+import {HTTP_DOMAIN_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/domainSummary';
+import {HTTP_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/http';
 import {QUERIES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/queries';
 import {QUERIES_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/querySummary';
 import {SESSION_HEALTH_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/sessionHealth';
@@ -7,6 +9,8 @@ export enum PrebuiltDashboardId {
   FRONTEND_SESSION_HEALTH = 1,
   BACKEND_QUERIES = 2,
   BACKEND_QUERIES_SUMMARY = 3,
+  HTTP = 4,
+  HTTP_DOMAIN_SUMMARY = 5,
 }
 
 export type PrebuiltDashboard = Omit<DashboardDetails, 'id'>;
@@ -15,4 +19,6 @@ export const PREBUILT_DASHBOARDS: Record<PrebuiltDashboardId, PrebuiltDashboard>
   [PrebuiltDashboardId.FRONTEND_SESSION_HEALTH]: SESSION_HEALTH_PREBUILT_CONFIG,
   [PrebuiltDashboardId.BACKEND_QUERIES]: QUERIES_PREBUILT_CONFIG,
   [PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY]: QUERIES_SUMMARY_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.HTTP]: HTTP_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.HTTP_DOMAIN_SUMMARY]: HTTP_DOMAIN_SUMMARY_PREBUILT_CONFIG,
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -1,0 +1,262 @@
+import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {
+  AVERAGE_DURATION_TEXT,
+  DASHBOARD_TITLE,
+  RESPONSE_CODES_TEXT,
+  THROUGHPUT_TEXT,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/settings';
+import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
+import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export const BASE_FILTERS = {
+  [SpanFields.SPAN_OP]: 'http.client',
+};
+
+const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString();
+
+const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
+  [
+    {
+      id: 'throughput-big-number',
+      title: THROUGHPUT_TEXT,
+      displayType: DisplayType.BIG_NUMBER,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: THROUGHPUT_TEXT,
+          conditions: FILTER_STRING,
+          fields: ['epm()'],
+          aggregates: ['epm()'],
+          columns: [],
+          orderby: 'epm()',
+        },
+      ],
+    },
+    {
+      id: 'duration-big-number',
+      title: AVERAGE_DURATION_TEXT,
+      displayType: DisplayType.BIG_NUMBER,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: AVERAGE_DURATION_TEXT,
+          conditions: FILTER_STRING,
+          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          columns: [],
+          orderby: `avg(${SpanFields.SPAN_SELF_TIME})`,
+        },
+      ],
+    },
+    {
+      id: '3xx-count-big-number',
+      title: t('3XX'),
+      displayType: DisplayType.BIG_NUMBER,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: t('3XX'),
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=300 tags[http.response.status_code,number]:<=399`,
+          fields: [`count(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
+          columns: [],
+          orderby: `count(${SpanFields.SPAN_DURATION})`,
+        },
+      ],
+    },
+    {
+      id: '4xx-count-big-number',
+      title: AVERAGE_DURATION_TEXT,
+      displayType: DisplayType.BIG_NUMBER,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: t('4XX'),
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=400 tags[http.response.status_code,number]:<=499`,
+          fields: [`count(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
+          columns: [],
+          orderby: `count(${SpanFields.SPAN_DURATION})`,
+        },
+      ],
+    },
+    {
+      id: 'txx-count-big-number',
+      title: t('5XX'),
+      displayType: DisplayType.BIG_NUMBER,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: t('5XX'),
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=500 tags[http.response.status_code,number]:<=599`,
+          fields: [`count(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
+          columns: [],
+          orderby: `count(${SpanFields.SPAN_DURATION})`,
+        },
+      ],
+    },
+    {
+      id: 'time-spent-big-number',
+      title: DataTitles.timeSpent,
+      displayType: DisplayType.BIG_NUMBER,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: DataTitles.timeSpent,
+          conditions: FILTER_STRING,
+          fields: [`sum(${SpanFields.SPAN_SELF_TIME})`],
+          aggregates: [`sum(${SpanFields.SPAN_SELF_TIME})`],
+          columns: [],
+          orderby: `sum(${SpanFields.SPAN_SELF_TIME})`,
+        },
+      ],
+    },
+  ],
+  0,
+  {h: 1, minH: 1}
+);
+
+const CHART_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
+  [
+    {
+      id: 'throughput-chart',
+      title: THROUGHPUT_TEXT,
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: THROUGHPUT_TEXT,
+          conditions: FILTER_STRING,
+          fields: ['epm()'],
+          aggregates: ['epm()'],
+          columns: [],
+          orderby: 'epm()',
+        },
+      ],
+    },
+    {
+      id: 'duration-chart',
+      title: AVERAGE_DURATION_TEXT,
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: AVERAGE_DURATION_TEXT,
+          conditions: FILTER_STRING,
+          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          columns: [],
+          orderby: `avg(${SpanFields.SPAN_SELF_TIME})`,
+        },
+      ],
+    },
+    {
+      id: 'response-codes-chart',
+      title: RESPONSE_CODES_TEXT,
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: '3XX',
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=300 tags[http.response.status_code,number]:<=399`,
+          fields: ['count(span.duration)'],
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          orderby: 'count(span.duration)',
+        },
+        {
+          name: '4XX',
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=400 tags[http.response.status_code,number]:<=499`,
+          fields: ['count(span.duration)'],
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          orderby: 'count(span.duration)',
+        },
+        {
+          name: '5XX',
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=500 tags[http.response.status_code,number]:<=599`,
+          fields: ['count(span.duration)'],
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          orderby: 'count(span.duration)',
+        },
+      ],
+    },
+  ],
+  1
+);
+
+const TRANSACTIONS_TABLE: Widget = {
+  id: 'transactions-table',
+  title: t('Transactions making requests to this domain'),
+  displayType: DisplayType.TABLE,
+  widgetType: WidgetType.SPANS,
+  interval: '5m',
+  queries: [
+    {
+      aggregates: [
+        'epm()',
+        `avg(${SpanFields.SPAN_SELF_TIME})`,
+        `sum(${SpanFields.SPAN_SELF_TIME})`,
+      ],
+      columns: [SpanFields.TRANSACTION],
+      fields: [
+        SpanFields.TRANSACTION,
+        'epm()',
+        `avg(${SpanFields.SPAN_SELF_TIME})`,
+        `sum(${SpanFields.SPAN_SELF_TIME})`,
+      ],
+      fieldAliases: [
+        t('Found In'),
+        THROUGHPUT_TEXT,
+        DataTitles.avg,
+        DataTitles.timeSpent,
+      ],
+      conditions: FILTER_STRING,
+      name: '',
+      orderby: '-sum(span.self_time)',
+    },
+  ],
+  layout: {
+    x: 0,
+    y: 3,
+    minH: 2,
+    h: 5,
+    w: 6,
+  },
+};
+
+export const HTTP_DOMAIN_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
+  dateCreated: '',
+  projects: [],
+  title: DASHBOARD_TITLE,
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: SpanFields.SPAN_DOMAIN,
+          name: SpanFields.SPAN_DOMAIN,
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
+  widgets: [...BIG_NUMBER_ROW_WIDGETS, ...CHART_ROW_WIDGETS, TRANSACTIONS_TABLE],
+};

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -74,7 +74,7 @@ const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
     },
     {
       id: '4xx-count-big-number',
-      title: AVERAGE_DURATION_TEXT,
+      title: t('4XX'),
       displayType: DisplayType.BIG_NUMBER,
       widgetType: WidgetType.SPANS,
       interval: '5m',

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -5,6 +5,7 @@ import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/type
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {
   AVERAGE_DURATION_TEXT,
+  BASE_FILTERS,
   DASHBOARD_TITLE,
   RESPONSE_CODES_TEXT,
   THROUGHPUT_TEXT,
@@ -12,10 +13,6 @@ import {
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {SpanFields} from 'sentry/views/insights/types';
-
-export const BASE_FILTERS = {
-  [SpanFields.SPAN_OP]: 'http.client',
-};
 
 const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString();
 
@@ -90,7 +87,7 @@ const BIG_NUMBER_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
       ],
     },
     {
-      id: 'txx-count-big-number',
+      id: '5xx-count-big-number',
       title: t('5XX'),
       displayType: DisplayType.BIG_NUMBER,
       widgetType: WidgetType.SPANS,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
@@ -1,0 +1,172 @@
+import {t} from 'sentry/locale';
+import {RATE_UNIT_TITLE, RateUnit} from 'sentry/utils/discover/fields';
+import {FieldKind} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import {type PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {
+  AVERAGE_DURATION_TEXT,
+  DASHBOARD_TITLE,
+  RESPONSE_CODES_TEXT,
+  THROUGHPUT_TEXT,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/settings';
+import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
+import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export const BASE_FILTERS = {
+  [SpanFields.SPAN_OP]: 'http.client',
+};
+
+const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString();
+
+const FIRST_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
+  [
+    {
+      id: 'throughput-chart',
+      title: THROUGHPUT_TEXT,
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: THROUGHPUT_TEXT,
+          conditions: FILTER_STRING,
+          fields: ['epm()'],
+          aggregates: ['epm()'],
+          columns: [],
+          orderby: 'epm()',
+        },
+      ],
+    },
+    {
+      id: 'duration-chart',
+      title: AVERAGE_DURATION_TEXT,
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: AVERAGE_DURATION_TEXT,
+          conditions: FILTER_STRING,
+          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          columns: [],
+          orderby: `avg(${SpanFields.SPAN_SELF_TIME})`,
+        },
+      ],
+    },
+    {
+      id: 'response-codes-chart',
+      title: RESPONSE_CODES_TEXT,
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: '3XX',
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=300 tags[http.response.status_code,number]:<=399`,
+          fields: ['count(span.duration)'],
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          orderby: 'count(span.duration)',
+        },
+        {
+          name: '4XX',
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=400 tags[http.response.status_code,number]:<=499`,
+          fields: ['count(span.duration)'],
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          orderby: 'count(span.duration)',
+        },
+        {
+          name: '5XX',
+          conditions: `${FILTER_STRING} tags[http.response.status_code,number]:>=500 tags[http.response.status_code,number]:<=599`,
+          fields: ['count(span.duration)'],
+          aggregates: ['count(span.duration)'],
+          columns: [],
+          orderby: 'count(span.duration)',
+        },
+      ],
+    },
+  ],
+  0
+);
+
+const DOMAIN_TABLE: Widget = {
+  id: 'domain-table',
+  title: t('Domains'),
+  displayType: DisplayType.TABLE,
+  widgetType: WidgetType.SPANS,
+  interval: '5m',
+  queries: [
+    {
+      aggregates: [
+        'epm()',
+        `avg(${SpanFields.SPAN_SELF_TIME})`,
+        `sum(${SpanFields.SPAN_SELF_TIME})`,
+      ],
+      columns: [SpanFields.SPAN_DOMAIN, SpanFields.PROJECT],
+      fields: [
+        SpanFields.SPAN_DOMAIN,
+        SpanFields.PROJECT,
+        'epm()',
+        `avg(${SpanFields.SPAN_SELF_TIME})`,
+        `sum(${SpanFields.SPAN_SELF_TIME})`,
+      ],
+      fieldAliases: [
+        t('Domain'),
+        t('Project'),
+        `${t('Requests')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`,
+        DataTitles.avg,
+        DataTitles.timeSpent,
+      ],
+      linkedDashboards: [
+        {
+          dashboardId: '-1',
+          field: SpanFields.SPAN_DOMAIN,
+          staticDashboardId: 5,
+        },
+      ],
+      conditions: FILTER_STRING,
+      name: '',
+      orderby: '-sum(span.self_time)',
+    },
+  ],
+  layout: {
+    x: 0,
+    y: 2,
+    minH: 2,
+    h: 4,
+    w: 6,
+  },
+};
+
+export const HTTP_PREBUILT_CONFIG: PrebuiltDashboard = {
+  dateCreated: '',
+  projects: [],
+  title: DASHBOARD_TITLE,
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: SpanFields.USER_GEO_SUBREGION,
+          name: SpanFields.USER_GEO_SUBREGION,
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: SpanFields.SPAN_DOMAIN,
+          name: SpanFields.SPAN_DOMAIN,
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
+  widgets: [...FIRST_ROW_WIDGETS, DOMAIN_TABLE],
+};

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
@@ -6,6 +6,7 @@ import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/type
 import {type PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {
   AVERAGE_DURATION_TEXT,
+  BASE_FILTERS,
   DASHBOARD_TITLE,
   RESPONSE_CODES_TEXT,
   THROUGHPUT_TEXT,
@@ -13,10 +14,6 @@ import {
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {SpanFields} from 'sentry/views/insights/types';
-
-export const BASE_FILTERS = {
-  [SpanFields.SPAN_OP]: 'http.client',
-};
 
 const FILTER_STRING = MutableSearch.fromQueryObject(BASE_FILTERS).formatString();
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/settings.ts
@@ -1,8 +1,13 @@
 import {t} from 'sentry/locale';
 import {RATE_UNIT_TITLE, RateUnit} from 'sentry/utils/discover/fields';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export const DASHBOARD_TITLE = t('Outbound API Requests');
 
 export const THROUGHPUT_TEXT = `${t('Requests')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`;
 export const AVERAGE_DURATION_TEXT = t('Average Duration');
 export const RESPONSE_CODES_TEXT = t('Response Codes (3XX, 4XX, 5XX)');
+
+export const BASE_FILTERS = {
+  [SpanFields.SPAN_OP]: 'http.client',
+};

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/settings.ts
@@ -1,0 +1,8 @@
+import {t} from 'sentry/locale';
+import {RATE_UNIT_TITLE, RateUnit} from 'sentry/utils/discover/fields';
+
+export const DASHBOARD_TITLE = t('Outbound API Requests');
+
+export const THROUGHPUT_TEXT = `${t('Requests')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`;
+export const AVERAGE_DURATION_TEXT = t('Average Duration');
+export const RESPONSE_CODES_TEXT = t('Response Codes (3XX, 4XX, 5XX)');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.spec.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.spec.tsx
@@ -1,0 +1,39 @@
+// write some cases for spaceWidgetsEquallyOnRow
+
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import type {Widget} from 'sentry/views/dashboards/types';
+
+import {spaceWidgetsEquallyOnRow} from './spaceWidgetsEquallyOnRow';
+
+describe('spaceWidgetsEquallyOnRow', () => {
+  it('should space widgets equally on a row', () => {
+    const widgets: Widget[] = [WidgetFixture({id: '1'}), WidgetFixture({id: '2'})];
+
+    const result = spaceWidgetsEquallyOnRow(widgets, 0);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        id: '1',
+        layout: expect.objectContaining({x: 0, y: 0, w: 3, h: 2}),
+      })
+    );
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        id: '2',
+        layout: expect.objectContaining({x: 3, y: 0, w: 3, h: 2}),
+      })
+    );
+  });
+
+  it('should throw an error if there are more widgets than the number of columns', () => {
+    const widgets: Widget[] = Array.from({length: 7}, (_, i) =>
+      WidgetFixture({id: `widget-${i}`})
+    );
+
+    expect(() => spaceWidgetsEquallyOnRow(widgets, 0)).toThrow(
+      'Expected no more than 6 widgets, got 7'
+    );
+  });
+});

--- a/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.spec.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.spec.tsx
@@ -1,5 +1,3 @@
-// write some cases for spaceWidgetsEquallyOnRow
-
 import {WidgetFixture} from 'sentry-fixture/widget';
 
 import type {Widget} from 'sentry/views/dashboards/types';

--- a/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.ts
@@ -1,0 +1,27 @@
+import type {Widget, WidgetLayout} from 'sentry/views/dashboards/types';
+
+const MAX_WIDGETS_PER_ROW = 6;
+
+export function spaceWidgetsEquallyOnRow(
+  widgets: Widget[],
+  y: number,
+  height: Pick<WidgetLayout, 'h' | 'minH'> = {h: 2, minH: 2}
+): Widget[] {
+  if (widgets.length > MAX_WIDGETS_PER_ROW) {
+    throw new Error(
+      `Expected no more than ${MAX_WIDGETS_PER_ROW} widgets, got ${widgets.length}`
+    );
+  }
+
+  const widgetWidth = Math.floor(MAX_WIDGETS_PER_ROW / widgets.length);
+
+  return widgets.map((widget, idx) => ({
+    ...widget,
+    layout: {
+      x: idx * widgetWidth,
+      y,
+      w: widgetWidth,
+      ...height,
+    },
+  }));
+}

--- a/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.ts
@@ -1,19 +1,18 @@
+import {NUM_DESKTOP_COLS} from 'sentry/views/dashboards/dashboard';
 import type {Widget, WidgetLayout} from 'sentry/views/dashboards/types';
-
-const MAX_WIDGETS_PER_ROW = 6;
 
 export function spaceWidgetsEquallyOnRow(
   widgets: Widget[],
   y: number,
   height: Pick<WidgetLayout, 'h' | 'minH'> = {h: 2, minH: 2}
 ): Widget[] {
-  if (widgets.length > MAX_WIDGETS_PER_ROW) {
+  if (widgets.length > NUM_DESKTOP_COLS) {
     throw new Error(
-      `Expected no more than ${MAX_WIDGETS_PER_ROW} widgets, got ${widgets.length}`
+      `Expected no more than ${NUM_DESKTOP_COLS} widgets, got ${widgets.length}`
     );
   }
 
-  const widgetWidth = Math.floor(MAX_WIDGETS_PER_ROW / widgets.length);
+  const widgetWidth = Math.floor(NUM_DESKTOP_COLS / widgets.length);
 
   return widgets.map((widget, idx) => ({
     ...widget,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow.ts
@@ -12,6 +12,10 @@ export function spaceWidgetsEquallyOnRow(
     );
   }
 
+  if (widgets.length === 0) {
+    return [];
+  }
+
   const widgetWidth = Math.floor(NUM_DESKTOP_COLS / widgets.length);
 
   return widgets.map((widget, idx) => ({

--- a/static/app/views/insights/http/utils/useHasDashboardsPlatformizedHttp.tsx
+++ b/static/app/views/insights/http/utils/useHasDashboardsPlatformizedHttp.tsx
@@ -1,0 +1,7 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useHasDashboardsPlatformizedHttp() {
+  const organization = useOrganization();
+
+  return organization.features.includes('insights-http-dashboard-migration');
+}

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -30,6 +30,8 @@ import {
   isAValidSort,
 } from 'sentry/views/insights/http/components/tables/domainsTable';
 import {Referrer} from 'sentry/views/insights/http/referrers';
+import useHasDashboardsPlatformizedHttp from 'sentry/views/insights/http/utils/useHasDashboardsPlatformizedHttp';
+import {PlatformizedHttpOverview} from 'sentry/views/insights/http/views/platformizedOverview';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export function HTTPLandingPage() {
@@ -152,6 +154,11 @@ function PageWithProviders() {
   const maxPickableDays = useMaxPickableDays({
     dataCategories: [DataCategory.SPANS],
   });
+
+  const hasDashboardsPlatformizedHttp = useHasDashboardsPlatformizedHttp();
+  if (hasDashboardsPlatformizedHttp) {
+    return <PlatformizedHttpOverview />;
+  }
 
   return (
     <ModulePageProviders

--- a/static/app/views/insights/http/views/platformizedOverview.tsx
+++ b/static/app/views/insights/http/views/platformizedOverview.tsx
@@ -1,0 +1,20 @@
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
+import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+
+export function PlatformizedHttpOverview() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
+  return (
+    <ModulePageProviders
+      moduleName="http"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
+      <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.HTTP} />
+    </ModulePageProviders>
+  );
+}


### PR DESCRIPTION
1. Convert the http module into a prebuilt dashboard as much as we can
<img width="1490" height="1009" alt="image" src="https://github.com/user-attachments/assets/abd90b14-4d12-495b-8a13-ba6cde4f4403" />

3. The dashboard will be rendered instead if the flag is on
4. Add a util to help make widgets lie on the same row in prebuilt dashboards.