### PR TITLE
fix(crons): Handle deleted environments in serializers

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -111,15 +111,16 @@ class MonitorEnvironmentSerializer(Serializer):
 
         return {
             monitor_env: {
-                "environment": environments[monitor_env.environment_id],
+                "environment": environments.get(monitor_env.environment_id),
                 "active_incident": serialized_incidents.get(monitor_env.id),
             }
             for monitor_env in item_list
         }
 
     def serialize(self, obj, attrs, user, **kwargs) -> MonitorEnvironmentSerializerResponse:
+        environment = attrs["environment"]
         return {
-            "name": attrs["environment"].name,
+            "name": environment.name if environment else "[removed]",
             "status": obj.get_status_display(),
             "isMuted": obj.is_muted,
             "dateCreated": obj.monitor.date_added,
@@ -339,7 +340,8 @@ class MonitorCheckInSerializer(Serializer):
         for checkin in item_list:
             env_name = None
             if checkin.monitor_environment:
-                env_name = envs[checkin.monitor_environment.environment_id].name
+                env = envs.get(checkin.monitor_environment.environment_id)
+                env_name = env.name if env else "[removed]"
 
             attrs[checkin]["environment_name"] = env_name
 

--- a/tests/sentry/monitors/test_serializers.py
+++ b/tests/sentry/monitors/test_serializers.py
@@ -1,0 +1,58 @@
+from sentry.api.serializers import serialize
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment
+from sentry.monitors.serializers import MonitorCheckInSerializer, MonitorEnvironmentSerializer
+from sentry.testutils.cases import TestCase
+
+
+class MonitorEnvironmentSerializerTest(TestCase):
+    def test_serialize_with_deleted_environment(self):
+        """
+        Test that MonitorEnvironmentSerializer handles missing environments gracefully.
+        This can happen when an environment is deleted but MonitorEnvironment records still reference it.
+
+        Regression test for https://sentry.sentry.io/issues/SENTRY-5CTA/
+        """
+        monitor = self.create_monitor()
+        # Create a monitor environment with a non-existent environment_id
+        monitor_env = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment_id=999999,  # Non-existent environment ID
+        )
+
+        # This should not raise a KeyError
+        result = serialize([monitor_env], self.user, MonitorEnvironmentSerializer())
+
+        assert len(result) == 1
+        # When environment is missing, the serialization should still work
+        # The name will be "[removed]" since the environment doesn't exist
+        assert result[0]["name"] == "[removed]"
+
+
+class MonitorCheckInSerializerTest(TestCase):
+    def test_serialize_with_deleted_environment(self):
+        """
+        Test that MonitorCheckInSerializer handles missing environments gracefully.
+        This can happen when an environment is deleted but check-ins still reference it.
+
+        Regression test for https://sentry.sentry.io/issues/SENTRY-5CTA/
+        """
+        monitor = self.create_monitor()
+        # Create a monitor environment with a non-existent environment_id
+        monitor_env = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment_id=999999,  # Non-existent environment ID
+        )
+
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_env,
+            project_id=monitor.project_id,
+            status=CheckInStatus.OK,
+        )
+
+        # This should not raise a KeyError
+        result = serialize([checkin], self.user, MonitorCheckInSerializer())
+
+        assert len(result) == 1
+        # When environment is missing, environment should be "[removed]"
+        assert result[0]["environment"] == "[removed]"


### PR DESCRIPTION
Protect environment lookups in MonitorEnvironmentSerializer and MonitorCheckInSerializer against missing environment IDs. When an environment has been deleted but MonitorEnvironment or MonitorCheckIn records still reference it, return "[removed]" instead of raising a KeyError.

Fixes SENTRY-5CTA