### PR TITLE
fix(ui): Button's label clipped

### DIFF
--- a/static/app/components/core/button/button.tsx
+++ b/static/app/components/core/button/button.tsx
@@ -81,7 +81,6 @@ const ButtonLabel = styled('span', {
     isPropValid(prop) &&
     !['size', 'borderless'].includes(prop),
 })<Pick<CommonButtonProps, 'size' | 'borderless'>>`
-  height: 100%;
   min-width: 0;
   display: flex;
   align-items: center;

--- a/static/app/components/core/button/linkButton.tsx
+++ b/static/app/components/core/button/linkButton.tsx
@@ -115,7 +115,6 @@ const ButtonLabel = styled('span', {
     isPropValid(prop) &&
     !['size', 'borderless'].includes(prop),
 })<Pick<CommonButtonProps, 'size' | 'borderless'>>`
-  height: 100%;
   min-width: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION

Button label text clipping was introduced by [PR #104384 (UI2 merge) ](https://github.com/getsentry/sentry/pull/104753)which combined with the existing height: 100% on ButtonLabel, forced the label to match the button's full height and constrained text within a tight lineHeight: 1rem, cutting off descenders on letters like g, j, p, q, y.

**Before**
<img width="1740" height="462" alt="image" src="https://github.com/user-attachments/assets/188f9dad-0973-42e9-9684-7f553e5a479b" />



**After**

<img width="841" height="224" alt="image" src="https://github.com/user-attachments/assets/2b9e392b-1704-48dc-ade6-4f6a7a412943" />
