### PR TITLE
fix(preprod): Add diff delta values to existing install and download columns of github check (EME-641)

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -96,7 +96,7 @@ def _format_artifact_summary(
     """Format summary for artifacts with size data."""
     artifact_metric_rows = _create_sorted_artifact_metric_rows(artifacts, size_metrics_map)
 
-    grouped_rows: dict[str, list[str]] = {"android": [], "non_android": []}
+    grouped_rows: dict[str, list[str]] = {"android": [], "ios": []}
     group_order: list[str] = []
 
     for artifact, size_metrics in artifact_metric_rows:
@@ -162,7 +162,7 @@ def _format_artifact_summary(
 
         row = f"| {name_text} | {configuration_text} | {version_string} | {download_text} | {install_text} | {na_text} |"
 
-        group_key = "android" if artifact.is_android() else "non_android"
+        group_key = "android" if artifact.is_android() else "ios"
         grouped_rows[group_key].append(row)
         if group_key not in group_order:
             group_order.append(group_key)
@@ -176,13 +176,15 @@ def _format_artifact_summary(
 
     tables: list[str] = []
     for group_key in group_order:
-        if not grouped_rows[group_key]:
-            continue
-
-        if group_key == "android":
-            tables.append(_render_table(grouped_rows[group_key], str(_("Uncompressed Size"))))
-        else:
-            tables.append(_render_table(grouped_rows[group_key], str(_("Install Size"))))
+        if grouped_rows[group_key]:
+            if group_key == "android":
+                header = "### Android Builds\n\n"
+                table = _render_table(grouped_rows[group_key], str(_("Uncompressed Size")))
+                tables.append(f"{header}{table}")
+            else:
+                header = "### iOS Builds\n\n"
+                table = _render_table(grouped_rows[group_key], str(_("Install Size")))
+                tables.append(f"{header}{table}")
 
     return "\n\n".join(tables)
 

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -169,7 +169,7 @@ def _format_artifact_summary(
 
     def _render_table(rows: list[str], install_label: str) -> str:
         return _(
-            "| Name | Configuration | Version | Download | {install_label} | Approval |\n"
+            "| Name | Configuration | Version | Download Size | {install_label} | Approval |\n"
             "|------|--------------|---------|----------|-----------------|----------|\n"
             "{table_rows}"
         ).format(table_rows="\n".join(rows), install_label=install_label)
@@ -180,9 +180,9 @@ def _format_artifact_summary(
             continue
 
         if group_key == "android":
-            tables.append(_render_table(grouped_rows[group_key], str(_("Uncompressed"))))
+            tables.append(_render_table(grouped_rows[group_key], str(_("Uncompressed Size"))))
         else:
-            tables.append(_render_table(grouped_rows[group_key], str(_("Install"))))
+            tables.append(_render_table(grouped_rows[group_key], str(_("Install Size"))))
 
     return "\n\n".join(tables)
 

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -147,6 +147,9 @@ def _format_artifact_summary(
 
         name_text = f"[{app_name}<br>`{app_id}`]({artifact_url})"
 
+        download_text = f"{download_size_display} ({download_change})"
+        install_text = f"{install_size_display} ({install_change})"
+
         # Configuration
         configuration_text = (
             f"{artifact.build_configuration.name or '--'}" if artifact.build_configuration else "--"
@@ -156,13 +159,13 @@ def _format_artifact_summary(
         na_text = str(_("N/A"))
 
         table_rows.append(
-            f"| {name_text} | {configuration_text} | {version_string} | {download_size_display} | {download_change} | {install_size_display} | {install_change} | {na_text} |"
+            f"| {name_text} | {configuration_text} | {version_string} | {download_text} | {install_text} | {na_text} |"
         )
 
     install_label = str(_("Uncompressed")) if artifact.is_android() else str(_("Install"))
     return _(
-        "| Name | Configuration | Version | Download | Change | {install_label} | Change | Approval |\n"
-        "|------|---------------|---------|----------|--------|-----------------|--------|----------|\n"
+        "| Name | Configuration | Version | Download | {install_label} | Approval |\n"
+        "|------|--------------|---------|----------|-----------------|----------|\n"
         "{table_rows}"
     ).format(table_rows="\n".join(table_rows), install_label=install_label)
 

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -796,8 +796,8 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         tables = summary.strip().split("\n\n")
         assert len(tables) == 2
 
-        android_table = next(t for t in tables if "Uncompressed" in t.split("\n")[0])
-        ios_table = next(t for t in tables if "Install" in t.split("\n")[0])
+        android_table = next(t for t in tables if "Uncompressed Size" in t.split("\n")[0])
+        ios_table = next(t for t in tables if "Install Size" in t.split("\n")[0])
 
         assert "com.example.android" in android_table
         assert "com.example.ios" in ios_table

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -793,14 +793,18 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             [android_artifact, ios_artifact], size_metrics_map, StatusCheckStatus.SUCCESS
         )
 
-        tables = summary.strip().split("\n\n")
-        assert len(tables) == 2
+        # Split by double newlines - should have 2 table sections (each with header + table)
+        sections = summary.strip().split("\n\n")
+        assert len(sections) == 4  # 2 headers + 2 tables
 
-        android_table = next(t for t in tables if "Uncompressed Size" in t.split("\n")[0])
-        ios_table = next(t for t in tables if "Install Size" in t.split("\n")[0])
+        # Check for headers and tables
+        assert "## Android Builds" in summary
+        assert "## iOS Builds" in summary
+        assert "Uncompressed Size" in summary
+        assert "Install Size" in summary
 
-        assert "com.example.android" in android_table
-        assert "com.example.ios" in ios_table
+        assert "com.example.android" in summary
+        assert "com.example.ios" in summary
 
 
 @region_silo_test

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -557,15 +557,10 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert subtitle == "1 app analyzed"
 
         # Verify that size changes are calculated and displayed
-        assert "4.2 MB" in summary  # Current download size
-        assert "8.6 MB" in summary  # Current install size
+        # (4.2MB - 4.0MB = 209.7KB, 8.6MB - 8.3MB = 314.6KB)
+        assert "4.2 MB (+209.7 KB)" in summary  # Current download size
+        assert "8.6 MB (+314.6 KB)" in summary  # Current install size
 
-        # Verify that changes are shown (4.2MB - 4.0MB = 209.7KB, 8.6MB - 8.3MB = 314.6KB)
-        assert "+209.7 KB" in summary  # Download change
-        assert "+314.6 KB" in summary  # Install change
-
-        # Verify the table structure includes the Change columns
-        assert "Change" in summary
         assert "com.example.android" in summary
         assert "1.0.3 (42)" in summary
 

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -793,18 +793,25 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             [android_artifact, ios_artifact], size_metrics_map, StatusCheckStatus.SUCCESS
         )
 
-        # Split by double newlines - should have 2 table sections (each with header + table)
-        sections = summary.strip().split("\n\n")
-        assert len(sections) == 4  # 2 headers + 2 tables
+        # Build expected URLs
+        android_url = f"http://testserver/organizations/{self.organization.slug}/preprod/{self.project.slug}/{android_artifact.id}"
+        ios_url = f"http://testserver/organizations/{self.organization.slug}/preprod/{self.project.slug}/{ios_artifact.id}"
 
-        # Check for headers and tables
-        assert "## Android Builds" in summary
-        assert "## iOS Builds" in summary
-        assert "Uncompressed Size" in summary
-        assert "Install Size" in summary
+        expected = f"""\
+### Android Builds
 
-        assert "com.example.android" in summary
-        assert "com.example.ios" in summary
+| Name | Configuration | Version | Download Size | Uncompressed Size | Approval |
+|------|--------------|---------|----------|-----------------|----------|
+| [-- (Android)<br>`com.example.android`]({android_url}) | -- | 1.0.0 (1) | 1.0 MB (N/A) | 2.1 MB (N/A) | N/A |
+
+### iOS Builds
+
+| Name | Configuration | Version | Download Size | Install Size | Approval |
+|------|--------------|---------|----------|-----------------|----------|
+| [-- (iOS)<br>`com.example.ios`]({ios_url}) | -- | 2.0.0 (2) | 2.1 MB (N/A) | 3.1 MB (N/A) | N/A |\
+"""
+
+        assert summary == expected
 
 
 @region_silo_test


### PR DESCRIPTION
This pull request improves the artifact summary table used in size checks to make download and install size changes easier to read. It removes the separate Change columns and instead combines the size and change information into a single column for improved clarity.

Now renders two tables  to group artifacts by platform and render separate, clearly labeled tables for Android and iOS artifacts. The reason for doing this was because on Android we can represent the install size only the uncompressed wise so mixing headers was confusing.

A new test case has been added to verify correct rendering when artifacts from multiple platforms are present.

Existing tests have been updated accordingly to reflect the new table structure and content.

**Artifact summary table formatting:**

* Combined the download and install size values with their respective change values into single columns (`download_text` and `install_text`), removing the separate "Change" columns from the summary table in `src/sentry/preprod/vcs/status_checks/size/templates.py`. [[1]](diffhunk://#diff-6f2304aa321f1acced02b8c16165fbe54422e9cd7eb2e71825e1b154a17d873cR150-R152) [[2]](diffhunk://#diff-6f2304aa321f1acced02b8c16165fbe54422e9cd7eb2e71825e1b154a17d873cL159-R168)

**Test updates:**

* Updated `test_size_changes_with_base_artifacts` in `tests/sentry/preprod/vcs/status_checks/size/test_templates.py` to assert the new combined format and removed checks for the old "Change" columns.

## Before
<img width="872" height="169" alt="Screenshot 2025-12-11 at 14 57 48" src="https://github.com/user-attachments/assets/b2776b32-cd93-4262-b364-3fc8b167fee6" />


## After

<img width="828" height="378" alt="Screenshot 2025-12-16 at 19 26 55" src="https://github.com/user-attachments/assets/8b9c4c85-3b24-46ef-ae52-27aea070597d" />

## Testing

- Tested by updating existing template tests
- Manual E2E integration test performed to validate (https://github.com/cameroncooke/sentry_test_app/pull/1/checks?check_run_id=57792748389)
