### PR TITLE
feat(ui): OverflowBoundaryContext

### DIFF
--- a/static/app/components/core/boundaryContext.tsx
+++ b/static/app/components/core/boundaryContext.tsx
@@ -1,0 +1,9 @@
+import {createContext, useContext} from 'react';
+
+const BoundaryContext = createContext<string | null>(null);
+
+export const BoundaryContextProvider = BoundaryContext.Provider;
+
+export const useBoundaryContext = () => {
+  return useContext(BoundaryContext);
+};

--- a/static/app/components/core/compactSelect/compactSelect.stories.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.stories.tsx
@@ -1,8 +1,8 @@
 import {Fragment, useCallback, useEffect, useId, useState} from 'react';
 import debounce from 'lodash/debounce';
 
+import {BoundaryContextProvider} from '@sentry/scraps/boundaryContext';
 import {Flex} from '@sentry/scraps/layout';
-import {OverflowBoundaryContextProvider} from '@sentry/scraps/overflowBoundaryContext';
 
 import {IconSiren} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -451,8 +451,8 @@ export default Storybook.story('CompactSelect', story => {
         </p>
         <p>
           Containers that do not want <code>compactSelect</code> instances to grow beyond
-          them can put their id in the <code>OverflowBoundaryContext</code>. You can also
-          set a custom maximum width for the menu using the <code>menuWidth</code> prop.
+          them can put their id in the <code>BoundaryContext</code>. You can also set a
+          custom maximum width for the menu using the <code>menuWidth</code> prop.
         </p>
 
         <Flex gap="md" direction="column" height="300px" align="start" justify="start">
@@ -466,7 +466,7 @@ export default Storybook.story('CompactSelect', story => {
                 triggerProps={{children: 'Unbound (might break)'}}
                 options={options}
               />
-              <OverflowBoundaryContextProvider value={id}>
+              <BoundaryContextProvider value={id}>
                 <CompactSelect
                   value={value}
                   onChange={newValue => {
@@ -475,7 +475,7 @@ export default Storybook.story('CompactSelect', story => {
                   triggerProps={{children: 'Bound to Parent'}}
                   options={options}
                 />
-              </OverflowBoundaryContextProvider>
+              </BoundaryContextProvider>
               <CompactSelect
                 value={value}
                 menuWidth="250px"

--- a/static/app/components/core/compactSelect/compactSelect.stories.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.stories.tsx
@@ -1,9 +1,13 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, useEffect, useId, useState} from 'react';
 import debounce from 'lodash/debounce';
+
+import {Flex} from '@sentry/scraps/layout';
+import {OverflowBoundaryContextProvider} from '@sentry/scraps/overflowBoundaryContext';
 
 import {IconSiren} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import * as Storybook from 'sentry/stories';
+import {SizingWindow} from 'sentry/stories';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 
 import {CompactSelect} from './';
@@ -422,6 +426,68 @@ export default Storybook.story('CompactSelect', story => {
           }}
           options={options}
         />
+      </Fragment>
+    );
+  });
+
+  story('Limit Menu Width', () => {
+    const [value, setValue] = useState<string>('');
+    const options = [
+      {value: '1', label: 'Short option'},
+      {value: '2', label: 'A longer option', details: 'With details'},
+      {
+        value: '3',
+        label:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
+      },
+    ];
+    const id = useId();
+
+    return (
+      <Fragment>
+        <p>
+          Per default, the dropdown menu will grow to fit the width of its longest item,
+          but it's constrained by the <code>main</code> DOM element's width.
+        </p>
+        <p>
+          Containers that do not want <code>compactSelect</code> instances to grow beyond
+          them can put their id in the <code>OverflowBoundaryContext</code>. You can also
+          set a custom maximum width for the menu using the <code>menuWidth</code> prop.
+        </p>
+
+        <Flex gap="md" direction="column" height="300px" align="start" justify="start">
+          {props => (
+            <SizingWindow id={id} {...props}>
+              <CompactSelect
+                value={value}
+                onChange={newValue => {
+                  setValue(newValue.value);
+                }}
+                triggerProps={{children: 'Unbound (might break)'}}
+                options={options}
+              />
+              <OverflowBoundaryContextProvider value={id}>
+                <CompactSelect
+                  value={value}
+                  onChange={newValue => {
+                    setValue(newValue.value);
+                  }}
+                  triggerProps={{children: 'Bound to Parent'}}
+                  options={options}
+                />
+              </OverflowBoundaryContextProvider>
+              <CompactSelect
+                value={value}
+                menuWidth="250px"
+                onChange={newValue => {
+                  setValue(newValue.value);
+                }}
+                triggerProps={{children: 'Fixed width 250px'}}
+                options={options}
+              />
+            </SizingWindow>
+          )}
+        </Flex>
       </Fragment>
     );
   });

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -15,7 +15,7 @@ import {useKeyboard} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
 import type {OverlayTriggerState} from '@react-stately/overlays';
 
-import {useOverflowBoundaryContext} from '@sentry/scraps/overflowBoundaryContext';
+import {useBoundaryContext} from '@sentry/scraps/boundaryContext';
 
 import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
@@ -278,7 +278,7 @@ export function Control({
     },
   });
 
-  const overflowBoundaryId = useOverflowBoundaryContext();
+  const overflowBoundaryId = useBoundaryContext();
   const overflowBoundary = overflowBoundaryId
     ? document.getElementById(overflowBoundaryId)
     : null;

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -15,6 +15,8 @@ import {useKeyboard} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
 import type {OverlayTriggerState} from '@react-stately/overlays';
 
+import {useOverflowBoundaryContext} from '@sentry/scraps/overflowBoundaryContext';
+
 import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {Input} from 'sentry/components/core/input';
@@ -276,6 +278,11 @@ export function Control({
     },
   });
 
+  const overflowBoundaryId = useOverflowBoundaryContext();
+  const overflowBoundary = overflowBoundaryId
+    ? document.getElementById(overflowBoundaryId)
+    : null;
+
   // Manage overlay position
   const {
     isOpen: overlayIsOpen,
@@ -299,6 +306,7 @@ export function Control({
       ...preventOverflowOptions,
       boundary:
         preventOverflowOptions?.boundary ??
+        overflowBoundary ??
         document.querySelector('main') ??
         document.getElementById('main') ??
         undefined,

--- a/static/app/components/core/overflowBoundaryContext.tsx
+++ b/static/app/components/core/overflowBoundaryContext.tsx
@@ -1,0 +1,9 @@
+import {createContext, useContext} from 'react';
+
+const OverflowBoundaryContext = createContext<string | null>(null);
+
+export const OverflowBoundaryContextProvider = OverflowBoundaryContext.Provider;
+
+export const useOverflowBoundaryContext = () => {
+  return useContext(OverflowBoundaryContext);
+};

--- a/static/app/components/core/overflowBoundaryContext.tsx
+++ b/static/app/components/core/overflowBoundaryContext.tsx
@@ -1,9 +1,0 @@
-import {createContext, useContext} from 'react';
-
-const OverflowBoundaryContext = createContext<string | null>(null);
-
-export const OverflowBoundaryContextProvider = OverflowBoundaryContext.Provider;
-
-export const useOverflowBoundaryContext = () => {
-  return useContext(OverflowBoundaryContext);
-};

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -4,7 +4,7 @@ import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion, type Transition} from 'framer-motion';
 
-import {OverflowBoundaryContextProvider} from '@sentry/scraps/overflowBoundaryContext';
+import {BoundaryContextProvider} from '@sentry/scraps/boundaryContext';
 
 import {space} from 'sentry/styles/space';
 
@@ -94,7 +94,7 @@ export function SlideOverPanel({
   const collapsedStyle = position ? COLLAPSED_STYLES[position] : COLLAPSED_STYLES.right;
 
   return (
-    <OverflowBoundaryContextProvider value={id}>
+    <BoundaryContextProvider value={id}>
       <_SlideOverPanel
         ref={ref}
         id={id}
@@ -123,7 +123,7 @@ export function SlideOverPanel({
             ? null
             : children}
       </_SlideOverPanel>
-    </OverflowBoundaryContextProvider>
+    </BoundaryContextProvider>
   );
 }
 

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -1,8 +1,10 @@
-import {useEffect, useState, useTransition} from 'react';
+import {useEffect, useId, useState, useTransition} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion, type Transition} from 'framer-motion';
+
+import {OverflowBoundaryContextProvider} from '@sentry/scraps/overflowBoundaryContext';
 
 import {space} from 'sentry/styles/space';
 
@@ -81,6 +83,8 @@ export function SlideOverPanel({
     });
   }, []);
 
+  const id = useId();
+
   const renderFunctionProps: ChildRenderProps = {
     isOpening: isTransitioning || !isContentVisible,
   };
@@ -90,33 +94,36 @@ export function SlideOverPanel({
   const collapsedStyle = position ? COLLAPSED_STYLES[position] : COLLAPSED_STYLES.right;
 
   return (
-    <_SlideOverPanel
-      ref={ref}
-      initial={collapsedStyle}
-      animate={openStyle}
-      exit={collapsedStyle}
-      position={position}
-      transition={{
-        ...theme.motion.framer.spring.moderate,
-        ...transitionProps,
-      }}
-      role="complementary"
-      aria-hidden={false}
-      aria-label={ariaLabel ?? 'slide out drawer'}
-      className={className}
-      data-test-id={testId}
-      panelWidth={panelWidth}
-    >
-      {/* Render the child content. If it's a render prop, pass the `isOpening`
+    <OverflowBoundaryContextProvider value={id}>
+      <_SlideOverPanel
+        ref={ref}
+        id={id}
+        initial={collapsedStyle}
+        animate={openStyle}
+        exit={collapsedStyle}
+        position={position}
+        transition={{
+          ...theme.motion.framer.spring.moderate,
+          ...transitionProps,
+        }}
+        role="complementary"
+        aria-hidden={false}
+        aria-label={ariaLabel ?? 'slide out drawer'}
+        className={className}
+        data-test-id={testId}
+        panelWidth={panelWidth}
+      >
+        {/* Render the child content. If it's a render prop, pass the `isOpening`
       prop. We expect the render prop to render a skeleton UI if `isOpening` is
       true. If `children` is not a render prop, render nothing while
       transitioning. */}
-      {typeof children === 'function'
-        ? children(renderFunctionProps)
-        : renderFunctionProps.isOpening
-          ? null
-          : children}
-    </_SlideOverPanel>
+        {typeof children === 'function'
+          ? children(renderFunctionProps)
+          : renderFunctionProps.isOpening
+            ? null
+            : children}
+      </_SlideOverPanel>
+    </OverflowBoundaryContextProvider>
   );
 }
 


### PR DESCRIPTION
This PR introduces an `OverflowBoundaryContext`, exposed from `scraps`, which consumers can use to limit the size of dropdown menus (currently only for `compactSelect`). Per default, the menu can grow to accommodate its largest option, but it’s limited by the size of the `<main>` section.

In some cases, parent contains might want to further limit the width, e.g. for sidebars, drawers. The first consumer is the `SlideOverPanel` to fix a bug in dashboards. @gggritso FYI

| before | after |
|--------|--------|
| <img width="489" height="967" alt="Screenshot 2025-12-11 at 11 00 59" src="https://github.com/user-attachments/assets/36f06aca-8dd6-440f-827d-9d8689d476b4" /> | <img width="489" height="967" alt="Screenshot 2025-12-11 at 10 59 46" src="https://github.com/user-attachments/assets/19c62cfe-4169-44e7-90a7-83ecf335772a" /> |