### PR TITLE
feat(seer): Implement toggling individual repos for code-review on seer org settings

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -86,17 +86,23 @@ export type Repository = {
   url: string;
 };
 
+type CodeReviewTrigger = 'on_command_phrase' | 'on_new_commit' | 'on_ready_for_review';
+
 /**
  * Available only when calling API with `expand=settings` query parameter
  */
 export interface RepositoryWithSettings extends Repository {
   settings: null | {
-    codeReviewTriggers: Array<
-      'on_command_phrase' | 'on_new_commit' | 'on_ready_for_review'
-    >;
+    codeReviewTriggers: CodeReviewTrigger[];
     enabledCodeReview: boolean;
   };
 }
+
+export const DEFAULT_CODE_REVIEW_TRIGGERS: CodeReviewTrigger[] = [
+  'on_command_phrase',
+  'on_ready_for_review',
+  'on_new_commit',
+];
 
 /**
  * Integration Repositories from OrganizationIntegrationReposEndpoint

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
@@ -1,4 +1,3 @@
-import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Checkbox} from '@sentry/scraps/checkbox/checkbox';
@@ -47,15 +46,15 @@ export default function SeerRepoTableRow({repository: initialRepository}: Props)
   // do optimistic updates, without re-rendering the entire table.
   // `initialRepository` will become stale at that point, but we'll have fresh data
   // in the cache to override it.
-  const didUpdate = useRef(false);
+  const {mutate: mutateRepositorySettings, data: mutationData} =
+    useBulkUpdateRepositorySettings();
+
   const {data, isError, isPending} = useRepositoryWithSettings({
     repositoryId: initialRepository.id,
     initialData: [initialRepository, undefined, undefined],
-    enabled: didUpdate.current,
+    enabled: Boolean(mutationData),
   });
   const repository = isError || isPending ? initialRepository : data;
-
-  const {mutate: mutateRepositorySettings} = useBulkUpdateRepositorySettings();
 
   return (
     <SimpleTable.Row key={repository.id}>
@@ -138,7 +137,6 @@ export default function SeerRepoTableRow({repository: initialRepository}: Props)
                   addSuccessMessage(t('Code review updated for %s', repository.name));
                 },
                 onSettled: () => {
-                  didUpdate.current = true;
                   queryClient.invalidateQueries({queryKey});
                 },
               }

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
@@ -110,6 +110,7 @@ export default function SeerRepoTableRow({repository: initialRepository}: Props)
             const optimisticData = {
               ...repository,
               settings: {
+                codeReviewTriggers: DEFAULT_CODE_REVIEW_TRIGGERS,
                 ...repository.settings,
                 enabledCodeReview: e.target.checked,
               },

--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -20,7 +20,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateOrganization} from 'sentry/utils/useUpdateOrganization';
 
 import {useSeerOnboardingContext} from 'getsentry/views/seerAutomation/onboarding/hooks/seerOnboardingContext';
-import {useUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useUpdateRepositorySettings';
+import {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
 
 import {
   Field,
@@ -58,7 +58,7 @@ export function ConfigureCodeReviewStep() {
     useUpdateOrganization(organization);
 
   const {mutate: updateRepositorySettings, isPending: isUpdateRepositorySettingsPending} =
-    useUpdateRepositorySettings();
+    useBulkUpdateRepositorySettings();
 
   const handleNextStep = useCallback(() => {
     const existingRepostoriesToRemove = unselectedCodeReviewRepositories

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
@@ -1,3 +1,4 @@
+import type {RepositoryWithSettings} from 'sentry/types/integrations';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -7,12 +8,12 @@ interface RepositorySettings {
   repositoryIds: string[];
 }
 
-export function useUpdateRepositorySettings() {
+export function useBulkUpdateRepositorySettings() {
   const organization = useOrganization();
 
-  return useMutation({
+  return useMutation<RepositoryWithSettings[], Error, RepositorySettings, unknown>({
     mutationFn: (data: RepositorySettings) => {
-      return fetchMutation<RepositorySettings[]>({
+      return fetchMutation<RepositoryWithSettings[]>({
         method: 'PUT',
         url: `/organizations/${organization.slug}/repos/settings/`,
         data: {

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings.tsx
@@ -1,0 +1,34 @@
+import type {RepositoryWithSettings} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+import {
+  useApiQuery,
+  type ApiQueryKey,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props extends Partial<UseApiQueryOptions<RepositoryWithSettings>> {
+  repositoryId: string;
+}
+
+export function getRepositoryWithSettingsQueryKey(
+  organization: Organization,
+  repositoryId: string
+) {
+  return [
+    `/organizations/${organization.slug}/repos/${repositoryId}/`,
+    {query: {expand: 'settings'}},
+  ] satisfies ApiQueryKey;
+}
+
+export default function useRepositoryWithSettings({repositoryId, ...options}: Props) {
+  const organization = useOrganization();
+
+  return useApiQuery<RepositoryWithSettings>(
+    getRepositoryWithSettingsQueryKey(organization, repositoryId),
+    {
+      staleTime: 0,
+      ...options,
+    }
+  );
+}

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useUpdateRepositorySettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useUpdateRepositorySettings.tsx
@@ -12,7 +12,7 @@ export function useUpdateRepositorySettings() {
 
   return useMutation({
     mutationFn: (data: RepositorySettings) => {
-      return fetchMutation<RepositorySettings>({
+      return fetchMutation<RepositorySettings[]>({
         method: 'PUT',
         url: `/organizations/${organization.slug}/repos/settings/`,
         data: {

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -3,6 +3,7 @@ import {ExternalLink} from '@sentry/scraps/link/link';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {t, tct} from 'sentry/locale';
+import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -29,11 +30,8 @@ export default function SeerAutomationSettings() {
 
           // Second section
           autoEnableCodeReview: organization.autoEnableCodeReview ?? true,
-          defaultCodeReviewTriggers: organization.defaultCodeReviewTriggers ?? [
-            'on_command_phrase',
-            'on_ready_for_review',
-            'on_new_commit',
-          ],
+          defaultCodeReviewTriggers:
+            organization.defaultCodeReviewTriggers ?? DEFAULT_CODE_REVIEW_TRIGGERS,
 
           // Third section
           enableSeerEnhancedAlerts: organization.enableSeerEnhancedAlerts ?? true,


### PR DESCRIPTION
This takes care to manage api requests when the repo list is large. We start by doing fetches for lists of repos, and their settings. This lets us render the table page (previously implemented)

Then when a user changes a setting we enable fetching just that repo data as a single-request. This will override whatever we fetched in the initial lists. Also having this single-repo API call this makes it much easier to do optimistic updates in the ui, which we've implemented with some calls to the cache.

<img width="1165" height="478" alt="SCR-20251212-lpxy" src="https://github.com/user-attachments/assets/d08394dc-ea48-4f87-829c-35ea0f31fc2a" />
