### PR TITLE
fix(seer): Avoid nested links in the Seer>Project settings list

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -81,7 +81,7 @@ export default function SeerProjectTableRow({project}: Props) {
       </SimpleTable.RowCell>
       <SimpleTable.RowCell>
         <Link to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}>
-          <ProjectBadge project={project} avatarSize={16} />
+          <ProjectBadge disableLink project={project} avatarSize={16} />
         </Link>
       </SimpleTable.RowCell>
       <SimpleTable.RowCell justify="end">


### PR DESCRIPTION
Browser console was yelling about `<a>` nested inside of `<a>`