### PR TITLE
fix: Remove `open` prop of `SlideOverPanel`

### DIFF
--- a/static/app/components/core/slideOverPanel/slideOverPanel.mdx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.mdx
@@ -28,17 +28,18 @@ The `SlideOverPanel` component is a panel that can appear on the right, left, or
 ## Basic Usage
 
 ```jsx
-<Button onClick={() => setIsPanelOpen(true)}>Open Panel</Button>
+<Button onClick={() => setIsPanelOpen(true)}>Open Panel</Button>;
 
-<SlideOverPanel open={isPanelOpen} position="right">
-  <Container border="primary" height="100%" padding="md">
-    <Button onClick={() => setIsPanelOpen(false)}>Close Panel</Button>
-  </Container>
-</SlideOverPanel>
+{
+  isPanelOpen && (
+    <SlideOverPanel position="right">
+      <Container border="primary" height="100%" padding="md">
+        <Button onClick={() => setIsPanelOpen(false)}>Close Panel</Button>
+      </Container>
+    </SlideOverPanel>
+  );
+}
 ```
-
-> [!NOTE]
-> It's also possible to conditionally render the panel (e.g., `{isPanelOpen && <SlideOverPanel ...`). We do not recommend this approach. If you do this, the panel will not defer rendering its contents (see below).
 
 ## Skeleton UI
 
@@ -59,15 +60,37 @@ To enable a loading skeleton, pass a render prop as the children to `SlideOverPa
 ```jsx
 <Button onClick={() => setIsPanelOpen(true)}>Open Panel</Button>
 
