### PR TITLE
fix(tracemetrics): Make scroll-to-top appear earlier

### DIFF
--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -532,7 +532,9 @@ export function LogsInfiniteTable({
         {!embeddedOptions?.replay && (
           <BackToTopButton
             virtualizer={virtualizer}
-            hidden={isPending || (firstItemIndex ?? 0) === 0}
+            hidden={
+              isPending || ((firstItemIndex ?? 0) === 0 && (scrollOffset ?? 0) < 550)
+            }
             setIsFunctionScrolling={setIsFunctionScrolling}
           />
         )}


### PR DESCRIPTION
This will cause the scroll to top button appear is you are >1 virtual page or >550px away from the top of page, which should be approximately when you can no longer see the chart or header.
