### PR TITLE
feat(uptime): Add `cURL` example to http snippet

### DIFF
--- a/static/app/views/alerts/rules/uptime/httpSnippet.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/httpSnippet.spec.tsx
@@ -1,6 +1,6 @@
 import {generateSentryTraceHeader} from '@sentry/core';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {HTTPSnippet} from './httpSnippet';
 
@@ -10,7 +10,7 @@ jest.mock('@sentry/core', () => ({
 }));
 
 describe('HTTPSnippet', () => {
-  it('renders', () => {
+  it('renders HTTP Request tab by default', () => {
     render(
       <HTTPSnippet
         url="https://example.com/test?query=value"
@@ -27,6 +27,10 @@ describe('HTTPSnippet', () => {
       false
     );
 
+    // Check that both tabs are present
+    expect(screen.getByRole('button', {name: 'HTTP Request'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'cURL Example'})).toBeInTheDocument();
+
     const expected = [
       'POST /test?query=value HTTP/1.1',
       'Host: example.com',
@@ -38,9 +42,48 @@ describe('HTTPSnippet', () => {
       `{"key": "value"}`,
     ].join('\r\n');
 
-    const codeElem = screen.getByText('POST /test?query=value HTTP/1.1', {exact: false});
+    const codeElem = screen.getByText(/POST \/test\?query=value HTTP\/1\.1/);
 
     // Using toHaveTextContent would be nice here, but it loses the newlines.
     expect(codeElem.innerHTML).toBe(expected);
+  });
+
+  it('renders cURL command when cURL tab is clicked', async () => {
+    render(
+      <HTTPSnippet
+        url="https://example.com/test?query=value"
+        method="POST"
+        body='{"key": "value"}'
+        headers={[['X-Something', 'Header Value']]}
+        traceSampling={false}
+      />
+    );
+
+    // Click on cURL tab
+    await userEvent.click(screen.getByRole('button', {name: 'cURL Example'}));
+
+    // Check that cURL command is rendered
+    expect(screen.getByText(/curl -X POST/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/https:\/\/example\.com\/test\?query=value/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders cURL command without body for GET request', async () => {
+    render(
+      <HTTPSnippet
+        url="https://example.com/test"
+        method="GET"
+        body={null}
+        headers={[]}
+        traceSampling
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'cURL Example'}));
+
+    expect(screen.getByText(/curl -X GET/)).toBeInTheDocument();
+    // Should not have -d flag for GET requests without body
+    expect(screen.queryByText(/-d/)).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/uptime/httpSnippet.tsx
+++ b/static/app/views/alerts/rules/uptime/httpSnippet.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {generateSentryTraceHeader} from '@sentry/core';
 
@@ -15,6 +15,8 @@ interface Props {
 }
 
 export function HTTPSnippet({body, headers, method, url, traceSampling}: Props) {
+  const [selectedTab, setSelectedTab] = useState('http');
+
   const exampleTrace = useMemo(
     () =>
       generateSentryTraceHeader(undefined, undefined, traceSampling ? undefined : false),
@@ -32,27 +34,45 @@ export function HTTPSnippet({body, headers, method, url, traceSampling}: Props) 
     : urlObject.pathname;
 
   const appendedBody = body ? `\r\n${body}` : '';
-  const additionaLheaders = [
+  const additionaLheaders: Array<[string, string]> = [
     ...headers,
     [
       'User-Agent',
       'SentryUptimeBot/1.0 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)',
     ],
-    ['Sentry-Trace', exampleTrace],
   ];
 
-  if (appendedBody !== '') {
+  if (exampleTrace) {
+    additionaLheaders.push(['Sentry-Trace', exampleTrace]);
+  }
+
+  if (appendedBody) {
     additionaLheaders.push(['Content-Size', new Blob([appendedBody]).size.toString()]);
   }
 
   const joinedHeaders =
     additionaLheaders.map(([key, value]) => `${key}: ${value}`).join('\r\n') + '\r\n';
 
-  const request = `${method} ${pathname} HTTP/1.1\r\nHost: ${urlObject.host}\r\n${joinedHeaders}${appendedBody}`;
+  const httpRequest = `${method} ${pathname} HTTP/1.1\r\nHost: ${urlObject.host}\r\n${joinedHeaders}${appendedBody}`;
+
+  const headerArgs = additionaLheaders
+    .map(([key, value]) => `-H "${key}: ${value.replace(/"/g, '\\"')}"`)
+    .join(' \\\n  ');
+
+  const bodyArg = body ? ` \\\n  -d '${body.replace(/'/g, "'\\''")}'` : '';
+  const curlCommand = `curl -X ${method} \\\n  ${headerArgs}${bodyArg} \\\n  "${url}"`;
 
   return (
-    <MaxSizedSnippet filename={t('Expected Check Request')} language="http">
-      {request}
+    <MaxSizedSnippet
+      language={selectedTab === 'http' ? 'http' : 'bash'}
+      tabs={[
+        {label: t('HTTP Request'), value: 'http'},
+        {label: t('cURL Example'), value: 'curl'},
+      ]}
+      selectedTab={selectedTab}
+      onTabClick={setSelectedTab}
+    >
+      {selectedTab === 'http' ? httpRequest : curlCommand}
     </MaxSizedSnippet>
   );
 }


### PR DESCRIPTION
Looks like this now

<img alt="clipboard.png" width="779" src="https://i.imgur.com/KSTmfe4.png" />