### PR TITLE
feat(derived_code_mappings): Support single-file paths

### DIFF
--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -40,6 +40,7 @@ class CodeMapping(NamedTuple):
 
 SLASH = "/"
 BACKSLASH = "\\"  # This is the Python representation of a single backslash
+NOT_FOUND = -1
 
 
 def derive_code_mappings(
@@ -427,13 +428,20 @@ def find_roots(frame_filename: FrameInfo, source_path: str) -> tuple[str, str]:
         stack_path = stack_path[1:]
 
     if stack_path == source_path:
+        # e.g. stack_path: foo/foo.py -> source_path: foo/foo.py
         return (stack_root, "")
-    elif source_path.endswith(stack_path):  # "Packaged" logic
-        source_prefix = source_path.rpartition(stack_path)[0]
-        return (
-            f"{stack_root}{frame_filename.stack_root}/".replace("//", "/"),
-            f"{source_prefix}{frame_filename.stack_root}/".replace("//", "/"),
-        )
+    elif source_path.endswith(stack_path):
+        if stack_path.find("/") == NOT_FOUND:
+            # Single-file path (e.g. stack_path: foo.py -> source_path: src/foo.py)
+            return ("", source_path.replace(stack_path, ""))
+        else:
+            # "Packaged" logic
+            # e.g. stack_path: some_package/src/foo.py -> source_path: src/foo.py
+            source_prefix = source_path.rpartition(stack_path)[0]
+            return (
+                f"{stack_root}{frame_filename.stack_root}/".replace("//", "/"),
+                f"{source_prefix}{frame_filename.stack_root}/".replace("//", "/"),
+            )
     elif stack_path.endswith(source_path):
         stack_prefix = stack_path.rpartition(source_path)[0]
         return (f"{stack_root}{stack_prefix}", "")

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -40,7 +40,6 @@ class CodeMapping(NamedTuple):
 
 SLASH = "/"
 BACKSLASH = "\\"  # This is the Python representation of a single backslash
-NOT_FOUND = -1
 
 
 def derive_code_mappings(
@@ -431,7 +430,7 @@ def find_roots(frame_filename: FrameInfo, source_path: str) -> tuple[str, str]:
         # e.g. stack_path: foo/foo.py -> source_path: foo/foo.py
         return (stack_root, "")
     elif source_path.endswith(stack_path):
-        if stack_path.find("/") == NOT_FOUND:
+        if stack_path.find("/") > -1:
             # Single-file path (e.g. stack_path: foo.py -> source_path: src/foo.py)
             return ("", source_path.replace(stack_path, ""))
         else:

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -430,7 +430,7 @@ def find_roots(frame_filename: FrameInfo, source_path: str) -> tuple[str, str]:
         # e.g. stack_path: foo/foo.py -> source_path: foo/foo.py
         return (stack_root, "")
     elif source_path.endswith(stack_path):
-        if stack_path.find("/") > -1:
+        if stack_path.find("/") == -1:
             # Single-file path (e.g. stack_path: foo.py -> source_path: src/foo.py)
             return ("", source_path.replace(stack_path, ""))
         else:

--- a/src/sentry/issues/auto_source_code_config/frame_info.py
+++ b/src/sentry/issues/auto_source_code_config/frame_info.py
@@ -18,9 +18,8 @@ from .utils.platform import PlatformConfig
 
 NOT_FOUND = -1
 
-# Regex patterns for unsupported frame paths
+# Regex pattern for unsupported frame paths
 UNSUPPORTED_FRAME_PATH_PATTERN = re.compile(r"^[\[<]|https?://", re.IGNORECASE)
-UNSUPPORTED_NORMALIZED_PATH_PATTERN = re.compile(r"^[^/]*$")
 
 
 def create_frame_info(frame: Mapping[str, Any], platform: str | None = None) -> FrameInfo:
@@ -76,11 +75,7 @@ class PathBasedFrameInfo(FrameInfo):
         # the straight path prefix and drive letter
         self.normalized_path, removed_prefix = remove_prefixes(frame_file_path)
 
-        if (
-            not frame_file_path
-            or UNSUPPORTED_FRAME_PATH_PATTERN.search(frame_file_path)
-            or UNSUPPORTED_NORMALIZED_PATH_PATTERN.search(self.normalized_path)
-        ):
+        if not frame_file_path or UNSUPPORTED_FRAME_PATH_PATTERN.search(frame_file_path):
             raise UnsupportedFrameInfo("This path is not supported.")
 
         if not get_extension(frame_file_path):

--- a/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
@@ -181,10 +181,19 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
         assert response.status_code == 404, response.content
 
     @patch("sentry.integrations.github.integration.GitHubIntegration.get_trees_for_org")
-    def test_get_unsupported_frame_info(self, mock_get_trees_for_org: Any) -> None:
+    def test_get_single_file_path(self, mock_get_trees_for_org: Any) -> None:
         config_data = {
             "stacktraceFilename": "top_level_file.py",
         }
+        expected_matches = [
+            {
+                "filename": "top_level_file.py",
+                "repo_name": "getsentry/codemap",
+                "repo_branch": "master",
+                "stacktrace_root": "",
+                "source_path": "",
+            }
+        ]
 
         mock_get_trees_for_org.return_value = {
             "getsentry/codemap": RepoTree(
@@ -196,7 +205,8 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             )
         }
         response = self.client.get(self.url, data=config_data, format="json")
-        assert response.status_code == 400, response.content
+        assert response.status_code == 200, response.content
+        assert response.data == expected_matches
 
     def test_non_project_member_permissions(self) -> None:
         config_data = {

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -211,14 +211,21 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
         assert resp.status_code == 400, resp.content
         assert resp.data == {"sourceUrl": ["Could not find repo"]}
 
-    def test_unsupported_frame_info(self) -> None:
+    def test_single_file_path(self) -> None:
         source_url = (
             "https://github.com/getsentry/sentry/blob/master/src/project_stacktrace_link.py"
         )
         stack_path = "project_stacktrace_link.py"
         resp = self.make_post(source_url, stack_path)
-        assert resp.status_code == 400, resp.content
-        assert resp.data == {"detail": "Unsupported frame info"}
+        assert resp.status_code == 200, resp.content
+        assert resp.data == {
+            "integrationId": self.integration.id,
+            "repositoryId": self.repo.id,
+            "provider": "github",
+            "stackRoot": "",
+            "sourceRoot": "src/",
+            "defaultBranch": "master",
+        }
 
     def test_basic(self) -> None:
         source_url = "https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py"

--- a/tests/sentry/issues/auto_source_code_config/test_frame_info.py
+++ b/tests/sentry/issues/auto_source_code_config/test_frame_info.py
@@ -21,14 +21,6 @@ UNSUPPORTED_FRAME_FILENAMES = [
     "<anonymous>",
     "<frozen importlib._bootstrap>",
     "[native code]",
-    "O$t",
-    "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
-    # Top level files
-    "README",  # top level file
-    "/gtm.js",  # Rejected because it's a top level file and not because it has a backslash
-    "ssl.py",
-    "initialization.dart",
-    "backburner.js",
 ]
 
 # Files with "http" substring that should be ACCEPTED
@@ -42,7 +34,9 @@ LEGITIMATE_HTTP_FILENAMES = [
 ]
 
 NO_EXTENSION_FRAME_FILENAMES = [
-    "/foo/bar/baz",  # no extension
+    "/foo/bar/baz",
+    "README",
+    "O$t",
 ]
 
 

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -301,6 +301,15 @@ class TestGenericBehaviour(BaseDeriveCodeMappings):
         assert len(all_cm) == 1
         assert all_cm[0].automatically_generated is False
 
+    def test_single_file_path(self) -> None:
+        """Test that single-file paths like Program.cs are handled correctly."""
+        self._process_and_assert_configuration_changes(
+            repo_trees={REPO1: ["src/foo/bar.py"]},
+            frames=[self.frame("bar.py", True)],
+            platform="python",
+            expected_new_code_mappings=[self.code_mapping("", "src/foo/")],
+        )
+
     def test_dry_run_platform(self) -> None:
         frame_filename = "foo/bar.py"
         file_in_repo = "src/foo/bar.py"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/86169

Remove restriction that rejected frame paths without a "/" character,
allowing code mappings for root-level files like "Program.cs".

When the stack path is a single file (no directory), find_roots() now
returns the source prefix as the source root (e.g. bar.py maps to
src/foo/ when the repo contains src/foo/bar.py).