### PR TITLE
feat(infra): Add seed as input to shuffle-tests job

### DIFF
--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -11,7 +11,6 @@ on:
       seed:
         description: The seed for the test ordering
         required: false
-        default: ''
 
   # Run once a day
   schedule:
@@ -47,8 +46,7 @@ jobs:
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
       # If this increases, make sure to also increase `flags.backend.after_n_builds` in `codecov.yml`.
       MATRIX_INSTANCE_TOTAL: 11
-      SENTRY_SHUFFLE_TESTS: true
-      # Conditionally sets SENTRY_SHUFFLE_TESTS_SEED if inputs.seed is non-empty
+      # Only set SENTRY_SHUFFLE_TESTS_SEED if a seed was provided as input
       SENTRY_SHUFFLE_TESTS_SEED: ${{ inputs.seed && inputs.seed || '' }}
 
     steps:

--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -9,7 +9,7 @@ on:
         required: true
         default: 'true'
       seed:
-        description: The seed for the random number generator
+        description: The seed for the test ordering
         required: false
         default: ''
 

--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -46,8 +46,6 @@ jobs:
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
       # If this increases, make sure to also increase `flags.backend.after_n_builds` in `codecov.yml`.
       MATRIX_INSTANCE_TOTAL: 11
-      # Only set SENTRY_SHUFFLE_TESTS_SEED if a seed was provided as input
-      SENTRY_SHUFFLE_TESTS_SEED: ${{ inputs.seed && inputs.seed || '' }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -57,10 +55,14 @@ jobs:
         id: setup
         with:
           mode: backend-ci
+        env:
+          SENTRY_SHUFFLE_TESTS_SEED: ${{ inputs.seed }}
 
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           make test-python-ci
+        env:
+          SENTRY_SHUFFLE_TESTS_SEED: ${{ inputs.seed }}
 
       - name: Inspect failure
         if: failure()

--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -8,6 +8,10 @@ on:
         description: Whether to get per-test coverage (uses ./github/workflows/codecov_per_test_coverage.yml)
         required: true
         default: 'true'
+      seed:
+        description: The seed for the random number generator
+        required: false
+
   # Run once a day
   schedule:
     - cron: '0 1 * * *'
@@ -18,7 +22,7 @@ concurrency:
 
 env:
   SENTRY_SHUFFLE_TESTS: true
-
+  SENTRY_SHUFFLE_TESTS_SEED: ${{ inputs.seed }}
 jobs:
   per-test-coverage:
     if: ${{ inputs.per-test-coverage == 'true' || github.event_name == 'schedule' }}

--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -11,6 +11,7 @@ on:
       seed:
         description: The seed for the random number generator
         required: false
+        default: ''
 
   # Run once a day
   schedule:

--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -23,7 +23,6 @@ concurrency:
 
 env:
   SENTRY_SHUFFLE_TESTS: true
-  SENTRY_SHUFFLE_TESTS_SEED: ${{ inputs.seed }}
 jobs:
   per-test-coverage:
     if: ${{ inputs.per-test-coverage == 'true' || github.event_name == 'schedule' }}
@@ -48,6 +47,9 @@ jobs:
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
       # If this increases, make sure to also increase `flags.backend.after_n_builds` in `codecov.yml`.
       MATRIX_INSTANCE_TOTAL: 11
+      SENTRY_SHUFFLE_TESTS: true
+      # Conditionally sets SENTRY_SHUFFLE_TESTS_SEED if inputs.seed is non-empty
+      SENTRY_SHUFFLE_TESTS_SEED: ${{ inputs.seed && inputs.seed || '' }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -415,7 +415,8 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     items[:] = keep
 
     if os.environ.get("SENTRY_SHUFFLE_TESTS"):
-        seed = int(os.environ.get("SENTRY_SHUFFLE_TESTS_SEED", time.time()))
+        seed_env = os.environ.get("SENTRY_SHUFFLE_TESTS_SEED")
+        seed = int(seed_env) if seed_env else int(time.time())
         config.get_terminal_writer().line(f"SENTRY_SHUFFLE_TESTS_SEED: {seed}")
         _shuffle(items, random.Random(seed))
 


### PR DESCRIPTION
Adds an input to the `shuffle-tests` workflow to allow me to reproduce failed test runs with upcoming changes. Will help to quickly validate if branch changes work when I invoke the workflow.

<img width="1347" height="596" alt="Screenshot 2025-12-10 at 9 37 41 AM" src="https://github.com/user-attachments/assets/bc869553-edfc-4a60-b3f8-822fee4a7791" />
