### PR TITLE
fix(seer): Iterate on the seer autofix settings apis

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -535,6 +535,9 @@ from sentry.seer.endpoints.organization_seer_onboarding_check import Organizatio
 from sentry.seer.endpoints.organization_seer_rpc import OrganizationSeerRpcEndpoint
 from sentry.seer.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheck
 from sentry.seer.endpoints.organization_trace_summary import OrganizationTraceSummaryEndpoint
+from sentry.seer.endpoints.project_autofix_automation_settings import (
+    ProjectAutofixAutomationSettingsEndpoint,
+)
 from sentry.seer.endpoints.project_seer_preferences import ProjectSeerPreferencesEndpoint
 from sentry.seer.endpoints.seer_rpc import SeerRpcServiceEndpoint
 from sentry.seer.endpoints.trace_explorer_ai_query import TraceExplorerAIQuery
@@ -2674,6 +2677,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/alert-rules/$",
         ProjectAlertRuleIndexEndpoint.as_view(),
         name="sentry-api-0-project-alert-rules",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/autofix/automation-settings/$",
+        ProjectAutofixAutomationSettingsEndpoint.as_view(),
+        name="sentry-api-0-project-autofix-automation-settings",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/alert-rule-task/(?P<task_uuid>[^/]+)/$",

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -8,6 +8,7 @@ import pydantic
 import requests
 from django.conf import settings
 from pydantic import BaseModel
+from rest_framework import serializers
 from urllib3 import Retry
 
 from sentry import features, options, ratelimits
@@ -140,6 +141,28 @@ class CodingAgentStateUpdateRequest(BaseModel):
 autofix_connection_pool = connection_from_url(
     settings.SEER_AUTOFIX_URL,
 )
+
+
+class SeerAutofixSettingsSerializer(serializers.Serializer):
+    """Base serializer for autofixAutomationTuning and automatedRunStoppingPoint"""
+
+    autofixAutomationTuning = serializers.ChoiceField(
+        choices=[opt.value for opt in AutofixAutomationTuningSettings],
+        required=False,
+        help_text="The tuning setting for the projects.",
+    )
+    automatedRunStoppingPoint = serializers.ChoiceField(
+        choices=[opt.value for opt in AutofixStoppingPoint],
+        required=False,
+        help_text="The stopping point for the projects.",
+    )
+
+    def validate(self, data):
+        if "autofixAutomationTuning" not in data and "automatedRunStoppingPoint" not in data:
+            raise serializers.ValidationError(
+                "At least one of 'autofixAutomationTuning' or 'automatedRunStoppingPoint' must be provided."
+            )
+        return data
 
 
 def get_project_seer_preferences(project_id: int) -> SeerRawPreferenceResponse:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -24,6 +24,7 @@ from sentry.seer.models import (
     SeerApiError,
     SeerApiResponseValidationError,
     SeerPermissionError,
+    SeerProjectPreference,
     SeerRawPreferenceResponse,
     SeerRepoDefinition,
 )
@@ -163,6 +164,16 @@ class SeerAutofixSettingsSerializer(serializers.Serializer):
                 "At least one of 'autofixAutomationTuning' or 'automatedRunStoppingPoint' must be provided."
             )
         return data
+
+
+def default_seer_project_preference(project: Project) -> SeerProjectPreference:
+    return SeerProjectPreference(
+        organization_id=project.organization.id,
+        project_id=project.id,
+        repositories=[],
+        automated_run_stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
+        automation_handoff=None,
+    )
 
 
 def get_project_seer_preferences(project_id: int) -> SeerRawPreferenceResponse:

--- a/src/sentry/seer/blueprints/api.md
+++ b/src/sentry/seer/blueprints/api.md
@@ -14,7 +14,7 @@ returns a response _will_ document the full interchange format. Clients may opt
 to restrict response data or provide a subset of the request data. The API may
 or may not accept partial payloads.
 
-## Organization Autofix Automation Settings [/organizations/<organization_id_or_slug>/autofix-automation-settings/]
+## Organization Autofix Automation Settings [/organizations/<organization_id_or_slug>/autofix/automation-settings/]
 
 Bulk endpoint for managing project-level autofix automation settings across an organization.
 

