### PR TITLE
feat(llm-detector): Add `offender_span_ids`

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -49,6 +49,7 @@ class DetectedIssue(BaseModel):
     impact: str
     evidence: str
     missing_telemetry: str | None = None
+    offender_span_ids: list[str]
     title: str
     # context fields, not LLM generated
     trace_id: str
@@ -129,6 +130,7 @@ def create_issue_occurrence_from_detection(
         "impact": detected_issue.impact,
         "evidence": detected_issue.evidence,
         "missing_telemetry": detected_issue.missing_telemetry,
+        "offender_span_ids": detected_issue.offender_span_ids,
     }
 
     evidence_display = [

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -84,6 +84,7 @@ class LLMIssueDetectionTest(TestCase):
             impact="High - may cause request failures",
             evidence="Connection pool at 95% capacity",
             missing_telemetry="Database connection metrics",
+            offender_span_ids=["span_1", "span_2"],
             trace_id="abc123xyz",
             transaction_name="test_transaction",
         )
@@ -149,6 +150,7 @@ class LLMIssueDetectionTest(TestCase):
             evidence="Response time > 2s",
             trace_id="xyz789",
             transaction_name="api_endpoint",
+            offender_span_ids=["span_1", "span_2"],
         )
 
         create_issue_occurrence_from_detection(
@@ -211,6 +213,7 @@ class LLMIssueDetectionTest(TestCase):
                     "impact": "High - causes performance degradation",
                     "evidence": "15 queries executed sequentially",
                     "missing_telemetry": "Database query attribution",
+                    "offender_span_ids": ["span_1", "span_2"],
                     "trace_id": "trace_id_1",
                     "transaction_name": "POST /some/thing",
                 },
@@ -220,6 +223,7 @@ class LLMIssueDetectionTest(TestCase):
                     "impact": "Medium - may cause OOM",
                     "evidence": "Objects not released after use",
                     "missing_telemetry": None,
+                    "offender_span_ids": ["span_3"],
                     "trace_id": "trace_id_2",
                     "transaction_name": "GET /another/",
                 },


### PR DESCRIPTION
pr to update the output to include this field https://github.com/getsentry/seer/pull/4229. this pr adds the data to the occurrence so it will appear on the issue 
fixes https://linear.app/getsentry/issue/ID-1135/trace-explorer-should-highlight-offending-span