### PR TITLE
feat(aci): add disabled alert to error/metric monitors and alerts

### DIFF
--- a/static/app/views/automations/components/disabledAlert.spec.tsx
+++ b/static/app/views/automations/components/disabledAlert.spec.tsx
@@ -2,6 +2,7 @@ import {AutomationFixture} from 'sentry-fixture/automations';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {DisabledAlert} from './disabledAlert';
 
@@ -86,7 +87,11 @@ describe('DisabledAlert', () => {
 
     await userEvent.hover(enableButton);
     expect(
-      await screen.findByText('You do not have permission to enable this alert')
+      await screen.findByText(
+        textWithMarkupMatcher(
+          'You do not have permission to edit this alert. Ask your organization owner or manager to enable alert access for you.'
+        )
+      )
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/automations/components/disabledAlert.spec.tsx
+++ b/static/app/views/automations/components/disabledAlert.spec.tsx
@@ -1,0 +1,92 @@
+import {AutomationFixture} from 'sentry-fixture/automations';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {DisabledAlert} from './disabledAlert';
+
+describe('DisabledAlert', () => {
+  const organization = OrganizationFixture({
+    access: ['org:write', 'alerts:write'],
+    alertsMemberWrite: true,
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('does not render when automation is enabled', () => {
+    const automation = AutomationFixture({enabled: true});
+
+    const {container} = render(<DisabledAlert automation={automation} />, {
+      organization,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders alert with message and enable button when automation is disabled', () => {
+    const automation = AutomationFixture({enabled: false});
+
+    render(<DisabledAlert automation={automation} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText('This alert is disabled and will not send notifications.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Enable'})).toBeInTheDocument();
+  });
+
+  it('enables automation when enable button is clicked', async () => {
+    const automation = AutomationFixture({
+      id: '123',
+      enabled: false,
+    });
+
+    const updateRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/123/',
+      method: 'PUT',
+      body: {...automation, enabled: true},
+    });
+
+    render(<DisabledAlert automation={automation} />, {
+      organization,
+    });
+
+    const enableButton = await screen.findByRole('button', {name: 'Enable'});
+    expect(enableButton).toBeEnabled();
+
+    await userEvent.click(enableButton);
+
+    await waitFor(() => {
+      expect(updateRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'PUT',
+          data: {id: '123', name: automation.name, enabled: true},
+        })
+      );
+    });
+  });
+
+  it('disables enable button when user does not have alerts:write permission', async () => {
+    const organizationWithoutAccess = OrganizationFixture({
+      access: ['org:read'],
+      alertsMemberWrite: false,
+    });
+    const automation = AutomationFixture({enabled: false});
+
+    render(<DisabledAlert automation={automation} />, {
+      organization: organizationWithoutAccess,
+    });
+
+    const enableButton = screen.getByRole('button', {name: 'Enable'});
+    expect(enableButton).toBeDisabled();
+
+    await userEvent.hover(enableButton);
+    expect(
+      await screen.findByText('You do not have permission to enable this alert')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/automations/components/disabledAlert.tsx
+++ b/static/app/views/automations/components/disabledAlert.tsx
@@ -1,0 +1,60 @@
+import {hasEveryAccess} from 'sentry/components/acl/access';
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {IconPlay} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Automation} from 'sentry/types/workflowEngine/automations';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useUpdateAutomation} from 'sentry/views/automations/hooks';
+
+type DisabledAlertProps = {
+  automation: Automation;
+};
+
+/**
+ * Alert banner for users to quickly understand that an automation is
+ * disabled and not actively running, and give them a one-click way to
+ * enable it. The alert automatically hides when the automation is enabled.
+ */
+export function DisabledAlert({automation}: DisabledAlertProps) {
+  const organization = useOrganization();
+  const {mutate: updateAutomation, isPending: isEnabling} = useUpdateAutomation();
+
+  const canEdit = hasEveryAccess(['alerts:write'], {organization});
+
+  if (automation.enabled) {
+    return null;
+  }
+
+  const handleEnable = () => {
+    updateAutomation({
+      id: automation.id,
+      name: automation.name,
+      enabled: true,
+    });
+  };
+
+  return (
+    <Alert.Container>
+      <Alert
+        type="muted"
+        trailingItems={
+          <Button
+            size="xs"
+            icon={<IconPlay />}
+            onClick={handleEnable}
+            disabled={isEnabling || !canEdit}
+            aria-label={t('Enable')}
+            title={
+              canEdit ? undefined : t('You do not have permission to enable this alert')
+            }
+          >
+            {t('Enable')}
+          </Button>
+        }
+      >
+        {t('This alert is disabled and will not send notifications.')}
+      </Alert>
+    </Alert.Container>
+  );
+}

--- a/static/app/views/automations/components/disabledAlert.tsx
+++ b/static/app/views/automations/components/disabledAlert.tsx
@@ -1,8 +1,10 @@
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Link} from 'sentry/components/core/link';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconPlay} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateAutomation} from 'sentry/views/automations/hooks';
@@ -34,23 +36,40 @@ export function DisabledAlert({automation}: DisabledAlertProps) {
     });
   };
 
