### PR TITLE
chore(preprod): Show gap in categories size as unmapped

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
@@ -21,6 +21,17 @@ export function AppSizeCategories(props: AppSizeCategoriesProps) {
     categorySizes[categoryKey] = totalSize;
   });
 
+  const categorizedTotal = Object.values(categorySizes).reduce(
+    (sum, size) => sum + size,
+    0
+  );
+
+  // Binary overhead not in category_breakdown (padding, alignment)
+  const unmappedSize = treemapData.root.size - categorizedTotal;
+  if (unmappedSize > 0) {
+    categorySizes[TreemapType.UNMAPPED] = unmappedSize;
+  }
+
   const totalSize = treemapData.root.size;
 
   const pieData = Object.entries(categorySizes)


### PR DESCRIPTION
Close https://linear.app/getsentry/issue/EME-646/component-breakdown-percentages-dont-match

We want to fix the mismatch in size, but the problem is that in `_calculate_category_breakdown` we only count actual files whereas root.size includes synthetic unmapped nodes too. If we try to just include another category for nodes that fall into the unmapped category, we end up double counting.

Parent node sizes already include their unmapped children. If we summed all unmapped nodes from the tree and added them as a separate category, we'd count them twice:
- Once in the parent's size (e.g., __TEXT = 655,360 bytes includes its unmapped padding)
- Again as a separate unmapped category

Instead, we calculate unmapped as root.size - sum(category_breakdown) to make the chart math clear