### PR TITLE
fix(aci): use project slug instead of deprecated name

### DIFF
--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -211,7 +211,7 @@ export function DetectorLink({detector, className, openInNewTab}: DetectorLinkPr
 
   const detectorName =
     detector.type === 'issue_stream'
-      ? t('All Issues in %s', project?.name || 'project')
+      ? t('All Issues in %s', project?.slug || 'project')
       : detector.name;
 
   const detectorLink =


### PR DESCRIPTION
project name is a deprecated field, we should be using slug instead