### PR TITLE
fix(aci): Update create alert buttons to reference monitors

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -193,11 +193,6 @@ export default function CreateAlertButton({
     event.preventDefault();
     onEnter?.();
 
-    if (isWorkflowEngineEnabled) {
-      navigateTo(makeMonitorCreatePathname(organization.slug), router);
-      return;
-    }
-
     navigateTo(createAlertUrl(':projectId'), router);
   }
 

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -27,6 +27,8 @@ import {
   AlertWizardRuleTemplates,
   DEFAULT_WIZARD_TEMPLATE,
 } from 'sentry/views/alerts/wizard/options';
+import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
+import {getMetricMonitorUrl} from 'sentry/views/insights/common/utils/getMetricMonitorUrl';
 
 type CreateAlertFromViewButtonProps = Omit<LinkButtonProps, 'aria-label' | 'to'> & {
   /**
@@ -78,32 +80,50 @@ export function CreateAlertFromViewButton({
       AlertWizardRuleTemplates[alertType]
     : DEFAULT_WIZARD_TEMPLATE;
 
-  const to = {
-    pathname: makeAlertsPathname({
-      path: '/new/metric/',
-      organization,
-    }),
-    query: {
-      ...queryParams,
-      createFromDiscover: true,
-      disableMetricDataset,
-      referrer,
-      ...alertTemplate,
-      project: project?.slug,
-      aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
-    },
-  };
+  const isWorkflowEngineEnabled = organization.features.includes('workflow-engine-ui');
+
+  const to = isWorkflowEngineEnabled
+    ? getMetricMonitorUrl({
+        project,
+        environment: queryParams.environment,
+        aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
+        dataset: alertTemplate.dataset,
+        organization,
+        name: alertTemplate.query,
+        query: queryParams.query as string | undefined,
+        referrer,
+        eventTypes: alertTemplate.eventTypes,
+      })
+    : {
+        pathname: makeAlertsPathname({
+          path: '/new/metric/',
+          organization,
+        }),
+        query: {
+          ...queryParams,
+          createFromDiscover: true,
+          disableMetricDataset,
+          referrer,
+          ...alertTemplate,
+          project: project?.slug,
+          aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
+        },
+      };
 
   const handleClick = () => {
     onClick?.();
   };
+
+  const createButtonLabel = isWorkflowEngineEnabled
+    ? t('Create Monitor')
+    : t('Create Alert');
 
   return (
     <CreateAlertButton
       organization={organization}
       onClick={handleClick}
       to={to}
-      aria-label={t('Create Alert')}
+      aria-label={createButtonLabel}
       {...buttonProps}
     />
   );
@@ -141,6 +161,10 @@ export default function CreateAlertButton({
   const router = useRouter();
   const api = useApi();
   const {projects} = useProjects();
+  const isWorkflowEngineEnabled = organization.features.includes('workflow-engine-ui');
+  const defaultButtonLabel = isWorkflowEngineEnabled
+    ? t('Create Monitor')
+    : t('Create Alert');
   const createAlertUrl = (providedProj: string): string => {
     const params = new URLSearchParams();
     if (referrer) {
@@ -149,20 +173,30 @@ export default function CreateAlertButton({
     if (providedProj !== ':projectId') {
       params.append('project', providedProj);
     }
-    if (alertOption) {
+    if (alertOption && !isWorkflowEngineEnabled) {
       params.append('alert_option', alertOption);
+    }
+    const queryString = params.toString();
+    if (isWorkflowEngineEnabled) {
+      const basePath = makeMonitorCreatePathname(organization.slug);
+      return queryString ? `${basePath}?${queryString}` : basePath;
     }
     return (
       makeAlertsPathname({
         path: '/wizard/',
         organization,
-      }) + `?${params.toString()}`
+      }) + (queryString ? `?${queryString}` : '')
     );
   };
 
   function handleClickWithoutProject(event: React.MouseEvent) {
     event.preventDefault();
     onEnter?.();
+
+    if (isWorkflowEngineEnabled) {
+      navigateTo(makeMonitorCreatePathname(organization.slug), router);
+      return;
+    }
 
     navigateTo(createAlertUrl(':projectId'), router);
   }
@@ -202,9 +236,13 @@ export default function CreateAlertButton({
         },
       }}
       onClick={projectSlug ? onEnter : handleClickWithoutProject}
+      aria-label={
+        (buttonProps as Record<string, string | undefined>)['aria-label'] ??
+        defaultButtonLabel
+      }
       {...buttonProps}
     >
-      {buttonProps.children ?? t('Create Alert')}
+      {buttonProps.children ?? defaultButtonLabel}
     </LinkButton>
   );
 

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -18,6 +18,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import type EventView from 'sentry/utils/discover/eventView';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
@@ -89,8 +90,7 @@ export function CreateAlertFromViewButton({
         aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
         dataset: alertTemplate.dataset,
         organization,
-        name: alertTemplate.query,
-        query: queryParams.query as string | undefined,
+        query: decodeScalar(queryParams.query),
         referrer,
         eventTypes: alertTemplate.eventTypes,
       })
@@ -236,10 +236,6 @@ export default function CreateAlertButton({
         },
       }}
       onClick={projectSlug ? onEnter : handleClickWithoutProject}
-      aria-label={
-        (buttonProps as Record<string, string | undefined>)['aria-label'] ??
-        defaultButtonLabel
-      }
       {...buttonProps}
     >
       {buttonProps.children ?? defaultButtonLabel}

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -47,11 +47,15 @@ function ChartContextMenu({
         : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
     if (visualizeYAxes.length === 1) {
+      const newAlertLabel = organization.features.includes('workflow-engine-ui')
+        ? t('Create a Monitor')
+        : t('Create an Alert');
+
       const yAxis = visualizeYAxes[0]!.yAxis;
       menuItems.push({
         key: 'create-alert',
-        textValue: t('Create an Alert'),
-        label: t('Create an Alert'),
+        textValue: newAlertLabel,
+        label: newAlertLabel,
         disabled: isVisualizeEquation(visualizeYAxes[0]!),
         to: getAlertsUrl({
           project,
@@ -95,9 +99,13 @@ function ChartContextMenu({
         },
       }));
 
+      const newAlertLabel = organization.features.includes('workflow-engine-ui')
+        ? t('Create a Monitor for')
+        : t('Create an Alert for');
+
       menuItems.push({
         key: 'create-alert',
-        label: t('Create an alert for'),
+        label: newAlertLabel,
         children: alertsUrls ?? [],
         disabled: !alertsUrls || alertsUrls.length === 0,
         isSubmenu: true,

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -152,10 +152,14 @@ export function useSaveAsItems({
       };
     });
 
+    const newAlertLabel = organization.features.includes('workflow-engine-ui')
+      ? t('A Monitor for')
+      : t('An Alert for');
+
     return {
       key: 'create-alert',
-      label: t('An Alert for'),
-      textValue: t('An Alert for'),
+      label: newAlertLabel,
+      textValue: newAlertLabel,
       children: alertsUrls ?? [],
       disabled: !alertsUrls || alertsUrls.length === 0,
       isSubmenu: true,

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -150,10 +150,14 @@ export function ToolbarSaveAs() {
     },
   });
 
+  const newAlertLabel = organization.features.includes('workflow-engine-ui')
+    ? t('A Monitor for')
+    : t('An Alert for');
+
   items.push({
     key: 'create-alert',
-    label: t('An Alert for'),
-    textValue: t('An Alert for'),
+    label: newAlertLabel,
+    textValue: newAlertLabel,
     children: alertsUrls ?? [],
     disabled: !alertsUrls || alertsUrls.length === 0,
     isSubmenu: true,

--- a/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
+++ b/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
@@ -10,7 +10,7 @@ type Params = {
   dataset: Dataset;
   organization: Organization;
   project: Project | undefined;
-  environment?: string | string[];
+  environment?: string | string[] | null;
   eventTypes?: EventTypes[];
   name?: string;
   query?: string;


### PR DESCRIPTION
There are a few different areas that refer to "Create an Alert" instead of "Create a Monitor"

<img width="188" height="124" alt="CleanShot 2025-12-09 at 15 45 07@2x" src="https://github.com/user-attachments/assets/538faefd-bebf-4e58-afb7-fb3d7a4898e9" />
<img width="218" height="262" alt="CleanShot 2025-12-09 at 15 45 01@2x" src="https://github.com/user-attachments/assets/d7b7b644-2150-408c-acd3-97f2b7a51f1e" />
<img width="336" height="374" alt="CleanShot 2025-12-09 at 15 44 57@2x" src="https://github.com/user-attachments/assets/b9545df2-403e-4e6b-b3df-c2515460ddee" />
