### PR TITLE
theme: theme.textColor is now theme.tokens.content.primary

### DIFF
--- a/static/app/components/activity/item/avatar.tsx
+++ b/static/app/components/activity/item/avatar.tsx
@@ -46,7 +46,7 @@ const SystemAvatar = styled('span')<SystemAvatarProps>`
   align-items: center;
   width: ${p => p.size}px;
   height: ${p => p.size}px;
-  background-color: ${p => p.theme.textColor};
+  background-color: ${p => p.theme.tokens.content.primary};
   color: ${p => p.theme.background};
   border-radius: 50%;
 `;

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -144,7 +144,7 @@ const TooltipWrapper = styled('div')`
 `;
 
 const StyledText = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   max-width: 114px;
   ${p => p.theme.overflowEllipsis};
 `;

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -282,7 +282,7 @@ const TruncatedFooterText = styled('div')`
 const LearnMoreWrapper = styled('div')`
   position: relative;
   max-width: 230px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   padding: ${space(1.5)};
   border-top: 1px solid ${p => p.theme.innerBorder};

--- a/static/app/components/calendar/calendarStylesWrapper.tsx
+++ b/static/app/components/calendar/calendarStylesWrapper.tsx
@@ -30,7 +30,7 @@ const CalendarStylesWrapper = styled('div')`
   }
 
   .rdrDayNumber span {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 
   .rdrDay:not(.rdrDayPassive) .rdrStartEdge ~ .rdrDayNumber span,
@@ -180,7 +180,7 @@ const CalendarStylesWrapper = styled('div')`
   .rdrMonthPicker select,
   .rdrYearPicker select {
     background: none;
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     font-weight: ${p => p.theme.fontWeight.normal};
     font-size: ${p => p.theme.fontSize.lg};
     padding: ${space(0.25)} ${space(1)};
@@ -236,12 +236,12 @@ const CalendarStylesWrapper = styled('div')`
   }
 
   .rdrPprevButton i {
-    border-right-color: ${p => p.theme.textColor};
+    border-right-color: ${p => p.theme.tokens.content.primary};
     margin: 0;
   }
 
   .rdrNextButton i {
-    border-left-color: ${p => p.theme.textColor};
+    border-left-color: ${p => p.theme.tokens.content.primary};
     margin: 0;
   }
 

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -724,11 +724,11 @@ const getTooltipStyles = (p: {theme: Theme}) => css`
     justify-content: center;
   }
   .tooltip-release.tooltip-series {
-    color: ${p.theme.textColor};
+    color: ${p.theme.tokens.content.primary};
   }
   .tooltip-release-timerange {
     font-size: ${p.theme.fontSize.xs};
-    color: ${p.theme.textColor};
+    color: ${p.theme.tokens.content.primary};
   }
   .tooltip-series {
     border-bottom: none;
@@ -743,10 +743,10 @@ const getTooltipStyles = (p: {theme: Theme}) => css`
   }
   .tooltip-label strong {
     font-weight: ${p.theme.fontWeight.normal};
-    color: ${p.theme.textColor};
+    color: ${p.theme.tokens.content.primary};
   }
   .tooltip-label-value {
-    color: ${p.theme.textColor};
+    color: ${p.theme.tokens.content.primary};
   }
   .tooltip-label-indent {
     margin-left: 18px;

--- a/static/app/components/charts/breakdownBars.tsx
+++ b/static/app/components/charts/breakdownBars.tsx
@@ -78,7 +78,7 @@ const BarContainer = styled('div')<{cursor: 'pointer' | 'default'}>`
 
 const Label = styled('span')`
   position: relative;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   z-index: 2;
   font-size: ${p => p.theme.fontSize.sm};
 `;

--- a/static/app/components/charts/components/legend.tsx
+++ b/static/app/components/charts/components/legend.tsx
@@ -36,7 +36,7 @@ export default function Legend(
       itemGap: 12,
       align: 'left' as const,
       textStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         verticalAlign: 'top',
         fontSize: 11,
         fontFamily: theme.text.family,
@@ -44,9 +44,9 @@ export default function Legend(
       },
       inactiveColor: theme.subText,
       pageTextStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
       },
-      pageIconColor: theme.textColor,
+      pageIconcolor: theme.tokens.content.primary,
       pageIconInactiveColor: theme.disabled,
       pageIconSize: 8.75,
       pageIcons: {

--- a/static/app/components/charts/components/legend.tsx
+++ b/static/app/components/charts/components/legend.tsx
@@ -46,7 +46,7 @@ export default function Legend(
       pageTextStyle: {
         color: theme.tokens.content.primary,
       },
-      pageIconcolor: theme.tokens.content.primary,
+      pageIconColor: theme.tokens.content.primary,
       pageIconInactiveColor: theme.disabled,
       pageIconSize: 8.75,
       pageIcons: {

--- a/static/app/components/checkInTimeline/timelineCursor.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.tsx
@@ -180,7 +180,7 @@ const CursorLabel = styled(Overlay)<{
   font-variant-numeric: tabular-nums;
   width: max-content;
   padding: ${space(0.75)} ${space(1)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   line-height: 1.2;
   position: absolute;

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -266,11 +266,11 @@ const BoldEmail = styled('strong')`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.textColor};
-  border-bottom: 1px dotted ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
+  border-bottom: 1px dotted ${p => p.theme.tokens.content.primary};
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
@@ -310,7 +310,7 @@ const Meta = styled(TextOverflow)<{hasStreamlinedUI?: boolean}>`
   }
 
   a:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
@@ -330,12 +330,12 @@ const MetaWrapper = styled('div')`
 `;
 
 const StyledExternalLink = styled(ExternalLink)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   text-decoration: underline;
   text-decoration-color: ${p => p.theme.translucentGray200};
 
   :hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
@@ -351,7 +351,7 @@ const AuthorWrapper = styled('span')`
   }
 
   &:has(svg):hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     & svg {
       opacity: 1;
     }

