### PR TITLE
fix(autofix): correct webhooks + nits

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -21,10 +22,14 @@ from sentry.seer.autofix.prompts import (
 )
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.explorer.client import SeerExplorerClient
+from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
+from sentry.sentry_apps.utils.webhooks import SeerActionType
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
     from sentry.models.organization import Organization
+
+logger = logging.getLogger(__name__)
 
 
 class AutofixStep(StrEnum):
@@ -96,6 +101,32 @@ def build_step_prompt(step: AutofixStep, group: Group) -> str:
     )
 
 
+def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerActionType:
+    step_to_action_type = {
+        AutofixStep.ROOT_CAUSE: {
+            False: SeerActionType.ROOT_CAUSE_STARTED,
+            True: SeerActionType.ROOT_CAUSE_COMPLETED,
+        },
+        AutofixStep.SOLUTION: {
+            False: SeerActionType.SOLUTION_STARTED,
+            True: SeerActionType.SOLUTION_COMPLETED,
+        },
+        AutofixStep.CODE_CHANGES: {
+            False: SeerActionType.CODING_STARTED,
+            True: SeerActionType.CODING_COMPLETED,
+        },
+        AutofixStep.IMPACT_ASSESSMENT: {
+            False: SeerActionType.IMPACT_ASSESSMENT_STARTED,
+            True: SeerActionType.IMPACT_ASSESSMENT_COMPLETED,
+        },
+        AutofixStep.TRIAGE: {
+            False: SeerActionType.TRIAGE_STARTED,
+            True: SeerActionType.TRIAGE_COMPLETED,
+        },
+    }
+    return step_to_action_type[step][is_completed]
+
+
 def trigger_autofix_explorer(
     group: Group,
     step: AutofixStep,
@@ -124,6 +155,7 @@ def trigger_autofix_explorer(
         user=None,  # No user personalization for autofix
         category_key="autofix",
         category_value=str(group.id),
+        intelligence_level="high",
         on_completion_hook=AutofixOnCompletionHook,
         enable_coding=config.enable_coding,
     )
@@ -134,19 +166,41 @@ def trigger_autofix_explorer(
         metadata = None
         if stopping_point:
             metadata = {"stopping_point": stopping_point.value, "group_id": group.id}
-        return client.start_run(
+        run_id = client.start_run(
             prompt=prompt,
             artifact_key=step.value if config.artifact_schema else None,
             artifact_schema=config.artifact_schema,
             metadata=metadata,
         )
     else:
-        return client.continue_run(
+        client.continue_run(
             run_id=run_id,
             prompt=prompt,
             artifact_key=step.value if config.artifact_schema else None,
             artifact_schema=config.artifact_schema,
         )
+
+    # Send "started" webhook after we have the run_id
+    webhook_action_type = get_step_webhook_action_type(step, is_completed=False)
+    try:
+        broadcast_webhooks_for_organization.delay(
+            resource_name="seer",
+            event_name=webhook_action_type.value,
+            organization_id=group.organization.id,
+            payload={"run_id": run_id},
+        )
+    except Exception:
+        logger.exception(
+            "autofix.trigger_webhook_failed",
+            extra={
+                "organization_id": group.organization.id,
+                "webhook_event": webhook_action_type.value,
+                "step": step.value,
+                "run_id": run_id,
+            },
+        )
+
+    return run_id
 
 
 def get_autofix_explorer_state(organization: Organization, group_id: int):

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -11,6 +11,7 @@ from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.explorer.client_utils import fetch_run_status
 from sentry.seer.explorer.on_completion_hook import ExplorerOnCompletionHook
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
+from sentry.sentry_apps.utils.webhooks import SeerActionType
 
 if TYPE_CHECKING:
     from sentry.seer.explorer.client_models import Artifact, SeerRunState
@@ -69,7 +70,9 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
         cls._maybe_continue_pipeline(organization, run_id, state, artifacts)
 
     @classmethod
-    def _send_step_webhook(cls, organization, run_id, artifacts: dict[str, Artifact], state):
+    def _send_step_webhook(
+        cls, organization, run_id, artifacts: dict[str, Artifact], state: SeerRunState
+    ):
         """
         Send webhook for the completed step.
 
@@ -78,39 +81,56 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
         """
         # Determine which artifact was just created and send appropriate webhook
         # We check in reverse priority order (most recent step first)
-        webhook_event = None
         webhook_payload = {"run_id": run_id}
 
-        if "triage" in artifacts and artifacts["triage"].data:
-            webhook_event = "triage_completed"
-            webhook_payload["triage"] = artifacts["triage"].data
+        # Iterate through blocks in reverse order (most recent first)
+        # to find which step just completed
+        webhook_action_type: SeerActionType | None = None
+        for block in reversed(state.blocks):
+            # Check for code changes
+            if block.file_patches:
+                webhook_action_type = SeerActionType.CODING_COMPLETED
+                patches_by_repo = state.get_file_patches_by_repo()
+                webhook_payload["code_changes"] = {
+                    repo: [
+                        {
+                            "path": p.patch.path,
+                            "type": p.patch.type,
+                            "added": p.patch.added,
+                            "removed": p.patch.removed,
+                        }
+                        for p in patches
+                    ]
+                    for repo, patches in patches_by_repo.items()
+                }
+                break
 
-        elif "impact_assessment" in artifacts and artifacts["impact_assessment"].data:
-            webhook_event = "impact_assessment_completed"
-            webhook_payload["impact_assessment"] = artifacts["impact_assessment"].data
+            # Check for artifacts
+            if block.artifacts:
+                artifact_map = {artifact.key: artifact for artifact in block.artifacts}
 
-        elif state.has_code_changes()[0]:
-            # Code changes step - check file patches
-            webhook_event = "coding_completed"
-            patches_by_repo = state.get_file_patches_by_repo()
-            webhook_payload["code_changes"] = {
-                repo: [{"path": p.patch.path, "type": p.patch.type} for p in patches]
-                for repo, patches in patches_by_repo.items()
-            }
+                if "solution" in artifact_map and artifact_map["solution"].data:
+                    webhook_action_type = SeerActionType.SOLUTION_COMPLETED
+                    webhook_payload["solution"] = artifact_map["solution"].data
+                    break
+                elif "root_cause" in artifact_map and artifact_map["root_cause"].data:
+                    webhook_action_type = SeerActionType.ROOT_CAUSE_COMPLETED
+                    webhook_payload["root_cause"] = artifact_map["root_cause"].data
+                    break
+                elif "impact_assessment" in artifact_map and artifact_map["impact_assessment"].data:
+                    webhook_action_type = SeerActionType.IMPACT_ASSESSMENT_COMPLETED
+                    webhook_payload["impact_assessment"] = artifact_map["impact_assessment"].data
+                    break
+                elif "triage" in artifact_map and artifact_map["triage"].data:
+                    webhook_action_type = SeerActionType.TRIAGE_COMPLETED
+                    webhook_payload["triage"] = artifact_map["triage"].data
+                    break
 
-        elif "solution" in artifacts and artifacts["solution"].data:
-            webhook_event = "solution_completed"
-            webhook_payload["solution"] = artifacts["solution"].data
-
-        elif "root_cause" in artifacts and artifacts["root_cause"].data:
-            webhook_event = "root_cause_completed"
-            webhook_payload["root_cause"] = artifacts["root_cause"].data
-
-        if webhook_event:
+        if webhook_action_type:
             try:
                 broadcast_webhooks_for_organization.delay(
                     resource_name="seer",
-                    event_name=webhook_event,
+                    event_name=webhook_action_type.value,
                     organization_id=organization.id,
                     payload=webhook_payload,
                 )
@@ -120,7 +140,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
                     extra={
                         "run_id": run_id,
                         "organization_id": organization.id,
-                        "webhook_event": webhook_event,
+                        "webhook_event": webhook_action_type.value,
                     },
                 )
 

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -76,14 +76,15 @@ def impact_assessment_prompt(*, short_id: str, title: str, culprit: str) -> str:
 
         Steps:
         1. Fetch the issue details to understand the error and its frequency
-        2. Examine what functionality is affected
-        3. Consider user-facing impact, data integrity, and system stability
-        4. Identify which components or services are impacted
+        2. Understand upstream and downstream dependencies
+        3. Check for relevant metrics, performance data, and connected issues
+        4. Consider affected functionality, user-facing impact, data integrity, and system stability
 
         When you have assessed the impact, generate the impact_assessment artifact with:
         - one_line_description: A concise summary of the overall impact in under 30 words
         - impacts: List of specific impacts, each with:
           - label: What is impacted (e.g., "User Authentication", "Payment Flow")
+          - rating: Severity of the impact. High is an urgent incident, medium is a significant but non-urgent problem, low is a minor issue or no impact at all.
           - impact_description: One line describing the impact
           - evidence: Evidence or reasoning for this assessment
         """

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -21,8 +21,8 @@ def root_cause_prompt(*, short_id: str, title: str, culprit: str) -> str:
 
         When you have enough information, generate the root_cause artifact with:
         - one_line_description: A concise summary under 30 words
-        - five_whys: Chain of "why" statements leading to the root cause.
-        - reproduction_steps: Steps that would reproduce this issue
+        - five_whys: Chain of "why" statements leading to the root cause, each under 15 words.
+        - reproduction_steps: Steps that would reproduce this issue, each under 15 words.
         """
     )
 

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -145,4 +145,8 @@ class SentryAppEventType(StrEnum):
     SEER_SOLUTION_COMPLETED = "seer.solution_completed"
     SEER_CODING_STARTED = "seer.coding_started"
     SEER_CODING_COMPLETED = "seer.coding_completed"
+    SEER_TRIAGE_STARTED = "seer.triage_started"
+    SEER_TRIAGE_COMPLETED = "seer.triage_completed"
+    SEER_IMPACT_ASSESSMENT_STARTED = "seer.impact_assessment_started"
+    SEER_IMPACT_ASSESSMENT_COMPLETED = "seer.impact_assessment_completed"
     SEER_PR_CREATED = "seer.pr_created"

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -47,6 +47,10 @@ class SeerActionType(SentryAppActionType):
     SOLUTION_COMPLETED = "solution_completed"
     CODING_STARTED = "coding_started"
     CODING_COMPLETED = "coding_completed"
+    TRIAGE_STARTED = "triage_started"
+    TRIAGE_COMPLETED = "triage_completed"
+    IMPACT_ASSESSMENT_STARTED = "impact_assessment_started"
+    IMPACT_ASSESSMENT_COMPLETED = "impact_assessment_completed"
     PR_CREATED = "pr_created"
 
 

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -7,7 +7,14 @@ from sentry.seer.autofix.on_completion_hook import (
     AutofixOnCompletionHook,
 )
 from sentry.seer.autofix.utils import AutofixStoppingPoint
-from sentry.seer.explorer.client_models import Artifact
+from sentry.seer.explorer.client_models import (
+    Artifact,
+    ExplorerFilePatch,
+    FilePatch,
+    MemoryBlock,
+    Message,
+)
+from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 
 
@@ -191,3 +198,113 @@ class TestPipelineConstants(TestCase):
         assert STOPPING_POINT_TO_STEP[AutofixStoppingPoint.SOLUTION] == AutofixStep.SOLUTION
         assert STOPPING_POINT_TO_STEP[AutofixStoppingPoint.CODE_CHANGES] == AutofixStep.CODE_CHANGES
         assert AutofixStoppingPoint.OPEN_PR not in STOPPING_POINT_TO_STEP
+
+
+class TestAutofixOnCompletionHookWebhooks(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_send_step_webhook_artifact_types(self, mock_broadcast):
+        """Tests webhook sending for all artifact-based step types."""
+        state = MagicMock()
+        run_id = 123
+
+        test_cases = [
+            {
+                "artifact_key": "root_cause",
+                "artifact_data": {"cause": "test"},
+                "expected_event": SeerActionType.ROOT_CAUSE_COMPLETED,
+                "expected_payload_key": "root_cause",
+            },
+            {
+                "artifact_key": "solution",
+                "artifact_data": {"steps": ["step1"]},
+                "expected_event": SeerActionType.SOLUTION_COMPLETED,
+                "expected_payload_key": "solution",
+            },
+            {
+                "artifact_key": "triage",
+                "artifact_data": {"suspect_commit": "abc123"},
+                "expected_event": SeerActionType.TRIAGE_COMPLETED,
+                "expected_payload_key": "triage",
+            },
+            {
+                "artifact_key": "impact_assessment",
+                "artifact_data": {"impact": "high"},
+                "expected_event": SeerActionType.IMPACT_ASSESSMENT_COMPLETED,
+                "expected_payload_key": "impact_assessment",
+            },
+        ]
+
+        for i, test_case in enumerate(test_cases):
+            mock_broadcast.reset_mock()
+            block = MemoryBlock(
+                id=f"block{i+1}",
+                message=Message(message="test", role="tool_use"),
+                timestamp="2024-01-01T00:00:00Z",
+                artifacts=[
+                    Artifact(
+                        key=test_case["artifact_key"],
+                        data=test_case["artifact_data"],
+                        reason="test",
+                    )
+                ],
+            )
+            state.blocks = [block]
+            AutofixOnCompletionHook._send_step_webhook(self.organization, run_id, {}, state)
+
+            mock_broadcast.assert_called_once()
+            call_kwargs = mock_broadcast.call_args.kwargs
+            if i == 0:  # First test - verify common fields
+                assert call_kwargs["resource_name"] == "seer"
+                assert call_kwargs["organization_id"] == self.organization.id
+                assert call_kwargs["payload"]["run_id"] == run_id
+            assert call_kwargs["event_name"] == test_case["expected_event"].value
+            assert (
+                call_kwargs["payload"][test_case["expected_payload_key"]]
+                == test_case["artifact_data"]
+            )
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_send_step_webhook_coding(self, mock_broadcast):
+        """Sends coding_completed webhook when file patches exist."""
+        state = MagicMock()
+        file_patch = ExplorerFilePatch(
+            repo_name="test-repo",
+            patch=FilePatch(path="test.py", type="M", added=5, removed=2),
+        )
+        block = MemoryBlock(
+            id="block_coding",
+            message=Message(message="test", role="tool_use"),
+            timestamp="2024-01-01T00:00:00Z",
+            file_patches=[file_patch],
+        )
+        state.blocks = [block]
+        state.get_file_patches_by_repo.return_value = {"test-repo": [file_patch]}
+
+        AutofixOnCompletionHook._send_step_webhook(self.organization, 123, {}, state)
+
+        mock_broadcast.assert_called_once()
+        call_kwargs = mock_broadcast.call_args.kwargs
+        assert call_kwargs["event_name"] == SeerActionType.CODING_COMPLETED.value
+        assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["path"] == "test.py"
+        assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["added"] == 5
+        assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["removed"] == 2
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_send_step_webhook_no_artifacts_no_webhook(self, mock_broadcast):
+        """Does not send webhook when no artifacts or file patches exist."""
+        state = MagicMock()
+        block = MemoryBlock(
+            id="block_empty",
+            message=Message(message="test", role="tool_use"),
+            timestamp="2024-01-01T00:00:00Z",
+            artifacts=[],
+        )
+        state.blocks = [block]
+
+        AutofixOnCompletionHook._send_step_webhook(self.organization, 123, {}, state)
+
+        mock_broadcast.assert_not_called()

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -1,3 +1,4 @@
+from typing import TypedDict
 from unittest.mock import MagicMock, patch
 
 from sentry.seer.autofix.autofix_agent import AutofixStep
@@ -211,7 +212,13 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         state = MagicMock()
         run_id = 123
 
-        test_cases = [
+        class TestCaseDict(TypedDict):
+            artifact_key: str
+            artifact_data: dict
+            expected_event: SeerActionType
+            expected_payload_key: str
+
+        test_cases: list[TestCaseDict] = [
             {
                 "artifact_key": "root_cause",
                 "artifact_data": {"cause": "test"},


### PR DESCRIPTION
Fixes webhook logic for explorer-based autofix (sending non-existent types for the new steps + selecting incorrect type)
Tacking on prompt updates too for clarity.

Closes AIML-2057