### PR TITLE
fix(infra): Fix test_dual_write test pollution causing flakes

### DIFF
--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -39,8 +39,9 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
 
     def test_dual_write__min_zero(self) -> None:
         dcg = self.create_data_condition_group()
-        self.payload["value"] = "-10"
-        dc = self.translate_to_data_condition(self.payload, dcg)
+        local_payload = self.payload.copy()
+        local_payload["value"] = "-10"
+        dc = self.translate_to_data_condition(local_payload, dcg)
 
         assert dc.type == self.condition
         assert dc.comparison == {


### PR DESCRIPTION
Fixes the new #1 offending flaky test found with `shuffle-tests`, `test_dual_write`.
<img width="1351" height="650" alt="Screenshot 2025-12-10 at 9 39 00 PM" src="https://github.com/user-attachments/assets/271a725d-985f-4694-9a5e-7aa54579f615" />

The underlying issue was a mutation of global state that would only be hit when `test_dual_write__min_zero` was ran before `test_dual_write`. This fixes this with a proper copy/mutation

Repro'd and confirmed fixed with 
```
pytest tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py::TestIssueOccurrencesCondition::test_dual_write__min_zero tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py::TestIssueOccurrencesCondition::test_dual_write -v
```