--- a/src/sentry/seer/blueprints/api.md
+++ b/src/sentry/seer/blueprints/api.md
@@ -1,0 +1,154 @@
+# Seer Autofix Settings API
+
+Host: https://sentry.io/api/0
+
+**Authors.**
+
+@ryan953
+
+**How to read this document.**
+
+This document is structured by resource with each resource having actions that
+can be performed against it. Every action that either accepts a request or
+returns a response _will_ document the full interchange format. Clients may opt
+to restrict response data or provide a subset of the request data. The API may
+or may not accept partial payloads.
+
+## Organization Autofix Automation Settings [/organizations/<organization_id_or_slug>/autofix-automation-settings/]
+
+Bulk endpoint for managing project-level autofix automation settings across an organization.
+
+### List Projects with Settings [GET]
+
+Retrieves a paginated list of projects with their autofix automation settings.
+
+- Parameters
+  - query (optional, string) - Search query to filter by project name or slug.
+
+**Attributes**
+
+| Column                    | Type   | Description                                                                                                                  |
+| ------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| projectId                 | int    | The project ID                                                                                                               |
+| autofixAutomationTuning   | string | The tuning setting for automated autofix. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`) |
+| automatedRunStoppingPoint | string | The stopping point for automated runs. One of: `code_changes`, `open_pr`, (deprecated values: `root_cause`, `solution`)      |
+| reposCount                | int    | Number of repositories configured for the project                                                                            |
+
+- Response 200
+
+  ```json
+  [
+    {
+      "projectId": 123,
+      "autofixAutomationTuning": "medium",
+      "automatedRunStoppingPoint": "code_changes",
+      "reposCount": 2
+    },
+    {
+      "projectId": 456,
+      "autofixAutomationTuning": "off",
+      "automatedRunStoppingPoint": "root_cause",
+      "reposCount": 0
+    }
+  ]
+  ```
+
+### Bulk Update Settings [POST]
+
+Bulk create/update the autofix automation settings for multiple projects in a single request.
+
+- Request (application/json)
+
+**Attributes**
+
+| Column                    | Type      | Required | Description                                                                                            |
+| ------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| projectIds                | list[int] | Yes      | List of project IDs to update (min: 1, max: 1000)                                                      |
+| autofixAutomationTuning   | string    | No\*     | The tuning setting. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`) |
+| automatedRunStoppingPoint | string    | No\*     | The stopping point. One of: `code_changes`, `open_pr`, (deprecated values: `root_cause`, `solution`)   |
+
+\* At least one of either `autofixAutomationTuning` or `automatedRunStoppingPoint` must be provided.
+
+```json
+{
+  "projectIds": [123, 456, 789],
+  "autofixAutomationTuning": "medium",
+  "automatedRunStoppingPoint": "code_changes"
+}
+```
+
+- Response 204
+
+  No content on success.
+
+- Response 400
+
+  ```json
+  {
+    "autofixAutomationTuning": ["This field is required."],
+    "automatedRunStoppingPoint": ["This field is required."]
+  }
+  ```
+
+## Project Autofix Automation Settings [/projects/<organization_id_or_slug>/<project_id_or_slug>/autofix/automation-settings/]
+
+Endpoint for managing autofix automation settings for a specific project.
+
+### Get Project Settings [GET]
+
+Retrieves the autofix automation settings for a specific project.
+
+**Attributes**
+
+| Column                    | Type   | Description                                                                                                                  |
+| ------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| autofixAutomationTuning   | string | The tuning setting for automated autofix. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`) |
+| automatedRunStoppingPoint | string | The stopping point for automated runs. One of: `code_changes`, `open_pr`, (deprecated values: `root_cause`, `solution`)      |
+| reposCount                | int    | Number of repositories configured for the project                                                                            |
+
+- Response 200
+
+  ```json
+  {
+    "projectId": 123,
+    "autofixAutomationTuning": "medium",
+    "automatedRunStoppingPoint": "code_changes",
+    "reposCount": 2
+  }
+  ```
+
+### Update Project Settings [PUT]
+
+Update the autofix automation settings for a specific project.
+
+- Request (application/json)
+
+**Attributes**
+
+| Column                    | Type   | Required | Description                                                                                            |
+| ------------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------ |
+| autofixAutomationTuning   | string | No\*     | The tuning setting. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`) |
+| automatedRunStoppingPoint | string | No\*     | The stopping point. One of: `code_changes`, `open_pr`, (deprecated values: `root_cause`, `solution`)   |
+
+\* At least one of `autofixAutomationTuning` or `automatedRunStoppingPoint` must be provided.
+
+```json
+{
+  "autofixAutomationTuning": "high",
+  "automatedRunStoppingPoint": "open_pr"
+}
+```
+
+- Response 204
+
+  No content on success.
+
+- Response 400
+
+  ```json
+  {
+    "non_field_errors": [
+      "At least one of 'autofixAutomationTuning' or 'automatedRunStoppingPoint' must be provided."
+    ]
+  }
+  ```

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.db import router, transaction
 from django.db.models import Q
 from rest_framework import serializers
@@ -21,19 +23,10 @@ from sentry.seer.autofix.utils import (
     bulk_set_project_preferences,
 )
 
-OPTION_KEY = "sentry:autofix_automation_tuning"
 
-
-class SeerAutofixSettingGetSerializer(serializers.Serializer):
+class SeerAutofixSettingGetResponseSerializer(serializers.Serializer):
     """Serializer for OrganizationAutofixAutomationSettingsEndpoint.get query params"""
 
-    projectIds = serializers.ListField(
-        child=serializers.IntegerField(),
-        required=False,
-        allow_null=True,
-        max_length=1000,
-        help_text="Optional list of project IDs to filter by. Maximum 1000 projects.",
-    )
     query = serializers.CharField(
         required=False,
         allow_blank=True,
@@ -42,35 +35,36 @@ class SeerAutofixSettingGetSerializer(serializers.Serializer):
     )
 
 
-class SeerAutofixSettingSerializer(serializers.Serializer):
-    """Serializer for OrganizationAutofixAutomationSettingsEndpoint.put"""
+class SeerAutofixSettingsPostSerializer(serializers.Serializer):
+    """Serializer for OrganizationAutofixAutomationSettingsEndpoint.post"""
 
     projectIds = serializers.ListField(
         child=serializers.IntegerField(),
         required=True,
         min_length=1,
         max_length=1000,
-        help_text="List of project IDs to update settings for.",
+        help_text="List of project IDs to create/update settings for.",
     )
