### PR TITLE
fix(detectors): Render list _after_ visualisation

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -212,14 +212,6 @@ function DetectorListTable({
         {isSuccess && detectors.length === 0 && (
           <SimpleTable.Empty>{t('No monitors found')}</SimpleTable.Empty>
         )}
-        {detectors.map(detector => (
-          <DetectorListRow
-            key={detector.id}
-            detector={detector}
-            selected={selected.has(detector.id)}
-            onSelect={handleSelect}
-          />
-        ))}
         {hasVisualization && (
           <PositionedGridLineOverlay
             stickyCursor
@@ -232,6 +224,14 @@ function DetectorListTable({
             cursorOverlayAnchorOffset={10}
           />
         )}
+        {detectors.map(detector => (
+          <DetectorListRow
+            key={detector.id}
+            detector={detector}
+            selected={selected.has(detector.id)}
+            onSelect={handleSelect}
+          />
+        ))}
       </DetectorListSimpleTable>
     </TableContainer>
   );


### PR DESCRIPTION
As it is right now, rendering the PositionedGridLineOverlay at the end
of the list causes the `:last-child` to incorrectly target the grid line
overlay, instead of the last row in the list.

Before

<img alt="clipboard.png" width="276" src="https://i.imgur.com/GYzGhwI.png" />

After

<img alt="clipboard.png" width="260" src="https://i.imgur.com/enV0I1H.png" />