### PR TITLE
feat(aci): Metric monitor form should default to number of errors

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -157,10 +157,10 @@ export const DEFAULT_THRESHOLD_METRIC_FORM_DATA = {
   sensitivity: AlertRuleSensitivity.MEDIUM,
   thresholdType: AlertRuleThresholdType.ABOVE_AND_BELOW,
 
-  dataset: DetectorDataset.SPANS,
-  aggregateFunction: 'avg(span.duration)',
+  dataset: DetectorDataset.ERRORS,
+  aggregateFunction: 'count()',
   interval: 60 * 60, // One hour in seconds
-  query: '',
+  query: 'is:unresolved',
 } satisfies Partial<MetricDetectorFormData>;
 
 /**
@@ -490,7 +490,7 @@ export function metricSavedDetectorToFormData(
 
   const dataset = snubaQuery?.dataset
     ? getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes)
-    : DetectorDataset.SPANS;
+    : DetectorDataset.ERRORS;
 
   const datasetConfig = getDatasetConfig(dataset);
   const anomalyCondition = getAnomalyCondition(detector);

--- a/static/app/views/detectors/components/forms/metric/useInitialMetricDetectorFormData.spec.tsx
+++ b/static/app/views/detectors/components/forms/metric/useInitialMetricDetectorFormData.spec.tsx
@@ -7,6 +7,27 @@ import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useInitialMetricDetectorFormData} from './useInitialMetricDetectorFormData';
 
 describe('useInitialMetricDetectorFormData', () => {
+  it('returns default errors template when no query params', () => {
+    const organization = OrganizationFixture();
+    const {result} = renderHookWithProviders(useInitialMetricDetectorFormData, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {},
+        },
+      },
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        dataset: DetectorDataset.ERRORS,
+        aggregateFunction: 'count()',
+        query: 'is:unresolved',
+      })
+    );
+  });
+
   it('parses dataset, aggregate, query, environment, and name from URL', () => {
     const organization = OrganizationFixture({features: ['performance-view']});
     const {result} = renderHookWithProviders(useInitialMetricDetectorFormData, {

--- a/static/app/views/detectors/components/forms/metric/useInitialMetricDetectorFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/useInitialMetricDetectorFormData.tsx
@@ -54,7 +54,9 @@ export function useInitialMetricDetectorFormData(): Partial<MetricDetectorFormDa
     datasetConfig,
     organization
   );
-  const queryFromUrl = decodeScalar(location.query.query, '') ?? '';
+  const queryFromUrl = decodeScalar(location.query.query);
+  const defaultQuery = DEFAULT_THRESHOLD_METRIC_FORM_DATA.query ?? '';
+  const query = queryFromUrl === undefined ? defaultQuery : queryFromUrl;
   const environmentFromUrl = decodeScalar(location.query.environment, '') ?? '';
   const nameFromUrl = decodeScalar(location.query.name, '') ?? '';
 
@@ -62,7 +64,7 @@ export function useInitialMetricDetectorFormData(): Partial<MetricDetectorFormDa
     ...DEFAULT_THRESHOLD_METRIC_FORM_DATA,
     dataset,
     aggregateFunction: aggregateFromUrl ?? defaultAggregate,
-    query: queryFromUrl,
+    query,
     environment: environmentFromUrl,
     name: nameFromUrl,
   } satisfies Partial<MetricDetectorFormData>;

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -111,10 +111,14 @@ describe('DetectorEdit', () => {
         '100'
       );
 
-      // Name should be auto-generated from defaults (Spans + count(span.duration))
+      // Name should be auto-generated from defaults (Errors + count())
       expect(await screen.findByTestId('editable-text-label')).toHaveTextContent(
-        'Number of spans above 100 over past 1 hour'
+        'Number of errors above 100 over past 1 hour'
       );
+
+      // Switch to spans dataset to access span aggregates
+      await userEvent.click(screen.getByText('Errors'));
+      await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Spans'}));
 
       // Change aggregate from count() to p75(span.duration)
       await userEvent.click(screen.getByRole('button', {name: 'count'}));
@@ -200,11 +204,11 @@ describe('DetectorEdit', () => {
               },
               dataSources: [
                 {
-                  aggregate: 'count(span.duration)',
-                  dataset: 'events_analytics_platform',
-                  eventTypes: ['trace_item_span'],
-                  query: '',
-                  queryType: 1,
+                  aggregate: 'count()',
+                  dataset: 'events',
+                  eventTypes: ['default', 'error'],
+                  query: 'is:unresolved',
+                  queryType: 0,
                   timeWindow: 3600,
                   environment: null,
                 },
@@ -236,7 +240,7 @@ describe('DetectorEdit', () => {
 
       await screen.findByText('New Monitor');
 
-      await userEvent.click(screen.getByLabelText('Throughput'));
+      await userEvent.click(screen.getByTestId('template-selector'));
       await userEvent.click(
         await screen.findByRole('option', {name: 'Number of Errors'})
       );
@@ -377,16 +381,12 @@ describe('DetectorEdit', () => {
       const description = screen.getByRole('textbox', {name: 'description'});
       await userEvent.type(description, 'This is my metric monitor description');
 
-      // Pick errors dataset
-      await userEvent.click(screen.getByText('Spans'));
-      await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Errors'}));
-
       await userEvent.type(
         screen.getByRole('spinbutton', {name: 'High threshold'}),
         '100'
       );
 
-      await userEvent.click(screen.getByLabelText('Add a search term'));
+      await userEvent.click(screen.getByTestId('query-builder-input'));
       await userEvent.paste(
         // Filter to a specific event type
         'event.type:error'
@@ -414,7 +414,7 @@ describe('DetectorEdit', () => {
                   environment: null,
                   // Event type has moved from the query to the eventTypes field
                   eventTypes: ['error'],
-                  query: '',
+                  query: 'is:unresolved',
                   queryType: 0,
                   timeWindow: 3600,
                 },
@@ -568,7 +568,7 @@ describe('DetectorEdit', () => {
       });
 
       // Open dataset dropdown
-      await userEvent.click(screen.getByText('Spans'));
+      await userEvent.click(screen.getByText('Errors'));
 
       // Verify transactions option is not available for new detectors
       expect(
@@ -644,11 +644,11 @@ describe('DetectorEdit', () => {
               },
               dataSources: [
                 {
-                  aggregate: 'count(span.duration)',
-                  dataset: 'events_analytics_platform',
-                  eventTypes: ['trace_item_span'],
-                  query: '',
-                  queryType: 1,
+                  aggregate: 'count()',
+                  dataset: 'events',
+                  eventTypes: ['default', 'error'],
+                  query: 'is:unresolved',
+                  queryType: 0,
                   timeWindow: 3600,
                   environment: null,
                 },
@@ -674,6 +674,10 @@ describe('DetectorEdit', () => {
       const title = await screen.findByText('New Monitor');
       await userEvent.click(title);
       await userEvent.keyboard('Apdex{enter}');
+
+      // Switch to Spans dataset to access apdex aggregate
+      await userEvent.click(screen.getByText('Errors'));
+      await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Spans'}));
 
       // Change aggregate from count to apdex
       await userEvent.click(screen.getByRole('button', {name: 'count'}));
@@ -724,7 +728,7 @@ describe('DetectorEdit', () => {
                   aggregate: 'apdex(span.duration,100)',
                   dataset: 'events_analytics_platform',
                   eventTypes: ['trace_item_span'],
-                  query: '',
+                  query: 'is:unresolved',
                   queryType: 1,
                   timeWindow: 3600,
                   environment: null,


### PR DESCRIPTION
When creating a new metric monitor, use "number of errors" as the default since it is the most commonly-used metric alert.