-    fixes = serializers.BooleanField(
-        required=True,
-        help_text="Whether to enable fixes for the projects.",
-    )
-    pr_creation = serializers.BooleanField(
+    autofixAutomationTuning = serializers.ChoiceField(
+        choices=[opt.value for opt in AutofixAutomationTuningSettings],
         required=False,
-        default=False,
-        help_text="Whether to enable PR creation for the projects. Requires fixes to be enabled.",
+        help_text="The tuning setting for the projects.",
+    )
+    automatedRunStoppingPoint = serializers.ChoiceField(
+        choices=[opt.value for opt in AutofixStoppingPoint],
+        required=False,
+        help_text="The stopping point for the projects.",
     )
 
     def validate(self, data):
-        # If fixes is disabled, pr_creation must also be disabled
-        if not data.get("fixes") and data.get("pr_creation"):
+        if "autofixAutomationTuning" not in data and "automatedRunStoppingPoint" not in data:
             raise serializers.ValidationError(
-                {"pr_creation": "PR creation cannot be enabled when fixes is disabled."}
+                "At least one of 'autofixAutomationTuning' or 'automatedRunStoppingPoint' must be provided."
             )
         return data
 
 
+#
 @region_silo_endpoint
 class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
     """Bulk endpoint for managing project level autofix automation settings."""
@@ -79,7 +73,7 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
 
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
-        "PUT": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     permission_classes = (OrganizationPermission,)
@@ -91,25 +85,29 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
             return []
 
         project_ids_list = [project.id for project in projects]
-        tuning_options = ProjectOption.objects.get_value_bulk(projects, OPTION_KEY)
-        seer_preferences = bulk_get_project_preferences(organization.id, project_ids_list) or {}
-
+        autofix_automation_tuning_map = ProjectOption.objects.get_value_bulk(
+            projects, "sentry:autofix_automation_tuning"
+        )
+        seer_preferences_map = bulk_get_project_preferences(organization.id, project_ids_list) or {}
         results = []
         for project in projects:
-            tuning_value = tuning_options.get(project) or AutofixAutomationTuningSettings.OFF.value
-            seer_pref = seer_preferences.get(str(project.id)) or {}
+            autofix_automation_tuning = (
+                autofix_automation_tuning_map.get(project)
+                or AutofixAutomationTuningSettings.OFF.value
+            )
+            seer_pref = seer_preferences_map.get(str(project.id)) or {}
+            automated_run_stopping_point = (
+                seer_pref.get("automated_run_stopping_point")
+                or AutofixStoppingPoint.CODE_CHANGES.value
+            )
+            repos_count = len(seer_pref.get("repositories") or [])
 
             results.append(
                 {
                     "projectId": project.id,
-                    "projectSlug": project.slug,
-                    "projectName": project.name,
-                    "projectPlatform": project.platform,
-                    "fixes": tuning_value != AutofixAutomationTuningSettings.OFF.value,
-                    "prCreation": seer_pref.get("automated_run_stopping_point")
-                    == AutofixStoppingPoint.OPEN_PR.value,
-                    "tuning": tuning_value,
-                    "reposCount": len(seer_pref.get("repositories") or []),
+                    "autofixAutomationTuning": autofix_automation_tuning,
+                    "automatedRunStoppingPoint": automated_run_stopping_point,
+                    "reposCount": repos_count,
                 }
             )
         return results
@@ -123,7 +121,7 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         :qparam string query: Optional search query to filter by project name or slug.
         :auth: required
         """
-        serializer = SeerAutofixSettingGetSerializer(
+        serializer = SeerAutofixSettingGetResponseSerializer(
             data={
                 "projectIds": request.GET.getlist("projectIds") or None,
                 "query": request.GET.get("query"),
@@ -132,19 +130,9 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        data = serializer.validated_data
-        project_ids = data.get("projectIds")
+        queryset = Project.objects.filter(organization_id=organization.id)
 
-        if project_ids:
-            authorized_projects = self.get_projects(
-                request, organization, project_ids=set(project_ids)
-            )
-            authorized_project_ids = [p.id for p in authorized_projects]
-            queryset = Project.objects.filter(id__in=authorized_project_ids)
-        else:
-            queryset = Project.objects.filter(organization_id=organization.id)
-
-        query = data.get("query")
+        query = serializer.validated_data.get("query")
         if query:
             queryset = queryset.filter(Q(name__icontains=query) | Q(slug__icontains=query))
 
@@ -158,58 +146,52 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
             paginator_cls=OffsetPaginator,
         )
 
-    def put(self, request: Request, organization: Organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
-        Bulk update the autofix automation settings of projects in a single request.
+        Bulk create/update the autofix automation settings of projects in a single request.
 
         :pparam string organization_id_or_slug: the id or slug of the organization.
         :auth: required
         """
-        serializer = SeerAutofixSettingSerializer(data=request.data)
+        serializer = SeerAutofixSettingsPostSerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        data = serializer.validated_data
-        project_ids = set(data["projectIds"])
-        fixes_enabled = data["fixes"]
-        pr_creation_enabled = data.get("pr_creation", False)
+        project_ids = set[int](serializer.validated_data["projectIds"] or [])
+        autofix_automation_tuning = serializer.validated_data.get("autofixAutomationTuning")
+        automated_run_stopping_point = serializer.validated_data.get("automatedRunStoppingPoint")
 
         projects = self.get_projects(request, organization, project_ids=project_ids)
 
-        tuning_setting = (
-            AutofixAutomationTuningSettings.MEDIUM
-            if fixes_enabled
-            else AutofixAutomationTuningSettings.OFF
-        )
+        preferences_to_set: list[dict[str, Any]] = []
+        if automated_run_stopping_point:
+            project_ids_list = [project.id for project in projects]
+            existing_preferences = bulk_get_project_preferences(organization.id, project_ids_list)
 
-        stopping_point = (
-            AutofixStoppingPoint.OPEN_PR
-            if pr_creation_enabled
-            else AutofixStoppingPoint.CODE_CHANGES
-        )
+            for project in projects:
+                project_id_str = str(project.id)
+                existing_pref = existing_preferences.get(project_id_str, {})
 
-        project_ids_list = [project.id for project in projects]
-        existing_preferences = bulk_get_project_preferences(organization.id, project_ids_list)
-
-        preferences_to_set = []
-        for project in projects:
-            project_id_str = str(project.id)
-            existing_pref = existing_preferences.get(project_id_str, {})
-
-            preferences_to_set.append(
-                {
-                    **existing_pref,
-                    "organization_id": organization.id,
-                    "project_id": project.id,
-                    "automated_run_stopping_point": stopping_point.value,
-                }
-            )
+                preferences_to_set.append(
+                    {
+                        **existing_pref,
+                        "organization_id": organization.id,
+                        "project_id": project.id,
+                        "automated_run_stopping_point": automated_run_stopping_point.value,
+                    }
+                )
 
         # Wrap DB writes and Seer API call in a transaction.
         # If Seer API fails, DB changes are rolled back.
         with transaction.atomic(router.db_for_write(ProjectOption)):
-            for project in projects:
-                project.update_option(OPTION_KEY, tuning_setting.value)
+            if autofix_automation_tuning:
+                autofix_automation_tuning_value = (
+                    autofix_automation_tuning or AutofixAutomationTuningSettings.OFF
+                )
+                for project in projects:
+                    project.update_option(
+                        "sentry:autofix_automation_tuning", autofix_automation_tuning_value.value
+                    )
 
             if preferences_to_set:
                 bulk_set_project_preferences(organization.id, preferences_to_set)

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -22,6 +22,7 @@ from sentry.seer.autofix.utils import (
     SeerAutofixSettingsSerializer,
     bulk_get_project_preferences,
     bulk_set_project_preferences,
+    default_seer_project_preference,
 )
 
 
@@ -156,6 +157,7 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
 
                 preferences_to_set.append(
                     {
+                        **default_seer_project_preference(project).dict(),
                         **existing_pref,
                         "organization_id": organization.id,
                         "project_id": project.id,

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -19,6 +19,7 @@ from sentry.models.project import Project
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
+    SeerAutofixSettingsSerializer,
     bulk_get_project_preferences,
     bulk_set_project_preferences,
 )
@@ -35,7 +36,7 @@ class SeerAutofixSettingGetResponseSerializer(serializers.Serializer):
     )
 
 
-class SeerAutofixSettingsPostSerializer(serializers.Serializer):
+class SeerAutofixSettingsPostSerializer(SeerAutofixSettingsSerializer):
     """Serializer for OrganizationAutofixAutomationSettingsEndpoint.post"""
 
     projectIds = serializers.ListField(
@@ -45,26 +46,8 @@ class SeerAutofixSettingsPostSerializer(serializers.Serializer):
         max_length=1000,
         help_text="List of project IDs to create/update settings for.",
     )
-    autofixAutomationTuning = serializers.ChoiceField(
-        choices=[opt.value for opt in AutofixAutomationTuningSettings],
-        required=False,
-        help_text="The tuning setting for the projects.",
-    )
-    automatedRunStoppingPoint = serializers.ChoiceField(
-        choices=[opt.value for opt in AutofixStoppingPoint],
-        required=False,
-        help_text="The stopping point for the projects.",
-    )
-
-    def validate(self, data):
-        if "autofixAutomationTuning" not in data and "automatedRunStoppingPoint" not in data:
-            raise serializers.ValidationError(
-                "At least one of 'autofixAutomationTuning' or 'automatedRunStoppingPoint' must be provided."
-            )
-        return data
 
 
-#
 @region_silo_endpoint
 class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
     """Bulk endpoint for managing project level autofix automation settings."""

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -79,9 +79,8 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
                 or AutofixAutomationTuningSettings.OFF.value
             )
             seer_pref = seer_preferences_map.get(str(project.id)) or {}
