### PR TITLE
ref(scraps): unify theme.form

### DIFF
--- a/static/app/components/core/input/input.chonk.tsx
+++ b/static/app/components/core/input/input.chonk.tsx
@@ -29,7 +29,11 @@ export const chonkInputStyles = ({
     lineHeight: theme.form[size].lineHeight,
     minHeight: theme.form[size].minHeight,
 
-    ...theme.formPadding[size],
+    paddingBottom: theme.form[size].paddingBottom,
+    paddingLeft: theme.form[size].paddingLeft,
+    paddingRight: theme.form[size].paddingRight,
+    paddingTop: theme.form[size].paddingBottom,
+
     ...theme.formRadius[size],
 
     '&::placeholder': {

--- a/static/app/components/core/input/input.chonk.tsx
+++ b/static/app/components/core/input/input.chonk.tsx
@@ -34,7 +34,7 @@ export const chonkInputStyles = ({
     paddingRight: theme.form[size].paddingRight,
     paddingTop: theme.form[size].paddingBottom,
 
-    ...theme.formRadius[size],
+    borderRadius: theme.form[size].borderRadius,
 
     '&::placeholder': {
       color: theme.tokens.content.muted,

--- a/static/app/components/core/input/input.chonk.tsx
+++ b/static/app/components/core/input/input.chonk.tsx
@@ -24,7 +24,11 @@ export const chonkInputStyles = ({
     ...(monospace ? {fontFamily: theme.text.familyMono} : {}),
     ...(readOnly ? {cursor: 'default'} : {}),
 
-    ...theme.form[size],
+    fontSize: theme.form[size].fontSize,
+    height: theme.form[size].height,
+    lineHeight: theme.form[size].lineHeight,
+    minHeight: theme.form[size].minHeight,
+
     ...theme.formPadding[size],
     ...theme.formRadius[size],
 

--- a/static/app/components/core/input/input.chonk.tsx
+++ b/static/app/components/core/input/input.chonk.tsx
@@ -32,7 +32,7 @@ export const chonkInputStyles = ({
     paddingBottom: theme.form[size].paddingBottom,
     paddingLeft: theme.form[size].paddingLeft,
     paddingRight: theme.form[size].paddingRight,
-    paddingTop: theme.form[size].paddingBottom,
+    paddingTop: theme.form[size].paddingTop,
 
     borderRadius: theme.form[size].borderRadius,
 

--- a/static/app/components/core/input/input.tsx
+++ b/static/app/components/core/input/input.tsx
@@ -67,7 +67,10 @@ const legacyInputStyles = (p: InputStylesProps & {theme: Theme}) => css`
   ${p.monospace ? `font-family: ${p.theme.text.familyMono};` : ''}
   ${p.readOnly ? 'cursor: default;' : ''}
 
-  ${p.theme.form[p.size ?? 'md']}
+  font-size: ${p.theme.form[p.size ?? 'md'].fontSize};
+  height: ${p.theme.form[p.size ?? 'md'].height};
+  line-height: ${p.theme.form[p.size ?? 'md'].lineHeight};
+  min-height: ${p.theme.form[p.size ?? 'md'].minHeight};
   ${p.theme.formPadding[p.size ?? 'md']}
 
   &::placeholder {

--- a/static/app/components/core/input/input.tsx
+++ b/static/app/components/core/input/input.tsx
@@ -71,7 +71,10 @@ const legacyInputStyles = (p: InputStylesProps & {theme: Theme}) => css`
   height: ${p.theme.form[p.size ?? 'md'].height};
   line-height: ${p.theme.form[p.size ?? 'md'].lineHeight};
   min-height: ${p.theme.form[p.size ?? 'md'].minHeight};
-  ${p.theme.formPadding[p.size ?? 'md']}
+  padding-bottom: ${p.theme.form[p.size ?? 'md'].paddingBottom};
+  padding-left: ${p.theme.form[p.size ?? 'md'].paddingLeft};
+  padding-right: ${p.theme.form[p.size ?? 'md'].paddingRight};
+  padding-top: ${p.theme.form[p.size ?? 'md'].paddingTop};
 
   &::placeholder {
     color: ${p.theme.formPlaceholder};

--- a/static/app/components/core/input/inputGroup.chonk.tsx
+++ b/static/app/components/core/input/inputGroup.chonk.tsx
@@ -39,15 +39,14 @@ const chonkInputStyles = ({
   ${leadingWidth &&
   css`
     padding-left: calc(
-      ${theme.formPadding[size].paddingLeft}px + ${chonkItemsPadding[size]}px +
-        ${leadingWidth}px
+      ${theme.form[size].paddingLeft}px + ${chonkItemsPadding[size]}px + ${leadingWidth}px
     );
   `}
 
   ${trailingWidth &&
   css`
     padding-right: calc(
-      ${theme.formPadding[size].paddingRight}px + ${chonkItemsPadding[size]}px +
+      ${theme.form[size].paddingRight}px + ${chonkItemsPadding[size]}px +
         ${trailingWidth}px
     );
   `}
@@ -65,7 +64,7 @@ export const ChonkStyledLeadingItemsWrap = chonkStyled(InputItemsWrap)<{
   size: NonNullable<InputStyleProps['size']>;
   disablePointerEvents?: boolean;
 }>`
-    left: ${p => p.theme.formPadding[p.size].paddingLeft + 1}px;
+    left: ${p => p.theme.form[p.size].paddingLeft + 1}px;
     ${p => p.disablePointerEvents && `pointer-events: none;`}
   `;
 
@@ -73,6 +72,6 @@ export const ChonkStyledTrailingItemsWrap = chonkStyled(InputItemsWrap)<{
   size: NonNullable<InputStyleProps['size']>;
   disablePointerEvents?: boolean;
 }>`
-    right: ${p => p.theme.formPadding[p.size].paddingRight + 1}px;
+    right: ${p => p.theme.form[p.size].paddingRight + 1}px;
     ${p => p.disablePointerEvents && `pointer-events: none;`}
   `;

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -218,14 +218,14 @@ const getInputStyles = ({
   ${leadingWidth &&
   css`
     padding-left: calc(
-      ${theme.formPadding[size ?? 'md'].paddingLeft}px * 1.5 + ${leadingWidth}px
+      ${theme.form[size ?? 'md'].paddingLeft}px * 1.5 + ${leadingWidth}px
     );
   `}
 
   ${trailingWidth &&
   css`
     padding-right: calc(
-      ${theme.formPadding[size ?? 'md'].paddingRight}px * 1.5 + ${trailingWidth}px
+      ${theme.form[size ?? 'md'].paddingRight}px * 1.5 + ${trailingWidth}px
     );
   `}
 `;
@@ -249,7 +249,7 @@ const InputLeadingItemsWrap = withChonk(
     size: NonNullable<InputStyleProps['size']>;
     disablePointerEvents?: boolean;
   }>`
-    left: ${p => p.theme.formPadding[p.size].paddingLeft + 1}px;
+    left: ${p => p.theme.form[p.size].paddingLeft + 1}px;
     ${p => p.disablePointerEvents && `pointer-events: none;`}
   `,
   ChonkStyledLeadingItemsWrap
@@ -260,7 +260,7 @@ const InputTrailingItemsWrap = withChonk(
     size: NonNullable<InputStyleProps['size']>;
     disablePointerEvents?: boolean;
   }>`
-    right: ${p => p.theme.formPadding[p.size].paddingRight * 0.75 + 1}px;
+    right: ${p => p.theme.form[p.size].paddingRight * 0.75 + 1}px;
     ${p => p.disablePointerEvents && `pointer-events: none;`}
   `,
   ChonkStyledTrailingItemsWrap

--- a/static/app/components/core/segmentedControl/segmentedControl.chonk.tsx
+++ b/static/app/components/core/segmentedControl/segmentedControl.chonk.tsx
@@ -28,7 +28,10 @@ export const ChonkStyledGroupWrap = chonkStyled('div')<{
   grid-auto-flow: column;
   min-width: 0;
 
-  ${p => p.theme.form[p.size]}
+  font-size: ${p => p.theme.form[p.size].fontSize};
+  height: ${p => p.theme.form[p.size].height};
+  line-height: ${p => p.theme.form[p.size].lineHeight};
+  min-height: ${p => p.theme.form[p.size].minHeight};
 
   & > label:first-child {
     border-top-right-radius: 0;

--- a/static/app/components/core/segmentedControl/segmentedControl.tsx
+++ b/static/app/components/core/segmentedControl/segmentedControl.tsx
@@ -258,7 +258,10 @@ const GroupWrap = withChonk(
     border-radius: ${p => p.theme.borderRadius};
     min-width: 0;
 
-    ${p => p.theme.form[p.size]}
+    font-size: ${p => p.theme.form[p.size].fontSize};
+    height: ${p => p.theme.form[p.size].height};
+    line-height: ${p => p.theme.form[p.size].lineHeight};
+    min-height: ${p => p.theme.form[p.size].minHeight};
   `,
   ChonkStyledGroupWrap
 );

--- a/static/app/components/core/select/select.chonk.tsx
+++ b/static/app/components/core/select/select.chonk.tsx
@@ -69,7 +69,7 @@ export const getChonkStylesConfig = ({
       ...debossedBackground(theme),
       border: `1px solid ${theme.border}`,
       boxShadow,
-      ...theme.formRadius[size],
+      borderRadius: theme.form[size].borderRadius,
       transition: `border ${theme.motion.smooth.fast}, box-shadow ${theme.motion.smooth.fast}`,
       alignItems: 'center',
       ...(state.isFocused && theme.focusRing(boxShadow)),

--- a/static/app/components/core/select/select.chonk.tsx
+++ b/static/app/components/core/select/select.chonk.tsx
@@ -1,5 +1,4 @@
 import {css} from '@emotion/react';
-import omit from 'lodash/omit';
 
 import {Button} from 'sentry/components/core/button';
 import {debossedBackground} from 'sentry/components/core/chonk';
@@ -79,7 +78,9 @@ export const getChonkStylesConfig = ({
         cursor: 'not-allowed',
         opacity: '60%',
       }),
-      ...omit(theme.form[size], 'height'),
+      minHeight: theme.form[size].minHeight,
+      fontSize: theme.form[size].fontSize,
+      lineHeight: theme.form[size].lineHeight,
       ...(state.isMulti && {
         maxHeight: '12em', // 10 lines (1.2em * 10) + padding
         overflow: 'hidden',

--- a/static/app/components/core/select/select.chonk.tsx
+++ b/static/app/components/core/select/select.chonk.tsx
@@ -13,6 +13,12 @@ import {chonkStyled} from 'sentry/utils/theme/theme';
 // We don't care about any options for the styles config
 export type StylesConfig = ReactSelectStylesConfig<any, boolean>;
 
+export const selectSpacing = {
+  md: '8px',
+  sm: '6px',
+  xs: '4px',
+} as const satisfies Record<FormSize, string>;
+
 const multiValueSizeMapping = {
   md: {
     height: '20px',
@@ -131,7 +137,7 @@ export const getChonkStylesConfig = ({
       paddingTop: 0,
       paddingBottom: 0,
       paddingLeft: theme.form[size].paddingLeft,
-      paddingRight: theme.formSpacing[size],
+      paddingRight: selectSpacing[size],
       ...(state.isMulti && {
         maxHeight: 'inherit',
         overflowY: 'auto',
@@ -197,7 +203,7 @@ export const getChonkStylesConfig = ({
     indicatorsContainer: () => ({
       display: 'grid',
       gridAutoFlow: 'column',
-      marginRight: theme.formSpacing[size],
+      marginRight: selectSpacing[size],
     }),
     clearIndicator: indicatorStyles,
     dropdownIndicator: indicatorStyles,

--- a/static/app/components/core/select/select.chonk.tsx
+++ b/static/app/components/core/select/select.chonk.tsx
@@ -129,7 +129,7 @@ export const getChonkStylesConfig = ({
       // flex alignItems makes sure we don't need paddings
       paddingTop: 0,
       paddingBottom: 0,
-      paddingLeft: theme.formPadding[size].paddingLeft,
+      paddingLeft: theme.form[size].paddingLeft,
       paddingRight: theme.formSpacing[size],
       ...(state.isMulti && {
         maxHeight: 'inherit',
@@ -149,7 +149,7 @@ export const getChonkStylesConfig = ({
       alignItems: 'center',
       marginLeft: 0,
       marginRight: 0,
-      width: `calc(100% - ${theme.formPadding[size].paddingLeft}px - ${space(0.5)})`,
+      width: `calc(100% - ${theme.form[size].paddingLeft}px - ${space(0.5)})`,
     }),
     placeholder: (provided, state) => ({
       ...provided,

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -256,7 +256,7 @@ const getStylesConfig = ({
     valueContainer: (provided, state) => ({
       ...provided,
       alignItems: 'center',
-      paddingLeft: theme.formPadding[size ?? 'md'].paddingLeft,
+      paddingLeft: theme.form[size ?? 'md'].paddingLeft,
       paddingRight: space(0.5),
       // offset horizontal margin/padding from multiValue (space(0.25)) &
       // multiValueLabel (space(0.75))
@@ -279,9 +279,7 @@ const getStylesConfig = ({
       alignItems: 'center',
       marginLeft: 0,
       marginRight: 0,
-      width: `calc(100% - ${theme.formPadding[size ?? 'md'].paddingLeft}px - ${space(
-        0.5
-      )})`,
+      width: `calc(100% - ${theme.form[size ?? 'md'].paddingLeft}px - ${space(0.5)})`,
     }),
     placeholder: provided => ({
       ...provided,

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -5,7 +5,6 @@ import Creatable from 'react-select/creatable';
 import type {CSSObject, Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import omit from 'lodash/omit';
 
 import {
   ChonkClearIndicator,
@@ -219,7 +218,9 @@ const getStylesConfig = ({
       ...(!state.isSearchable && {
         cursor: 'pointer',
       }),
-      ...omit(theme.form[size ?? 'md'], 'height'),
+      minHeight: theme.form[size ?? 'md'].minHeight,
+      fontSize: theme.form[size ?? 'md'].fontSize,
+      lineHeight: theme.form[size ?? 'md'].lineHeight,
       ...(state.isMulti && {
         maxHeight: '20.8em', // 10 lines (1.8em * 10) + padding
         overflow: 'hidden',

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -10,6 +10,7 @@ import {
   ChonkClearIndicator,
   ChonkDropdownIndicator,
   getChonkStylesConfig,
+  selectSpacing,
   type StylesConfig,
 } from '@sentry/scraps/select/select.chonk';
 
@@ -386,7 +387,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
       content: `"${label}"`,
       color: theme.isChonk ? theme.gray500 : theme.gray300,
       fontWeight: 600,
-      marginRight: theme.formSpacing[size ?? 'md'],
+      marginRight: selectSpacing[size ?? 'md'],
     },
   });
 

--- a/static/app/components/core/tabs/tab.chonk.tsx
+++ b/static/app/components/core/tabs/tab.chonk.tsx
@@ -78,7 +78,10 @@ export const chonkInnerWrapStyles = ({
   display: flex;
   align-items: center;
   position: relative;
-  ${theme.form[size]};
+  height: ${theme.form[size].height};
+  min-height: ${theme.form[size].minHeight};
+  font-size: ${theme.form[size].fontSize};
+  line-height: ${theme.form[size].lineHeight};
   padding: ${paddingPerSize(theme, orientation)[size]};
   border-radius: ${theme.borderRadius};
   transform: translateY(1px);

--- a/static/app/components/modals/debugFileCustomRepository/http.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/http.tsx
@@ -262,8 +262,7 @@ const StyledSelectField = styled(SelectField)`
 `;
 
 const PasswordInput = styled(Input)`
-  padding-right: ${p =>
-    p.theme.formPadding.md.paddingRight + CLEAR_PASSWORD_BUTTON_SIZE}px;
+  padding-right: ${p => p.theme.form.md.paddingRight + CLEAR_PASSWORD_BUTTON_SIZE}px;
 `;
 
 const ClearPasswordButton = styled(Button)`

--- a/static/app/components/modals/projectCreationModal.tsx
+++ b/static/app/components/modals/projectCreationModal.tsx
@@ -257,7 +257,7 @@ const Footer = styled('div')`
 const StyledPlatformIcon = styled(PlatformIcon)`
   position: absolute;
   top: 50%;
-  left: ${p => p.theme.formPadding.md.paddingLeft}px;
+  left: ${p => p.theme.form.md.paddingLeft}px;
   transform: translateY(-50%);
 `;
 
@@ -265,7 +265,7 @@ const ProjectNameInputWrap = styled('div')`
   position: relative;
 `;
 const ProjectNameInput = styled(Input)`
-  padding-left: calc(${p => p.theme.formPadding.md.paddingLeft}px * 1.5 + 20px);
+  padding-left: calc(${p => p.theme.form.md.paddingLeft}px * 1.5 + 20px);
 `;
 
 export const modalCss = css`

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -453,11 +453,6 @@ type FormTheme = {
       height: string;
       lineHeight: string;
       minHeight: string;
-    }
-  >;
-  formPadding: Record<
-    FormSize,
-    {
       paddingBottom: number;
       paddingLeft: number;
       paddingRight: number;
@@ -995,39 +990,26 @@ const formTheme: FormTheme = {
       minHeight: '36px',
       fontSize: '0.875rem',
       lineHeight: '1rem',
-    },
-    sm: {
-      height: '32px',
-      minHeight: '32px',
-      fontSize: '0.875rem',
-      lineHeight: '1rem',
-    },
-    xs: {
-      height: '28px',
-      minHeight: '28px',
-      fontSize: '0.75rem',
-      lineHeight: '1rem',
-    },
-  },
-
-  /**
-   * Padding for form inputs
-   * @TODO(jonasbadalic) This should exist on form component
-   */
-  formPadding: {
-    md: {
       paddingLeft: 16,
       paddingRight: 16,
       paddingTop: 12,
       paddingBottom: 12,
     },
     sm: {
+      height: '32px',
+      minHeight: '32px',
+      fontSize: '0.875rem',
+      lineHeight: '1rem',
       paddingLeft: 12,
       paddingRight: 12,
       paddingTop: 8,
       paddingBottom: 8,
     },
     xs: {
+      height: '28px',
+      minHeight: '28px',
+      fontSize: '0.75rem',
+      lineHeight: '1rem',
       paddingLeft: 8,
       paddingRight: 8,
       paddingTop: 6,

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -460,7 +460,6 @@ type FormTheme = {
       paddingTop: number;
     }
   >;
-  formSpacing: Record<FormSize, string>;
 };
 
 const iconSizes: Record<Size, string> = {
@@ -1013,11 +1012,6 @@ const formTheme: FormTheme = {
       paddingBottom: 6,
       borderRadius: radius.sm,
     },
-  },
-  formSpacing: {
-    md: '8px',
-    sm: '6px',
-    xs: '4px',
   },
 };
 

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -449,6 +449,7 @@ type FormTheme = {
   form: Record<
     FormSize,
     {
+      borderRadius: string;
       fontSize: string;
       height: string;
       lineHeight: string;
@@ -457,12 +458,6 @@ type FormTheme = {
       paddingLeft: number;
       paddingRight: number;
       paddingTop: number;
-    }
-  >;
-  formRadius: Record<
-    FormSize,
-    {
-      borderRadius: string;
     }
   >;
   formSpacing: Record<FormSize, string>;
@@ -994,6 +989,7 @@ const formTheme: FormTheme = {
       paddingRight: 16,
       paddingTop: 12,
       paddingBottom: 12,
+      borderRadius: radius.lg,
     },
     sm: {
       height: '32px',
@@ -1004,6 +1000,7 @@ const formTheme: FormTheme = {
       paddingRight: 12,
       paddingTop: 8,
       paddingBottom: 8,
+      borderRadius: radius.md,
     },
     xs: {
       height: '28px',
@@ -1014,17 +1011,7 @@ const formTheme: FormTheme = {
       paddingRight: 8,
       paddingTop: 6,
       paddingBottom: 6,
-    },
-  },
-  formRadius: {
-    md: {
-      borderRadius: '8px',
-    },
-    sm: {
-      borderRadius: '6px',
-    },
-    xs: {
-      borderRadius: '5px',
+      borderRadius: radius.sm,
     },
   },
   formSpacing: {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -607,13 +607,13 @@ const ProjectNameInputWrap = styled('div')`
 `;
 
 const ProjectNameInput = styled(Input)`
-  padding-left: calc(${p => p.theme.formPadding.md.paddingLeft}px * 1.5 + 20px);
+  padding-left: calc(${p => p.theme.form.md.paddingLeft}px * 1.5 + 20px);
 `;
 
 const StyledPlatformIcon = styled(PlatformIcon)`
   position: absolute;
   top: 50%;
-  left: ${p => p.theme.formPadding.md.paddingLeft}px;
+  left: ${p => p.theme.form.md.paddingLeft}px;
   transform: translateY(-50%);
 `;
 

--- a/static/gsApp/utils/useFeedbackInit.tsx
+++ b/static/gsApp/utils/useFeedbackInit.tsx
@@ -49,9 +49,9 @@ export default function useFeedbackInit() {
         --outline: 1px auto ${theme.tokens.border.accent};
         --interactive-filter: brightness(${theme.type === 'dark' ? '110%' : '95%'});
         --border: 1px solid ${theme.tokens.border.primary};
-        --button-border-radius: ${theme.formRadius.md.borderRadius};
-        --button-primary-border-radius: ${theme.formRadius.md.borderRadius};
-        --input-border-radius: ${theme.formRadius.md.borderRadius};
+        --button-border-radius: ${theme.form.md.borderRadius};
+        --button-primary-border-radius: ${theme.form.md.borderRadius};
+        --input-border-radius: ${theme.form.md.borderRadius};
       }
     `;
     document.head.appendChild(styleElement);


### PR DESCRIPTION
`formPadding`, `formRadius` are now both available in `theme.form`, while `theme.formSpacing` was moved to the `Select` component, as this is the only place using it.