### PR TITLE
fix(ui): align dashboard button sizes with PageFilterBar

### DIFF
--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -174,7 +174,7 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
         setSelectedFilterKey(null);
         setIsSelectingFilterKey(true);
       }}
-      size="md"
+      size="sm"
       menuWidth="300px"
       menuTitle={
         <MenuTitleWrapper>
@@ -190,8 +190,9 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
       trigger={triggerProps => (
         <Button
           {...triggerProps}
+          size="sm"
           aria-label={t('Add Global Filter')}
-          icon={<IconAdd size="sm" />}
+          icon={<IconAdd />}
         />
       )}
     />

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -304,6 +304,7 @@ function FilterSelector({
       <CompactSelect
         multiple={false}
         disabled={false}
+        size="sm"
         options={options}
         value={activeFilterValues.length > 0 ? activeFilterValues[0] : undefined}
         onChange={option => {
@@ -331,6 +332,7 @@ function FilterSelector({
       checkboxPosition="leading"
       searchable
       disabled={false}
+      size="sm"
       options={options}
       value={activeFilterValues}
       searchPlaceholder={t('Search or enter a custom value...')}

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -280,6 +280,7 @@ function NumericFilterSelector({
     <CompactSelect
       disabled={false}
       value=""
+      size="sm"
       options={[]}
       hideOptions
       onChange={() => {}}

--- a/static/app/views/dashboards/releasesSelectControl.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.tsx
@@ -66,6 +66,7 @@ function ReleasesSelectControl({
       clearable
       searchable
       id={id}
+      size="sm"
       disabled={isDisabled}
       loading={loading}
       menuTitle={<MenuTitleWrapper>{t('Filter Releases')}</MenuTitleWrapper>}


### PR DESCRIPTION
before (“All Releases” and “+” buttons are too large):

<img width="1346" height="123" alt="Screenshot 2025-12-15 at 09 49 10" src="https://github.com/user-attachments/assets/d10dddba-4d2b-4ce1-a12e-73427fa83eec" />

after (all buttons have the same size):

<img width="1346" height="123" alt="Screenshot 2025-12-15 at 09 52 14" src="https://github.com/user-attachments/assets/643f7c7a-5300-4c4f-88a1-2ea8fae88297" />

/edit: found some more selects that can go into these filters 😅 

before:

<img width="964" height="68" alt="Screenshot 2025-12-15 at 10 19 11" src="https://github.com/user-attachments/assets/59fb2d47-7d7f-4955-8a5d-38ea9666233c" />

after:
<img width="932" height="68" alt="Screenshot 2025-12-15 at 10 18 39" src="https://github.com/user-attachments/assets/73115ef2-ea0f-440e-bbb8-33a641d24468" />
