### PR TITLE
feat(issues): Add inbound filters for Turbopack `ChunkLoadError`

### DIFF
--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -347,8 +347,13 @@ def _chunk_load_error_filter() -> RuleCondition:
     https://domain.com/_next/static/chunks/29107295-0151559bd23117ba.js)
     """
     values = [
+        # Webpack
         ("ChunkLoadError", "Loading chunk *"),
         ("*Uncaught *", "ChunkLoadError: Loading chunk *"),
+        # Turbopack
+        ("ChunkLoadError", "Failed to load chunk *"),
+        ("*Uncaught *", "ChunkLoadError: Failed to load chunk *"),
+        # Promise rejections
         ("Error", "Uncaught (in promise): ChunkLoadError*"),
     ]
 

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -1,7 +1,5 @@
 ---
-created: '2025-09-30T21:02:50.335965+00:00'
-creator: sentry
-source: tests/sentry/relay/test_config.py
+source: tests/sentry/relay/test_config.py::test_get_project_config
 ---
 config:
   allowedDomains:
@@ -104,6 +102,26 @@ config:
                 op: glob
                 value:
                 - 'ChunkLoadError: Loading chunk *'
+              op: and
+            - inner:
+              - name: ty
+                op: glob
+                value:
+                - ChunkLoadError
+              - name: value
+                op: glob
+                value:
+                - Failed to load chunk *
+              op: and
+            - inner:
+              - name: ty
+                op: glob
+                value:
+                - '*Uncaught *'
+              - name: value
+                op: glob
+                value:
+                - 'ChunkLoadError: Failed to load chunk *'
               op: and
             - inner:
               - name: ty


### PR DESCRIPTION
Current matchers will not filter these chunkload errors for turbopack. (see https://github.com/vercel/next.js/pull/86593)

ref https://linear.app/getsentry/issue/JS-1301/support-chunkloaderror-filtering-for-turbopack
ref https://github.com/getsentry/sentry-javascript/issues/18498