### PR TITLE
feat(seer): Implement bulk editing for repo code-review settings

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -53,10 +53,11 @@ export default function SeerRepoTable() {
   const {mutate: mutateRepositorySettings} = useBulkUpdateRepositorySettings({
     onSuccess: mutations => {
       setMutations(prev => {
-        return mutations.reduce(
-          (map, mutation) => ({...map, [mutation.id]: mutation}),
-          prev
-        );
+        const updated = {...prev};
+        mutations.forEach(mutation => {
+          updated[mutation.id] = mutation;
+        });
+        return updated;
       });
     },
     onSettled: mutations => {

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {debounce, parseAsString, useQueryState} from 'nuqs';
 
@@ -14,11 +14,14 @@ import {t} from 'sentry/locale';
 import type {RepositoryWithSettings} from 'sentry/types/integrations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
-import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {useQueryClient, type ApiQueryKey} from 'sentry/utils/queryClient';
 import {parseAsSort} from 'sentry/utils/queryString';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import SeerRepoTableHeader from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTableHeader';
 import SeerRepoTableRow from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTableRow';
+import {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
+import {getRepositoryWithSettingsQueryKey} from 'getsentry/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings';
 
 const SUPPORTED_PROVIDERS = [
   'github',
@@ -27,21 +30,43 @@ const SUPPORTED_PROVIDERS = [
 ];
 
 export default function SeerRepoTable() {
+  const queryClient = useQueryClient();
+  const organization = useOrganization();
   const {
-    data: repositories,
-    isFetching,
+    data: repositoriesWithSettings,
     error,
-    // Depends on https://github.com/getsentry/sentry/pull/104713/changes
+    isFetching,
   } = useOrganizationRepositoriesWithSettings();
 
   const supportedRepositories = useMemo(
     () =>
-      // TODO(ryan953): Is there another field to use here?
-      repositories.filter(repository =>
+      repositoriesWithSettings.filter(repository =>
         SUPPORTED_PROVIDERS.includes(repository.provider.id)
       ),
-    [repositories]
+    [repositoriesWithSettings]
   );
+
+  const [mutationData, setMutations] = useState<Record<string, RepositoryWithSettings>>(
+    {}
+  );
+
+  const {mutate: mutateRepositorySettings} = useBulkUpdateRepositorySettings({
+    onSuccess: mutations => {
+      setMutations(prev => {
+        return mutations.reduce(
+          (map, mutation) => ({...map, [mutation.id]: mutation}),
+          prev
+        );
+      });
+    },
+    onSettled: mutations => {
+      (mutations ?? []).forEach(mutation => {
+        queryClient.invalidateQueries({
+          queryKey: getRepositoryWithSettingsQueryKey(organization, mutation.id),
+        });
+      });
+    },
+  });
 
   const [searchTerm, setSearchTerm] = useQueryState(
     'query',
@@ -90,8 +115,9 @@ export default function SeerRepoTable() {
   if (isFetching) {
     return (
       <RepoTable
+        mutateRepositorySettings={mutateRepositorySettings}
         onSortClick={setSort}
-        repositories={repositories}
+        repositories={filteredRepositories}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         sort={sort}
@@ -106,8 +132,9 @@ export default function SeerRepoTable() {
   if (error) {
     return (
       <RepoTable
+        mutateRepositorySettings={mutateRepositorySettings}
         onSortClick={setSort}
-        repositories={repositories}
+        repositories={filteredRepositories}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         sort={sort}
@@ -126,6 +153,7 @@ export default function SeerRepoTable() {
       queryKey={queryKey}
     >
       <RepoTable
+        mutateRepositorySettings={mutateRepositorySettings}
         onSortClick={setSort}
         repositories={filteredRepositories}
         searchTerm={searchTerm}
@@ -133,7 +161,12 @@ export default function SeerRepoTable() {
         sort={sort}
       >
         {filteredRepositories.map(repository => (
-          <SeerRepoTableRow key={repository.id} repository={repository} />
+          <SeerRepoTableRow
+            key={repository.id}
+            mutateRepositorySettings={mutateRepositorySettings}
+            mutationData={mutationData}
+            repository={repository}
+          />
         ))}
       </RepoTable>
     </ListItemCheckboxProvider>
@@ -142,6 +175,7 @@ export default function SeerRepoTable() {
 
 function RepoTable({
   children,
+  mutateRepositorySettings,
   onSortClick,
   repositories,
   searchTerm,
@@ -149,6 +183,7 @@ function RepoTable({
   sort,
 }: {
   children: React.ReactNode;
+  mutateRepositorySettings: ReturnType<typeof useBulkUpdateRepositorySettings>['mutate'];
   onSortClick: (sort: Sort) => void;
   repositories: RepositoryWithSettings[];
   searchTerm: string;
@@ -175,8 +210,9 @@ function RepoTable({
 
       <SimpleTableWithColumns>
         <SeerRepoTableHeader
-          repositories={repositories}
+          mutateRepositorySettings={mutateRepositorySettings}
           onSortClick={onSortClick}
+          repositories={repositories}
           sort={sort}
         />
         {children}

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -5,17 +5,23 @@ import {Alert} from '@sentry/scraps/alert/alert';
 import {Checkbox} from '@sentry/scraps/checkbox/checkbox';
 import {Flex} from '@sentry/scraps/layout/flex';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t, tct, tn} from 'sentry/locale';
-import type {RepositoryWithSettings} from 'sentry/types/integrations';
+import {
+  DEFAULT_CODE_REVIEW_TRIGGERS,
+  type RepositoryWithSettings,
+} from 'sentry/types/integrations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 import {parseQueryKey} from 'sentry/utils/queryClient';
 
 import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
+import type {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
 
 interface Props {
+  mutateRepositorySettings: ReturnType<typeof useBulkUpdateRepositorySettings>['mutate'];
   onSortClick: (key: Sort) => void;
   repositories: RepositoryWithSettings[];
   sort: Sort;
@@ -27,23 +33,50 @@ const COLUMNS = [
   {title: t('Code Review'), key: 'code_review'},
 ];
 
-export default function SeerRepoTableHeader({onSortClick, repositories, sort}: Props) {
+export default function SeerRepoTableHeader({
+  onSortClick,
+  repositories,
+  sort,
+  mutateRepositorySettings,
+}: Props) {
   const canWrite = useCanWriteSettings();
   const listItemCheckboxState = useListItemCheckboxContext();
-  const {
-    countSelected,
-    isAllSelected,
-    isAnySelected,
-    queryKey,
-    selectAll,
-    selectedIds: _selectedIds,
-  } = listItemCheckboxState;
+  const {countSelected, isAllSelected, isAnySelected, queryKey, selectAll, selectedIds} =
+    listItemCheckboxState;
   const queryOptions = parseQueryKey(queryKey).options;
   const queryString = queryOptions?.query?.query;
 
-  const handleBulkCodeReview = (_value: 'on' | 'off') => {
-    // const codeReview = value ? 'on' : 'off';
-    // Depends on https://github.com/getsentry/sentry/pull/104722
+  const handleBulkCodeReview = (enabledCodeReview: boolean) => {
+    const repositoryIds =
+      selectedIds === 'all' ? repositories.map(repo => repo.id) : selectedIds;
+    mutateRepositorySettings(
+      {
+        // TODO: we should not be overriding the existing code review triggers for the repositories
+        codeReviewTriggers: DEFAULT_CODE_REVIEW_TRIGGERS,
+        enabledCodeReview,
+        repositoryIds,
+      },
+      {
+        onError: () => {
+          addErrorMessage(
+            tn(
+              'Failed to update code review for %s repository',
+              'Failed to update code review for %s repositories',
+              repositoryIds.length
+            )
+          );
+        },
+        onSuccess: () => {
+          addSuccessMessage(
+            tn(
+              'Code review updated for %s repository',
+              'Code review updated for %s repositories',
+              repositoryIds.length
+            )
+          );
+        },
+      }
+    );
   };
 
   return (
@@ -95,12 +128,12 @@ export default function SeerRepoTableHeader({onSortClick, repositories, sort}: P
                 {
                   key: 'on',
                   label: t('On'),
-                  onAction: () => handleBulkCodeReview('on'),
+                  onAction: () => handleBulkCodeReview(true),
                 },
                 {
                   key: 'off',
                   label: t('Off'),
-                  onAction: () => handleBulkCodeReview('off'),
+                  onAction: () => handleBulkCodeReview(false),
                 },
               ]}
               triggerLabel={t('Code Review')}

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
@@ -31,10 +31,16 @@ import useRepositoryWithSettings, {
 } from 'getsentry/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings';
 
 interface Props {
+  mutateRepositorySettings: ReturnType<typeof useBulkUpdateRepositorySettings>['mutate'];
+  mutationData: Record<string, RepositoryWithSettings>;
   repository: RepositoryWithSettings;
 }
 
-export default function SeerRepoTableRow({repository: initialRepository}: Props) {
+export default function SeerRepoTableRow({
+  mutateRepositorySettings,
+  mutationData,
+  repository: initialRepository,
+}: Props) {
   const queryClient = useQueryClient();
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
@@ -46,13 +52,10 @@ export default function SeerRepoTableRow({repository: initialRepository}: Props)
   // do optimistic updates, without re-rendering the entire table.
   // `initialRepository` will become stale at that point, but we'll have fresh data
   // in the cache to override it.
-  const {mutate: mutateRepositorySettings, data: mutationData} =
-    useBulkUpdateRepositorySettings();
-
   const {data, isError, isPending} = useRepositoryWithSettings({
     repositoryId: initialRepository.id,
     initialData: [initialRepository, undefined, undefined],
-    enabled: Boolean(mutationData),
+    enabled: mutationData[initialRepository.id] !== undefined,
   });
   const repository = isError || isPending ? initialRepository : data;
 

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
@@ -1,5 +1,9 @@
 import type {RepositoryWithSettings} from 'sentry/types/integrations';
-import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import {
+  fetchMutation,
+  useMutation,
+  type UseMutationOptions,
+} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface RepositorySettings {
@@ -8,7 +12,12 @@ interface RepositorySettings {
   repositoryIds: string[];
 }
 
-export function useBulkUpdateRepositorySettings() {
+export function useBulkUpdateRepositorySettings(
+  options?: Omit<
+    UseMutationOptions<RepositoryWithSettings[], Error, RepositorySettings, unknown>,
+    'mutationFn'
+  >
+) {
   const organization = useOrganization();
 
   return useMutation<RepositoryWithSettings[], Error, RepositorySettings, unknown>({
@@ -23,5 +32,6 @@ export function useBulkUpdateRepositorySettings() {
         },
       });
     },
+    ...options,
   });
 }


### PR DESCRIPTION
This is a followup to https://github.com/getsentry/sentry/pull/104886 which adds some complexity, but hoists some state up into the main Table component to share it better with each row. 

Now we can bulk-edit items in the list in addition to setting things specifically. 
Doing a bulk-edit will result in re-fetches for each item in the list. So if someone clicks to select all items it could be crazy as we re-fetch everything :(
For bulk editing a few items this works great. I don't expect people will be hammering this page with changes, so a little jank is going to be ok to start with.

https://github.com/user-attachments/assets/d5c553bd-4262-4529-9f6e-401da4a9f6d5

