### PR TITLE
feat(trace-tree-node): Adding tests for drawer node details

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.spec.tsx
@@ -1,0 +1,79 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {TraceTreeNodeExtra} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
+import {SiblingAutogroupNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/siblingAutogroupNode';
+import {
+  makeEAPSpan,
+  makeSiblingAutogroup,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {AutogroupNodeDetails} from './index';
+
+const createMockExtra = (
+  overrides: Partial<TraceTreeNodeExtra> = {}
+): TraceTreeNodeExtra => ({
+  organization: OrganizationFixture(),
+  ...overrides,
+});
+
+describe('AutogroupNodeDetails', () => {
+  it('renders autogroup details with title and description', () => {
+    const organization = OrganizationFixture();
+    const extra = createMockExtra({organization});
+    const autogroupValue = makeSiblingAutogroup({
+      span_id: 'test-span-id',
+      autogrouped_by: {
+        op: 'db.query',
+        description: 'SELECT * FROM users',
+      },
+    });
+
+    const childSpanValue = makeEAPSpan({event_id: 'child-span-1'});
+    const childNode = new EapSpanNode(null, childSpanValue, extra);
+    const node = new SiblingAutogroupNode(null, autogroupValue, extra);
+    node.children = [childNode];
+
+    render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <AutogroupNodeDetails
+          node={node as any}
+          organization={organization}
+          onTabScrollToNode={jest.fn()}
+          onParentClick={jest.fn()}
+          manager={null}
+          replay={null}
+          traceId="test-trace-id"
+        />
+      </TraceStateProvider>
+    );
+
+    // Verify title is rendered
+    expect(screen.getByText('Autogroup')).toBeInTheDocument();
+
+    // Verify span ID subtitle is rendered
+    expect(screen.getByText(/ID: test-span-id/)).toBeInTheDocument();
+
+    // Verify explanation text is rendered
+    expect(
+      screen.getByText(/This block represents autogrouped spans/)
+    ).toBeInTheDocument();
+
+    // Verify criteria bullet points are rendered
+    expect(
+      screen.getByText('5 or more siblings with the same operation and description')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('2 or more descendants with the same operation')
+    ).toBeInTheDocument();
+
+    // Verify usage instruction is rendered
+    expect(
+      screen.getByText(/You can either open this autogroup using the chevron/)
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.spec.tsx
@@ -52,18 +52,14 @@ describe('AutogroupNodeDetails', () => {
       </TraceStateProvider>
     );
 
-    // Verify title is rendered
     expect(screen.getByText('Autogroup')).toBeInTheDocument();
 
-    // Verify span ID subtitle is rendered
     expect(screen.getByText(/ID: test-span-id/)).toBeInTheDocument();
 
-    // Verify explanation text is rendered
     expect(
       screen.getByText(/This block represents autogrouped spans/)
     ).toBeInTheDocument();
 
-    // Verify criteria bullet points are rendered
     expect(
       screen.getByText('5 or more siblings with the same operation and description')
     ).toBeInTheDocument();
@@ -71,7 +67,6 @@ describe('AutogroupNodeDetails', () => {
       screen.getByText('2 or more descendants with the same operation')
     ).toBeInTheDocument();
 
-    // Verify usage instruction is rendered
     expect(
       screen.getByText(/You can either open this autogroup using the chevron/)
     ).toBeInTheDocument();

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
@@ -55,13 +55,10 @@ describe('ErrorNodeDetails', () => {
       </TraceStateProvider>
     );
 
-    // Verify title is rendered
     expect(screen.getByText('Error')).toBeInTheDocument();
 
-    // Verify error ID subtitle is rendered
     expect(screen.getByText(/ID: test-error-id/)).toBeInTheDocument();
 
-    // Verify explanatory text is rendered
     expect(
       screen.getByText(/This error is related to an ongoing issue/)
     ).toBeInTheDocument();

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
@@ -1,0 +1,69 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import type {TraceTreeNodeExtra} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {ErrorNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/errorNode';
+import {makeTraceError} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {ErrorNodeDetails} from './error';
+
+const createMockExtra = (
+  overrides: Partial<TraceTreeNodeExtra> = {}
+): TraceTreeNodeExtra => ({
+  organization: OrganizationFixture(),
+  ...overrides,
+});
+
+describe('ErrorNodeDetails', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders error details with title and ID', () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '1', slug: 'project_slug'});
+
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    const errorValue = makeTraceError({
+      event_id: 'test-error-id',
+      title: 'TypeError: Cannot read property of undefined',
+      level: 'error',
+      message: 'Something went wrong',
+    });
+
+    const extra = createMockExtra({organization});
+    const node = new ErrorNode(null, errorValue, extra);
+
+    render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <ErrorNodeDetails
+          node={node as any}
+          organization={organization}
+          onTabScrollToNode={jest.fn()}
+          onParentClick={jest.fn()}
+          manager={null}
+          replay={null}
+          traceId="test-trace-id"
+          tree={null as any}
+        />
+      </TraceStateProvider>
+    );
+
+    // Verify title is rendered
+    expect(screen.getByText('Error')).toBeInTheDocument();
+
+    // Verify error ID subtitle is rendered
+    expect(screen.getByText(/ID: test-error-id/)).toBeInTheDocument();
+
+    // Verify explanatory text is rendered
+    expect(
+      screen.getByText(/This error is related to an ongoing issue/)
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.spec.tsx
@@ -1,0 +1,110 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import type {TraceTreeNodeExtra} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {NoInstrumentationNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/noInstrumentationNode';
+import {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
+import {makeSpan} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {MissingInstrumentationNodeDetails} from './missingInstrumentation';
+
+const createMockExtra = (
+  overrides: Partial<TraceTreeNodeExtra> = {}
+): TraceTreeNodeExtra => ({
+  organization: OrganizationFixture(),
+  ...overrides,
+});
+
+describe('MissingInstrumentationNodeDetails', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders missing instrumentation details with title and subtitle', () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '1', slug: 'project_slug'});
+
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    const extra = createMockExtra({organization});
+
+    // Create previous and next span nodes
+    const previousSpanValue = makeSpan({
+      span_id: 'previous-span-id',
+      op: 'db.query',
+      description: 'SELECT * FROM users',
+      start_timestamp: 1000,
+      timestamp: 1001,
+    });
+    const previousNode = new SpanNode(null, previousSpanValue, extra);
+
+    const nextSpanValue = makeSpan({
+      span_id: 'next-span-id',
+      op: 'http.client',
+      description: 'GET /api/data',
+      start_timestamp: 1002,
+      timestamp: 1003,
+    });
+    const nextNode = new SpanNode(null, nextSpanValue, extra);
+
+    // Create the missing instrumentation span value
+    const missingInstrumentationValue = {
+      type: 'missing_instrumentation' as const,
+      start_timestamp: 1001,
+      timestamp: 1002,
+    };
+
+    const node = new NoInstrumentationNode(
+      previousNode,
+      nextNode,
+      null,
+      missingInstrumentationValue,
+      extra
+    );
+
+    // Mock the transaction API (used to fetch event transaction)
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/:/`,
+      method: 'GET',
+      body: null,
+    });
+
+    render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <MissingInstrumentationNodeDetails
+          node={node as any}
+          organization={organization}
+          onTabScrollToNode={jest.fn()}
+          onParentClick={jest.fn()}
+          manager={null}
+          replay={null}
+          traceId="test-trace-id"
+          tree={null as any}
+        />
+      </TraceStateProvider>
+    );
+
+    // Verify title is rendered
+    expect(screen.getByText('No Instrumentation')).toBeInTheDocument();
+
+    // Verify subtitle is rendered
+    expect(screen.getByText('How Awkward')).toBeInTheDocument();
+
+    // Verify explanatory text is rendered
+    expect(
+      screen.getByText(/It looks like there's more than 100ms unaccounted for/)
+    ).toBeInTheDocument();
+
+    // Verify settings note is rendered
+    expect(
+      screen.getByText(
+        "If you'd prefer, you can also turn the feature off in the settings above."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.spec.tsx
@@ -67,7 +67,6 @@ describe('MissingInstrumentationNodeDetails', () => {
       extra
     );
 
-    // Mock the transaction API (used to fetch event transaction)
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/:/`,
       method: 'GET',
@@ -89,18 +88,14 @@ describe('MissingInstrumentationNodeDetails', () => {
       </TraceStateProvider>
     );
 
-    // Verify title is rendered
     expect(screen.getByText('No Instrumentation')).toBeInTheDocument();
 
-    // Verify subtitle is rendered
     expect(screen.getByText('How Awkward')).toBeInTheDocument();
 
-    // Verify explanatory text is rendered
     expect(
       screen.getByText(/It looks like there's more than 100ms unaccounted for/)
     ).toBeInTheDocument();
 
-    // Verify settings note is rendered
     expect(
       screen.getByText(
         "If you'd prefer, you can also turn the feature off in the settings above."

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
@@ -1,0 +1,151 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import type {TraceTreeNodeExtra} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
+import {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
+import {
+  makeEAPSpan,
+  makeSpan,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {EAPSpanNodeDetails, SpanNodeDetails} from './index';
+
+const createMockExtra = (
+  overrides: Partial<TraceTreeNodeExtra> = {}
+): TraceTreeNodeExtra => ({
+  organization: OrganizationFixture(),
+  ...overrides,
+});
+
+describe('SpanNodeDetails', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders EAP span details with title, ID, op, and description', async () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '1', slug: 'project_slug'});
+
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    const spanValue = makeEAPSpan({
+      event_id: 'test-span-id',
+      op: 'db.query',
+      description: 'SELECT * FROM users',
+      project_id: 1,
+      project_slug: 'project_slug',
+    });
+
+    const extra = createMockExtra({organization});
+    const node = new EapSpanNode(null, spanValue, extra);
+
+    // Mock the trace item details API
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${spanValue.event_id}/`,
+      method: 'GET',
+      body: {
+        itemId: spanValue.event_id,
+        timestamp: new Date().toISOString(),
+        attributes: [],
+        meta: {},
+      },
+    });
+
+    // Mock the transaction API (returns undefined for non-transaction spans)
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+    });
+
+    // Mock the avg span duration query
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+    });
+
+    // Mock logs query
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/logs/`,
+      method: 'GET',
+      body: {data: []},
+    });
+
+    render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <EAPSpanNodeDetails
+          node={node as any}
+          organization={organization}
+          onTabScrollToNode={jest.fn()}
+          onParentClick={jest.fn()}
+          manager={null}
+          replay={null}
+          traceId="test-trace-id"
+          tree={null as any}
+        />
+      </TraceStateProvider>
+    );
+
+    // Verify title is rendered
+    expect(await screen.findByText('Span')).toBeInTheDocument();
+
+    // Verify span ID subtitle is rendered
+    expect(screen.getByText(/ID: test-span-id/)).toBeInTheDocument();
+
+    // Verify op is rendered
+    expect(screen.getByText('db.query')).toBeInTheDocument();
+
+    // Verify description is rendered
+    expect(screen.getByText(/SELECT \* FROM users/)).toBeInTheDocument();
+  });
+
+  it('renders non-EAP span details with title, ID, op, and description', () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '1', slug: 'project_slug'});
+
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    const spanValue = makeSpan({
+      span_id: 'legacy-span-id',
+      op: 'http.client',
+      description: 'GET /api/users',
+    });
+
+    const extra = createMockExtra({organization});
+    const node = new SpanNode(null, spanValue, extra);
+
+    render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <SpanNodeDetails
+          node={node as any}
+          organization={organization}
+          onTabScrollToNode={jest.fn()}
+          onParentClick={jest.fn()}
+          manager={null}
+          replay={null}
+          traceId="test-trace-id"
+          tree={null as any}
+        />
+      </TraceStateProvider>
+    );
+
+    // Verify title is rendered
+    expect(screen.getByText('Span')).toBeInTheDocument();
+
+    // Verify span ID subtitle is rendered
+    expect(screen.getByText(/ID: legacy-span-id/)).toBeInTheDocument();
+
+    // Verify op is rendered (may appear multiple times)
+    expect(screen.getAllByText('http.client').length).toBeGreaterThan(0);
+
+    // Verify description is rendered (may appear multiple times)
+    expect(screen.getAllByText(/GET \/api\/users/).length).toBeGreaterThan(0);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
@@ -45,7 +45,6 @@ describe('SpanNodeDetails', () => {
     const extra = createMockExtra({organization});
     const node = new EapSpanNode(null, spanValue, extra);
 
-    // Mock the trace item details API
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/trace-items/${spanValue.event_id}/`,
       method: 'GET',
@@ -57,21 +56,18 @@ describe('SpanNodeDetails', () => {
       },
     });
 
-    // Mock the transaction API (returns undefined for non-transaction spans)
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
       body: {data: []},
     });
 
-    // Mock the avg span duration query
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
       body: {data: []},
     });
 
-    // Mock logs query
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/logs/`,
       method: 'GET',
@@ -93,16 +89,12 @@ describe('SpanNodeDetails', () => {
       </TraceStateProvider>
     );
 
-    // Verify title is rendered
     expect(await screen.findByText('Span')).toBeInTheDocument();
 
-    // Verify span ID subtitle is rendered
     expect(screen.getByText(/ID: test-span-id/)).toBeInTheDocument();
 
-    // Verify op is rendered
     expect(screen.getByText('db.query')).toBeInTheDocument();
 
-    // Verify description is rendered
     expect(screen.getByText(/SELECT \* FROM users/)).toBeInTheDocument();
   });
 
@@ -136,16 +128,12 @@ describe('SpanNodeDetails', () => {
       </TraceStateProvider>
     );
 
-    // Verify title is rendered
     expect(screen.getByText('Span')).toBeInTheDocument();
 
-    // Verify span ID subtitle is rendered
     expect(screen.getByText(/ID: legacy-span-id/)).toBeInTheDocument();
 
-    // Verify op is rendered (may appear multiple times)
     expect(screen.getAllByText('http.client').length).toBeGreaterThan(0);
 
-    // Verify description is rendered (may appear multiple times)
     expect(screen.getAllByText(/GET \/api\/users/).length).toBeGreaterThan(0);
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
@@ -63,12 +63,6 @@ describe('SpanNodeDetails', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: []},
-    });
-
-    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/logs/`,
       method: 'GET',
       body: {data: []},

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.spec.tsx
@@ -1,0 +1,98 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import type {TraceTreeNodeExtra} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {TransactionNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode';
+import {
+  makeEventTransaction,
+  makeTransaction,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {TransactionNodeDetails} from './index';
+
+const createMockExtra = (
+  overrides: Partial<TraceTreeNodeExtra> = {}
+): TraceTreeNodeExtra => ({
+  organization: OrganizationFixture(),
+  ...overrides,
+});
+
+describe('TransactionNodeDetails', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders transaction details with title, ID, and op', async () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '1', slug: 'project-slug'});
+
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    const transactionValue = makeTransaction({
+      event_id: 'test-transaction-id',
+      'transaction.op': 'http.server',
+      transaction: 'GET /api/users',
+      project_slug: 'project-slug',
+      start_timestamp: 1000,
+      timestamp: 1001,
+    });
+
+    const extra = createMockExtra({organization});
+    const node = new TransactionNode(null, transactionValue, extra);
+
+    // Mock the transaction event API
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/${project.slug}:${transactionValue.event_id}/`,
+      method: 'GET',
+      body: makeEventTransaction({
+        eventID: transactionValue.event_id,
+        projectSlug: project.slug,
+        title: 'GET /api/users',
+        contexts: {
+          trace: {
+            op: 'http.server',
+          },
+        },
+      }),
+    });
+
+    // Mock the spans query for cache metrics
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+    });
+
+    render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <TransactionNodeDetails
+          node={node as any}
+          organization={organization}
+          onTabScrollToNode={jest.fn()}
+          onParentClick={jest.fn()}
+          manager={null}
+          replay={null}
+          traceId="test-trace-id"
+          tree={null as any}
+        />
+      </TraceStateProvider>
+    );
+
+    // Verify title is rendered
+    expect(await screen.findByText('Transaction')).toBeInTheDocument();
+
+    // Verify transaction ID subtitle is rendered
+    expect(screen.getByText(/ID: test-transaction-id/)).toBeInTheDocument();
+
+    // Verify op is rendered (may appear multiple times)
+    expect(screen.getAllByText('http.server').length).toBeGreaterThan(0);
+
+    // Verify transaction name is rendered (may appear multiple times)
+    expect(screen.getAllByText(/GET \/api\/users/).length).toBeGreaterThan(0);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.spec.tsx
@@ -61,7 +61,6 @@ describe('TransactionNodeDetails', () => {
       }),
     });
 
-    // Mock the spans query for cache metrics
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
@@ -83,16 +82,12 @@ describe('TransactionNodeDetails', () => {
       </TraceStateProvider>
     );
 
-    // Verify title is rendered
     expect(await screen.findByText('Transaction')).toBeInTheDocument();
 
-    // Verify transaction ID subtitle is rendered
     expect(screen.getByText(/ID: test-transaction-id/)).toBeInTheDocument();
 
-    // Verify op is rendered (may appear multiple times)
     expect(screen.getAllByText('http.server').length).toBeGreaterThan(0);
 
-    // Verify transaction name is rendered (may appear multiple times)
     expect(screen.getAllByText(/GET \/api\/users/).length).toBeGreaterThan(0);
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/index.spec.tsx
@@ -1,0 +1,77 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import type {TraceTreeNodeExtra} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {UptimeCheckNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode';
+import {makeUptimeCheck} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {UptimeNodeDetails} from './index';
+
+const createMockExtra = (
+  overrides: Partial<TraceTreeNodeExtra> = {}
+): TraceTreeNodeExtra => ({
+  organization: OrganizationFixture(),
+  ...overrides,
+});
+
+describe('UptimeNodeDetails', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders uptime check details with title and check ID', async () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({id: '1', slug: 'project_slug'});
+
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    const uptimeCheckValue = makeUptimeCheck({
+      event_id: 'test-uptime-check-id',
+      name: 'GET https://example.com',
+      description: 'Uptime check for example.com',
+      project_id: 1,
+      project_slug: 'project_slug',
+    });
+
+    const extra = createMockExtra({organization});
+    const node = new UptimeCheckNode(null, uptimeCheckValue, extra);
+
+    // Mock the trace item details API
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${uptimeCheckValue.event_id}/`,
+      method: 'GET',
+      body: {
+        itemId: uptimeCheckValue.event_id,
+        timestamp: new Date().toISOString(),
+        attributes: [],
+        meta: {},
+      },
+    });
+
+    render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <UptimeNodeDetails
+          node={node as any}
+          organization={organization}
+          onTabScrollToNode={jest.fn()}
+          onParentClick={jest.fn()}
+          manager={null}
+          replay={null}
+          traceId="test-trace-id"
+          tree={null as any}
+        />
+      </TraceStateProvider>
+    );
+
+    // Verify title is rendered
+    expect(await screen.findByText('Uptime Check Request')).toBeInTheDocument();
+
+    // Verify check ID subtitle is rendered
+    expect(screen.getByText(/Check ID: test-uptime-check-id/)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/index.spec.tsx
@@ -41,7 +41,6 @@ describe('UptimeNodeDetails', () => {
     const extra = createMockExtra({organization});
     const node = new UptimeCheckNode(null, uptimeCheckValue, extra);
 
-    // Mock the trace item details API
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/trace-items/${uptimeCheckValue.event_id}/`,
       method: 'GET',


### PR DESCRIPTION
- We do have tests for the drawer component loading in [trace.spec.tsx](https://github.com/getsentry/sentry/blob/master/static/app/views/performance/newTraceDetails/trace.spec.tsx#L1354-L1391)

- Added some tests for checking that the **_CONTENT_** in the drawer loads