-            automated_run_stopping_point = (
-                seer_pref.get("automated_run_stopping_point")
-                or AutofixStoppingPoint.CODE_CHANGES.value
+            automated_run_stopping_point = seer_pref.get(
+                "automated_run_stopping_point", AutofixStoppingPoint.CODE_CHANGES.value
             )
             repos_count = len(seer_pref.get("repositories") or [])
 

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -177,7 +177,7 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
                         **existing_pref,
                         "organization_id": organization.id,
                         "project_id": project.id,
-                        "automated_run_stopping_point": automated_run_stopping_point.value,
+                        "automated_run_stopping_point": automated_run_stopping_point,
                     }
                 )
 
@@ -186,11 +186,11 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         with transaction.atomic(router.db_for_write(ProjectOption)):
             if autofix_automation_tuning:
                 autofix_automation_tuning_value = (
-                    autofix_automation_tuning or AutofixAutomationTuningSettings.OFF
+                    autofix_automation_tuning or AutofixAutomationTuningSettings.OFF.value
                 )
                 for project in projects:
                     project.update_option(
-                        "sentry:autofix_automation_tuning", autofix_automation_tuning_value.value
+                        "sentry:autofix_automation_tuning", autofix_automation_tuning_value
                     )
 
             if preferences_to_set:

--- a/src/sentry/seer/endpoints/project_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/project_autofix_automation_settings.py
@@ -14,6 +14,7 @@ from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import (
+    AutofixStoppingPoint,
     SeerAutofixSettingsSerializer,
     bulk_set_project_preferences,
     default_seer_project_preference,
@@ -53,7 +54,8 @@ class ProjectAutofixAutomationSettingsEndpoint(ProjectEndpoint):
             data={
                 "projectId": project.id,
                 "autofixAutomationTuning": autofix_automation_tuning,
-                "automatedRunStoppingPoint": seer_pref.automated_run_stopping_point,
+                "automatedRunStoppingPoint": seer_pref.automated_run_stopping_point
+                or AutofixStoppingPoint.CODE_CHANGES.value,
                 "reposCount": len(seer_pref.repositories),
             },
         )

--- a/src/sentry/seer/endpoints/project_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/project_autofix_automation_settings.py
@@ -88,9 +88,8 @@ class ProjectAutofixAutomationSettingsEndpoint(ProjectEndpoint):
                 "autofixAutomationTuning": autofix_automation_tuning
                 or AutofixAutomationTuningSettings.OFF.value,
                 "automatedRunStoppingPoint": (
-                    seer_pref.automated_run_stopping_point
-                    if seer_pref
-                    else AutofixStoppingPoint.CODE_CHANGES.value
+                    (seer_pref.automated_run_stopping_point if seer_pref else None)
+                    or AutofixStoppingPoint.CODE_CHANGES.value
                 ),
                 "reposCount": len(seer_pref.repositories if seer_pref else []),
             },

--- a/src/sentry/seer/endpoints/project_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/project_autofix_automation_settings.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any
+
+import sentry_sdk
+from django.db import router, transaction
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import ProjectPermission
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.models.options.project_option import ProjectOption
+from sentry.models.project import Project
+from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.autofix.utils import (
+    AutofixStoppingPoint,
+    bulk_set_project_preferences,
+    get_project_seer_preferences,
+)
+from sentry.seer.models import SeerApiResponseValidationError
+
+
+class SeerAutofixSettingPutSerializer(serializers.Serializer):
+    """Serializer for OrganizationAutofixAutomationSettingsEndpoint.put"""
+
+    autofixAutomationTuning = serializers.ChoiceField(
+        choices=[opt.value for opt in AutofixAutomationTuningSettings],
+        required=False,
+        help_text="The tuning setting for the projects.",
+    )
+    automatedRunStoppingPoint = serializers.ChoiceField(
+        choices=[opt.value for opt in AutofixStoppingPoint],
+        required=False,
+        help_text="The stopping point for the projects.",
+    )
+
+    def validate(self, data):
+        if "autofixAutomationTuning" not in data and "automatedRunStoppingPoint" not in data:
+            raise serializers.ValidationError(
+                "At least one of 'autofixAutomationTuning' or 'automatedRunStoppingPoint' must be provided."
+            )
+        return data
+
+
+@region_silo_endpoint
+class ProjectAutofixAutomationSettingsEndpoint(ProjectEndpoint):
+    """Bulk endpoint for managing project level autofix automation settings."""
+
+    owner = ApiOwner.CODING_WORKFLOWS
+
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
+
+    permission_classes = (ProjectPermission,)
+
+    def get(self, request: Request, project: Project) -> Response:
+        """
+        Specific project with its autofix automation settings.
+
+        :pparam string organization_id_or_slug: the id or slug of the organization.
+        :pparam string project_id_or_slug: project ID to read.
+        :auth: required
+        """
+
+        autofix_automation_tuning = ProjectOption.objects.get_value(
+            project, "sentry:autofix_automation_tuning"
+        )
+        seer_pref = None
+        try:
+            raw_prefs = get_project_seer_preferences(project.id)
+            seer_pref = raw_prefs.preference if raw_prefs else None
+        except SeerApiResponseValidationError:
+            pass
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            return Response(status=500, data={"error": "Failed to read Seer project preferences"})
+
+        return Response(
+            status=200,
+            data={
+                "projectId": project.id,
+                "autofixAutomationTuning": autofix_automation_tuning
+                or AutofixAutomationTuningSettings.OFF.value,
+                "automatedRunStoppingPoint": (
+                    seer_pref.automated_run_stopping_point
+                    if seer_pref
+                    else AutofixStoppingPoint.CODE_CHANGES.value
+                ),
+                "reposCount": len(seer_pref.repositories if seer_pref else []),
+            },
+        )
+
+    def put(self, request: Request, project: Project) -> Response:
+        """
+        Update the autofix automation settings for a project.
+
+        :pparam string organization_id_or_slug: the id or slug of the organization.
+        :pparam string project_id_or_slug: the id or slug of the project.
+        :auth: required
+        """
+        serializer = SeerAutofixSettingPutSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        autofix_automation_tuning = serializer.validated_data.get("autofixAutomationTuning")
+        automated_run_stopping_point = serializer.validated_data.get("automatedRunStoppingPoint")
+
+        preferences_to_set: list[dict[str, Any]] = []
+        if automated_run_stopping_point:
+            seer_pref = None
+            try:
+                raw_prefs = get_project_seer_preferences(project.id)
+                seer_pref = raw_prefs.preference if raw_prefs else None
+            except SeerApiResponseValidationError:
+                pass
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+                return Response(
+                    status=500, data={"error": "Failed to read Seer project preferences"}
+                )
+
+            preferences_to_set.append(
+                {
+                    **(seer_pref.dict() if seer_pref else {}),
+                    "automated_run_stopping_point": automated_run_stopping_point,
+                }
+            )
+
+        # Wrap DB writes and Seer API call in a transaction.
+        # If Seer API fails, DB changes are rolled back.
+        with transaction.atomic(router.db_for_write(ProjectOption)):
+            if autofix_automation_tuning:
+                autofix_automation_tuning_value = (
+                    autofix_automation_tuning or AutofixAutomationTuningSettings.OFF
+                )
+
+                project.update_option(
+                    "sentry:autofix_automation_tuning", autofix_automation_tuning_value
+                )
+
+            if preferences_to_set:
+                bulk_set_project_preferences(project.organization.id, preferences_to_set)
+
+        return Response(status=204)

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -589,6 +589,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/artifact-bundles/$bundleId/files/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/artifact-bundles/$bundleId/files/$fileId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/artifact-lookup/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/autofix/automation-settings/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/cluster-transaction-names/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/codeowners/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/codeowners/$codeownersId/'

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -171,7 +171,9 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             {
                 "organization_id": self.organization.id,
                 "project_id": project.id,
+                "repositories": [],
                 "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+                "automation_handoff": None,
             }
         ]
 
