### PR TITLE
refactor(billing): migrate billing calculations to use formatting config

### DIFF
--- a/static/app/constants/index.spec.tsx
+++ b/static/app/constants/index.spec.tsx
@@ -19,8 +19,8 @@ describe('DATA_CATEGORY_INFO', () => {
         expect(formatting.unitType).toBe('bytes');
         expect(formatting.reservedMultiplier).toBe(10 ** 9); // GIGABYTE
         expect(formatting.bigNumUnit).toBe(1);
-        expect(formatting.priceFormatting.minIntegerDigits).toBe(2);
-        expect(formatting.priceFormatting.maxIntegerDigits).toBe(2);
+        expect(formatting.priceFormatting.minFractionDigits).toBe(2);
+        expect(formatting.priceFormatting.maxFractionDigits).toBe(2);
       }
     });
 
@@ -45,8 +45,8 @@ describe('DATA_CATEGORY_INFO', () => {
         expect(formatting.unitType).toBe('durationHours');
         expect(formatting.reservedMultiplier).toBe(3_600_000); // MILLISECONDS_IN_HOUR
         expect(formatting.bigNumUnit).toBe(0);
-        expect(formatting.priceFormatting.minIntegerDigits).toBe(5);
-        expect(formatting.priceFormatting.maxIntegerDigits).toBe(7);
+        expect(formatting.priceFormatting.minFractionDigits).toBe(5);
+        expect(formatting.priceFormatting.maxFractionDigits).toBe(7);
         expect(formatting.projectedAbbreviated).toBe(true);
       }
     });
@@ -65,8 +65,8 @@ describe('DATA_CATEGORY_INFO', () => {
         expect(formatting.unitType).toBe('count');
         expect(formatting.reservedMultiplier).toBe(1);
         expect(formatting.bigNumUnit).toBe(0);
-        expect(formatting.priceFormatting.minIntegerDigits).toBe(5);
-        expect(formatting.priceFormatting.maxIntegerDigits).toBe(7);
+        expect(formatting.priceFormatting.minFractionDigits).toBe(5);
+        expect(formatting.priceFormatting.maxFractionDigits).toBe(7);
         expect(formatting.projectedAbbreviated).toBe(true);
       }
     });

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -265,7 +265,7 @@ const DEFAULT_COUNT_FORMATTING = {
   unitType: 'count' as const,
   reservedMultiplier: 1,
   bigNumUnit: 0 as const,
-  priceFormatting: {minIntegerDigits: 5, maxIntegerDigits: 7},
+  priceFormatting: {minFractionDigits: 5, maxFractionDigits: 7},
   projectedAbbreviated: true,
 };
 
@@ -277,7 +277,7 @@ const BYTES_FORMATTING = {
   unitType: 'bytes' as const,
   reservedMultiplier: GIGABYTE,
   bigNumUnit: 1 as const,
-  priceFormatting: {minIntegerDigits: 2, maxIntegerDigits: 2},
+  priceFormatting: {minFractionDigits: 2, maxFractionDigits: 2},
   projectedAbbreviated: true,
 };
 
