### PR TITLE
feat(occurrences): Add rollout utils

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3681,6 +3681,26 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Controls whether an org should read data both from Snuba and EAP.
+# Will not use or display the EAP data to the user; rather, will just compare the
+# data from each source and log whether they match.
+register(
+    "eap.occurrences.should_double_read",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Controls whether a callsite should use EAP data instead of Snuba data.
+# Callsites should only be added after they're known to be safe.
+register(
+    "eap.occurrences.callsites_using_eap_data_allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
 # Killswich for LLM issue detection
 register(
     "issue-detection.llm-detection.enabled",

--- a/src/sentry/search/eap/occurrences/rollout_utils.py
+++ b/src/sentry/search/eap/occurrences/rollout_utils.py
@@ -1,0 +1,49 @@
+from collections.abc import Callable
+from typing import Any
+
+from sentry import options
+from sentry.utils import metrics
+
+
+def should_double_read_from_eap() -> bool:
+    return options.get("eap.occurrences.should_double_read")
+
+
+def should_callsite_use_eap_data_in_read(callsite: str) -> bool:
+    return callsite in options.get("eap.occurrences.callsites_using_eap_data_allowlist")
+
+
+def validate_read(
+    snuba_data: Any,
+    eap_data: Any,
+    callsite: str,
+    is_null_result: bool | None = None,
+    reasonable_match_comparator: Callable[[Any, Any], bool] | None = None,
+) -> None:
+    """
+    Checks whether a read from EAP Occurrences matches exactly with a read from snuba.
+    Inputs:
+      * snuba_data: Some data from Snuba (e.g. dict[str, str])
+      * eap_data: Some data from EAP (of format expecting to match snuba_data)
+      * callsite: Where your read is taking place.
+      * is_null_result: Whether the result is a "null result" (e.g. empty array). This
+          helps us to determine whether a "match" is significant.
+      * reasonable_match_comparator: None, or a function taking snuba_data & eap_data and
+          returning True if the read is "reasonable" and False otherwise.
+    """
+    tags = {
+        "callsite": callsite,
+        "exact_match": snuba_data == eap_data,
+        "source_of_truth": "eap" if should_callsite_use_eap_data_in_read(callsite) else "snuba",
+    }
+
+    if is_null_result is not None:
+        tags["is_null_result"] = is_null_result
+
+    if reasonable_match_comparator is not None:
+        tags["reasonable_match"] = reasonable_match_comparator(snuba_data, eap_data)
+
+    metrics.incr(
+        "eap.occurrences.validate_reads",
+        tags=tags,
+    )


### PR DESCRIPTION
We want to control how reads from Occurrences on EAP happen. Generally, we want it to look like:
* We roll out ingestion to some % of a region
* (Optional pause to wait for some data)
* We roll out double-read to the region
* The snuba & EAP results will start different — because EAP doesn't have full retention for the full region yet — but should track to zero differences over time.

Then, for each new read we onboard:
* Gate reading at all behind the standard rollout
* Gate using the data behind the callsite allowlist
* Set up a reasonable_match comparator
* Land PR.
* Observe data for callsite.
* Should have 100% reasonable_match rate.
* Should have exact_match rate go to 100% over time.
* Once exact_match has been at 100% for some time, add callsite to allowlist.