@@ -230,7 +232,9 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             {
                 "organization_id": self.organization.id,
                 "project_id": project.id,
+                "repositories": [],
                 "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+                "automation_handoff": None,
             }
         ]
 

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -17,484 +17,286 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
 
     @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    @patch(
         "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
     )
-    def test_put_fixes_enabled_sets_medium_tuning(
-        self, mock_bulk_get_preferences, mock_bulk_set_preferences
-    ):
+    def test_get_returns_default_settings_for_all_projects(self, mock_bulk_get_preferences):
+        project1 = self.create_project(organization=self.organization, name="Project One")
+        project2 = self.create_project(organization=self.organization, name="Project Two")
+
         mock_bulk_get_preferences.return_value = {}
-        project1 = self.create_project(organization=self.organization)
-        project2 = self.create_project(organization=self.organization)
 
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [project1.id, project2.id],
-                "fixes": True,
+        response = self.client.get(self.url, {})
+
+        assert response.status_code == 200
+        assert response.data == [
+            {
+                "projectId": project1.id,
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.OFF.value,
+                "automatedRunStoppingPoint": AutofixStoppingPoint.CODE_CHANGES.value,
+                "reposCount": 0,
             },
-            format="json",
-        )
+            {
+                "projectId": project2.id,
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.OFF.value,
+                "automatedRunStoppingPoint": AutofixStoppingPoint.CODE_CHANGES.value,
+                "reposCount": 0,
+            },
+        ]
 
-        assert response.status_code == 204
-
-        project1.refresh_from_db()
-        project2.refresh_from_db()
-        assert (
-            project1.get_option("sentry:autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        assert (
-            project2.get_option("sentry:autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.MEDIUM.value
-        )
-
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        assert call_args[0][0] == self.organization.id
-        preferences = call_args[0][1]
-        assert len(preferences) == 2
-        for pref in preferences:
-            assert pref["automated_run_stopping_point"] == AutofixStoppingPoint.CODE_CHANGES.value
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
     @patch(
         "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
     )
-    def test_put_fixes_and_pr_creation_enabled(
-        self, mock_bulk_get_preferences, mock_bulk_set_preferences
-    ):
+    def test_get_returns_projects_matching_query(self, mock_bulk_get_preferences):
+        project1 = self.create_project(organization=self.organization, name="Project One")
+        project2 = self.create_project(organization=self.organization, name="Project Two")
+
         mock_bulk_get_preferences.return_value = {}
-        project = self.create_project(organization=self.organization)
 
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [project.id],
-                "fixes": True,
-                "pr_creation": True,
-            },
-            format="json",
-        )
+        # Search by name
+        response = self.client.get(self.url, {"query": project1.name})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["projectId"] == project1.id
 
-        assert response.status_code == 204
+        # Search by slug
+        response = self.client.get(self.url, {"query": project2.slug})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["projectId"] == project2.id
 
-        project.refresh_from_db()
-        assert (
-            project.get_option("sentry:autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.MEDIUM.value
-        )
-
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert preferences[0]["automated_run_stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_put_fixes_disabled_sets_off_tuning(
-        self, mock_bulk_get_preferences, mock_bulk_set_preferences
-    ):
-        mock_bulk_get_preferences.return_value = {}
-        project = self.create_project(organization=self.organization)
-
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [project.id],
-                "fixes": False,
-            },
-            format="json",
-        )
-
-        assert response.status_code == 204
-
-        project.refresh_from_db()
-        assert (
-            project.get_option("sentry:autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.OFF.value
-        )
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_put_preserves_existing_preferences(
-        self, mock_bulk_get_preferences, mock_bulk_set_preferences
-    ):
-        project = self.create_project(organization=self.organization)
-        existing_repos = [{"name": "existing-repo", "owner": "existing-owner"}]
-        mock_bulk_get_preferences.return_value = {
-            str(project.id): {
-                "organization_id": self.organization.id,
-                "project_id": project.id,
-                "repositories": existing_repos,
-                "automated_run_stopping_point": AutofixStoppingPoint.ROOT_CAUSE.value,
-            }
-        }
-
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [project.id],
-                "fixes": True,
-                "pr_creation": True,
-            },
-            format="json",
-        )
-
-        assert response.status_code == 204
-
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert preferences[0]["repositories"] == existing_repos
-        assert preferences[0]["automated_run_stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
-
-    def test_put_pr_creation_without_fixes_fails(self):
-        project = self.create_project(organization=self.organization)
-
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [project.id],
-                "fixes": False,
-                "pr_creation": True,
-            },
-            format="json",
-        )
-
-        assert response.status_code == 400
-        assert "pr_creation" in response.data
-
-    def test_put_empty_project_ids(self):
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [],
-                "fixes": True,
-            },
-            format="json",
-        )
-
-        assert response.status_code == 400
-
-    def test_put_missing_fixes_field(self):
-        project = self.create_project(organization=self.organization)
-
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [project.id],
-            },
-            format="json",
-        )
-
-        assert response.status_code == 400
-        assert "fixes" in response.data
-
-    def test_put_project_not_in_organization(self):
-        other_org = self.create_organization()
-        other_project = self.create_project(organization=other_org)
-
-        response = self.client.put(
-            self.url,
-            data={
-                "projectIds": [other_project.id],
-                "fixes": True,
-            },
-            format="json",
-        )
-
-        assert response.status_code == 403
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_returns_settings_for_projects(self, mock_bulk_get_preferences):
-        project1 = self.create_project(
-            organization=self.organization, name="Project One", platform="javascript"
-        )
-        project2 = self.create_project(
-            organization=self.organization, name="Project Two", platform="python"
-        )
-
-        project1.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        project2.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF.value
-        )
-
-        mock_bulk_get_preferences.return_value = {
-            str(project1.id): {
-                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
-                "repositories": [{"name": "repo1"}, {"name": "repo2"}],
-            },
-            str(project2.id): {
-                "automated_run_stopping_point": AutofixStoppingPoint.CODE_CHANGES.value,
-                "repositories": [],
-            },
-        }
-
-        response = self.client.get(
-            self.url, {"projectIds": [project1.id, project2.id]}, format="json"
-        )
-
+        # Search find any matches
+        response = self.client.get(self.url, {"query": "Project"})
         assert response.status_code == 200
         assert len(response.data) == 2
 
