### PR TITLE
feat(admin): fix resultGrid to accept cell_id; update userCustomers to use this route

### DIFF
--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -21,7 +21,7 @@ function UserCustomers({userId}: Props) {
     <CustomerGrid
       panelTitle="Organization Membership"
       path={`/_admin/users/${userId}/`}
-      endpoint={`/users/${userId}/customers/`}
+      endpoint={`/_admin/cells/$cell_id/users/${userId}/customers/`}
       hasSearch={false}
       sortOptions={undefined}
       filters={undefined}

--- a/static/gsAdmin/views/userDetails.spec.tsx
+++ b/static/gsAdmin/views/userDetails.spec.tsx
@@ -19,7 +19,7 @@ describe('User Details', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/users/${mockUser.id}/customers/`,
+      url: `/_admin/cells/us/users/${mockUser.id}/customers/`,
       body: [{}],
     });
 


### PR DESCRIPTION
This was awkward: the ResultGrid has its own region selector control, but the downstream consumer (UserCustomers) needs to set an endpoint.  Rather than try to disentangle this, I opted to expose a "$cell_id" value that can be string-compared against and replaced, when the ResultGrid is updated (and so use local state instead of props.)