### PR TITLE
ref(scraps): remove borderRadius from theme

### DIFF
--- a/static/app/components/core/alert/alert.tsx
+++ b/static/app/components/core/alert/alert.tsx
@@ -188,7 +188,7 @@ const AlertPanel = styled('div')<AlertProps & {hovered: boolean}>`
   gap: ${space(1)};
   color: ${p => getAlertColors(p.theme, p.type).color};
   font-size: ${p => p.theme.font.size.md};
-  border-radius: ${p => p.theme.borderRadius};
+  border-radius: ${p => p.theme.radius.md};
   border: 1px solid ${p => getAlertColors(p.theme, p.type).border};
   padding: ${space(1.5)} ${space(2)};
   background-image: ${p =>

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -565,7 +565,6 @@ const commonTheme = {
     },
   },
 
-  borderRadius: '6px',
   ...legacyTypography,
   ...typography,
 };

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1352,7 +1352,7 @@ const MarkdownContainer = styled('div')`
   pre {
     margin: 0;
     padding: ${p => p.theme.space.sm};
-    border-radius: ${p => p.theme.borderRadius};
+    border-radius: ${p => p.theme.radius.md};
   }
   img {
     max-height: 200px;


### PR DESCRIPTION
this is a leftover from:
- #104748

seems like I forgot to remove the actual value from the theme.