### PR TITLE
fix(ACI): Correctly read target_type and target_identifier values from Action.config

### DIFF
--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -55,6 +55,7 @@ class NotifyEmailAction(EventAction):
         fallthrough_choice = self.data.get("fallthrough_type", None) or self.data.get(
             "fallthroughType", None
         )
+
         fallthrough_type = (
             FallthroughChoiceType(fallthrough_choice)
             if fallthrough_choice

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -47,12 +47,11 @@ class NotifyEmailAction(EventAction):
             "group_id": group.id,
             "notification_uuid": notification_uuid,
         }
+        # XXX: temporarily support both types, after ACI GA we should only need to support snake case
         target_type_value = self.data.get("target_type") or self.data.get("targetType")
         target_type = ActionTargetType(target_type_value)
         target_identifier = self.data.get("target_identifier") or self.data.get("targetIdentifier")
         skip_digests = self.data.get("skip_digests", False) or self.data.get("skipDigests", False)
-
-        # XXX: temporarily support both types, but after GA we should only need to support fallthrough_type
         fallthrough_choice = self.data.get("fallthrough_type") or self.data.get("fallthroughType")
 
         fallthrough_type = (

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -47,14 +47,13 @@ class NotifyEmailAction(EventAction):
             "group_id": group.id,
             "notification_uuid": notification_uuid,
         }
-        target_type = ActionTargetType(self.data["targetType"])
-        target_identifier = self.data.get("targetIdentifier", None)
-        skip_digests = self.data.get("skipDigests", False)
+        target_type_value = self.data.get("target_type") or self.data.get("targetType")
+        target_type = ActionTargetType(target_type_value)
+        target_identifier = self.data.get("target_identifier") or self.data.get("targetIdentifier")
+        skip_digests = self.data.get("skip_digests", False) or self.data.get("skipDigests", False)
 
         # XXX: temporarily support both types, but after GA we should only need to support fallthrough_type
-        fallthrough_choice = self.data.get("fallthrough_type", None) or self.data.get(
-            "fallthroughType", None
-        )
+        fallthrough_choice = self.data.get("fallthrough_type") or self.data.get("fallthroughType")
 
         fallthrough_type = (
             FallthroughChoiceType(fallthrough_choice)

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -51,7 +51,7 @@ class NotifyEmailAction(EventAction):
         target_type_value = self.data.get("target_type") or self.data.get("targetType")
         target_type = ActionTargetType(target_type_value)
         target_identifier = self.data.get("target_identifier") or self.data.get("targetIdentifier")
-        skip_digests = self.data.get("skip_digests", False) or self.data.get("skipDigests", False)
+        skip_digests = self.data.get("skipDigests", False)
         fallthrough_choice = self.data.get("fallthrough_type") or self.data.get("fallthroughType")
 
         fallthrough_type = (

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -17,6 +17,7 @@ from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 from sentry.workflow_engine.typings.notification_action import (
     ActionTarget,
     ActionTargetType,
@@ -163,17 +164,13 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
             "target_display": None,
             "target_identifier": None,
         }
-        # XXX: some tests fail without this
-        self.issue_alert_rule = Rule.objects.create(
-            label="test rule",
+        self.issue_stream_detector = self.create_detector(
             project=self.project,
-            owner_team_id=self.team.id,
-        )
-        self.create_alert_rule_workflow(
-            workflow=self.error_workflow, rule_id=self.issue_alert_rule.id
+            type=IssueStreamGroupType.slug,
         )
 
     @with_feature("organizations:workflow-engine-single-process-workflows")
+    @with_feature("organizations:workflow-engine-ui-links")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
     def test_full_integration(self) -> None:
         action_config = {
@@ -200,6 +197,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
         assert sent.to == [self.user.email]
         assert "uh oh" in sent.subject
 
+    @with_feature("organizations:workflow-engine-ui-links")
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
     def test_full_integration_all_members_fallthrough(self) -> None:
@@ -225,6 +223,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
         assert sent.to == [self.user.email]
         assert "uh oh" in sent.subject
 
+    @with_feature("organizations:workflow-engine-ui-links")
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
     def test_full_integration_noone_fallthrough(self) -> None:
@@ -247,6 +246,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
 
         assert len(mail.outbox) == 0
 
+    @with_feature("organizations:workflow-engine-ui-links")
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
     def test_full_integration_fallthrough_not_provided(self) -> None:
@@ -270,6 +270,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
         assert sent.to == [self.user.email]
         assert "uh oh" in sent.subject
 
+    @with_feature("organizations:workflow-engine-ui-links")
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
     def test_hack_mail_workflow(self) -> None:

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -163,7 +163,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
             "target_display": None,
             "target_identifier": None,
         }
-        # XXX: tests fail without this
+        # XXX: some tests fail without this
         self.issue_alert_rule = Rule.objects.create(
             label="test rule",
             project=self.project,
@@ -250,10 +250,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
     def test_full_integration_fallthrough_not_provided(self) -> None:
-        action_data = {}
-        action = self.create_action(
-            config=self.issue_owners_action_config, type="email", data=action_data
-        )
+        action = self.create_action(config=self.issue_owners_action_config, type="email", data={})
         self.create_data_condition_group_action(condition_group=self.condition_group, action=action)
 
         with self.tasks():


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/104613 to properly read `target_type` and `target_identifier` from `Action` models' `config` field - we store them in snake case, not camel case. For now we need to support both as we are still processing some rules through the old system.