### PR TITLE
fix(aci): Make update_data_source_for_detector more accurate

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -456,7 +456,11 @@ def update_data_source_for_detector(alert_rule: AlertRule, detector: Detector) -
         )
         return
 
-    current_subscription = QuerySubscription.objects.filter(snuba_query=snuba_query.id).first()
+    current_subscription = (
+        QuerySubscription.objects.filter(snuba_query=snuba_query.id)
+        .exclude(status=QuerySubscription.Status.DELETING.value)
+        .first()
+    )
     if not current_subscription:
         logger.error(
             "No QuerySubscription found for AlertRule's SnubaQuery",

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -757,7 +757,7 @@ class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
             type="something",
             status=QuerySubscription.Status.ACTIVE.value,
         )
-        original_subscription.delete()
+        original_subscription.update(status=QuerySubscription.Status.DELETING.value)
 
         dual_update_migrated_alert_rule(self.metric_alert)
 


### PR DESCRIPTION
QuerySubscriptions aren't guaranteed to be deleted when we're copying over, so we need to be sure we're filtering out the QuerySubscription that is scheduled for deletion when we look for the id that should be assigned.
