### PR TITLE
feat(agents): Preserve icon on spans with error

### DIFF
--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -8,6 +8,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import Count from 'sentry/components/count';
 import {IconChat, IconChevron, IconCode, IconFire, IconFix} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
+import {t} from 'sentry/locale';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {
@@ -221,8 +222,23 @@ const TraceListItem = memo(function TraceListItem({
       onClick={onClick}
       indent={indent}
     >
-      <Flex align="center" style={{color: safeColor}}>
+      <Flex
+        align="center"
+        position="relative"
+        style={{color: safeColor, background: 'inherit'}}
+      >
         {icon}
+        {hasErrors && (
+          <Tooltip delay={300} title={t('This span encountered an error')} skipWrapper>
+            <Container
+              position="absolute"
+              radius="full"
+              style={{bottom: -6, right: -6, padding: 1, background: 'inherit'}}
+            >
+              <IconFire display="block" size="xs" color="red300" />
+            </Container>
+          </Tooltip>
+        )}
       </Flex>
       <Stack gap="xs" flex="1" minWidth="0">
         <Flex align="center" gap="xs">
@@ -397,7 +413,6 @@ function getNodeInfo(node: AITraceSpanNode, colors: readonly string[]) {
 
   // Override the color and icon if the node has errors
   if (hasError(node)) {
-    nodeInfo.icon = <IconFire size="md" color="red300" />;
     nodeInfo.color = colors[6];
   }
 


### PR DESCRIPTION
### Problem
In the AI trace we substitute the span icon with an error icon whenever there is an error on the span status or an issue connected to it. This confused users as they were not sure anymore what type of span they see.

### Solution
Preserve the original icon and show the error icon additionally.
Also include a tooltip to explain the meaning of the flame / error icon.


https://github.com/user-attachments/assets/662a440e-701f-457c-9367-25818165aa49

