### PR TITLE
feat(onboarding): Add wizard based onboarding flow for react router projects

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -129,12 +129,6 @@ export const platformProductAvailability = {
     ProductSolution.LOGS,
     ProductSolution.METRICS,
   ],
-  'javascript-react-router': [
-    ProductSolution.PERFORMANCE_MONITORING,
-    ProductSolution.SESSION_REPLAY,
-    ProductSolution.LOGS,
-    ProductSolution.METRICS,
-  ],
   'javascript-vue': [
     ProductSolution.PERFORMANCE_MONITORING,
     ProductSolution.SESSION_REPLAY,

--- a/static/app/gettingStartedDocs/javascript-react-router/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/onboarding.spec.tsx
@@ -11,98 +11,26 @@ describe('javascript-react-router onboarding docs', () => {
     renderWithOnboardingLayout(docs);
 
     // Renders main headings
-    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {name: /Upload Source Maps/i})
+      screen.getByRole('heading', {name: 'Automatic Configuration (Recommended)'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    // Includes Sentry import statement in multiple configure sections
-    expect(
-      screen.getAllByText(
-        textWithMarkupMatcher(/import \* as Sentry from ["']@sentry\/react-router["'];/)
-      )
-    ).toHaveLength(4);
-  });
-
-  it('displays sample rates by default', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [
-        ProductSolution.ERROR_MONITORING,
-        ProductSolution.PERFORMANCE_MONITORING,
-        ProductSolution.SESSION_REPLAY,
-      ],
-    });
 
     expect(
-      screen.getAllByText(textWithMarkupMatcher(/tracesSampleRate/)).length
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText(textWithMarkupMatcher(/replaysSessionSampleRate/)).length
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText(textWithMarkupMatcher(/replaysOnErrorSampleRate/)).length
-    ).toBeGreaterThan(0);
-  });
-
-  it('enables performance by setting tracesSampleRate to 1 and adding integration', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [
-        ProductSolution.ERROR_MONITORING,
-        ProductSolution.PERFORMANCE_MONITORING,
-      ],
-    });
-
-    expect(
-      screen.getAllByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/)).length
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry\.reactRouterTracingIntegration\(\)/))
+      screen.getByText(textWithMarkupMatcher(/npx @sentry\/wizard@latest -i reactRouter/))
     ).toBeInTheDocument();
   });
 
