### PR TITLE
feat(seer): Update `autoEnableCodeReview` when changing steps in onboarding

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -12,8 +12,8 @@ import {
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUpdateOrganization} from 'sentry/views/settings/dynamicSampling/utils/useUpdateOrganization';
 
+import {useUpdateOrganization} from './hooks/useUpdateOrganization';
 import {
   Field,
   FieldDescription,
@@ -32,15 +32,16 @@ export function ConfigureCodeReviewStep() {
     organization.autoEnableCodeReview ?? true
   );
 
-  const {mutate: updateOrganization} = useUpdateOrganization();
+  const {mutate: updateOrganization} = useUpdateOrganization(organization);
 
   const handleNextStep = useCallback(() => {
-    // TODO: Save to backend
     if (enableCodeReview !== organization.autoEnableCodeReview) {
       updateOrganization({
         autoEnableCodeReview: enableCodeReview,
       });
     }
+
+    // TODO: Save selectedCodeReviewRepositories to backend
 
     setCurrentStep(currentStep + 1);
   }, [

--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -12,6 +12,7 @@ import {
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUpdateOrganization} from 'sentry/views/settings/dynamicSampling/utils/useUpdateOrganization';
 
 import {
   Field,
@@ -28,14 +29,27 @@ export function ConfigureCodeReviewStep() {
   const {currentStep, setCurrentStep} = useGuidedStepsContext();
 
   const [enableCodeReview, setEnableCodeReview] = useState(
-    organization.autoEnableCodeReview
+    organization.autoEnableCodeReview ?? true
   );
+
+  const {mutate: updateOrganization} = useUpdateOrganization();
 
   const handleNextStep = useCallback(() => {
     // TODO: Save to backend
+    if (enableCodeReview !== organization.autoEnableCodeReview) {
+      updateOrganization({
+        autoEnableCodeReview: enableCodeReview,
+      });
+    }
 
     setCurrentStep(currentStep + 1);
-  }, [setCurrentStep, currentStep]);
+  }, [
+    setCurrentStep,
+    currentStep,
+    enableCodeReview,
+    organization.autoEnableCodeReview,
+    updateOrganization,
+  ]);
 
   return (
     <Fragment>

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useUpdateOrganization.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useUpdateOrganization.tsx
@@ -1,0 +1,74 @@
+import OrganizationStore from 'sentry/stores/organizationStore';
+import type {Organization} from 'sentry/types/organization';
+import {
+  fetchMutation,
+  setApiQueryData,
+  useMutation,
+  useQueryClient,
+  type ApiQueryKey,
+} from 'sentry/utils/queryClient';
+
+interface Variables extends Partial<Organization> {}
+
+type Context =
+  | {
+      previousOrganization: Organization;
+      error?: never;
+    }
+  | {
+      error: Error;
+      previousOrganization?: never;
+    };
+
+function makeDetailedOrganizationQueryKey(organization: Organization): ApiQueryKey {
+  return [`/organizations/${organization.slug}/`];
+}
+
+export function useUpdateOrganization(organization: Organization) {
+  const queryClient = useQueryClient();
+
+  const queryKey = makeDetailedOrganizationQueryKey(organization);
+
+  return useMutation<Organization, Error, Variables, Context>({
+    onMutate: (data: Variables) => {
+      const previousOrganization =
+        queryClient.getQueryData<Organization>(queryKey) ||
+        OrganizationStore.get().organization ||
+        organization;
+
+      if (!previousOrganization) {
+        return {error: new Error('Previous organization not found')};
+      }
+
+      const updatedOrganization = {
+        ...previousOrganization,
+        ...data,
+      };
+
+      // Update caches optimistically
+      OrganizationStore.onUpdate(updatedOrganization);
+      setApiQueryData<Organization>(queryClient, queryKey, updatedOrganization);
+
+      return {previousOrganization};
+    },
+    mutationFn: (data: Variables) => {
+      return fetchMutation<Organization>({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/`,
+        data: {...data},
+      });
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousOrganization) {
+        OrganizationStore.onUpdate(context.previousOrganization);
+        queryClient.setQueryData(queryKey, context.previousOrganization);
+      }
+    },
+    onSettled: () => {
+      // Invalidate to refetch and ensure consistency for the queryCache
+      // ProjectsStore should've been updated already. It could be out of sync if
+      // there are multiple mutations in parallel.
+      queryClient.invalidateQueries({queryKey});
+    },
+  });
+}


### PR DESCRIPTION
Update organization.autoEnableCodeReview when we go to next step in the CR step.

This is using the `useUpdateOrganization` hook from https://github.com/getsentry/sentry/pull/104730 -- will unify after that PR gets approved.
