### PR TITLE
acceptance: bump runners to 10

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -57,11 +57,11 @@ jobs:
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
       fail-fast: false
       matrix:
-        # XXX: Use 5 runners when backend changes are present, 12 runners for frontend-only changes
-        instance: ${{ needs.files-changed.outputs.backend_all == 'true' && fromJSON('[0, 1, 2, 3, 4]') || fromJSON('[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]') }}
+        # XXX: Use 5 runners when backend changes are present, 10 runners for frontend-only changes
+        instance: ${{ needs.files-changed.outputs.backend_all == 'true' && fromJSON('[0, 1, 2, 3, 4]') || fromJSON('[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]') }}
     env:
-      # XXX: MATRIX_INSTANCE_TOTAL must match the matrix size (5 for backend changes, 12 for frontend-only)
-      MATRIX_INSTANCE_TOTAL: ${{ needs.files-changed.outputs.backend_all == 'true' && '5' || '12' }}
+      # XXX: MATRIX_INSTANCE_TOTAL must match the matrix size (5 for backend changes, 10 for frontend-only)
+      MATRIX_INSTANCE_TOTAL: ${{ needs.files-changed.outputs.backend_all == 'true' && '5' || '10' }}
       TEST_GROUP_STRATEGY: roundrobin
 
     steps:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -57,11 +57,11 @@ jobs:
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
       fail-fast: false
       matrix:
-        # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
-        instance: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        # XXX: Use 5 runners when backend changes are present, 12 runners for frontend-only changes
+        instance: ${{ needs.files-changed.outputs.backend_all == 'true' && fromJSON('[0, 1, 2, 3, 4]') || fromJSON('[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]') }}
     env:
-      # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-      MATRIX_INSTANCE_TOTAL: 12
+      # XXX: MATRIX_INSTANCE_TOTAL must match the matrix size (5 for backend changes, 12 for frontend-only)
+      MATRIX_INSTANCE_TOTAL: ${{ needs.files-changed.outputs.backend_all == 'true' && '5' || '12' }}
       TEST_GROUP_STRATEGY: roundrobin
 
     steps:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -58,10 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
-        instance: [0, 1, 2, 3, 4]
+        instance: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-      MATRIX_INSTANCE_TOTAL: 5
+      MATRIX_INSTANCE_TOTAL: 12
       TEST_GROUP_STRATEGY: roundrobin
 
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -84,7 +84,7 @@ flags:
     # Do not send any status checks until n coverage reports are uploaded.
     # NOTE: If you change this, make sure to change `comment.after_n_builds` below as well.
     # this should match MATRIX_INSTANCE_TOTAL in accpetance.yml
-    after_n_builds: 5
+    after_n_builds: 12
 
 # https://docs.codecov.com/docs/flags#two-approaches-to-flag-management
 flag_management:

--- a/codecov.yml
+++ b/codecov.yml
@@ -83,8 +83,8 @@ flags:
     carryforward: true
     # Do not send any status checks until n coverage reports are uploaded.
     # NOTE: If you change this, make sure to change `comment.after_n_builds` below as well.
-    # this should match MATRIX_INSTANCE_TOTAL in accpetance.yml
-    after_n_builds: 12
+    # this should match MATRIX_INSTANCE_TOTAL in accpetance.yml when backend_all == true
+    after_n_builds: 5
 
 # https://docs.codecov.com/docs/flags#two-approaches-to-flag-management
 flag_management:


### PR DESCRIPTION
Rationale:
Acceptance tests are a bottleneck for frontend only PRs where backend tests are not required. Each runner takes about 2.5min of setup time, so there are diminishing returns past a certain point. With the following changes, we should bring acceptance tests into the ballpark of 7min, which is close to our jest test suite.