### PR TITLE
feat(billing): Add-on product trials in _admin

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -20,7 +20,7 @@ import {DataCategory} from 'sentry/types/core';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 import CustomerOverview from 'admin/components/customers/customerOverview';
-import {PlanTier, ReservedBudgetCategoryType} from 'getsentry/types';
+import {AddOnCategory, PlanTier} from 'getsentry/types';
 
 describe('CustomerOverview', () => {
   it('renders DetailLabels for SubscriptionSummary section', () => {
@@ -397,7 +397,7 @@ describe('CustomerOverview', () => {
 
   it('renders product trials based on current subscription state', () => {
     const organization = OrganizationFixture();
-    const am3_subscription = SubscriptionFixture({
+    const am3Subscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
       planTier: PlanTier.AM3,
@@ -432,10 +432,14 @@ describe('CustomerOverview', () => {
         },
       ],
     });
+    am3Subscription.addOns!.seer = {
+      ...am3Subscription.addOns!.seer!,
+      isAvailable: false,
+    };
 
     render(
       <CustomerOverview
-        customer={am3_subscription}
+        customer={am3Subscription}
         onAction={jest.fn()}
         organization={organization}
       />
@@ -462,11 +466,11 @@ describe('CustomerOverview', () => {
       DataCategory.PROFILE_DURATION,
       DataCategory.PROFILE_DURATION_UI,
       DataCategory.LOG_BYTE,
-      ReservedBudgetCategoryType.SEER,
+      AddOnCategory.LEGACY_SEER,
     ];
 
     const assertProductTrialActions = (
-      category: DataCategory | ReservedBudgetCategoryType,
+      category: DataCategory | AddOnCategory,
       formattedDisplayName: string,
       shouldNotIncludeTrialCategory = false
     ) => {
@@ -503,7 +507,7 @@ describe('CustomerOverview', () => {
           expect(startTrialButton).toBeDisabled();
           expect(stopTrialButton).toBeDisabled();
           expect(within(definition).getByText(/Active \(/)).toBeInTheDocument();
-        } else if (category === ReservedBudgetCategoryType.SEER) {
+        } else if (category === AddOnCategory.LEGACY_SEER) {
           expect(allowTrialButton).toBeEnabled();
           expect(startTrialButton).toBeDisabled();
           expect(stopTrialButton).toBeDisabled();
@@ -521,26 +525,25 @@ describe('CustomerOverview', () => {
       }
     };
 
-    am3_subscription.planDetails.categories.forEach(category => {
+    am3Subscription.planDetails.categories.forEach(category => {
       const formattedDisplayName = toTitleCase(
-        am3_subscription.planDetails.categoryDisplayNames?.[category]?.plural ?? category,
+        am3Subscription.planDetails.categoryDisplayNames?.[category]?.plural ?? category,
         {allowInnerUpperCase: true}
       );
       assertProductTrialActions(category, formattedDisplayName);
     });
-    Object.values(am3_subscription.planDetails.availableReservedBudgetTypes).forEach(
-      productGroup => {
-        const formattedDisplayName = toTitleCase(productGroup.productName, {
+    Object.values(am3Subscription.addOns || {}).forEach(addOn => {
+      const formattedDisplayName =
+        toTitleCase(addOn.productName, {
           allowInnerUpperCase: true,
-        });
-        assertProductTrialActions(productGroup.apiName, formattedDisplayName);
-      }
-    );
+        }) + (addOn.apiName === AddOnCategory.LEGACY_SEER ? ' (Legacy)' : '');
+      assertProductTrialActions(addOn.apiName, formattedDisplayName);
+    });
 
     possibleTrialCategories.forEach(category => {
       if (
-        !am3_subscription.planDetails.categories.includes(category as DataCategory) &&
-        !Object.keys(am3_subscription.planDetails.availableReservedBudgetTypes).includes(
+        !am3Subscription.planDetails.categories.includes(category as DataCategory) &&
+        !Object.keys(am3Subscription.planDetails.availableReservedBudgetTypes).includes(
           category
         )
       ) {
@@ -558,7 +561,7 @@ describe('CustomerOverview', () => {
       features: ['dynamic-sampling'],
       desiredSampleRate: 0.75,
     });
-    const am3_subscription = SubscriptionFixture({
+    const am3Subscription = SubscriptionFixture({
       organization,
       plan: 'am3_team',
       planTier: PlanTier.AM3,
@@ -571,7 +574,7 @@ describe('CustomerOverview', () => {
 
     render(
       <CustomerOverview
-        customer={am3_subscription}
+        customer={am3Subscription}
         onAction={jest.fn()}
         organization={organization}
       />

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -30,12 +30,13 @@ import type {
   ReservedBudgetMetricHistory,
   Subscription,
 } from 'getsentry/types';
-import {BillingType, OnDemandBudgetMode} from 'getsentry/types';
+import {AddOnCategory, BillingType, OnDemandBudgetMode} from 'getsentry/types';
 import {
   displayBudgetName,
   formatBalance,
   formatReservedWithUnits,
   getActiveProductTrial,
+  getBilledCategory,
   getProductTrial,
   RETENTION_SETTINGS_CATEGORIES,
 } from 'getsentry/utils/billing';
@@ -471,9 +472,11 @@ function CustomerOverview({customer, onAction, organization}: Props) {
       customer.planDetails?.categories.includes(categoryInfo.plural)
   );
 
-  const productTrialCategoryGroups = Object.values(
-    customer.planDetails?.availableReservedBudgetTypes || {}
-  ).filter(group => group.canProductTrial);
+  const productTrialAddOns = Object.values(customer.addOns || {}).filter(
+    // TODO(billing): Right now all our add-ons can use product trials, but in future we should distinguish this
+    // like we do for other product types
+    addOn => addOn.isAvailable
+  );
 
   const categoryHasUsedProductTrial = (category: DataCategory) => {
     const trial = getProductTrial(customer.productTrials ?? [], category);
@@ -757,7 +760,7 @@ function CustomerOverview({customer, onAction, organization}: Props) {
             </ExternalLink>
           </DetailLabel>
         </DetailList>
-        {productTrialCategories.length + productTrialCategoryGroups.length > 0 && (
+        {productTrialCategories.length + productTrialAddOns.length > 0 && (
           <Fragment>
             <h6>Product Trials</h6>
             <ProductTrialsDetailListContainer>
@@ -773,13 +776,15 @@ function CustomerOverview({customer, onAction, organization}: Props) {
                   categoryName
                 );
               })}
-              {productTrialCategoryGroups.map(group => {
-                const category = group.dataCategories[0]; // doesn't matter which category we use
+              {productTrialAddOns.map(addOn => {
+                const category = getBilledCategory(customer, addOn.apiName);
                 if (category) {
                   return getTrialManagementActions(
                     category,
-                    group.apiName,
-                    group.productName
+                    addOn.apiName,
+                    addOn.apiName === AddOnCategory.LEGACY_SEER
+                      ? addOn.productName + ' (Legacy)'
+                      : addOn.productName
                   );
                 }
                 return null;

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -210,7 +210,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.SEER_USER]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_USER],
     feature: 'seer-user-billing',
-    canProductTrial: true,
+    canProductTrial: false,
     maxAdminGift: 10_000, // TODO(seer): Update this to the actual max admin gift
     freeEventsMultiple: 1,
     tallyType: 'seat',


### PR DESCRIPTION
Updates _admin product trial actions to use `subscription.addOns` to determine what product trials to render. 