### PR TITLE
fix(ACI): Fix no one fallthrough type

### DIFF
--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -47,12 +47,11 @@ class NotifyEmailAction(EventAction):
             "group_id": group.id,
             "notification_uuid": notification_uuid,
         }
-
         target_type = ActionTargetType(self.data["targetType"])
         target_identifier = self.data.get("targetIdentifier", None)
         skip_digests = self.data.get("skipDigests", False)
 
-        fallthrough_choice = self.data.get("fallthroughType", None)
+        fallthrough_choice = self.data.get("fallthrough_type", None)
         fallthrough_type = (
             FallthroughChoiceType(fallthrough_choice)
             if fallthrough_choice

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -51,7 +51,10 @@ class NotifyEmailAction(EventAction):
         target_identifier = self.data.get("targetIdentifier", None)
         skip_digests = self.data.get("skipDigests", False)
 
-        fallthrough_choice = self.data.get("fallthrough_type", None)
+        # XXX: temporarily support both types, but after GA we should only need to support fallthrough_type
+        fallthrough_choice = self.data.get("fallthrough_type", None) or self.data.get(
+            "fallthroughType", None
+        )
         fallthrough_type = (
             FallthroughChoiceType(fallthrough_choice)
             if fallthrough_choice

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -1,6 +1,7 @@
 from django.core import mail
 
 from sentry.eventstream.types import EventStreamEventType
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.mail.actions import NotifyEmailAction
 from sentry.mail.forms.notify_email import NotifyEmailForm
@@ -14,7 +15,10 @@ from sentry.tasks.post_process import post_process_group
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.skips import requires_snuba
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = requires_snuba
 
@@ -122,7 +126,7 @@ class NotifyEmailFormTest(TestCase):
         assert form.is_valid()
 
 
-class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase):
+class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
     rule_cls = NotifyEmailAction
 
     def test_simple(self) -> None:
@@ -211,6 +215,64 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase):
         sent = mail.outbox[0]
         assert sent.to == [self.user.email]
         assert "uh oh" in sent.subject
+
+    @with_feature("organizations:workflow-engine-single-process-workflows")
+    @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
+    def test_workflow_engine_full_integration_noone_fallthrough(self) -> None:
+        from sentry.workflow_engine.typings.notification_action import (
+            ActionTarget,
+            FallthroughChoiceType,
+        )
+
+        one_min_ago = before_now(minutes=1).isoformat()
+        event = self.store_event(
+            data={
+                "message": "hello",
+                "exception": {"type": "Foo", "value": "uh oh"},
+                "level": "error",
+                "timestamp": one_min_ago,
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        error_workflow, error_detector, detector_workflow_error, condition_group = (
+            self.create_detector_and_workflow(
+                name_prefix="error",
+                workflow_triggers=self.create_data_condition_group(),
+                detector_type=ErrorGroupType.slug,
+            )
+        )
+        self.create_workflow_data_condition_group(
+            workflow=error_workflow, condition_group=condition_group
+        )
+
+        action_config = {
+            "target_type": ActionTarget.ISSUE_OWNERS.value,
+            "target_display": None,
+            "target_identifier": None,
+        }
+        action_data = {"fallthrough_type": FallthroughChoiceType.NO_ONE.value}
+        action = self.create_action(config=action_config, type="email", data=action_data)
+        self.create_data_condition_group_action(condition_group=condition_group, action=action)
+        issue_alert_rule = Rule.objects.create(
+            label="test rule",
+            project=self.project,
+            owner_team_id=self.team.id,
+        )
+        self.create_alert_rule_workflow(workflow=error_workflow, rule_id=issue_alert_rule.id)
+
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        assert len(mail.outbox) == 0
 
     def test_full_integration_fallthrough_not_provided(self) -> None:
         one_min_ago = before_now(minutes=1).isoformat()

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -216,7 +216,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
         assert sent.to == [self.user.email]
         assert "uh oh" in sent.subject
 
-    def test_full_integration_noone_fallthrough(self) -> None:
+    def test_legacy_full_integration_noone_fallthrough(self) -> None:
         one_min_ago = before_now(minutes=1).isoformat()
         event = self.store_event(
             data={
@@ -254,7 +254,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
 
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
-    def test_workflow_engine_full_integration_noone_fallthrough(self) -> None:
+    def test_full_integration_noone_fallthrough(self) -> None:
         from sentry.workflow_engine.typings.notification_action import (
             ActionTarget,
             FallthroughChoiceType,
@@ -290,12 +290,6 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
         action_data = {"fallthrough_type": FallthroughChoiceType.NO_ONE.value}
         action = self.create_action(config=action_config, type="email", data=action_data)
         self.create_data_condition_group_action(condition_group=condition_group, action=action)
-        issue_alert_rule = Rule.objects.create(
-            label="test rule",
-            project=self.project,
-            owner_team_id=self.team.id,
-        )
-        self.create_alert_rule_workflow(workflow=error_workflow, rule_id=issue_alert_rule.id)
 
         with self.tasks():
             post_process_group(


### PR DESCRIPTION
Since [migrating the action data fallthrough type](https://github.com/getsentry/sentry/pull/103764) and [removing the logic to support both snake case and camel case](https://github.com/getsentry/sentry/pull/103996) customers who have actions with a fallthrough type of "no one" have been receiving a surplus of notifications because the default value is `FallthroughChoiceType.ACTIVE_MEMBERS` and we were not properly fetching the `fallthrough_type`.

Fixes https://getsentry.atlassian.net/browse/ACI-564
Fixes https://github.com/getsentry/sentry/issues/104478

Note that this PR fixes only `fallthrough_type` and the other options for `target_type` and `target_identifier` are also incorrectly attempting to fetch a camel case value when it's actually stored in snake case in the database. This will need to be fixed in a follow up PR. 