### PR TITLE
fix(discover): Update docs link for getting samples via dynamic sampling

### DIFF
--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -245,7 +245,7 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
             'A user has temporarily adjusted sampling priorities, increasing the odds of getting events matching your search query. [link:Learn more.]',
             {
               link: (
-                <ExternalLink href="https://docs.sentry.io/product/performance/retention-priorities/#investigation-mode" />
+                <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#get-samples" />
               ),
             }
           )}
@@ -269,7 +269,7 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
                 {
                   code: <code />,
                   link: (
-                    <ExternalLink href="https://docs.sentry.io/product/performance/retention-priorities/#investigation-mode" />
+                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#get-samples" />
                   ),
                 }
               )
@@ -277,7 +277,7 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
                 'We can find more events that match your search query by adjusting your sampling priorities for an hour, increasing the odds of getting matching events. [link:Learn more.]',
                 {
                   link: (
-                    <ExternalLink href="https://docs.sentry.io/product/performance/retention-priorities/#investigation-mode" />
+                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#get-samples" />
                   ),
                 }
               )


### PR DESCRIPTION
This old docs link was removed in https://github.com/getsentry/sentry-docs/pull/11791.

Updating to https://docs.sentry.io/organization/dynamic-sampling/#get-samples since that is where the documentation was moved to.