### PR TITLE
chore(seer): Rename column to be more general in cases when we support other types of agents

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -25,7 +25,7 @@ const COLUMNS = [
   {title: t('Project'), key: 'project', sortKey: 'project'},
   {title: t('Auto Fix'), key: 'fixes'},
   {title: t('PR Creation'), key: 'pr_creation'},
-  {title: t('Cursor Agent'), key: 'is_delegated'},
+  {title: t('Background Agent'), key: 'is_delegated'},
   {title: t('Repos'), key: 'repos'},
 ];
 

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -164,11 +164,13 @@ export default function SeerProjectTableRow({project, organization}: Props) {
                   {
                     onError: () => {
                       addErrorMessage(
-                        t('Failed to update Cursor Agent for %s', project.name)
+                        t('Failed to update background agent for %s', project.name)
                       );
                     },
                     onSuccess: () => {
-                      addSuccessMessage(t('Updated Cursor Agent for %s', project.name));
+                      addSuccessMessage(
+                        t('Updated background agent for %s', project.name)
+                      );
                     },
                   }
                 );


### PR DESCRIPTION
We don't need to call out `Cursor Agent` specifically. The column is more generic as `Background Agent`

<img width="555" height="205" alt="SCR-20251210-jswu" src="https://github.com/user-attachments/assets/0e29752e-365f-41e1-9634-73b51eba2e5a" />
