### PR TITLE
fix(spans-migration): query for `updating` query subscriptions

### DIFF
--- a/src/sentry/explore/translation/alerts_translation.py
+++ b/src/sentry/explore/translation/alerts_translation.py
@@ -69,7 +69,8 @@ def _get_old_query_info(snuba_query: SnubaQuery):
 
 def translate_detector_and_update_subscription_in_snuba(snuba_query: SnubaQuery):
     query_subscription_qs = QuerySubscription.objects.filter(
-        snuba_query_id=snuba_query.id, status=QuerySubscription.Status.ACTIVE.value
+        snuba_query_id=snuba_query.id,
+        status__in=[QuerySubscription.Status.ACTIVE.value, QuerySubscription.Status.UPDATING.value],
     )
     query_subscription = query_subscription_qs.first()
 


### PR DESCRIPTION
in some of our previous runs we had some queries error out at updating the query subscription so its stuck in the `updating` state and we can't roll forward. Just adding the `updating` state to the query so we can catch these alerts.