### PR TITLE
chore(triage signals): Set org level default to medium too

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -507,9 +507,11 @@ def set_default_project_autofix_automation_tuning(
     """Called once at project creation time to set the initial autofix automation tuning."""
     org_default = organization.get_option("sentry:default_autofix_automation_tuning")
 
-    if org_default == "off":
+    if org_default == AutofixAutomationTuningSettings.OFF:
         # Explicit "off" is always respected, regardless of feature flag
-        project.update_option("sentry:autofix_automation_tuning", "off")
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
+        )
     elif is_seer_seat_based_tier_enabled(organization):
         # Feature flag ON overrides everything except explicit "off"
         project.update_option(

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -4,7 +4,11 @@ from datetime import datetime, timedelta
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.seer.autofix.constants import AutofixStatus, SeerAutomationSource
+from sentry.seer.autofix.constants import (
+    AutofixAutomationTuningSettings,
+    AutofixStatus,
+    SeerAutomationSource,
+)
 from sentry.seer.autofix.utils import (
     bulk_get_project_preferences,
     bulk_set_project_preferences,
@@ -124,6 +128,9 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
 
     # Set org-level options
     organization.update_option("sentry:enable_seer_coding", True)
+    organization.update_option(
+        "sentry:default_autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+    )
 
     # Invalidate seat-based tier cache so new settings take effect immediately
     cache.delete(get_seer_seat_based_tier_cache_key(organization_id))
@@ -138,7 +145,9 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     for project in projects:
         project.update_option("sentry:seer_scanner_automation", True)
         # New automation default for the new pricing is medium.
-        project.update_option("sentry:autofix_automation_tuning", "medium")
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+        )
 
     preferences_by_id = bulk_get_project_preferences(organization_id, project_ids)
 

--- a/tests/sentry/tasks/test_autofix.py
+++ b/tests/sentry/tasks/test_autofix.py
@@ -152,8 +152,9 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        # Check org-level option
+        # Check org-level options
         assert self.organization.get_option("sentry:enable_seer_coding") is True
+        assert self.organization.get_option("sentry:default_autofix_automation_tuning") == "medium"
 
         # Check project-level options
         assert project1.get_option("sentry:seer_scanner_automation") is True


### PR DESCRIPTION
## PR Details
+ Set the org level default `default_autofix_automation_tuning` in the migration task. Also checking for this in a test. 
+ In other places I am replacing the use of strings for the enum (which is a string) to standardize stuff. No change logically.
