### PR TITLE
feat: Add expand param to list org repos endpoint for repository settings

### DIFF
--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -1,11 +1,18 @@
+from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.repository import Repository
+from sentry.models.repositorysettings import RepositorySettings
 
 
-class RepositorySerializerResponse(TypedDict):
+class RepositorySettingsSerializerResponse(TypedDict):
+    enabledCodeReview: bool
+    codeReviewTriggers: list[str]
+
+
+class RepositorySerializerResponse(TypedDict, total=False):
     id: str
     name: str
     url: str | None
@@ -15,11 +22,48 @@ class RepositorySerializerResponse(TypedDict):
     integrationId: str | None
     externalSlug: str | None
     externalId: str | None
+    settings: RepositorySettingsSerializerResponse | None
+
+
+@register(RepositorySettings)
+class RepositorySettingsSerializer(Serializer):
+    def serialize(
+        self, obj: RepositorySettings, attrs: Mapping[str, Any], user: Any, **kwargs: Any
+    ) -> RepositorySettingsSerializerResponse:
+        return {
+            "enabledCodeReview": obj.enabled_code_review,
+            "codeReviewTriggers": list(obj.code_review_triggers),
+        }
 
 
 @register(Repository)
 class RepositorySerializer(Serializer):
-    def serialize(self, obj: Repository, attrs, user, **kwargs) -> RepositorySerializerResponse:
+    def __init__(self, expand: Sequence[str] | None = None) -> None:
+        super().__init__()
+        self.expand = expand or []
+
+    def _expand(self, key: str) -> bool:
+        return key in self.expand
+
+    def get_attrs(
+        self, item_list: Sequence[Repository], user: Any, **kwargs: Any
+    ) -> dict[Repository, dict[str, Any]]:
+        result: dict[Repository, dict[str, Any]] = {repo: {} for repo in item_list}
+
+        if self._expand("settings"):
+            repo_ids = [repo.id for repo in item_list]
+            settings_by_repo = {
+                setting.repository_id: setting
+                for setting in RepositorySettings.objects.filter(repository_id__in=repo_ids)
+            }
+            for repo in item_list:
+                result[repo]["settings"] = settings_by_repo.get(repo.id)
+
+        return result
+
+    def serialize(
+        self, obj: Repository, attrs: Mapping[str, Any], user: Any, **kwargs: Any
+    ) -> RepositorySerializerResponse:
         external_slug = None
         integration_id = None
         if obj.integration_id:
@@ -31,7 +75,7 @@ class RepositorySerializer(Serializer):
         else:
             provider = {"id": "unknown", "name": "Unknown Provider"}
 
-        return {
+        data: RepositorySerializerResponse = {
             "id": str(obj.id),
             "name": obj.config.get("pending_deletion_name", obj.name),
             "url": obj.url,
@@ -42,3 +86,12 @@ class RepositorySerializer(Serializer):
             "externalSlug": external_slug,
             "externalId": obj.external_id,
         }
+
+        if self._expand("settings"):
+            settings = attrs.get("settings")
+            if settings:
+                data["settings"] = RepositorySettingsSerializer().serialize(settings, {}, user)
+            else:
+                data["settings"] = None
+
+        return data

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -116,6 +116,7 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releasefile import ReleaseFile, update_artifact_index
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.repository import Repository
+from sentry.models.repositorysettings import RepositorySettings
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.savedsearch import SavedSearch
@@ -901,6 +902,19 @@ class Factories:
             external_id=external_id,
         )
         return repo
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.REGION)
+    def create_repository_settings(
+        repository: Repository,
+        enabled_code_review: bool = False,
+        code_review_triggers: list[str] | None = None,
+    ) -> RepositorySettings:
+        return RepositorySettings.objects.create(
+            repository=repository,
+            enabled_code_review=enabled_code_review,
+            code_review_triggers=code_review_triggers or [],
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -279,6 +279,9 @@ class Fixtures:
             project = self.project
         return Factories.create_repo(project, *args, **kwargs)
 
+    def create_repository_settings(self, *args, **kwargs):
+        return Factories.create_repository_settings(*args, **kwargs)
+
     def create_commit(self, *args, **kwargs):
         return Factories.create_commit(*args, **kwargs)
 


### PR DESCRIPTION

This PR aims to add the ability to "expand" related models to the organization repository endpoint, and in particular uptake for the new RepositorySettings model.

Also adds a couple UTs and a new factory for creating repository settings.

Pattern mostly copied from these examples:
https://github.com/getsentry/sentry/blob/8592e74bbd014d1d44b7cd973379e5278ceb5b41/src/sentry/core/endpoints/organization_teams.py#L158
https://github.com/getsentry/sentry/blob/85b873ec3d9fbc6ec38f7c63fe83e832391ecb27/src/sentry/api/serializers/models/group_stream.py#L472-L482


Closes https://linear.app/getsentry/issue/ENG-6093/api-add-expand-query-param-to-listrepos-api-endpoint-to-include

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
