### PR TITLE
feat(tracemetrics): Enforce a single metric in widget builder

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -72,11 +72,7 @@ function TraceMetricsSearchBar({
   const hasTraceMetricsDashboards = useHasTraceMetricsDashboards();
   const {state: widgetBuilderState} = useWidgetBuilderContext();
 
-  // TODO: Make decision on how filtering works with multiple trace metrics
-  // We should probably limit it to only one metric for now because there's no way
-  // to filter by multiple metrics at the same time, unless the filter _ONLY_ includes
-  // tags for both metrics.
-  const traceMetric = widgetBuilderState.traceMetrics?.[0];
+  const traceMetric = widgetBuilderState.traceMetric;
 
   const traceItemAttributeConfig = {
     traceItemType: TraceItemDataset.TRACEMETRICS,
@@ -249,6 +245,9 @@ function getSeriesRequest(
       groupBy: widget.queries[0]!.columns,
     };
   }
+
+  // The events-timeseries response errors on duplicate yAxis values, so we need to remove them
+  requestData.yAxis = [...new Set(requestData.yAxis)];
 
   if (samplingMode) {
     requestData.sampling = samplingMode;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -871,16 +871,6 @@ function Visualize({error, setError}: VisualizeProps) {
                               fields.length <= 1 || !canDelete || isOnlyFieldOrAggregate
                             }
                             onClick={() => {
-                              if (state.dataset === WidgetType.TRACEMETRICS) {
-                                // Ensure to remove the trace metric that corresponds to the field being deleted
-                                dispatch({
-                                  type: BuilderStateAction.SET_TRACE_METRIC,
-                                  payload:
-                                    state.traceMetrics?.filter(
-                                      (_traceMetric, i) => i !== index
-                                    ) ?? [],
-                                });
-                              }
                               dispatch({
                                 type: updateAction,
                                 payload: fields?.filter((_field, i) => i !== index) ?? [],

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
@@ -1,0 +1,86 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {AggregationKeyWithAlias} from 'sentry/utils/discover/fields';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {MetricSelectRow} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow';
+import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+
+const DASHBOARD_WIDGET_BUILDER_PATHNAME =
+  '/organizations/org-slug/dashboards/new/widget/new/';
+
+describe('MetricSelectRow', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            ['metric.name']: 'test_metric',
+            ['metric.type']: 'counter',
+            ['count(metric.name)']: 1,
+          },
+          {
+            ['metric.name']: 'other_metric',
+            ['metric.type']: 'counter',
+            ['count(metric.name)']: 1,
+          },
+        ],
+      },
+    });
+  });
+  it('renders the same metric for all rows', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <MetricSelectRow
+          field={{
+            kind: 'function',
+            function: [
+              'per_second' as AggregationKeyWithAlias,
+              'value',
+              undefined,
+              undefined,
+            ],
+          }}
+          index={0}
+          disabled={false}
+        />
+        <MetricSelectRow
+          field={{
+            kind: 'function',
+            function: ['sum' as AggregationKeyWithAlias, 'value', undefined, undefined],
+          }}
+          index={0}
+          disabled={false}
+        />
+      </WidgetBuilderProvider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+            query: {
+              yAxis: [
+                'per_second(value,test_metric,counter,-)',
+                'sum(value,test_metric,counter,-)',
+              ],
+              dataset: WidgetType.TRACEMETRICS,
+              displayType: DisplayType.LINE,
+            },
+          },
+        },
+      }
+    );
+
+    // Both metric selectors show the same metric value
+    const metricSelectors = await screen.findAllByRole('button', {name: 'test_metric'});
+    expect(metricSelectors).toHaveLength(2);
+
+    // Change the metric to 'other_metric'
+    await userEvent.click(metricSelectors[0]!);
+    await userEvent.click(await screen.findByRole('option', {name: 'other_metric'}));
+
+    // Both metric selectors show the new metric value
+    expect(new Set(metricSelectors.map(selector => selector.textContent))).toEqual(
+      new Set(['other_metric'])
+    );
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import cloneDeep from 'lodash/cloneDeep';
 
 import {Flex} from '@sentry/scraps/layout';
 
