### PR TITLE
fix(ui): DesyncedFilterIndicator positioning

### DIFF
--- a/static/app/components/organizations/pageFilters/desyncedFilter.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFilter.tsx
@@ -42,7 +42,7 @@ export const DesyncedFilterIndicator = styled('div')`
   background: ${p => p.theme.active};
   border: solid 1px ${p => p.theme.tokens.background.primary};
   position: absolute;
-  top: -${space(0.25)};
+  top: 0;
   right: -${space(0.75)};
 `;
 


### PR DESCRIPTION
recent changes to how `Buttons` are positioned make it so that `DesyncedFilterIndicator` doesn’t need an additional negative placement for its `top` position. On the contrary - this now makes it being cut-off:

before:

<img width="969" height="150" alt="Screenshot 2025-12-15 at 10 30 57" src="https://github.com/user-attachments/assets/f1288cce-bb19-4d30-84c6-a8927cd93fc4" />

after:

<img width="969" height="150" alt="Screenshot 2025-12-15 at 10 56 44" src="https://github.com/user-attachments/assets/eb42379d-709e-4aca-9394-ce29c412af96" />
