### PR TITLE
feat(replays): Granular permissions frontend

### DIFF
--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
 import LazyLoad from 'sentry/components/lazyLoad';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
 import {ReplayGroupContextProvider} from 'sentry/components/replays/replayGroupContext';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -104,23 +105,25 @@ export function ReplayClipSection({event, group, replayId}: Props) {
   );
 
   return (
-    <ReplaySectionMinHeight
-      title={t('Session Replay')}
-      actions={allReplaysButton}
-      type={SectionKey.REPLAY}
-    >
-      <ErrorBoundary mini>
-        <ReplayGroupContextProvider groupId={group?.id} eventId={event.id}>
-          {hasStreamlinedUI ? (
-            lazyReplay
-          ) : (
-            <ReactLazyLoad debounce={50} height={448} offset={0} once>
-              {lazyReplay}
-            </ReactLazyLoad>
-          )}
-        </ReplayGroupContextProvider>
-      </ErrorBoundary>
-    </ReplaySectionMinHeight>
+    <ReplayAccess>
+      <ReplaySectionMinHeight
+        title={t('Session Replay')}
+        actions={allReplaysButton}
+        type={SectionKey.REPLAY}
+      >
+        <ErrorBoundary mini>
+          <ReplayGroupContextProvider groupId={group?.id} eventId={event.id}>
+            {hasStreamlinedUI ? (
+              lazyReplay
+            ) : (
+              <ReactLazyLoad debounce={50} height={448} offset={0} once>
+                {lazyReplay}
+              </ReactLazyLoad>
+            )}
+          </ReplayGroupContextProvider>
+        </ErrorBoundary>
+      </ReplaySectionMinHeight>
+    </ReplayAccess>
   );
 }
 

--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -8,7 +8,7 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
 import LazyLoad from 'sentry/components/lazyLoad';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
+import {ReplayAccess} from 'sentry/components/replays/replayAccess';
 import {ReplayGroupContextProvider} from 'sentry/components/replays/replayGroupContext';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';

