### PR TITLE
feat(explorer): collect user timezone in context

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -25,6 +25,7 @@ from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.users.models.user import User as SentryUser
+from sentry.users.models.user_option import UserOption
 from sentry.users.services.user.model import RpcUser
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,7 @@ def collect_user_org_context(
             "user_id": None,
             "user_name": None,
             "user_email": None,
+            "user_timezone": None,
             "user_teams": [],
             "user_projects": [],
             "all_org_projects": all_org_projects,
@@ -99,11 +101,15 @@ def collect_user_org_context(
     if isinstance(user, SentryUser):
         user_name = user.name
 
+    # Get user's timezone setting (IANA timezone name, e.g., "America/Los_Angeles")
+    user_timezone = UserOption.objects.get_value(user, "timezone")
+
     return {
         "org_slug": organization.slug,
         "user_id": user.id,
         "user_name": user_name,
         "user_email": user.email,
+        "user_timezone": user_timezone,
         "user_teams": user_teams,
         "user_projects": user_projects,
         "all_org_projects": all_org_projects,

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -25,8 +25,9 @@ from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.users.models.user import User as SentryUser
-from sentry.users.models.user_option import UserOption
 from sentry.users.services.user.model import RpcUser
+from sentry.users.services.user_option import user_option_service
+from sentry.users.services.user_option.service import get_option_from_list
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +103,8 @@ def collect_user_org_context(
         user_name = user.name
 
     # Get user's timezone setting (IANA timezone name, e.g., "America/Los_Angeles")
-    user_timezone = UserOption.objects.get_value(user, "timezone")
+    user_options = user_option_service.get_many(filter={"user_ids": [user.id], "key": "timezone"})
+    user_timezone = get_option_from_list(user_options, key="timezone")
 
     return {
         "org_slug": organization.slug,

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -125,6 +125,7 @@ class CollectUserOrgContextTest(APITestCase):
         assert context["user_id"] == self.user.id
         assert context["user_name"] == self.user.name
         assert context["user_email"] == self.user.email
+        assert context["user_timezone"] is None  # No timezone set by default
 
         # Should have exactly one team
         assert len(context["user_teams"]) == 1
@@ -172,3 +173,14 @@ class CollectUserOrgContextTest(APITestCase):
         # All org projects should still be present
         all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
         assert all_project_slugs == {"project-1", "project-2", "other-project"}
+
+    def test_collect_context_with_timezone(self):
+        """Test context collection includes user's timezone setting"""
+        from sentry.users.models.user_option import UserOption
+
+        UserOption.objects.set_value(self.user, "timezone", "America/Los_Angeles")
+
+        context = collect_user_org_context(self.user, self.organization)
+
+        assert context is not None
+        assert context["user_timezone"] == "America/Los_Angeles"

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -176,9 +176,11 @@ class CollectUserOrgContextTest(APITestCase):
 
     def test_collect_context_with_timezone(self):
         """Test context collection includes user's timezone setting"""
-        from sentry.users.models.user_option import UserOption
+        from sentry.users.services.user_option import user_option_service
 
-        UserOption.objects.set_value(self.user, "timezone", "America/Los_Angeles")
+        user_option_service.set_option(
+            user_id=self.user.id, key="timezone", value="America/Los_Angeles"
+        )
 
         context = collect_user_org_context(self.user, self.organization)
 


### PR DESCRIPTION
Collects user timezone from settings as part of user-org context sent to seer

part of AIML-1990

requires https://github.com/getsentry/seer/pull/4239