### PR TITLE
feat(dashboards): Add loading skeleton for Widget Builder

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, RefCallback, useCallback, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
@@ -151,13 +151,20 @@ function WidgetBuilderSlideout({
     [setIsPreviewDraggable]
   );
 
-  const observeForDraggablePreview = useCallback(
-    (elem: HTMLDivElement | null) => {
+  const observeForDraggablePreview = useCallback<RefCallback<HTMLDivElement>>(
+    elem => {
       if (elem) {
         observer.observe(elem);
       } else if (!elem) {
+        // According to React documentation and my observations of reality, this
+        // will never happen. According to TypeScript, it might. Better safe
+        // than sorry!
         observer.disconnect();
       }
+
+      return () => {
+        observer.disconnect();
+      };
     },
     [observer]
   );

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -1,4 +1,11 @@
-import {Fragment, RefCallback, useCallback, useEffect, useMemo, useState} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type RefCallback,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -15,7 +15,6 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import Placeholder from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t, tctCode} from 'sentry/locale';
-import {VerySlowComponent} from 'sentry/stories/playground/slideOverPanel';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
@@ -420,7 +419,6 @@ function WidgetBuilderSlideout({
                   />
                 </Fragment>
               )}
-              <VerySlowComponent />
             </SlideoutBodyWrapper>
           </Fragment>
         );


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/104627, the contents of the Widget Builder are "deferred", which means that the panel opens up early, and the contents render while it's animating. Unfortunately by default, the panel is blank while loading.

This PR adds a loading skeleton with placeholders. I also had to change how we set up the intersection observers. In short, we can't use normal refs anymore because the containers for the chart mount _late_. Instead, I'm using callback refs, which fire once the elements are mounted.

**e.g.,**

https://github.com/user-attachments/assets/0549f98a-19c1-482c-b6c0-743e05b1628f

This PR is best enjoyed with whitespace off!