### PR TITLE
fix(aci): return full workflow in PUT response

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
@@ -122,6 +122,8 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
                 data=workflow.get_audit_log_data(),
             )
 
+        workflow.refresh_from_db()
+
         return Response(
             serialize(workflow, request.user, WorkflowSerializer()),
             status=200,


### PR DESCRIPTION
We were running into a problem where the workflow details PUT response was not returning the full workflow (action filters were being returned as an empty list). This led to incorrect errors being displayed in the UI about the workflow being invalid when there are 0 actions.

Refreshing the workflow before serializing fixed this for me locally.