@@ -289,7 +289,7 @@ const DURATION_HOURS_FORMATTING = {
   unitType: 'durationHours' as const,
   reservedMultiplier: MILLISECONDS_IN_HOUR,
   bigNumUnit: 0 as const,
-  priceFormatting: {minIntegerDigits: 5, maxIntegerDigits: 7},
+  priceFormatting: {minFractionDigits: 5, maxFractionDigits: 7},
   projectedAbbreviated: true,
 };
 

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -154,13 +154,13 @@ interface DataCategoryFormattingInfo {
    */
   bigNumUnit: 0 | 1;
   /**
-   * Formatting options for price display.
-   * minIntegerDigits: minimum integer digits (bytes use 2, counts use 5)
-   * maxIntegerDigits: maximum integer digits (bytes use 2, counts use 7)
+   * Formatting options for price display (decimal places).
+   * minFractionDigits: minimum fraction digits (bytes use 2, counts use 5)
+   * maxFractionDigits: maximum fraction digits (bytes use 2, counts use 7)
    */
   priceFormatting: {
-    maxIntegerDigits: number;
-    minIntegerDigits: number;
+    maxFractionDigits: number;
+    minFractionDigits: number;
   };
   /**
    * Whether to use abbreviated formatting for projected values.

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -14,6 +14,7 @@ import {defined} from 'sentry/utils';
 import {PlanTier} from 'getsentry/types';
 import {formatReservedWithUnits} from 'getsentry/utils/billing';
 import {
+  getCategoryInfoFromPlural,
   getPlanCategoryName,
   getSingularCategoryName,
   isByteCategory,
@@ -21,8 +22,6 @@ import {
 import UnitTypeItem from 'getsentry/views/amCheckout/components/unitTypeItem';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
 import * as utils from 'getsentry/views/amCheckout/utils';
-
-const ATTACHMENT_DIGITS = 2;
 
 function renderHovercardBody() {
   return (
@@ -107,6 +106,8 @@ function VolumeSliders({
             buckets: activePlan.planCategories[category],
           });
 
+          const categoryInfo = getCategoryInfoFromPlural(category);
+
           const min = allowedValues[0];
           const max = allowedValues.slice(-1)[0];
 
@@ -114,12 +115,8 @@ function VolumeSliders({
           const price = utils.displayPrice({cents: eventBucket.price});
           const unitPrice = utils.displayUnitPrice({
             cents: eventBucket.unitPrice || 0,
-            ...(category === DataCategory.ATTACHMENTS
-              ? {
-                  minDigits: ATTACHMENT_DIGITS,
-                  maxDigits: ATTACHMENT_DIGITS,
-                }
-              : {}),
+            minDigits: categoryInfo?.formatting.priceFormatting.minFractionDigits,
+            maxDigits: categoryInfo?.formatting.priceFormatting.maxFractionDigits,
           });
 
           const sliderId = `slider-${category}`;

--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -133,9 +133,8 @@ function AllocationForm({
   }, [allocationVolume, costPerItem]);
 
   const metricUnit = useMemo(() => {
-    return selectedMetric === DataCategory.ATTACHMENTS
-      ? BigNumUnits.KILO_BYTES
-      : BigNumUnits.NUMBERS;
+    const categoryInfo = getCategoryInfoFromPlural(selectedMetric);
+    return categoryInfo?.formatting.bigNumUnit ?? BigNumUnits.NUMBERS;
   }, [selectedMetric]);
 
   useEffect(() => {

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -69,9 +69,8 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
   const hasOrgWritePerms = hasPermissions(organization, 'org:write');
   const canViewSpendAllocation = hasBillingPerms || hasOrgWritePerms;
   const metricUnit = useMemo(() => {
-    return selectedMetric === DataCategory.ATTACHMENTS
-      ? BigNumUnits.KILO_BYTES
-      : BigNumUnits.NUMBERS;
+    const categoryInfo = getCategoryInfoFromPlural(selectedMetric);
+    return categoryInfo?.formatting.bigNumUnit ?? BigNumUnits.NUMBERS;
   }, [selectedMetric]);
 
   const supportedCategories = planDetails.categories.filter(

--- a/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
+++ b/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
@@ -15,6 +15,7 @@ import {DataCategory} from 'sentry/types/core';
 
 import type {Subscription} from 'getsentry/types';
 import {displayBudgetName} from 'getsentry/utils/billing';
+import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
 import {displayPrice} from 'getsentry/views/amCheckout/utils';
 
 import {Card, HalvedGrid} from './components/styles';
@@ -42,9 +43,8 @@ function RootAllocationCard({
   }, [rootAllocation]);
 
   const metricUnit = useMemo(() => {
-    return selectedMetric === DataCategory.ATTACHMENTS
-      ? BigNumUnits.KILO_BYTES
-      : BigNumUnits.NUMBERS;
+    const categoryInfo = getCategoryInfoFromPlural(selectedMetric as DataCategory);
+    return categoryInfo?.formatting.bigNumUnit ?? BigNumUnits.NUMBERS;
   }, [selectedMetric]);
 
   return (


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1814/stack-4-migrate-billing-calculations-to-use-formatting-config

Continues from https://github.com/getsentry/sentry/pull/104688

- Fix priceFormatting property names (minIntegerDigits -> minFractionDigits). Generally to match where it will be used: https://github.com/getsentry/sentry/blob/c5d181b394dd3511af6f45071186efa353d0e618/static/gsApp/views/amCheckout/utils.tsx#L136-L139
- Update calculateCategoryPrepaidUsage to use formatting.reservedMultiplier
- Update displayUnitPrice callers to use priceFormatting from config
- Update BigNumUnits usage in spendAllocations to use formatting.bigNumUnit