### PR TITLE
fix(replay): Fix replay timeline scrubber zoom

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -2,7 +2,6 @@ import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import Stacked from 'sentry/components/container/stacked';
-import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
 import {
   MajorGridlines,
@@ -87,6 +86,7 @@ export default function ReplayTimeline() {
 
 const CenteredStack = styled(Stacked)`
   align-items: center;
+  position: absolute;
 `;
 
 const VisibleStack = styled(Stacked)`
@@ -94,7 +94,8 @@ const VisibleStack = styled(Stacked)`
   width: 100%;
 `;
 
-const VisiblePanel = styled(Panel)`
+const VisiblePanel = styled('div')`
+  border-radius: ${p => p.theme.radius.md};
   height: 100%;
   width: 100%;
   margin: 0;

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -2,6 +2,8 @@ import {useCallback, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout/flex';
+
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {DateTime} from 'sentry/components/dateTime';
@@ -101,9 +103,9 @@ export default function TimeAndScrubberGrid({
 
   return (
     <Grid id="replay-timeline-tooltip-container" isCompact={isCompact}>
-      <Padded style={{gridArea: 'currentTime'}}>
+      <Flex justify="center" padding="0 lg" style={{gridArea: 'currentTime'}}>
         <ReplayCurrentTime />
-      </Padded>
+      </Flex>
 
       <TimelineWrapper
         style={{gridArea: 'timeline'}}
@@ -131,7 +133,7 @@ export default function TimeAndScrubberGrid({
         ) : null}
       </ScrubberWrapper>
 
-      <Padded style={{gridArea: 'duration'}}>
+      <Flex justify="center" padding="0 lg" style={{gridArea: 'duration'}}>
         {durationMs === undefined ? (
           '--:--'
         ) : timestampType === 'absolute' ? (
@@ -139,7 +141,7 @@ export default function TimeAndScrubberGrid({
         ) : (
           <Duration duration={[durationMs, 'ms']} precision="sec" />
         )}
-      </Padded>
+      </Flex>
     </Grid>
   );
 }
@@ -170,10 +172,11 @@ const Grid = styled('div')<{isCompact: boolean}>`
 
 const TimelineWrapper = styled('div')`
   position: relative;
-  height: 100%;
+  height: 28px;
   display: flex;
   align-items: center;
   cursor: pointer;
+  overflow: hidden;
 
   & > * {
     height: 20px;
@@ -186,10 +189,4 @@ const ScrubberWrapper = styled('div')`
   display: flex;
   align-items: center;
   cursor: pointer;
-`;
-
-const Padded = styled('div')`
-  display: flex;
-  justify-content: center;
-  padding-inline: ${space(1.5)};
 `;


### PR DESCRIPTION
Fixes REPLAY-848
Fixes REPLAY-849

Fixes the timeline so it shows up on all surfaces (Replay Details, Issue Details, Issue Details > Replays)
Zooming the timeline 'properly' hides everything as expected. And it scrolls left/right sticking to the edge of the space when we reach the start/end of the replay.


| Desc | Img |
| --- | --- |
| Replay Details, replay start | <img width="715" height="79" alt="SCR-20251214-mjcj" src="https://github.com/user-attachments/assets/09ab3bfa-ae07-4f4d-bf2d-f89848732bf9" />
| Replay Details, middle of playback | <img width="711" height="82" alt="SCR-20251214-mjbg" src="https://github.com/user-attachments/assets/2088dcab-3264-4fae-97df-47126f16e7d3" />
| Issue Details | <img width="570" height="91" alt="SCR-20251214-mjdm" src="https://github.com/user-attachments/assets/8f0bcfc8-9232-4007-b8b1-0883c7c768f1" />
| Issue > Replay | <img width="588" height="95" alt="SCR-20251214-mjen" src="https://github.com/user-attachments/assets/86504b8b-c290-40d1-81f6-228e3217c41e" />

