### PR TITLE
feat(cache) Add a django cache adapter that reconnects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,7 @@ module = [
     "onelogin.saml2.auth.*",
     "onelogin.saml2.constants.*",
     "onelogin.saml2.idp_metadata_parser.*",
+    "pymemcache.*",
     "P4",
     "rb.*",
     "statsd.*",

--- a/src/sentry/cache/backends/reconnectingmemcache.py
+++ b/src/sentry/cache/backends/reconnectingmemcache.py
@@ -1,5 +1,6 @@
 import time
 from collections.abc import Mapping
+from threading import Lock
 
 import pymemcache
 from django.core.cache.backends.memcached import PyMemcacheCache
@@ -23,6 +24,7 @@ class ReconnectingMemcache(PyMemcacheCache):
         self._reconnect_age: int = params.get("OPTIONS", {}).pop("reconnect_age", 300)
         self._last_reconnect_at: float = time.time()
         self._backend: pymemcache.Client | None = None
+        self._backend_lock = Lock()
 
         super().__init__(server, params)
 
@@ -31,15 +33,20 @@ class ReconnectingMemcache(PyMemcacheCache):
         """
         Overload PyMemcacheCache._cache with periodic reconnections.
         """
+        reconnect = False
         age = time.time() - self._last_reconnect_at
-        if age >= self._reconnect_age and self._backend:
-            # Close the underlying cache connection if we haven't done that recently.
-            metrics.incr("cache.memcache.reconnect")
-            self._backend.close()
-            self._backend = None
+        if not self._backend or age >= self._reconnect_age:
+            reconnect = True
 
-        if not self._backend:
+        if reconnect and self._backend_lock.acquire(timeout=1.0):
+            # Close the underlying cache connection if we haven't done that recently.
+            if self._backend:
+                self._backend.close()
+                self._backend = None
+
+            metrics.incr("cache.memcache.reconnect")
             self._backend = self._class(self.client_servers, **self._options)
             self._last_reconnect_at = time.time()
+            self._backend_lock.release()
 
         return self._backend

--- a/src/sentry/cache/backends/reconnectingmemcache.py
+++ b/src/sentry/cache/backends/reconnectingmemcache.py
@@ -1,0 +1,52 @@
+import time
+
+from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
+from django.core.cache.backends.memcached import PyMemcacheCache
+
+from sentry.utils import metrics
+
+
+class ReconnectingMemcache(BaseCache):
+    """
+    A django cache adapter that wraps a Pymemcache adapter.
+    Periodically, this adapter will close and reconnect the underlying
+    cache adapter to help even out load on Twemproxy.
+    """
+
+    def __init__(self, server, params) -> None:
+        self._reconnect_age: int = params.get("OPTIONS", {}).pop("reconnect_age", 300)
+
+        super().__init__(params)
+        self._server = server
+        self._params = params
+        self._backend: BaseCache | None = None
+        self._last_reconnect_at: float = time.time()
+
+    def _get_backend(self) -> BaseCache:
+        """
+        Get the wrapped backend. Will close the wrapped connection
+        if it has reached the `reconnect_age`.
+        """
+        age = time.time() - self._last_reconnect_at
+        if not self._backend:
+            self._backend = PyMemcacheCache(self._server, self._params)
+            self._last_reconnect_at = time.time()
+
+        if age >= self._reconnect_age:
+            # Close the underlying cache connection if we haven't done that recently.
+            metrics.incr("cache.memcache.reconnect")
+            self._backend.close()
+
+        return self._backend
+
+    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        return self._get_backend().add(key, value, timeout=timeout, version=version)
+
+    def get(self, key, default=None, version=None):
+        return self._get_backend().get(key, version=version)
+
+    def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        return self._get_backend().set(key, value, timeout=timeout, version=version)
+
+    def delete(self, key, version=None):
+        return self._get_backend().delete(key, version=version)


### PR DESCRIPTION
We often see load-imbalances in our memcache clusters. Application containers connect through a pool of twemproxy instances, and because application containers are long-lived and only connect on startup, we can end up with imbalanced load.

By periodically disconnecting and reconnecting to twemproxy we have a better chance of getting more even load distribution. It doesn't look like we have memcache available in CI right now, and writing tests with only mocks would yield tautological tests.

Refs PRODENG-702