### PR TITLE
chore: Add `dev-ui-production` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
     "fix:prettier": "prettier \"**/*{.md,.yaml,.js,.mjs,.jsx,.ts,.tsx}\" --write --log-level=error --experimental-cli --no-cache",
     "dev": "pnpm install --frozen-lockfile && sentry devserver",
     "dev-ui": "NODE_OPTIONS='--experimental-transform-types' SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 SENTRY_UI_HOT_RELOAD=1 rspack serve",
+    "dev-ui-production": "NODE_OPTIONS='--experimental-transform-types' NODE_ENV=production SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 SENTRY_UI_HOT_RELOAD=1 rspack --mode production serve",
     "dev-ui-admin": "SENTRY_ADMIN_UI_DEV=1 pnpm run dev-ui",
     "dev-ui-storybook": "STORYBOOK_TYPES=1 pnpm run dev-ui",
     "dev-acceptance": "NODE_OPTIONS='--experimental-transform-types' NO_DEV_SERVER=1 NODE_ENV=development rspack --watch",


### PR DESCRIPTION
This is useful for performance testing and profiling, to see locally how fast something runs in a production-like setting. I use this a bunch when tuning performance, so I thought others might find it useful. No sweat it not!
