### PR TITLE
ref(seer): has_available_reserved_budget -> check_seer_quota

### DIFF
--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -37,7 +37,7 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     from sentry import quotas
     from sentry.constants import DataCategory
 
-    has_budget: bool = quotas.backend.has_available_reserved_budget(
+    has_budget: bool = quotas.backend.check_seer_quota(
         org_id=group.organization.id, data_category=DataCategory.SEER_SCANNER
     )
     if not has_budget:

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -599,7 +599,7 @@ def trigger_autofix(
         )
 
     # check billing quota for autofix
-    has_budget: bool = quotas.backend.has_available_reserved_budget(
+    has_budget: bool = quotas.backend.check_seer_quota(
         org_id=group.organization.id,
         data_category=DataCategory.SEER_AUTOFIX,
     )

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -368,7 +368,7 @@ def run_automation(
     ):
         return
 
-    has_budget: bool = quotas.backend.has_available_reserved_budget(
+    has_budget: bool = quotas.backend.check_seer_quota(
         org_id=group.organization.id,
         data_category=DataCategory.SEER_AUTOFIX,
     )

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -435,7 +435,7 @@ def is_issue_eligible_for_seer_automation(group: Group) -> bool:
     if not seer_enabled:
         return False
 
-    has_budget: bool = quotas.backend.has_available_reserved_budget(
+    has_budget: bool = quotas.backend.check_seer_quota(
         org_id=group.organization.id, data_category=DataCategory.SEER_SCANNER
     )
     if not has_budget:

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -151,7 +151,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         if not user_acknowledgement:  # If the user has acknowledged, the org must have too.
             org_acknowledgement = get_seer_org_acknowledgement(org)
 
-        has_autofix_quota: bool = quotas.backend.has_available_reserved_budget(
+        has_autofix_quota: bool = quotas.backend.check_seer_quota(
             org_id=org.id, data_category=DataCategory.SEER_AUTOFIX
         )
 

--- a/src/sentry/seer/endpoints/organization_seer_setup_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_setup_check.py
@@ -46,10 +46,10 @@ class OrganizationSeerSetupCheck(OrganizationEndpoint):
             return Response(status=400)
 
         # Check quotas
-        has_seer_scanner_quota: bool = quotas.backend.has_available_reserved_budget(
+        has_seer_scanner_quota: bool = quotas.backend.check_seer_quota(
             org_id=organization.id, data_category=DataCategory.SEER_SCANNER
         )
-        has_autofix_quota: bool = quotas.backend.has_available_reserved_budget(
+        has_autofix_quota: bool = quotas.backend.check_seer_quota(
             org_id=organization.id, data_category=DataCategory.SEER_AUTOFIX
         )
 

--- a/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
+++ b/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
@@ -28,7 +28,7 @@ class FetchIssueSummaryTest(TestCase):
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_fetch_issue_summary_with_hide_ai_features_enabled(
         self, mock_has_budget, mock_rate_limited, mock_seer_ack
     ):
@@ -50,7 +50,7 @@ class FetchIssueSummaryTest(TestCase):
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_fetch_issue_summary_with_hide_ai_features_disabled(
         self, mock_has_budget, mock_rate_limited, mock_seer_ack, mock_get_issue_summary
     ):
@@ -104,7 +104,7 @@ class FetchIssueSummaryTest(TestCase):
 
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_fetch_issue_summary_without_enable_seer_enhanced_alerts(
         self, mock_has_budget: MagicMock, mock_seer_ack: MagicMock
     ) -> None:
@@ -148,7 +148,7 @@ class FetchIssueSummaryTest(TestCase):
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_fetch_issue_summary_no_budget(
         self, mock_has_budget: MagicMock, mock_rate_limited: MagicMock, mock_seer_ack: MagicMock
     ) -> None:
@@ -166,7 +166,7 @@ class FetchIssueSummaryTest(TestCase):
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_fetch_issue_summary_timeout_error(
         self, mock_has_budget, mock_rate_limited, mock_seer_ack, mock_get_issue_summary
     ):
@@ -189,7 +189,7 @@ class FetchIssueSummaryTest(TestCase):
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
     @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_fetch_issue_summary_api_error(
         self, mock_has_budget, mock_rate_limited, mock_seer_ack, mock_get_issue_summary
     ):

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -256,7 +256,7 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
             with patch(
                 "sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner"
             ) as mock_ack:
-                with patch("sentry.quotas.backend.has_available_reserved_budget") as mock_budget:
+                with patch("sentry.quotas.backend.check_seer_quota") as mock_budget:
                     mock_ack.return_value = True
                     mock_budget.return_value = True
                     self.project.update_option("sentry:seer_scanner_automation", True)
@@ -298,7 +298,7 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
             mock_get_acknowledgement.assert_called_once_with(self.organization)
 
     @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_returns_false_when_no_budget_available(
         self, mock_has_budget, mock_get_acknowledgement
     ):
@@ -316,7 +316,7 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
             )
 
     @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_returns_true_when_all_conditions_met(self, mock_has_budget, mock_get_acknowledgement):
         """Test returns True when all eligibility conditions are met."""
         with self.feature("organizations:gen-ai-features"):
@@ -333,7 +333,7 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
             )
 
     @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_returns_true_when_issue_type_always_triggers(
         self, mock_has_budget, mock_get_acknowledgement
     ):

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -785,7 +785,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_high_fixability_code_changes(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
@@ -811,7 +811,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_medium_fixability_solution(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
@@ -837,7 +837,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_without_feature_flag(self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger):
         self.project.update_option("sentry:autofix_automation_tuning", "always")
@@ -989,7 +989,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_user_preference_limits_high_fixability(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_fetch, mock_trigger
@@ -1021,7 +1021,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_fixability_limits_permissive_user_preference(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_fetch, mock_trigger
@@ -1053,7 +1053,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_no_user_preference_uses_fixability_only(
         self, mock_gen, mock_budget, mock_state, mock_rate, mock_fetch, mock_trigger
@@ -1092,7 +1092,7 @@ class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    @patch("sentry.seer.autofix.issue_summary.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.seer.autofix.issue_summary.quotas.backend.check_seer_quota")
     def test_alert_skips_automation_below_threshold(
         self, mock_budget, mock_state, mock_fixability, mock_trigger
     ):
@@ -1122,7 +1122,7 @@ class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    @patch("sentry.seer.autofix.issue_summary.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.seer.autofix.issue_summary.quotas.backend.check_seer_quota")
     def test_alert_runs_automation_above_threshold(
         self, mock_budget, mock_state, mock_fixability, mock_trigger, mock_rate_limit
     ):

--- a/tests/sentry/seer/endpoints/test_organization_seer_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_setup_check.py
@@ -89,7 +89,7 @@ class OrganizationSeerSetupCheckSuccessTest(OrganizationSeerSetupCheckTestBase):
             "userHasAcknowledged": False,
         }
 
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_no_autofix_quota(self, mock_has_budget: MagicMock) -> None:
         """
         Test when the organization has no autofix quota available.
@@ -112,7 +112,7 @@ class OrganizationSeerSetupCheckSuccessTest(OrganizationSeerSetupCheckTestBase):
             "hasScannerQuota": True,
         }
 
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_no_scanner_quota(self, mock_has_budget: MagicMock) -> None:
         """
         Test when the organization has no scanner quota available.
@@ -135,7 +135,7 @@ class OrganizationSeerSetupCheckSuccessTest(OrganizationSeerSetupCheckTestBase):
             "hasScannerQuota": False,
         }
 
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     def test_no_quotas_available(self, mock_has_budget: MagicMock) -> None:
         """
         Test when the organization has no quotas available for either service.

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2859,7 +2859,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
         mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch("sentry.seer.autofix.utils.is_seer_scanner_rate_limited")
-    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    @patch("sentry.quotas.backend.check_seer_quota")
     @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner")
     @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
@@ -3301,7 +3301,7 @@ class TriageSignalsV0TestMixin(BasePostProgressGroupMixin):
 class SeerAutomationHelperFunctionsTestMixin(BasePostProgressGroupMixin):
     """Unit tests for is_issue_eligible_for_seer_automation."""
 
-    @patch("sentry.quotas.backend.has_available_reserved_budget", return_value=True)
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.seer_setup.get_seer_org_acknowledgement_for_scanner", return_value=True)
     @patch("sentry.features.has", return_value=True)
     def test_is_issue_eligible_for_seer_automation(


### PR DESCRIPTION
close BIL-1821

confirmed w/ @brendanhsentry that we should let `seat_object=None` (default val)
