### PR TITLE
feat(seer): Update enrollment copy and change requirements to advance steps

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import configureCodeReviewImg from 'sentry-images/spot/seer-config-check.svg';
 
-import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Switch} from '@sentry/scraps/switch';
@@ -47,7 +46,6 @@ export function ConfigureCodeReviewStep() {
     clearRootCauseAnalysisRepositories,
     selectedCodeReviewRepositories,
     unselectedCodeReviewRepositories,
-    setCodeReviewRepositories,
   } = useSeerOnboardingContext();
 
   const [enableCodeReview, setEnableCodeReview] = useState(
@@ -173,15 +171,8 @@ export function ConfigureCodeReviewStep() {
   const handleChangeCodeReview = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setEnableCodeReview(e.target.checked);
-
-      // Unselect selected repositories if code review is disabled
-      if (!e.target.checked) {
-        setCodeReviewRepositories(
-          Object.fromEntries(selectedCodeReviewRepositories.map(repo => [repo.id, false]))
-        );
-      }
     },
-    [setEnableCodeReview, setCodeReviewRepositories, selectedCodeReviewRepositories]
+    [setEnableCodeReview]
   );
 
   return (
@@ -201,11 +192,16 @@ export function ConfigureCodeReviewStep() {
 
             <Field>
               <Flex direction="column" flex="1" gap="xs">
-                <FieldLabel>{t('AI Code Review')}</FieldLabel>
+                <FieldLabel>{t('Enable Auto Code Review Enrollment')}</FieldLabel>
                 <FieldDescription>
-                  {t(
-                    'For all repos below, AND for all newly connected repos, Seer will review your PRs and flag potential bugs.'
-                  )}
+                  <p>
+                    {t(
+                      'For all new repositories, Seer will review your PRs and flag potential bugs. '
+                    )}
+                    {t(
+                      'The repositories selected below will have code reviews enabled regardless of this setting.'
+                    )}
+                  </p>
                 </FieldDescription>
               </Flex>
               <Switch
@@ -214,12 +210,7 @@ export function ConfigureCodeReviewStep() {
                 onChange={handleChangeCodeReview}
               />
             </Field>
-            {enableCodeReview ? null : (
-              <Alert type="info">
-                {t('AI Code Review needs to be enabled in order to select repositories.')}
-              </Alert>
-            )}
-            <RepositorySelector disabled={!enableCodeReview} />
+            <RepositorySelector />
           </PanelBody>
         </MaxWidthPanel>
 

--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -193,14 +193,11 @@ export function ConfigureCodeReviewStep() {
 
             <Field>
               <Flex direction="column" flex="1" gap="xs">
-                <FieldLabel>{t('Enable Code Review')}</FieldLabel>
+                <FieldLabel>{t('Enable AI Code Review')}</FieldLabel>
                 <FieldDescription>
                   <p>
                     {t(
                       'For all new repositories, Seer will review your PRs and flag potential bugs. '
-                    )}
-                    {t(
-                      'The repositories selected below will have code reviews enabled regardless of this setting.'
                     )}
                   </p>
                 </FieldDescription>

--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -193,7 +193,7 @@ export function ConfigureCodeReviewStep() {
 
             <Field>
               <Flex direction="column" flex="1" gap="xs">
-                <FieldLabel>{t('Enable Auto Code Review Enrollment')}</FieldLabel>
+                <FieldLabel>{t('Enable Code Review')}</FieldLabel>
                 <FieldDescription>
                   <p>
                     {t(

--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -86,6 +86,7 @@ export function ConfigureCodeReviewStep() {
         );
       });
 
+    // Turn on code review for the selected repositories.
     const updateEnabledCodeReview = () =>
       new Promise<void>((resolve, reject) => {
         if (selectedCodeReviewRepositories.length === 0) {
@@ -96,7 +97,7 @@ export function ConfigureCodeReviewStep() {
         updateRepositorySettings(
           {
             codeReviewTriggers: DEFAULT_CODE_REVIEW_TRIGGERS,
-            enabledCodeReview: enableCodeReview,
+            enabledCodeReview: true,
             repositoryIds: selectedCodeReviewRepositories.map(repo => repo.id),
           },
           {

--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import configureRootCauseAnalysisImg from 'sentry-images/spot/seer-config-connect-2.svg';
 
 import {Button} from '@sentry/scraps/button';
+import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
@@ -123,13 +124,13 @@ export function ConfigureRootCauseAnalysisStep() {
     [addRootCauseAnalysisRepository]
   );
 
+  // We don't want to allow the user to finish the step if there are no projects mapped to the repositories.
+  // It is ok to advance if there are no repositories selected because they'll have configured the RCA/Auto PR creation settings.
   const isFinishDisabled = useMemo(() => {
     const mappings = Object.values(repositoryProjectMapping);
     return (
-      !mappings.length ||
       mappings.length !== selectedRootCauseAnalysisRepositories.length ||
-      Boolean(mappings.some(mappedProjects => mappedProjects.length === 0)) ||
-      selectedRootCauseAnalysisRepositories.length === 0
+      Boolean(mappings.some(mappedProjects => mappedProjects.length === 0))
     );
   }, [repositoryProjectMapping, selectedRootCauseAnalysisRepositories.length]);
 
@@ -148,11 +149,16 @@ export function ConfigureRootCauseAnalysisStep() {
 
             <Field>
               <Flex direction="column" flex="1" gap="xs">
-                <FieldLabel>{t('Enable Root Cause Analysis')}</FieldLabel>
+                <FieldLabel>{t('Enable Auto Root Cause Analysis Enrollment')}</FieldLabel>
                 <FieldDescription>
-                  {t(
-                    'For all projects below AND newly added projects, Seer will automatically analyze highly actionable issues, create a root cause analysis, and propose a solution.'
-                  )}
+                  <Text>
+                    {t(
+                      'For all new projects, Seer will automatically analyze highly actionable issues, create a root cause analysis, and propose a solution. '
+                    )}
+                    {t(
+                      'The repositories selected below will have root cause analysis enabled regardless of this setting.'
+                    )}
+                  </Text>
                 </FieldDescription>
               </Flex>
               <Switch

--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -155,9 +155,6 @@ export function ConfigureRootCauseAnalysisStep() {
                     {t(
                       'For all new projects, Seer will automatically analyze highly actionable issues, create a root cause analysis, and propose a solution. '
                     )}
-                    {t(
-                      'The repositories selected below will have root cause analysis enabled regardless of this setting.'
-                    )}
                   </Text>
                 </FieldDescription>
               </Flex>

--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -149,7 +149,7 @@ export function ConfigureRootCauseAnalysisStep() {
 
             <Field>
               <Flex direction="column" flex="1" gap="xs">
-                <FieldLabel>{t('Enable Auto Root Cause Analysis Enrollment')}</FieldLabel>
+                <FieldLabel>{t('Enable Root Cause Analysis')}</FieldLabel>
                 <FieldDescription>
                   <Text>
                     {t(

--- a/static/gsApp/views/seerAutomation/onboarding/repositorySelector.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/repositorySelector.tsx
@@ -19,7 +19,7 @@ import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations
 
 import {useSeerOnboardingContext} from 'getsentry/views/seerAutomation/onboarding/hooks/seerOnboardingContext';
 
-export function RepositorySelector({disabled = false}: {disabled?: boolean}) {
+export function RepositorySelector() {
   const {
     provider,
     isRepositoriesFetching,
@@ -90,7 +90,6 @@ export function RepositorySelector({disabled = false}: {disabled?: boolean}) {
         <InputGroup.Input
           type="text"
           name="search"
-          disabled={disabled}
           placeholder={t('Search & filter available repositories')}
           size="sm"
           value={searchQuery}
@@ -105,9 +104,7 @@ export function RepositorySelector({disabled = false}: {disabled?: boolean}) {
             : tct('Select all ([count])', {count: filteredRepositories.length})}
         </Label>
         <Checkbox
-          disabled={
-            disabled || isRepositoriesFetching || filteredRepositories.length === 0
-          }
+          disabled={isRepositoriesFetching || filteredRepositories.length === 0}
           checked={!allSelected && !allUnselected ? 'indeterminate' : allSelected}
           onChange={handleToggleAll}
           id="select-all-repositories"
@@ -122,7 +119,6 @@ export function RepositorySelector({disabled = false}: {disabled?: boolean}) {
             {filteredRepositories.map(repository => (
               <RepositoryRow
                 key={repository.id}
-                disabled={disabled}
                 repository={repository}
                 checked={selectedIds.has(repository.id)}
                 onChange={handleToggleRepository}
@@ -179,26 +175,22 @@ export function RepositorySelector({disabled = false}: {disabled?: boolean}) {
 
 interface RepositoryRowProps {
   checked: boolean;
-  disabled: boolean;
   onChange: (repositoryId: string, newValue: boolean) => void;
   repository: Repository;
 }
 
-const RepositoryRow = memo(
-  ({repository, disabled, checked, onChange}: RepositoryRowProps) => {
-    return (
-      <RepositoryItem>
-        <Label htmlFor={repository.id}>{repository.name}</Label>
-        <Checkbox
-          id={repository.id}
-          checked={checked}
-          onChange={e => onChange?.(repository.id, e.target.checked)}
-          disabled={disabled}
-        />
-      </RepositoryItem>
-    );
-  }
-);
+const RepositoryRow = memo(({repository, checked, onChange}: RepositoryRowProps) => {
+  return (
+    <RepositoryItem>
+      <Label htmlFor={repository.id}>{repository.name}</Label>
+      <Checkbox
+        id={repository.id}
+        checked={checked}
+        onChange={e => onChange?.(repository.id, e.target.checked)}
+      />
+    </RepositoryItem>
+  );
+});
 
 const Label = styled('label')`
   font-weight: ${p => p.theme.fontWeight.normal};


### PR DESCRIPTION
Clarify that the switches (except auto PR creation) are separate from the added/selected repositories. This also makes some additional UX changes:

In Code Review:

* You are allowed to select repos when enrollment is off
* Removed notice that disabled the rows when enrollment is off

Old:
<img width="625" height="114" alt="image" src="https://github.com/user-attachments/assets/2dcf00ef-f70c-4751-9105-eb2510e54a72" />

New:

<img width="627" height="108" alt="image" src="https://github.com/user-attachments/assets/929fdf9c-1b0c-4785-8bdb-7fd4e172f625" />

In RCA:

* Removed requirement that you have at least 1 repository added
* All repos that are added still require projects to be mapped


Old:
<img width="632" height="190" alt="image" src="https://github.com/user-attachments/assets/c6bf7e91-1900-4fbb-8a4d-4d53d99b6b60" />

New:
<img width="629" height="207" alt="image" src="https://github.com/user-attachments/assets/22dd374b-74e2-4247-8228-18a579ebdb12" />