--- a/static/app/components/core/badge/alertBadge.chonk.tsx
+++ b/static/app/components/core/badge/alertBadge.chonk.tsx
@@ -11,14 +11,14 @@ function makeChonkAlertBadgeDiamondBackgroundTheme(
 ): React.CSSProperties {
   if (isDisabled) {
     return {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       background: theme.colors.surface500,
       border: `1px solid ${theme.colors.surface100}`,
     };
   }
   if (isIssue) {
     return {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       background: theme.colors.surface500,
       border: `1px solid ${theme.colors.surface100}`,
     };

--- a/static/app/components/core/checkbox/checkbox.tsx
+++ b/static/app/components/core/checkbox/checkbox.tsx
@@ -106,7 +106,7 @@ const NativeHiddenCheckbox = withChonk(
 
     & + * {
       box-shadow: ${p => p.theme.dropShadowMedium} inset;
-      color: ${p => p.theme.textColor};
+      color: ${p => p.theme.tokens.content.primary};
       border: 1px solid ${p => p.theme.border};
 
       svg {

--- a/static/app/components/core/menuListItem/menuListItem.chonk.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.chonk.tsx
@@ -29,7 +29,7 @@ function getTextColor({
       return theme.errorText;
     case 'default':
     default:
-      return theme.textColor;
+      return theme.tokens.content.primary;
   }
 }
 

--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -301,7 +301,7 @@ function getTextColor({
       return theme.errorText;
     case 'default':
     default:
-      return theme.textColor;
+      return theme.tokens.content.primary;
   }
 }
 

--- a/static/app/components/core/segmentedControl/segmentedControl.tsx
+++ b/static/app/components/core/segmentedControl/segmentedControl.tsx
@@ -450,7 +450,7 @@ function getTextColor({
   }
 
   return css`
-    color: ${theme.textColor};
+    color: ${theme.tokens.content.primary};
   `;
 }
 

--- a/static/app/components/core/select/select.chonk.tsx
+++ b/static/app/components/core/select/select.chonk.tsx
@@ -109,7 +109,7 @@ export const getChonkStylesConfig = ({
 
     option: provided => ({
       ...provided,
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       background: 'transparent',
       padding: 0,
       ':active': {
@@ -139,7 +139,7 @@ export const getChonkStylesConfig = ({
     }),
     input: provided => ({
       ...provided,
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       margin: 0,
     }),
     singleValue: (provided, state) => ({

--- a/static/app/components/core/select/select.chonk.tsx
+++ b/static/app/components/core/select/select.chonk.tsx
@@ -55,7 +55,7 @@ export const getChonkStylesConfig = ({
     padding: '0 4px 0 4px',
     alignItems: 'center',
     cursor: state.isDisabled ? 'not-allowed' : 'pointer',
-    color: state.isDisabled ? theme.disabled : theme.textColor,
+    color: state.isDisabled ? theme.disabled : theme.tokens.content.primary,
     ':hover': {
       color: 'currentcolor',
     },
@@ -65,7 +65,7 @@ export const getChonkStylesConfig = ({
   return {
     control: (_, state) => ({
       display: 'flex',
-      color: state.isDisabled ? theme.disabled : theme.textColor,
+      color: state.isDisabled ? theme.disabled : theme.tokens.content.primary,
       ...debossedBackground(theme),
       border: `1px solid ${theme.border}`,
       boxShadow,
@@ -144,7 +144,7 @@ export const getChonkStylesConfig = ({
     }),
     singleValue: (provided, state) => ({
       ...provided,
-      color: state.isDisabled ? theme.disabled : theme.textColor,
+      color: state.isDisabled ? theme.disabled : theme.tokens.content.primary,
       display: 'flex',
       alignItems: 'center',
       marginLeft: 0,
@@ -157,7 +157,7 @@ export const getChonkStylesConfig = ({
     }),
     multiValue: provided => ({
       ...provided,
-      color: isDisabled ? theme.disabled : theme.textColor,
+      color: isDisabled ? theme.disabled : theme.tokens.content.primary,
       backgroundColor: theme.background,
       borderRadius: '4px',
       border: `1px solid ${theme.border}`,
@@ -170,7 +170,7 @@ export const getChonkStylesConfig = ({
     }),
     multiValueLabel: provided => ({
       ...provided,
-      color: isDisabled ? theme.disabled : theme.textColor,
+      color: isDisabled ? theme.disabled : theme.tokens.content.primary,
       padding: multiValueSizeMapping[size].spacing,
       paddingLeft: multiValueSizeMapping[size].spacing,
       height: multiValueSizeMapping[size].height,

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -246,7 +246,7 @@ const getStylesConfig = ({
     option: provided => ({
       ...provided,
       cursor: 'pointer',
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       background: 'transparent',
       padding: 0,
       ':active': {
@@ -289,7 +289,7 @@ const getStylesConfig = ({
     }),
     multiValue: provided => ({
       ...provided,
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       backgroundColor: theme.background,
       borderRadius: '2px',
       border: `1px solid ${theme.border}`,
@@ -298,7 +298,7 @@ const getStylesConfig = ({
     }),
     multiValueLabel: provided => ({
       ...provided,
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       padding: '0',
       paddingLeft: space(0.75),
       lineHeight: '1.8',

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -156,7 +156,7 @@ const _SlideOverPanel = styled(motion.div, {
 
   box-shadow: ${p => (p.theme.isChonk ? undefined : p.theme.dropShadowHeavy)};
   background: ${p => p.theme.background};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   text-align: left;
 

--- a/static/app/components/core/tabs/tab.tsx
+++ b/static/app/components/core/tabs/tab.tsx
@@ -244,7 +244,7 @@ const TabWrap = withChonk(
     overflowing: boolean;
     selected: boolean;
   }>`
-    color: ${p => (p.selected ? p.theme.activeText : p.theme.textColor)};
+    color: ${p => (p.selected ? p.theme.activeText : p.theme.tokens.content.primary)};
     white-space: nowrap;
     cursor: pointer;
 

--- a/static/app/components/core/tooltip/tooltip.tsx
+++ b/static/app/components/core/tooltip/tooltip.tsx
@@ -115,7 +115,7 @@ const TooltipContent = styled(Overlay, {
   padding: ${space(1)} ${space(1.5)};
   overflow-wrap: break-word;
   max-width: ${p => p.maxWidth ?? 225}px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   line-height: 1.2;
   text-align: center;

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -116,7 +116,7 @@ const StyledLogoSentry = styled(LogoSentry)`
   margin-right: auto;
   width: 130px;
   height: 30px;
-  fill: ${p => p.theme.textColor};
+  fill: ${p => p.theme.tokens.content.primary};
 `;
 
 const FreeTrialTextShort = styled('span')`

--- a/static/app/components/discover/quickContextCommitRow.tsx
+++ b/static/app/components/discover/quickContextCommitRow.tsx
@@ -78,7 +78,7 @@ const LinkToPullRequest = styled(TextOverflow)`
 
 const LinkToCommit = styled(TextOverflow)<{hasPrTitle: string | null | undefined}>`
   font-size: ${p => (p.hasPrTitle ? p.theme.fontSize.sm : p.theme.fontSize.lg)};
-  color: ${p => (p.hasPrTitle ? p.theme.subText : p.theme.textColor)};
+  color: ${p => (p.hasPrTitle ? p.theme.subText : p.theme.tokens.content.primary)};
   line-height: 1.5;
   margin: 0;
 `;

--- a/static/app/components/dropdownBubble.tsx
+++ b/static/app/components/dropdownBubble.tsx
@@ -73,7 +73,7 @@ const DropdownBubble = styled(
   {shouldForwardProp: prop => typeof prop === 'string' && isPropValid(prop)}
 )`
   background: ${p => p.theme.background};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   border: 1px solid ${p => p.theme.border};
   position: absolute;
   right: 0;

--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -155,7 +155,7 @@ Anyway, we apologize for the inconvenience.`
 }
 
 const Wrapper = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: ${space(3)};
   max-width: 1000px;
   margin: auto;

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -200,7 +200,7 @@ const CommentsLink = styled(Link)`
   gap: ${space(0.5)};
   align-items: center;
   grid-auto-flow: column;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   position: relative;
 `;
 
@@ -216,7 +216,7 @@ const AnnotationNoMargin = styled(EventAnnotation)`
 `;
 
 const LoggerAnnotation = styled(AnnotationNoMargin)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   position: relative;
   min-width: 10px;
   ${p => p.theme.overflowEllipsis};

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -177,10 +177,10 @@ const IconWrapper = styled('span')`
 
 const TitleWithLink = styled(Link)`
   ${p => p.theme.overflowEllipsis};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -414,7 +414,7 @@ export function AutofixChanges({
 const PreviewContent = styled('div')`
   display: flex;
   flex-direction: column;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   margin-top: ${space(2)};
 `;
 

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -762,10 +762,10 @@ const LineNumber = styled('div')<{lineType: DiffLineType}>`
 
   ${p =>
     p.lineType === DiffLineType.ADDED &&
-    `background-color: ${DIFF_COLORS.added}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.added}; color: ${p.theme.tokens.content.primary}`};
   ${p =>
     p.lineType === DiffLineType.REMOVED &&
-    `background-color: ${DIFF_COLORS.removed}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.removed}; color: ${p.theme.tokens.content.primary}`};
 
   & + & {
     padding-left: 0;
@@ -783,10 +783,10 @@ const DiffContent = styled('div')<{lineType: DiffLineType}>`
 
   ${p =>
     p.lineType === DiffLineType.ADDED &&
-    `background-color: ${DIFF_COLORS.addedRow}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.addedRow}; color: ${p.theme.tokens.content.primary}`};
   ${p =>
     p.lineType === DiffLineType.REMOVED &&
-    `background-color: ${DIFF_COLORS.removedRow}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.removedRow}; color: ${p.theme.tokens.content.primary}`};
 
   &::before {
     content: ${p =>
@@ -819,7 +819,7 @@ const ActionButton = styled(Button)<{isHovered: boolean}>`
   font-family: ${p => p.theme.text.family};
   background-color: ${p =>
     p.isHovered ? p.theme.button.default.background : p.theme.background};
-  color: ${p => (p.isHovered ? p.theme.pink400 : p.theme.textColor)};
+  color: ${p => (p.isHovered ? p.theme.pink400 : p.theme.tokens.content.primary)};
   transition:
     background-color 0.2s ease-in-out,
     color 0.2s ease-in-out;

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -880,7 +880,7 @@ const RemovedLines = styled('div')`
 
 const RemovedLine = styled('div')`
   background-color: ${DIFF_COLORS.removedRow};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: ${space(0.25)} ${space(0.5)};
   white-space: pre-wrap;
 `;
@@ -913,7 +913,7 @@ const SectionTitle = styled('p')`
   margin: ${space(1)} 0;
   font-size: ${p => p.theme.fontSize.md};
   font-weight: bold;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-family: ${p => p.theme.text.family};
 `;
 
@@ -927,6 +927,6 @@ const OverlayTitle = styled('h3')`
   margin: 0 0 ${space(2)} 0;
   font-size: ${p => p.theme.fontSize.md};
   font-weight: bold;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-family: ${p => p.theme.text.family};
 `;

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -809,7 +809,7 @@ const MessageContent = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   padding-top: ${space(0.5)};
   font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   word-break: break-word;
   overflow-wrap: break-word;
   white-space: pre-wrap;
@@ -868,7 +868,7 @@ const ReworkText = styled('span')`
   color: ${p => p.theme.subText};
 
   ${ReworkHeaderSection}:hover & {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -465,7 +465,7 @@ const StyledAnimatedSeerIcon = styled(IconSeer)`
   transition: opacity 0.2s ease;
   top: 0;
   flex-shrink: 0;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   z-index: 10000;
 `;
 

--- a/static/app/components/events/autofix/autofixSolutionEventItem.tsx
+++ b/static/app/components/events/autofix/autofixSolutionEventItem.tsx
@@ -286,7 +286,8 @@ const StyledTimelineHeader = styled('div')<{isSelected: boolean; isActive?: bool
   opacity: ${p => (p.isSelected ? 1 : 0.6)};
   text-decoration: ${p =>
     p.isSelected ? (p.isActive ? 'underline dashed' : 'none') : 'line-through'};
-  text-decoration-color: ${p => (p.isSelected ? p.theme.green300 : p.theme.textColor)};
+  text-decoration-color: ${p =>
+    p.isSelected ? p.theme.green300 : p.theme.tokens.content.primary};
   text-decoration-thickness: 1px;
   text-underline-offset: 4px;
   transition: opacity 0.2s ease;

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -267,7 +267,7 @@ const CardHeader = styled('div')`
 const AgentTitle = styled('h4')`
   margin: 0 0 ${p => p.theme.space.xs} 0;
   font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const CardContent = styled('div')`
@@ -291,7 +291,7 @@ const Label = styled('span')`
 `;
 
 const Value = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSize.sm};
 `;

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -315,7 +315,9 @@ const ResultItem = styled('div')`
 
 const ResultDescription = styled('div')<{status: CodingAgentStatus}>`
   color: ${p =>
-    p.status === CodingAgentStatus.FAILED ? p.theme.errorText : p.theme.textColor};
+    p.status === CodingAgentStatus.FAILED
+      ? p.theme.errorText
+      : p.theme.tokens.content.primary};
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`

--- a/static/app/components/events/autofix/insights/autofixInsightCard.tsx
+++ b/static/app/components/events/autofix/insights/autofixInsightCard.tsx
@@ -343,10 +343,10 @@ const MiniHeader = styled('p')<{expanded?: boolean}>`
   margin: 0;
   flex: 1;
   word-break: break-word;
-  color: ${p => (p.expanded ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.expanded ? p.theme.tokens.content.primary : p.theme.subText)};
 
   code {
-    color: ${p => (p.expanded ? p.theme.textColor : p.theme.subText)};
+    color: ${p => (p.expanded ? p.theme.tokens.content.primary : p.theme.subText)};
   }
 `;
 

--- a/static/app/components/events/autofix/insights/autofixInsightSources.tsx
+++ b/static/app/components/events/autofix/insights/autofixInsightSources.tsx
@@ -262,7 +262,7 @@ const OverlayButtonGroup = styled('div')`
 
 const OverlayTitle = styled('div')`
   font-weight: bold;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-family: ${p => p.theme.text.family};
 `;
 

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -256,7 +256,7 @@ function cleanBreadcrumbData<B extends Record<string, any> | undefined | null>(
 }
 
 const Link = styled('a')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   text-decoration: underline;
   text-decoration-style: dotted;
   word-break: break-all;
@@ -275,5 +275,5 @@ const BreadcrumbText = styled(Timeline.Text)`
   white-space: pre-wrap;
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;

--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -158,13 +158,13 @@ const SectionHeader = styled('div')`
   }
 
   & small {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     font-size: ${p => p.theme.fontSize.md};
     margin-right: ${space(0.5)};
     margin-left: ${space(0.5)};
   }
   & small > span {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     font-weight: ${p => p.theme.fontWeight.normal};
   }
 

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -470,7 +470,7 @@ const TreeValue = styled('div')<{hasErrors?: boolean}>`
   font-size: ${p => p.theme.fontSize.sm};
   word-break: break-word;
   grid-column: span 1;
-  color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
+  color: ${p => (p.hasErrors ? 'inherit' : p.theme.tokens.content.primary)};
 `;
 
 const TreeKey = styled(TreeValue)<{hasErrors?: boolean}>`

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -80,7 +80,7 @@ const CollapseButton = styled(Button)<{folded: boolean}>`
 
 const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`
   grid-column: 2;
-  color: ${p => (p.isContributing ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.isContributing ? p.theme.tokens.content.primary : p.theme.subText)};
 `;
 
 export const GroupingHint = styled('small')`

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -54,13 +54,13 @@ const GroupingValue = styled('code')<{
   font-size: ${p => p.theme.fontSize.sm};
   padding: 0 ${space(0.25)};
   background: ${p => (p.contributes ? 'rgba(112, 163, 214, 0.1)' : 'transparent')};
-  color: ${p => (p.contributes ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.contributes ? p.theme.tokens.content.primary : p.theme.subText)};
 
   ${({valueType, theme, contributes}) =>
     (valueType === 'function' || valueType === 'symbol') &&
     css`
       font-weight: ${contributes ? theme.fontWeight.bold : 'normal'};
-      color: ${contributes ? theme.textColor : theme.subText};
+      color: ${contributes ? theme.tokens.content.primary : theme.subText};
     `}
 `;
 

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -226,7 +226,7 @@ const ContributionIcon = styled(({isContributing, ...p}: any) =>
 `;
 
 const GroupingTree = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const TextWithQuestionTooltip = styled('div')`

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -265,9 +265,9 @@ const IconSubtitle = styled(Tooltip)`
 
 const StyledVersion = styled(Version)`
   font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/category.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/category.tsx
@@ -22,7 +22,7 @@ const Category = memo(function Category({category, searchTerm}: Props) {
 export default Category;
 
 const Wrapper = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   font-weight: ${p => p.theme.fontWeight.bold};
 `;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/time/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/time/index.tsx
@@ -52,7 +52,7 @@ export default Time;
 
 const Wrapper = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const Title = styled('div')`

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
@@ -495,7 +495,7 @@ const ToggleButton = styled(Button)`
 
   :hover,
   :focus {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/components/events/interfaces/crashContent/exception/relatedExceptions.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/relatedExceptions.tsx
@@ -212,5 +212,5 @@ const Circle = styled('div')`
   border-radius: 50%;
   height: 12px;
   width: 12px;
-  border: 1px solid ${p => p.theme.textColor};
+  border: 1px solid ${p => p.theme.tokens.content.primary};
 `;

--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -173,7 +173,7 @@ const EventLineLabel = styled(Overlay, {
 })<{left: number; timelineWidth: number}>`
   width: max-content;
   padding: ${space(0.75)} ${space(1)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   position: absolute;
   bottom: ${space(1)};

--- a/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
@@ -86,7 +86,7 @@ const StatusColumn = styled(Column)`
 `;
 
 const FileName = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-family: ${p => p.theme.text.family};
   font-size: ${p => p.theme.fontSize.md};
   margin-right: ${space(0.5)};

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/generalInfo.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/generalInfo.tsx
@@ -57,7 +57,7 @@ const Wrapper = styled('div')`
 `;
 
 const Label = styled('div')<{coloredBg?: boolean}>`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: ${space(1)} ${space(1.5)} ${space(1)} ${space(1)};
   ${p => p.coloredBg && `background-color: ${p.theme.backgroundSecondary};`}
 `;

--- a/static/app/components/events/interfaces/frame/assembly.tsx
+++ b/static/app/components/events/interfaces/frame/assembly.tsx
@@ -44,7 +44,7 @@ const AssemblyWrapper = styled('div')`
   font-size: 80%;
   display: flex;
   flex-wrap: wrap;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   text-align: center;
   position: relative;
   padding: ${space(0.25)} ${space(3)};

--- a/static/app/components/events/interfaces/frame/contextLineNumber.tsx
+++ b/static/app/components/events/interfaces/frame/contextLineNumber.tsx
@@ -47,7 +47,7 @@ const Wrapper = styled('div')`
   height: 24px;
   width: 58px;
   display: inline-block;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   margin-right: ${space(1)};
 

--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -259,7 +259,7 @@ const StyledExternalLink = styled(ExternalLink)`
 `;
 
 const InFramePosition = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   opacity: 0.6;
 `;
 

--- a/static/app/components/events/rrwebReplayer/baseRRWebReplayer.tsx
+++ b/static/app/components/events/rrwebReplayer/baseRRWebReplayer.tsx
@@ -164,7 +164,7 @@ const BaseRRWebReplayer = styled(BaseRRWebReplayerComponent)`
     border: 1px solid ${p => p.theme.border};
     border-top: none;
     position: relative;
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 
   .rr-timeline {
@@ -176,7 +176,7 @@ const BaseRRWebReplayer = styled(BaseRRWebReplayerComponent)`
 
   .rr-timeline__time {
     text-align: center;
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 
   .rr-progress {
@@ -232,7 +232,7 @@ const BaseRRWebReplayer = styled(BaseRRWebReplayerComponent)`
   }
 
   .rr-controller__btns button {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     width: 28px;
     height: 28px;
     display: flex;
@@ -246,7 +246,7 @@ const BaseRRWebReplayer = styled(BaseRRWebReplayerComponent)`
     transition: background 200ms ease;
 
     > svg {
-      fill: ${p => p.theme.textColor};
+      fill: ${p => p.theme.tokens.content.primary};
     }
   }
 

--- a/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
@@ -57,7 +57,7 @@ const SectionWrapper = styled('section')`
 
 const SectionTitle = styled('h3')`
   margin: 0;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.md};
   text-transform: capitalize;
   user-select: none;

--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -51,6 +51,6 @@ const Blockquote = styled('blockquote')`
     line-height: 1.6;
     padding: 0;
     word-break: break-word;
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -179,9 +179,9 @@ const LinkedFeedbackCard = styled(Link)`
   border: 1px solid transparent;
   border-radius: ${space(0.75)};
 
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
   &[data-selected='true'] {
     background: ${p => p.theme.purple100};

--- a/static/app/components/forms/fieldGroup/fieldLabel.tsx
+++ b/static/app/components/forms/fieldGroup/fieldLabel.tsx
@@ -10,7 +10,7 @@ interface FieldLabelProps extends Pick<FieldGroupProps, 'disabled'> {}
 export const FieldLabel = styled('div', {
   shouldForwardProp: p => p !== 'disabled' && isPropValid(p),
 })<FieldLabelProps>`
-  color: ${p => (p.disabled ? p.theme.disabled : p.theme.textColor)};
+  color: ${p => (p.disabled ? p.theme.disabled : p.theme.tokens.content.primary)};
   display: flex;
   gap: ${space(0.5)};
   line-height: 16px;

--- a/static/app/components/forms/fields/fileField.tsx
+++ b/static/app/components/forms/fields/fileField.tsx
@@ -99,7 +99,7 @@ export default function FileField({accept, hideControlState, ...props}: FileFiel
 }
 
 const FileName = styled('span')<{hasFile: boolean}>`
-  color: ${p => (p.hasFile ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.hasFile ? p.theme.tokens.content.primary : p.theme.subText)};
 `;
 
 const BrowseIndicator = styled('span')`

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -393,7 +393,7 @@ const CardTitle = styled('div')<{preview?: boolean}>`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: ${space(0.5)} ${space(0.5)} 0 ${space(1)};
   justify-content: space-between;
 `;
@@ -415,7 +415,7 @@ const CardTitleText = styled('p')`
 const CardTitleIcon = styled('div')`
   display: flex;
   align-items: center;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const CardContent = styled('div')`

--- a/static/app/components/group/issueSeerBadge.tsx
+++ b/static/app/components/group/issueSeerBadge.tsx
@@ -62,7 +62,7 @@ const SeerLink = styled(Link)`
   gap: ${space(0.5)};
   align-items: center;
   grid-auto-flow: column;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   position: relative;
 `;
 

--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -168,7 +168,7 @@ function SentryAppExternalIssueActions({
 }
 
 const StyledSentryAppComponentIcon = styled(SentryAppComponentIcon)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   width: ${space(3)};
   height: ${space(3)};
   cursor: pointer;
@@ -195,7 +195,7 @@ const IssueLinkContainer = styled('div')`
 `;
 
 const StyledIcon = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   cursor: pointer;
 `;
 

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -293,7 +293,7 @@ const StepHeading = styled('h4')<{isActive: boolean}>`
   margin: 0;
   font-weight: ${p => p.theme.fontWeight.bold};
   font-size: ${p => p.theme.fontSize.lg};
-  color: ${p => (p.isActive ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.isActive ? p.theme.tokens.content.primary : p.theme.subText)};
 `;
 
 const StepDoneIcon = styled(IconCheckmark, {
@@ -312,7 +312,7 @@ const StepOptionalLabel = styled('div')`
 `;
 
 const ChildrenWrapper = styled('div')<{isActive: boolean}>`
-  color: ${p => (p.isActive ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.isActive ? p.theme.tokens.content.primary : p.theme.subText)};
 
   p {
     margin-bottom: ${space(1)};

--- a/static/app/components/highlight.tsx
+++ b/static/app/components/highlight.tsx
@@ -46,7 +46,7 @@ function HighlightComponent({className, children, disabled, text}: Props) {
 const Highlight = styled(HighlightComponent)`
   font-weight: ${p => p.theme.fontWeight.normal};
   background-color: ${p => p.theme.yellow200};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 export default Highlight;

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -138,7 +138,7 @@ const IssueSyncListElementContainer = styled('div')`
 export const IntegrationLink = styled('a')<{disabled?: boolean}>`
   text-decoration: none;
   margin-left: ${space(1)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   cursor: pointer;
   line-height: 1.2;
   white-space: nowrap;

--- a/static/app/components/issues/suspect/suspectFlags.tsx
+++ b/static/app/components/issues/suspect/suspectFlags.tsx
@@ -122,7 +122,7 @@ const TagValueRow = styled('li')`
   align-items: center;
   padding: ${space(0.25)} ${space(0.75)};
   border-radius: ${p => p.theme.borderRadius};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-variant-numeric: tabular-nums;
 
   &:nth-child(2n) {

--- a/static/app/components/issues/suspect/suspectTable.tsx
+++ b/static/app/components/issues/suspect/suspectTable.tsx
@@ -52,7 +52,7 @@ const GradientBox = styled('div')`
     ${p => p.theme.backgroundSecondary}FF 100%
   );
   border-radius: ${p => p.theme.borderRadius};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: ${space(1)};
   height: max-content;
   display: flex;

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -288,7 +288,7 @@ export const Subject = styled('div')`
 export const ValueSection = styled('div')<{hasEmptySubject: boolean; hasErrors: boolean}>`
   font-family: ${p => p.theme.text.familyMono};
   word-break: break-word;
-  color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
+  color: ${p => (p.hasErrors ? 'inherit' : p.theme.tokens.content.primary)};
   grid-column: ${p => (p.hasEmptySubject ? '1 / -1' : 'span 1')};
   display: grid;
   grid-template-columns: 1fr auto;

--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -46,7 +46,7 @@ const Key = styled('dt')<{type: Props['type']}>`
   ${commonStyles};
   display: flex;
   align-items: center;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const Value = styled('dd')<{type: Props['type']}>`

--- a/static/app/components/lastCommit.tsx
+++ b/static/app/components/lastCommit.tsx
@@ -93,9 +93,9 @@ const Meta = styled('div')`
 `;
 
 const StyledCommitLink = styled(CommitLink)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   &:hover {
-    color: ${p => p.theme.textColor};
-    text-decoration: underline dotted ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
+    text-decoration: underline dotted ${p => p.theme.tokens.content.primary};
   }
 `;

--- a/static/app/components/modals/demoSignUp.tsx
+++ b/static/app/components/modals/demoSignUp.tsx
@@ -135,7 +135,7 @@ const CloseButton = styled(Button)`
   width: 30px;
   border-radius: 50%;
   background: ${p => p.theme.background};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 export default DemoSignUpModal;

--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -476,7 +476,7 @@ const FooterMessage = styled('p')`
   border-radius: ${p => p.theme.borderRadius};
   border: solid 1px ${p => p.theme.alert.warning.border};
   background: ${p => p.theme.alert.warning.backgroundLight};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
 `;
 

--- a/static/app/components/panels/panelHeader.tsx
+++ b/static/app/components/panels/panelHeader.tsx
@@ -32,7 +32,7 @@ const PanelHeader = styled('div')<Props>`
   /* Do not apply text styles to overlay elements such as dropdowns */
   > *:not(:has([data-overlay], button, a[role='button']), button, a[role='button']),
   &:not(:has(> *)) {
-    color: ${p => (p.lightText ? p.theme.subText : p.theme.textColor)};
+    color: ${p => (p.lightText ? p.theme.subText : p.theme.tokens.content.primary)};
     font-size: ${p => p.theme.fontSize.sm};
     font-weight: ${p => p.theme.fontWeight.bold};
     text-transform: uppercase;

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -131,7 +131,7 @@ const PillValue = styled(PillName)`
     margin: 0 0 0 ${space(1)};
     color: ${p => p.theme.subText};
     &:hover {
-      color: ${p => p.theme.textColor};
+      color: ${p => p.theme.tokens.content.primary};
     }
   }
 `;

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -331,7 +331,7 @@ const ClearButton = styled(Button)`
   justify-content: center;
   border-radius: 50%;
   background: ${p => p.theme.background};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const TransparentLoadingMask = styled(LoadingMask)<{visible: boolean}>`

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -386,7 +386,7 @@ const PlatformCard = styled(
     align-items: center;
     justify-content: center;
     width: 100%;
-    color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
+    color: ${p => (p.selected ? p.theme.tokens.content.primary : p.theme.subText)};
     text-align: center;
     font-size: ${p => p.theme.fontSize.xs};
     text-transform: uppercase;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
@@ -375,7 +375,7 @@ const ProfilingDetailsListItem = styled('li')<{
     font-weight: ${p => p.theme.fontWeight.normal};
     margin: 0;
     padding: ${p => (p.size === 'sm' ? space(0.25) : space(0.5))} 0;
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     max-height: ${p => (p.size === 'sm' ? '24px' : undefined)};
 
     &::after {
@@ -390,7 +390,7 @@ const ProfilingDetailsListItem = styled('li')<{
     }
 
     &:hover {
-      color: ${p => p.theme.textColor};
+      color: ${p => p.theme.tokens.content.primary};
     }
   }
 

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -391,7 +391,7 @@ export const ProfilingDetailsListItem = styled('li')<{
     font-weight: ${p => p.theme.fontWeight.normal};
     margin: 0;
 
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
 
     display: inline-block;
 
@@ -407,7 +407,7 @@ export const ProfilingDetailsListItem = styled('li')<{
     }
 
     &:hover {
-      color: ${p => p.theme.textColor};
+      color: ${p => p.theme.tokens.content.primary};
     }
   }
 

--- a/static/app/components/profiling/profilingContextMenu.tsx
+++ b/static/app/components/profiling/profilingContextMenu.tsx
@@ -39,7 +39,7 @@ const MenuContentContainer = styled('div')`
   background: ${p => (p.tabIndex === 0 ? p.theme.hover : undefined)};
 
   &:focus {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     background: ${p => p.theme.hover};
     outline: none;
   }
@@ -120,7 +120,7 @@ const MenuButton = styled('button')`
   opacity: ${p => (p.disabled ? 0.7 : undefined)};
 
   &:focus {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     background: ${p => p.theme.hover};
     outline: none;
   }
@@ -196,7 +196,7 @@ const MenuItem = styled(({ref, ...props}: MenuItemProps) => {
   );
 })`
   cursor: pointer;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   background: transparent;
   padding: 0 ${space(0.5)};
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -178,7 +178,7 @@ const StyledTimelineItem = styled(Timeline.Item)`
 `;
 
 const ReplayTimestamp = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   align-self: flex-start;
 `;

--- a/static/app/components/replays/list/__stories__/replayListItem.tsx
+++ b/static/app/components/replays/list/__stories__/replayListItem.tsx
@@ -123,13 +123,13 @@ const SubText = styled('div')`
 `;
 
 const DisplayName = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.md};
   font-weight: ${p => p.theme.fontWeight.bold};
   line-height: normal;
   ${p => p.theme.overflowEllipsis};
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;

--- a/static/app/components/replays/table/deleteReplays.tsx
+++ b/static/app/components/replays/table/deleteReplays.tsx
@@ -289,7 +289,7 @@ const SubText = styled('div')`
 `;
 
 const DisplayName = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.md};
   font-weight: ${p => p.theme.fontWeight.bold};
   line-height: normal;

--- a/static/app/components/resourceCard.tsx
+++ b/static/app/components/resourceCard.tsx
@@ -35,7 +35,7 @@ const StyledImg = styled('img')`
 `;
 
 const StyledTitle = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.lg};
   text-align: center;
   font-weight: ${p => p.theme.fontWeight.bold};

--- a/static/app/components/savedEntityTable.tsx
+++ b/static/app/components/savedEntityTable.tsx
@@ -139,7 +139,7 @@ SavedEntityTable.CellStar = function CellStar({
 };
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   text-decoration: underline;
   text-decoration-color: ${p => p.theme.border};
   ${p => p.theme.overflowEllipsis};

--- a/static/app/components/search/searchResultWrapper.tsx
+++ b/static/app/components/search/searchResultWrapper.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 const SearchResultWrapper = styled('div')<{highlighted?: boolean}>`
   cursor: pointer;
   display: block;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: 10px;
   scroll-margin: 120px;
 

--- a/static/app/components/searchBar/searchDropdown.tsx
+++ b/static/app/components/searchBar/searchDropdown.tsx
@@ -585,7 +585,7 @@ const SearchItemTitleWrapper = styled('div')<{hasSingleField?: boolean}>`
   flex-shrink: ${p => (p.hasSingleField ? '1' : '0')};
   max-width: ${p => (p.hasSingleField ? '100%' : 'min(280px, 50%)')};
 
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: ${p => p.theme.fontWeight.normal};
   font-size: ${p => p.theme.fontSize.md};
   margin: 0;

--- a/static/app/components/searchBar/searchDropdown.tsx
+++ b/static/app/components/searchBar/searchDropdown.tsx
@@ -598,7 +598,7 @@ const RestOfWordsContainer = styled('span')<{
   hasSplit?: boolean;
   isFirstWordHidden?: boolean;
 }>`
-  color: ${p => (p.hasSplit ? p.theme.blue400 : p.theme.textColor)};
+  color: ${p => (p.hasSplit ? p.theme.blue400 : p.theme.tokens.content.primary)};
   margin-left: ${p => (p.isFirstWordHidden ? space(1) : '0px')};
 `;
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
@@ -81,7 +81,7 @@ export function FilterKey({item, state, token, onActiveChange}: FilterKeyProps) 
 
 const KeyButton = styled(UnstyledButton)`
   padding: 0 ${space(0.25)} 0 ${space(0.5)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   border-left: 1px solid transparent;
   border-right: 1px solid transparent;
   width: 100%;

--- a/static/app/components/searchQueryBuilder/tokens/filter/specificDatePicker.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/specificDatePicker.tsx
@@ -284,7 +284,7 @@ const TimeUtcWrapper = styled('div')`
 `;
 
 const UtcPickerLabel = styled('label')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   white-space: nowrap;
   display: flex;
   align-items: center;
@@ -307,7 +307,7 @@ const CheckboxLabel = styled('label')`
   margin: 0;
   gap: ${space(1)};
   font-weight: ${p => p.theme.fontWeight.normal};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   cursor: pointer;
 `;
 

--- a/static/app/components/slider/index.tsx
+++ b/static/app/components/slider/index.tsx
@@ -315,7 +315,7 @@ const SliderLabelWrapper = styled('div')`
 
 const SliderLabel = styled('label')`
   font-weight: ${p => p.theme.fontWeight.normal};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const SliderLabelOutput = styled('output')`

--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -275,7 +275,7 @@ const ValueMultiLineString = styled('pre')`
   border-radius: 4px;
   padding: 2px 4px;
   background-color: transparent;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const ValueStrippedString = styled('span')`

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -173,7 +173,7 @@ const ColumnHeaderCell = styled('div')<{isSorted?: boolean}>`
   ${p =>
     p.isSorted &&
     css`
-      color: ${p.theme.textColor};
+      color: ${p.theme.tokens.content.primary};
     `}
 `;
 

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -531,7 +531,7 @@ const FooterMessage = styled('p')`
   border-radius: ${p => p.theme.borderRadius};
   border: solid 1px ${p => p.theme.alert.warning.border};
   background: ${p => p.theme.alert.warning.backgroundLight};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
 `;
 

--- a/static/app/components/workflowEngine/gridCell/issueCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/issueCell.tsx
@@ -66,7 +66,7 @@ const IssueWrapper = styled(Link)`
 
   ${p => css`
     &:hover [data-group-title] {
-      color: ${p.theme.textColor};
+      color: ${p.theme.tokens.content.primary};
       text-decoration: underline;
     }
   `}

--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -86,7 +86,7 @@ export function TitleCell({
 }
 
 const Name = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   align-items: center;
   gap: ${space(0.5)};

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -295,12 +295,12 @@ const StyledOverlay = styled(Overlay)`
 
   /* Make section headers darker in this component */
   p[id][aria-hidden='true'] {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
 const SectionTitle = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: 600;
   text-transform: uppercase;
 `;

--- a/static/app/stories/view/storyTableOfContents.tsx
+++ b/static/app/stories/view/storyTableOfContents.tsx
@@ -307,7 +307,7 @@ const StyledLink = styled('a')<{hasActiveChild: boolean; isActive: boolean}>`
 
   &:hover {
     background: ${p => p.theme.tokens.background.tertiary};
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 
   ${p =>

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -138,7 +138,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
       background: transparent;
     }
 
-    color: ${theme.textColor};
+    color: ${theme.tokens.content.primary};
     background: ${theme.tokens.background.primary};
   }
 
@@ -147,12 +147,12 @@ const styles = (theme: Theme, isDark: boolean) => css`
     /*this updates styles set by base.less to match our theme*/
     body.theme-dark {
       background: ${theme.tokens.background.primary};
-      color: ${theme.textColor};
+      color: ${theme.tokens.content.primary};
     }
     body.theme-system {
       @media (prefers-color-scheme: dark) {
         background: ${theme.tokens.background.primary};
-        color: ${theme.textColor};
+        color: ${theme.tokens.content.primary};
       }
     }
     /*this updates styles set by shared-components.less to match our theme*/
@@ -186,7 +186,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
 
   pre,
   code {
-    color: ${theme.textColor};
+    color: ${theme.tokens.content.primary};
   }
 
   pre {
@@ -258,7 +258,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
             border-bottom-color: ${theme.border};
 
             a {
-              color: ${theme.textColor};
+              color: ${theme.tokens.content.primary};
 
               &:hover {
                 color: ${theme.linkHoverColor};
@@ -280,13 +280,13 @@ const styles = (theme: Theme, isDark: boolean) => css`
           & > li {
             &.active {
               a {
-                color: ${theme.textColor} !important;
+                color: ${theme.tokens.content.primary} !important;
                 border-bottom-color: ${theme.active} !important;
               }
             }
 
             a:hover {
-              color: ${theme.textColor} !important;
+              color: ${theme.tokens.content.primary} !important;
             }
           }
           &.border-bottom {
@@ -322,7 +322,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
               background-color: ${theme.background};
             }
             .btn-toggle {
-              color: ${theme.textColor};
+              color: ${theme.tokens.content.primary};
               background: transparent;
             }
             .title {
@@ -360,17 +360,17 @@ const styles = (theme: Theme, isDark: boolean) => css`
         /* Global Selection header date picker */
         .rdrCalendarWrapper {
           background: ${theme.background};
-          color: ${theme.textColor};
+          color: ${theme.tokens.content.primary};
         }
         .rdrDayDisabled {
           background-color: ${theme.backgroundSecondary};
           color: ${theme.disabled};
         }
         .rdrMonthAndYearPickers select {
-          color: ${theme.textColor};
+          color: ${theme.tokens.content.primary};
         }
         .dropdown-menu {
-          color: ${theme.textColor};
+          color: ${theme.tokens.content.primary};
           background-color: ${theme.background} !important;
           border: 1px solid ${theme.border};
           &:before {

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -361,8 +361,8 @@ export const makeLightChonkFlamegraphTheme = (theme: Theme): FlamegraphTheme => 
       SAMPLE_TICK_COLOR: hexToColorChannels(theme.colors.red400, 0.5),
 
       // Cursors and labels
-      LABEL_FONT_COLOR: theme.textColor,
-      BAR_LABEL_FONT_COLOR: theme.textColor,
+      LABEL_FONT_color: theme.tokens.content.primary,
+      BAR_LABEL_FONT_color: theme.tokens.content.primary,
       CHART_CURSOR_INDICATOR: theme.subText,
       CHART_LABEL_COLOR: theme.subText,
       CURSOR_CROSSHAIR: theme.border,
@@ -452,8 +452,8 @@ export const makeDarkChonkFlamegraphTheme = (theme: Theme): FlamegraphTheme => {
       SAMPLE_TICK_COLOR: hexToColorChannels(theme.colors.red400, 0.5),
 
       // Cursors and labels
-      LABEL_FONT_COLOR: theme.textColor,
-      BAR_LABEL_FONT_COLOR: theme.textColor,
+      LABEL_FONT_color: theme.tokens.content.primary,
+      BAR_LABEL_FONT_color: theme.tokens.content.primary,
       CHART_CURSOR_INDICATOR: theme.subText,
       CHART_LABEL_COLOR: theme.subText,
       CURSOR_CROSSHAIR: theme.border,

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -361,8 +361,8 @@ export const makeLightChonkFlamegraphTheme = (theme: Theme): FlamegraphTheme => 
       SAMPLE_TICK_COLOR: hexToColorChannels(theme.colors.red400, 0.5),
 
       // Cursors and labels
-      LABEL_FONT_color: theme.tokens.content.primary,
-      BAR_LABEL_FONT_color: theme.tokens.content.primary,
+      LABEL_FONT_COLOR: theme.tokens.content.primary,
+      BAR_LABEL_FONT_COLOR: theme.tokens.content.primary,
       CHART_CURSOR_INDICATOR: theme.subText,
       CHART_LABEL_COLOR: theme.subText,
       CURSOR_CROSSHAIR: theme.border,
@@ -452,8 +452,8 @@ export const makeDarkChonkFlamegraphTheme = (theme: Theme): FlamegraphTheme => {
       SAMPLE_TICK_COLOR: hexToColorChannels(theme.colors.red400, 0.5),
 
       // Cursors and labels
-      LABEL_FONT_color: theme.tokens.content.primary,
-      BAR_LABEL_FONT_color: theme.tokens.content.primary,
+      LABEL_FONT_COLOR: theme.tokens.content.primary,
+      BAR_LABEL_FONT_COLOR: theme.tokens.content.primary,
       CHART_CURSOR_INDICATOR: theme.subText,
       CHART_LABEL_COLOR: theme.subText,
       CURSOR_CROSSHAIR: theme.border,

--- a/static/app/views/alerts/rules/issue/details/issuesList.tsx
+++ b/static/app/views/alerts/rules/issue/details/issuesList.tsx
@@ -162,7 +162,7 @@ const TitleWrapper = styled('div')`
 
 const MessageWrapper = styled('span')`
   ${p => p.theme.overflowEllipsis};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const PaginationWrapper = styled('div')`

--- a/static/app/views/alerts/rules/issue/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/issue/details/sidebar.tsx
@@ -231,7 +231,7 @@ const ConditionsBadge = styled('span')`
   background-color: ${p => p.theme.surface200};
   padding: 0 ${space(0.75)};
   border-radius: ${p => p.theme.borderRadius};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   margin-bottom: ${space(1)};
   width: fit-content;

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -667,7 +667,7 @@ const StyledCircleIndicator = styled(CircleIndicator)`
 const ChartFilters = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
   font-family: ${p => p.theme.text.family};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: inline-grid;
   grid-template-columns: max-content max-content auto;
   align-items: center;

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -425,7 +425,7 @@ const TriggerText = styled('span')`
   background-color: ${p => p.theme.surface200};
   padding: ${space(0.25)} ${space(0.75)};
   border-radius: ${p => p.theme.borderRadius};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   width: 100%;
   font-weight: ${p => p.theme.fontWeight.normal};

--- a/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
+++ b/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
@@ -155,7 +155,7 @@ export function IncompatibleAlertQuery(props: IncompatibleAlertQueryProps) {
 }
 
 const StyledAlert = styled(Alert)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const StyledUnorderedList = styled('ul')`

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1622,7 +1622,7 @@ const AlertInfo = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
   font-family: ${p => p.theme.text.family};
   font-weight: ${p => p.theme.fontWeight.normal};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const StyledCircleIndicator = styled(CircleIndicator)`

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -157,7 +157,8 @@ function CheckInBodyCell({
       return <Cell>{httpStatusCode}</Cell>;
     }
     case 'checkStatus': {
-      const color = tickStyle(theme)[checkStatus].labelColor ?? theme.textColor;
+      const color =
+        tickStyle(theme)[checkStatus].labelColor ?? theme.tokens.content.primary;
       const checkStatusReasonLabel = checkStatusReason
         ? reasonToText[checkStatusReason](check)
         : null;

--- a/static/app/views/alerts/wizard/radioPanelGroup.tsx
+++ b/static/app/views/alerts/wizard/radioPanelGroup.tsx
@@ -80,11 +80,11 @@ const RadioLineItem = styled('label')<{
 
   &:hover,
   &:focus {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 
   &[aria-checked='true'] {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/auth/loginForm.tsx
+++ b/static/app/views/auth/loginForm.tsx
@@ -156,7 +156,7 @@ const LostPasswordLink = styled(Link)`
   font-size: ${p => p.theme.fontSize.md};
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/auth/registerForm.tsx
+++ b/static/app/views/auth/registerForm.tsx
@@ -99,7 +99,7 @@ const PrivacyPolicyLink = styled(ExternalLink)`
   color: ${p => p.theme.subText};
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/automations/components/automationListTable/connectedDetectors.tsx
+++ b/static/app/views/automations/components/automationListTable/connectedDetectors.tsx
@@ -92,7 +92,7 @@ const WiderHovercard = styled(Hovercard)`
 `;
 
 const ConnectedDetectors = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   flex-direction: row;
   gap: ${space(0.5)};

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -169,7 +169,7 @@ const Panel = styled('div')`
 `;
 
 const ConditionGroupHeader = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const ConditionGroupWrapper = styled('div')<{showDivider?: boolean}>`

--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -146,11 +146,11 @@ const CardLink = styled(Link)`
   display: flex;
   flex-direction: column;
 
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   &:focus,
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
 
     ${Title} {
       text-decoration: underline;
@@ -192,7 +192,7 @@ const DateSelected = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
   display: grid;
   grid-column-gap: ${space(1)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   ${p => p.theme.overflowEllipsis};
 `;
 

--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -56,7 +56,7 @@ function DashboardCard({
         to={to}
         aria-label={title}
       >
-        <InteractionStateLayer as="div" color={theme.textColor} />
+        <InteractionStateLayer as="div" color={theme.tokens.content.primary} />
 
         <CardHeader>
           <CardContent>

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -392,12 +392,12 @@ const DateSelected = styled('div')`
   font-size: ${p => p.theme.fontSize.md};
   display: grid;
   grid-column-gap: ${space(1)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   ${p => p.theme.overflowEllipsis};
 `;
 
 const DateStatus = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding-left: ${space(1)};
 `;
 

--- a/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
+++ b/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
@@ -98,7 +98,7 @@ export function DetectorListConnectedAutomations({
 }
 
 const ConnectedAutomations = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   flex-direction: row;
   gap: ${space(0.5)};
@@ -119,7 +119,7 @@ const HovercardRow = styled(Link)`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: ${space(1)} ${space(2)};
 
   min-height: 64px;
@@ -133,7 +133,7 @@ const HovercardRow = styled(Link)`
   }
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 
   &:hover strong {

--- a/static/app/views/detectors/components/detectorListTable/detectorTypeCell.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorTypeCell.tsx
@@ -23,7 +23,7 @@ export function DetectorTypeCell({
 }
 
 const Type = styled('div')<{disabled: boolean}>`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   flex-direction: row;
   gap: ${space(0.5)};

--- a/static/app/views/discover/querycard.tsx
+++ b/static/app/views/discover/querycard.tsx
@@ -138,7 +138,7 @@ const DateSelected = styled('div')`
   display: grid;
   grid-column-gap: ${space(1)};
   ${p => p.theme.overflowEllipsis};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const DateStatus = styled('span')`

--- a/static/app/views/discover/table/arithmeticInput.tsx
+++ b/static/app/views/discover/table/arithmeticInput.tsx
@@ -464,7 +464,7 @@ const DropdownListItem = styled(ListItem)`
 `;
 
 const DropdownItemTitleWrapper = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: ${p => p.theme.fontWeight.normal};
   font-size: ${p => p.theme.fontSize.md};
   margin: 0;

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -488,7 +488,7 @@ const ActionMenuTrigger = styled(Button)`
 const ActionMenuTriggerV2 = styled('div')<{hasLinks?: boolean}>`
   a,
   span {
-    color: ${p => (p.hasLinks ? p.theme.linkColor : p.theme.textColor)};
+    color: ${p => (p.hasLinks ? p.theme.linkColor : p.theme.tokens.content.primary)};
   }
   :hover {
     cursor: pointer;

--- a/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
@@ -75,7 +75,7 @@ const List = styled('ul')`
   margin-bottom: 0 !important;
   box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
   background: ${p => p.theme.backgroundElevated};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
   overflow: hidden;

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -511,7 +511,7 @@ const HintTextContainer = styled('div')`
 
 const HintName = styled('span')`
   font-weight: ${p => p.theme.fontWeight.normal};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const HintOperator = styled('span')`

--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -565,7 +565,7 @@ const TreeValue = styled('div')<{hasErrors?: boolean}>`
   font-size: ${p => p.theme.fontSize.sm};
   word-break: break-word;
   grid-column: span 1;
-  color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
+  color: ${p => (p.hasErrors ? 'inherit' : p.theme.tokens.content.primary)};
 `;
 
 const TreeKey = styled(TreeValue)<{hasErrors?: boolean}>`

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -130,7 +130,7 @@ const PerformanceScoreLabelContainer = styled('div')`
 const PerformanceScoreLabel = styled('div')`
   width: 100%;
   font-size: ${p => p.theme.fontSize.lg};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: ${p => p.theme.fontWeight.bold};
 `;
 

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -289,7 +289,7 @@ function PerformanceScoreRingWithTooltips({
           textCss={() => css`
             font-size: 32px;
             font-weight: ${theme.fontWeight.bold};
-            color: ${theme.textColor};
+            color: ${theme.tokens.content.primary};
           `}
           segmentColors={ringSegmentColors}
           backgroundColors={ringBackgroundColors}
@@ -346,7 +346,7 @@ const ProgressRingContainer = styled('div')``;
 
 const ProgressRingText = styled('text')<{isLink?: boolean}>`
   font-size: ${p => p.theme.fontSize.md};
-  fill: ${p => (p.isLink ? p.theme.blue300 : p.theme.textColor)};
+  fill: ${p => (p.isLink ? p.theme.blue300 : p.theme.tokens.content.primary)};
   font-weight: ${p => p.theme.fontWeight.bold};
   text-transform: uppercase;
   text-anchor: middle;

--- a/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.tsx
@@ -314,7 +314,7 @@ const MeterBarBody = styled('div')`
 const MeterHeader = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
   font-weight: ${p => p.theme.fontWeight.bold};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   width: 100%;
   padding: 0 ${space(1)};
@@ -327,7 +327,7 @@ const MeterValueText = styled('div')`
   align-items: center;
   font-size: ${p => p.theme.fontSize.xl};
   font-weight: ${p => p.theme.fontWeight.bold};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   flex: 1;
   text-align: center;
   padding: 0 ${space(1)};

--- a/static/app/views/insights/crons/components/detailsSidebar.tsx
+++ b/static/app/views/insights/crons/components/detailsSidebar.tsx
@@ -207,7 +207,7 @@ const MonitorSlug = styled('button')`
   background: transparent;
   border: none;
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/insights/crons/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/overviewRow.tsx
@@ -244,7 +244,7 @@ export function OverviewRow({
 const DetailsLink = styled(Link)`
   display: block;
   padding: ${space(3)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   &:focus-visible {
     outline: none;

--- a/static/app/views/insights/mobile/screens/components/vitalCard.tsx
+++ b/static/app/views/insights/mobile/screens/components/vitalCard.tsx
@@ -64,7 +64,7 @@ const MeterBarBody = styled('div')`
 
 const MeterHeader = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: inline-block;
   text-align: center;
   width: 100%;
@@ -75,7 +75,7 @@ const MeterValueText = styled('div')`
   justify-content: center;
   align-items: center;
   font-size: ${p => p.theme.fontSize.xl};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   flex: 1;
   text-align: center;
 `;

--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -179,7 +179,7 @@ function DetailsLine(props: {children: React.ReactNode}) {
 }
 
 const InnerDetailsLink = styled(Link)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   &:focus-visible {
     outline: none;

--- a/static/app/views/integrationPipeline/components/headerWithHelp.tsx
+++ b/static/app/views/integrationPipeline/components/headerWithHelp.tsx
@@ -31,5 +31,5 @@ const Header = styled('div')`
 const StyledLogoSentry = styled(LogoSentry)`
   width: 130px;
   height: 30px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -209,7 +209,7 @@ const TagBarGlobalSelectionLink = styled(GlobalSelectionLink)`
   position: relative;
   display: flex;
   line-height: 2.2;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   margin-bottom: ${space(0.5)};
   padding: 0 ${space(1)};
   background: ${p => p.theme.backgroundSecondary};
@@ -217,7 +217,7 @@ const TagBarGlobalSelectionLink = styled(GlobalSelectionLink)`
   overflow: hidden;
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     text-decoration: underline;
     ${TagBarBackground} {
       background: ${p => (p.theme.isChonk ? p.theme.blue300 : p.theme.purple200)};

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -365,7 +365,7 @@ const ColumnSort = styled(Link)`
   font-weight: ${p => p.theme.fontWeight.bold};
   text-decoration: underline;
   text-decoration-style: dotted;
-  text-decoration-color: ${p => p.theme.textColor};
+  text-decoration-color: ${p => p.theme.tokens.content.primary};
   &:hover {
     color: ${p => p.theme.subText};
   }
@@ -411,7 +411,7 @@ const UserSubtitle = styled('div')`
 `;
 
 const ValueLink = styled(Link)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   word-break: break-all;
 `;
 

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -129,7 +129,7 @@ const TagPanel = styled('div')`
 `;
 
 const TagHeader = styled('h5')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.md};
   font-weight: ${p => p.theme.fontWeight.bold};
   margin: 0;

--- a/static/app/views/issueDetails/reprocessingProgress.tsx
+++ b/static/app/views/issueDetails/reprocessingProgress.tsx
@@ -69,7 +69,7 @@ const Inner = styled('div')`
 const Header = styled('div')`
   display: grid;
   gap: ${space(1)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   max-width: 557px;
 `;
 

--- a/static/app/views/issueDetails/sectionToggleButton.tsx
+++ b/static/app/views/issueDetails/sectionToggleButton.tsx
@@ -24,7 +24,7 @@ const ToggleButton = styled(Button)`
   color: ${p => p.theme.subText};
   :hover,
   :focus {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
   font-weight: ${p => p.theme.fontWeight.bold};
 `;

--- a/static/app/views/issueDetails/streamline/eventListTable.tsx
+++ b/static/app/views/issueDetails/streamline/eventListTable.tsx
@@ -145,7 +145,7 @@ export const Header = styled('div')`
 `;
 
 export const Title = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: ${p => p.theme.fontWeight.bold};
   font-size: ${p => p.theme.fontSize.md};
 `;
@@ -215,7 +215,7 @@ const StreamlineGridEditable = styled('div')`
 
     td:not(:nth-child(2)) {
       a {
-        color: ${p => p.theme.textColor};
+        color: ${p => p.theme.tokens.content.primary};
         text-decoration: underline;
         text-decoration-color: ${p => p.theme.border};
       }

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -405,12 +405,12 @@ const TagPreviewGrid = styled(Link)`
   padding: 0 ${p => p.theme.space.sm};
   margin: 0 -${p => p.theme.space.sm};
   border-radius: ${p => p.theme.borderRadius};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
 
   &:hover {
     background: ${p => p.theme.backgroundTertiary};
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/streamline/occurrenceSummary.tsx
@@ -170,7 +170,7 @@ const ItemTimeSince = styled(TimeSince)`
 `;
 
 const ItemLink = styled(Link)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.lg};
   text-decoration: underline;
   text-decoration-style: dotted;

--- a/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
@@ -106,7 +106,7 @@ const ParticipantListWrapper = styled('div')`
   max-height: 325px;
   overflow-y: auto;
   border-radius: ${p => p.theme.borderRadius};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   & > div:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.border};

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -671,7 +671,7 @@ const CollapsedSummaryCard = styled('div')`
   cursor: pointer;
   font-size: ${p => p.theme.fontSize.md};
   font-weight: 500;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   transition: box-shadow 0.2s;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
   &:hover {

--- a/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceIssue.tsx
@@ -126,7 +126,7 @@ export function getTitleSubtitleMessage(event: TimelineEvent) {
 const TraceIssueLinkContainer = styled(Link)`
   display: flex;
   gap: ${space(2)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   padding: ${space(2)} ${space(2)} ${space(2)} ${space(2)};
   margin: ${space(1)} 0 ${space(1)} 0;
   border: 1px solid ${p => p.theme.border};
@@ -135,7 +135,7 @@ const TraceIssueLinkContainer = styled(Link)`
 
   &:hover {
     background-color: ${p => p.theme.backgroundTertiary};
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -180,7 +180,7 @@ const YouAreHereItem = styled('div')`
 const EventItemRoot = styled(Link)`
   display: grid;
   grid-template-columns: max-content auto;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   gap: ${space(1)};
   width: 100%;
   padding: ${space(1)} ${space(1)} ${space(0.5)} ${space(1)};
@@ -189,7 +189,7 @@ const EventItemRoot = styled(Link)`
 
   &:hover {
     background-color: ${p => p.theme.surface200};
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -101,7 +101,7 @@ const GraphToggle = styled('a')<{active: boolean}>`
   &:hover,
   &:focus,
   &:active {
-    color: ${p => (p.active ? p.theme.textColor : p.theme.disabled)};
+    color: ${p => (p.active ? p.theme.tokens.content.primary : p.theme.disabled)};
   }
 `;
 

--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -1216,7 +1216,7 @@ const ClusterTitle = styled('h3')`
   margin: 0;
   font-size: ${p => p.theme.fontSize.xl};
   font-weight: 600;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   line-height: 1.3;
   word-break: break-word;
 `;
@@ -1324,7 +1324,7 @@ const Tab = styled('button')<{isActive: boolean}>`
   `}
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
@@ -1381,7 +1381,7 @@ const IssuePreviewLink = styled(Link)`
 const IssueTitle = styled('div')`
   font-size: ${p => p.theme.fontSize.md};
   font-weight: 600;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   line-height: 1.4;
   ${p => p.theme.overflowEllipsis};
 
@@ -1452,7 +1452,7 @@ const InfoLabel = styled('span')`
 `;
 
 const InfoValue = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   word-break: break-word;
 `;
 
@@ -1480,7 +1480,7 @@ const ShowMoreButton = styled('button')`
   &:hover {
     background: ${p => p.theme.backgroundTertiary};
     border-color: ${p => p.theme.purple300};
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -1304,7 +1304,7 @@ const Tab = styled('button')<{isActive: boolean}>`
   padding: ${space(1)} ${space(1.5)};
   font-size: ${p => p.theme.fontSize.sm};
   font-weight: 500;
-  color: ${p => (p.isActive ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.isActive ? p.theme.tokens.content.primary : p.theme.subText)};
   cursor: pointer;
   position: relative;
   margin-bottom: -1px;

--- a/static/app/views/nav/mobileTopbar.tsx
+++ b/static/app/views/nav/mobileTopbar.tsx
@@ -165,6 +165,6 @@ const NavigationOverlay = styled('nav')`
   flex-direction: column;
   background: ${p => p.theme.surface200};
   z-index: ${p => p.theme.zIndex.modal};
-  --color: ${p => p.theme.textColor};
+  --color: ${p => p.theme.tokens.content.primary};
   --color-hover: ${p => p.theme.activeText};
 `;

--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -216,5 +216,5 @@ const SectionTitleWrapper = styled('div')`
   text-transform: none;
   font-size: ${p => p.theme.fontSize.md};
   font-weight: ${p => p.theme.fontWeight.normal};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -320,14 +320,14 @@ const baseNavItemStyles = (p: {isMobile: boolean; theme: Theme}) => css`
   gap: ${space(1.5)};
   align-items: center;
   padding: ${space(1.5)} ${space(3)};
-  color: ${p.theme.textColor};
+  color: ${p.theme.tokens.content.primary};
   font-size: ${p.theme.fontSize.md};
   font-weight: ${p.theme.fontWeight.normal};
   line-height: 1;
   width: 100%;
 
   &:hover {
-    color: ${p.theme.textColor};
+    color: ${p.theme.tokens.content.primary};
   }
 
   & > * {

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -324,7 +324,7 @@ const Section = styled('div')<{layout: NavLayout}>`
 
 const sectionTitleStyles = (p: {isMobile: boolean; theme: Theme}) => css`
   font-weight: ${p.theme.fontWeight.bold};
-  color: ${p.theme.textColor};
+  color: ${p.theme.tokens.content.primary};
   padding: ${space(0.75)} ${space(1)};
   width: 100%;
   ${p.isMobile &&

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -436,7 +436,7 @@ const StyledNavItem = styled(Link)<ItemProps>`
   padding: 4px ${space(1)};
   height: 34px;
   align-items: center;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.md};
   font-weight: ${p => p.theme.fontWeight.normal};
   line-height: 177.75%;

--- a/static/app/views/nav/userDropdown.tsx
+++ b/static/app/views/nav/userDropdown.tsx
@@ -65,5 +65,5 @@ const SectionTitleWrapper = styled('div')`
   text-transform: none;
   font-size: ${p => p.theme.fontSize.md};
   font-weight: ${p => p.theme.fontWeight.normal};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;

--- a/static/app/views/onboarding/components/stepHeading.tsx
+++ b/static/app/views/onboarding/components/stepHeading.tsx
@@ -37,7 +37,8 @@ const StepHeading = styled(
     background-color: ${p =>
       isChonkTheme(p.theme) ? p.theme.colors.chonk.yellow400 : p.theme.yellow300};
     border-radius: 50%;
-    color: ${p => (isChonkTheme(p.theme) ? p.theme.colors.black : p.theme.textColor)};
+    color: ${p =>
+      isChonkTheme(p.theme) ? p.theme.colors.black : p.theme.tokens.content.primary};
     font-size: 1rem;
   }
 `;

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -324,7 +324,7 @@ const Header = styled('header')`
 const LogoSvg = styled(LogoSentry)`
   width: 130px;
   height: 30px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const OnboardingStep = styled(motion.div)`

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -154,7 +154,7 @@ function TeamStatsControls({
               fontSize: theme.fontSize.md,
               ':before': {
                 ...provided[':before'],
-                color: theme.textColor,
+                color: theme.tokens.content.primary,
                 marginRight: space(1.5),
                 marginLeft: space(0.5),
               },

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -914,7 +914,7 @@ const TraceStylingWrapper = styled('div')`
     position: absolute;
     font-size: 10px;
     font-weight: ${p => p.theme.fontWeight.bold};
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     background-color: ${p => p.theme.background};
     border-radius: 100px;
     border: 1px solid ${p => p.theme.border};
@@ -1006,7 +1006,7 @@ const TraceStylingWrapper = styled('div')`
       background: repeating-linear-gradient(
           to bottom,
           transparent 0 4px,
-          ${p => p.theme.textColor} 4px 8px
+          ${p => p.theme.tokens.content.primary} 4px 8px
         )
         80%/2px 100% no-repeat;
 

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -191,7 +191,7 @@ const VitalPillValue = styled('div')`
   border-left: none;
   border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
   background: ${p => p.theme.background};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.lg};
   padding: 0 ${space(1)};
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/request.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/request.tsx
@@ -286,7 +286,7 @@ const Monospace = styled('span')`
 `;
 
 const Path = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   text-transform: none;
   font-weight: ${p => p.theme.fontWeight.normal};
 
@@ -305,6 +305,6 @@ const StyledIconOpen = styled(IconOpen)`
   top: 1px;
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -510,7 +510,7 @@ const CloseButton = styled(Button)`
   height: 100%;
   border-bottom: 2px solid transparent;
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
@@ -551,7 +551,7 @@ const PanelWrapper = styled('div')<{
   right: 0;
   position: relative;
   background: ${p => p.theme.background};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   text-align: left;
   z-index: 10;
 `;
@@ -683,7 +683,7 @@ const TabButton = styled('button')`
   margin: 0;
   padding: 0 ${space(0.25)};
   font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   background: transparent;
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
@@ -305,9 +305,9 @@ const HighlightsSubtitle = styled(Tooltip)`
 
 const StyledVersion = styled(Version)`
   font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSummary.tsx
@@ -199,7 +199,7 @@ const SectionTitle = styled('h6')`
 `;
 
 const SectionContent = styled(MarkedText)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.md};
   line-height: 1.4;
   margin-bottom: ${space(3)};
@@ -241,7 +241,7 @@ const StyledListItem = styled('li')`
 
 const StyledLink = styled(Link)`
   text-decoration: none;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: 600;
   margin-right: 6px;
 `;

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -444,7 +444,7 @@ class VitalCard extends Component<Props, State> {
         show: false,
       },
       lineStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         type: 'solid',
       },
       tooltip: {

--- a/static/app/views/performance/utils/getIntervalLine.tsx
+++ b/static/app/views/performance/utils/getIntervalLine.tsx
@@ -36,12 +36,12 @@ export function getIntervalLine(
 
   const periodLine: LineChartSeries = {
     data: [],
-    color: theme.textColor,
+    color: theme.tokens.content.primary,
     markLine: {
       data: [],
       label: {},
       lineStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         type: 'dashed',
         width: label ? 1 : 2,
       },
@@ -56,7 +56,7 @@ export function getIntervalLine(
   const periodLineLabel = {
     fontSize: 11,
     show: label,
-    color: theme.textColor,
+    color: theme.tokens.content.primary,
     silent: label,
   };
 
@@ -130,7 +130,7 @@ export function getIntervalLine(
     ],
     label: {show: false},
     lineStyle: {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       type: 'solid',
       width: 2,
     },

--- a/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
@@ -104,7 +104,7 @@ export function AppSizeCategories(props: AppSizeCategoriesProps) {
             <div style="font-family: Rubik;">
               <div style="display: flex; align-items: center; font-size: 12px; font-weight: bold; line-height: 1; margin-bottom: ${theme.space.md}; gap: ${theme.space.md}">
                 <div style="flex: initial; width: 8px !important; height: 8px !important; border-radius: 50%; background-color: ${params.color};"></div>
-                <span style="color: ${theme.textColor}">${params.name}</span>
+                <span style="color: ${theme.tokens.content.primary}">${params.name}</span>
               </div>
               <div style="display: flex; flex-direction: column; line-height: 1; gap: ${theme.space.sm}">
                 <p style="font-size: 14px; font-weight: bold; margin-bottom: -2px;">${formatBytesBase10(value)}</p>

--- a/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
@@ -61,7 +61,7 @@ export function AppSizeCategories(props: AppSizeCategoriesProps) {
         formatter: '{b}\n{d}%',
         fontSize: 12,
         fontFamily: 'Rubik',
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
       },
       labelLine: {
         show: true,
@@ -94,7 +94,7 @@ export function AppSizeCategories(props: AppSizeCategoriesProps) {
     padding: 12,
     extraCssText: 'border-radius: 6px;',
     textStyle: {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       fontFamily: 'Rubik',
     },
     formatter: function (params: any) {

--- a/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
@@ -287,7 +287,7 @@ const LegendDot = styled('div')<{isActive: boolean}>`
 
 const LegendLabel = styled('span')`
   font-size: 12px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: 400;
 `;
 
@@ -298,7 +298,7 @@ const MoreContainer = styled('div')`
 
 const MoreLabel = styled('span')`
   font-size: 12px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: 500;
   white-space: nowrap;
 `;

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -300,7 +300,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     padding: 12,
     extraCssText: 'border-radius: 6px;',
     textStyle: {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       fontFamily: 'Rubik',
     },
     formatter: function (params: any) {

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -314,7 +314,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
             <div style="font-family: Rubik;">
               <div style="display: flex; align-items: center; font-size: 12px; font-weight: bold; line-height: 1; margin-bottom: ${theme.space.md}; gap: ${theme.space.md}">
                 <div style="flex: initial; width: 8px !important; height: 8px !important; border-radius: 50%; background-color: ${params.data?.itemStyle?.borderColor || theme.border};"></div>
-                <span style="color: ${theme.textColor}">${params.data?.category || 'Other'}</span>
+                <span style="color: ${theme.tokens.content.primary}">${params.data?.category || 'Other'}</span>
               </div>
               <div style="display: flex; flex-direction: column; line-height: 1; gap: ${theme.space.sm}">
                 <p style="font-size: 14px; font-weight: bold; margin-bottom: -2px;">${params.name}</p>

--- a/static/app/views/profiling/landing/functionTrendsWidget.tsx
+++ b/static/app/views/profiling/landing/functionTrendsWidget.tsx
@@ -391,7 +391,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
 
     const dividingLine = {
       data: [],
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       seriesName: 'dividing line',
       markLine: {},
     };
@@ -399,7 +399,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
       data: [{xAxis: seriesMid}],
       label: {show: false},
       lineStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         type: 'solid',
         width: 2,
       },
@@ -412,7 +412,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
 
     const beforeLine = {
       data: [],
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       seriesName: 'before line',
       markLine: {},
     };
@@ -426,13 +426,13 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
       label: {
         fontSize: 11,
         show: true,
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         silent: true,
         formatter: 'Past',
         position: 'insideStartTop',
       },
       lineStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         type: 'dashed',
         width: 1,
       },
@@ -444,7 +444,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
 
     const afterLine = {
       data: [],
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       seriesName: 'after line',
       markLine: {},
     };
@@ -461,13 +461,13 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
       label: {
         fontSize: 11,
         show: true,
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         silent: true,
         formatter: 'Present',
         position: 'insideEndBottom',
       },
       lineStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         type: 'dashed',
         width: 1,
       },

--- a/static/app/views/profiling/landing/profilesSummaryChart.tsx
+++ b/static/app/views/profiling/landing/profilesSummaryChart.tsx
@@ -195,7 +195,7 @@ export function ProfilesSummaryChart({
 
 const ProfilesChartTitle = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: ${p => p.theme.fontWeight.bold};
   padding: ${space(0.25)} ${space(1)};
 `;

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -787,7 +787,7 @@ const ProfileDigestHeader = styled('div')`
 `;
 
 const ProfileDigestLabel = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   font-weight: ${p => p.theme.fontWeight.bold};
   text-transform: uppercase;

--- a/static/app/views/profiling/profileSummary/profilingSparklineChart.tsx
+++ b/static/app/views/profiling/profileSummary/profilingSparklineChart.tsx
@@ -72,7 +72,7 @@ function makeSeriesBeforeAfterLines(
 ): LineChartSeries[] {
   const dividingLine = {
     data: [],
-    color: theme.textColor,
+    color: theme.tokens.content.primary,
     seriesName: 'dividing line',
     markLine: {},
   };
@@ -80,7 +80,7 @@ function makeSeriesBeforeAfterLines(
     data: [{xAxis: breakpoint * 1e3}],
     label: {show: false},
     lineStyle: {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       type: 'solid',
       width: 2,
     },
@@ -93,7 +93,7 @@ function makeSeriesBeforeAfterLines(
 
   const beforeLine = {
     data: [],
-    color: theme.textColor,
+    color: theme.tokens.content.primary,
     seriesName: 'before line',
     markLine: {},
   };
@@ -108,7 +108,7 @@ function makeSeriesBeforeAfterLines(
       show: false,
     },
     lineStyle: {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       type: 'dashed',
       width: 1,
     },
@@ -120,7 +120,7 @@ function makeSeriesBeforeAfterLines(
 
   const afterLine = {
     data: [],
-    color: theme.textColor,
+    color: theme.tokens.content.primary,
     seriesName: 'after line',
     markLine: {},
   };
@@ -138,7 +138,7 @@ function makeSeriesBeforeAfterLines(
       show: false,
     },
     lineStyle: {
-      color: theme.textColor,
+      color: theme.tokens.content.primary,
       type: 'dashed',
       width: 1,
     },

--- a/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
@@ -271,7 +271,7 @@ class Chart extends Component<ChartProps, ChartState> {
       itemGap: 12,
       align: 'left' as const,
       textStyle: {
-        color: theme.textColor,
+        color: theme.tokens.content.primary,
         verticalAlign: 'top',
         fontSize: 11,
         fontFamily: theme.text.family,

--- a/static/app/views/releases/detail/commitsAndFiles/releaseCommit.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/releaseCommit.tsx
@@ -129,11 +129,11 @@ const BoldEmail = styled('strong')`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.textColor};
-  border-bottom: 1px dotted ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
+  border-bottom: 1px dotted ${p => p.theme.tokens.content.primary};
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
@@ -154,7 +154,7 @@ const Meta = styled(TextOverflow)`
   }
 
   a:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 
@@ -186,7 +186,7 @@ const AuthorWrapper = styled('span')`
   }
 
   &:has(svg):hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     & svg {
       opacity: 1;
     }

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -203,7 +203,7 @@ const IconWrapper = styled('span')`
     display: flex;
     &:hover {
       cursor: pointer;
-      color: ${p => p.theme.textColor};
+      color: ${p => p.theme.tokens.content.primary};
     }
   }
 `;

--- a/static/app/views/releases/detail/overview/releaseArchivedNotice.tsx
+++ b/static/app/views/releases/detail/overview/releaseArchivedNotice.tsx
@@ -38,7 +38,7 @@ const UnarchiveButton = styled(Button)`
   &:hover,
   &:focus,
   &:active {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx
@@ -126,7 +126,7 @@ const NumericCell = styled(Cell)`
 const DescriptionCell = styled(Cell)`
   text-align: left;
   overflow: visible;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const ExpanderCell = styled(Cell)`

--- a/static/app/views/releases/detail/overview/sidebar/commitAuthorBreakdown.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/commitAuthorBreakdown.tsx
@@ -115,7 +115,7 @@ const AuthorLine = styled('div')`
 `;
 
 const AuthorName = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   ${p => p.theme.overflowEllipsis};
 `;
 

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -352,7 +352,7 @@ const TooltipWrapper = styled('span')`
 `;
 
 const AdoptionEnvironment = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   margin-left: ${space(0.5)};
   font-size: ${p => p.theme.fontSize.sm};
 `;

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -199,7 +199,7 @@ function ReleaseAdoption({
         return label && Object.values(releaseMarkLinesLabels).includes(label)
           ? ''
           : `<span>${formatAbbreviatedNumber(absoluteCount)} <span style="color: ${
-              theme.textColor
+              theme.tokens.content.primary
             };margin-left: ${space(0.5)}">${value}%</span></span>`;
       },
       filter: (_, seriesParam: any) => {

--- a/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
@@ -152,7 +152,7 @@ const InnerRow = styled('div')`
 
 const Text = styled('div')<{bold?: boolean; right?: boolean}>`
   text-align: ${p => (p.right ? 'right' : 'left')};
-  color: ${p => (p.bold ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.bold ? p.theme.tokens.content.primary : p.theme.subText)};
   padding-bottom: ${space(0.25)};
   ${p => p.theme.overflowEllipsis};
 `;

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -347,7 +347,7 @@ const FinalizeWrapper = styled('div')`
 
 const PackageName = styled('div')`
   font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   align-items: center;
   gap: ${space(0.5)};

--- a/static/app/views/releases/list/releaseCard/releaseCardStatsPeriod.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardStatsPeriod.tsx
@@ -59,11 +59,11 @@ const Wrapper = styled('div')`
 `;
 
 const Period = styled(Link)<{selected: boolean}>`
-  color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
+  color: ${p => (p.selected ? p.theme.tokens.content.primary : p.theme.subText)};
 
   &:hover,
   &:focus {
-    color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
+    color: ${p => (p.selected ? p.theme.tokens.content.primary : p.theme.subText)};
   }
 `;
 

--- a/static/app/views/relocation/components/stepHeading.tsx
+++ b/static/app/views/relocation/components/stepHeading.tsx
@@ -35,7 +35,8 @@ const StepHeading = styled((props: React.ComponentProps<typeof motion.h2>) => (
     background-color: ${p =>
       isChonkTheme(p.theme) ? p.theme.colors.chonk.yellow400 : p.theme.yellow300};
     border-radius: 50%;
-    color: ${p => (isChonkTheme(p.theme) ? p.theme.colors.black : p.theme.textColor)};
+    color: ${p =>
+      isChonkTheme(p.theme) ? p.theme.colors.black : p.theme.tokens.content.primary};
     font-size: 1rem;
   }
 `;

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -368,7 +368,7 @@ const Header = styled('header')`
 const LogoSvg = styled(LogoSentry)`
   width: 130px;
   height: 30px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const OnboardingStep = styled((props: React.ComponentProps<typeof motion.div>) => (

--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -324,7 +324,7 @@ const Chapter = styled('summary')`
   align-items: center;
   font-size: ${p => p.theme.fontSize.lg};
   padding: 0 ${space(0.75)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   &:hover {
     background-color: ${p => p.theme.backgroundSecondary};
@@ -382,7 +382,7 @@ const ChapterTitle = styled('div')`
 const ReplayTimestamp = styled('span')`
   display: flex;
   gap: ${space(0.5)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   font-weight: ${p => p.theme.fontWeight.normal};
   justify-content: flex-end;

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -513,7 +513,7 @@ const BlockContentWrapper = styled('div')<{hasOnlyTools?: boolean}>`
 
 const BlockContent = styled(MarkedText)`
   width: 100%;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   white-space: pre-wrap;
   word-wrap: break-word;
   padding-bottom: 0;

--- a/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
+++ b/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
@@ -252,10 +252,10 @@ const LineNumber = styled('div')<{lineType: DiffLineType}>`
 
   ${p =>
     p.lineType === DiffLineType.ADDED &&
-    `background-color: ${DIFF_COLORS.added}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.added}; color: ${p.theme.tokens.content.primary}`};
   ${p =>
     p.lineType === DiffLineType.REMOVED &&
-    `background-color: ${DIFF_COLORS.removed}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.removed}; color: ${p.theme.tokens.content.primary}`};
 
   & + & {
     padding-left: 0;
@@ -273,10 +273,10 @@ const DiffContent = styled('div')<{lineType: DiffLineType}>`
 
   ${p =>
     p.lineType === DiffLineType.ADDED &&
-    `background-color: ${DIFF_COLORS.addedRow}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.addedRow}; color: ${p.theme.tokens.content.primary}`};
   ${p =>
     p.lineType === DiffLineType.REMOVED &&
-    `background-color: ${DIFF_COLORS.removedRow}; color: ${p.theme.textColor}`};
+    `background-color: ${DIFF_COLORS.removedRow}; color: ${p.theme.tokens.content.primary}`};
 
   &::before {
     content: ${p =>

--- a/static/app/views/seerExplorer/inputSection.tsx
+++ b/static/app/views/seerExplorer/inputSection.tsx
@@ -255,7 +255,7 @@ const InputRow = styled('div')`
 const InputTextarea = styled(TextArea)`
   width: 100%;
   margin: ${p => p.theme.space.sm};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   resize: none;
   overflow-y: auto;
 `;

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -502,7 +502,7 @@ const Toggle = styled(Button)`
   color: ${p => p.theme.subText};
   &:hover,
   &:focus {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
   > *:first-child {
     display: grid;

--- a/static/app/views/settings/components/settingsBreadcrumb/crumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/crumb.tsx
@@ -12,7 +12,7 @@ const Crumb = styled('div')`
   white-space: nowrap;
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -82,7 +82,7 @@ const CrumbLink = styled(RouterLink)`
 
   color: ${p => p.theme.subText};
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/settings/components/settingsWrapper.tsx
+++ b/static/app/views/settings/components/settingsWrapper.tsx
@@ -30,7 +30,7 @@ const StyledSettingsWrapper = styled('div')`
   flex: 1;
   font-size: ${p => p.theme.fontSize.md};
   line-height: ${p => p.theme.text.lineHeightBody};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   .messages-container {
     margin: 0;

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -114,7 +114,7 @@ const SubscriptionDescription = styled('div')`
 const SubscriptionTitle = styled('div')`
   font-size: ${p => p.theme.fontSize.lg};
   line-height: 1;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   white-space: nowrap;
   margin-bottom: ${space(0.75)};
 `;

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -437,7 +437,7 @@ const Details = styled('div')`
 const DetailLabel = styled('div')`
   font-weight: ${p => p.theme.fontWeight.bold};
   margin-bottom: ${space(0.5)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const Footer = styled('div')`

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -237,7 +237,7 @@ export default function TeamNotificationSettings() {
 }
 
 const NotDisabledText = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   line-height: ${space(2)};
 `;
 const NotDisabledSubText = styled('div')`

--- a/static/gsAdmin/components/debounceSearch.tsx
+++ b/static/gsAdmin/components/debounceSearch.tsx
@@ -157,7 +157,7 @@ function DebounceSearch({
 }
 
 const Card = styled('div')<{highlight?: boolean}>`
-  color: ${p => (p.highlight ? p.theme.active : p.theme.textColor)};
+  color: ${p => (p.highlight ? p.theme.active : p.theme.tokens.content.primary)};
   background: ${p => (p.highlight ? p.theme.gray100 : p.theme.background)};
   box-shadow: ${p => p.theme.dropShadowMedium};
   padding: ${space(2)};

--- a/static/gsAdmin/globalStyles.tsx
+++ b/static/gsAdmin/globalStyles.tsx
@@ -3,7 +3,7 @@ import {css, Global} from '@emotion/react';
 
 const styles = (theme: Theme) => css`
   body {
-    color: ${theme.textColor};
+    color: ${theme.tokens.content.primary};
     background: ${theme.backgroundSecondary};
   }
 

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -177,7 +177,7 @@ const HeaderTitle = styled('h3')`
   margin: 0;
   font-size: ${p => p.theme.fontSize.xl};
   font-weight: normal;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const OverviewWrap = styled('div')`

--- a/static/gsAdmin/views/launchpadAdminPage.tsx
+++ b/static/gsAdmin/views/launchpadAdminPage.tsx
@@ -435,7 +435,7 @@ const InfoDisplay = styled('div')`
     font-family: ${p => p.theme.text.familyMono};
     font-size: 12px;
     line-height: 1.4;
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -146,7 +146,7 @@ const Logo = styled(Link)`
   align-items: center;
   gap: ${space(1)};
   text-transform: uppercase;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.xl};
   font-weight: bold;
 `;
@@ -172,7 +172,7 @@ const NavLink = styled(ListLink)`
   --activeIndicatorWidth: ${space(0.5)};
 
   padding: ${space(0.25)} 0;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   align-items: center;
   gap: ${space(1)};

--- a/static/gsAdmin/views/notFound.tsx
+++ b/static/gsAdmin/views/notFound.tsx
@@ -28,7 +28,7 @@ const HeaderTitle = styled('h3')`
   margin: 0;
   font-size: ${p => p.theme.fontSize.xl};
   font-weight: normal;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 export default NotFound;

--- a/static/gsApp/components/creditCardEdit/legacyForm.tsx
+++ b/static/gsApp/components/creditCardEdit/legacyForm.tsx
@@ -128,19 +128,19 @@ function CreditCardFormInner({
 
   const stripeElementStyles = {
     base: {
-      backgroundColor: theme.isChonk ? theme.tokens.background.primary : theme.background,
-      color: theme.isChonk ? theme.tokens.content.primary : theme.textColor,
+      backgroundColor: theme.tokens.background.primary,
+      color: theme.tokens.content.primary,
       fontFamily: theme.text.family,
       fontWeight: 400,
       fontSize: theme.fontSize.lg,
       '::placeholder': {
-        color: theme.isChonk ? theme.tokens.content.muted : theme.gray300,
+        color: theme.tokens.content.muted,
       },
-      iconColor: theme.isChonk ? theme.tokens.content.primary : theme.gray300,
+      iconColor: theme.tokens.content.primary,
     },
     invalid: {
-      color: theme.isChonk ? theme.tokens.content.danger : theme.red300,
-      iconColor: theme.isChonk ? theme.tokens.content.danger : theme.red300,
+      color: theme.tokens.content.danger,
+      iconColor: theme.tokens.content.danger,
     },
   };
 

--- a/static/gsApp/components/dashboardBanner.tsx
+++ b/static/gsApp/components/dashboardBanner.tsx
@@ -36,7 +36,7 @@ function DashboardBanner({organization}: Props) {
 
 const StyledBanner = styled(Banner)`
   background-color: ${p => p.theme.purple100};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const DashboardBackground = styled('div')`

--- a/static/gsApp/components/dataConsentPriorityLearnMore.tsx
+++ b/static/gsApp/components/dataConsentPriorityLearnMore.tsx
@@ -85,7 +85,7 @@ export default withSubscription(DataConsentPriorityLearnMore);
 const LearnMoreWrapper = styled('div')`
   position: relative;
   max-width: 230px;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.sm};
   padding: ${space(1.5)};
   border-top: 1px solid ${p => p.theme.innerBorder};

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -647,7 +647,7 @@ const Dot = styled('span')`
   border-radius: ${p => p.theme.borderRadius};
   width: ${space(0.5)};
   height: ${space(0.5)};
-  background-color: ${p => p.theme.textColor};
+  background-color: ${p => p.theme.tokens.content.primary};
 `;
 
 const AlertBody = styled('div')`

--- a/static/gsApp/components/promotionPriceDisplay.tsx
+++ b/static/gsApp/components/promotionPriceDisplay.tsx
@@ -35,7 +35,7 @@ const PriceHeader = styled('div')`
 
 const Price = styled('div')`
   display: flex;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const Currency = styled('div')`

--- a/static/gsApp/components/stripeWrapper.tsx
+++ b/static/gsApp/components/stripeWrapper.tsx
@@ -48,7 +48,7 @@ function StripeWrapper({
             colorDanger: theme.danger,
             colorSuccess: theme.success,
             colorWarning: theme.warning,
-            iconColor: theme.textColor,
+            iconcolor: theme.tokens.content.primary,
           },
           rules: {
             '.Input': {

--- a/static/gsApp/components/stripeWrapper.tsx
+++ b/static/gsApp/components/stripeWrapper.tsx
@@ -44,11 +44,11 @@ function StripeWrapper({
           variables: {
             borderRadius: theme.borderRadius,
             colorBackground: theme.background,
-            colorText: theme.textColor,
+            colorText: theme.tokens.content.primary,
             colorDanger: theme.danger,
             colorSuccess: theme.success,
             colorWarning: theme.warning,
-            iconcolor: theme.tokens.content.primary,
+            iconColor: theme.tokens.content.primary,
           },
           rules: {
             '.Input': {

--- a/static/gsApp/components/upsellModal/featureList.tsx
+++ b/static/gsApp/components/upsellModal/featureList.tsx
@@ -129,10 +129,10 @@ const FeatureLink = styled(motion.div)`
   margin-bottom: ${space(0.5)};
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
   }
   &[aria-selected] {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     font-weight: bold;
   }
 `;

--- a/static/gsApp/views/amCheckout/components/checkoutOption.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutOption.tsx
@@ -43,7 +43,7 @@ export default CheckoutOption;
 
 const Option = styled('div')<{isSelected: boolean}>`
   width: 100%;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   cursor: pointer;
   position: relative;
 

--- a/static/gsApp/views/amCheckout/components/checkoutOverview.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutOverview.tsx
@@ -449,7 +449,7 @@ const OriginalPrice = styled('div')`
 
 const DetailPrice = styled('div')`
   justify-self: end;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   justify-content: end;
 `;

--- a/static/gsApp/views/amCheckout/components/checkoutOverviewV2.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutOverviewV2.tsx
@@ -400,7 +400,7 @@ const SpaceBetweenRow = styled('div')`
 const Title = styled('div')`
   font-size: ${p => p.theme.fontSize.lg};
   font-weight: 600;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   line-height: initial;
 `;
 
@@ -446,7 +446,7 @@ const TotalSeparator = styled(Separator)`
 
 const Price = styled('div')`
   justify-self: end;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   justify-content: end;
 `;
@@ -464,7 +464,7 @@ const AdditionalMonthlyCharge = styled('div')`
 `;
 
 const EmphasisText = styled('span')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: 600;
 `;
 

--- a/static/gsApp/views/amCheckout/components/checkoutOverviewV2.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutOverviewV2.tsx
@@ -420,7 +420,8 @@ const ReservedVolumes = styled('div')`
 `;
 
 const ReservedItem = styled(Title)<{isIndividualProduct?: boolean}>`
-  color: ${p => (p.isIndividualProduct ? p.theme.textColor : p.theme.subText)};
+  color: ${p =>
+    p.isIndividualProduct ? p.theme.tokens.content.primary : p.theme.subText};
   font-weight: ${p => (p.isIndividualProduct ? 600 : 'normal')};
   text-wrap: balance;
 

--- a/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
+++ b/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
@@ -39,7 +39,7 @@ const MoreLink = styled(ExternalLink)<{color?: string}>`
   &:hover,
   &:focus,
   &:active {
-    color: ${p => p.color ?? p.theme.textColor};
+    color: ${p => p.color ?? p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/gsApp/views/amCheckout/components/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/components/planSelectRow.tsx
@@ -217,7 +217,7 @@ const PlanOption = styled(PanelItem)<{isSelected?: boolean}>`
     p.isSelected &&
     css`
       background: ${p.theme.backgroundSecondary};
-      color: ${p.theme.textColor};
+      color: ${p.theme.tokens.content.primary};
     `}
 `;
 

--- a/static/gsApp/views/amCheckout/components/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/components/planSelectRow.tsx
@@ -271,7 +271,7 @@ const PlanDetails = styled('div')`
   display: inline-grid;
   gap: ${space(0.75)};
   font-size: ${p => p.theme.fontSize.xl};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const PlanName = styled('div')`
@@ -294,7 +294,7 @@ const PriceHeader = styled('div')`
 const Price = styled('div')`
   display: inline-grid;
   grid-template-columns: repeat(3, auto);
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const Currency = styled('span')`

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -377,7 +377,7 @@ const SectionHeader = styled('div')`
   display: grid;
   grid-template-columns: repeat(2, auto);
   justify-content: space-between;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.xl};
 `;
 

--- a/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
+++ b/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
@@ -127,7 +127,7 @@ const CreditCardOption = styled(PanelItem)<{isSelected?: boolean}>`
     p.isSelected &&
     css`
       background: ${p.theme.backgroundSecondary};
-      color: ${p.theme.textColor};
+      color: ${p.theme.tokens.content.primary};
     `}
 `;
 

--- a/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
+++ b/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
@@ -136,7 +136,7 @@ const Label = styled('label')`
   grid-template-columns: max-content auto;
   gap: ${space(1.5)};
   padding: ${space(2)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: normal;
   width: 100%;
   margin: 0;
@@ -150,7 +150,7 @@ const CardDetails = styled('div')`
   display: inline-grid;
   gap: ${space(0.75)};
   font-size: ${p => p.theme.fontSize.xl};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-weight: 600;
 `;
 
@@ -163,7 +163,7 @@ const Description = styled(TextBlock)`
 
 const AddCardSetup = styled(CreditCardSetup)`
   padding: ${space(2)} ${space(2)} 0;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 
   .form-actions {
     display: grid;

--- a/static/gsApp/views/amCheckout/steps/onDemandSpend.tsx
+++ b/static/gsApp/views/amCheckout/steps/onDemandSpend.tsx
@@ -141,7 +141,7 @@ const Header = styled('div')`
   display: inline-grid;
   gap: ${space(1)};
   font-size: ${p => p.theme.fontSize.xl};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const Description = styled(TextBlock)`
@@ -156,7 +156,7 @@ const InputContainer = styled('div')`
   gap: ${space(1.5)};
   align-items: center;
   justify-items: end;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const InputHeader = styled('div')`
@@ -176,7 +176,7 @@ const Currency = styled('span')`
 
 const OnDemandInput = styled(Input)`
   padding-left: ${space(4)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   text-align: right;
   height: 36px;
 `;

--- a/static/gsApp/views/amCheckout/steps/productSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.tsx
@@ -337,6 +337,6 @@ const FeatureItem = styled('div')`
   display: grid;
   grid-template-columns: ${p => p.theme.space.xl} 1fr;
   align-items: start;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   gap: ${p => p.theme.space.md};
 `;

--- a/static/gsApp/views/amCheckout/steps/reviewAndConfirm.tsx
+++ b/static/gsApp/views/amCheckout/steps/reviewAndConfirm.tsx
@@ -389,7 +389,7 @@ const StyledPanelBody = styled(PanelBody)`
 `;
 
 const Preview = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.md};
 `;
 

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
@@ -358,7 +358,7 @@ const Currency = styled('div')`
 `;
 
 const PayAsYouGoInput = styled(Input)`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   max-width: 120px;
   height: 36px;
   text-align: right;

--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -276,7 +276,7 @@ const DetailTitle = styled('div')`
 `;
 
 const Amount = styled('div')`
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   font-size: ${p => p.theme.fontSize.xl};
 `;
 

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -390,7 +390,7 @@ const BudgetModeOption = styled(PanelItem)<{isSelected?: boolean}>`
     p.isSelected &&
     css`
       background: ${p.theme.backgroundSecondary};
-      color: ${p.theme.textColor};
+      color: ${p.theme.tokens.content.primary};
     `}
 `;
 

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -426,7 +426,7 @@ const BudgetDetails = styled('div')`
   display: inline-grid;
   gap: ${space(0.75)};
   font-size: ${p => p.theme.fontSize.xl};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
 `;
 
 const Title = styled('div')`
@@ -455,7 +455,7 @@ const Currency = styled('div')`
 
 const OnDemandInput = styled(Input)`
   padding-left: ${space(4)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   max-width: 140px;
   height: 36px;
 `;

--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -538,7 +538,7 @@ const SubSectionBody = styled(PanelTable)`
 
 const Title = styled('div')`
   font-size: ${p => p.theme.fontSize.xl};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   display: flex;
   justify-content: space-between;
 `;

--- a/static/gsApp/views/subscriptionPage/headerCards/subscriptionCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/subscriptionCard.tsx
@@ -132,7 +132,7 @@ const PlanHeader = styled('div')<{isPastDue?: boolean}>`
   display: flex;
   gap: ${space(0.5)};
   align-items: center;
-  color: ${p => (p.isPastDue ? p.theme.red300 : p.theme.textColor)};
+  color: ${p => (p.isPastDue ? p.theme.red300 : p.theme.tokens.content.primary)};
   font-size: ${p => p.theme.fontSize.xl};
   font-weight: bold;
   white-space: nowrap;

--- a/static/gsApp/views/subscriptionPage/onDemandSummary.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSummary.tsx
@@ -308,14 +308,14 @@ const Currency = styled('span')`
     padding: 10px 10px 9px;
     position: absolute;
     content: '$';
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.primary};
     font-size: ${p => p.theme.fontSize.lg};
   }
 `;
 
 const OnDemandInput = styled(Input)`
   padding-left: ${space(4)};
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.primary};
   max-width: 140px;
   height: 36px;
 `;

--- a/static/gsApp/views/subscriptionPage/usageLog.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.tsx
@@ -188,7 +188,7 @@ function UsageLog({location, subscription}: Props) {
                     colorConfig={{
                       icon: index === 0 ? theme.active : theme.gray300,
                       iconBorder: index === 0 ? theme.active : theme.gray300,
-                      title: theme.textColor,
+                      title: theme.tokens.content.primary,
                     }}
                     icon={<IconCircleFill />}
                     title={formatEntryTitle(entry.event)}


### PR DESCRIPTION
We are migrating towards the use of semantic tokens and away from custom styles. Going forward, the best way to use styled text is to use use [`<Text>`](https://sentry.sentry.io/stories/typography/text/) - in this case, the default color is primary, meaning these styles would become redundant. The variants supported by Text should match similar variants as our Button, so that the APIs become more familiar and we can start building intuition around the usage, hopefully making everyone's developer experience slightly more enjoyable.

In this PR, we migrate away from most instances, meaning the top level definition cannot yet be removed. Some lingering ones are usages like `<Icon color="textColor"/>`, which will also be removed in a followup PR where we start to remove ColorOrAlias and move icons towards variants like `warning | danger ...`.

ref DE-328