### PR TITLE
fix(np): Remove frozen dataclass due to task/dict behavior

### DIFF
--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -42,10 +42,6 @@ class NotificationService[T: NotificationData]:
     @staticmethod
     def has_access(organization: Organization | RpcOrganization, source: str) -> bool:
         if not features.has("organizations:notification-platform", organization):
-            logger.info(
-                "notification.platform.has_access.feature_flag_disabled",
-                extra={"organization_id": organization.id, "source": source},
-            )
             return False
 
         option_key = f"notifications.platform-rate.{source}"
@@ -63,16 +59,6 @@ class NotificationService[T: NotificationData]:
             return False
 
         modulo_result = sample_modulo(option_key, organization.id)
-        logger.info(
-            "notification.platform.has_access.sample_modulo",
-            extra={
-                "organization_id": organization.id,
-                "source": source,
-                "option_key": option_key,
-                "modulo_result": modulo_result,
-                "sample_rate": options.get(option_key),
-            },
-        )
         return modulo_result
 
     def notify_target(self, *, target: NotificationTarget) -> None:

--- a/src/sentry/notifications/platform/templates/custom_rule.py
+++ b/src/sentry/notifications/platform/templates/custom_rule.py
@@ -18,14 +18,14 @@ def format_datetime(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
-@dataclass(frozen=True)
+@dataclass
 class CustomRuleSamplesFulfilled(NotificationData):
-    source = "custom-rule-samples-fulfilled"
     query: str | None
     num_samples: int
     start_date: datetime
     end_date: datetime
     discover_link: str
+    source: str = "custom-rule-samples-fulfilled"
 
 
 @template_registry.register(CustomRuleSamplesFulfilled.source)

--- a/src/sentry/notifications/platform/templates/data_export.py
+++ b/src/sentry/notifications/platform/templates/data_export.py
@@ -23,11 +23,11 @@ def format_date(date: datetime) -> str:
     return date.strftime("%I:%M %p on %B %d, %Y (%Z)")
 
 
-@dataclass(frozen=True)
+@dataclass
 class DataExportSuccess(NotificationData):
-    source = "data-export-success"
     export_url: str
     expiration_date: datetime
+    source: str = "data-export-success"
 
 
 @template_registry.register(DataExportSuccess.source)
@@ -55,12 +55,12 @@ class DataExportSuccessTemplate(NotificationTemplate[DataExportSuccess]):
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class DataExportFailure(NotificationData):
-    source = "data-export-failure"
     error_message: str
     error_payload: dict[str, Any]
     creation_date: datetime
+    source: str = "data-export-failure"
 
 
 @template_registry.register(DataExportFailure.source)

--- a/src/sentry/notifications/platform/templates/repository.py
+++ b/src/sentry/notifications/platform/templates/repository.py
@@ -12,12 +12,12 @@ from sentry.notifications.platform.types import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass
 class UnableToDeleteRepository(NotificationData):
-    source = "unable-to-delete-repository"
     repository_name: str
     provider_name: str
     error_message: str
+    source: str = "unable-to-delete-repository"
 
 
 @template_registry.register(UnableToDeleteRepository.source)

--- a/src/sentry/notifications/platform/templates/sample.py
+++ b/src/sentry/notifications/platform/templates/sample.py
@@ -20,7 +20,7 @@ from sentry.notifications.platform.types import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass
 class ErrorAlertData(NotificationData):
     source = "error-alert-service"
     error_type: str
@@ -32,6 +32,7 @@ class ErrorAlertData(NotificationData):
     chart_url: str
     issue_url: str
     assign_url: str
+    source: str = "error-alert-service"
 
 
 @template_registry.register(ErrorAlertData.source)
@@ -114,9 +115,8 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class DeploymentData(NotificationData):
-    source = "deployment-service"
     project_name: str
     version: str
     environment: str
@@ -125,6 +125,7 @@ class DeploymentData(NotificationData):
     commit_message: str
     deployment_url: str
     rollback_url: str
+    source: str = "deployment-service"
 
 
 @template_registry.register(DeploymentData.source)
@@ -184,9 +185,8 @@ class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class SlowLoadMetricAlertData(NotificationData):
-    source = "slow-load-metric-alert"
     alert_type: str
     severity: str
     project_name: str
@@ -197,6 +197,7 @@ class SlowLoadMetricAlertData(NotificationData):
     threshold: str
     start_time: str
     chart_url: str
+    source: str = "slow-load-metric-alert"
 
 
 @template_registry.register(SlowLoadMetricAlertData.source)
@@ -243,15 +244,15 @@ class SlowLoadMetricAlertNotificationTemplate(NotificationTemplate[SlowLoadMetri
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class PerformanceAlertData(NotificationData):
-    source = "performance-monitoring"
     metric_name: str
     threshold: str
     current_value: str
     project_name: str
     chart_url: str
     investigation_url: str
+    source: str = "performance-monitoring"
 
 
 @template_registry.register(PerformanceAlertData.source)
@@ -310,14 +311,14 @@ class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlert
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class TeamUpdateData(NotificationData):
-    source = "team-communication"
     team_name: str
     update_type: str
     message: str
     author: str
     timestamp: str
+    source: str = "team-communication"
 
 
 @template_registry.register(TeamUpdateData.source)

--- a/src/sentry/notifications/platform/templates/sample.py
+++ b/src/sentry/notifications/platform/templates/sample.py
@@ -22,7 +22,6 @@ from sentry.notifications.platform.types import (
 
 @dataclass
 class ErrorAlertData(NotificationData):
-    source = "error-alert-service"
     error_type: str
     error_message: str
     project_name: str


### PR DESCRIPTION
This change isn't ideal but removing the immutability is the simplest way to fix this issue. When going from  service -> notify_task_async task boundary the notification data gets turned to a dict that doesn't include the source attribute because it's a field that wasn't instantiated in that data instance.

Also removes some misc logging