+  const permissionTooltipText = tct(
+    'You do not have permission to edit this alert. Ask your organization owner or manager to [settingsLink:enable alert access] for you.',
+    {
+      settingsLink: (
+        <Link
+          to={{
+            pathname: `/settings/${organization.slug}/`,
+            hash: 'alertsMemberWrite',
+          }}
+        />
+      ),
+    }
+  );
+
   return (
     <Alert.Container>
       <Alert
         type="muted"
         trailingItems={
-          <Button
-            size="xs"
-            icon={<IconPlay />}
-            onClick={handleEnable}
-            disabled={isEnabling || !canEdit}
-            aria-label={t('Enable')}
-            title={
-              canEdit ? undefined : t('You do not have permission to enable this alert')
-            }
+          <Tooltip
+            title={canEdit ? undefined : permissionTooltipText}
+            disabled={canEdit}
+            isHoverable
           >
-            {t('Enable')}
-          </Button>
+            <Button
+              size="xs"
+              icon={<IconPlay />}
+              onClick={handleEnable}
+              disabled={isEnabling || !canEdit}
+              aria-label={t('Enable')}
+            >
+              {t('Enable')}
+            </Button>
+          </Tooltip>
         }
       >
         {t('This alert is disabled and will not send notifications.')}

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -117,7 +117,7 @@ describe('AutomationDetail', () => {
       );
     });
 
-    expect(screen.getByText('Enable')).toBeInTheDocument();
+    expect(screen.getAllByText('Enable')).toHaveLength(2);
   });
 
   describe('Action warnings', () => {

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -34,6 +34,7 @@ import AutomationHistoryList from 'sentry/views/automations/components/automatio
 import {AutomationStatsChart} from 'sentry/views/automations/components/automationStatsChart';
 import ConditionsPanel from 'sentry/views/automations/components/conditionsPanel';
 import ConnectedMonitorsList from 'sentry/views/automations/components/connectedMonitorsList';
+import {DisabledAlert} from 'sentry/views/automations/components/disabledAlert';
 import {useAutomationQuery, useUpdateAutomation} from 'sentry/views/automations/hooks';
 import {getAutomationActionsWarning} from 'sentry/views/automations/hooks/utils';
 import {
@@ -75,11 +76,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
         </DetailLayout.Header>
         <DetailLayout.Body>
           <DetailLayout.Main>
-            {!automation.enabled && (
-              <Alert type="muted">
-                {t('This alert is disabled and will not send notifications.')}
-              </Alert>
-            )}
+            <DisabledAlert automation={automation} />
             {automation.enabled && warning && (
               <Alert type={warning.color === 'warning' ? 'warning' : 'error'}>
                 {warning.message}

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -75,7 +75,12 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
         </DetailLayout.Header>
         <DetailLayout.Body>
           <DetailLayout.Main>
-            {warning && (
+            {!automation.enabled && (
+              <Alert type="muted">
+                {t('This alert is disabled and will not send notifications.')}
+              </Alert>
+            )}
+            {automation.enabled && warning && (
               <Alert type={warning.color === 'warning' ? 'warning' : 'error'}>
                 {warning.message}
               </Alert>

--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -5,6 +5,7 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
@@ -79,17 +80,21 @@ export function EditDetectorAction({detector}: {detector: Detector}) {
       );
 
   return (
-    <LinkButton
-      to={`${makeMonitorDetailsPathname(organization.slug, detector.id)}edit/`}
-      priority="primary"
-      icon={<IconEdit />}
-      size="sm"
-      disabled={!canEdit}
+    <Tooltip
       title={canEdit ? undefined : permissionTooltipText}
-      tooltipProps={{isHoverable: true}}
+      disabled={canEdit}
+      isHoverable
     >
-      {t('Edit')}
-    </LinkButton>
+      <LinkButton
+        to={`${makeMonitorDetailsPathname(organization.slug, detector.id)}edit/`}
+        priority="primary"
+        icon={<IconEdit />}
+        size="sm"
+        disabled={!canEdit}
+      >
+        {t('Edit')}
+      </LinkButton>
+    </Tooltip>
   );
 }
 

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -10,6 +10,7 @@ import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
@@ -70,6 +71,10 @@ export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsPr
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
+          <DisabledAlert
+            detector={detector}
+            message={t('This monitor is disabled and not creating issues.')}
+          />
           <DatePageFilter />
           <DetectorDetailsOngoingIssues detector={detector} />
           <DetectorDetailsAutomations detector={detector} />

--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -1,9 +1,11 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
+import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
 import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
 import {MetricDetectorDetailsChart} from 'sentry/views/detectors/components/details/metric/chart';
@@ -43,6 +45,10 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
+          <DisabledAlert
+            detector={detector}
+            message={t('This monitor is disabled and not creating issues.')}
+          />
           {detectorDataset === DetectorDataset.TRANSACTIONS && (
             <TransactionsDatasetWarning />
           )}


### PR DESCRIPTION
uses reusable DisabledAlert component from https://github.com/getsentry/sentry/pull/103165 to show an alert for disabled metric and error monitors, and adds a matching component for alerts

<img width="591" height="166" alt="Screenshot 2025-12-11 at 8 53 16 AM" src="https://github.com/user-attachments/assets/ea1b72ed-3538-4f87-9e02-b4a384de91fb" />
