### PR TITLE
feat(issues): Switch to two query "empty tags" query

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -204,6 +204,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Whether to allow issue only search on the issue list
     manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use 2-query subtraction approach for empty tag counts (avoids query-size limits)
+    manager.add("organizations:issue-tags-subtraction-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enabling this will remove the consent flow for free generative AI features such as issue feedback summaries
     manager.add("organizations:gen-ai-consent-flow-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:metric-issue-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/issues/endpoints/group_tags.py
+++ b/src/sentry/issues/endpoints/group_tags.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import tagstore
+from sentry import features, tagstore
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.helpers.environments import get_environments
@@ -62,12 +62,19 @@ class GroupTagsEndpoint(GroupEndpoint):
 
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
 
+        use_subtraction_query = features.has(
+            "organizations:issue-tags-subtraction-query",
+            group.project.organization,
+            actor=request.user,
+        )
+
         tag_keys = backend.get_group_tag_keys_and_top_values(
             group,
             environment_ids,
             keys=keys,
             value_limit=value_limit,
             tenant_ids={"organization_id": group.project.organization_id},
+            use_subtraction_query=use_subtraction_query,
         )
 
         data = serialize(tag_keys, request.user)

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -907,7 +907,7 @@ class SnubaTagStorage(TagStorage):
         total_filters = dict(filters)
         total_filters.pop(self.key_column, None)
 
-        total_events: int = snuba.query(
+        total_events: int | None = snuba.query(
             dataset=dataset,
             start=start,
             end=end,
@@ -918,6 +918,8 @@ class SnubaTagStorage(TagStorage):
             referrer=Referrer.TAGSTORE__GET_TAG_KEYS_AND_TOP_VALUES_EMPTY_COUNTS,
             tenant_ids=tenant_ids,
         )
+        if total_events is None:
+            return {k: {"count": 0} for k in keys_to_check}
 
         non_empty_filters = dict(filters)
         non_empty_filters[self.key_column] = keys_to_check

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -899,7 +899,7 @@ class SnubaTagStorage(TagStorage):
         end: datetime | None,
     ) -> dict[str, dict[str, Any]]:
         """
-        Two-query subtraction approach: empty_count(k) = total_events - non_empty_events(k).
+        Two-query subtraction: empty_count(k) = total_events - non_empty_events(k).
 
         Avoids per-key countIf that can exceed ClickHouse query-size limits.
         """

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -21,6 +21,7 @@ from sentry.tagstore.types import GroupTagValue, TagValue
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
@@ -285,6 +286,28 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
         assert len(top_release_values) == 1
         assert {v.value for v in top_release_values} == {"releaseme"}
         assert all(v.times_seen == 2 for v in top_release_values)
+
+    @with_feature("organizations:issue-tags-subtraction-query")
+    def test_get_group_tag_keys_and_top_values_subtraction_query(self) -> None:
+        """Test the 2-query subtraction approach for empty tag counts."""
+        perf_group, env = self.perf_group_and_env
+
+        result = list(
+            self.ts.get_group_tag_keys_and_top_values(
+                perf_group,
+                [env.id],
+                tenant_ids={"referrer": "r", "organization_id": 1234},
+                use_subtraction_query=True,
+            )
+        )
+        result.sort(key=lambda r: r.key)
+
+        # biz tag: event 1 has "baz", event 2 is missing it (empty)
+        assert result[0].key == "biz"
+        biz_values = {tv.value: tv.times_seen for tv in result[0].top_values}
+        assert biz_values.get("baz") == 1
+        assert biz_values.get("") == 1  # missing key counted as empty
+        assert result[0].count == 2
 
     def test_get_group_tag_keys_and_top_values_generic_issue(self) -> None:
         group, env = self.generic_group_and_env


### PR DESCRIPTION
Previously we were making a query with a countIf() for each tag that could error if the issue had too many tags. I thought we had gotten around this by shortening the query. Instead of looping over keys or some other solution, make two simple queries then subtract to figure out the total number of empty tags.

fixes SENTRY-5BVA
