### PR TITLE
fix(aci): set action config values to `null` instead of `''` or undefined

### DIFF
--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -20,10 +20,10 @@ export interface TicketCreationAction extends Action {
 }
 
 export interface ActionConfig {
+  targetDisplay: string | null;
+  targetIdentifier: string | null;
   targetType: ActionTarget | null;
   sentryAppIdentifier?: SentryAppIdentifier;
-  targetDisplay?: string;
-  targetIdentifier?: string;
 }
 
 export enum ActionTarget {

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -75,7 +75,7 @@ function TargetIdentifierField() {
     <AutomationBuilderInput
       name={`${actionId}.config.targetIdentifier`}
       placeholder={t('channel ID or URL')}
-      value={action.config.targetIdentifier}
+      value={action.config.targetIdentifier ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
           config: {...action.config, targetIdentifier: e.target.value},

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -489,12 +489,12 @@ function getDefaultConfig(actionHandler: ActionHandler): ActionConfig {
     actionHandler.sentryApp?.id ??
     actionHandler.integrations?.[0]?.services?.[0]?.id ??
     actionHandler.services?.[0]?.slug ??
-    '';
+    null;
   const targetDisplay =
     actionHandler.sentryApp?.name ??
     actionHandler.integrations?.[0]?.services?.[0]?.name ??
     actionHandler.services?.[0]?.name ??
-    '';
+    null;
 
   return {
     targetType,

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -50,11 +50,10 @@ export const stripActionFields = (action: Action) => {
   const {id: _id, ...actionWithoutId} = action;
 
   // Strip targetDisplay from email action config
-  if (action.type === ActionType.EMAIL && action.config) {
-    const {targetDisplay: _targetDisplay, ...configWithoutTargetDisplay} = action.config;
+  if ([ActionType.EMAIL, ActionType.WEBHOOK].includes(action.type) && action.config) {
     return {
       ...actionWithoutId,
-      config: configWithoutTargetDisplay,
+      config: {...action.config, targetDisplay: null},
     };
   }
 

--- a/static/app/views/automations/components/forms/automationNameUtils.spec.tsx
+++ b/static/app/views/automations/components/forms/automationNameUtils.spec.tsx
@@ -17,6 +17,8 @@ describe('automationNameUtils', () => {
         type: ActionType.EMAIL,
         config: {
           targetType: ActionTarget.ISSUE_OWNERS,
+          targetDisplay: null,
+          targetIdentifier: null,
         },
       });
 
@@ -29,6 +31,7 @@ describe('automationNameUtils', () => {
         config: {
           targetType: ActionTarget.TEAM,
           targetDisplay: 'backend',
+          targetIdentifier: 'team-123',
         },
       });
 
@@ -41,6 +44,7 @@ describe('automationNameUtils', () => {
         config: {
           targetType: ActionTarget.USER,
           targetDisplay: 'john@example.com',
+          targetIdentifier: 'user-456',
         },
       });
 
@@ -53,6 +57,7 @@ describe('automationNameUtils', () => {
         config: {
           targetType: ActionTarget.SENTRY_APP,
           targetDisplay: 'My App',
+          targetIdentifier: 'app-789',
         },
       });
 
@@ -65,6 +70,7 @@ describe('automationNameUtils', () => {
         config: {
           targetType: null,
           targetDisplay: 'Custom Webhook',
+          targetIdentifier: 'webhook-123',
         },
       });
 
@@ -90,6 +96,7 @@ describe('automationNameUtils', () => {
           config: {
             targetType: ActionTarget.TEAM,
             targetDisplay: 'backend',
+            targetIdentifier: 'team-123',
           },
         }),
       ];
@@ -105,6 +112,7 @@ describe('automationNameUtils', () => {
           config: {
             targetType: ActionTarget.TEAM,
             targetDisplay: 'backend',
+            targetIdentifier: 'team-123',
           },
         }),
         ActionFixture({
@@ -112,6 +120,7 @@ describe('automationNameUtils', () => {
           config: {
             targetType: ActionTarget.SENTRY_APP,
             targetDisplay: 'Slack',
+            targetIdentifier: 'app-789',
           },
         }),
       ];
@@ -129,6 +138,7 @@ describe('automationNameUtils', () => {
           config: {
             targetType: ActionTarget.TEAM,
             targetDisplay: 'team',
+            targetIdentifier: 'team-123',
           },
         })
       );
@@ -147,6 +157,7 @@ describe('automationNameUtils', () => {
         config: {
           targetType: ActionTarget.USER,
           targetDisplay: longDescription,
+          targetIdentifier: 'user-456',
         },
       });
       const actions = new Array(5).fill(action);
@@ -165,6 +176,7 @@ describe('automationNameUtils', () => {
           config: {
             targetType: ActionTarget.USER,
             targetDisplay: veryLongDescription,
+            targetIdentifier: 'user-456',
           },
         }),
         ActionFixture({
@@ -172,6 +184,7 @@ describe('automationNameUtils', () => {
           config: {
             targetType: ActionTarget.USER,
             targetDisplay: veryLongDescription,
+            targetIdentifier: 'user-789',
           },
         }),
       ];
@@ -189,6 +202,7 @@ describe('automationNameUtils', () => {
           config: {
             targetType: ActionTarget.TEAM,
             targetDisplay: 'team',
+            targetIdentifier: 'team-123',
           },
         })
       );
@@ -211,6 +225,7 @@ describe('automationNameUtils', () => {
                 config: {
                   targetType: ActionTarget.TEAM,
                   targetDisplay: 'backend',
+                  targetIdentifier: 'team-123',
                 },
               }),
             ],
@@ -222,6 +237,7 @@ describe('automationNameUtils', () => {
                 config: {
                   targetType: ActionTarget.SENTRY_APP,
                   targetDisplay: 'Slack',
+                  targetIdentifier: 'app-789',
                 },
               }),
             ],

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -179,7 +179,7 @@ describe('AutomationNewSettings', () => {
                     type: 'slack',
                     config: {
                       targetType: 'specific',
-                      targetIdentifier: '',
+                      targetIdentifier: null,
                       targetDisplay: '#alerts',
                     },
                     integrationId: '1',
@@ -191,6 +191,7 @@ describe('AutomationNewSettings', () => {
                     config: {
                       targetType: 'user',
                       targetIdentifier: '1',
+                      targetDisplay: null,
                     },
                     data: {},
                     status: 'active',

--- a/tests/js/fixtures/automations.ts
+++ b/tests/js/fixtures/automations.ts
@@ -65,6 +65,7 @@ export function ActionFixture(params: Partial<Action> = {}): Action {
     config: {
       targetType: ActionTarget.SPECIFIC,
       targetIdentifier: 'C123456',
+      targetDisplay: null,
     },
     integrationId: 'integration-1',
     data: {},


### PR DESCRIPTION
The Action validators were failing because the Action configs expect `null` for nonexistent values, not `''`.

Additionally, when stripping Actions of their `targetDisplay`, we were previously removing the field from the config, but to keep typing consistent we should be setting `targetDisplay: null`