### PR TITLE
chore(i18n): Remove "Defaulting to english" console warning

### DIFF
--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -70,10 +70,6 @@ type FormatArg = ComponentMap | React.ReactNode;
  */
 function getClient(): Jed | null {
   if (!i18n) {
-    // If this happens, it could mean that an import was added/changed where
-    // locale initialization does not happen soon enough.
-    // eslint-disable-next-line no-console
-    console.warn('Locale not set, defaulting to English');
     return setLocale(DEFAULT_LOCALE_DATA);
   }
 

--- a/static/app/utils/silence-react-unsafe-warnings.ts
+++ b/static/app/utils/silence-react-unsafe-warnings.ts
@@ -8,8 +8,6 @@ const ignoredWarnings = [
   /componentWill.* has been renamed, and is not recommended for use.*/,
   // Moment failures. Why is this happening?
   /moment construction falls back/,
-  // Locale not set during tests
-  /Locale not set, defaulting to English/,
 ];
 
 window.console.warn = (message: any, ...args: any[]) => {


### PR DESCRIPTION
This happens on every pageload, regardless of what locale is chosen. The page does render/rerender in other languages according to what the user has selected, so this isnt doing anything useful

Test Plan:
1. Go to https://sentry.io/settings/account/details/ and change your language settings. 
    - Mine started in English, I switched to German
3. Do a full pageload (we don't async load language files if that preference changes)
4. Notice that the warning is in the console
5. Notice that the page is rendering with the chosen language

Now in step 4 the warning is gone!