### PR TITLE
fix(aci): add % suffix to data condition field

### DIFF
--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {AutomationBuilderNumberInput} from 'sentry/components/workflowEngine/form/automationBuilderNumberInput';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
@@ -18,7 +20,7 @@ export function CountBranch() {
 
 export function PercentBranch() {
   return tct('[value] higher [interval] compared to [comparison_interval]', {
-    value: <ValueField />,
+    value: <PercentValueField />,
     interval: <IntervalField />,
     comparison_interval: <ComparisonIntervalField />,
   });
@@ -40,6 +42,14 @@ function ValueField() {
         removeError(condition.id);
       }}
     />
+  );
+}
+
+function PercentValueField() {
+  return (
+    <PercentWrapper>
+      <ValueField />%
+    </PercentWrapper>
   );
 }
 
@@ -80,3 +90,9 @@ function ComparisonIntervalField() {
     />
   );
 }
+
+const PercentWrapper = styled('div')`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;


### PR DESCRIPTION
Adds a % after the number input for certain data conditions. Adding the % within the input box doesn't work with the up/down arrows for the number input stepping.

<img width="820" height="178" alt="Screenshot 2025-12-10 at 10 32 24 AM" src="https://github.com/user-attachments/assets/98f5c051-246b-4d48-96da-52e0938cd3ba" />
