### PR TITLE
fix(aci): deep link Create Monitor buttons to /new/settings link

### DIFF
--- a/static/app/views/detectors/list/common/detectorListActions.tsx
+++ b/static/app/views/detectors/list/common/detectorListActions.tsx
@@ -51,7 +51,9 @@ export function DetectorListActions({detectorType, children}: DetectorListAction
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
-  const createPath = makeMonitorCreatePathname(organization.slug);
+  const createPath = detectorType
+    ? `${makeMonitorCreatePathname(organization.slug)}settings/`
+    : makeMonitorCreatePathname(organization.slug);
   const project = selection.projects.find(pid => pid !== ALL_ACCESS_PROJECTS);
   const createQuery = detectorType ? {project, detectorType} : {project};
   const canCreateDetector = useCanCreateDetector(detectorType);

--- a/static/app/views/detectors/list/common/detectorListActions.tsx
+++ b/static/app/views/detectors/list/common/detectorListActions.tsx
@@ -10,7 +10,10 @@ import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
-import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
+import {
+  makeMonitorCreatePathname,
+  makeMonitorCreateSettingsPathname,
+} from 'sentry/views/detectors/pathnames';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {useCanCreateDetector} from 'sentry/views/detectors/utils/useCanCreateDetector';
 
@@ -52,7 +55,7 @@ export function DetectorListActions({detectorType, children}: DetectorListAction
   const {selection} = usePageFilters();
 
   const createPath = detectorType
-    ? `${makeMonitorCreatePathname(organization.slug)}settings/`
+    ? makeMonitorCreateSettingsPathname(organization.slug)
     : makeMonitorCreatePathname(organization.slug);
   const project = selection.projects.find(pid => pid !== ALL_ACCESS_PROJECTS);
   const createQuery = detectorType ? {project, detectorType} : {project};

--- a/static/app/views/detectors/pathnames.tsx
+++ b/static/app/views/detectors/pathnames.tsx
@@ -23,6 +23,10 @@ export const makeMonitorCreatePathname = (orgSlug: string) => {
   return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}new/`);
 };
 
+export const makeMonitorCreateSettingsPathname = (orgSlug: string) => {
+  return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}new/settings/`);
+};
+
 export const makeMonitorEditPathname = (orgSlug: string, monitorId: string) => {
   return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}${monitorId}/edit/`);
 };


### PR DESCRIPTION
clicking the Create Monitor button on the list view for a specific monitor type should link to the `/new/settings` page (step 2 of monitor creation) for that type, rather than the type picker page (step 1)