### PR TITLE
feat(preprod): Add empty preprod settings page

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -693,6 +693,11 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/settings/project/tempest')),
     },
     {
+      path: 'preprod/',
+      name: t('Preprod'),
+      component: make(() => import('sentry/views/settings/project/preprod')),
+    },
+    {
       path: 'keys/',
       name: t('Client Keys'),
       children: [

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -134,6 +134,13 @@ export default function getConfiguration({
           title: t('PlayStation'),
           show: () => !!(organization && hasTempestAccess(organization)) && !isSelfHosted,
         },
+        {
+          path: `${pathPrefix}/preprod/`,
+          title: t('Preprod'),
+          show: () => !!organization?.features?.includes('preprod-issues'),
+          badge: () => 'beta',
+          description: t('Size analysis and build distribution configuration.'),
+        },
       ],
     },
     {

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -1,0 +1,26 @@
+import {Fragment} from 'react';
+
+import Feature from 'sentry/components/acl/feature';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+
+export default function PreprodSettings() {
+  return (
+    <Fragment>
+      <Feature features="organizations:preprod-issues" renderDisabled>
+        <SentryDocumentTitle title={t('Preprod')} />
+        <SettingsPageHeader
+          title={t('Preprod')}
+          action={
+            <ButtonBar gap="lg">
+              <FeedbackButton />
+            </ButtonBar>
+          }
+        />
+      </Feature>
+    </Fragment>
+  );
+}


### PR DESCRIPTION
This is a 'project' settings page behind the
`organizations:preprod-issues` flag. In future it will host the settings
for e.g. size analysis issue configuration and similar.
