### PR TITLE
feat(java): Pass exception to symbolicate request

### DIFF
--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -182,6 +182,11 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     stacktrace_infos = find_stacktraces_in_data(data)
     stacktraces = [
         {
+            **(
+                {"exception": {"type": sinfo.exception_type, "module": sinfo.exception_module}}
+                if sinfo.get_exception()
+                else {}
+            ),
             "frames": [
                 _normalize_frame(frame, index)
                 for index, frame in enumerate(sinfo.stacktrace.get("frames") or ())

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -184,7 +184,7 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         {
             **(
                 {"exception": {"type": sinfo.exception_type, "module": sinfo.exception_module}}
-                if sinfo.get_exception()
+                if sinfo.exception_type and sinfo.exception_module
                 else {}
             ),
             "frames": [

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -40,6 +40,8 @@ class StacktraceInfo(NamedTuple):
     container: dict[str, Any]
     platforms: set[str]
     is_exception: bool
+    exception_type: str | None
+    exception_module: str | None
 
     def __hash__(self) -> int:
         return id(self)
@@ -49,6 +51,14 @@ class StacktraceInfo(NamedTuple):
 
     def __ne__(self, other: object) -> bool:
         return self is not other
+
+    def get_exception(self) -> str | None:
+        """Returns the fully qualified exception name (module.type) or None if not an exception."""
+        if self.exception_type is None:
+            return None
+        if self.exception_module:
+            return f"{self.exception_module}.{self.exception_type}"
+        return self.exception_type
 
     def get_frames(self) -> Sequence[dict[str, Any]]:
         return _safe_get_frames(self.stacktrace)
@@ -225,6 +235,10 @@ def find_stacktraces_in_data(
         container: Any = None,
         # Whether or not the container is from `exception.values`
         is_exception: bool = False,
+        # The exception type (e.g., "ValueError") if this stacktrace belongs to an exception
+        exception_type: str | None = None,
+        # The exception module (e.g., "__builtins__") if this stacktrace belongs to an exception
+        exception_module: str | None = None,
         # Prevent skipping empty/null stacktraces from `exception.values` (other empty/null
         # stacktraces are always skipped)
         include_empty_exceptions: bool = False,
@@ -244,6 +258,8 @@ def find_stacktraces_in_data(
                 container=container,
                 platforms=platforms,
                 is_exception=is_exception,
+                exception_type=exception_type,
+                exception_module=exception_module,
             )
         )
 
@@ -253,6 +269,8 @@ def find_stacktraces_in_data(
             exc.get("stacktrace"),
             container=exc,
             is_exception=True,
+            exception_type=exc.get("type"),
+            exception_module=exc.get("module"),
             include_empty_exceptions=include_empty_exceptions,
         )
 


### PR DESCRIPTION
Depends on https://github.com/getsentry/symbolicator/pull/1845

This is necessary for complete symbolication of Java frames when there are [rewriteFrame](https://r8.googlesource.com/r8/+/refs/heads/main/doc/retrace.md#rewriteframe-introduced-at-version-2_0) annotations involved. See the linked PR.