### PR TITLE
theme: remove diffSliderDragHandleHover

### DIFF
--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -206,7 +206,7 @@ const DragHandle = styled('div')`
   &:hover,
   &:active {
     &::after {
-      background: ${p => p.theme.diffSliderDragHandleHover};
+      background: ${p => p.theme.colors.blue500};
     }
   }
 
@@ -219,7 +219,7 @@ const DragHandle = styled('div')`
   }
 
   &[data-resizing]::after {
-    background: ${p => p.theme.diffSliderDragHandleHover};
+    background: ${p => p.theme.colors.blue500};
   }
 `;
 

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1479,11 +1479,6 @@ const generateAliases = (
   chartOther: tokens.content.muted,
 
   /**
-   * Hover color of the drag handle used in the content slider diff view.
-   */
-  diffSliderDragHandleHover: colors.blue500,
-
-  /**
    * Default Progressbar color
    */
   progressBar: colors.chonk.blue400,


### PR DESCRIPTION
Does not need to exist on theme, and will be converted to a token in the future.