-        result1 = next(r for r in response.data if r["projectId"] == project1.id)
-        result2 = next(r for r in response.data if r["projectId"] == project2.id)
-
-        assert result1["fixes"] is True
-        assert result1["prCreation"] is True
-        assert result1["tuning"] == AutofixAutomationTuningSettings.MEDIUM.value
-        assert result1["projectSlug"] == project1.slug
-        assert result1["projectName"] == "Project One"
-        assert result1["projectPlatform"] == "javascript"
-        assert result1["reposCount"] == 2
-
-        assert result2["fixes"] is False
-        assert result2["prCreation"] is False
-        assert result2["tuning"] == AutofixAutomationTuningSettings.OFF.value
-        assert result2["projectName"] == "Project Two"
-        assert result2["projectPlatform"] == "python"
-        assert result2["reposCount"] == 0
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_returns_defaults_for_projects_without_settings(self, mock_bulk_get_preferences):
-        project = self.create_project(organization=self.organization)
-        mock_bulk_get_preferences.return_value = {}
-
-        response = self.client.get(self.url, {"projectIds": [project.id]}, format="json")
-
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["projectId"] == project.id
-        assert response.data[0]["fixes"] is False
-        assert response.data[0]["prCreation"] is False
-        assert response.data[0]["tuning"] == AutofixAutomationTuningSettings.OFF.value
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_all_projects_when_no_project_ids(self, mock_bulk_get_preferences):
-        project1 = self.create_project(organization=self.organization)
-        project2 = self.create_project(organization=self.organization)
-        mock_bulk_get_preferences.return_value = {}
-
-        response = self.client.get(self.url, format="json")
-
-        assert response.status_code == 200
-
-        project_ids = [r["projectId"] for r in response.data]
-        assert project1.id in project_ids
-        assert project2.id in project_ids
-
-    def test_get_invalid_project_ids(self):
-        response = self.client.get(self.url, {"projectIds": ["not-an-int"]}, format="json")
-
-        assert response.status_code == 400
-        assert "projectIds" in response.data
-
-    def test_get_unauthorized_project_ids_returns_403(self):
-        project = self.create_project(organization=self.organization)
-        other_org = self.create_organization()
-        other_project = self.create_project(organization=other_org)
-
-        response = self.client.get(
-            self.url, {"projectIds": [project.id, other_project.id]}, format="json"
-        )
-
-        assert response.status_code == 403
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_multiple_project_ids_query_params(self, mock_bulk_get_preferences):
-        project1 = self.create_project(organization=self.organization)
-        project2 = self.create_project(organization=self.organization)
-        mock_bulk_get_preferences.return_value = {}
-        response = self.client.get(
-            f"{self.url}?projectIds={project1.id}&projectIds={project2.id}", format="json"
-        )
-
-        assert response.status_code == 200
-        assert len(response.data) == 2
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_pagination(self, mock_bulk_get_preferences):
-        for i in range(5):
-            self.create_project(organization=self.organization, slug=f"project-{i}")
-        mock_bulk_get_preferences.return_value = {}
-
-        response = self.client.get(self.url, {"per_page": 2}, format="json")
-
-        assert response.status_code == 200
-        assert len(response.data) == 2
-        assert "Link" in response
-
-    def test_get_too_many_project_ids(self):
-        project_ids = list(range(1, 1002))
-        query_string = "&".join([f"projectIds={pid}" for pid in project_ids])
-        response = self.client.get(f"{self.url}?{query_string}", format="json")
-
-        # Django will reject this with 400 before our code runs due to DATA_UPLOAD_MAX_NUMBER_FIELDS
-        assert response.status_code == 400
-
-    def test_get_nonexistent_project_ids_returns_403(self):
-        response = self.client.get(self.url, {"projectIds": [99999, 99998]}, format="json")
-        assert response.status_code == 403
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_pr_creation_false_when_stopping_point_is_code_changes(
-        self, mock_bulk_get_preferences
-    ):
-        project = self.create_project(organization=self.organization)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        mock_bulk_get_preferences.return_value = {
-            str(project.id): {
-                "automated_run_stopping_point": AutofixStoppingPoint.CODE_CHANGES.value,
-            },
-        }
-
-        response = self.client.get(self.url, {"projectIds": [project.id]}, format="json")
-
-        assert response.status_code == 200
-        assert response.data[0]["fixes"] is True
-        assert response.data[0]["prCreation"] is False
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_pr_creation_false_when_no_seer_preference(self, mock_bulk_get_preferences):
-        project = self.create_project(organization=self.organization)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        mock_bulk_get_preferences.return_value = {}
-
-        response = self.client.get(self.url, {"projectIds": [project.id]}, format="json")
-
-        assert response.status_code == 200
-        assert response.data[0]["fixes"] is True
-        assert response.data[0]["prCreation"] is False
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_search_by_name(self, mock_bulk_get_preferences):
-        self.create_project(organization=self.organization, name="Frontend App", slug="frontend")
-        self.create_project(organization=self.organization, name="Backend API", slug="backend")
-        self.create_project(organization=self.organization, name="Mobile App", slug="mobile")
-        mock_bulk_get_preferences.return_value = {}
-
-        response = self.client.get(self.url, {"query": "Frontend"}, format="json")
-
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["projectName"] == "Frontend App"
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_search_by_slug(self, mock_bulk_get_preferences):
-        self.create_project(organization=self.organization, name="Frontend App", slug="frontend")
-        self.create_project(organization=self.organization, name="Backend API", slug="backend")
-        mock_bulk_get_preferences.return_value = {}
-
-        response = self.client.get(self.url, {"query": "backend"}, format="json")
-
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["projectSlug"] == "backend"
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_search_no_results(self, mock_bulk_get_preferences):
-        self.create_project(organization=self.organization, name="Frontend App", slug="frontend")
-        mock_bulk_get_preferences.return_value = {}
-
-        response = self.client.get(self.url, {"query": "nonexistent"}, format="json")
-
+        # Search finds no matches
+        response = self.client.get(self.url, {"query": "nonexistent"})
         assert response.status_code == 200
         assert len(response.data) == 0
 
     @patch(
         "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
     )
