### PR TITLE
feat(aci): Always redirect from alerts when clicking from notification

### DIFF
--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -154,12 +154,17 @@ export const withDetectorDetailsRedirect = <P extends Record<string, any>>(
     const {ruleId, detectorId} = useParams();
     const location = useLocation();
     const alertId = location.query.alert as string | undefined;
+    const notificationUuid = location.query.notification_uuid;
 
+    const hasWorkflowEngineUI = organization.features.includes('workflow-engine-ui');
     const hasRedirectOptOut = organization.features.includes(
       'workflow-engine-redirect-opt-out'
     );
     const shouldRedirect =
-      !hasRedirectOptOut && organization.features.includes('workflow-engine-ui');
+      (!hasRedirectOptOut ||
+        // When clicking from a notification, we never want to opt out of the redirect
+        !!notificationUuid) &&
+      hasWorkflowEngineUI;
 
     // Check for incident open period if alertId is present
     const {data: incidentGroupOpenPeriod, isPending: isOpenPeriodPending} =

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
 import {useNavContext} from 'sentry/views/nav/context';
@@ -73,13 +72,15 @@ export function IssuesSecondaryNav() {
 }
 
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
-  const user = useUser();
   const organization = useOrganization();
   const {layout} = useNavContext();
   const isSticky = layout === NavLayout.SIDEBAR;
 
+  const hasRedirectOptOut = organization.features.includes(
+    'workflow-engine-redirect-opt-out'
+  );
   const shouldRedirectToWorkflowEngineUI =
-    !user.isStaff && organization.features.includes('workflow-engine-ui');
+    !hasRedirectOptOut && organization.features.includes('workflow-engine-ui');
 
   const alertsLink = shouldRedirectToWorkflowEngineUI
     ? `${makeMonitorBasePathname(organization.slug)}?alertsRedirect=true`


### PR DESCRIPTION
We have an opt-out flag for redirects that we use to be able to test the old UI while we make the new one. This should not apply to notification links however. We still want those to direct to the new UI, so this adds a carve-out for that situation.