### PR TITLE
feat(seer): Add a settings page to list all repos Seer can be configed against

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -1,38 +1,62 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 
-import type {Repository} from 'sentry/types/integrations';
+import type {Repository, RepositoryWithSettings} from 'sentry/types/integrations';
 import useFetchSequentialPages from 'sentry/utils/api/useFetchSequentialPages';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function useOrganizationRepositories() {
+interface Props {
+  query?: Record<string, string>;
+}
+
+export function useOrganizationRepositories<T extends Repository = Repository>(
+  {query = {}} = {} as Props
+) {
+  const queryRef = useRef<Record<string, string>>(query);
+  useEffect(() => {
+    queryRef.current = query;
+  }, [query]);
+
   const organization = useOrganization();
 
   const getQueryKey = useCallback(
     ({cursor, per_page}: {cursor: string; per_page: number}): ApiQueryKey => [
       `/organizations/${organization.slug}/repos/`,
-      {query: {cursor, per_page}},
+      {query: {...queryRef.current, cursor, per_page}},
     ],
     [organization.slug]
   );
 
-  const {pages, isFetching} = useFetchSequentialPages<Repository[]>({
+  const {pages, isFetching, ...rest} = useFetchSequentialPages<T[]>({
     getQueryKey,
     perPage: 100,
     enabled: true,
   });
 
-  return {
-    data: useMemo(() => {
-      const flattenedRepos = pages.flat();
-      const uniqueReposMap = new Map<string, Repository>();
-      flattenedRepos.forEach(repo => {
-        if (repo.externalId && !uniqueReposMap.has(repo.externalId)) {
-          uniqueReposMap.set(repo.externalId, repo);
-        }
-      });
-      return Array.from(uniqueReposMap.values());
-    }, [pages]),
-    isFetching,
-  };
+  const data = useMemo(() => {
+    const flattenedRepos = pages.flat();
+    const uniqueReposMap = new Map<string, T>();
+    flattenedRepos.forEach(repo => {
+      if (repo.externalId && !uniqueReposMap.has(repo.externalId)) {
+        uniqueReposMap.set(repo.externalId, repo);
+      }
+    });
+    return Array.from(uniqueReposMap.values());
+  }, [pages]);
+
+  return useMemo(
+    () => ({
+      ...rest,
+      data,
+      isFetching,
+    }),
+    [data, isFetching, rest]
+  );
+}
+
+// TODO(ryan953): express this in typescript instead of having the extra function
+export function useOrganizationRepositoriesWithSettings() {
+  return useOrganizationRepositories<RepositoryWithSettings>({
+    query: {expand: 'settings'},
+  });
 }

--- a/static/app/components/repositories/getRepoStatusLabel.tsx
+++ b/static/app/components/repositories/getRepoStatusLabel.tsx
@@ -1,0 +1,17 @@
+import type {Repository} from 'sentry/types/integrations';
+import {RepositoryStatus} from 'sentry/types/integrations';
+
+export default function getRepoStatusLabel(repo: Repository) {
+  switch (repo.status) {
+    case RepositoryStatus.PENDING_DELETION:
+      return 'Deletion Queued';
+    case RepositoryStatus.DELETION_IN_PROGRESS:
+      return 'Deletion in Progress';
+    case RepositoryStatus.DISABLED:
+      return 'Disabled';
+    case RepositoryStatus.HIDDEN:
+      return 'Disabled';
+    default:
+      return null;
+  }
+}

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -8,6 +8,7 @@ import {Button} from 'sentry/components/core/button';
 import {ExternalLink} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import PanelItem from 'sentry/components/panels/panelItem';
+import getRepoStatusLabel from 'sentry/components/repositories/getRepoStatusLabel';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -22,22 +23,7 @@ type Props = {
   showProvider?: boolean;
 };
 
-function getStatusLabel(repo: Repository) {
-  switch (repo.status) {
-    case RepositoryStatus.PENDING_DELETION:
-      return 'Deletion Queued';
-    case RepositoryStatus.DELETION_IN_PROGRESS:
-      return 'Deletion in Progress';
-    case RepositoryStatus.DISABLED:
-      return 'Disabled';
-    case RepositoryStatus.HIDDEN:
-      return 'Disabled';
-    default:
-      return null;
-  }
-}
-
-function RepositoryRow({
+export default function RepositoryRow({
   repository,
   onRepositoryChange,
   orgSlug,
@@ -49,9 +35,7 @@ function RepositoryRow({
   const cancelDelete = () =>
     cancelDeleteRepository(api, orgSlug, repository.id).then(
       data => {
-        if (onRepositoryChange) {
-          onRepositoryChange(data);
-        }
+        onRepositoryChange?.(data);
       },
       () => {}
     );
@@ -59,9 +43,7 @@ function RepositoryRow({
   const deleteRepo = () =>
     hideRepository(api, orgSlug, repository.id).then(
       data => {
-        if (onRepositoryChange) {
-          onRepositoryChange(data);
-        }
+        onRepositoryChange?.(data);
       },
       () => {}
     );
@@ -99,7 +81,7 @@ function RepositoryRow({
           <RepositoryTitleAndUrl>
             <RepositoryTitle>
               <strong>{repository.name}</strong>
-              {!isActive && <small> &mdash; {getStatusLabel(repository)}</small>}
+              {!isActive && <small> &mdash; {getRepoStatusLabel(repository)}</small>}
               {repository.status === RepositoryStatus.PENDING_DELETION && (
                 <StyledButton
                   size="xs"
@@ -162,5 +144,3 @@ const RepositoryTitle = styled('div')`
   /* accommodate cancel button height */
   line-height: 26px;
 `;
-
-export default RepositoryRow;

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1227,7 +1227,6 @@ function buildRoutes(): RouteObject[] {
         },
         {
           path: 'repos/',
-          name: t('Seer'),
           component: make(() => import('getsentry/views/seerAutomation/repos')),
         },
         {

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -86,6 +86,10 @@ export type Repository = {
   url: string;
 };
 
+export interface RepositoryWithSettings extends Repository {
+  codeReviewTriggers: string[];
+  enabledCodeReview: boolean;
+}
 /**
  * Integration Repositories from OrganizationIntegrationReposEndpoint
  */

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -1,0 +1,187 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+import {debounce, parseAsString, useQueryState} from 'nuqs';
+
+import {InputGroup} from '@sentry/scraps/input/inputGroup';
+import {Stack} from '@sentry/scraps/layout/stack';
+
+import {useOrganizationRepositoriesWithSettings} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconSearch} from 'sentry/icons/iconSearch';
+import {t} from 'sentry/locale';
+import type {RepositoryWithSettings} from 'sentry/types/integrations';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {parseAsSort} from 'sentry/utils/queryString';
+
+import SeerRepoTableHeader from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTableHeader';
+import SeerRepoTableRow from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTableRow';
+
+export default function SeerRepoTable() {
+  const {
+    data: repositories,
+    isFetching,
+    error,
+    // Depends on https://github.com/getsentry/sentry/pull/104713/changes
+  } = useOrganizationRepositoriesWithSettings();
+
+  const supportedRepositories = useMemo(
+    () =>
+      // TODO(ryan953): Is there another field to use here?
+      repositories.filter(repository => repository.provider.name === 'GitHub'),
+    [repositories]
+  );
+
+  const [searchTerm, setSearchTerm] = useQueryState(
+    'query',
+    parseAsString.withDefault('')
+  );
+
+  const [sort, setSort] = useQueryState(
+    'sort',
+    parseAsSort.withDefault({field: 'name', kind: 'asc'})
+  );
+
+  const queryKey: ApiQueryKey = ['seer-repos', {query: {query: searchTerm, sort}}];
+
+  const sortedRepositories = useMemo(() => {
+    return supportedRepositories.toSorted((a, b) => {
+      if (sort.field === 'name') {
+        return sort.kind === 'asc'
+          ? a.name.localeCompare(b.name)
+          : b.name.localeCompare(a.name);
+      }
+
+      // TODO: if we can bulk-fetch all the preferences, then it'll be easier to sort by fixes, pr creation, and repos
+      // if (sort.field === 'fixes') {
+      //   return a.slug.localeCompare(b.slug);
+      // }
+      // if (sort.field === 'pr_creation') {
+      //   return a.platform.localeCompare(b.platform);
+      // }
+      // if (sort.field === 'repos') {
+      //   return a.status.localeCompare(b.status);
+      // }
+      return 0;
+    });
+  }, [supportedRepositories, sort]);
+
+  const filteredRepositories = useMemo(() => {
+    const lowerCase = searchTerm?.toLowerCase() ?? '';
+    if (lowerCase) {
+      return sortedRepositories.filter(repository =>
+        repository.name.toLowerCase().includes(lowerCase)
+      );
+    }
+    return sortedRepositories;
+  }, [sortedRepositories, searchTerm]);
+
+  if (isFetching) {
+    return (
+      <RepoTable
+        onSortClick={setSort}
+        repositories={repositories}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        sort={sort}
+      >
+        <SimpleTable.Empty>
+          <LoadingIndicator />
+        </SimpleTable.Empty>
+      </RepoTable>
+    );
+  }
+
+  if (error) {
+    return (
+      <RepoTable
+        onSortClick={setSort}
+        repositories={repositories}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        sort={sort}
+      >
+        <SimpleTable.Empty>
+          <LoadingError />
+        </SimpleTable.Empty>
+      </RepoTable>
+    );
+  }
+
+  return (
+    <ListItemCheckboxProvider
+      hits={filteredRepositories.length}
+      knownIds={filteredRepositories.map(repository => repository.id)}
+      queryKey={queryKey}
+    >
+      <RepoTable
+        onSortClick={setSort}
+        repositories={filteredRepositories}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        sort={sort}
+      >
+        {filteredRepositories.map(repository => (
+          <SeerRepoTableRow key={repository.id} repository={repository} />
+        ))}
+      </RepoTable>
+    </ListItemCheckboxProvider>
+  );
+}
+
+function RepoTable({
+  children,
+  onSortClick,
+  repositories,
+  searchTerm,
+  setSearchTerm,
+  sort,
+}: {
+  children: React.ReactNode;
+  onSortClick: (sort: Sort) => void;
+  repositories: RepositoryWithSettings[];
+  searchTerm: string;
+  setSearchTerm: ReturnType<typeof useQueryState<string>>[1];
+  sort: Sort;
+}) {
+  return (
+    <Stack gap="lg">
+      <FiltersContainer>
+        <InputGroup>
+          <InputGroup.LeadingItems disablePointerEvents>
+            <IconSearch />
+          </InputGroup.LeadingItems>
+          <InputGroup.Input
+            size="md"
+            placeholder={t('Search')}
+            value={searchTerm ?? ''}
+            onChange={e =>
+              setSearchTerm(e.target.value, {limitUrlUpdates: debounce(125)})
+            }
+          />
+        </InputGroup>
+      </FiltersContainer>
+
+      <SimpleTableWithColumns>
+        <SeerRepoTableHeader
+          repositories={repositories}
+          onSortClick={onSortClick}
+          sort={sort}
+        />
+        {children}
+      </SimpleTableWithColumns>
+    </Stack>
+  );
+}
+
+const FiltersContainer = styled('div')`
+  flex-grow: 1;
+  min-width: 0;
+`;
+
+const SimpleTableWithColumns = styled(SimpleTable)`
+  grid-template-columns: max-content 1fr repeat(2, max-content);
+`;

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -1,0 +1,189 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Alert} from '@sentry/scraps/alert/alert';
+import {Checkbox} from '@sentry/scraps/checkbox/checkbox';
+import {Flex} from '@sentry/scraps/layout/flex';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t, tct, tn} from 'sentry/locale';
+import type {RepositoryWithSettings} from 'sentry/types/integrations';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+import {parseQueryKey} from 'sentry/utils/queryClient';
+
+import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
+
+interface Props {
+  onSortClick: (key: Sort) => void;
+  repositories: RepositoryWithSettings[];
+  sort: Sort;
+}
+
+const COLUMNS = [
+  {title: t('Name'), key: 'name', sortKey: 'name'},
+  {title: t('Projects'), key: 'projects'},
+  {title: t('Code Review'), key: 'code_review'},
+];
+
+export default function SeerRepoTableHeader({onSortClick, repositories, sort}: Props) {
+  const canWrite = useCanWriteSettings();
+  const listItemCheckboxState = useListItemCheckboxContext();
+  const {
+    countSelected,
+    isAllSelected,
+    isAnySelected,
+    queryKey,
+    selectAll,
+    selectedIds: _selectedIds,
+  } = listItemCheckboxState;
+  const queryOptions = parseQueryKey(queryKey).options;
+  const queryString = queryOptions?.query?.query;
+
+  const handleBulkCodeReview = (_value: 'on' | 'off') => {
+    // const codeReview = value ? 'on' : 'off';
+    // Depends on https://github.com/getsentry/sentry/pull/104722
+  };
+
+  return (
+    <Fragment>
+      <TableHeader>
+        <SimpleTable.HeaderCell>
+          <SelectAllCheckbox
+            listItemCheckboxState={listItemCheckboxState}
+            repositories={repositories}
+          />
+        </SimpleTable.HeaderCell>
+        {COLUMNS.map(({title, key, sortKey}) => (
+          <SimpleTable.HeaderCell
+            key={key}
+            handleSortClick={
+              sortKey
+                ? () =>
+                    onSortClick({
+                      field: sortKey,
+                      kind:
+                        sortKey === sort.field
+                          ? sort.kind === 'asc'
+                            ? 'desc'
+                            : 'asc'
+                          : 'desc',
+                    })
+                : undefined
+            }
+            sort={sort?.field === sortKey ? sort.kind : undefined}
+          >
+            {title}
+          </SimpleTable.HeaderCell>
+        ))}
+      </TableHeader>
+
+      {isAnySelected ? (
+        <TableHeader>
+          <TableCellFirst>
+            <SelectAllCheckbox
+              listItemCheckboxState={listItemCheckboxState}
+              repositories={repositories}
+            />
+          </TableCellFirst>
+          <TableCellsRemainingContent align="center" gap="md">
+            <DropdownMenu
+              isDisabled={!canWrite}
+              size="xs"
+              items={[
+                {
+                  key: 'on',
+                  label: t('On'),
+                  onAction: () => handleBulkCodeReview('on'),
+                },
+                {
+                  key: 'off',
+                  label: t('Off'),
+                  onAction: () => handleBulkCodeReview('off'),
+                },
+              ]}
+              triggerLabel={t('Code Review')}
+            />
+          </TableCellsRemainingContent>
+        </TableHeader>
+      ) : null}
+
+      {isAllSelected === 'indeterminate' ? (
+        <FullGridAlert type="warning" system>
+          <Flex justify="center" wrap="wrap" gap="md">
+            {tn('Selected %s repository.', 'Selected %s repositories.', countSelected)}
+            <a onClick={selectAll}>
+              {queryString
+                ? tct('Select all repositories that match: [queryString].', {
+                    queryString: <var>{queryString}</var>,
+                  })
+                : t('Select all repositories.')}
+            </a>
+          </Flex>
+        </FullGridAlert>
+      ) : null}
+
+      {isAllSelected === true ? (
+        <FullGridAlert type="warning" system>
+          <Flex justify="center" wrap="wrap">
+            <span>
+              {queryString
+                ? tct('Selected all repositories matching: [queryString].', {
+                    queryString: <var>{queryString}</var>,
+                  })
+                : countSelected > repositories.length
+                  ? t('Selected all %s+ repositories.', repositories.length)
+                  : tn(
+                      'Selected %s repository.',
+                      'Selected all %s repositories.',
+                      countSelected
+                    )}
+            </span>
+          </Flex>
+        </FullGridAlert>
+      ) : null}
+    </Fragment>
+  );
+}
+
+function SelectAllCheckbox({
+  listItemCheckboxState: {deselectAll, isAllSelected, selectedIds, selectAll},
+  repositories,
+}: {
+  listItemCheckboxState: ReturnType<typeof useListItemCheckboxContext>;
+  repositories: RepositoryWithSettings[];
+}) {
+  return (
+    <Checkbox
+      id="repository-table-select-all"
+      checked={isAllSelected}
+      disabled={repositories.length === 0}
+      onChange={() => {
+        if (isAllSelected === true || selectedIds.length === repositories.length) {
+          deselectAll();
+        } else {
+          selectAll();
+        }
+      }}
+    />
+  );
+}
+
+const TableHeader = styled(SimpleTable.Header)`
+  grid-row: 1;
+  z-index: ${p => p.theme.zIndex.initial};
+  height: min-content;
+`;
+
+const TableCellFirst = styled(SimpleTable.HeaderCell)`
+  grid-column: 1;
+`;
+
+const TableCellsRemainingContent = styled(Flex)`
+  grid-column: 2 / -1;
+`;
+
+const FullGridAlert = styled(Alert)`
+  grid-column: 1 / -1;
+`;

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
@@ -1,0 +1,89 @@
+import styled from '@emotion/styled';
+
+import {Checkbox} from '@sentry/scraps/checkbox/checkbox';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink, Link} from '@sentry/scraps/link/link';
+import {Switch} from '@sentry/scraps/switch/switch';
+
+import {ProjectList} from 'sentry/components/projectList';
+import getRepoStatusLabel from 'sentry/components/repositories/getRepoStatusLabel';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconOpen} from 'sentry/icons/iconOpen';
+import {RepositoryStatus, type RepositoryWithSettings} from 'sentry/types/integrations';
+import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
+
+interface Props {
+  repository: RepositoryWithSettings;
+}
+
+export default function SeerRepoTableRow({repository}: Props) {
+  const organization = useOrganization();
+
+  const canWrite = useCanWriteSettings();
+  const {isSelected, toggleSelected} = useListItemCheckboxContext();
+
+  return (
+    <SimpleTable.Row key={repository.id}>
+      <SimpleTable.RowCell>
+        <CheckboxClickTarget htmlFor={`replay-table-select-${repository.id}`}>
+          <Checkbox
+            id={`replay-table-select-${repository.id}`}
+            disabled={isSelected(repository.id) === 'all-selected'}
+            checked={isSelected(repository.id) !== false}
+            onChange={() => {
+              toggleSelected(repository.id);
+            }}
+          />
+        </CheckboxClickTarget>
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell>
+        <Stack gap="xs">
+          <Link to={`/settings/${organization.slug}/seer/repos/${repository.id}/`}>
+            <Flex align="center">
+              <strong>{repository.name}</strong>
+              {repository.status !== RepositoryStatus.ACTIVE && (
+                <small> &mdash; {getRepoStatusLabel(repository)}</small>
+              )}
+            </Flex>
+          </Link>
+          <Flex align="center">
+            {<small>{repository.provider.name}</small>}
+            {repository.url && <span>&nbsp;&mdash;&nbsp;</span>}
+            {repository.url && (
+              <ExternalLink href={repository.url}>
+                <Flex align="center" gap="xs">
+                  <small>{repository.url.replace('https://', '')}</small>
+                  <IconOpen size="xs" />
+                </Flex>
+              </ExternalLink>
+            )}
+          </Flex>
+        </Stack>
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell justify="end">
+        <ProjectList projectSlugs={[]} />
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell justify="end">
+        <Switch
+          disabled={!canWrite}
+          checked={repository.enabledCodeReview}
+          onChange={() => {
+            // TODO: Implement code review
+          }}
+        />
+      </SimpleTable.RowCell>
+    </SimpleTable.Row>
+  );
+}
+
+const CheckboxClickTarget = styled('label')`
+  cursor: pointer;
+  display: block;
+  margin: -${p => p.theme.space.md};
+  padding: ${p => p.theme.space.md};
+  max-width: unset;
+  line-height: 0;
+`;

--- a/static/gsApp/views/seerAutomation/repos.tsx
+++ b/static/gsApp/views/seerAutomation/repos.tsx
@@ -1,9 +1,10 @@
+import SeerRepoTable from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTable';
 import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 
 export default function SeerAutomationRepos() {
   return (
     <SeerSettingsPageWrapper>
-      <p>Repos</p>
+      <SeerRepoTable />
     </SeerSettingsPageWrapper>
   );
 }


### PR DESCRIPTION
We've got all the ui buttons for bulk-selections working here, but there's no mutations yet for individuals or bulk actions.

Also missing is repo-specific dropdowns to make search easier. Right now we only support GitHub and GitHub Enterprise, so idk if that's critical to start with tbh. 

I haven't got the project information pulled in, that'll be similar to what's on the Projects tab.


<img width="1239" height="821" alt="SCR-20251210-paxu" src="https://github.com/user-attachments/assets/f9e8cfbb-ee51-4100-8d38-956d912ded0f" />