-    def test_get_handles_none_seer_preferences(self, mock_bulk_get_preferences):
-        project = self.create_project(organization=self.organization)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        mock_bulk_get_preferences.return_value = None
+    def test_get_paginates_results(self, mock_bulk_get_preferences):
+        for i in range(5):
+            self.create_project(organization=self.organization, slug=f"project-{i}")
 
-        response = self.client.get(self.url, {"projectIds": [project.id]}, format="json")
+        mock_bulk_get_preferences.return_value = {}
 
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["projectId"] == project.id
-        assert response.data[0]["fixes"] is True
-        assert response.data[0]["prCreation"] is False
-        assert response.data[0]["reposCount"] == 0
+        response1 = self.client.get(self.url, {"per_page": "3"})
+        assert response1.status_code == 200
+        assert 'rel="previous"; results="false"' in response1.headers["Link"]
+        assert 'rel="next"; results="true"' in response1.headers["Link"]
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
-    )
-    def test_get_handles_none_project_preference_value(self, mock_bulk_get_preferences):
-        project = self.create_project(organization=self.organization)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        mock_bulk_get_preferences.return_value = {str(project.id): None}
-
-        response = self.client.get(self.url, {"projectIds": [project.id]}, format="json")
-
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["projectId"] == project.id
-        assert response.data[0]["fixes"] is True
-        assert response.data[0]["prCreation"] is False
-        assert response.data[0]["reposCount"] == 0
+        response2 = self.client.get(self.url, {"per_page": "3", "cursor": "3:1:0"})
+        assert response2.status_code == 200
+        assert 'rel="previous"; results="true"' in response2.headers["Link"]
+        assert 'rel="next"; results="false"' in response2.headers["Link"]
 
     @patch(
         "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
     )
-    def test_get_handles_none_repositories_value(self, mock_bulk_get_preferences):
-        project = self.create_project(organization=self.organization)
-        project.update_option(
+    def test_get_reads_project_preferences(self, mock_bulk_get_preferences):
+        project1 = self.create_project(organization=self.organization, name="Project One")
+        project2 = self.create_project(organization=self.organization, name="Project Two")
+
+        project1.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
         )
+        project2.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
+        )
+
         mock_bulk_get_preferences.return_value = {
-            str(project.id): {
+            str(project1.id): {
+                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+                "repositories": [{"name": "test-repo", "owner": "test-owner"}],
+            },
+            str(project2.id): {
                 "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
                 "repositories": None,
-            }
+            },
         }
 
-        response = self.client.get(self.url, {"projectIds": [project.id]}, format="json")
-
+        response = self.client.get(self.url)
         assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["reposCount"] == 0
+        assert response.data == [
+            {
+                "projectId": project1.id,
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value,
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+                "reposCount": 1,
+            },
+            {
+                "projectId": project2.id,
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.HIGH.value,
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+                "reposCount": 0,
+            },
+        ]
+
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
+    )
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    def test_post_creates_project_preferences(
+        self, mock_bulk_get_preferences, mock_bulk_set_preferences
+    ):
+        project = self.create_project(organization=self.organization)
+
+        mock_bulk_get_preferences.return_value = {}
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project.id],
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value,
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        assert response.status_code == 204
+
+        project.refresh_from_db()
+        assert (
+            project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.MEDIUM.value
+        )
+
+        mock_bulk_set_preferences.assert_called_once()
+        call_args = mock_bulk_set_preferences.call_args
+        preferences = call_args[0][1]
+        assert preferences == [
+            {
+                "organization_id": self.organization.id,
+                "project_id": project.id,
+                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+            }
+        ]
+
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
+    )
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    def test_post_updates_each_preference_field_independently(
+        self, mock_bulk_get_preferences, mock_bulk_set_preferences
+    ):
+        project = self.create_project(organization=self.organization)
+        assert (
+            project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.OFF.value
+        )
+
+        mock_bulk_get_preferences.return_value = {}
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project.id],
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value,
+            },
+        )
+
+        assert response.status_code == 204
+
+        project.refresh_from_db()
+        assert (
+            project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.MEDIUM.value
+        )
+        mock_bulk_set_preferences.assert_not_called()
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project.id],
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+
+        project.refresh_from_db()
+        assert (
+            project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.MEDIUM.value
+        )
+
+        mock_bulk_set_preferences.assert_called_once()
+        call_args = mock_bulk_set_preferences.call_args
+        preferences = call_args[0][1]
+        assert preferences == [
+            {
+                "organization_id": self.organization.id,
+                "project_id": project.id,
+                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+            }
+        ]
+
+    def test_post_requires_one_or_more_project_ids(self):
+        response = self.client.post(
+            self.url,
+            {"automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value},
+        )
+        assert response.status_code == 400
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [],
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        assert response.status_code == 400
+
+    def test_post_rejects_invalid_project_ids(self):
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [99999],
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        assert response.status_code == 403
+
+    def test_post_rejects_invalid_tuning(self):
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [99999],
+                "autofixAutomationTuning": "invalid",
+            },
+        )
+        assert response.status_code == 400
+
+    def test_post_rejects_invalid_stopping_point(self):
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [99999],
+                "automatedRunStoppingPoint": "invalid",
+            },
+        )
+        assert response.status_code == 400
+
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    def test_post_rejects_projects_not_in_organization(self, mock_bulk_get_preferences):
+        project1 = self.create_project(organization=self.organization, name="Project One")
+        project2 = self.create_project(organization=self.organization, name="Project Two")
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project1.id, project2.id, other_project.id],
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        assert response.status_code == 403

