### PR TITLE
feat(cells) Add tracer logs to ReactPage

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -15,6 +15,7 @@ from sentry.api.utils import generate_region_url
 from sentry.models.organization import Organization
 from sentry.organizations.absolute_url import customer_domain_path, generate_organization_url
 from sentry.organizations.services.organization import organization_service
+from sentry.silo.base import SiloMode
 from sentry.types.region import (
     find_all_multitenant_region_names,
     get_region_by_name,
@@ -218,6 +219,18 @@ class ReactPageView(ControlSiloOrganizationView, ReactMixin):
         return super().handle_auth_required(request, *args, **kwargs)
 
     def handle(self, request: HttpRequest, organization, **kwargs) -> HttpResponse:
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            # This shouldn't happen as all requests in production for HTML pages
+            # should be in control.
+            logger.info(
+                "react_page.region_silo",
+                extra={
+                    "url": request.get_full_path(),
+                    "method": request.method,
+                    "user-agent": request.headers.get("User-Agent"),
+                },
+            )
+
         return self.handle_react(request, organization=organization)
 
 


### PR DESCRIPTION
In #104552 I want to make `ReactPage` control-only. This change *should* be a no-op for saas, but I want to make sure of that first by validating with real traffic.

Refs INFRENG-238
