### PR TITLE
feat(search-bar): Add fuzzy search option

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4290,7 +4290,7 @@ describe('SearchQueryBuilder', () => {
       await userEvent.type(screen.getByRole('textbox'), 'random value');
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getAllByText('span.description')[2]!
+        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
       );
 
       expect(
@@ -4351,7 +4351,7 @@ describe('SearchQueryBuilder', () => {
         await userEvent.type(screen.getByRole('textbox'), 'random value');
 
         await userEvent.click(
-          within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
+          within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
         );
 
         expect(
@@ -4373,7 +4373,7 @@ describe('SearchQueryBuilder', () => {
         await userEvent.type(screen.getByRole('textbox'), 'random value');
 
         await userEvent.click(
-          within(screen.getByRole('listbox')).getAllByText('span.description')[0]!
+          within(screen.getByRole('listbox')).getAllByText('span.description')[2]!
         );
 
         expect(

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4290,7 +4290,7 @@ describe('SearchQueryBuilder', () => {
       await userEvent.type(screen.getByRole('textbox'), 'random value');
 
       await userEvent.click(
-        within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
+        within(screen.getByRole('listbox')).getAllByText('span.description')[2]!
       );
 
       expect(
@@ -4339,7 +4339,29 @@ describe('SearchQueryBuilder', () => {
         ).toBeInTheDocument();
       });
 
-      it('should replace raw search keys with defined key:contains:"value space', async () => {
+      it('should replace raw search keys with defined key:contains:"value space"', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />
+        );
+
+        await userEvent.type(screen.getByRole('textbox'), 'random value');
+
+        await userEvent.click(
+          within(screen.getByRole('listbox')).getAllByText('span.description')[1]!
+        );
+
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}"random value"`,
+          })
+        ).toBeInTheDocument();
+      });
+
+      it('should replace raw search keys with fuzzy search', async () => {
         render(
           <SearchQueryBuilder
             {...defaultProps}
@@ -4356,7 +4378,7 @@ describe('SearchQueryBuilder', () => {
 
         expect(
           screen.getByRole('row', {
-            name: `span.description:${WildcardOperators.CONTAINS}"random value"`,
+            name: `span.description:*random*value*`,
           })
         ).toBeInTheDocument();
       });

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -191,6 +191,29 @@ export function createRawSearchFilterContainsValueItem(
   };
 }
 
+export function createRawSearchFuzzyFilterItem(
+  key: string,
+  value: string
+): RawSearchFilterIsValueItem {
+  const formattedValue = escapeFilterValue(value)
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replaceAll(' ', '*');
+
+  const filter = `${key}:*${formattedValue}*`;
+
+  return {
+    key: getEscapedKey(filter),
+    label: <FormattedQuery query={filter} />,
+    value: filter,
+    textValue: filter,
+    hideCheck: true,
+    showDetailsInOverlay: true,
+    details: null,
+    type: 'raw-search-filter-is-value',
+  };
+}
+
 export function createRecentFilterItem({filter}: {filter: TokenResult<Token.FILTER>}) {
   const key = getKeyName(filter.key);
   return {

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -287,11 +287,11 @@ export function useSortedFilterKeyItems({
             : inputValue;
 
           return [
+            createRawSearchFilterContainsValueItem(key, value),
+            createRawSearchFilterIsValueItem(key, value),
             ...(/\w \w/.test(inputValue)
               ? [createRawSearchFuzzyFilterItem(key, inputValue)]
               : []),
-            createRawSearchFilterContainsValueItem(key, value),
-            createRawSearchFilterIsValueItem(key, value),
           ];
         }) ?? [];
 

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -14,6 +14,7 @@ import {
   createLogicFilterItem,
   createRawSearchFilterContainsValueItem,
   createRawSearchFilterIsValueItem,
+  createRawSearchFuzzyFilterItem,
   createRawSearchItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
 import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
@@ -286,6 +287,9 @@ export function useSortedFilterKeyItems({
             : inputValue;
 
           return [
+            ...(/\w \w/.test(inputValue)
+              ? [createRawSearchFuzzyFilterItem(key, inputValue)]
+              : []),
             createRawSearchFilterContainsValueItem(key, value),
             createRawSearchFilterIsValueItem(key, value),
           ];


### PR DESCRIPTION
This PR adds in a fuzzy search option as part of the raw search replace functionality:

(Note: the fuzzy search option has been moved to be last in the list)
<img width="342" height="173" alt="Screenshot 2025-12-11 at 12 39 44" src="https://github.com/user-attachments/assets/8dc1b0cf-9852-493e-bba8-90c91ed00e9e" />
