### PR TITLE
feat(seer): Limit prepopulating repos for RCA step

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -20,6 +20,7 @@ interface SeerOnboardingContextProps {
     newValue: string | undefined
   ) => void;
   changeRootCauseAnalysisRepository: (oldRepoId: string, newRepoId: string) => void;
+  clearRootCauseAnalysisRepositories: () => void;
   installationData: OrganizationIntegration[] | undefined;
   isInstallationPending: boolean;
   isProviderPending: boolean;
@@ -47,6 +48,7 @@ const SeerOnboardingContext = createContext<SeerOnboardingContextProps>({
   repositoryProjectMapping: {},
   changeRepositoryProjectMapping: () => {},
   changeRootCauseAnalysisRepository: () => {},
+  clearRootCauseAnalysisRepositories: () => {},
   setCodeReviewRepositories: () => {},
   removeRootCauseAnalysisRepository: () => {},
   addRootCauseAnalysisRepository: () => {},
@@ -156,6 +158,11 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
     [repositoriesMap]
   );
 
+  const clearRootCauseAnalysisRepositories = useCallback(() => {
+    setRootCauseAnalysisRepositories([]);
+    setRepositoryProjectMapping({});
+  }, [setRootCauseAnalysisRepositories, setRepositoryProjectMapping]);
+
   const addRootCauseAnalysisRepository = useCallback(
     (repoId: string) => {
       const repo = repositoriesMap[repoId];
@@ -256,6 +263,7 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
         repositoryProjectMapping,
         addRepositoryProjectMappings,
         changeRepositoryProjectMapping,
+        clearRootCauseAnalysisRepositories,
       }}
     >
       {children}


### PR DESCRIPTION
If a user selects a large # of repos, it can be overwhelming in the RCA step as you need to map projects for each repo. Instead we are capping the # of selected repos to 10 before we decide to not show any repos on the next screen. The user will need to manually add repos from a dropdown instead.
