### PR TITLE
feat(aci): Remove is:unresolved when switching from errors dataset

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.spec.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.spec.tsx
@@ -1,0 +1,105 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import OrganizationStore from 'sentry/stores/organizationStore';
+import {DetectorFormProvider} from 'sentry/views/detectors/components/forms/context';
+import {NewMetricDetectorForm} from 'sentry/views/detectors/components/forms/metric/metric';
+
+describe('NewMetricDetectorForm', () => {
+  const organization = OrganizationFixture({
+    features: ['workflow-engine-ui', 'visibility-explore-view'],
+  });
+  const project = ProjectFixture({id: '1', slug: 'proj-1'});
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    OrganizationStore.reset();
+    OrganizationStore.onUpdate(organization);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/measurements-meta/',
+      body: {measurements: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/metrics/data/',
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/is/values/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
+    });
+  });
+
+  it('removes is filters when switching away from the errors dataset', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue" project={project}>
+        <NewMetricDetectorForm />
+      </DetectorFormProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/new/metric/',
+            query: {
+              dataset: 'errors',
+              query: 'is:unresolved status:500',
+              project: project.id,
+            },
+          },
+        },
+      }
+    );
+
+    let search = await screen.findByTestId('search-query-builder');
+
+    // Should have is:resolved and status:500 filters
+    expect(within(search).getByRole('row', {name: 'is:unresolved'})).toBeInTheDocument();
+    expect(within(search).getByRole('row', {name: 'status:500'})).toBeInTheDocument();
+
+    // Switch to spans dataset
+    await selectEvent.select(screen.getByLabelText(/dataset/i), 'Spans');
+
+    search = await screen.findByTestId('search-query-builder');
+    // is:unresolved filter should be removed
+    expect(
+      within(search).queryByRole('row', {name: 'is:unresolved'})
+    ).not.toBeInTheDocument();
+    // status:500 filter should still be present
+    expect(within(search).getByRole('row', {name: 'status:500'})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -49,6 +49,7 @@ import {
 import {MetricDetectorPreviewChart} from 'sentry/views/detectors/components/forms/metric/previewChart';
 import {DetectorQueryFilterBuilder} from 'sentry/views/detectors/components/forms/metric/queryFilterBuilder';
 import {ResolveSection} from 'sentry/views/detectors/components/forms/metric/resolveSection';
+import {sanitizeDetectorQuery} from 'sentry/views/detectors/components/forms/metric/sanitizeDetectorQuery';
 import {TemplateSection} from 'sentry/views/detectors/components/forms/metric/templateSection';
 import {useAutoMetricDetectorName} from 'sentry/views/detectors/components/forms/metric/useAutoMetricDetectorName';
 import {useDatasetChoices} from 'sentry/views/detectors/components/forms/metric/useDatasetChoices';
@@ -383,6 +384,7 @@ function CustomizeMetricSection() {
   const datasetChoices = useDatasetChoices();
   const formContext = useContext(FormContext);
   const dataset = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.dataset);
+  const query = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.query);
   const isTransactionsDataset = dataset === DetectorDataset.TRANSACTIONS;
 
   return (
@@ -426,6 +428,17 @@ function CustomizeMetricSection() {
                       formContext.form?.setValue(
                         METRIC_DETECTOR_FORM_FIELDS.detectionType,
                         supportedDetectionTypes[0]
+                      );
+                    }
+
+                    const sanitizedQuery = sanitizeDetectorQuery({
+                      dataset: newDataset,
+                      query,
+                    });
+                    if (sanitizedQuery !== query) {
+                      formContext.form?.setValue(
+                        METRIC_DETECTOR_FORM_FIELDS.query,
+                        sanitizedQuery
                       );
                     }
                   }}

--- a/static/app/views/detectors/components/forms/metric/metricTemplateOptions.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricTemplateOptions.tsx
@@ -28,6 +28,7 @@ export const METRIC_TEMPLATE_OPTIONS: TemplateOption[] = [
     label: t('Users Experiencing Errors'),
     detectorDataset: DetectorDataset.ERRORS,
     aggregate: 'count_unique(user)',
+    query: 'is:unresolved',
   },
   {
     key: 'trace_item_throughput',

--- a/static/app/views/detectors/components/forms/metric/sanitizeDetectorQuery.tsx
+++ b/static/app/views/detectors/components/forms/metric/sanitizeDetectorQuery.tsx
@@ -1,0 +1,22 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+
+/**
+ * The default "number of errors" template includes "is:unresolved", which
+ * is not supported by any other datasets. To avoid invalid queries when
+ * the user changes the dataset, we remove it from the query.
+ */
+export function sanitizeDetectorQuery({
+  dataset,
+  query,
+}: {
+  dataset: DetectorDataset;
+  query: string;
+}): string {
+  if (dataset === DetectorDataset.ERRORS || !query) {
+    return query;
+  }
+  const mutableSearch = new MutableSearch(query);
+  mutableSearch.removeFilter('is');
+  return mutableSearch.formatString();
+}

--- a/static/app/views/detectors/components/forms/metric/templateSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/templateSection.tsx
@@ -14,6 +14,7 @@ import {
   useMetricDetectorFormField,
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {METRIC_TEMPLATE_OPTIONS} from 'sentry/views/detectors/components/forms/metric/metricTemplateOptions';
+import {sanitizeDetectorQuery} from 'sentry/views/detectors/components/forms/metric/sanitizeDetectorQuery';
 import {useDatasetChoices} from 'sentry/views/detectors/components/forms/metric/useDatasetChoices';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
@@ -151,10 +152,13 @@ export function TemplateSection() {
               METRIC_DETECTOR_FORM_FIELDS.aggregateFunction,
               uiAggregate
             );
-            // Only set query if template has one and user hasn't customized the filter
-            if (meta.query !== undefined && !currentQuery) {
-              formContext.form?.setValue(METRIC_DETECTOR_FORM_FIELDS.query, meta.query);
-            }
+            const newQuery = currentQuery
+              ? sanitizeDetectorQuery({
+                  dataset: meta.detectorDataset,
+                  query: currentQuery,
+                })
+              : (meta.query ?? '');
+            formContext.form?.setValue(METRIC_DETECTOR_FORM_FIELDS.query, newQuery);
           }}
         />
       </Flex>

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -728,7 +728,7 @@ describe('DetectorEdit', () => {
                   aggregate: 'apdex(span.duration,100)',
                   dataset: 'events_analytics_platform',
                   eventTypes: ['trace_item_span'],
-                  query: 'is:unresolved',
+                  query: '',
                   queryType: 1,
                   timeWindow: 3600,
                   environment: null,


### PR DESCRIPTION
This helps ensure that the query remains valid without requiring the user to remove the `is:unresolved` filter when switching datasets. This is a pretty dumb and simple approach that could be refined in the future, but for now IMO this is better than the current behavior.