### PR TITLE
feat(autofix UI): Disable the autofix button if repos are not linked [feature flagged]

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -25,7 +25,7 @@ from sentry.seer.autofix.utils import (
     is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
-from sentry.seer.models import SeerApiError
+from sentry.seer.models import SeerApiError, SeerApiResponseValidationError
 from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -147,7 +147,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 has_repos = bool(project_preferences.code_mapping_repos)
                 if not has_repos:
                     integration_check = "no_repos_linked_in_seer_settings"
-            except SeerApiError:
+            except (SeerApiError, SeerApiResponseValidationError):
                 # If API fails allow the user to continue with the flow.
                 integration_check = None
 


### PR DESCRIPTION
## PR Details
+ Adds new seerReposLinked boolean field to the /issues/{group_id}/autofix/setup/ endpoint response
+ When seat-based Seer tier is enabled, checks if repos are linked via get_project_seer_preferences. Returns false when no repos are linked, true otherwise. Defaults to true to avoid blocking users if API fails or tier is disabled
+ Frontend can use this to disable the "Start Root Cause Analysis" button when repos aren't configured. Will make a PR for that next.