### PR TITLE
feat(ui): Add `useUpdateOrganization` to use in Seer onboarding

### DIFF
--- a/static/app/utils/useUpdateOrganization.spec.tsx
+++ b/static/app/utils/useUpdateOrganization.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
+import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import OrganizationStore from 'sentry/stores/organizationStore';
@@ -12,16 +13,7 @@ describe('useUpdateOrganization', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-        },
-        mutations: {
-          retry: false,
-        },
-      },
-    });
+    queryClient = makeTestQueryClient();
     OrganizationStore.reset();
   });
 

--- a/static/app/utils/useUpdateOrganization.spec.tsx
+++ b/static/app/utils/useUpdateOrganization.spec.tsx
@@ -99,7 +99,7 @@ describe('useUpdateOrganization', () => {
     expect(OrganizationStore.get().organization?.name).toBe('Original Name');
 
     // Trigger mutation and wait for it to fail
-    await act(async () => {
+    act(() => {
       result.current.mutateAsync({name: 'Updated Name'}).catch(() => {
         // Expected to throw
       });

--- a/static/app/utils/useUpdateOrganization.spec.tsx
+++ b/static/app/utils/useUpdateOrganization.spec.tsx
@@ -1,0 +1,126 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import OrganizationStore from 'sentry/stores/organizationStore';
+import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+
+import {useUpdateOrganization} from './useUpdateOrganization';
+
+describe('useUpdateOrganization', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+    OrganizationStore.reset();
+  });
+
+  it('updates OrganizationStore on successful mutation', async () => {
+    const organization = OrganizationFixture({
+      slug: 'test-org',
+      name: 'Original Name',
+    });
+
+    // Set up initial store state
+    OrganizationStore.onUpdate(organization);
+
+    const updatedOrganization = {
+      ...organization,
+      name: 'Updated Name',
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      method: 'PUT',
+      body: updatedOrganization,
+    });
+
+    const {result} = renderHook(() => useUpdateOrganization(organization), {
+      wrapper: ({children}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    // Verify initial state
+    expect(OrganizationStore.get().organization?.name).toBe('Original Name');
+
+    // Trigger mutation
+    result.current.mutate({name: 'Updated Name'});
+
+    // OrganizationStore should be optimistically updated
+    await waitFor(() => {
+      expect(OrganizationStore.get().organization?.name).toBe('Updated Name');
+    });
+
+    // Wait for mutation to complete
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // Verify OrganizationStore still has the updated value
+    expect(OrganizationStore.get().organization?.name).toBe('Updated Name');
+  });
+
+  it('rolls back OrganizationStore on mutation error', async () => {
+    const organization = OrganizationFixture({
+      slug: 'test-org',
+      name: 'Original Name',
+    });
+
+    // Set up initial store state
+    OrganizationStore.onUpdate(organization);
+
+    const onUpdateSpy = jest.spyOn(OrganizationStore, 'onUpdate');
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      method: 'PUT',
+      statusCode: 500,
+      body: {detail: 'Internal Server Error'},
+    });
+
+    const {result} = renderHook(() => useUpdateOrganization(organization), {
+      wrapper: ({children}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    // Verify initial state
+    expect(OrganizationStore.get().organization?.name).toBe('Original Name');
+
+    // Trigger mutation and wait for it to fail
+    await act(async () => {
+      result.current.mutateAsync({name: 'Updated Name'}).catch(() => {
+        // Expected to throw
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    // Verify OrganizationStore.onUpdate was called twice:
+    // 1. Optimistic update with new name
+    // 2. Rollback with original name
+    expect(onUpdateSpy).toHaveBeenCalledTimes(2);
+    expect(onUpdateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'Updated Name'})
+    );
+    expect(onUpdateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'Original Name'})
+    );
+
+    // Verify final state is rolled back
+    expect(OrganizationStore.get().organization?.name).toBe('Original Name');
+  });
+});

--- a/static/app/utils/useUpdateOrganization.tsx
+++ b/static/app/utils/useUpdateOrganization.tsx
@@ -1,0 +1,77 @@
+import OrganizationStore from 'sentry/stores/organizationStore';
+import type {Organization} from 'sentry/types/organization';
+import {
+  fetchMutation,
+  setApiQueryData,
+  useMutation,
+  useQueryClient,
+  type ApiQueryKey,
+} from 'sentry/utils/queryClient';
+
+interface Variables extends Partial<Organization> {}
+
+type Context =
+  | {
+      previousOrganization: Organization;
+      error?: never;
+    }
+  | {
+      error: Error;
+      previousOrganization?: never;
+    };
+
+function makeDetailedOrganizationQueryKey(organization: Organization): ApiQueryKey {
+  return [
+    `/organizations/${organization.slug}/`,
+    {query: {detailed: 1, include_feature_flags: 1}},
+  ];
+}
+
+export function useUpdateOrganization(organization: Organization) {
+  const queryClient = useQueryClient();
+
+  const queryKey = makeDetailedOrganizationQueryKey(organization);
+
+  return useMutation<Organization, Error, Variables, Context>({
+    onMutate: (data: Variables) => {
+      const previousOrganization =
+        queryClient.getQueryData<Organization>(queryKey) ||
+        OrganizationStore.get().organization ||
+        organization;
+
+      if (!previousOrganization) {
+        return {error: new Error('Previous organization not found')};
+      }
+
+      const updatedOrganization = {
+        ...previousOrganization,
+        ...data,
+      };
+
+      // Update caches optimistically
+      OrganizationStore.onUpdate(updatedOrganization);
+      setApiQueryData<Organization>(queryClient, queryKey, updatedOrganization);
+
+      return {previousOrganization};
+    },
+    mutationFn: (data: Variables) => {
+      return fetchMutation<Organization>({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/`,
+        data: {...data},
+      });
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousOrganization) {
+        OrganizationStore.onUpdate(context.previousOrganization);
+        queryClient.setQueryData(queryKey, context.previousOrganization);
+      }
+    },
+    onSettled: () => {
+      // Invalidate to refetch and ensure consistency for the queryCache
+      // ProjectsStore should've been updated already. It could be out of sync if
+      // there are multiple mutations in parallel.
+      queryClient.invalidateQueries({queryKey});
+    },
+  });
+}

--- a/static/app/utils/useUpdateOrganization.tsx
+++ b/static/app/utils/useUpdateOrganization.tsx
@@ -55,7 +55,7 @@ export function useUpdateOrganization(organization: Organization) {
       return fetchMutation<Organization>({
         method: 'PUT',
         url: `/organizations/${organization.slug}/`,
-        data: {...data},
+        data,
       });
     },
     onError: (_error, _variables, context) => {

--- a/static/app/utils/useUpdateOrganization.tsx
+++ b/static/app/utils/useUpdateOrganization.tsx
@@ -21,10 +21,7 @@ type Context =
     };
 
 function makeDetailedOrganizationQueryKey(organization: Organization): ApiQueryKey {
-  return [
-    `/organizations/${organization.slug}/`,
-    {query: {detailed: 1, include_feature_flags: 1}},
-  ];
+  return [`/organizations/${organization.slug}/`];
 }
 
 export function useUpdateOrganization(organization: Organization) {


### PR DESCRIPTION
~This is basically c&p of `useUpdateProject`.~

To be used in Seer onboarding for updating code review option. Will follow-up to remove [b61b74b/static/app/views/settings/dynamicSampling/utils/useUpdateOrganization.tsx#L33](https://github.com/getsentry/sentry/blob/b61b74b40d5e174018d5d9e69e99f7fbaf281d69/static/app/views/settings/dynamicSampling/utils/useUpdateOrganization.tsx#L33) 