### PR TITLE
feat(seer): Save RCA step changes to backend

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -112,7 +112,7 @@ export function ConfigureRootCauseAnalysisStep() {
 
         // repo.name = `githubOrg/repositoryName`, need to split it for backend
         const [owner, name] = (repo.name || '/').split('/');
-        if (!owner || !name) {
+        if (!owner || !name || !repo.provider) {
           Sentry.logger.error('Seer Onboarding: Invalid repository name', {
             repoName: repo.name,
           });
@@ -122,9 +122,9 @@ export function ConfigureRootCauseAnalysisStep() {
           external_id: repo.externalId,
           integration_id: repo.integrationId,
           organization_id: parseInt(organization.id, 10),
-          owner: owner || '',
-          provider: repo.provider?.name || '',
-          name: name || '',
+          owner,
+          provider: repo.provider?.name,
+          name,
         });
       }
     }

--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -302,7 +302,7 @@ export function ConfigureRootCauseAnalysisStep() {
           size="md"
           onClick={handleNextStep}
           priority={isFinishDisabled ? 'default' : 'primary'}
-          disabled={isFinishDisabled}
+          disabled={isSubmitOnboardingPending || isFinishDisabled}
           aria-label={t('Last Step')}
         >
           {t('Last Step')}

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useCodeMappings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useCodeMappings.tsx
@@ -37,8 +37,8 @@ export function useCodeMappings({enabled}: UseCodeMappingsParams) {
     const map = new Map<string, Set<string>>();
     codeMappings.forEach(mapping => {
       const existingProjects = map.get(mapping.repoId) || new Set<string>();
-      if (!existingProjects.has(mapping.projectSlug)) {
-        existingProjects.add(mapping.projectSlug);
+      if (!existingProjects.has(mapping.projectId)) {
+        existingProjects.add(mapping.projectId);
         map.set(mapping.repoId, existingProjects);
       }
     });

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useSubmitSeerOnboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useSubmitSeerOnboarding.tsx
@@ -1,0 +1,49 @@
+import getApiUrl from 'sentry/utils/api/getApiUrl';
+import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export interface BackendRepository {
+  external_id: string;
+  integration_id: string;
+  name: string;
+  organization_id: number;
+  owner: string;
+  provider: string;
+  base_commit_sha?: string;
+  branch_name?: string;
+  branch_overrides?: Array<{
+    branch_name: string;
+    tag_name: string;
+    tag_value: string;
+  }>;
+  instructions?: string;
+  provider_raw?: string;
+}
+
+interface SeerOnboardingPayload {
+  fixes: boolean;
+  pr_creation: boolean;
+  project_repo_mapping: Record<string, BackendRepository[]>;
+}
+
+export function useSubmitSeerOnboarding() {
+  const organization = useOrganization();
+
+  return useMutation({
+    mutationFn: (data: SeerOnboardingPayload) => {
+      return fetchMutation<SeerOnboardingPayload>({
+        method: 'POST',
+        url: getApiUrl('/organizations/$organizationIdOrSlug/seer/onboarding/', {
+          path: {
+            organizationIdOrSlug: organization.slug,
+          },
+        }),
+        data: {
+          fixes: data.fixes,
+          pr_creation: data.pr_creation,
+          project_repo_mapping: data.project_repo_mapping,
+        },
+      });
+    },
+  });
+}

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useSubmitSeerOnboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useSubmitSeerOnboarding.tsx
@@ -39,9 +39,11 @@ export function useSubmitSeerOnboarding() {
           },
         }),
         data: {
-          fixes: data.fixes,
-          pr_creation: data.pr_creation,
-          project_repo_mapping: data.project_repo_mapping,
+          autofix: {
+            fixes: data.fixes,
+            pr_creation: data.pr_creation,
+            project_repo_mapping: data.project_repo_mapping,
+          },
         },
       });
     },

--- a/static/gsApp/views/seerAutomation/onboarding/repositoryToProjectConfiguration.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/repositoryToProjectConfiguration.tsx
@@ -191,7 +191,7 @@ const RepositoryRow = memo(function RepositoryRow({
 
 function getProjectItem(project: Project) {
   return {
-    value: project.slug,
+    value: project.id,
     textValue: project.slug,
     label: (
       <ProjectBadge


### PR DESCRIPTION
Loads "enable RCA" + "auto PR creation" settings from org and save to onboarding endpoint when going to next step.
