### PR TITLE
feat(seer): Allow users to add more repos in RCA onboarding step

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Flex} from 'sentry/components/core/layout/flex';
 import {Switch} from 'sentry/components/core/switch';
 import {
@@ -13,6 +14,7 @@ import {
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelItem from 'sentry/components/panels/panelItem';
 import Placeholder from 'sentry/components/placeholder';
+import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useProjects from 'sentry/utils/useProjects';
 
@@ -31,7 +33,9 @@ export function ConfigureRootCauseAnalysisStep() {
     repositoryProjectMapping,
     changeRepositoryProjectMapping,
     changeRootCauseAnalysisRepository,
+    addRootCauseAnalysisRepository,
     addRepositoryProjectMappings,
+    repositories,
   } = useSeerOnboardingContext();
 
   const {
@@ -84,6 +88,30 @@ export function ConfigureRootCauseAnalysisStep() {
       changeRepositoryProjectMapping(repoId, index, newValue);
     },
     [changeRepositoryProjectMapping, repositoryProjectMapping]
+  );
+
+  const availableRepositories = useMemo(() => {
+    return (
+      repositories?.filter(
+        repo =>
+          !selectedRootCauseAnalysisRepositories.some(selected => selected.id === repo.id)
+      ) ?? []
+    );
+  }, [repositories, selectedRootCauseAnalysisRepositories]);
+
+  const repositoryOptions = useMemo(() => {
+    return availableRepositories.map(repo => ({
+      value: repo.id,
+      label: repo.name,
+      textValue: repo.name,
+    }));
+  }, [availableRepositories]);
+
+  const handleAddRepository = useCallback(
+    (option: {value: string}) => {
+      addRootCauseAnalysisRepository(option.value);
+    },
+    [addRootCauseAnalysisRepository]
   );
 
   const isFinishDisabled = useMemo(() => {
@@ -139,12 +167,31 @@ export function ConfigureRootCauseAnalysisStep() {
             </Field>
 
             {isProjectsLoaded && !isProjectsFetching ? (
-              <RepositoryToProjectConfiguration
-                isPending={isCodeMappingsLoading}
-                projects={projects}
-                onChange={handleRepositoryProjectMappingsChange}
-                onChangeRepository={changeRootCauseAnalysisRepository}
-              />
+              <Fragment>
+                <RepositoryToProjectConfiguration
+                  isPending={isCodeMappingsLoading}
+                  projects={projects}
+                  onChange={handleRepositoryProjectMappingsChange}
+                  onChangeRepository={changeRootCauseAnalysisRepository}
+                />
+                {availableRepositories.length > 0 && (
+                  <AddRepoRow>
+                    <CompactSelect
+                      size="sm"
+                      searchable
+                      value={undefined}
+                      strategy="fixed"
+                      triggerProps={{
+                        icon: <IconAdd />,
+                        children: t('Add Repository'),
+                      }}
+                      onChange={handleAddRepository}
+                      options={repositoryOptions}
+                      menuTitle={t('Select Repository')}
+                    />
+                  </AddRepoRow>
+                )}
+              </Fragment>
             ) : (
               <Flex direction="column" gap="md" padding="md">
                 {selectedRootCauseAnalysisRepositories.map(repository => (
@@ -188,4 +235,9 @@ const FieldDescription = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
   color: ${p => p.theme.subText};
   line-height: 1.4;
+`;
+
+const AddRepoRow = styled(PanelItem)`
+  align-items: center;
+  justify-content: flex-end;
 `;

--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 import {Flex} from 'sentry/components/core/layout/flex';
 import {Switch} from 'sentry/components/core/switch';
 import {
@@ -108,7 +108,7 @@ export function ConfigureRootCauseAnalysisStep() {
   }, [availableRepositories]);
 
   const handleAddRepository = useCallback(
-    (option: {value: string}) => {
+    (option: SelectOption<string>) => {
       addRootCauseAnalysisRepository(option.value);
     },
     [addRootCauseAnalysisRepository]

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -12,6 +12,7 @@ import {useIntegrationProvider} from './useIntegrationProvider';
 
 interface SeerOnboardingContextProps {
   addRepositoryProjectMappings: (additionalMappings: Record<string, string[]>) => void;
+  addRootCauseAnalysisRepository: (repoId: string) => void;
   changeRepositoryProjectMapping: (
     repoId: string,
     index: number,
@@ -47,6 +48,7 @@ const SeerOnboardingContext = createContext<SeerOnboardingContextProps>({
   changeRootCauseAnalysisRepository: () => {},
   setCodeReviewRepositories: () => {},
   removeRootCauseAnalysisRepository: () => {},
+  addRootCauseAnalysisRepository: () => {},
   addRepositoryProjectMappings: () => {},
 });
 
@@ -153,6 +155,25 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
     [repositoriesMap]
   );
 
+  const addRootCauseAnalysisRepository = useCallback(
+    (repoId: string) => {
+      const repo = repositoriesMap[repoId];
+      if (!repo) {
+        return;
+      }
+
+      // Add repository to the list
+      setRootCauseAnalysisRepositories(prev => [...prev, repo]);
+
+      // Initialize empty project mapping
+      setRepositoryProjectMapping(prev => ({
+        ...prev,
+        [repoId]: [],
+      }));
+    },
+    [repositoriesMap]
+  );
+
   const addRepositoryProjectMappings = useCallback(
     (additionalMappings: Record<string, string[]>) => {
       setRepositoryProjectMapping(prev => {
@@ -161,8 +182,8 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
           ...Object.fromEntries(
             Object.entries(additionalMappings)
               .map(([repoId, projects]) => {
-                // Don't overwrite existing mappings
-                if (prev[repoId]) {
+                // Don't overwrite existing mappings that have projects
+                if (prev[repoId] && prev[repoId].length > 0) {
                   return null;
                 }
                 return [repoId, projects];
@@ -226,6 +247,7 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
         selectedRootCauseAnalysisRepositories,
         removeRootCauseAnalysisRepository,
         changeRootCauseAnalysisRepository,
+        addRootCauseAnalysisRepository,
         repositoryProjectMapping,
         addRepositoryProjectMappings,
         changeRepositoryProjectMapping,

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -1,4 +1,5 @@
 import {createContext, useCallback, useContext, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {useOrganizationRepositories} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import type {
@@ -159,6 +160,10 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
     (repoId: string) => {
       const repo = repositoriesMap[repoId];
       if (!repo) {
+        Sentry.logger.warn(
+          'SeerOnboarding: Repository not found when adding new repository',
+          {repoId}
+        );
         return;
       }
 


### PR DESCRIPTION
This allows the user to add a repository when they are on the RCA onboarding step. The repos selected in Code Review step may not always be the same as RCA.