-  it('enables replay by setting replay sample rates', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [
-        ProductSolution.ERROR_MONITORING,
-        ProductSolution.SESSION_REPLAY,
-      ],
-    });
+  it('displays the verify instructions', () => {
+    renderWithOnboardingLayout(docs);
 
+    // Shows sentry-example-page instruction
     expect(
-      screen.getByText(textWithMarkupMatcher(/replaysSessionSampleRate: 0\.1/))
+      screen.getByText(textWithMarkupMatcher(/visit \/sentry-example-page/))
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/replaysOnErrorSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-  });
 
-  it('enables profiling by setting profiling sample rates', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-    });
-
+    // Shows alternative verification method
     expect(
-      screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/nodeProfilingIntegration\(\)/))
-    ).toBeInTheDocument();
-  });
-
-  it('enables logs by setting enableLogs to true and shows logger usage in verify step', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getAllByText(textWithMarkupMatcher(/enableLogs: true/)).length
-    ).toBeGreaterThan(0);
-
-    // When logs are selected, verify step includes a Sentry logger call
-    expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry\.logger\.info\(/))
+      screen.getByText(textWithMarkupMatcher(/myUndefinedFunction\(\)/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/javascript-react-router/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/onboarding.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 
 import {ExternalLink} from 'sentry/components/core/link';
+import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {
   DocsParams,
   OnboardingConfig,
@@ -8,112 +9,7 @@ import type {
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-import {getClientSetupSnippet} from './utils';
-
-function getServerSetupSnippet(params: DocsParams) {
-  const logsSnippet = params.isLogsSelected
-    ? `
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`
-    : '';
-
-  const performanceSnippet = params.isPerformanceSelected
-    ? `
-  tracesSampleRate: 1.0, // Capture 100% of the transactions`
-    : '';
-
-  const profilingSnippet = params.isProfilingSelected
-    ? `
-  profilesSampleRate: 1.0, // profile every transaction`
-    : '';
-
-  const profilingImport = params.isProfilingSelected
-    ? `
-import { nodeProfilingIntegration } from '@sentry/profiling-node';`
-    : '';
-
-  const integrationsList = [];
-
-  if (params.isProfilingSelected) {
-    integrationsList.push(`
-    // Profiling
-    nodeProfilingIntegration(),`);
-  }
-
-  const integrationsCode =
-    integrationsList.length > 0
-      ? `
-  integrations: [${integrationsList.join('')}
-  ],`
-      : '';
-
-  return `
-import * as Sentry from "@sentry/react-router";${profilingImport}
-
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  // Adds request headers and IP for users, for more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,${integrationsCode}${logsSnippet}${performanceSnippet}${profilingSnippet}
-});`;
-}
-
-const getRootErrorBoundarySnippet = () => `
-import * as Sentry from "@sentry/react-router";
-
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let message = "Oops!";
-  let details = "An unexpected error occurred.";
-  let stack: string | undefined;
-
-  if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "Error";
-    details =
-      error.status === 404
-        ? "The requested page could not be found."
-        : error.statusText || details;
-  } else if (error && error instanceof Error) {
-    // you only want to capture non 404-errors that reach the boundary
-    Sentry.captureException(error);
-    if (import.meta.env.DEV) {
-      details = error.message;
-      stack = error.stack;
-    }
-  }
-
-  return (
-    <main>
-      <h1>{message}</h1>
-      <p>{details}</p>
-      {stack && (
-        <pre>
-          <code>{stack}</code>
-        </pre>
-      )}
-    </main>
-  );
-}`;
-
-const getServerEntrySnippet = () => `
-import * as Sentry from '@sentry/react-router';
-import { createReadableStreamFromReadable } from '@react-router/node';
-import { renderToPipeableStream } from 'react-dom/server';
-import { ServerRouter } from 'react-router';
-import { type HandleErrorFunction } from 'react-router';
-
-const handleRequest = Sentry.createSentryHandleRequest({
-  ServerRouter,
-  renderToPipeableStream,
-  createReadableStreamFromReadable,
-});
-
-export default handleRequest;
-
-export const handleError = Sentry.createSentryHandleError({
-  logErrors: false
-});
-
-// ... rest of your server entry`;
+import {getInstallSnippet} from './utils';
 
 const getVerifySnippet = (params: DocsParams) => {
   const logsCode = params.isLogsSelected
@@ -132,21 +28,13 @@ const getVerifySnippet = (params: DocsParams) => {
 import type { Route } from "./+types/error-page";
 
 export async function loader() {${logsCode}${metricsCode}
-  throw new Error("Sentry Test Error");
+  throw new Error("My first Sentry error!");
 }
 
-export default function ErrorPage() {
-  return <div>This page will throw an error!</div>;
+export default function ExamplePage() {
+  return <div>Loading this page will throw an error</div>;
 }`;
 };
-
-const getPackageJsonScriptsSnippet = () => `
-{
-  "scripts": {
-    "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router dev",
-    "start": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router-serve ./build/server/index.js"
-  }
-}`;
 
 export const onboarding: OnboardingConfig = {
   introduction: () => (
@@ -164,149 +52,50 @@ export const onboarding: OnboardingConfig = {
       </p>
     </Fragment>
   ),
-  install: () => [
+  install: (params: DocsParams) => [
     {
-      type: StepType.INSTALL,
+      title: t('Automatic Configuration (Recommended)'),
       content: [
         {
           type: 'text',
           text: tct(
-            'Install the Sentry React Router SDK using [code:npm], [code:yarn], or [code:pnpm]:',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'code',
-          tabs: [
+            'Configure your app automatically by running the [wizardLink:Sentry wizard] in the root of your project.',
             {
-              label: 'npm',
-              language: 'bash',
-              code: 'npm install @sentry/react-router',
-            },
-            {
-              label: 'yarn',
-              language: 'bash',
-              code: 'yarn add @sentry/react-router',
-            },
-            {
-              label: 'pnpm',
-              language: 'bash',
-              code: 'pnpm add @sentry/react-router',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  configure: (params: DocsParams) => [
-    {
-      type: StepType.CONFIGURE,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            'First, expose the hooks in your app folder by running the reveal command:'
+              wizardLink: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react-router/#install" />
+              ),
+            }
           ),
         },
         {
           type: 'code',
           language: 'bash',
-          code: 'npx react-router reveal',
+          code: getInstallSnippet(params),
         },
       ],
     },
+  ],
+  configure: params => [
     {
-      title: t('Client Setup'),
+      collapsible: true,
+      title: t('Manual Configuration'),
       content: [
         {
           type: 'text',
           text: tct(
-            'Initialize the Sentry React Router SDK in your [code:entry.client.tsx] file, above where you call [code:hydrateRoot]:',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'code',
-          language: 'tsx',
-          code: getClientSetupSnippet(params),
-        },
-      ],
-    },
-    {
-      title: t('Error Boundary'),
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Update your [code:app/root.tsx] file to report any unhandled errors from your error boundary component by adding [code:Sentry.captureException]:',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'code',
-          language: 'tsx',
-          code: getRootErrorBoundarySnippet(),
-        },
-      ],
-    },
-    {
-      title: t('Server Setup'),
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'Create an [code:instrument.server.mjs] file in the root of your app:',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'code',
-          language: 'js',
-          code: getServerSetupSnippet(params),
-        },
-        {
-          type: 'text',
-          text: tct('Update your [code:entry.server.tsx] file:', {code: <code />}),
-        },
-        {
-          type: 'code',
-          language: 'tsx',
-          code: getServerEntrySnippet(),
-        },
-      ],
-    },
-    {
-      title: t('Update Scripts'),
-      content: [
-        {
-          type: 'text',
-          text: t(
-            'Update your package.json scripts to include the server instrumentation:'
-          ),
-        },
-        {
-          type: 'code',
-          language: 'json',
-          code: getPackageJsonScriptsSnippet(),
-        },
-      ],
-    },
-    {
-      title: t('Upload Source Maps (Optional)'),
-      content: [
-        {
-          type: 'text',
-          text: tct(
-            'To upload source maps to Sentry, follow the [link:instructions in our documentation].',
+            'Alternatively, you can also set up the SDK manually, by following the [manualSetupLink:manual setup docs].',
             {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react-router/#step-3-add-readable-stack-traces-with-source-maps-optional" />
+              manualSetupLink: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react-router/manual-setup/" />
               ),
             }
           ),
         },
+        {
+          type: 'custom',
+          content: <CopyDsnField params={params} />,
+        },
       ],
-      collapsible: true,
     },
   ],
   verify: params => [
@@ -316,13 +105,19 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: t(
-            'Create a route that throws an error to verify that Sentry is working. After opening this route in your browser, you should see the error in your Sentry issue stream.'
+            'Create a route that throws an error to verify that Sentry is working:'
           ),
         },
         {
           type: 'code',
           language: 'tsx',
           code: getVerifySnippet(params),
+        },
+        {
+          type: 'text',
+          text: t(
+            'After opening this route in your browser, you should see the error in your Sentry issue stream.'
+          ),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/javascript-react-router/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/onboarding.tsx
@@ -11,31 +11,6 @@ import {t, tct} from 'sentry/locale';
 
 import {getInstallSnippet} from './utils';
 
-const getVerifySnippet = (params: DocsParams) => {
-  const logsCode = params.isLogsSelected
-    ? `
-  // Send a log before throwing the error
-  Sentry.logger.info("User triggered test error", {
-    'action': 'test_loader_error',
-  });`
-    : '';
-  const metricsCode = params.isMetricsSelected
-    ? `
-  // Send a test metric before throwing the error
-  Sentry.metrics.count('test_counter', 1);`
-    : '';
-  return `
-import type { Route } from "./+types/error-page";
-
-export async function loader() {${logsCode}${metricsCode}
-  throw new Error("My first Sentry error!");
-}
-
-export default function ExamplePage() {
-  return <div>Loading this page will throw an error</div>;
-}`;
-};
-
 export const onboarding: OnboardingConfig = {
   introduction: () => (
     <Fragment>
@@ -98,25 +73,39 @@ export const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: params => [
+  verify: () => [
     {
       type: StepType.VERIFY,
       content: [
         {
           type: 'text',
-          text: t(
-            'Create a route that throws an error to verify that Sentry is working:'
+          text: tct(
+            'Start your development server and visit [code:/sentry-example-page] if you have set it up. Click the button to trigger a test error.',
+            {
+              code: <code />,
+            }
           ),
-        },
-        {
-          type: 'code',
-          language: 'tsx',
-          code: getVerifySnippet(params),
         },
         {
           type: 'text',
           text: t(
-            'After opening this route in your browser, you should see the error in your Sentry issue stream.'
+            'Or, trigger a sample error by calling a function that does not exist somewhere in your application.'
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: 'myUndefinedFunction();',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: t(
+            'If you see an issue in your Sentry Issues, you have successfully set up Sentry with React Router.'
           ),
         },
       ],

--- a/static/app/gettingStartedDocs/javascript-react-router/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/utils.tsx
@@ -2,6 +2,11 @@ import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/ty
 import {getFeedbackConfigOptions} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getReplayConfigOptions} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 
+export function getInstallSnippet({isSelfHosted, organization, project}: DocsParams) {
+  const urlParam = isSelfHosted ? '' : '--saas';
+  return `npx @sentry/wizard@latest -i reactRouter ${urlParam} --org ${organization.slug} --project ${project.slug}`;
+}
+
 export function getClientSetupSnippet(params: DocsParams) {
   const logsSnippet = params.isLogsSelected
     ? `


### PR DESCRIPTION
Changes the onboarding to use the wizard, similarly to other SDKs that have a wizard avaialble.

<img width="1880" height="1443" alt="Screenshot 2025-12-12 at 17 13 05" src="https://github.com/user-attachments/assets/8cbfcfb4-4ed3-4899-8cd7-fa0d6ed65a54" />

**Note**: Should be merged after https://github.com/getsentry/sentry-docs/pull/15805 was merged and deployed.