-<SlideOverPanel open={isPanelOpen} ePosition="right">
-  {({isOpening}) => isOpening ? <Placeholder /> :
-  <Container border="primary" height="100%" padding="md">
-    <Button onClick={() => setIsPanelOpen(false)}>Close Panel</Button>
-  </Container>
-}
-</SlideOverPanel>
+{isPanelOpen && (
+  <SlideOverPanel position="right">
+    {(options: {isOpening: boolean}) => {
+      return options.isOpening ? (
+        <SkeletonPanelContents onClick={closePanel} />
+      ) : (
+        <PanelContents onClick={closePanel} />
+      );
+    }}
+  </SlideOverPanel>
+)}
 ```
 
 ## Animating Panel Close
 
 Generally, we recommend not animating the panel on close, and simply removing it from the UI. In cases where you need to animate closing it (e.g., if it's coordinated with another animation), please wrap the panel in `<AnimatePresence>`.
+
+```jsx
+<Button onClick={() => setIsPanelOpen(true)}>Open Panel</Button>
+
+<AnimatePresence>
+  {isPanelOpen && (
+    <SlideOverPanel position="right">
+      {(options: {isOpening: boolean}) => {
+        return options.isOpening ? (
+          <SkeletonPanelContents onClick={closePanel} />
+        ) : (
+          <PanelContents onClick={closePanel} />
+        );
+      }}
+    </SlideOverPanel>
+  )}
+</AnimatePresence>
+```

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useEffectEvent, useState, useTransition} from 'react';
+import {useCallback, useEffect, useState, useTransition} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -33,10 +33,6 @@ type SlideOverPanelProps = {
   ariaLabel?: string;
   className?: string;
   'data-test-id'?: string;
-  /**
-   * Callback that fires every time the panel opens.
-   */
-  onOpen?: () => void;
   panelWidth?: string;
   position?: 'right' | 'bottom' | 'left';
   ref?: React.Ref<HTMLDivElement>;
@@ -51,7 +47,6 @@ export function SlideOverPanel({
   ariaLabel,
   children,
   className,
-  onOpen,
   position,
   transitionProps = {},
   panelWidth,
@@ -84,19 +79,6 @@ export function SlideOverPanel({
     startTransition(() => {
       setIsContentVisible(true);
     });
-  }, []);
-
-  // We do not want to re-run `onOpen` if it changes, we just want to run
-  // `onOpen` when the panel mounts, whatever `onOpen` happens to be at that
-  // moment. Wrap in effect event.
-  const handleOpen = useEffectEvent(() => {
-    onOpen?.();
-  });
-
-  // TODO: The `onOpen` props is not currently in use. It might be safe to
-  // remove this prop.
-  useEffect(() => {
-    handleOpen();
   }, []);
 
   // Create a fallback render function, in case the parent component passes

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState, useTransition} from 'react';
+import {useEffect, useState, useTransition} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -81,16 +81,6 @@ export function SlideOverPanel({
     });
   }, []);
 
-  // Create a fallback render function, in case the parent component passes
-  // `React.ReactNode` as `children`. This way, even if they don't pass a render
-  // prop they still get the benefit of fast panel opening.
-  const fallbackRenderFunction = useCallback<ChildRenderFunction>(
-    ({isOpening}: ChildRenderProps) => {
-      return isOpening ? null : (children as React.ReactNode); // This function should only ever run for `React.ReactNode`, its whole purpose is to create a render function for `React.ReactNode`
-    },
-    [children]
-  );
-
   const renderFunctionProps: ChildRenderProps = {
     isOpening: isTransitioning || !isContentVisible,
   };
@@ -119,11 +109,13 @@ export function SlideOverPanel({
     >
       {/* Render the child content. If it's a render prop, pass the `isOpening`
       prop. We expect the render prop to render a skeleton UI if `isOpening` is
-      true. Otherwise, pass `isOpening` to the fallback render prop, which shows
-      nothing while opening. */}
+      true. If `children` is not a render prop, render nothing while
+      transitioning. */}
       {typeof children === 'function'
         ? children(renderFunctionProps)
-        : fallbackRenderFunction(renderFunctionProps)}
+        : renderFunctionProps.isOpening
+          ? null
+          : children}
     </_SlideOverPanel>
   );
 }

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -75,7 +75,6 @@ function DrawerPanel({
         <DrawerSlidePanel
           ariaLabel={ariaLabel}
           position="right"
-          open
           ref={mergeRefs(panelRef, ref)}
           transitionProps={transitionProps}
           panelWidth="var(--drawer-width)" // Initial width only

--- a/static/app/stories/playground/slideOverPanel.tsx
+++ b/static/app/stories/playground/slideOverPanel.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback, useState, type ComponentProps} from 'react';
+import {AnimatePresence} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -14,11 +15,13 @@ export function SlideOverPanelPlayground() {
     <Fragment>
       <Button onClick={() => setIsPanelOpen(true)}>Open Panel</Button>
 
-      <SlideOverPanel open={isPanelOpen} position="right">
-        <Container border="primary" height="100%" padding="md">
-          <Button onClick={() => setIsPanelOpen(false)}>Close Panel</Button>
-        </Container>
-      </SlideOverPanel>
+      {isPanelOpen && (
+        <SlideOverPanel position="right">
+          <Container border="primary" height="100%" padding="md">
+            <Button onClick={() => setIsPanelOpen(false)}>Close Panel</Button>
+          </Container>
+        </SlideOverPanel>
+      )}
     </Fragment>
   );
 }
@@ -34,15 +37,19 @@ export function SlideOverPanelSkeletonPlayground() {
     <Fragment>
       <Button onClick={() => setIsPanelOpen(true)}>Open Panel</Button>
 
-      <SlideOverPanel open={isPanelOpen} position="right">
-        {(options: {isOpening: boolean}) => {
-          return options.isOpening ? (
-            <SkeletonPanelContents onClick={closePanel} />
-          ) : (
-            <PanelContents onClick={closePanel} />
-          );
-        }}
-      </SlideOverPanel>
+      <AnimatePresence>
+        {isPanelOpen && (
+          <SlideOverPanel position="right">
+            {(options: {isOpening: boolean}) => {
+              return options.isOpening ? (
+                <SkeletonPanelContents onClick={closePanel} />
+              ) : (
+                <PanelContents onClick={closePanel} />
+              );
+            }}
+          </SlideOverPanel>
+        )}
+      </AnimatePresence>
     </Fragment>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -209,7 +209,6 @@ function WidgetBuilderSlideout({
 
   return (
     <SlideOverPanel
-      open
       position="left"
       data-test-id="widget-slideout"
       transitionProps={animationTransitionSettings}

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -93,68 +93,67 @@ export function AppSizeInsightsSidebar({
             onClick={onClose}
           />
         )}
-        {isOpen && (
-          <SlideOverPanel
-            position="right"
-            panelWidth={`${constrainedWidth}px`}
-            ariaLabel={t('App size insights details')}
-          >
-            <Flex height="100%" direction="column">
-              <Header padding="xl" align="center" justify="between">
-                <Flex align="center" gap="sm">
-                  <Heading as="h2" size="xl">
-                    {t('Insights')}
-                  </Heading>
-                  <PageHeadingQuestionTooltip
-                    docsUrl={getInsightsDocsUrl(platform)}
-                    title={t(
-                      'Insights help you identify opportunities to reduce your app size.'
-                    )}
-                  />
-                </Flex>
-                <Button
-                  size="sm"
-                  icon={<IconClose />}
-                  aria-label={t('Close sidebar')}
-                  onClick={onClose}
+      </AnimatePresence>
+      {isOpen && (
+        <SlideOverPanel
+          position="right"
+          panelWidth={`${constrainedWidth}px`}
+          ariaLabel={t('App size insights details')}
+        >
+          <Flex height="100%" direction="column">
+            <Header padding="xl" align="center" justify="between">
+              <Flex align="center" gap="sm">
+                <Heading as="h2" size="xl">
+                  {t('Insights')}
+                </Heading>
+                <PageHeadingQuestionTooltip
+                  docsUrl={getInsightsDocsUrl(platform)}
+                  title={t(
+                    'Insights help you identify opportunities to reduce your app size.'
+                  )}
                 />
-              </Header>
+              </Flex>
+              <Button
+                size="sm"
+                icon={<IconClose />}
+                aria-label={t('Close sidebar')}
+                onClick={onClose}
+              />
+            </Header>
 
-              <Flex flex={1} position="relative" overflow="hidden">
-                <ResizeHandle
-                  onMouseDown={onMouseDown}
-                  onDoubleClick={onDoubleClick}
-                  data-is-held={isHeld}
-                  data-slide-direction="leftright"
-                >
-                  <IconGrabbable size="sm" />
-                </ResizeHandle>
+            <Flex flex={1} position="relative" overflow="hidden">
+              <ResizeHandle
+                onMouseDown={onMouseDown}
+                onDoubleClick={onDoubleClick}
+                data-is-held={isHeld}
+                data-slide-direction="leftright"
+              >
+                <IconGrabbable size="sm" />
+              </ResizeHandle>
 
-                <Flex flex={1} overflowY="auto" padding="xl">
-                  <Flex direction="column" gap="xl" width="100%">
-                    {processedInsights.map(insight => {
-                      const isGroupedInsight =
-                        insight.key === 'duplicate_files' ||
-                        insight.key === 'loose_images';
-                      return (
-                        <AppSizeInsightsSidebarRow
-                          key={insight.key}
-                          insight={insight}
-                          isExpanded={expandedInsights.has(insight.key)}
-                          onToggleExpanded={() => toggleExpanded(insight.key)}
-                          platform={platform}
-                          projectType={projectType}
-                          itemsPerPage={isGroupedInsight ? 10 : undefined}
-                        />
-                      );
-                    })}
-                  </Flex>
+              <Flex flex={1} overflowY="auto" padding="xl">
+                <Flex direction="column" gap="xl" width="100%">
+                  {processedInsights.map(insight => {
+                    const isGroupedInsight =
+                      insight.key === 'duplicate_files' || insight.key === 'loose_images';
+                    return (
+                      <AppSizeInsightsSidebarRow
+                        key={insight.key}
+                        insight={insight}
+                        isExpanded={expandedInsights.has(insight.key)}
+                        onToggleExpanded={() => toggleExpanded(insight.key)}
+                        platform={platform}
+                        projectType={projectType}
+                        itemsPerPage={isGroupedInsight ? 10 : undefined}
+                      />
+                    );
+                  })}
                 </Flex>
               </Flex>
             </Flex>
-          </SlideOverPanel>
-        )}
-      </AnimatePresence>
+          </Flex>
+        </SlideOverPanel>
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -93,66 +93,68 @@ export function AppSizeInsightsSidebar({
             onClick={onClose}
           />
         )}
-      </AnimatePresence>
-      <SlideOverPanel
-        open={isOpen}
-        position="right"
-        panelWidth={`${constrainedWidth}px`}
-        ariaLabel={t('App size insights details')}
-      >
-        <Flex height="100%" direction="column">
-          <Header padding="xl" align="center" justify="between">
-            <Flex align="center" gap="sm">
-              <Heading as="h2" size="xl">
-                {t('Insights')}
-              </Heading>
-              <PageHeadingQuestionTooltip
-                docsUrl={getInsightsDocsUrl(platform)}
-                title={t(
-                  'Insights help you identify opportunities to reduce your app size.'
-                )}
-              />
-            </Flex>
-            <Button
-              size="sm"
-              icon={<IconClose />}
-              aria-label={t('Close sidebar')}
-              onClick={onClose}
-            />
-          </Header>
+        {isOpen && (
+          <SlideOverPanel
+            position="right"
+            panelWidth={`${constrainedWidth}px`}
+            ariaLabel={t('App size insights details')}
+          >
+            <Flex height="100%" direction="column">
+              <Header padding="xl" align="center" justify="between">
+                <Flex align="center" gap="sm">
+                  <Heading as="h2" size="xl">
+                    {t('Insights')}
+                  </Heading>
+                  <PageHeadingQuestionTooltip
+                    docsUrl={getInsightsDocsUrl(platform)}
+                    title={t(
+                      'Insights help you identify opportunities to reduce your app size.'
+                    )}
+                  />
+                </Flex>
+                <Button
+                  size="sm"
+                  icon={<IconClose />}
+                  aria-label={t('Close sidebar')}
+                  onClick={onClose}
+                />
+              </Header>
 
-          <Flex flex={1} position="relative" overflow="hidden">
-            <ResizeHandle
-              onMouseDown={onMouseDown}
-              onDoubleClick={onDoubleClick}
-              data-is-held={isHeld}
-              data-slide-direction="leftright"
-            >
-              <IconGrabbable size="sm" />
-            </ResizeHandle>
+              <Flex flex={1} position="relative" overflow="hidden">
+                <ResizeHandle
+                  onMouseDown={onMouseDown}
+                  onDoubleClick={onDoubleClick}
+                  data-is-held={isHeld}
+                  data-slide-direction="leftright"
+                >
+                  <IconGrabbable size="sm" />
+                </ResizeHandle>
 
-            <Flex flex={1} overflowY="auto" padding="xl">
-              <Flex direction="column" gap="xl" width="100%">
-                {processedInsights.map(insight => {
-                  const isGroupedInsight =
-                    insight.key === 'duplicate_files' || insight.key === 'loose_images';
-                  return (
-                    <AppSizeInsightsSidebarRow
-                      key={insight.key}
-                      insight={insight}
-                      isExpanded={expandedInsights.has(insight.key)}
-                      onToggleExpanded={() => toggleExpanded(insight.key)}
-                      platform={platform}
-                      projectType={projectType}
-                      itemsPerPage={isGroupedInsight ? 10 : undefined}
-                    />
-                  );
-                })}
+                <Flex flex={1} overflowY="auto" padding="xl">
+                  <Flex direction="column" gap="xl" width="100%">
+                    {processedInsights.map(insight => {
+                      const isGroupedInsight =
+                        insight.key === 'duplicate_files' ||
+                        insight.key === 'loose_images';
+                      return (
+                        <AppSizeInsightsSidebarRow
+                          key={insight.key}
+                          insight={insight}
+                          isExpanded={expandedInsights.has(insight.key)}
+                          onToggleExpanded={() => toggleExpanded(insight.key)}
+                          platform={platform}
+                          projectType={projectType}
+                          itemsPerPage={isGroupedInsight ? 10 : undefined}
+                        />
+                      );
+                    })}
+                  </Flex>
+                </Flex>
               </Flex>
             </Flex>
-          </Flex>
-        </Flex>
-      </SlideOverPanel>
+          </SlideOverPanel>
+        )}
+      </AnimatePresence>
     </Fragment>
   );
 }


### PR DESCRIPTION
Right now, `SlideOverPanel` can be opened/closed by passing `<SlideOverPanel open={isPanelOpen}` or by conditionally rendering it with `isPanelOpen && <SlideOverPanel`. This is problematic because when there are two ways to open/close something, it means there are multiple ways we need to account for when thinking about animations and deferring rendering the contents.

This PR removes the `open` prop. `SlideOverPanel` now _must_ be rendered conditionally with `&&` in JSX. This required an update to how the contents are deferred on mount, but otherwise behaviour is preserved.

I was pushed towards the `isOpen &&` API due to a practical problem in Dashboards, but I also think it's a reasonable choice overall.

## Rationale

Consider:

```
<Container>
  <SlideOverPanel ...
  <PreviewWidget /...