@@ -29,12 +28,9 @@ export function MetricSelectRow({
           traceMetric={traceMetric}
           onChange={option => {
             if (field.kind === 'function') {
-              const newTraceMetric = cloneDeep(traceMetric);
-              newTraceMetric.name = option.name;
-              newTraceMetric.type = option.type;
               dispatch({
                 type: BuilderStateAction.SET_TRACE_METRIC,
-                payload: newTraceMetric,
+                payload: option,
               });
             }
           }}

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
@@ -20,10 +20,7 @@ export function MetricSelectRow({
 }) {
   const {state, dispatch} = useWidgetBuilderContext();
 
-  const traceMetric =
-    field.kind === 'function' && field.function[2] && field.function[3]
-      ? {name: field.function[2], type: field.function[3]}
-      : (state.traceMetric ?? {name: '', type: ''});
+  const traceMetric = state.traceMetric ?? {name: '', type: ''};
 
   return (
     <Flex gap="0" width="100%" minWidth="0">
@@ -32,7 +29,7 @@ export function MetricSelectRow({
           traceMetric={traceMetric}
           onChange={option => {
             if (field.kind === 'function') {
-              const newTraceMetric = cloneDeep(state.traceMetric) ?? {name: '', type: ''};
+              const newTraceMetric = cloneDeep(traceMetric);
               newTraceMetric.name = option.name;
               newTraceMetric.type = option.type;
               dispatch({

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
@@ -23,7 +23,7 @@ export function MetricSelectRow({
   const traceMetric =
     field.kind === 'function' && field.function[2] && field.function[3]
       ? {name: field.function[2], type: field.function[3]}
-      : (state.traceMetrics?.[index] ?? {name: '', type: ''});
+      : (state.traceMetric ?? {name: '', type: ''});
 
   return (
     <Flex gap="0" width="100%" minWidth="0">
@@ -32,21 +32,12 @@ export function MetricSelectRow({
           traceMetric={traceMetric}
           onChange={option => {
             if (field.kind === 'function') {
-              const newYAxes = cloneDeep(state.yAxis) ?? [];
-              const newTraceMetrics = cloneDeep(state.traceMetrics) ?? [];
-              newTraceMetrics[index] = {name: option.name, type: option.type};
-              newYAxes[index] = {
-                function: [field.function[0], 'value', undefined, undefined],
-                alias: undefined,
-                kind: 'function',
-              };
+              const newTraceMetric = cloneDeep(state.traceMetric) ?? {name: '', type: ''};
+              newTraceMetric.name = option.name;
+              newTraceMetric.type = option.type;
               dispatch({
                 type: BuilderStateAction.SET_TRACE_METRIC,
-                payload: newTraceMetrics,
-              });
-              dispatch({
-                type: BuilderStateAction.SET_Y_AXIS,
-                payload: newYAxes,
+                payload: newTraceMetric,
               });
             }
           }}

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -65,7 +65,7 @@ export type WidgetBuilderStateQueryParams = {
   sort?: string[];
   thresholds?: string;
   title?: string;
-  traceMetrics?: string;
+  traceMetric?: string;
   yAxis?: string[];
 };
 
@@ -106,7 +106,7 @@ type WidgetAction =
       type: typeof BuilderStateAction.SET_THRESHOLDS;
     }
   | {
-      payload: TraceMetric[] | undefined;
+      payload: TraceMetric | undefined;
       type: typeof BuilderStateAction.SET_TRACE_METRIC;
     };
 type WidgetBuilderStateActionOptions = {
@@ -126,7 +126,7 @@ export interface WidgetBuilderState {
   sort?: Sort[];
   thresholds?: ThresholdsConfig | null;
   title?: string;
-  traceMetrics?: TraceMetric[];
+  traceMetric?: TraceMetric;
   yAxis?: Column[];
 }
 
@@ -195,11 +195,13 @@ function useWidgetBuilderState(): {
     deserializer: deserializeLinkedDashboards,
     serializer: serializeLinkedDashboards,
   });
-  const [traceMetrics, setTraceMetrics] = useQueryParamState<TraceMetric[] | undefined>({
-    fieldName: 'traceMetrics',
+  // TraceMetric widgets only support a single metric at this time. All aggregates
+  // must be in reference to this metric.
+  const [traceMetric, setTraceMetric] = useQueryParamState<TraceMetric | undefined>({
+    fieldName: 'traceMetric',
     decoder: decodeScalar,
-    deserializer: deserializeTraceMetrics,
-    serializer: serializeTraceMetrics,
+    deserializer: deserializeTraceMetric,
+    serializer: serializeTraceMetric,
   });
 
   const state = useMemo(
@@ -216,7 +218,7 @@ function useWidgetBuilderState(): {
       legendAlias,
       thresholds,
       linkedDashboards,
-      traceMetrics,
+      traceMetric,
       // The selected aggregate is the last aggregate for big number widgets
       // if it hasn't been explicitly set
       selectedAggregate:
@@ -238,7 +240,7 @@ function useWidgetBuilderState(): {
       selectedAggregate,
       thresholds,
       linkedDashboards,
-      traceMetrics,
+      traceMetric,
     ]
   );
 
@@ -529,7 +531,7 @@ function useWidgetBuilderState(): {
             const sortField =
               dataset === WidgetType.TRACEMETRICS
                 ? (generateMetricAggregate(
-                    traceMetrics?.[0] ?? {name: '', type: ''},
+                    traceMetric ?? {name: '', type: ''},
                     firstYAxisNotEquation as QueryFieldValue
                   ) ?? '')
                 : (generateFieldAsString(firstYAxisNotEquation as QueryFieldValue) ??
@@ -616,18 +618,15 @@ function useWidgetBuilderState(): {
           if (action.payload.yAxis) {
             setYAxis(deserializeFields(action.payload.yAxis), options);
           }
-          if (action.payload.traceMetrics) {
-            setTraceMetrics(
-              deserializeTraceMetrics(action.payload.traceMetrics),
-              options
-            );
+          if (action.payload.traceMetric) {
+            setTraceMetric(deserializeTraceMetric(action.payload.traceMetric), options);
           }
           break;
         case BuilderStateAction.SET_THRESHOLDS:
           setThresholds(action.payload, options);
           break;
         case BuilderStateAction.SET_TRACE_METRIC:
-          setTraceMetrics(action.payload, options);
+          setTraceMetric(action.payload, options);
           break;
         default:
           break;
@@ -655,8 +654,8 @@ function useWidgetBuilderState(): {
       sort,
       dataset,
       limit,
-      setTraceMetrics,
-      traceMetrics,
+      setTraceMetric,
+      traceMetric,
     ]
   );
 
@@ -808,15 +807,15 @@ export function serializeThresholds(thresholds: ThresholdsConfig | null): string
   return JSON.stringify(thresholds);
 }
 
-export function serializeTraceMetrics(traceMetrics: TraceMetric[] | undefined): string {
-  return JSON.stringify(traceMetrics);
+export function serializeTraceMetric(traceMetric: TraceMetric | undefined): string {
+  return JSON.stringify(traceMetric);
 }
 
-function deserializeTraceMetrics(traceMetrics: string): TraceMetric[] | undefined {
-  if (traceMetrics === '') {
+function deserializeTraceMetric(traceMetric: string): TraceMetric | undefined {
+  if (traceMetric === '') {
     return undefined;
   }
-  return JSON.parse(traceMetrics);
+  return JSON.parse(traceMetric);
 }
 
 export default useWidgetBuilderState;

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.ts
@@ -3,7 +3,7 @@ import {
   serializeFields,
   serializeSorts,
   serializeThresholds,
-  serializeTraceMetrics,
+  serializeTraceMetric,
   type WidgetBuilderState,
   type WidgetBuilderStateQueryParams,
 } from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
@@ -11,16 +11,16 @@ import {
 export function convertBuilderStateToStateQueryParams(
   state: WidgetBuilderState
 ): WidgetBuilderStateQueryParams {
-  const {fields, yAxis, sort, thresholds, traceMetrics, ...rest} = state;
+  const {fields, yAxis, sort, thresholds, traceMetric, ...rest} = state;
   return {
     ...rest,
     field: serializeFields(fields ?? []),
     yAxis: serializeFields(yAxis ?? []),
     sort: serializeSorts(WidgetType.SPANS)(sort ?? []),
     thresholds: thresholds ? serializeThresholds(thresholds) : undefined,
-    traceMetrics:
-      traceMetrics && traceMetrics.length > 0
-        ? serializeTraceMetrics(traceMetrics)
+    traceMetric:
+      traceMetric?.name && traceMetric?.type
+        ? serializeTraceMetric(traceMetric)
         : undefined,
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -30,8 +30,8 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       // prior to making the request because the current types for y-axes do not support
       // the correct number of arguments required for trace metrics
       aggregates =
-        state.yAxis?.map((axis, index) => {
-          const traceMetric = state.traceMetrics?.[index] ?? {name: '', type: ''};
+        state.yAxis?.map(axis => {
+          const traceMetric = state.traceMetric ?? {name: '', type: ''};
           if (axis.kind === 'function') {
             return generateMetricAggregate(traceMetric, axis);
           }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -9,7 +9,7 @@ import {isChartDisplayType} from 'sentry/views/dashboards/utils';
 import {
   serializeFields,
   serializeThresholds,
-  serializeTraceMetrics,
+  serializeTraceMetric,
   type WidgetBuilderStateQueryParams,
 } from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -48,17 +48,16 @@ export function convertWidgetToBuilderStateParams(
     legendAlias = [];
   }
 
-  let traceMetrics: TraceMetric[] = [];
+  let traceMetric: TraceMetric | undefined = undefined;
   if (widget.widgetType === WidgetType.TRACEMETRICS) {
-    traceMetrics = firstWidgetQuery
-      ? firstWidgetQuery.aggregates.map(aggregate => {
-          const func = parseFunction(aggregate);
-          return {
-            name: func?.arguments?.[1] ?? '',
-            type: func?.arguments?.[2] ?? '',
-          };
-        })
-      : [];
+    const traceMetricReferenceAggregate = firstWidgetQuery?.aggregates[0];
+    if (traceMetricReferenceAggregate) {
+      const func = parseFunction(traceMetricReferenceAggregate);
+      traceMetric = {
+        name: func?.arguments?.[1] ?? '',
+        type: func?.arguments?.[2] ?? '',
+      };
+    }
   }
 
   return {
@@ -74,7 +73,6 @@ export function convertWidgetToBuilderStateParams(
     legendAlias,
     selectedAggregate: firstWidgetQuery?.selectedAggregate,
     thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
-    traceMetrics:
-      traceMetrics.length > 0 ? serializeTraceMetrics(traceMetrics) : undefined,
+    traceMetric: traceMetric ? serializeTraceMetric(traceMetric) : undefined,
   };
 }


### PR DESCRIPTION
We've decided that only a single metric will be queried at the moment. To query different metrics in the UI, we need to update the widget builder UI to colocate all of the different UI like filters, group-by etc to the metric. Limiting ourselves to a single metric makes the code simpler in a number of places because we can just simply update the state when the value changes.

We have to co-locate them to do multiple metrics because the filters are _normally_ applied to each aggregate, and if the filter uses tags that aren't present in the other metric, it will just produce an empty series.

Functionally:
- Changing a metric changes the other visualizes to use the same metric
- We ignore duplicate yAxes because it'll cause an error in the API if you send them