### PR TITLE
fix(seer): Stop overriding codeReviewTriggers when bulk updating settings

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -9,10 +9,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t, tct, tn} from 'sentry/locale';
-import {
-  DEFAULT_CODE_REVIEW_TRIGGERS,
-  type RepositoryWithSettings,
-} from 'sentry/types/integrations';
+import type {RepositoryWithSettings} from 'sentry/types/integrations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 import {parseQueryKey} from 'sentry/utils/queryClient';
@@ -51,8 +48,6 @@ export default function SeerRepoTableHeader({
       selectedIds === 'all' ? repositories.map(repo => repo.id) : selectedIds;
     mutateRepositorySettings(
       {
-        // TODO: we should not be overriding the existing code review triggers for the repositories
-        codeReviewTriggers: DEFAULT_CODE_REVIEW_TRIGGERS,
         enabledCodeReview,
         repositoryIds,
       },

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
@@ -6,11 +6,22 @@ import {
 } from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
-interface RepositorySettings {
-  codeReviewTriggers: string[];
-  enabledCodeReview: boolean;
-  repositoryIds: string[];
-}
+type RepositorySettings =
+  | {
+      enabledCodeReview: boolean;
+      repositoryIds: string[];
+      codeReviewTriggers?: never;
+    }
+  | {
+      codeReviewTriggers: string[];
+      repositoryIds: string[];
+      enabledCodeReview?: never;
+    }
+  | {
+      codeReviewTriggers: string[];
+      enabledCodeReview: boolean;
+      repositoryIds: string[];
+    };
 
 export function useBulkUpdateRepositorySettings(
   options?: Omit<
@@ -25,11 +36,7 @@ export function useBulkUpdateRepositorySettings(
       return fetchMutation<RepositoryWithSettings[]>({
         method: 'PUT',
         url: `/organizations/${organization.slug}/repos/settings/`,
-        data: {
-          codeReviewTriggers: data.codeReviewTriggers,
-          enabledCodeReview: data.enabledCodeReview,
-          repositoryIds: data.repositoryIds,
-        },
+        data,
       });
     },
     ...options,


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/104908
Depends on https://github.com/getsentry/sentry/pull/104918

Currently the backend expects that all fields will be passed to the bulk-edit endpoint, but that's only true in the wizard context, when we're creating everything for the first time: https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/api/endpoints/organization_repository_settings.py#L16-L41

On the settings page people can bulk-update fields, one field at a time.