### PR TITLE
fix(aci): Use em dash instead of 'unknown' for trigger history

### DIFF
--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -118,7 +118,7 @@ export default function AutomationHistoryList({
                   <TruncatedText>{row.detector.name}</TruncatedText>
                 </StyledLink>
               ) : (
-                t('Unknown detector')
+                '—'
               )}
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>


### PR DESCRIPTION
Before:

<img width="1644" height="710" alt="CleanShot 2025-12-09 at 15 02 54@2x" src="https://github.com/user-attachments/assets/596c4c71-be0d-4812-b578-402dda3d9e3c" />


After:

<img width="1660" height="734" alt="CleanShot 2025-12-09 at 15 02 42@2x" src="https://github.com/user-attachments/assets/be60dab1-84be-4022-8ab7-35caf30baaf0" />
