### PR TITLE
ref(tests): Improve local outbox flush error message

### DIFF
--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -38,6 +38,7 @@ from sentry.hybridcloud.rpc import REGION_NAME_LENGTH
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.utils import metrics
+from sentry.utils.env import in_test_environment
 
 THE_PAST = datetime.datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=datetime.UTC)
 
@@ -316,6 +317,16 @@ class OutboxBase(Model):
                         error_message = (
                             f"Could not flush shard category={category_number} ({category_name})"
                         )
+
+                        if in_test_environment():
+                            orig_error = f"{type(e).__name__}: {e}"
+                            error_message += (
+                                "\n\nNOTE: This error is the last in a chain. If you are seeing "
+                                + "this while running tests, your real problem is likely the error "
+                                + "causing this flush error:"
+                                + f"\n\n\t{orig_error}\n\n"
+                                + "Scroll up to that error for details."
+                            )
 
                         raise OutboxFlushError(error_message, coalesced) from e
 

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -311,10 +311,13 @@ class OutboxBase(Model):
                     try:
                         coalesced.send_signal()
                     except Exception as e:
-                        raise OutboxFlushError(
-                            f"Could not flush shard category={coalesced.category} ({OutboxCategory(coalesced.category).name})",
-                            coalesced,
-                        ) from e
+                        category_number = coalesced.category
+                        category_name = OutboxCategory(category_number).name
+                        error_message = (
+                            f"Could not flush shard category={category_number} ({category_name})"
+                        )
+
+                        raise OutboxFlushError(error_message, coalesced) from e
 
                 return True
         return False


### PR DESCRIPTION
When an `OutboxFlushError` is raised as part of running tests, most often the problem is not in fact with outbox flushing itself, but with whatever caused the outbox flushing to fail. This if far from obvious, though, as evidenced by the fact that multiple people have posted in slack asking how to fix flushing issues, when in fact their problem is something else entirely.

This therefore adds a note, and the text of the error causing the flush error, to the end of the error message if it's encountered while running tests. In prod, the error remains unchanged.

Before:

<img width="930" height="434" alt="image" src="https://github.com/user-attachments/assets/5f1b963f-8a1a-48e3-a70c-c0044bde87ec" />

After:

<img width="925" height="551" alt="image" src="https://github.com/user-attachments/assets/e577926b-ad3e-41c5-b3a5-725a5435786f" />
