### PR TITLE
feat(seer): Disallow onboarding when no Seer billing access

### DIFF
--- a/static/gsApp/views/seerAutomation/onboardingV2.tsx
+++ b/static/gsApp/views/seerAutomation/onboardingV2.tsx
@@ -51,7 +51,7 @@ export default function SeerOnboardingV2() {
           {tct(
             'Seer is not enabled for your organization. [link:Go to your billing settings] to enable Seer.',
             {
-              link: <Link to="/settings/billing/" />,
+              link: <Link to="/settings/billing/overview/?product=seer" />,
             }
           )}
         </Alert>


### PR DESCRIPTION
This disables onboarding when organization does not have Seer product enabled in billing.

<img width="955" height="208" alt="image" src="https://github.com/user-attachments/assets/41c2a75a-c6b6-4b8f-af43-02f515f363a0" />

or when you have billing access

<img width="1009" height="83" alt="image" src="https://github.com/user-attachments/assets/0850df8d-d3b1-49c9-a678-69338abaff22" />
