### PR TITLE
fix(aci): remove rule project check in digest generation

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -291,8 +291,6 @@ def build_digest(project: Project, records: Sequence[Record]) -> DigestInfo:
 
     for group_id, g in groups.items():
         assert g.project_id == project.id, "Group must belong to Project"
-    for rule_id, rule in rules.items():
-        assert rule.project_id == project.id, "Rule must belong to Project"
 
     tenant_ids = {"organization_id": project.organization_id}
     event_counts = tsdb.backend.get_timeseries_sums(


### PR DESCRIPTION
Fixes SENTRY-5EMS

See https://www.notion.so/sentry/Digests-failing-with-AssertionError-Rule-must-belong-to-Project-2c58b10e4b5d808fa847d163947145f6