### PR TITLE
fix(preprod): Use preprod namespace for tasks

### DIFF
--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from io import BytesIO
+from typing import Any
 
 from django.db import router, transaction
 from django.utils import timezone
@@ -20,7 +21,7 @@ from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compa
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import attachments_tasks
+from sentry.taskworker.namespaces import attachments_tasks, preprod_tasks
 from sentry.utils import metrics
 from sentry.utils.json import dumps_htmlsafe
 
@@ -31,7 +32,9 @@ logger = logging.getLogger(__name__)
 
 @instrumented_task(
     name="sentry.preprod.tasks.compare_preprod_artifact_size_analysis",
-    namespace=attachments_tasks,
+    namespace=preprod_tasks,
+    # TODO(EME-242): Remove once inflight tasks done.
+    alias_namespace=attachments_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
 )
@@ -39,6 +42,7 @@ def compare_preprod_artifact_size_analysis(
     project_id: int,
     org_id: int,
     artifact_id: int,
+    **kwargs: Any,
 ) -> None:
     logger.info(
         "preprod.size_analysis.compare.start",
@@ -231,7 +235,9 @@ def compare_preprod_artifact_size_analysis(
 
 @instrumented_task(
     name="sentry.preprod.tasks.manual_size_analysis_comparison",
-    namespace=attachments_tasks,
+    namespace=preprod_tasks,
+    # TODO(EME-242): Remove once inflight tasks done.
+    alias_namespace=attachments_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
 )
@@ -240,6 +246,7 @@ def manual_size_analysis_comparison(
     org_id: int,
     head_artifact_id: int,
     base_artifact_id: int,
+    **kwargs: Any,
 ) -> None:
     logger.info(
         "preprod.size_analysis.compare.manual.start",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -46,7 +46,9 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.preprod.tasks.assemble_preprod_artifact",
     retry=Retry(times=3),
-    namespace=attachments_tasks,
+    namespace=preprod_tasks,
+    # TODO(EME-242): Remove once inflight tasks done.
+    alias_namespace=attachments_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
 )
@@ -606,7 +608,9 @@ def _assemble_preprod_artifact_size_analysis(
 
 @instrumented_task(
     name="sentry.preprod.tasks.assemble_preprod_artifact_size_analysis",
-    namespace=attachments_tasks,
+    namespace=preprod_tasks,
+    # TODO(EME-242): Remove once inflight tasks done.
+    alias_namespace=attachments_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
 )
@@ -693,7 +697,9 @@ def _assemble_preprod_artifact_installable_app(
 
 @instrumented_task(
     name="sentry.preprod.tasks.assemble_preprod_artifact_installable_app",
-    namespace=attachments_tasks,
+    namespace=preprod_tasks,
+    # TODO(EME-242): Remove once inflight tasks done.
+    alias_namespace=attachments_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
 )

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -31,7 +31,7 @@ from sentry.preprod.vcs.status_checks.size.templates import format_status_check_
 from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import integrations_tasks
+from sentry.taskworker.namespaces import integrations_tasks, preprod_tasks
 from sentry.taskworker.retry import Retry
 
 logger = logging.getLogger(__name__)
@@ -39,12 +39,14 @@ logger = logging.getLogger(__name__)
 
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_status_check",
-    namespace=integrations_tasks,
+    namespace=preprod_tasks,
+    # TODO(EME-242): Remove once inflight tasks done.
+    alias_namespace=integrations_tasks,
     processing_deadline_duration=30,
     retry=Retry(times=3, ignore=(IntegrationConfigurationError,)),
     silo_mode=SiloMode.REGION,
 )
-def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
+def create_preprod_status_check_task(preprod_artifact_id: int, **kwargs: Any) -> None:
     try:
         preprod_artifact: PreprodArtifact | None = PreprodArtifact.objects.get(
             id=preprod_artifact_id


### PR DESCRIPTION
Sounds like we won't need our own pool anytime soon:
https://develop.sentry.dev/backend/application-domains/tasks/#task-namespaces
(own pool recommended when QPS >1500).

But putting all the tasks into our own namespace will help with accounting and make
our own pool easier if we ever do need it.

This is a two step process to avoid disrupting inflight tasks:
https://develop.sentry.dev/backend/application-domains/tasks/#moving-to-a-different-namespace

Also add `**kwargs` while we're here:
https://develop.sentry.dev/backend/application-domains/asynchronous-workers/#registering-a-task:~:text=Tasks%20must%20accept%20%60**kwargs%60%60%20to%20handle%20rolling%20compatibility.

Resolves EME-242