### PR TITLE
ref(ui): revert hard-coded menuWidth for Group By compactSelect

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -93,7 +93,6 @@ export function ToolbarGroupByDropdown({
         onChange={handleColumnChange}
         searchable
         triggerProps={{children: label, style: {width: '100%'}}}
-        menuWidth="300px"
         menuTitle="Group By"
         onSearch={onSearch}
         onClose={onClose}


### PR DESCRIPTION
This essentially reverts this hotfix:

- https://github.com/getsentry/sentry/pull/102462

because `compactSelect` has a default `boundary` set to the `<main>` page element.

before:

<img width="702" height="914" alt="Screenshot 2025-12-11 at 11 55 44" src="https://github.com/user-attachments/assets/46edc769-caae-4cd5-a5c3-ef7e6ab4e39c" />

after:
<img width="702" height="914" alt="Screenshot 2025-12-11 at 11 55 35" src="https://github.com/user-attachments/assets/41fa5cb1-930f-4dae-a343-94af044b421e" />
