### PR TITLE
fix(aci): New monitor form should handle missing project ID

### DIFF
--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -9,9 +9,9 @@ import type {
   DetectorType,
 } from 'sentry/types/workflowEngine/detectors';
 import {useLocation} from 'sentry/utils/useLocation';
-import useProjects from 'sentry/utils/useProjects';
 import {NewDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {NewDetectorFooter} from 'sentry/views/detectors/components/forms/common/footer';
+import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/context';
 import {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {useCreateDetectorFormSubmit} from 'sentry/views/detectors/hooks/useCreateDetectorFormSubmit';
@@ -41,9 +41,9 @@ export function NewDetectorLayout<
   detectorType,
 }: NewDetectorLayoutProps<TFormData, TUpdatePayload>) {
   const location = useLocation();
-  const {projects} = useProjects();
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
+  const formContext = useDetectorFormContext();
 
   const formSubmitHandler = useCreateDetectorFormSubmit({
     detectorType,
@@ -51,10 +51,8 @@ export function NewDetectorLayout<
   });
 
   const initialData = useMemo(() => {
-    const defaultProjectId = projects.find(p => p.isMember)?.id ?? projects[0]?.id;
-
     return {
-      projectId: (location.query.project as string) ?? defaultProjectId ?? '',
+      projectId: formContext.project.id,
       environment: (location.query.environment as string | undefined) || '',
       name: (location.query.name as string | undefined) || '',
       owner: (location.query.owner as string | undefined) || '',
@@ -62,12 +60,11 @@ export function NewDetectorLayout<
       ...initialFormData,
     };
   }, [
+    formContext.project.id,
     initialFormData,
     location.query.environment,
     location.query.name,
     location.query.owner,
-    location.query.project,
-    projects,
   ]);
 
   const formProps: FormProps = {

--- a/static/app/views/detectors/new-settings.tsx
+++ b/static/app/views/detectors/new-settings.tsx
@@ -1,3 +1,4 @@
+import orderBy from 'lodash/orderBy';
 import {parseAsString, useQueryState} from 'nuqs';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -37,7 +38,10 @@ export default function DetectorNewSettings() {
     );
   }
 
-  const project = projectId ? projects.find(p => p.id === projectId) : undefined;
+  const project = projectId
+    ? projects.find(p => p.id === projectId)
+    : orderBy(projects, ['isMember', 'isBookmarked'], ['desc', 'desc'])[0];
+
   if (!project) {
     return <LoadingError message={t('Project not found')} />;
   }

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -1,3 +1,4 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -6,6 +7,10 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import DetectorNew from 'sentry/views/detectors/new';
 
 describe('DetectorNew', () => {
+  const organization = OrganizationFixture({
+    features: ['workflow-engine-ui'],
+  });
+
   const projects = [
     ProjectFixture({
       id: '2',
@@ -21,7 +26,7 @@ describe('DetectorNew', () => {
   });
 
   it('sets query parameters for project, environment, and detectorType', async () => {
-    const {router} = render(<DetectorNew />);
+    const {router} = render(<DetectorNew />, {organization});
 
     // Set detectorType
     await userEvent.click(screen.getByRole('radio', {name: 'Uptime'}));
@@ -36,7 +41,6 @@ describe('DetectorNew', () => {
         pathname: `/organizations/org-slug/monitors/new/settings/`,
         query: {
           detectorType: 'uptime_domain_failure',
-          project: '1',
         },
       })
     );
@@ -44,6 +48,7 @@ describe('DetectorNew', () => {
 
   it('preserves project query parameter when navigating to the next step', async () => {
     const {router} = render(<DetectorNew />, {
+      organization,
       initialRouterConfig: {
         location: {
           pathname: '/organizations/org-slug/monitors/new/',
@@ -55,6 +60,7 @@ describe('DetectorNew', () => {
     await userEvent.click(screen.getByRole('radio', {name: 'Uptime'}));
 
     expect(router.location.query.detectorType).toBe('uptime_domain_failure');
+    expect(router.location.query.project).toBe('2');
 
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -39,9 +39,9 @@ describe('DetectorNew', () => {
     expect(router.location).toEqual(
       expect.objectContaining({
         pathname: `/organizations/org-slug/monitors/new/settings/`,
-        query: {
+        query: expect.objectContaining({
           detectorType: 'uptime_domain_failure',
-        },
+        }),
       })
     );
   });

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -8,21 +8,14 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
-import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
 import {
   DetectorTypeForm,
   useDetectorTypeQueryState,
 } from 'sentry/views/detectors/components/detectorTypeForm';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
-
-interface NewDetectorFormData {
-  detectorType: DetectorType;
-  project: string;
-}
 
 function NewDetectorBreadcrumbs() {
   const organization = useOrganization();
@@ -45,31 +38,26 @@ export default function DetectorNew() {
   const navigate = useNavigate();
   const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
-  const {projects} = useProjects();
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
   const [detectorType] = useDetectorTypeQueryState();
-  const [projectIdFromLocation] = useQueryState('project', parseAsString);
-  const defaultProject = projects.find(p => p.isMember) ?? projects[0];
+  const [projectId] = useQueryState('project', parseAsString);
 
   const newMonitorName = t('New Monitor');
 
   const formProps = {
-    onSubmit: (formData: any) => {
-      // Form doesn't allow type to be defined, cast to the expected shape
-      const data = formData as NewDetectorFormData;
+    onSubmit: () => {
       navigate({
         pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
         query: {
           detectorType,
-          project: data.project,
+          project: projectId,
         },
       });
     },
     initialData: {
       detectorType,
-      project: projectIdFromLocation ?? defaultProject?.id ?? '',
-    } satisfies NewDetectorFormData,
+    },
   };
 
   return (

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -51,7 +51,7 @@ export default function DetectorNew() {
         pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
         query: {
           detectorType,
-          project: projectId,
+          project: projectId ?? undefined,
         },
       });
     },


### PR DESCRIPTION
This fixes a bug where, if you clicked "create a monitor" from another page with "my projects" selected, the monitor creation form would error out.

- Consolidated all "default project selection" logic so that the selection happens in the monitor form and is stored in context on first render (this was occurring in a few different locations in order to append the `project` query param, but now we are leaving it empty and letting the form pick the default
- As a bonus, the default selection logic is a bit smarter, prioritizing projects that you are a member of and have bookmarked.