### PR TITLE
fix(code-review): Return enabled config for code review beta cohort

### DIFF
--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -17,7 +17,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.constants import DEFAULT_CODE_REVIEW_TRIGGERS, ObjectStatus
-from sentry.features import has
 from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -203,7 +202,8 @@ class CodeReviewRepoSettingsEndpoint(Endpoint):
         )
 
         if repo_settings is None:
-            if has("organizations:code-review-beta", organization_id=sentry_org_id):
+            organization = Organization.objects.filter(id=sentry_org_id).first()
+            if organization and features.has("organizations:code-review-beta", organization):
                 return Response(
                     {
                         "enabledCodeReview": True,

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -16,7 +16,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
 from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.constants import ObjectStatus
+from sentry.constants import DEFAULT_CODE_REVIEW_TRIGGERS, ObjectStatus
+from sentry.features import has
 from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -202,6 +203,14 @@ class CodeReviewRepoSettingsEndpoint(Endpoint):
         )
 
         if repo_settings is None:
+            if has("organizations:code-review-beta", organization_id=sentry_org_id):
+                return Response(
+                    {
+                        "enabledCodeReview": True,
+                        "codeReviewTriggers": DEFAULT_CODE_REVIEW_TRIGGERS,
+                    }
+                )
+
             return Response(
                 {
                     "enabledCodeReview": False,

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -567,7 +567,7 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         }
         auth = self._auth_header_for_get(url, params, "test-secret")
 
-        with self.feature({"organizations:code-review-beta": True}):
+        with self.feature({"organizations:code-review-beta": org}):
             resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
 
         assert resp.status_code == 200

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from django.urls import reverse
 
-from sentry.constants import ObjectStatus
+from sentry.constants import DEFAULT_CODE_REVIEW_TRIGGERS, ObjectStatus
 from sentry.models.repositorysettings import RepositorySettings
 from sentry.prevent.models import PreventAIConfiguration
 from sentry.prevent.types.config import PREVENT_AI_CONFIG_DEFAULT, PREVENT_AI_CONFIG_DEFAULT_V1
@@ -551,6 +551,30 @@ class TestCodeReviewRepoSettingsEndpoint(APITestCase):
         resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 200
         assert resp.data == {"enabledCodeReview": False, "codeReviewTriggers": []}
+
+    @patch(
+        "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
+        ["test-secret"],
+    )
+    def test_returns_enabled_with_default_triggers_when_code_review_beta_flag(self):
+        org = self.create_organization()
+
+        url = reverse("sentry-api-0-code-review-repo-settings")
+        params = {
+            "sentryOrgId": str(org.id),
+            "externalRepoId": "nonexistent-repo-id",
+            "provider": "integrations:github",
+        }
+        auth = self._auth_header_for_get(url, params, "test-secret")
+
+        with self.feature({"organizations:code-review-beta": True}):
+            resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
+
+        assert resp.status_code == 200
+        assert resp.data == {
+            "enabledCodeReview": True,
+            "codeReviewTriggers": DEFAULT_CODE_REVIEW_TRIGGERS,
+        }
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",


### PR DESCRIPTION
For the code review beta cohort, return default config