### PR TITLE
feat(aci): show test notification errors in UI

### DIFF
--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -142,11 +142,19 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
 
     // Only send test notification if there are no validation errors
     if (Object.keys(actionErrors).length === 0) {
-      await sendTestNotification(
-        actionFilterActions.map(action => {
-          return stripActionFields(action);
-        })
-      );
+      try {
+        await sendTestNotification(
+          actionFilterActions.map(action => {
+            return stripActionFields(action);
+          })
+        );
+      } catch (error: any) {
+        // Store test notification error in error context
+        setErrors({
+          ...errors,
+          ...error?.responseJSON?.detail,
+        });
+      }
     }
   }, [actionFilter.actions, sendTestNotification, errors, setErrors]);
 

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -129,14 +129,14 @@ interface ActionFilterBlockProps {
 
 function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
   const {state, actions} = useAutomationBuilderContext();
-  const {errors, setErrors} = useAutomationBuilderErrorContext();
+  const {setErrors} = useAutomationBuilderErrorContext();
   const {mutate: sendTestNotification, isPending} = useSendTestNotification({
     onError: (error: RequestError) => {
       // Store test notification error in error context
-      setErrors({
-        ...errors,
+      setErrors(prev => ({
+        ...prev,
         ...error?.responseJSON,
-      });
+      }));
     },
   });
 
@@ -147,7 +147,7 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
 
     // Validate actions before sending test notification
     const actionErrors = validateActions({actions: actionFilterActions});
-    setErrors({...errors, ...actionErrors});
+    setErrors(prev => ({...prev, ...actionErrors}));
 
     // Only send test notification if there are no validation errors
     if (Object.keys(actionErrors).length === 0) {
@@ -157,7 +157,7 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
         })
       );
     }
-  }, [actionFilter.actions, sendTestNotification, errors, setErrors]);
+  }, [actionFilter.actions, sendTestNotification, setErrors]);
 
   return (
     <IfThenWrapper>

--- a/static/app/views/automations/components/automationBuilderErrorContext.tsx
+++ b/static/app/views/automations/components/automationBuilderErrorContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext} from 'react';
+import {createContext, useContext, type Dispatch, type SetStateAction} from 'react';
 
 import type RequestError from 'sentry/utils/requestError/requestError';
 
@@ -6,7 +6,7 @@ export const AutomationBuilderErrorContext = createContext<{
   errors: Record<string, any>;
   mutationErrors: RequestError['responseJSON'];
   removeError: (errorId: string) => void;
-  setErrors: (errors: Record<string, string>) => void;
+  setErrors: (errors: Dispatch<SetStateAction<Record<string, any>>>) => void;
 } | null>(null);
 
 export const useAutomationBuilderErrorContext = () => {

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -126,7 +126,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
   const {state, actions} = useAutomationBuilderReducer(initialState);
 
   const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
-    Record<string, string>
+    Record<string, any>
   >({});
 
   const {mutateAsync: updateAutomation, error} = useUpdateAutomation();

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -313,5 +313,11 @@ export function useSendTestNotification(
       );
       options?.onSuccess?.(data, variables, context);
     },
+    onError: (error, variables, context) => {
+      addErrorMessage(
+        tn('Notification failed', 'Notifications failed', variables.length)
+      );
+      options?.onError?.(error, variables, context);
+    },
   });
 }

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -10,7 +10,11 @@ import type {
   DataConditionHandler,
   DataConditionHandlerGroupType,
 } from 'sentry/types/workflowEngine/dataConditions';
-import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import type {
+  ApiQueryKey,
+  UseApiQueryOptions,
+  UseMutationOptions,
+} from 'sentry/utils/queryClient';
 import {
   setApiQueryData,
   useApiQuery,
@@ -286,29 +290,28 @@ export function useUpdateAutomationsMutation() {
   });
 }
 
-export function useSendTestNotification() {
+export function useSendTestNotification(
+  options?: UseMutationOptions<void, RequestError, Array<Omit<Action, 'id'>>>
+) {
   const org = useOrganization();
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
 
-  return useMutation<void, void, Array<Omit<Action, 'id'>>>({
+  return useMutation<void, RequestError, Array<Omit<Action, 'id'>>>({
     mutationFn: data =>
       api.requestPromise(`/organizations/${org.slug}/test-fire-actions/`, {
         method: 'POST',
         data: {actions: data},
       }),
-    onSuccess: (_, variables, __) => {
+    ...options,
+    onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({
         queryKey: [`/organizations/${org.slug}/workflows/`],
       });
       addSuccessMessage(
         tn('Notification fired!', 'Notifications sent!', variables.length)
       );
-    },
-    onError: (_, variables, __) => {
-      addErrorMessage(
-        tn('Notification failed', 'Notifications failed', variables.length)
-      );
+      options?.onSuccess?.(data, variables, context);
     },
   });
 }

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -79,7 +79,7 @@ export default function AutomationNewSettings() {
   const maxWidth = theme.breakpoints.lg;
 
   const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
-    Record<string, string>
+    Record<string, any>
   >({});
   const removeError = useCallback((errorId: string) => {
     setAutomationBuilderErrors(prev => {


### PR DESCRIPTION
Surfacing test notification errors using the alert builder error context that we already have for form submission errors

<img width="881" height="481" alt="Screenshot 2025-12-10 at 12 18 04 PM" src="https://github.com/user-attachments/assets/168cafb0-e8be-4190-a1db-bb19e98d94de" />
