### PR TITLE
fix(seer settings): Fallback to code mappings if seer preferences don't exist

### DIFF
--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -166,7 +166,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     preferences_to_set = []
     projects_by_id = {p.id: p for p in projects}
     for project_id in project_ids:
-        existing_pref = preferences_by_id.get(str(project_id), {})
+        existing_pref = preferences_by_id[str(project_id)] or {}
 
         # Skip projects that already have an acceptable stopping point configured
         if existing_pref.get("automated_run_stopping_point") in ("open_pr", "code_changes"):

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -166,7 +166,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     preferences_to_set = []
     projects_by_id = {p.id: p for p in projects}
     for project_id in project_ids:
-        existing_pref = preferences_by_id[str(project_id)]
+        existing_pref = preferences_by_id.get(str(project_id))
         if not existing_pref:
             # No existing preferences, get repositories from code mappings
             repositories = get_autofix_repos_from_project_code_mappings(projects_by_id[project_id])
@@ -174,7 +174,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
             # Skip projects that already have an acceptable stopping point configured
             if existing_pref.get("automated_run_stopping_point") in ("open_pr", "code_changes"):
                 continue
-            repositories = existing_pref.get("repositories")
+            repositories = existing_pref.get("repositories") or []
 
         # Preserve existing repositories and automation_handoff, only update the stopping point
         preferences_to_set.append(

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -156,7 +156,6 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     # If seer is enabled for an org, every project must have project level settings
     for project in projects:
         project.update_option("sentry:seer_scanner_automation", True)
-        # New automation default for the new pricing is medium.
         project.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
         )
@@ -176,9 +175,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
         # Preserve existing repositories if set, otherwise fall back to code mappings
         repositories = existing_pref.get("repositories")
         if not repositories:
-            project = projects_by_id.get(project_id)
-            if project:
-                repositories = get_autofix_repos_from_project_code_mappings(project)
+            repositories = get_autofix_repos_from_project_code_mappings(projects_by_id[project_id])
 
         # Preserve existing repositories and automation_handoff, only update the stopping point
         preferences_to_set.append(


### PR DESCRIPTION
## PR Details
+ The migration function will use code mappings now as a fallback if seer preferences don't exist for a project. 
+ Also small change to use ObjectStatus.ACTIVE to get active projects. 
