### PR TITLE
feat(hybridcloud) Add response size metric

### DIFF
--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -572,11 +572,17 @@ class _RemoteSiloCall:
                 response = self._fire_test_request(headers, data)
             else:
                 response = self._fire_request(headers, data)
+            tags = self._metrics_tags(status=response.status_code)
             metrics.incr(
                 "hybrid_cloud.dispatch_rpc.response_code",
-                tags=self._metrics_tags(status=response.status_code),
+                tags=tags,
             )
-
+            metrics.distribution(
+                "hybrid_cloud.dispatch_rpc.response_bytes",
+                len(response.content),
+                tags=tags,
+                unit="byte",
+            )
             if response.status_code == 200:
                 return response.json()
             self._raise_from_response_status_error(response)

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -30,6 +30,7 @@ __all__ = [
     "timer",
     "timing",
     "gauge",
+    "distribution",
     "backend",
     "MutableTags",
     "ensure_crash_rate_in_bounds",


### PR DESCRIPTION
We have a few outlier responses that are triggering OOMs, add a metric to gain visibility on which methods have large response payloads.