### PR TITLE
chore(releases): docs link for empty state

### DIFF
--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -4,7 +4,7 @@ import {PlatformIcon} from 'platformicons';
 
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Flex} from 'sentry/components/core/layout';
-import {Link} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -12,7 +12,7 @@ import Pagination from 'sentry/components/pagination';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCheckmark, IconCommit} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   formattedPrimaryMetricDownloadSize,
@@ -172,8 +172,14 @@ export function PreprodBuildsTable({
       <SimpleTable.Empty>
         <Text as="p">
           {hasSearchQuery
-            ? t('No builds found for your search')
-            : t('There are no preprod builds associated with this project.')}
+            ? t('No mobile builds found for your search')
+            : tct('No mobile builds found, see our [link:documentation] for more info.', {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/size-analysis/">
+                    {t('Learn more')}
+                  </ExternalLink>
+                ),
+              })}
         </Text>
       </SimpleTable.Empty>
     );

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -543,9 +543,7 @@ describe('ReleasesList', () => {
       },
     });
 
-    expect(
-      await screen.findByText('There are no preprod builds associated with this project.')
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/No mobile builds found/)).toBeInTheDocument();
 
     expect(buildsMock).toHaveBeenCalledWith(
       `/projects/${organization.slug}/${mobileProject.slug}/preprodartifacts/list-builds/`,


### PR DESCRIPTION
small add to empty state to show docs, will work on better empty state later
<img width="2956" height="1366" alt="CleanShot 2025-12-11 at 11 55 58@2x" src="https://github.com/user-attachments/assets/14e637d9-b41d-43df-81db-1d1dd22654e1" />

