### PR TITLE
feat(autofix): Add backend check to disable autofix if repos are not connected [feature flagged]

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -165,6 +165,13 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 seer_repos_linked = has_project_connected_repos(org.id, group.project.id)
             except Exception:
                 # Default to True if the API call fails to avoid blocking users
+                logger.exception(
+                    "Error checking if project has Seer repos linked",
+                    extra={
+                        "org_id": org.id,
+                        "project_id": group.project.id,
+                    },
+                )
                 seer_repos_linked = True
 
         return Response(

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -162,9 +162,8 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 # Check if project has repos linked in Seer.
                 seer_repos_linked = has_project_connected_repos(org.id, group.project.id)
             except Exception as e:
-                # Default to True if the API call fails to avoid blocking users
+                # Default to False if we can't check if the project has repos linked in Seer.
                 sentry_sdk.capture_exception(e)
-                seer_repos_linked = True
 
         return Response(
             {

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -155,9 +155,11 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
             org_id=org.id, data_category=DataCategory.SEER_AUTOFIX
         )
 
-        seer_repos_linked = None
-        if is_seer_seat_based_tier_enabled(org):
+        seer_repos_linked = False
+        # Check if org has github integration and is on seat-based tier.
+        if integration_check is None and is_seer_seat_based_tier_enabled(org):
             try:
+                # Check if project has repos linked in Seer.
                 seer_repos_linked = has_project_connected_repos(org.id, group.project.id)
             except Exception as e:
                 # Default to True if the API call fails to avoid blocking users

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -287,9 +287,9 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         "sentry.seer.endpoints.group_autofix_setup_check.has_project_connected_repos",
         side_effect=Exception("API error"),
     )
-    def test_seer_repos_linked_defaults_to_true_on_error(self, mock_has_repos: MagicMock) -> None:
+    def test_seer_repos_linked_defaults_to_false_on_error(self, mock_has_repos: MagicMock) -> None:
         """
-        Test that seerReposLinked defaults to True when the API call fails.
+        Test that seerReposLinked defaults to False when the API call fails.
         """
         self._set_seat_based_tier_cache(True)
         # Don't set project repos cache - let the actual function run and raise an exception
@@ -300,7 +300,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
-        assert response.data["seerReposLinked"] is True
+        assert response.data["seerReposLinked"] is False
 
     def test_seer_repos_linked_is_false_when_feature_disabled(self) -> None:
         """

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -302,9 +302,9 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["seerReposLinked"] is True
 
-    def test_seer_repos_linked_is_none_when_feature_disabled(self) -> None:
+    def test_seer_repos_linked_is_false_when_feature_disabled(self) -> None:
         """
-        Test that seerReposLinked is None when seat-based tier is not enabled.
+        Test that seerReposLinked is False when seat-based tier is not enabled.
         """
         self._set_seat_based_tier_cache(False)
 
@@ -314,7 +314,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
-        assert response.data["seerReposLinked"] is None
+        assert response.data["seerReposLinked"] is False
 
 
 class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
@@ -343,6 +343,8 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
             "ok": False,
             "reason": "integration_missing",
         }
+        # seerReposLinked should be False when integration is missing
+        assert response.data["seerReposLinked"] is False
 
     @patch(
         "sentry.seer.endpoints.group_autofix_setup_check.get_repos_and_access",


### PR DESCRIPTION
## PR Details
+ Adds new seer_repos_linked boolean field to the /issues/{group_id}/autofix/setup/ endpoint response
+ When seat-based Seer tier is enabled, checks if repos are linked via get_project_seer_preferences. Returns false when no repos are linked, true otherwise. Defaults to False to enforce check if we fail the call.
+ Frontend can use this to disable the "Start Root Cause Analysis" button when repos aren't configured. Will make a PR for that next.
+ If the github integration itself doesn't exist then we don't even check for linked repos. 
