### PR TITLE
feat(reprocessing): temporarily disable reprocessing

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -4,7 +4,7 @@ import {AutoSizer, CellMeasurer, CellMeasurerCache, List} from 'react-virtualize
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {openModal, openReprocessEventModal} from 'sentry/actionCreators/modal';
+import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import type {SelectOption, SelectSection} from 'sentry/components/core/compactSelect';
 import {
@@ -211,16 +211,6 @@ export function DebugMeta({data, projectSlug, event}: DebugMetaProps) {
       filterSelections: defaultFilterSelections,
     });
   }, [data]);
-
-  const _handleReprocessEvent = useCallback(
-    (id: Group['id']) => {
-      openReprocessEventModal({
-        organization,
-        groupId: id,
-      });
-    },
-    [organization]
-  );
 
   const getScrollbarWidth = useCallback(() => {
     const panelTableWidth = panelTableRef?.current?.clientWidth ?? 0;

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -123,7 +123,7 @@ function applyImageFilters(
   return filteredImages;
 }
 
-export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
+export function DebugMeta({data, projectSlug, event}: DebugMetaProps) {
   const theme = useTheme();
   const organization = useOrganization();
   const listRef = useRef<List>(null);
@@ -212,7 +212,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
     });
   }, [data]);
 
-  const handleReprocessEvent = useCallback(
+  const _handleReprocessEvent = useCallback(
     (id: Group['id']) => {
       openReprocessEventModal({
         organization,
@@ -286,15 +286,13 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
             organization={organization}
             projSlug={projectSlug}
             event={event}
-            onReprocessEvent={
-              defined(groupId) ? () => handleReprocessEvent(groupId) : undefined
-            }
+            onReprocessEvent={undefined}
           />
         ),
         {modalCss: modalCss(theme)}
       );
     },
-    [event, groupId, handleReprocessEvent, organization, projectSlug, theme]
+    [event, organization, projectSlug, theme]
   );
 
   // This hook replaces the componentDidMount/WillUnmount calls from its class component

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import {EventStacktraceExceptionFixture} from 'sentry-fixture/eventStacktraceException';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -15,7 +14,6 @@ import {
 import GlobalModal from 'sentry/components/globalModal';
 import {mockTour} from 'sentry/components/tours/testUtils';
 import ConfigStore from 'sentry/stores/configStore';
-import ModalStore from 'sentry/stores/modalStore';
 import {GroupStatus, IssueCategory} from 'sentry/types/group';
 import * as analytics from 'sentry/utils/analytics';
 import {GroupActions} from 'sentry/views/issueDetails/actions';
@@ -132,48 +130,6 @@ describe('GroupActions', () => {
           data: {isBookmarked: true},
         })
       );
-    });
-  });
-
-  describe('reprocessing', () => {
-    it('renders ReprocessAction component if org has native exception event', async () => {
-      const event = EventStacktraceExceptionFixture({
-        platform: 'native',
-      });
-
-      render(
-        <GroupActions group={group} project={project} event={event} disabled={false} />,
-        {
-          organization,
-        }
-      );
-
-      await userEvent.click(screen.getByLabelText('More Actions'));
-
-      const reprocessActionButton = await screen.findByTestId('reprocess');
-      expect(reprocessActionButton).toBeInTheDocument();
-    });
-
-    it('open dialog by clicking on the ReprocessAction component', async () => {
-      const event = EventStacktraceExceptionFixture({
-        platform: 'native',
-      });
-
-      render(
-        <GroupActions group={group} project={project} event={event} disabled={false} />,
-        {
-          organization,
-        }
-      );
-
-      const onReprocessEventFunc = jest.spyOn(ModalStore, 'openModal');
-
-      await userEvent.click(screen.getByLabelText('More Actions'));
-
-      const reprocessActionButton = await screen.findByTestId('reprocess');
-      expect(reprocessActionButton).toBeInTheDocument();
-      await userEvent.click(reprocessActionButton);
-      await waitFor(() => expect(onReprocessEventFunc).toHaveBeenCalled());
     });
   });
 

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -43,7 +43,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets, SavedQueryDatasets} from 'sentry/utils/discover/types';
-import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {uniqueId} from 'sentry/utils/guid';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -569,7 +568,9 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
           {
             key: 'reprocess',
             label: t('Reprocess events'),
-            hidden: !displayReprocessEventAction(event),
+            // Temporarily disable reprocessing as a whole till we get to the bottom of why it is failing.
+            // This is done since it breaks in a way where it nukes the entire issue group of the customer (very unpleasant).
+            hidden: true,
             onAction: onReprocessEvent,
           },
           {


### PR DESCRIPTION
Temporarily disable reprocessing as it breaks the users issue group.

There have been multiple reports now of reprocessing not working correctly, although the underlying code has not changed in a while. Since reprocessing fails in such a way that it makes the entire issue group unusable we opt to disable it until we have the time / resources to fix it for good.