### PR TITLE
feat(trace-waterfall): Add warning for old traces

### DIFF
--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -79,6 +79,7 @@ export function getExploreUrl({
   referrer?: string;
   selection?: PageFilters;
   sort?: string;
+  table?: string;
   title?: string;
   visualize?: BaseVisualize[];
 }) {

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -65,6 +65,7 @@ export function getExploreUrl({
   sort,
   field,
   id,
+  table,
   title,
   referrer,
 }: {
@@ -101,6 +102,7 @@ export function getExploreUrl({
     field,
     utc,
     id,
+    table,
     title,
     referrer,
   };

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceOurlogs';
 import {TraceSummarySection} from 'sentry/views/performance/newTraceDetails/traceSummary';
 import {TraceTabsAndVitals} from 'sentry/views/performance/newTraceDetails/traceTabsAndVitals';
+import {PartialTraceDataWarning} from 'sentry/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning';
 import {TraceWaterfall} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
 import {
   TraceLayoutTabKeys,
@@ -164,6 +165,11 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
               tree={tree}
               traceSlug={traceSlug}
               organization={organization}
+            />
+            <PartialTraceDataWarning
+              timestamp={queryParams.timestamp}
+              logs={logsData}
+              tree={tree}
             />
             <TraceTabsAndVitals
               tabsConfig={{

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -28,7 +28,7 @@ interface TitleProps {
   rootEventResults: TraceRootEventQueryResults;
 }
 
-export function getTitle(representativeEvent: RepresentativeTraceEvent): {
+function getTitle(representativeEvent: RepresentativeTraceEvent): {
   subtitle: string | undefined;
   title: string;
 } | null {

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -28,7 +28,7 @@ interface TitleProps {
   rootEventResults: TraceRootEventQueryResults;
 }
 
-function getTitle(representativeEvent: RepresentativeTraceEvent): {
+export function getTitle(representativeEvent: RepresentativeTraceEvent): {
   subtitle: string | undefined;
   title: string;
 } | null {

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
@@ -54,11 +54,14 @@ describe('PartialTraceDataWarning', () => {
         screen.getByRole('link', {name: 'Search similar traces in the past 24 hours'})
       ).toBeInTheDocument();
 
+      const queryString = encodeURIComponent(
+        'is_transaction:true project.id:1 span.op:http.server'
+      );
       expect(
         screen.getByRole('link', {name: 'Search similar traces in the past 24 hours'})
       ).toHaveAttribute(
         'href',
-        `/organizations/${organization.slug}/explore/traces/?mode=samples&query=${encodeURIComponent('is_transaction:true span.op:http.server')}&statsPeriod=24h`
+        `/organizations/${organization.slug}/explore/traces/?mode=samples&query=${queryString}&statsPeriod=24h&table=trace`
       );
     });
   });

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
@@ -58,7 +58,7 @@ describe('PartialTraceDataWarning', () => {
         screen.getByRole('link', {name: 'Search similar traces in the past 24 hours'})
       ).toHaveAttribute(
         'href',
-        '/explore/traces/?mode=samples&table=trace&statsPeriod=24h&query=is_transaction:true span.op:http.server'
+        `/organizations/${organization.slug}/explore/traces/?mode=samples&query=${encodeURIComponent('is_transaction:true span.op:http.server')}&statsPeriod=24h`
       );
     });
   });

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
@@ -1,0 +1,110 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {
+  makeEAPSpan,
+  makeEAPTrace,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+import {PartialTraceDataWarning} from './partialTraceDataWarning';
+
+describe('PartialTraceDataWarning', () => {
+  describe('when the trace is older than 30 days', () => {
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2025, 0, 31));
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it('should render warning', () => {
+      const organization = OrganizationFixture();
+      const start = new Date('2024-01-01T00:00:00Z').getTime() / 1e3;
+
+      const eapTrace = makeEAPTrace([
+        makeEAPSpan({
+          op: 'http.server',
+          start_timestamp: start,
+          end_timestamp: start + 2,
+          children: [makeEAPSpan({start_timestamp: start + 1, end_timestamp: start + 4})],
+        }),
+      ]);
+
+      render(
+        <PartialTraceDataWarning
+          logs={[]}
+          timestamp={start}
+          tree={TraceTree.FromTrace(eapTrace, {replay: null, meta: null, organization})}
+        />,
+        {organization}
+      );
+
+      expect(screen.getByText('Partial Trace Data:')).toBeInTheDocument();
+
+      expect(
+        screen.getByText(
+          'Trace may be missing spans since the age of the trace is older than 30 days'
+        )
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', {name: 'Search similar traces in the past 24 hours'})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', {name: 'Search similar traces in the past 24 hours'})
+      ).toHaveAttribute(
+        'href',
+        '/explore/traces/?mode=samples&table=trace&statsPeriod=24h&query=is_transaction:true span.op:http.server'
+      );
+    });
+  });
+
+  describe('when the trace is younger than 30 days', () => {
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2025, 0, 1));
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it('should not render the warning', () => {
+      const organization = OrganizationFixture();
+      const start = new Date('2025-01-01T00:00:00Z').getTime() / 1e3;
+
+      const eapTrace = makeEAPTrace([
+        makeEAPSpan({
+          op: 'http.server',
+          start_timestamp: start,
+          end_timestamp: start + 2,
+          children: [makeEAPSpan({start_timestamp: start + 1, end_timestamp: start + 4})],
+        }),
+      ]);
+
+      render(
+        <PartialTraceDataWarning
+          logs={[]}
+          timestamp={start}
+          tree={TraceTree.FromTrace(eapTrace, {replay: null, meta: null, organization})}
+        />,
+        {organization}
+      );
+
+      expect(screen.queryByText('Partial Trace Data:')).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByText(
+          'Trace may be missing spans since the age of the trace is older than 30 days'
+        )
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('link', {name: 'Search similar traces in the past 24 hours'})
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.spec.tsx
@@ -54,14 +54,12 @@ describe('PartialTraceDataWarning', () => {
         screen.getByRole('link', {name: 'Search similar traces in the past 24 hours'})
       ).toBeInTheDocument();
 
-      const queryString = encodeURIComponent(
-        'is_transaction:true project.id:1 span.op:http.server'
-      );
+      const queryString = encodeURIComponent('is_transaction:true span.op:http.server');
       expect(
         screen.getByRole('link', {name: 'Search similar traces in the past 24 hours'})
       ).toHaveAttribute(
         'href',
-        `/organizations/${organization.slug}/explore/traces/?mode=samples&query=${queryString}&statsPeriod=24h&table=trace`
+        `/organizations/${organization.slug}/explore/traces/?mode=samples&project=1&query=${queryString}&statsPeriod=24h&table=trace`
       );
     });
   });

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.tsx
@@ -1,0 +1,67 @@
+import {useMemo} from 'react';
+import moment from 'moment-timezone';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tct} from 'sentry/locale';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import {getRepresentativeTraceEvent} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
+import {getTitle} from 'sentry/views/performance/newTraceDetails/traceHeader/title';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+interface PartialTraceDataWarningProps {
+  logs: OurLogsResponseItem[] | undefined;
+  timestamp: number | undefined;
+  tree: TraceTree;
+}
+
+export function PartialTraceDataWarning({
+  logs,
+  timestamp,
+  tree,
+}: PartialTraceDataWarningProps) {
+  const rep = getRepresentativeTraceEvent(tree, logs);
+  const traceTitle = getTitle(rep);
+
+  const queryString = useMemo(() => {
+    const search = new MutableSearch('');
+    search.addFilterValue('is_transaction', 'true');
+    search.addFilterValue('span.op', traceTitle?.title ?? '');
+    return search.formatString();
+  }, [traceTitle?.title]);
+
+  if (!timestamp) {
+    return null;
+  }
+
+  const now = moment();
+  const isTraceTooYoung = moment(timestamp * 1000).isAfter(now.subtract(30, 'days'));
+
+  if (isTraceTooYoung) {
+    return null;
+  }
+
+  const exploreUrl = `/explore/traces/?mode=${Mode.SAMPLES}&table=trace&statsPeriod=24h&query=${queryString}`;
+
+  return (
+    <Alert
+      type="warning"
+      trailingItems={
+        <Link to={exploreUrl}>{t('Search similar traces in the past 24 hours')}</Link>
+      }
+    >
+      <Text as="p">
+        {tct(
+          '[dataCategory] Trace may be missing spans since the age of the trace is older than 30 days',
+          {
+            dataCategory: <Text bold>{t('Partial Trace Data:')}</Text>,
+          }
+        )}
+      </Text>
+    </Alert>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/partialTraceDataWarning.tsx
@@ -45,17 +45,12 @@ export function PartialTraceDataWarning({
     const search = new MutableSearch('');
     search.addFilterValue('is_transaction', 'true');
 
-    const projectId = rep.event?.project_id;
-    if (projectId) {
-      search.addFilterValue('project.id', `${projectId}`);
-    }
-
     if (op) {
       search.addFilterValue('span.op', op);
     }
 
     return search.formatString();
-  }, [op, rep.event?.project_id]);
+  }, [op]);
 
   if (!timestamp) {
     return null;
@@ -68,6 +63,9 @@ export function PartialTraceDataWarning({
     return null;
   }
 
+  const projects =
+    typeof rep.event?.project_id === 'number' ? [rep.event?.project_id] : [];
+
   const exploreUrl = getExploreUrl({
     organization,
     mode: Mode.SAMPLES,
@@ -75,6 +73,7 @@ export function PartialTraceDataWarning({
     table: 'trace',
     selection: {
       ...selection,
+      projects,
       datetime: {
         start: null,
         end: null,


### PR DESCRIPTION
This PR adds in a warning alert to the trace detail page for when traces are older than 30 days. It also includes a link to the Explore -> Traces page, with pre-populated search filters so users can find up to date traces.

Ticket: EXP-645

Example:

<img width="1225" height="112" alt="Screenshot 2025-12-09 at 16 40 08" src="https://github.com/user-attachments/assets/49058efa-6e49-4467-9b9b-4aa1f563d548" />