### PR TITLE
chore(integrations): improve empty state message

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
@@ -133,12 +133,16 @@ export function IntegrationReposAddRepository({
         query.isFetching
           ? t('Searching\u2026')
           : debouncedSearch
-            ? tct(
-                'No repositories found. Newly added repositories may take a few minutes to appear. You may also need to check repository permissions for the [link:Sentry Github App].',
-                {
-                  link: <ExternalLink href="https://github.com/apps/sentry" />,
-                }
-              )
+            ? integration.provider.key === 'github'
+              ? tct(
+                  'No repositories found. Newly added repositories may take a few minutes to appear. You may also need to check repository permissions for the [link:Sentry Github App].',
+                  {
+                    link: <ExternalLink href="https://github.com/apps/sentry" />,
+                  }
+                )
+              : t(
+                  'No repositories found. Newly added repositories may take a few minutes to appear. You may also need to check repository permissions.'
+                )
             : t('Please enter a repository name')
       }
       searchPlaceholder={t('Search Repositories')}

--- a/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
@@ -3,8 +3,9 @@ import {useMemo, useState} from 'react';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {addRepository, migrateRepository} from 'sentry/actionCreators/integrations';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {ExternalLink} from 'sentry/components/core/link';
 import DropdownButton from 'sentry/components/dropdownButton';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import RepositoryStore from 'sentry/stores/repositoryStore';
 import type {
   Integration,
@@ -132,8 +133,11 @@ export function IntegrationReposAddRepository({
         query.isFetching
           ? t('Searching\u2026')
           : debouncedSearch
-            ? t(
-                'No repositories found. Newly added repositories may take a few minutes to appear.'
+            ? tct(
+                'No repositories found. Newly added repositories may take a few minutes to appear. You may also need to check repository permissions for the [link:Sentry Github App].',
+                {
+                  link: <ExternalLink href="https://github.com/apps/sentry" />,
+                }
               )
             : t('Please enter a repository name')
       }


### PR DESCRIPTION
The UI does not make it clear if you are trying to add a repo that Sentry does not have permissions for. This is an attempt to slightly improve that

New
<img width="668" height="558" alt="CleanShot 2025-12-09 at 16 18 15@2x" src="https://github.com/user-attachments/assets/a99c5caa-0625-42b7-b396-756214b2ce0a" />


Old
<img width="610" height="386" alt="CleanShot 2025-12-09 at 16 19 12@2x" src="https://github.com/user-attachments/assets/ef591518-7c70-43e5-850d-68676494dcf8" />
