### PR TITLE
fix(aci): update webhook action target_type

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -1,3 +1,4 @@
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
@@ -20,8 +21,8 @@ class WebhookActionHandler(ActionHandler):
                 "type": ["null"],
             },
             "target_type": {
-                "type": ["integer", "null"],
-                "enum": [None],
+                "type": ["integer"],
+                "enum": [ActionTarget.SPECIFIC.value],
             },
         },
     }


### PR DESCRIPTION
Updates the webhook action to expect a target_type of SPECIFIC. This is more consistent with other actions, such as messaging actions, ticketing actions, and oncall actions.

UPDATE: decided to close this PR since already migrated webhook actions to have `target_type: null`