### PR TITLE
chore(ACI): Add test coverage for legacy webhooks firing

### DIFF
--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -21,7 +21,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
-from sentry.workflow_engine.models import DataConditionGroup, DataConditionGroupAction
+from sentry.workflow_engine.models import DataConditionGroup, DataConditionGroupAction, Workflow
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 from sentry.workflow_engine.typings.notification_action import ActionTarget
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -179,7 +179,8 @@ class NotifyEventServiceWebhookActionTest(NotifyEventServiceActionTest):
         workflow = IssueAlertMigrator(rule, self.user.id).run()
 
         # fetch the if_dcg to get the action
-        dcg = DataConditionGroup.objects.exclude(workflow=workflow).first()
+        other_workflow = Workflow.objects.exclude(id=workflow.id).first()
+        dcg = DataConditionGroup.objects.get(workflow=other_workflow)
         dcga = DataConditionGroupAction.objects.get(condition_group=dcg.id)
         action = dcga.action
 

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -21,7 +21,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
-from sentry.workflow_engine.models import DataConditionGroup, DataConditionGroupAction, Workflow
+from sentry.workflow_engine.models import DataConditionGroupAction, WorkflowDataConditionGroup
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 from sentry.workflow_engine.typings.notification_action import ActionTarget
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -177,11 +177,8 @@ class NotifyEventServiceWebhookActionTest(NotifyEventServiceActionTest):
         )
         # dual write the rule to replicate current reality
         workflow = IssueAlertMigrator(rule, self.user.id).run()
-
-        # fetch the if_dcg to get the action
-        other_workflow = Workflow.objects.exclude(id=workflow.id).first()
-        dcg = DataConditionGroup.objects.get(workflow=other_workflow)
-        dcga = DataConditionGroupAction.objects.get(condition_group=dcg.id)
+        wdcg = WorkflowDataConditionGroup.objects.get(workflow=workflow)
+        dcga = DataConditionGroupAction.objects.get(condition_group=wdcg.condition_group)
         action = dcga.action
 
         action_config = {

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -1,13 +1,21 @@
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
+import responses
 from django.utils import timezone
 
+from sentry.eventstream.types import EventStreamEventType
+from sentry.models.rule import Rule
+from sentry.plugins.sentry_webhooks.plugin import WebHooksPlugin
 from sentry.rules.actions.notify_event_service import NotifyEventServiceAction
 from sentry.sentry_apps.tasks.sentry_apps import notify_sentry_app
 from sentry.silo.base import SiloMode
+from sentry.tasks.post_process import post_process_group
 from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
+from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
@@ -32,6 +40,87 @@ class NotifyEventServiceActionTest(RuleTestCase):
         assert len(results) == 1
         assert plugin.should_notify.call_count == 1
         assert results[0].callback is plugin.rule_notify
+
+    @responses.activate
+    def test_applies_correctly_for_legacy_webhooks(self) -> None:
+        self.event = self.get_event()
+        webhook = WebHooksPlugin()
+        responses.add(responses.POST, "http://my-fake-webhook.io")
+        webhook.set_option(project=self.project, key="urls", value="http://my-fake-webhook.io")
+        webhook.set_option(project=self.project, key="enabled", value=True)
+
+        Rule.objects.create(
+            project=self.event.project,
+            data={
+                "conditions": [
+                    {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+                ],
+                "actions": [
+                    {
+                        "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+                        "service": "webhooks",
+                        "uuid": uuid4().hex,
+                    }
+                ],
+            },
+        )
+
+        # results = list(rule.after(event=event))
+        # assert len(results) == 1
+        # webhook.rule_notify(event=event, futures=results)
+
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(self.event),
+                group_id=self.event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        # futures = [RuleFuture(rule, {})]
+        # webhook.rule_notify(self.event, futures)
+
+        assert len(responses.calls) == 1
+
+        payload = json.loads(responses.calls[0].request.body)
+        assert payload["level"] == "error"
+        assert payload["message"] == "こんにちは"
+        assert payload["event"]["id"] == self.event.event_id
+        assert payload["event"]["event_id"] == self.event.event_id
+        # assert payload["triggering_rules"] == ['Send a notification via {service}']
+
+    @responses.activate
+    def test_applies_correctly_for_legacy_webhooks_aci(self):
+        self.event = self.get_event()
+        webhook = WebHooksPlugin()
+        responses.add(responses.POST, "http://my-fake-webhook.io")
+        webhook.set_option(project=self.project, key="urls", value="http://my-fake-webhook.io")
+        webhook.set_option(project=self.project, key="enabled", value=True)
+
+        # create ACI objects
+
+        with self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(self.event),
+                group_id=self.event.group_id,
+                project_id=self.project.id,
+                eventstream_type=EventStreamEventType.Error.value,
+            )
+
+        assert len(responses.calls) == 1
+
+        payload = json.loads(responses.calls[0].request.body)
+        assert payload["level"] == "error"
+        assert payload["message"] == "こんにちは"
+        assert payload["event"]["id"] == self.event.event_id
+        assert payload["event"]["event_id"] == self.event.event_id
+        # assert payload["triggering_rules"] == ['Send a notification via {service}']
 
     def test_applies_correctly_for_sentry_apps(self) -> None:
         event = self.get_event()


### PR DESCRIPTION
While investigating a webhook payload being empty for a customer I found that we did not have test coverage, so this PR adds coverage for the legacy `Rule` models and the newer ACI models.

Part of https://linear.app/getsentry/issue/ECO-1307/webhook-payload-is-empty-for-alert-rule