### PR TITLE
feat(objectstore): Allow passing more client options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -382,7 +382,9 @@ register("fileblob.upload.use_lock", default=True, flags=FLAG_AUTOMATOR_MODIFIAB
 # Whether to use redis to cache `FileBlob.id` lookups
 register("fileblob.upload.use_blobid_cache", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# New `objectstore` service configuration
+# New `objectstore` service configuration. Additional supported options:
+# - propagate_traces: bool
+
 register(
     "objectstore.config",
     default={"base_url": "http://127.0.0.1:8888"},


### PR DESCRIPTION
Introduces options to reconfigure the objectstore client without code changes.
Note that we still need to restart to apply these changes as we cache the client
instance during the lifetime of the process.

Ref FS-190

