### PR TITLE
chore(aci): cast snake_case Action data to camelCase for Rules

### DIFF
--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -52,9 +52,7 @@ class NotifyEmailAction(EventAction):
         skip_digests = self.data.get("skipDigests", False)
 
         # XXX: temporarily support both types, but after GA we should only need to support fallthrough_type
-        fallthrough_choice = self.data.get("fallthrough_type", None) or self.data.get(
-            "fallthroughType", None
-        )
+        fallthrough_choice = self.data.get("fallthroughType", None)
         fallthrough_type = (
             FallthroughChoiceType(fallthrough_choice)
             if fallthrough_choice

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -8,7 +8,7 @@ from typing import Any, NotRequired, Protocol, TypedDict
 from django.core.exceptions import ValidationError
 
 from sentry import features
-from sentry.api.serializers.rest_framework.base import snake_to_camel_case
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.incidents.grouptype import MetricIssueEvidenceData
@@ -244,7 +244,7 @@ class BaseIssueAlertHandler(ABC):
             # mail action needs to have skipDigests set to True
             data["actions"][0]["skipDigests"] = True
 
-        camelcased_data = {snake_to_camel_case(key): value for key, value in dict(data).items()}
+        camelcased_data = convert_dict_key_case(dict(data), snake_to_camel_case)
 
         rule = Rule(
             id=action.id,

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -8,6 +8,7 @@ from typing import Any, NotRequired, Protocol, TypedDict
 from django.core.exceptions import ValidationError
 
 from sentry import features
+from sentry.api.serializers.rest_framework.base import snake_to_camel_case
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.incidents.grouptype import MetricIssueEvidenceData
@@ -243,12 +244,14 @@ class BaseIssueAlertHandler(ABC):
             # mail action needs to have skipDigests set to True
             data["actions"][0]["skipDigests"] = True
 
+        camelcased_data = {snake_to_camel_case(key): value for key, value in dict(data).items()}
+
         rule = Rule(
             id=action.id,
             project=detector.project,
             environment_id=environment_id,
             label=label,
-            data=dict(data),
+            data=camelcased_data,
             status=ObjectStatus.ACTIVE,
             source=RuleSource.ISSUE,
         )

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -172,7 +172,8 @@ class BaseIssueAlertHandler(ABC):
         blob.update(cls.get_target_identifier(action, mapping, organization_id))
         blob.update(cls.get_target_display(action, mapping))
         blob.update(cls.get_additional_fields(action, mapping))
-        return blob
+        camelcased_blob = convert_dict_key_case(blob, snake_to_camel_case)
+        return camelcased_blob
 
     @classmethod
     def create_rule_instance_from_action(
@@ -244,14 +245,12 @@ class BaseIssueAlertHandler(ABC):
             # mail action needs to have skipDigests set to True
             data["actions"][0]["skipDigests"] = True
 
-        camelcased_data = convert_dict_key_case(dict(data), snake_to_camel_case)
-
         rule = Rule(
             id=action.id,
             project=detector.project,
             environment_id=environment_id,
             label=label,
-            data=camelcased_data,
+            data=dict(data),
             status=ObjectStatus.ACTIVE,
             source=RuleSource.ISSUE,
         )


### PR DESCRIPTION
All data in workflow engine Actions should be stored as `snake_case`. However, when sending notifications through the Rules system (we create a fake Rule from the Action data and send the notification), Rules expects data to be in `camelCase`.

We should be casting any `snake_case` keys in `Action.data` into `camelCase`.

This likely explains some of the reports of excessive notifications, because we simply weren't parsing the configs correctly.

NOTE: Other parts of the codebase expect `legacy_rule_id` and `workflow_id` to be snake case so leaving those be for now