--- a/static/app/components/feedback/feedbackItem/replaySection.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.spec.tsx
@@ -1,0 +1,59 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+
+import ReplaySection from './replaySection';
+
+jest.mock('sentry/components/events/eventReplay/replayClipPreview', () => {
+  return function MockReplayClipPreview() {
+    return <div data-test-id="replay-clip-preview">Replay Clip Preview</div>;
+  };
+});
+
+describe('ReplaySection', () => {
+  const user = UserFixture({id: '1'});
+  const organization = OrganizationFixture({
+    features: ['session-replay'],
+  });
+
+  beforeEach(() => {
+    ConfigStore.set('user', user);
+  });
+
+  it('should render replay section when user has access', async () => {
+    render(
+      <ReplaySection
+        eventTimestampMs={Date.now()}
+        organization={organization}
+        replayId="test-replay-id"
+      />
+    );
+
+    expect(await screen.findByTestId('replay-clip-preview')).toBeInTheDocument();
+  });
+
+  it('should hide replay section when user does not have granular replay permissions', () => {
+    const orgWithGranularPermissions = OrganizationFixture({
+      features: ['session-replay', 'granular-replay-permissions'],
+      hasGranularReplayPermissions: true,
+      replayAccessMembers: [999], // User ID 1 is not in this list
+    });
+
+    const {container} = render(
+      <ReplaySection
+        eventTimestampMs={Date.now()}
+        organization={orgWithGranularPermissions}
+        replayId="test-replay-id"
+      />,
+      {
+        organization: orgWithGranularPermissions,
+      }
+    );
+
+    expect(screen.queryByTestId('replay-clip-preview')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/components/feedback/feedbackItem/replaySection.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.tsx
@@ -1,7 +1,7 @@
 import {lazy} from 'react';
 
 import LazyLoad from 'sentry/components/lazyLoad';
-import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
+import {ReplayAccess} from 'sentry/components/replays/replayAccess';
 import type {Organization} from 'sentry/types/organization';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 

--- a/static/app/components/feedback/feedbackItem/replaySection.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.tsx
@@ -1,6 +1,7 @@
 import {lazy} from 'react';
 
 import LazyLoad from 'sentry/components/lazyLoad';
+import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
 import type {Organization} from 'sentry/types/organization';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 
@@ -36,11 +37,13 @@ export default function ReplaySection({eventTimestampMs, organization, replayId}
   };
 
   return (
-    <LazyLoad
-      key={replayId}
-      {...props}
-      LazyComponent={LazyReplayClipPreviewComponent}
-      clipOffsets={CLIP_OFFSETS}
-    />
+    <ReplayAccess>
+      <LazyLoad
+        key={replayId}
+        {...props}
+        LazyComponent={LazyReplayClipPreviewComponent}
+        clipOffsets={CLIP_OFFSETS}
+      />
+    </ReplayAccess>
   );
 }

--- a/static/app/components/forms/fieldFromConfig.tsx
+++ b/static/app/components/forms/fieldFromConfig.tsx
@@ -2,6 +2,7 @@ import CollapsibleSection, {
   type CollapsibleSectionProps,
 } from 'sentry/components/forms/collapsibleSection';
 import type {FieldGroupProps} from 'sentry/components/forms/fieldGroup/types';
+import {SentryMemberSelectorField} from 'sentry/components/forms/fields/sentryMemberSelectorField';
 import SeparatorField from 'sentry/components/forms/fields/separatorField';
 import type {Field} from 'sentry/components/forms/types';
 import type {Scope} from 'sentry/types/core';
@@ -98,6 +99,8 @@ function FieldFromConfig(props: FieldFromConfigProps): React.ReactElement | null
       return (
         <SentryOrganizationRoleSelectorField {...(componentProps as RenderFieldProps)} />
       );
+    case 'sentry_member_selector':
+      return <SentryMemberSelectorField {...(componentProps as RenderFieldProps)} />;
     case 'select_async':
       return <SelectAsyncField {...(componentProps as SelectAsyncFieldProps)} />;
     case 'file':

--- a/static/app/components/forms/fields/sentryMemberSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryMemberSelectorField.spec.tsx
@@ -1,0 +1,41 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import MemberListStore from 'sentry/stores/memberListStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
+
+import {SentryMemberSelectorField} from './sentryMemberSelectorField';
+
+describe('SentryMemberSelectorField', () => {
+  const organization = OrganizationFixture();
+  const mockUsers = [UserFixture({id: '1', name: 'Jane Doe', email: 'jane@example.com'})];
+
+  beforeEach(() => {
+    MemberListStore.init();
+    MemberListStore.loadInitialData(mockUsers);
+    OrganizationStore.onUpdate(organization, {replace: true});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      body: [],
+    });
+  });
+
+  it('can select a member', async () => {
+    const mock = jest.fn();
+
+    render(
+      <SentryMemberSelectorField onChange={mock} name="member" label="Select Member" />
+    );
+
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Select Member'}),
+      'Jane Doe'
+    );
+
+    expect(mock).toHaveBeenCalledWith(1, expect.anything());
+  });
+});

--- a/static/app/components/forms/fields/sentryMemberSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberSelectorField.tsx
@@ -1,0 +1,47 @@
+import {useEffect} from 'react';
+
+import {UserAvatar} from '@sentry/scraps/avatar';
+
+import {t} from 'sentry/locale';
+import {useMembers} from 'sentry/utils/useMembers';
+
+import type {InputFieldProps} from './inputField';
+import SelectField from './selectField';
+
+export function SentryMemberSelectorField({
+  placeholder = t('Choose a member'),
+  multiple = false,
+  ...props
+}: InputFieldProps) {
+  const {members, fetching, onSearch, loadMore} = useMembers();
+  const memberOptions =
+    members?.map(member => ({
+      value: parseInt(member.id, 10),
+      label: member.name,
+      leadingItems: <UserAvatar user={member} />,
+    })) ?? [];
+
+  // We need to load some members initially
+  // Otherwise we only get options when searching.
+  useEffect(
+    () => {
+      loadMore();
+    },
+    // Only ensure things are loaded at mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return (
+    <SelectField
+      placeholder={placeholder}
+      options={memberOptions}
+      isLoading={fetching}
+      onInputChange={(value: any) => {
+        onSearch(value);
+      }}
+      multiple={multiple}
+      {...props}
+    />
+  );
+}

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -196,6 +196,11 @@ type SentryProjectSelectorType = {
   avatarSize?: number;
 };
 
+type SentryMemberSelectorType = {
+  type: 'sentry_member_selector';
+  multiple?: boolean;
+};
+
 type SentryOrganizationRoleSelectorType = {
   type: 'sentry_organization_role_selector';
 };
@@ -215,6 +220,7 @@ export type Field = (
   | TableType
   | ProjectMapperType
   | SentryProjectSelectorType
+  | SentryMemberSelectorType
   | SentryOrganizationRoleSelectorType
   | SelectAsyncType
   | ChoiceMapperType

--- a/static/app/components/replays/replayAccess.spec.tsx
+++ b/static/app/components/replays/replayAccess.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
 
-import {ReplayAccess, ReplayAccessFallbackAlert} from './ReplayAccess';
+import {ReplayAccess, ReplayAccessFallbackAlert} from './replayAccess';
 
 describe('ReplayAccess', () => {
   const user = UserFixture({id: '1'});

--- a/static/app/components/replays/replayAccess.spec.tsx
+++ b/static/app/components/replays/replayAccess.spec.tsx
@@ -1,0 +1,111 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+
+import {ReplayAccess, ReplayAccessFallbackAlert} from './ReplayAccess';
+
+describe('ReplayAccess', () => {
+  const user = UserFixture({id: '1'});
+
+  beforeEach(() => {
+    ConfigStore.set('user', user);
+  });
+
+  it('renders children when granular-replay-permissions feature is not enabled', () => {
+    const organization = OrganizationFixture({
+      features: [],
+    });
+
+    render(
+      <ReplayAccess fallback={<div>No access</div>}>
+        <div>Has access</div>
+      </ReplayAccess>,
+      {organization}
+    );
+
+    expect(screen.getByText('Has access')).toBeInTheDocument();
+    expect(screen.queryByText('No access')).not.toBeInTheDocument();
+  });
+
+  it('renders children when hasGranularReplayPermissions is false', () => {
+    const organization = OrganizationFixture({
+      features: ['granular-replay-permissions'],
+      hasGranularReplayPermissions: false,
+    });
+
+    render(
+      <ReplayAccess fallback={<div>No access</div>}>
+        <div>Has access</div>
+      </ReplayAccess>,
+      {organization}
+    );
+
+    expect(screen.getByText('Has access')).toBeInTheDocument();
+    expect(screen.queryByText('No access')).not.toBeInTheDocument();
+  });
+
+  it('renders children when user is in replayAccessMembers', () => {
+    const organization = OrganizationFixture({
+      features: ['granular-replay-permissions'],
+      hasGranularReplayPermissions: true,
+      replayAccessMembers: [1],
+    });
+
+    render(
+      <ReplayAccess fallback={<div>No access</div>}>
+        <div>Has access</div>
+      </ReplayAccess>,
+      {organization}
+    );
+
+    expect(screen.getByText('Has access')).toBeInTheDocument();
+    expect(screen.queryByText('No access')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback when user is not in replayAccessMembers', () => {
+    const organization = OrganizationFixture({
+      features: ['granular-replay-permissions'],
+      hasGranularReplayPermissions: true,
+      replayAccessMembers: [999],
+    });
+
+    render(
+      <ReplayAccess fallback={<div>No access</div>}>
+        <div>Has access</div>
+      </ReplayAccess>,
+      {organization}
+    );
+
+    expect(screen.queryByText('Has access')).not.toBeInTheDocument();
+    expect(screen.getByText('No access')).toBeInTheDocument();
+  });
+
+  it('renders null fallback by default when user does not have access', () => {
+    const organization = OrganizationFixture({
+      features: ['granular-replay-permissions'],
+      hasGranularReplayPermissions: true,
+      replayAccessMembers: [999],
+    });
+
+    const {container} = render(
+      <ReplayAccess>
+        <div>Has access</div>
+      </ReplayAccess>,
+      {organization}
+    );
+
+    expect(screen.queryByText('Has access')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('ReplayAccessFallbackAlert', () => {
+  it('renders the access denied alert message', () => {
+    render(<ReplayAccessFallbackAlert />);
+
+    expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
+  });
+});

--- a/static/app/components/replays/replayAccess.tsx
+++ b/static/app/components/replays/replayAccess.tsx
@@ -1,0 +1,35 @@
+import {Alert} from '@sentry/scraps/alert';
+
+import {t} from 'sentry/locale';
+import {useHasReplayAccess} from 'sentry/utils/replays/hooks/useHasReplayAccess';
+
+interface ReplayAccessProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+/**
+ * Guard component to check if the user has access to replay data based on the organization's replay permissions settings.
+ */
+export function ReplayAccess({children, fallback = null}: ReplayAccessProps) {
+  const hasAccess = useHasReplayAccess();
+  if (!hasAccess) {
+    return fallback;
+  }
+  return children;
+}
+
+export function ReplayAccessFallbackAlert() {
+  return (
+    <Alert
+      type="warning"
+      showIcon
+      defaultExpanded
+      expand={t(
+        'Replay access in this organization is limited to certain members. Please contact an organization admin to get access.'
+      )}
+    >
+      {t("You don't have access to this feature")}
+    </Alert>
+  );
+}

--- a/static/app/data/forms/organizationMembershipSettings.tsx
+++ b/static/app/data/forms/organizationMembershipSettings.tsx
@@ -109,6 +109,31 @@ const formGroups: JsonFormObject[] = [
           'Role required to download debug information files, proguard mappings and source maps.'
         ),
       },
+      {
+        name: 'hasGranularReplayPermissions',
+        type: 'boolean',
+        label: t('Restrict Replay Access'),
+        help: t(
+          'Allow granular access to replay data by selecting specific members of your organization.'
+        ),
+        confirm: {
+          isDangerous: true,
+          false: t(
+            'This will allow all members of your organization to access replay data. Do you want to continue?'
+          ),
+        },
+        visible: ({features}) => features.has('granular-replay-permissions'),
+      },
+      {
+        name: 'replayAccessMembers',
+        type: 'sentry_member_selector',
+        label: t('Replay Access Members'),
+        help: t('Select the members who will have access to replay data.'),
+        multiple: true,
+        visible: ({model, features}) =>
+          features.has('granular-replay-permissions') &&
+          model.getValue('hasGranularReplayPermissions'),
+      },
     ],
   },
 ];

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -71,6 +71,7 @@ export interface Organization extends OrganizationSummary {
   defaultRole: string;
   enhancedPrivacy: boolean;
   eventsMemberAdmin: boolean;
+  hasGranularReplayPermissions: boolean;
   isDefault: boolean;
   isDynamicallySampled: boolean;
   onboardingTasks: OnboardingTaskStatus[];
@@ -88,6 +89,7 @@ export interface Organization extends OrganizationSummary {
     projectLimit: number | null;
   };
   relayPiiConfig: string | null;
+  replayAccessMembers: number[];
   requiresSso: boolean;
   safeFields: string[];
   samplingMode: 'organization' | 'project';

--- a/static/app/utils/replays/hooks/useHasReplayAccess.tsx
+++ b/static/app/utils/replays/hooks/useHasReplayAccess.tsx
@@ -1,0 +1,17 @@
+import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
+
+/**
+ * Returns true if the user has access to replay data based on the organization's replay permissions settings.
+ */
+export function useHasReplayAccess() {
+  const organization = useOrganization();
+  const user = useUser();
+  const hasFeature = organization.features.includes('granular-replay-permissions');
+
+  if (!hasFeature || !organization.hasGranularReplayPermissions) {
+    return true;
+  }
+
+  return organization.replayAccessMembers.includes(parseInt(user.id, 10));
+}

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -5,10 +5,12 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
 import {ReplayListFixture} from 'sentry-fixture/replayList';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
+import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
@@ -76,6 +78,7 @@ type InitializeOrgProps = {
 
 describe('GroupReplays', () => {
   const mockGroup = GroupFixture();
+  const user = UserFixture({id: '1'});
 
   const initialRouterConfig = {
     route: '/organizations/:orgId/issues/:groupId/replays/',
@@ -100,6 +103,7 @@ describe('GroupReplays', () => {
   }
 
   beforeEach(() => {
+    ConfigStore.set('user', user);
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${mockGroup.id}/`,
       body: mockGroup,
@@ -127,6 +131,26 @@ describe('GroupReplays', () => {
       expect(
         screen.getByText("You don't have access to this feature")
       ).toBeInTheDocument();
+    });
+
+    it('should show access denied when user does not have granular replay permissions', async () => {
+      const {organization} = init({
+        organizationProps: {
+          features: ['session-replay', 'granular-replay-permissions'],
+          hasGranularReplayPermissions: true,
+          replayAccessMembers: [999], // User ID 1 is not in this list
+        },
+      });
+      render(<GroupReplays />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("You don't have access to this feature")
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -146,11 +146,9 @@ describe('GroupReplays', () => {
         initialRouterConfig,
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByText("You don't have access to this feature")
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText("You don't have access to this feature")
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -13,7 +13,7 @@ import {
 import {
   ReplayAccess,
   ReplayAccessFallbackAlert,
-} from 'sentry/components/replays/ReplayAccess';
+} from 'sentry/components/replays/replayAccess';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import {

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -10,6 +10,10 @@ import {
   SelectedReplayIndexProvider,
   useSelectedReplayIndex,
 } from 'sentry/components/replays/queryParams/selectedReplayIndex';
+import {
+  ReplayAccess,
+  ReplayAccessFallbackAlert,
+} from 'sentry/components/replays/ReplayAccess';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import {
@@ -77,6 +81,14 @@ function ReplayFilterMessage() {
 }
 
 export default function GroupReplays({group}: Props) {
+  return (
+    <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
+      <GroupReplaysContent group={group} />
+    </ReplayAccess>
+  );
+}
+
+function GroupReplaysContent({group}: Props) {
   const organization = useOrganization();
   const location = useLocation<ReplayListLocationQuery>();
   const hasStreamlinedUI = useHasStreamlinedUI();

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
@@ -63,7 +63,6 @@ describe('ReplayPreview', () => {
       }
     );
 
-    expect(screen.queryByText('Session Replay')).not.toBeInTheDocument();
     expect(container).toBeEmptyDOMElement();
   });
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
@@ -1,0 +1,84 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+import type {EventTransaction} from 'sentry/types/event';
+
+import ReplayPreview from './replayPreview';
+
+jest.mock('sentry/components/events/eventReplay/replayClipPreview', () => {
+  return function MockReplayClipPreview() {
+    return <div data-test-id="replay-clip-preview">Replay Clip Preview</div>;
+  };
+});
+
+describe('ReplayPreview', () => {
+  const user = UserFixture({id: '1'});
+  const organization = OrganizationFixture({
+    features: ['session-replay'],
+  });
+
+  beforeEach(() => {
+    ConfigStore.set('user', user);
+  });
+
+  it('should render replay preview when user has access', () => {
+    const event = EventFixture({
+      contexts: {
+        replay: {
+          replay_id: 'test-replay-id',
+        },
+      },
+    }) as EventTransaction;
+
+    render(<ReplayPreview event={event} organization={organization} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Session Replay')).toBeInTheDocument();
+  });
+
+  it('should hide replay preview when user does not have granular replay permissions', () => {
+    const orgWithGranularPermissions = OrganizationFixture({
+      features: ['session-replay', 'granular-replay-permissions'],
+      hasGranularReplayPermissions: true,
+      replayAccessMembers: [999], // User ID 1 is not in this list
+    });
+
+    const event = EventFixture({
+      contexts: {
+        replay: {
+          replay_id: 'test-replay-id',
+        },
+      },
+    }) as EventTransaction;
+
+    const {container} = render(
+      <ReplayPreview event={event} organization={orgWithGranularPermissions} />,
+      {
+        organization: orgWithGranularPermissions,
+      }
+    );
+
+    expect(screen.queryByText('Session Replay')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should return null when event has no replay id', () => {
+    const event = EventFixture({
+      contexts: {},
+    }) as EventTransaction;
+
+    const {container} = render(
+      <ReplayPreview event={event} organization={organization} />,
+      {
+        organization,
+      }
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import ReplayClipPreview from 'sentry/components/events/eventReplay/replayClipPreview';
+import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
@@ -65,13 +66,15 @@ export default function ReplayPreview({
   }
 
   return (
-    <InterimSection
-      title={t('Session Replay')}
-      type="trace_session_replay"
-      disableCollapsePersistence
-    >
-      <ReplaySection event={event} organization={organization} />
-    </InterimSection>
+    <ReplayAccess>
+      <InterimSection
+        title={t('Session Replay')}
+        type="trace_session_replay"
+        disableCollapsePersistence
+      >
+        <ReplaySection event={event} organization={organization} />
+      </InterimSection>
+    </ReplayAccess>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import ReplayClipPreview from 'sentry/components/events/eventReplay/replayClipPreview';
-import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
+import {ReplayAccess} from 'sentry/components/replays/replayAccess';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -4,7 +4,7 @@ import type {Location} from 'history';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
+import {ReplayAccess} from 'sentry/components/replays/replayAccess';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import {
   ReplayActivityColumn,

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -4,6 +4,7 @@ import type {Location} from 'history';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {ReplayAccess} from 'sentry/components/replays/ReplayAccess';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import {
   ReplayActivityColumn,
@@ -29,6 +30,14 @@ import useReplaysFromTransaction from './useReplaysFromTransaction';
 import useReplaysWithTxData from './useReplaysWithTxData';
 
 function TransactionReplays() {
+  return (
+    <ReplayAccess>
+      <TransactionReplaysContent />
+    </ReplayAccess>
+  );
+}
+
+function TransactionReplaysContent() {
   const {
     eventView: replayIdsEventView,
     organization,

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -4,7 +4,10 @@ import type {Location} from 'history';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {ReplayAccess} from 'sentry/components/replays/replayAccess';
+import {
+  ReplayAccess,
+  ReplayAccessFallbackAlert,
+} from 'sentry/components/replays/replayAccess';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import {
   ReplayActivityColumn,
@@ -31,7 +34,7 @@ import useReplaysWithTxData from './useReplaysWithTxData';
 
 function TransactionReplays() {
   return (
-    <ReplayAccess>
+    <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
       <TransactionReplaysContent />
     </ReplayAccess>
   );

--- a/static/app/views/replays/details.spec.tsx
+++ b/static/app/views/replays/details.spec.tsx
@@ -1,0 +1,93 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
+
+import ReplayDetails from './details';
+
+jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
+jest.mock('sentry/utils/replays/hooks/useReplayPageview');
+
+const mockUseLoadReplayReader = jest.mocked(useLoadReplayReader);
+mockUseLoadReplayReader.mockReturnValue({
+  attachments: [],
+  errors: [],
+  fetchError: undefined,
+  attachmentError: undefined,
+  isError: false,
+  isPending: false,
+  onRetry: jest.fn(),
+  projectSlug: ProjectFixture().slug,
+  replay: null,
+  replayId: 'test-replay-id',
+  replayRecord: ReplayRecordFixture(),
+  status: 'success' as const,
+});
+
+describe('ReplayDetails', () => {
+  const user = UserFixture({id: '1'});
+
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/replays/test-replay-id/',
+      query: {},
+    },
+    route: '/organizations/:orgId/replays/:replaySlug/',
+  };
+
+  beforeEach(() => {
+    ConfigStore.set('user', user);
+    mockUseLoadReplayReader.mockClear();
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replays/test-replay-id/',
+      body: {
+        data: {
+          id: 'test-replay-id',
+        },
+      },
+    });
+  });
+
+  it('should render replay details when user has access', () => {
+    const organization = OrganizationFixture({
+      features: ['session-replay'],
+    });
+
+    render(<ReplayDetails />, {
+      organization,
+      initialRouterConfig,
+    });
+
+    // Should not show access denied message
+    expect(
+      screen.queryByText("You don't have access to this feature")
+    ).not.toBeInTheDocument();
+    // Should render the replay details page content
+    expect(screen.getByText('Session Replay')).toBeInTheDocument();
+    // Should fetch replay data
+    expect(mockUseLoadReplayReader).toHaveBeenCalled();
+  });
+
+  it('should show access denied and not fetch data when user does not have granular replay permissions', () => {
+    const organization = OrganizationFixture({
+      features: ['session-replay', 'granular-replay-permissions'],
+      hasGranularReplayPermissions: true,
+      replayAccessMembers: [999], // User ID 1 is not in this list
+    });
+
+    render(<ReplayDetails />, {
+      organization,
+      initialRouterConfig,
+    });
+
+    expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
+    // Should not fetch replay data when user doesn't have access
+    expect(mockUseLoadReplayReader).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -9,7 +9,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {
   ReplayAccess,
   ReplayAccessFallbackAlert,
-} from 'sentry/components/replays/ReplayAccess';
+} from 'sentry/components/replays/replayAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -6,6 +6,10 @@ import AnalyticsArea from 'sentry/components/analyticsArea';
 import {Flex} from 'sentry/components/core/layout';
 import FullViewport from 'sentry/components/layouts/fullViewport';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {
+  ReplayAccess,
+  ReplayAccessFallbackAlert,
+} from 'sentry/components/replays/ReplayAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -26,6 +30,25 @@ import ReplayDetailsUserBadge from 'sentry/views/replays/detail/header/replayDet
 import ReplayDetailsPage from 'sentry/views/replays/detail/page';
 
 export default function ReplayDetails() {
+  return (
+    <AnalyticsArea name="details">
+      <ReplayAccess
+        fallback={
+          <Fragment>
+            <NewTopHeader>{t('Replay Details')}</NewTopHeader>
+            <Layout.Body>
+              <ReplayAccessFallbackAlert />
+            </Layout.Body>
+          </Fragment>
+        }
+      >
+        <ReplayDetailsContent />
+      </ReplayAccess>
+    </AnalyticsArea>
+  );
+}
+
+function ReplayDetailsContent() {
   const user = useUser();
   const location = useLocation();
   const organization = useOrganization();
@@ -81,23 +104,19 @@ export default function ReplayDetails() {
       <ReplayDetailsPage readerResult={readerResult} />
     </Fragment>
   );
+
   return (
-    <AnalyticsArea name="details">
-      <SentryDocumentTitle title={title}>
-        <FullViewport>
-          {replay ? (
-            <ReplayDetailsProviders
-              replay={replay}
-              projectSlug={readerResult.projectSlug}
-            >
-              {content}
-            </ReplayDetailsProviders>
-          ) : (
-            content
-          )}
-        </FullViewport>
-      </SentryDocumentTitle>
-    </AnalyticsArea>
+    <SentryDocumentTitle title={title}>
+      <FullViewport>
+        {replay ? (
+          <ReplayDetailsProviders replay={replay} projectSlug={readerResult.projectSlug}>
+            {content}
+          </ReplayDetailsProviders>
+        ) : (
+          content
+        )}
+      </FullViewport>
+    </SentryDocumentTitle>
   );
 }
 

--- a/static/app/views/replays/list.tsx
+++ b/static/app/views/replays/list.tsx
@@ -8,6 +8,10 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {LocalStorageReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
+import {
+  ReplayAccess,
+  ReplayAccessFallbackAlert,
+} from 'sentry/components/replays/ReplayAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
@@ -75,7 +79,9 @@ export default function ReplaysListContainer() {
                 <Grid gap="xl" columns="100%">
                   <ReplayListPageHeaderHook />
                   {hasSessionReplay && hasSentReplays.hasSentOneReplay ? (
-                    <ReplayIndexContainer />
+                    <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
+                      <ReplayIndexContainer />
+                    </ReplayAccess>
                   ) : (
                     <Fragment>
                       <Flex gap="xl" wrap="wrap">

--- a/static/app/views/replays/list.tsx
+++ b/static/app/views/replays/list.tsx
@@ -11,7 +11,7 @@ import {LocalStorageReplayPreferences} from 'sentry/components/replays/preferenc
 import {
   ReplayAccess,
   ReplayAccessFallbackAlert,
-} from 'sentry/components/replays/ReplayAccess';
+} from 'sentry/components/replays/replayAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -14,6 +14,7 @@ import {
 
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Config} from 'sentry/types/system';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -26,10 +27,12 @@ describe('OrganizationGeneralSettings', () => {
   const ENDPOINT = '/organizations/org-slug/';
   const organization = OrganizationFixture();
   let configState: Config;
+  let membersRequest: jest.Mock;
 
   beforeEach(() => {
     configState = ConfigStore.getState();
     OrganizationsStore.addOrReplace(organization);
+    OrganizationStore.onUpdate(organization, {replace: true});
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/auth-provider/`,
       method: 'GET',
@@ -38,6 +41,10 @@ describe('OrganizationGeneralSettings', () => {
       url: `/organizations/${organization.slug}/integrations/?provider_key=github`,
       method: 'GET',
       body: [GitHubIntegrationFixture()],
+    });
+    membersRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [],
     });
   });
 
@@ -73,6 +80,7 @@ describe('OrganizationGeneralSettings', () => {
       features: ['codecov-integration'],
       codecovAccess: false,
     });
+    OrganizationStore.onUpdate(organizationWithCodecovFeature, {replace: true});
     render(<OrganizationGeneralSettings />, {
       organization: organizationWithCodecovFeature,
     });
@@ -135,6 +143,7 @@ describe('OrganizationGeneralSettings', () => {
     ConfigStore.set('features', new Set(['system:multi-region']));
 
     const org = OrganizationFixture();
+    OrganizationStore.onUpdate(org, {replace: true});
     const updateMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
@@ -167,12 +176,15 @@ describe('OrganizationGeneralSettings', () => {
     );
   });
 
-  it('disables the entire form if user does not have write access', () => {
+  it('disables the entire form if user does not have write access', async () => {
     const readOnlyOrg = OrganizationFixture({access: ['org:read']});
+    OrganizationStore.onUpdate(readOnlyOrg, {replace: true});
 
     render(<OrganizationGeneralSettings />, {
       organization: readOnlyOrg,
     });
+
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
 
     const formElements = [
       ...screen.getAllByRole('textbox'),
@@ -191,12 +203,15 @@ describe('OrganizationGeneralSettings', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not have remove organization button without org:admin permission', () => {
+  it('does not have remove organization button without org:admin permission', async () => {
+    const orgWithWriteAccess = OrganizationFixture({access: ['org:write']});
+    OrganizationStore.onUpdate(orgWithWriteAccess, {replace: true});
+
     render(<OrganizationGeneralSettings />, {
-      organization: OrganizationFixture({
-        access: ['org:write'],
-      }),
+      organization: orgWithWriteAccess,
     });
+
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
 
     expect(
       screen.queryByRole('button', {name: /remove organization/i})
@@ -204,10 +219,12 @@ describe('OrganizationGeneralSettings', () => {
   });
 
   it('can remove organization when org admin', async () => {
+    const orgWithAdminAccess = OrganizationFixture({access: ['org:admin']});
+    OrganizationStore.onUpdate(orgWithAdminAccess, {replace: true});
     act(() => ProjectsStore.loadInitialData([ProjectFixture({slug: 'project'})]));
 
     render(<OrganizationGeneralSettings />, {
-      organization: OrganizationFixture({access: ['org:admin']}),
+      organization: orgWithAdminAccess,
     });
     renderGlobalModal();
 

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -57,7 +57,7 @@ function OrganizationSettingsForm({initialData, onSave}: Props) {
       location,
       disabled: !access.has('org:write'),
     }),
-    [access, location, organization]
+    [access, location, organization.features]
   );
 
   const generalForms = useMemo(() => {

--- a/static/gsApp/hooks/organizationMembershipSettingsForm.spec.tsx
+++ b/static/gsApp/hooks/organizationMembershipSettingsForm.spec.tsx
@@ -162,12 +162,13 @@ describe('OrganizationMembershipSettings', () => {
     const organization = OrganizationFixture({
       features: ['invite-members', 'granular-replay-permissions'],
       access: ['org:write'],
+      hasGranularReplayPermissions: true,
     });
     render(getComponent(organization), {organization});
     await waitFor(() => expect(membersRequest).toHaveBeenCalled());
-    expect(
-      screen.getByRole('checkbox', {name: 'Restrict Replay Access'})
-    ).toBeInTheDocument();
+    const checkbox = screen.getByRole('checkbox', {name: 'Restrict Replay Access'});
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toBeEnabled();
   });
 
   it('disables restrict replay access if user does not have org:write access', async () => {

--- a/static/gsApp/hooks/organizationMembershipSettingsForm.spec.tsx
+++ b/static/gsApp/hooks/organizationMembershipSettingsForm.spec.tsx
@@ -1,16 +1,20 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import organizationMembershipSettingsFields from 'sentry/data/forms/organizationMembershipSettings';
+import OrganizationStore from 'sentry/stores/organizationStore';
 import type {Organization} from 'sentry/types/organization';
 
 import OrganizationMembershipSettingsForm from 'getsentry/hooks/organizationMembershipSettingsForm';
 
 describe('OrganizationMembershipSettings', () => {
   const location = LocationFixture();
+  let membersRequest: jest.Mock;
+
   const getComponent = (organization: Organization) => {
+    OrganizationStore.onUpdate(organization, {replace: true});
     const access = new Set(organization.access);
     const jsonFormSettings = {
       features: new Set(organization.features),
@@ -26,102 +30,154 @@ describe('OrganizationMembershipSettings', () => {
     );
   };
 
-  it('renders alert banner and disables settings if org does not have invite-members', () => {
+  beforeEach(() => {
+    membersRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [],
+    });
+  });
+
+  it('renders alert banner and disables settings if org does not have invite-members', async () => {
     const organization = OrganizationFixture({features: [], access: []});
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(
       screen.getByText('You must be on a paid plan to invite additional members.')
     ).toBeInTheDocument();
     expect(screen.getByRole('checkbox', {name: 'Open Team Membership'})).toBeDisabled();
   });
 
-  it('renders alert banner and disables settings if org does not have invite-members and user has org:write access', () => {
+  it('renders alert banner and disables settings if org does not have invite-members and user has org:write access', async () => {
     const organization = OrganizationFixture({features: [], access: ['org:write']});
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(
       screen.getByText('You must be on a paid plan to invite additional members.')
     ).toBeInTheDocument();
     expect(screen.getByRole('checkbox', {name: 'Open Team Membership'})).toBeDisabled();
   });
 
-  it('does not render alert banner if org does not have invite-members', () => {
+  it('does not render alert banner if org does not have invite-members', async () => {
     const organization = OrganizationFixture({features: ['invite-members'], access: []});
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(
       screen.queryByText('You must be on a paid plan to invite additional members.')
     ).not.toBeInTheDocument();
     expect(screen.getByRole('checkbox', {name: 'Open Team Membership'})).toBeDisabled();
   });
 
-  it('does not render alert banner and enables settings if org has invite-members and user has org:write access', () => {
+  it('does not render alert banner and enables settings if org has invite-members and user has org:write access', async () => {
     const organization = OrganizationFixture({
       features: ['invite-members'],
       access: ['org:write'],
     });
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(
       screen.queryByText('You must be on a paid plan to invite additional members.')
     ).not.toBeInTheDocument();
     expect(screen.getByRole('checkbox', {name: 'Open Team Membership'})).toBeEnabled();
   });
 
-  it('disables default role selection if user does not have invite-members', () => {
+  it('disables default role selection if user does not have invite-members', async () => {
     const organization = OrganizationFixture({
       features: [],
       access: ['org:admin'],
     });
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(screen.getByRole('textbox', {name: 'Default Role'})).toBeDisabled();
   });
 
-  it('disables default role selection if user does not have org:admin access', () => {
+  it('disables default role selection if user does not have org:admin access', async () => {
     const organization = OrganizationFixture({
       features: ['invite-members'],
       access: ['org:write'],
     });
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(screen.getByRole('textbox', {name: 'Default Role'})).toBeDisabled();
   });
 
-  it('enables default role selection if user does not has org:admin access', () => {
+  it('enables default role selection if user does not has org:admin access', async () => {
     const organization = OrganizationFixture({
       features: ['invite-members'],
       access: ['org:write', 'org:admin'],
     });
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(screen.getByRole('textbox', {name: 'Default Role'})).toBeEnabled();
   });
 
-  it('disables member project creation if org does not have team-roles', () => {
+  it('disables member project creation if org does not have team-roles', async () => {
     const organization = OrganizationFixture({
       features: ['invite-members'],
       access: ['org:write'],
     });
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(
       screen.getByRole('checkbox', {name: 'Let Members Create Projects'})
     ).toBeDisabled();
   });
 
-  it('enables member project creation if org has team-roles', () => {
+  it('enables member project creation if org has team-roles', async () => {
     const organization = OrganizationFixture({
       features: ['invite-members', 'team-roles'],
       access: ['org:write'],
     });
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(
       screen.getByRole('checkbox', {name: 'Let Members Create Projects'})
     ).toBeEnabled();
   });
 
-  it('disables member project creation if user does not have org:write access', () => {
+  it('disables member project creation if user does not have org:write access', async () => {
     const organization = OrganizationFixture({
       features: ['invite-members', 'team-roles'],
       access: [],
     });
     render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
     expect(
       screen.getByRole('checkbox', {name: 'Let Members Create Projects'})
     ).toBeDisabled();
+  });
+
+  it('does not render restrict replay access if org does not have granular-replay-permissions', async () => {
+    const organization = OrganizationFixture({
+      features: ['invite-members'],
+      access: ['org:write'],
+    });
+    render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
+    expect(
+      screen.queryByRole('checkbox', {name: 'Restrict Replay Access'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders restrict replay access if org has granular-replay-permissions', async () => {
+    const organization = OrganizationFixture({
+      features: ['invite-members', 'granular-replay-permissions'],
+      access: ['org:write'],
+    });
+    render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
+    expect(
+      screen.getByRole('checkbox', {name: 'Restrict Replay Access'})
+    ).toBeInTheDocument();
+  });
+
+  it('disables restrict replay access if user does not have org:write access', async () => {
+    const organization = OrganizationFixture({
+      features: ['invite-members', 'granular-replay-permissions'],
+      access: [],
+      hasGranularReplayPermissions: true,
+    });
+    render(getComponent(organization), {organization});
+    await waitFor(() => expect(membersRequest).toHaveBeenCalled());
+    expect(screen.getByRole('checkbox', {name: 'Restrict Replay Access'})).toBeDisabled();
   });
 });

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -92,6 +92,8 @@ export function OrganizationFixture(params: Partial<Organization> = {}): Organiz
     defaultAutofixAutomationTuning: 'off',
     orgRoleList: OrgRoleListFixture(),
     teamRoleList: TeamRoleListFixture(),
+    hasGranularReplayPermissions: false,
+    replayAccessMembers: [],
     ...params,
   };
 }


### PR DESCRIPTION
Add org membership settings for allow-listing replay access.

https://github.com/user-attachments/assets/eaef606b-1e61-46fe-92e0-8c1d760bae0d

Introduce a guard component `<ReplayAccess/>` to check for the new permissions and wrap it around affected product areas:
- Embedded replay components (e.g. in issues details and trace details) simply get hidden.
- Replay-only product surface that gets pointed to by navigation elements displays an alert about missing permissions (e.g. replay list / details).
<img width="1470" height="605" alt="Screenshot 2025-12-10 at 11 13 54" src="https://github.com/user-attachments/assets/4dbe6840-9dce-4c49-a843-78b09ad49b46" />

- requires https://github.com/getsentry/sentry/pull/104446