</Container>
```

Imagine that the container has a panel, and a preview which both take up half the screen and slide in from opposite sides. The container takes up the full screen, and is shown over some background content. It's offset against the main sidebar.

- the container _must_ exist to account for the sidebar, and to correctly split space between the panel and preview
- the container must take up the whole screen, which means it prevents clicks on content underneath
- I need to hide/show the container, panel, preview when users click on buttons in the UI
- the panel and preview both have a slight animation to make it less jarring when they open-close

```
+-------------------------+
| +---------++---------+  |
| |         ||         |  |
| |         ||         |  |
| | Panel   || Preview |  |
| |         ||         |  |
| |         ||         |  |
| |         ||         |  |
| +---------++---------+  |
|                         |
|  Container              |
|                         |
+-------------------------+
```

There are two major problems.

1. How should I go about hiding/showing the container? The container blocks the content underneath. When the panel and the preview close, how do I hide the container? I could either make it "invisible" by turning off opacity and pointer events, or use `display: none`. The former is messy, and error prone. It's easy to accidentally leave this in, and cause issues with clicks. The latter is difficult, how do I coordinate setting `display: none` vs. the panel and preview when they slide? This is the case in the Widget Builder.
2. What if I need to remount the `Container` for some reason? e.g., the container might have some kind of context, or something else that needs to be remounted or re-rendered that might cause a re-mount of the panel. In that case, deferring the content of the panel won't work, since it's relying on the `open` prop state _changing_, but on initial mount there is no change. This is also the case in the Widget Builder. It's not possible to have a deferral mechanism that works both on mount and on prop change!

If the API is `isOpen &&` these problems are solved. I can just mount/unmount the entire tree, and everything works as expected. Since there is only one way to show/hide the panel, I can use one deferral method, and I don't need explanations in the doc for how to handle animations and deferral.

In short, controlling mounting/unmounting is a lot easier than controlling an `open` prop because I don't have to worry about keeping surrounding components in the DOM just to make animations and deferred rendering work.
