### PR TITLE
chore(ACI): Remove unused dual proc logging and flag

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -175,18 +175,6 @@ def fetch_metric_issue_open_periods(
                     **time_period,
                 },
             )
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-            organization,
-        ):
-            logger.info(
-                "fetching metric issue open periods",
-                extra={
-                    "organization_id": organization.id,
-                    "open_period_id": open_period_identifier,
-                    "response_data": resp.data,
-                },
-            )
         return resp.data
     except Exception as exc:
         logger.error(
@@ -353,17 +341,6 @@ def build_metric_alert_chart(
             chart_data.update(chart_data_detector)
         else:
             chart_data.update(chart_data_alert_rule)
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-            organization,
-        ):
-            logger.info(
-                "passed chart data",
-                extra={
-                    "chart_data": chart_data,
-                    "style": style,
-                },
-            )
         return charts.generate_chart(style, chart_data, size=size)
     except RuntimeError as exc:
         logger.error(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -158,20 +158,6 @@ class SubscriptionProcessor:
             )
             results = process_data_packet(metric_data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
 
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-            self.subscription.project.organization,
-        ):
-            logger.info(
-                "incidents.workflow_engine.results",
-                extra={
-                    "results": results,
-                    "num_results": len(results),
-                    "value": aggregation_value,
-                    "detector_id": detector.id,
-                    "subscription_update": subscription_update,
-                },
-            )
         return results
 
     def has_downgraded(self, dataset: str, organization: Organization) -> bool:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -181,6 +181,9 @@ def evaluate_workflow_triggers(
                         "workflow_id": workflow.id,
                     },
                 )
+        else:
+            if evaluation.triggered:
+                triggered_workflows.add(workflow)
 
     metrics_incr(
         "process_workflows.triggered_workflows",

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -25,10 +25,6 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
-from sentry.workflow_engine.processors.contexts.workflow_event_context import (
-    WorkflowEventContext,
-    WorkflowEventContextData,
-)
 from sentry.workflow_engine.processors.data_condition_group import get_data_conditions_for_group
 from sentry.workflow_engine.processors.workflow import (
     delete_workflow,
@@ -414,28 +410,6 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert triggered_workflows == {self.workflow}
-
-    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @patch("sentry.workflow_engine.processors.workflow.logger")
-    def test_logs_triggered_workflows(self, mock_logger: MagicMock) -> None:
-        ctx_token = WorkflowEventContext.set(
-            WorkflowEventContextData(
-                detector=self.detector,
-            )
-        )
-        evaluate_workflow_triggers({self.workflow}, self.event_data, self.event_start_time)
-        mock_logger.info.assert_called_once_with(
-            "workflow_engine.process_workflows.workflow_triggered",
-            extra={
-                "workflow_id": self.workflow.id,
-                "detector_id": self.detector.id,
-                "organization_id": self.workflow.organization.id,
-                "project_id": self.event_data.group.project.id,
-                "group_type": self.event_data.group.type,
-            },
-        )
-
-        WorkflowEventContext.reset(ctx_token)
 
     def test_workflow_trigger__no_conditions(self) -> None:
         assert self.workflow.when_condition_group


### PR DESCRIPTION
Remove unused dual processing logs and the related `organizations:workflow-engine-metric-alert-dual-processing-logs` flag.