### PR TITLE
feat(tagstore): add double-read from EAP

### DIFF
--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -7,6 +7,7 @@ import sentry_sdk
 from django.core.cache import cache
 from django.db.models import Q, QuerySet
 
+from sentry.models.environment import Environment
 from sentry.models.groupredirect import GroupRedirect
 
 """
@@ -107,3 +108,7 @@ def get_all_merged_group_ids(
         span.set_data("returned_group_id_len", len(output_set))
 
     return output_set
+
+
+def translate_environment_ids_to_names(environment_ids: Sequence[int]) -> set[str]:
+    return set(Environment.objects.filter(id__in=environment_ids).values_list("name", flat=True))

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -11,12 +11,23 @@ from typing import Any, Never, Protocol, TypedDict
 import sentry_sdk
 from dateutil.parser import parse as parse_datetime
 from django.core.cache import cache
+from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
+    AttributeDistributionsRequest,
+    StatsType,
+    TraceItemStatsRequest,
+)
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue, StrArray
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
+    ComparisonFilter,
+    TraceItemFilter,
+)
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query, Request
 
 from sentry import features, options
 from sentry.api.paginator import SequencePaginator
-from sentry.api.utils import default_start_end_dates
+from sentry.api.utils import default_start_end_dates, handle_query_errors
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -26,6 +37,10 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.replays.query import query_replays_dataset_tagkey_values
+from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
+from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.constants import (
     PROJECT_ALIAS,
     RELEASE_ALIAS,
@@ -37,12 +52,14 @@ from sentry.search.events.constants import (
 )
 from sentry.search.events.fields import FIELD_ALIASES
 from sentry.search.events.filter import _flip_field_sort
+from sentry.search.events.types import SnubaParams
+from sentry.services.eventstore.query_preprocessing import translate_environment_ids_to_names
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT, TagKeyStatus, TagStorage
 from sentry.tagstore.exceptions import GroupTagKeyNotFound, TagKeyNotFound
 from sentry.tagstore.types import GroupTagKey, GroupTagValue, TagKey, TagValue
-from sentry.utils import metrics, snuba
+from sentry.utils import metrics, snuba, snuba_rpc
 from sentry.utils.hashlib import md5_text
 from sentry.utils.snuba import (
     _prepare_start_end,
@@ -163,11 +180,118 @@ class SnubaTagStorage(TagStorage):
     value_column = "tags_value"
     format_string = "tags[{}]"
 
+    def __eap_get_tags_for_group(
+        self, tag_key: str, group: Group, environment_id: int | None, limit: int | None, **kwargs
+    ) -> GroupTagKey:
+        """
+        tag_key should be unformatted (i.e. "foo" rather than "tags[foo]")
+        """
+        attr_name = f"tags[{tag_key}]"
+        if limit is None or limit > 100:
+            # EAP imposes a limit of 100 buckets max
+            limit = 100
+
+        params = SnubaParams(
+            start=kwargs.get("start"),
+            end=kwargs.get("end"),
+            projects=[group.project],
+            organization=group.project.organization,
+        )
+
+        column_definitions = OCCURRENCE_DEFINITIONS
+        resolver = SearchResolver(
+            params=params,
+            config=SearchResolverConfig(auto_fields=True),
+            definitions=column_definitions,
+        )
+        referrer = Referrer.TAGSTORE__GET_TAG_KEYS_AND_TOP_VALUES
+        meta = resolver.resolve_meta(referrer=referrer)
+
+        stats_type = StatsType(
+            attribute_distributions=AttributeDistributionsRequest(
+                max_buckets=limit,
+                max_attributes=1,
+                attributes=[AttributeKey(name=attr_name, type=AttributeKey.Type.TYPE_STRING)],
+            )
+        )
+
+        # TODO: It should be possible for us to run this request without a group.
+        trace_item_filter = TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="group_id", type=AttributeKey.Type.TYPE_INT),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_int=group.id),
+            )
+        )
+
+        if environment_id:
+            environment_filter = TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name="environment", type=AttributeKey.Type.TYPE_STRING),
+                    op=ComparisonFilter.OP_IN,
+                    value=AttributeValue(
+                        val_str_array=StrArray(
+                            values=list(translate_environment_ids_to_names([environment_id]))
+                        )
+                    ),
+                )
+            )
+            trace_item_filter = TraceItemFilter(
+                and_filter=AndFilter(
+                    filters=[
+                        trace_item_filter,
+                        environment_filter,
+                    ],
+                )
+            )
+
+        rpc_request = TraceItemStatsRequest(
+            filter=trace_item_filter,
+            meta=meta,
+            stats_types=[stats_type],
+        )
+        with handle_query_errors():
+            item_stats_response = snuba_rpc.trace_item_stats_rpc(rpc_request)
+
+        data = item_stats_response.results[0].attribute_distributions.attributes
+        if len(data) == 0:
+            return GroupTagKey(
+                group_id=group.id,
+                key=tag_key,
+                values_seen=0,
+                count=0,
+                top_values=tuple(),
+            )
+        assert len(data) == 1 and data[0].attribute_name == attr_name
+
+        value_buckets = data[0].buckets
+
+        top_values = tuple(
+            GroupTagValue(
+                group_id=group.id,
+                key=tag_key,
+                value=bucket.label,
+                times_seen=int(bucket.value),
+                # TODO: Find way to fetch first/last seen.
+                first_seen=None,
+                last_seen=None,
+            )
+            for bucket in value_buckets
+        )
+
+        return GroupTagKey(
+            group_id=group.id,
+            key=tag_key,
+            values_seen=len(data[0].buckets),
+            count=sum([int(bucket.value) for bucket in value_buckets]),
+            top_values=top_values,
+        )
+
     def __get_tag_key_and_top_values(
         self,
         project_id,
         group: Group | None,
-        environment_id,
+        environment_id: int | None,
         key,
         limit: int | None = 3,
         raise_on_empty=True,
@@ -200,7 +324,7 @@ class SnubaTagStorage(TagStorage):
             orderby="-count",
             limit=limit,
             totals=True,
-            referrer="tagstore.__get_tag_key_and_top_values",
+            referrer=Referrer.TAGSTORE__GET_TAG_KEY_AND_TOP_VALUES,
             tenant_ids=tenant_ids,
         )
 
@@ -214,8 +338,9 @@ class SnubaTagStorage(TagStorage):
             if not has_non_empty_value:
                 raise TagKeyNotFound if group is None else GroupTagKeyNotFound
 
+        output: TagKey | GroupTagKey
         if group is None:
-            return _make_result(
+            output = _make_result(
                 key=key,
                 totals=totals,
                 result=result,
@@ -223,13 +348,53 @@ class SnubaTagStorage(TagStorage):
                 value_ctor=TagValue,
             )
         else:
-            return _make_result(
+            snuba_output = _make_result(
                 key=key,
                 totals=totals,
                 result=result,
                 key_ctor=functools.partial(GroupTagKey, group_id=group.id),
                 value_ctor=functools.partial(GroupTagValue, group_id=group.id),
             )
+            output = snuba_output
+
+            eap_callsite = "SnubaTagStorage::__get_tag_key_and_top_values"
+            if EAPOccurrencesComparator.should_check_experiment(eap_callsite):
+
+                def reasonable_group_tag_key_match(snuba: GroupTagKey, eap: GroupTagKey) -> bool:
+                    if snuba.group_id != eap.group_id or snuba.key != eap.key:
+                        return False
+
+                    if (
+                        snuba.values_seen is not None
+                        and eap.values_seen is not None
+                        and snuba.values_seen < eap.values_seen
+                    ) or (
+                        snuba.count is not None
+                        and eap.count is not None
+                        and snuba.count < eap.count
+                    ):
+                        return False
+
+                    snuba_values = {v.value: v for v in snuba.top_values}
+                    for eap_value in eap.top_values:
+                        if eap_value.value in snuba_values:
+                            if snuba_values[eap_value.value].times_seen < eap_value.times_seen:
+                                return False
+                    return True
+
+                eap_output = self.__eap_get_tags_for_group(
+                    key, group, environment_id, limit, **kwargs
+                )
+                EAPOccurrencesComparator.check_and_choose(
+                    snuba_output,
+                    eap_output,
+                    eap_callsite,
+                    is_experimental_data_a_null_result=eap_output.count == 0,
+                    reasonable_match_comparator=reasonable_group_tag_key_match,
+                )
+                # TODO: Once we have first/last seen, hook into allowlist to return EAP data
+
+        return output
 
     def __get_tag_keys(
         self,
@@ -514,6 +679,7 @@ class SnubaTagStorage(TagStorage):
         environment_id,
         key,
         tenant_ids=None,
+        **kwargs,
     ):
         return self.__get_tag_key_and_top_values(
             group.project_id,
@@ -522,6 +688,7 @@ class SnubaTagStorage(TagStorage):
             key,
             limit=TOP_VALUES_DEFAULT_LIMIT,
             tenant_ids=tenant_ids,
+            **kwargs,
         )
 
     def get_group_tag_keys(

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -119,7 +119,7 @@ class SafeRolloutComparator:
         experimental_data: TData,
         callsite: str,
         is_experimental_data_a_null_result: bool | None = None,
-        reasonable_match_comparator: Callable[[Any, Any], bool] | None = None,
+        reasonable_match_comparator: Callable[[TData, TData], bool] | None = None,
     ) -> TData:
         """
         This function does two things.


### PR DESCRIPTION
Very minimal MVP for one tagstore function.