### PR TITLE
ref(seer-explorer): Remove delete key message deletion behavior

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.spec.tsx
+++ b/static/app/views/seerExplorer/blockComponents.spec.tsx
@@ -1,5 +1,4 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import BlockComponent from './blockComponents';
 import type {Block} from './types';
@@ -81,35 +80,6 @@ describe('BlockComponent', () => {
       const blockElement = container.firstChild;
       await userEvent.click(blockElement as HTMLElement);
       expect(mockOnClick).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('Focus State', () => {
-    it('shows delete hint when isFocused=true', () => {
-      const block = createUserInputBlock();
-      render(
-        <BlockComponent block={block} blockIndex={0} isFocused onClick={mockOnClick} />
-      );
-
-      expect(
-        screen.getByText(textWithMarkupMatcher('Rethink from here ⌫'))
-      ).toBeInTheDocument();
-    });
-
-    it('does not show delete hint when isFocused=false', () => {
-      const block = createUserInputBlock();
-      render(
-        <BlockComponent
-          block={block}
-          blockIndex={0}
-          isFocused={false}
-          onClick={mockOnClick}
-        />
-      );
-
-      expect(
-        screen.queryByText(textWithMarkupMatcher('Rethink from here ⌫'))
-      ).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -24,9 +24,7 @@ interface BlockProps {
   isFocused?: boolean;
   isLast?: boolean;
   isLatestTodoBlock?: boolean;
-  isPolling?: boolean;
   onClick?: () => void;
-  onDelete?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   onNavigate?: () => void;
@@ -128,9 +126,7 @@ function BlockComponent({
   isLast,
   isLatestTodoBlock,
   isFocused,
-  isPolling,
   onClick,
-  onDelete,
   onMouseEnter,
   onMouseLeave,
   onNavigate,
@@ -274,11 +270,6 @@ function BlockComponent({
     onRegisterEnterHandler,
   ]);
 
-  const handleDeleteClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onDelete?.();
-  };
-
   const handleNavigateClick = (e: React.MouseEvent, linkIndex: number) => {
     e.stopPropagation();
     if (sortedToolLinks.length === 0) {
@@ -398,11 +389,6 @@ function BlockComponent({
                 transition={{duration: 0.1}}
               >
                 <ActionButtonBar gap="sm">
-                  {!isPolling && (
-                    <Button size="xs" priority="default" onClick={handleDeleteClick}>
-                      Rethink from here ⌫
-                    </Button>
-                  )}
                   {hasValidLinks && (
                     <ButtonBar merged gap="0">
                       {sortedToolLinks.map((_, idx) => (

--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -137,11 +137,9 @@ describe('ExplorerPanel', () => {
         sessionData:
           mockSessionData as useSeerExplorerModule.SeerExplorerResponse['session'],
         sendMessage: jest.fn(),
-        deleteFromIndex: jest.fn(),
         startNewSession: jest.fn(),
         isPolling: false,
         isPending: false,
-        deletedFromIndex: null,
         interruptRun: jest.fn(),
         interruptRequested: false,
         runId: null,

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -491,7 +491,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
                   index === blocks.length - 1 && !(isAwaitingUserInput && pendingInput)
                 }
                 isFocused={focusedBlockIndex === index}
-                isPolling={isPolling}
                 onClick={() => handleBlockClick(index)}
                 onMouseEnter={() => {
                   // Don't change focus while menu is open, if already on this block, or if hover is disabled

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -44,7 +44,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
   const {
     sessionData,
     sendMessage,
-    deleteFromIndex,
     startNewSession,
     isPolling,
     interruptRun,
@@ -410,7 +409,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
     isFileApprovalPending,
     isPolling,
     isQuestionPending,
-    onDeleteFromIndex: deleteFromIndex,
     onKeyPress: (blockIndex: number, key: 'Enter' | 'ArrowUp' | 'ArrowDown') => {
       const handler = blockEnterHandlers.current.get(blockIndex);
       const handled = handler?.(key) ?? false;
@@ -514,7 +512,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
                     hoveredBlockIndex.current = -1;
                   }
                 }}
-                onDelete={() => deleteFromIndex(index)}
                 onNavigate={() => setIsMinimized(true)}
                 onRegisterEnterHandler={handler => {
                   blockEnterHandlers.current.set(index, handler);

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.spec.tsx
@@ -191,41 +191,6 @@ describe('useBlockNavigation', () => {
     });
   });
 
-  describe('Backspace/Delete Navigation', () => {
-    it('deletes from focused block index on Backspace', () => {
-      const props = {...defaultProps, focusedBlockIndex: 1};
-      renderHook(() => useBlockNavigation(props));
-
-      const event = new KeyboardEvent('keydown', {key: 'Backspace'});
-      document.dispatchEvent(event);
-
-      expect(props.onDeleteFromIndex).toHaveBeenCalledWith(1);
-      expect(props.setFocusedBlockIndex).toHaveBeenCalledWith(-1);
-      expect(props.textareaRef.current?.focus).toHaveBeenCalled();
-    });
-
-    it('does not delete when focused on input', () => {
-      renderHook(() => useBlockNavigation(defaultProps));
-
-      const event = new KeyboardEvent('keydown', {key: 'Backspace'});
-      document.dispatchEvent(event);
-
-      expect(defaultProps.onDeleteFromIndex).not.toHaveBeenCalled();
-    });
-
-    it('does not delete when onDeleteFromIndex is not provided', () => {
-      const props = {...defaultProps, focusedBlockIndex: 1, onDeleteFromIndex: undefined};
-      renderHook(() => useBlockNavigation(props));
-
-      const event = new KeyboardEvent('keydown', {key: 'Backspace'});
-      document.dispatchEvent(event);
-
-      // Should still return focus to input
-      expect(props.setFocusedBlockIndex).toHaveBeenCalledWith(-1);
-      expect(props.textareaRef.current?.focus).toHaveBeenCalled();
-    });
-  });
-
   describe('Panel State Control', () => {
     it('ignores keyboard events when panel is closed', () => {
       const props = {...defaultProps, isOpen: false};

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
@@ -110,15 +110,6 @@ export function useBlockNavigation({
             scrollToElement(textareaElement);
           }
         }
-      } else if (e.key === 'Backspace' && focusedBlockIndex >= 0) {
-        e.preventDefault();
-        onDeleteFromIndex?.(focusedBlockIndex);
-        setFocusedBlockIndex(-1);
-        const textareaElement = textareaRef.current;
-        if (textareaElement) {
-          textareaElement.focus();
-          scrollToElement(textareaElement);
-        }
       } else if (e.key === 'Enter' && focusedBlockIndex >= 0) {
         e.preventDefault();
         onKeyPress?.(focusedBlockIndex, 'Enter');

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
@@ -13,7 +13,6 @@ interface UseBlockNavigationProps {
   isMinimized?: boolean;
   isPolling?: boolean;
   isQuestionPending?: boolean;
-  onDeleteFromIndex?: (index: number) => void;
   onKeyPress?: (blockIndex: number, key: 'Enter' | 'ArrowUp' | 'ArrowDown') => boolean;
   onNavigate?: () => void;
 }
@@ -29,7 +28,6 @@ export function useBlockNavigation({
   isMinimized = false,
   isPolling = false,
   isQuestionPending = false,
-  onDeleteFromIndex,
   onKeyPress,
   onNavigate,
 }: UseBlockNavigationProps) {
@@ -129,7 +127,6 @@ export function useBlockNavigation({
     isMinimized,
     isPolling,
     isQuestionPending,
-    onDeleteFromIndex,
     onKeyPress,
     onNavigate,
   ]);

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -24,7 +24,6 @@ describe('useSeerExplorer', () => {
       expect(result.current.sessionData).toBeNull();
       expect(result.current.isPolling).toBe(false);
       expect(result.current.runId).toBeNull();
-      expect(result.current.deletedFromIndex).toBeNull();
     });
   });
 
@@ -139,39 +138,6 @@ describe('useSeerExplorer', () => {
       });
 
       expect(result.current.runId).toBeNull();
-      expect(result.current.deletedFromIndex).toBeNull();
-    });
-  });
-
-  describe('deleteFromIndex', () => {
-    it('sets deleted from index', () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/seer/explorer-chat/`,
-        method: 'GET',
-        body: {session: null},
-      });
-
-      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
-        organization,
-      });
-
-      act(() => {
-        result.current.deleteFromIndex(2);
-      });
-
-      expect(result.current.deletedFromIndex).toBe(2);
-    });
-
-    it('filters messages based on deleted index', () => {
-      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
-        organization,
-      });
-
-      act(() => {
-        result.current.deleteFromIndex(1);
-      });
-
-      expect(result.current.deletedFromIndex).toBe(1);
     });
   });
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -384,8 +384,6 @@ export const useSeerExplorer = () => {
       );
       if (currentSignature !== optimistic.baselineSignature) {
         setOptimistic(null);
-        // Reveal all real blocks immediately after the server responds
-        setDeletedFromIndex(null);
       }
     }
   }, [apiData?.session?.blocks, optimistic]);
@@ -423,8 +421,6 @@ export const useSeerExplorer = () => {
     if (!hasLoadingMessage && filteredSessionData.status !== 'processing') {
       setWaitingForResponse(false);
       setInterruptRequested(false);
-      // Clear deleted index once response is complete
-      setDeletedFromIndex(null);
     }
   }
 
@@ -437,7 +433,6 @@ export const useSeerExplorer = () => {
     // Reset state.
     setRunId(null);
     setWaitingForResponse(false);
-    setDeletedFromIndex(null);
     setOptimistic(null);
     setInterruptRequested(false);
     if (orgSlug) {
@@ -462,7 +457,6 @@ export const useSeerExplorer = () => {
     (newRunId: number) => {
       // Clear any optimistic state from previous run
       setOptimistic(null);
-      setDeletedFromIndex(null);
       setWaitingForResponse(false);
       setInterruptRequested(false);
 


### PR DESCRIPTION
## Summary

Removes the keyboard shortcut that deletes messages when pressing Backspace/Delete while a message block is focused in the seer explorer.

## Changes

- Removed the Backspace/Delete key handler in `useBlockNavigation` hook that was calling `onDeleteFromIndex()`
- This prevents accidental message deletion when users press these keys while navigating messages

## Test plan

- [ ] Open seer explorer
- [ ] Navigate to a message block using arrow keys
- [ ] Press Backspace or Delete key
- [ ] Verify the message is NOT deleted
- [ ] Verify other keyboard shortcuts (arrows, Tab, Enter) still work correctly