### PR TITLE
chore(infra): Fix WorkflowEventContext test pollution

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -418,7 +418,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch("sentry.workflow_engine.processors.workflow.logger")
     def test_logs_triggered_workflows(self, mock_logger: MagicMock) -> None:
-        WorkflowEventContext.set(
+        ctx_token = WorkflowEventContext.set(
             WorkflowEventContextData(
                 detector=self.detector,
             )
@@ -434,6 +434,8 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
                 "group_type": self.event_data.group.type,
             },
         )
+
+        WorkflowEventContext.reset(ctx_token)
 
     def test_workflow_trigger__no_conditions(self) -> None:
         assert self.workflow.when_condition_group


### PR DESCRIPTION
Investigating test results that cause `shuffle-tests` to fail uncovered `test_resetting_context` as the #1 offending test failure when tests are shuffled. After some investigation, it was clear one test in particular was not resetting the `WorkflowEventContext` after running.

<img width="1300" height="680" alt="Screenshot 2025-12-09 at 2 29 07 PM" src="https://github.com/user-attachments/assets/86a1fb24-99c3-43ce-af64-c4616bdf77ed" />


I could then consistently reproduce the failure with 
```
pytest tests/sentry/workflow_engine/processors/test_workflow.py tests/sentry/workflow_engine/processors/contexts/test_workflow_event_context.py
```

This now consistently passes when the reset is added to the `test_logs_triggered_workflows` test.