### PR TITLE
fix(eap): Cast OOB ints to str

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -42,6 +42,10 @@ def _encode_value(value: Any) -> AnyValue:
         # Note: bool check must come before int check since bool is a subclass of int
         return AnyValue(bool_value=value)
     elif isinstance(value, int):
+        # int_value is a signed int64, so it has a range of valid values.
+        # if value doesn't fit into an int64, cast it to string.
+        if abs(value) >= (2**63):
+            return AnyValue(string_value=str(value))
         return AnyValue(int_value=value)
     elif isinstance(value, float):
         return AnyValue(double_value=value)


### PR DESCRIPTION
We're seeing an error (https://sentry.sentry.io/issues/7087482631/) where we're trying to encode ints that are OOB of the `int64` max.

In this edge case, let's cast to `str`. (Better than dropping the data and fixes the problem for now. If it's a problem later we can look into it again.)