--- a/tests/sentry/seer/endpoints/test_project_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_project_autofix_automation_settings.py
@@ -1,0 +1,174 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+
+from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.models import SeerProjectPreference, SeerRawPreferenceResponse, SeerRepoDefinition
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationAutofixAutomationProjectSettingsEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-project-autofix-automation-settings"
+    method = "get"
+
+    seer_repo = SeerRepoDefinition(
+        name="test-repo",
+        owner="test-owner",
+        external_id="test-external-id",
+        provider="github",
+    )
+
+    def setUp(self):
+        super().setUp()
+        # The test likely fails because `self.organization` and `self.project` are not set up before this.
+        # In most Sentry tests, you need to create the organization and the project first, e.g.:
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.url = reverse(
+            self.endpoint,
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+        self.login_as(user=self.user)
+
+    @patch("sentry.seer.endpoints.project_autofix_automation_settings.get_project_seer_preferences")
+    def test_get_returns_default_settings(self, mock_get_preferences):
+        mock_get_preferences.return_value = None
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data == {
+            "projectId": self.project.id,
+            "autofixAutomationTuning": AutofixAutomationTuningSettings.OFF.value,
+            "automatedRunStoppingPoint": AutofixStoppingPoint.CODE_CHANGES.value,
+            "reposCount": 0,
+        }
+
+    @patch("sentry.seer.endpoints.project_autofix_automation_settings.get_project_seer_preferences")
+    def test_get_returns_saved_settings(self, mock_get_preferences):
+        self.project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
+        )
+        mock_get_preferences.return_value = SeerRawPreferenceResponse(
+            preference=SeerProjectPreference(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                repositories=[self.seer_repo],
+                automated_run_stopping_point=AutofixStoppingPoint.OPEN_PR.value,
+            )
+        )
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data == {
+            "projectId": self.project.id,
+            "autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value,
+            "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+            "reposCount": 1,
+        }
+
+    def test_post_rejects_invalid_tuning(self):
+        response = self.client.put(self.url, {"autofixAutomationTuning": "invalid"})
+        assert response.status_code == 400
+
+    def test_put_rejects_invalid_stopping_point(self):
+        response = self.client.put(self.url, {"automatedRunStoppingPoint": "invalid"})
+        assert response.status_code == 400
+
+    @patch("sentry.seer.endpoints.project_autofix_automation_settings.bulk_set_project_preferences")
+    @patch("sentry.seer.endpoints.project_autofix_automation_settings.get_project_seer_preferences")
+    def test_put_updates_all_fields(self, mock_get_preferences, mock_bulk_set_preferences):
+        self.project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF.value
+        )
+        mock_get_preferences.return_value = SeerRawPreferenceResponse(
+            preference=SeerProjectPreference(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                repositories=[self.seer_repo],
+                automated_run_stopping_point=AutofixStoppingPoint.OPEN_PR.value,
+            )
+        )
+
+        response = self.client.put(
+            self.url,
+            {
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value,
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+
+        assert response.status_code == 204
+
+        self.project.refresh_from_db()
+        assert (
+            self.project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.MEDIUM.value
+        )
+
+        mock_bulk_set_preferences.assert_called_once()
+        call_args = mock_bulk_set_preferences.call_args
+        preferences = call_args[0][1]
+        assert preferences == [
+            {
+                "organization_id": self.organization.id,
+                "project_id": self.project.id,
+                "repositories": [self.seer_repo.dict()],
+                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+                "automation_handoff": None,
+            }
+        ]
+
+    @patch("sentry.seer.endpoints.project_autofix_automation_settings.bulk_set_project_preferences")
+    @patch("sentry.seer.endpoints.project_autofix_automation_settings.get_project_seer_preferences")
+    def test_put_updates_passed_fields(self, mock_get_preferences, mock_bulk_set_preferences):
+        self.project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF.value
+        )
+        mock_get_preferences.return_value = SeerRawPreferenceResponse(
+            preference=SeerProjectPreference(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                repositories=[self.seer_repo],
+                automated_run_stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
+                automation_handoff=None,
+            )
+        )
+
+        response = self.client.put(
+            self.url,
+            {"autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value},
+        )
+
+        assert response.status_code == 204
+
+        self.project.refresh_from_db()
+        assert (
+            self.project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.MEDIUM.value
+        )
+
+        mock_bulk_set_preferences.assert_not_called()
+
+        response = self.client.put(
+            self.url,
+            {"automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value},
+        )
+
+        mock_bulk_set_preferences.assert_called_once()
+        call_args = mock_bulk_set_preferences.call_args
+        preferences = call_args[0][1]
+        assert preferences == [
+            {
+                "organization_id": self.organization.id,
+                "project_id": self.project.id,
+                "repositories": [self.seer_repo.dict()],
+                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+                "automation_handoff": None,
+            }
+        ]

--- a/tests/sentry/seer/endpoints/test_project_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_project_autofix_automation_settings.py
@@ -36,7 +36,7 @@ class OrganizationAutofixAutomationProjectSettingsEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.project_autofix_automation_settings.get_project_seer_preferences")
     def test_get_returns_default_settings(self, mock_get_preferences):
-        mock_get_preferences.return_value = None
+        mock_get_preferences.return_value = SeerRawPreferenceResponse(preference=None)
 
         response = self.client.get(self.url)
 


### PR DESCRIPTION
This PR makes some revisions to the `/organizations/<organization_id_or_slug>/autofix/automation-settings/` endpoint, and adds `/projects/<organization_id_or_slug>/<project_id_or_slug>/autofix/automation-settings/` to round out the api.

An overview of where we are not can be found in the `blueprints/api.md`.

I'll list some of the changes i wanted to see: 
- `GET` previously accepted a list of `projectIds`. This was in addition to accepting the `query` param, and seemed redundant
- `GET` was returning extra data that duplicates what's in the project-list endpoint already: slug and platform. We don't need to return those again. When we fetch a list of settings not all projects might have settings yet, so what we will do is zip together project-list data with whatever settings are returned.
- `GET` was abstracting over the raw db fields, making it impossible to tell if a project had configured agent delegation. This is critical info we need on the page. It's better to expose the raw data, or fix it at the source if it's insufficient. Creating yet another data type specific for a page design is not needed.
- `PUT` this create/update endpoint seems confused about whether it should update one or many projects. As an endpoint on what amounts to an `index` route, it should be a Create and use POST. I created the `/projects/*` endpoint with a PUT to better handle specific updates
- Creating or updating should allow either automation-tuning OR stopping-point to be set. We'll set the other value to a default if it's not set yet in the db. If a value is set in the db then we shouldn't silently change it; this makes it easier for people to toggle things on and off again without having to re-create all settings from scratch each time
