### PR TITLE
fix(aci): Correct direction of resolution threshold

### DIFF
--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
@@ -255,7 +255,9 @@ export function useMetricDetectorThresholdSeries({
           markArea: createThresholdMarkArea(
             theme.green300,
             displayResolution,
-            resolution.type !== DataConditionType.GREATER
+            [DataConditionType.GREATER, DataConditionType.GREATER_OR_EQUAL].includes(
+              resolution.type
+            )
           ),
           data: [],
         };


### PR DESCRIPTION
This was only working for "above" resolution thresholds, and was not checking for both gte/gt