### PR TITLE
fix(assisted-query): return built in fields for spans and logs

### DIFF
--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -12,10 +12,6 @@ logger = logging.getLogger(__name__)
 API_KEY_SCOPES = ["org:read", "project:read", "event:read"]
 
 
-# Built-in span fields that are always available for querying
-# Derived from SENTRY_SPAN_STRING_TAGS and SENTRY_SPAN_NUMBER_TAGS
-# in frontend (static/app/views/explore/constants.tsx)
-# These are merged with dynamic API fields in the search UI
 _SPAN_BUILT_IN_STRING_FIELDS = [
     "id",
     "project",
@@ -40,10 +36,6 @@ _SPAN_BUILT_IN_NUMBER_FIELDS = [
 ]
 
 
-# Built-in log fields that are always available for querying
-# Derived from SENTRY_LOG_STRING_TAGS and SENTRY_LOG_NUMBER_TAGS
-# in frontend (static/app/views/explore/constants.tsx)
-# These are merged with dynamic API fields in the search UI
 _LOG_BUILT_IN_STRING_FIELDS = [
     "trace",
     "id",

--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -12,6 +12,77 @@ logger = logging.getLogger(__name__)
 API_KEY_SCOPES = ["org:read", "project:read", "event:read"]
 
 
+# Built-in span fields that are always available for querying
+# Derived from SENTRY_SPAN_STRING_TAGS and SENTRY_SPAN_NUMBER_TAGS
+# in frontend (static/app/views/explore/constants.tsx)
+# These are merged with dynamic API fields in the search UI
+_SPAN_BUILT_IN_STRING_FIELDS = [
+    "id",
+    "project",
+    "span.description",
+    "span.op",
+    "timestamp",
+    "transaction",
+    "trace",
+    "is_transaction",
+    "sentry.normalized_description",
+    "release",
+    "project.id",
+    "sdk.name",
+    "sdk.version",
+    "span.system",
+    "span.category",
+]
+
+_SPAN_BUILT_IN_NUMBER_FIELDS = [
+    "span.duration",
+    "span.self_time",
+]
+
+
+# Built-in log fields that are always available for querying
+# Derived from SENTRY_LOG_STRING_TAGS and SENTRY_LOG_NUMBER_TAGS
+# in frontend (static/app/views/explore/constants.tsx)
+# These are merged with dynamic API fields in the search UI
+_LOG_BUILT_IN_STRING_FIELDS = [
+    "trace",
+    "id",
+    "message",
+    "severity",
+    "timestamp",
+]
+
+_LOG_BUILT_IN_NUMBER_FIELDS = [
+    "severity_number",
+]
+
+
+def _get_built_in_fields(item_type: str = "spans") -> list[dict[str, Any]]:
+    """
+    Get built-in fields for the specified item type.
+
+    Args:
+        item_type: Type of trace item ("spans" or "logs")
+
+    Returns:
+        List of built-in field definitions with key and type.
+    """
+    if item_type == "logs":
+        string_fields = _LOG_BUILT_IN_STRING_FIELDS
+        number_fields = _LOG_BUILT_IN_NUMBER_FIELDS
+    else:
+        string_fields = _SPAN_BUILT_IN_STRING_FIELDS
+        number_fields = _SPAN_BUILT_IN_NUMBER_FIELDS
+
+    built_in_fields = []
+    for field in string_fields:
+        built_in_fields.append({"key": field, "type": "string"})
+    for field in number_fields:
+        built_in_fields.append({"key": field, "type": "number"})
+
+    return built_in_fields
+
+
 def get_attribute_names(
     *,
     org_id: int,
@@ -42,7 +113,12 @@ def get_attribute_names(
             "fields": {
                 "string": ["span.op", "span.description", ...],
                 "number": ["span.duration", ...]
-            }
+            },
+            "built_in_fields": [
+                {"key": "span.op", "type": "string"},
+                {"key": "span.duration", "type": "number"},
+                ...
+            ]
         }
     """
     organization = Organization.objects.get(id=org_id)
@@ -78,7 +154,9 @@ def get_attribute_names(
 
         fields[attr_type] = [item["name"] for item in resp.data]
 
-    return {"fields": fields}
+    built_in_fields = _get_built_in_fields(item_type)
+
+    return {"fields": fields, "built_in_fields": built_in_fields}
 
 
 def get_attribute_values_with_substring(

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -50,6 +50,25 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 ],
                 "number": ["span.duration"],
             },
+            "built_in_fields": [
+                {"key": "id", "type": "string"},
+                {"key": "project", "type": "string"},
+                {"key": "span.description", "type": "string"},
+                {"key": "span.op", "type": "string"},
+                {"key": "timestamp", "type": "string"},
+                {"key": "transaction", "type": "string"},
+                {"key": "trace", "type": "string"},
+                {"key": "is_transaction", "type": "string"},
+                {"key": "sentry.normalized_description", "type": "string"},
+                {"key": "release", "type": "string"},
+                {"key": "project.id", "type": "string"},
+                {"key": "sdk.name", "type": "string"},
+                {"key": "sdk.version", "type": "string"},
+                {"key": "span.system", "type": "string"},
+                {"key": "span.category", "type": "string"},
+                {"key": "span.duration", "type": "number"},
+                {"key": "span.self_time", "type": "number"},
+            ],
         }
 
     def test_get_attribute_values_with_substring(self) -> None:


### PR DESCRIPTION
Noticed some built in fields like `trace` were missing sometimes and causing valid queries to get rejected.
I got these lists of fields from the hardcoded ones in the search bar UI on the frontend

Closes AIML-2087