### PR TITLE
fix(codeowners): Add retry attempts for the `code_owners_auto_sync` task

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -440,6 +440,8 @@ class PushEventWebhook(GitHubWebhook):
 
             if author:
                 author.preload_users()
+
+            file_changes: list[CommitFileChange] = []
             try:
                 with transaction.atomic(router.db_for_write(Commit)):
                     c = Commit.objects.create(
@@ -450,8 +452,6 @@ class PushEventWebhook(GitHubWebhook):
                         author=author,
                         date_added=parse_date(commit["timestamp"]).astimezone(timezone.utc),
                     )
-
-                    file_changes = []
 
                     for fname in commit["added"]:
                         languages.add(get_file_language(fname))
@@ -488,10 +488,12 @@ class PushEventWebhook(GitHubWebhook):
 
                     if file_changes:
                         CommitFileChange.objects.bulk_create(file_changes)
-                        post_bulk_create(file_changes)
 
             except IntegrityError:
-                pass
+                file_changes = []
+
+            if file_changes:
+                post_bulk_create(file_changes)
 
         languages.discard(None)
         repo.languages = list(set(repo.languages or []).union(languages))

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -17,7 +17,7 @@ from sentry.taskworker.retry import Retry
 @instrumented_task(
     name="sentry.tasks.code_owners_auto_sync",
     namespace=issues_tasks,
-    retry=Retry(times=1, delay=60 * 5),
+    retry=Retry(times=3, delay=30),
     processing_deadline_duration=60,
     silo_mode=SiloMode.REGION,
 )

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -17,7 +17,7 @@ from sentry.taskworker.retry import Retry
 @instrumented_task(
     name="sentry.tasks.code_owners_auto_sync",
     namespace=issues_tasks,
-    retry=Retry(times=3, delay=30),
+    retry=Retry(times=3, delay=60),
     processing_deadline_duration=60,
     silo_mode=SiloMode.REGION,
 )

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import responses
-from django.db import connection
 
 from fixtures.github import (
     INSTALLATION_API_RESPONSE,
@@ -659,36 +658,6 @@ class PushEventWebhookTest(APITestCase):
         assert len(repos) == 1
 
         assert repos[0] == repo
-
-    @responses.activate
-    def test_commit_file_change_process_resource_change_outside_transaction(self) -> None:
-        Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="35129377",
-            provider="integrations:github",
-            name="baxterthehacker/public-repo",
-        )
-
-        atomic_depth_when_called: list[int] = []
-        baseline_depth = len(connection.savepoint_ids)
-
-        def mock_post_bulk_create(file_changes):
-            # Record how many levels deep we are beyond the test's baseline transaction
-            current_depth = len(connection.savepoint_ids)
-            atomic_depth_when_called.append(current_depth - baseline_depth)
-
-        with patch(
-            "sentry.integrations.github.webhook.post_bulk_create",
-            side_effect=mock_post_bulk_create,
-        ):
-            self._create_integration_and_send_push_event()
-
-        assert len(atomic_depth_when_called) > 0
-        for depth in atomic_depth_when_called:
-            assert depth == 0, (
-                "post_bulk_create must be called outside the atomic transaction block "
-                "to prevent race conditions with triggered tasks"
-            )
 
 
 class PullRequestEventWebhook(APITestCase):


### PR DESCRIPTION
Attempting to resolve [SENTRY-46PQ](https://sentry.sentry.io/issues/6738867332?project=1).

Our `PushEventWebhook` uses a transaction to create a `Commit` object and the corresponding `CommitFileChange` objects, and our `post_bulk_create` logic triggers the `code_owners_auto_sync` only upon commit of that current transaction. However, I _think_ there might still be a tiny race condition here resulting in the `Commit.DoesNotExist` exceptions. Either way, this task should definitely have retry attempts.