### PR TITLE
fix(settings): Prevent error on Undo allowed domain change

### DIFF
--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -152,8 +152,27 @@ export const fields = {
         </Hovercard>
       ),
     }),
-    getValue: val => extractMultilineFields(val),
-    setValue: val => convertMultilineFieldValue(val),
+    getValue: (val: unknown) => {
+      if (typeof val === 'string') {
+        return extractMultilineFields(val);
+      }
+
+      if (Array.isArray(val) && val.every(item => typeof item === 'string')) {
+        return extractMultilineFields(val.join('\n'));
+      }
+
+      return [];
+    },
+    setValue: (val: unknown) => {
+      if (
+        typeof val === 'string' ||
+        (Array.isArray(val) && val.every(item => typeof item === 'string'))
+      ) {
+        return convertMultilineFieldValue(val);
+      }
+
+      return '';
+    },
   },
   scrapeJavaScript: {
     name: 'scrapeJavaScript',

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -158,7 +158,7 @@ export const fields = {
       }
 
       if (Array.isArray(val) && val.every(item => typeof item === 'string')) {
-        return extractMultilineFields(val.join('\n'));
+        return val;
       }
 
       return [];


### PR DESCRIPTION
Clicking Undo in the toast passes an array of strings to getValue. Add protection to these functions defined as `any`

fixes JAVASCRIPT-33BA