### PR TITLE
feat(dashboards): Measure time to open the Widget Builder

### DIFF
--- a/static/app/utils/scheduleMicroTask.ts
+++ b/static/app/utils/scheduleMicroTask.ts
@@ -1,0 +1,21 @@
+const SUPPORTS_QUEUE_MICROTASK = window && 'queueMicrotask' in window;
+
+export function scheduleMicroTask(callback: () => void) {
+  if (SUPPORTS_QUEUE_MICROTASK) {
+    window.queueMicrotask(callback);
+  } else {
+    Promise.resolve()
+      .then(callback)
+      .catch(e => {
+        // Escape the promise and throw the error so it gets reported
+        if (window) {
+          window.setTimeout(() => {
+            throw e;
+          });
+        } else {
+          // Best effort and just rethrow
+          throw e;
+        }
+      });
+  }
+}

--- a/static/app/utils/useLocalStorageState.ts
+++ b/static/app/utils/useLocalStorageState.ts
@@ -2,28 +2,9 @@ import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
 import localStorageWrapper from 'sentry/utils/localStorage';
 
-const SUPPORTS_QUEUE_MICROTASK = window && 'queueMicrotask' in window;
-const SUPPORTS_LOCAL_STORAGE = window && 'localStorage' in window;
+import {scheduleMicroTask} from './scheduleMicroTask';
 
-function scheduleMicroTask(callback: () => void) {
-  if (SUPPORTS_QUEUE_MICROTASK) {
-    window.queueMicrotask(callback);
-  } else {
-    Promise.resolve()
-      .then(callback)
-      .catch(e => {
-        // Escape the promise and throw the error so it gets reported
-        if (window) {
-          window.setTimeout(() => {
-            throw e;
-          });
-        } else {
-          // Best effort and just rethrow
-          throw e;
-        }
-      });
-  }
-}
+const SUPPORTS_LOCAL_STORAGE = window && 'localStorage' in window;
 
 // Attempt to parse JSON. If it fails, swallow the error and return null.
 // As an improvement, we should maybe allow users to intercept here or possibly use

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -648,6 +648,9 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onEditWidget = (widget: Widget) => {
+    // Start measuring the "onEdit" click handler duration
+    const start = performance.now();
+
     const {navigate, organization, params, location, dashboard} = this.props;
     const {modifiedDashboard} = this.state;
     const currentDashboard = modifiedDashboard ?? dashboard;
@@ -686,6 +689,17 @@ class DashboardDetail extends Component<Props, State> {
       }),
       {preventScrollReset: true}
     );
+
+    // Schedule stopping the timer for the end of the current task queue tick.
+    // This roughly corresponds to when React finishes the rendering and
+    // painting, and gives a decent idea of how long it took to open the Widget
+    // Builder
+    Promise.resolve().then(() => {
+      const duration = performance.now() - start;
+      Sentry.metrics.distribution('dashboards.widget.onEdit', duration, {
+        unit: 'millisecond',
+      });
+    });
   };
 
   handleSaveWidget = ({index, widget}: {index: number | undefined; widget: Widget}) => {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -47,6 +47,7 @@ import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metr
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
 import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
+import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -694,7 +695,7 @@ class DashboardDetail extends Component<Props, State> {
     // This roughly corresponds to when React finishes the rendering and
     // painting, and gives a decent idea of how long it took to open the Widget
     // Builder
-    Promise.resolve().then(() => {
+    scheduleMicroTask(() => {
       const duration = performance.now() - start;
       Sentry.metrics.distribution('dashboards.widget.onEdit', duration, {
         unit: 'millisecond',


### PR DESCRIPTION
Unfortunately, our INP instrumentation isn't granular enough, and not frequent enough to actually get useful numbers. Instead, I'm adding manual instrumentation to measure the duration of the "Edit Widget" handler, which corresponds closely to how long it takes to open the Widget Builder.
