### PR TITLE
fix(escalating_forecast): Fix Weekly Escalating Forecasts task timeouts

### DIFF
--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -24,7 +24,7 @@ ParsedGroupsCount = dict[int, GroupCount]
 
 logger = logging.getLogger(__name__)
 
-ITERATOR_CHUNK = 10_000
+ITERATOR_CHUNK = 5_000
 
 
 @instrumented_task(


### PR DESCRIPTION
Reduced amount of projects we query for from 10k to 5k, should help us avoid timing out on this query.