### PR TITLE
ref(anomaly threshold): remove feature flag check

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from urllib3 import Retry
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
-from sentry import features
 from sentry.conf.server import (
     SEER_ANOMALY_DETECTION_ALERT_DATA_URL,
     SEER_ANOMALY_DETECTION_ENDPOINT_URL,
@@ -242,14 +241,10 @@ def get_anomaly_threshold_data_from_seer(
     data = results.get("data")
     if data:
         # Adjust timestamps to be one time window behind for data points after detector creation
-        if features.has(
-            "organizations:anomaly-detection-threshold-data",
-            subscription.project.organization,
-        ):
-            snuba_query: SnubaQuery = subscription.snuba_query
-            _adjust_timestamps_for_time_window(
-                data_points=data,
-                time_window_seconds=snuba_query.time_window,
-                detector_created_at=subscription.date_added.timestamp(),
-            )
+        snuba_query: SnubaQuery = subscription.snuba_query
+        _adjust_timestamps_for_time_window(
+            data_points=data,
+            time_window_seconds=snuba_query.time_window,
+            detector_created_at=subscription.date_added.timestamp(),
+        )
     return data


### PR DESCRIPTION
`get_anomaly_threshold_data_from_seer()` is not called unless the feature flag is already enabled
