### PR TITLE
ref(scraps): remove chart aliases from theme

### DIFF
--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -182,7 +182,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         ?.slice() as string[];
 
       if (hasOther) {
-        color.push(theme.chartOther);
+        color.push(theme.tokens.content.muted);
       }
 
       const series = stats
@@ -245,7 +245,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         .getColorPalette(stats.length - 1 - (hasOther ? 1 : 0))
         ?.slice() as string[];
       if (hasOther) {
-        color.push(theme.chartOther);
+        color.push(theme.tokens.content.muted);
       }
 
       const series = stats
@@ -307,7 +307,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         .getColorPalette(stats.length - 1 - (hasOther ? 1 : 0))
         ?.slice() as string[] | undefined;
       if (hasOther) {
-        color?.push(theme.chartOther);
+        color?.push(theme.tokens.content.muted);
       }
 
       const series = stats

--- a/static/app/chartcuterie/metricAlert.tsx
+++ b/static/app/chartcuterie/metricAlert.tsx
@@ -56,7 +56,7 @@ export function makeMetricAlertCharts(theme: Theme): Array<RenderDescriptor<Char
     axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
     splitLine: {
       lineStyle: {
-        color: theme.chartLineColor,
+        color: theme.colors.gray300,
         opacity: 0.3,
       },
     },

--- a/static/app/chartcuterie/metricDetector.tsx
+++ b/static/app/chartcuterie/metricDetector.tsx
@@ -58,7 +58,7 @@ export function makeMetricDetectorCharts(
     axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
     splitLine: {
       lineStyle: {
-        color: theme.chartLineColor,
+        color: theme.colors.gray300,
         opacity: 0.3,
       },
     },

--- a/static/app/components/charts/components/xAxis.tsx
+++ b/static/app/components/charts/components/xAxis.tsx
@@ -60,12 +60,12 @@ function XAxis({
     splitNumber: 4,
     axisLine: {
       lineStyle: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
       },
     },
     axisTick: {
       lineStyle: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
       },
     },
     splitLine: {
@@ -73,7 +73,7 @@ function XAxis({
     },
     axisLabel: {
       hideOverlap: true,
-      color: theme.chartLabel,
+      color: theme.tokens.content.muted,
       fontFamily: theme.text.family,
       margin: 12,
 

--- a/static/app/components/charts/components/yAxis.tsx
+++ b/static/app/components/charts/components/yAxis.tsx
@@ -19,7 +19,7 @@ export default function YAxis({theme, ...props}: Props): YAXisComponentOption {
       },
       splitLine: {
         lineStyle: {
-          color: theme.chartLineColor,
+          color: theme.colors.gray300,
           opacity: 0.3,
         },
       },

--- a/static/app/components/charts/components/yAxis.tsx
+++ b/static/app/components/charts/components/yAxis.tsx
@@ -14,7 +14,7 @@ export default function YAxis({theme, ...props}: Props): YAXisComponentOption {
         show: false,
       },
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         fontFamily: theme.text.family,
       },
       splitLine: {

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -279,7 +279,7 @@ class Chart extends Component<ChartProps, State> {
           .slice())
       : undefined;
     if (chartColors?.length && hasOther) {
-      chartColors.push(theme.chartOther);
+      chartColors.push(theme.tokens.content.muted);
     }
     const chartOptions = {
       colors: chartColors,

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -317,7 +317,7 @@ class Chart extends Component<ChartProps, State> {
         : undefined,
       yAxis: {
         axisLabel: {
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
           formatter: (value: number) => {
             if (timeseriesResultsTypes) {
               // Check to see if all series output types are the same. If not, then default to number.

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -40,6 +40,11 @@ interface ContainerLayoutProps {
 
   position?: Responsive<'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'>;
 
+  top?: Responsive<React.CSSProperties['top']>;
+  bottom?: Responsive<React.CSSProperties['bottom']>;
+  left?: Responsive<React.CSSProperties['left']>;
+  right?: Responsive<React.CSSProperties['right']>;
+
   overflow?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
   overflowX?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
   overflowY?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
@@ -156,6 +161,7 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'borderBottom',
   'borderLeft',
   'borderRight',
+  'bottom',
   'column',
   'display',
   'flex',
@@ -164,6 +170,7 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'flexShrink',
   'height',
   'justifySelf',
+  'left',
   'margin',
   'marginTop',
   'marginBottom',
@@ -184,7 +191,9 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'paddingRight',
   'position',
   'radius',
+  'right',
   'row',
+  'top',
   'width',
 ]);
 
@@ -210,6 +219,11 @@ export const Container = styled(
 )`
   ${p => rc('display', p.display, p.theme)};
   ${p => rc('position', p.position, p.theme)};
+
+  ${p => rc('top', p.top, p.theme)};
+  ${p => rc('bottom', p.bottom, p.theme)};
+  ${p => rc('left', p.left, p.theme)};
+  ${p => rc('right', p.right, p.theme)};
 
   ${p => rc('overflow', p.overflow, p.theme)};
   ${p => rc('overflow-x', p.overflowX, p.theme)};

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -40,11 +40,6 @@ interface ContainerLayoutProps {
 
   position?: Responsive<'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'>;
 
-  top?: Responsive<React.CSSProperties['top']>;
-  bottom?: Responsive<React.CSSProperties['bottom']>;
-  left?: Responsive<React.CSSProperties['left']>;
-  right?: Responsive<React.CSSProperties['right']>;
-
   overflow?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
   overflowX?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
   overflowY?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
@@ -161,7 +156,6 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'borderBottom',
   'borderLeft',
   'borderRight',
-  'bottom',
   'column',
   'display',
   'flex',
@@ -170,7 +164,6 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'flexShrink',
   'height',
   'justifySelf',
-  'left',
   'margin',
   'marginTop',
   'marginBottom',
@@ -191,9 +184,7 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'paddingRight',
   'position',
   'radius',
-  'right',
   'row',
-  'top',
   'width',
 ]);
 
@@ -219,11 +210,6 @@ export const Container = styled(
 )`
   ${p => rc('display', p.display, p.theme)};
   ${p => rc('position', p.position, p.theme)};
-
-  ${p => rc('top', p.top, p.theme)};
-  ${p => rc('bottom', p.bottom, p.theme)};
-  ${p => rc('left', p.left, p.theme)};
-  ${p => rc('right', p.right, p.theme)};
 
   ${p => rc('overflow', p.overflow, p.theme)};
   ${p => rc('overflow-x', p.overflowX, p.theme)};

--- a/static/app/components/events/eventStatisticalDetector/breakpointChartOptions.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChartOptions.tsx
@@ -103,7 +103,7 @@ function getBreakpointChartOptionsFromData(
     yAxis: {
       minInterval: durationUnit,
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter: (value: number) =>
           axisLabelFormatter(value, 'duration', undefined, durationUnit),
       },

--- a/static/app/components/events/eventStatisticalDetector/eventThroughput.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventThroughput.tsx
@@ -143,7 +143,7 @@ function EventThroughputInner({event, group}: EventThroughputProps) {
       xAxis: {show: false, type: 'time'},
       yAxis: {
         axisLabel: {
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
           formatter: (value: number) =>
             axisLabelFormatter(value, 'rate', true, undefined, RateUnit.PER_SECOND),
         },

--- a/static/app/components/progressRing.tsx
+++ b/static/app/components/progressRing.tsx
@@ -56,7 +56,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   justify-content: center;
   height: 100%;
   width: 100%;
-  color: ${p => p.theme.chartLabel};
+  color: ${p => p.theme.tokens.content.muted};
   font-size: ${p => p.theme.fontSize.xs};
   transition: color 100ms;
   ${p => p.textCss?.(p)}

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1401,11 +1401,6 @@ const generateAliases = (
   chartLabel: tokens.content.muted,
 
   /**
-   * Color for the 'others' series in topEvent charts
-   */
-  chartOther: tokens.content.muted,
-
-  /**
    * Default Progressbar color
    */
   progressBar: colors.chonk.blue400,

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1396,11 +1396,6 @@ const generateAliases = (
   chartLineColor: colors.gray300,
 
   /**
-   * Color for chart label text
-   */
-  chartLabel: tokens.content.muted,
-
-  /**
    * Default Progressbar color
    */
   progressBar: colors.chonk.blue400,

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1390,12 +1390,6 @@ const generateAliases = (
   formPlaceholder: colors.gray300,
 
   /**
-   * Color of lines that flow across the background of the chart to indicate axes levels
-   * (This should only be used for yAxis)
-   */
-  chartLineColor: colors.gray300,
-
-  /**
    * Default Progressbar color
    */
   progressBar: colors.chonk.blue400,

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -366,7 +366,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
     },
     yAxis: {
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter: (value: number) => {
           if (timeseriesResultsTypes) {
             return axisLabelFormatterUsingAggregateOutputType(

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -234,7 +234,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
     : [];
   // TODO(wmak): Need to change this when updating dashboards to support variable topEvents
   if (shouldColorOther) {
-    colors[colors.length] = theme.chartOther;
+    colors[colors.length] = theme.tokens.content.muted;
   }
 
   // Create a list of series based on the order of the fields,

--- a/static/app/views/discover/miniGraph.tsx
+++ b/static/app/views/discover/miniGraph.tsx
@@ -228,7 +228,7 @@ class MiniGraph extends Component<Props> {
                 show: false,
               },
               axisLabel: {
-                color: theme.chartLabel,
+                color: theme.tokens.content.muted,
                 fontFamily: theme.text.family,
                 fontSize: 12,
                 formatter: (value: number) =>

--- a/static/app/views/discover/miniGraph.tsx
+++ b/static/app/views/discover/miniGraph.tsx
@@ -209,7 +209,7 @@ class MiniGraph extends Component<Props> {
             : undefined;
 
           if (chartColors?.length && hasOther) {
-            chartColors.push(theme.chartOther);
+            chartColors.push(theme.tokens.content.muted);
           }
 
           const chartOptions = {

--- a/static/app/views/explore/components/attributeBreakdowns/styles.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/styles.tsx
@@ -394,7 +394,7 @@ function Chart({
                 hideOverlap: false,
                 showMaxLabel: false,
                 showMinLabel: false,
-                color: theme.chartLabel,
+                color: theme.tokens.content.muted,
                 interval: 0,
                 fontSize: CHART_AXIS_LABEL_FONT_SIZE,
                 formatter: (value: string) =>

--- a/static/app/views/explore/components/chart/chartVisualization.tsx
+++ b/static/app/views/explore/components/chart/chartVisualization.tsx
@@ -49,12 +49,12 @@ export function ChartVisualization({
       // values instead of the aggregate function.
       if (s.yAxis === chartInfo.yAxis) {
         return new DataPlottableConstructor(markDelayedData(s, INGESTION_DELAY), {
-          color: s.meta.isOther ? theme.chartOther : undefined,
+          color: s.meta.isOther ? theme.tokens.content.muted : undefined,
           stack: 'all',
         });
       }
       return new DataPlottableConstructor(markDelayedData(s, INGESTION_DELAY), {
-        color: s.meta.isOther ? theme.chartOther : undefined,
+        color: s.meta.isOther ? theme.tokens.content.muted : undefined,
         stack: 'all',
       });
     });

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
@@ -46,7 +46,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   justify-content: center;
   height: 100%;
   width: 100%;
-  color: ${p => p.theme.chartLabel};
+  color: ${p => p.theme.tokens.content.muted};
   font-size: ${p => p.theme.fontSize.xs};
   transition: color 300ms;
   ${p => p.textCss?.(p)}

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -210,7 +210,7 @@ function Chart({
       max: dataMax,
       type: 'value',
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter(value: number) {
           return axisLabelFormatter(value, 'number', true);
         },
@@ -278,7 +278,7 @@ function Chart({
       max: dataMax,
       type: log ? 'log' : 'value',
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter(value: number) {
           return axisLabelFormatter(
             value,
@@ -472,7 +472,7 @@ function Chart({
             splitNumber: definedAxisTicks,
             max: dataMax,
             axisLabel: {
-              color: theme.chartLabel,
+              color: theme.tokens.content.muted,
               formatter(value: number) {
                 return axisLabelFormatter(
                   value,

--- a/static/app/views/insights/pages/mcp/components/groupedDurationWidget.tsx
+++ b/static/app/views/insights/pages/mcp/components/groupedDurationWidget.tsx
@@ -99,7 +99,7 @@ export default function GroupedDurationWidget(props: GroupedDurationWidgetProps)
         plottables: timeSeries.map(
           (ts, index) =>
             new Line(ts, {
-              color: ts.meta.isOther ? theme.chartOther : colorPalette[index],
+              color: ts.meta.isOther ? theme.tokens.content.muted : colorPalette[index],
             })
         ),
       }}

--- a/static/app/views/insights/pages/mcp/components/groupedErrorRateWidget.tsx
+++ b/static/app/views/insights/pages/mcp/components/groupedErrorRateWidget.tsx
@@ -99,7 +99,7 @@ export default function GroupedErrorRateWidget(props: GroupedErrorRateWidgetProp
         plottables: timeSeries.map(
           (ts, index) =>
             new Line(ts, {
-              color: ts.meta.isOther ? theme.chartOther : colorPalette[index],
+              color: ts.meta.isOther ? theme.tokens.content.muted : colorPalette[index],
             })
         ),
       }}

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -275,7 +275,7 @@ const outputChartColors = (theme: Theme) => {
         theme.chart.colors[5][3],
         theme.chart.colors[5][4],
         theme.chart.colors[5][5],
-        theme.chartOther, // Projected
+        theme.tokens.content.muted, // Projected
       ] as const);
 };
 

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -478,7 +478,7 @@ function UsageChartBody({
         minInterval: yAxisMinInterval,
         axisLabel: {
           formatter: yAxisLabelFormatter,
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
         },
       }}
       series={series}

--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -111,7 +111,7 @@ function Chart({
           minInterval: durationUnit,
           splitNumber: definedAxisTicks,
           axisLabel: {
-            color: theme.chartLabel,
+            color: theme.tokens.content.muted,
             formatter(value: number) {
               return axisLabelFormatter(
                 value,
@@ -130,7 +130,7 @@ function Chart({
           minInterval: durationUnit,
           max: dataMax,
           axisLabel: {
-            color: theme.chartLabel,
+            color: theme.tokens.content.muted,
             formatter(value: number) {
               return axisLabelFormatter(
                 value,
@@ -147,7 +147,7 @@ function Chart({
           max: dataMax,
           minInterval: durationUnit,
           axisLabel: {
-            color: theme.chartLabel,
+            color: theme.tokens.content.muted,
             formatter(value: number) {
               return axisLabelFormatter(
                 value,

--- a/static/app/views/performance/landing/chart/histogramChart.tsx
+++ b/static/app/views/performance/landing/chart/histogramChart.tsx
@@ -95,7 +95,7 @@ export function Chart(props: ChartProps) {
   const yAxis = {
     type: 'value' as const,
     axisLabel: {
-      color: theme.chartLabel,
+      color: theme.tokens.content.muted,
       formatter: (value: number | string) => formatAbbreviatedNumber(value),
     },
   };

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/content.tsx
@@ -120,7 +120,7 @@ function Content({
     yAxis: {
       minInterval: durationUnit,
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter: (value: number) => {
           return axisLabelFormatter(value, 'duration', undefined, durationUnit);
         },

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/chart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/chart.tsx
@@ -30,7 +30,7 @@ function Chart(props: Props) {
         minInterval: durationUnit,
         type: 'value' as const,
         axisLabel: {
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
           // Use p50() to force time formatting.
           formatter: (value: number) =>
             axisLabelFormatter(value, 'duration', undefined, durationUnit),

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -209,7 +209,7 @@ function SidebarChartsContainer({
         interval: 0.2,
         axisLabel: {
           formatter: (value: number) => `${formatFloat(value, 1)}`,
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
         },
         ...axisLineConfig,
       },
@@ -221,7 +221,7 @@ function SidebarChartsContainer({
         max: 1.0,
         axisLabel: {
           formatter: (value: number) => formatPercentage(value, 0),
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
         },
         ...axisLineConfig,
       },

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/content.tsx
@@ -110,7 +110,7 @@ function Content({
       min: 0,
       minInterval: durationUnit,
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter: (value: number) =>
           axisLabelFormatter(value, 'duration', undefined, durationUnit),
       },

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/content.tsx
@@ -95,7 +95,7 @@ function Content({
     yAxis: {
       minInterval: durationUnit,
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         // p75(measurements.fcp) coerces the axis to be time based
         formatter: (value: number) =>
           axisLabelFormatter(value, 'duration', undefined, durationUnit),

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -288,7 +288,7 @@ class VitalCard extends Component<Props, State> {
       type: 'value' as const,
       max,
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter: (value: string | number) => formatAbbreviatedNumber(value),
       },
     };

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -216,7 +216,7 @@ export function Chart({
       max: yMax + yMargin,
       minInterval: durationUnit,
       axisLabel: {
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         formatter: (value: number) =>
           axisLabelFormatter(value, 'duration', undefined, durationUnit),
       },

--- a/static/app/views/profiling/landing/functionTrendsWidget.tsx
+++ b/static/app/views/profiling/landing/functionTrendsWidget.tsx
@@ -491,7 +491,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
       },
       yAxis: {
         axisLabel: {
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
           formatter: (value: number) => axisLabelFormatter(value, 'duration'),
         },
       },
@@ -502,7 +502,7 @@ function FunctionTrendsChart({func, trendFunction}: FunctionTrendsChartProps) {
         valueFormatter: (value: number) => tooltipFormatter(value, 'duration'),
       },
     };
-  }, [theme.chartLabel]);
+  }, [theme.tokens.content.muted]);
 
   return (
     <ChartZoom {...selection.datetime}>

--- a/static/app/views/profiling/landing/profilesSummaryChart.tsx
+++ b/static/app/views/profiling/landing/profilesSummaryChart.tsx
@@ -154,7 +154,7 @@ export function ProfilesSummaryChart({
           gridIndex: 0,
           scale: true,
           axisLabel: {
-            color: theme.chartLabel,
+            color: theme.tokens.content.muted,
             formatter(value: number) {
               return axisLabelFormatter(value, 'integer');
             },
@@ -164,7 +164,7 @@ export function ProfilesSummaryChart({
           gridIndex: 1,
           scale: true,
           axisLabel: {
-            color: theme.chartLabel,
+            color: theme.tokens.content.muted,
             formatter(value: number) {
               return axisLabelFormatter(value, 'duration');
             },
@@ -174,7 +174,7 @@ export function ProfilesSummaryChart({
     };
 
     return baseProps;
-  }, [hideCount, series, seriesOrder, theme.chartLabel]);
+  }, [hideCount, series, seriesOrder, theme.tokens.content.muted]);
 
   return (
     <ProfilesChartContainer>

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -446,7 +446,7 @@ function FunctionChart<F extends BreakdownFunction>({
       },
       yAxis: {
         axisLabel: {
-          color: theme.chartLabel,
+          color: theme.tokens.content.muted,
           formatter: (value: number) => axisLabelFormatter(value, 'duration'),
         },
       },
@@ -457,7 +457,7 @@ function FunctionChart<F extends BreakdownFunction>({
         valueFormatter: (value: number) => tooltipFormatter(value, 'duration'),
       },
     };
-  }, [theme.chartLabel]);
+  }, [theme.tokens.content.muted]);
 
   if (stats?.isPending) {
     return (

--- a/static/app/views/projectsDashboard/projectChart.tsx
+++ b/static/app/views/projectsDashboard/projectChart.tsx
@@ -162,7 +162,7 @@ export function ProjectChart({
         margin: 2,
         showMaxLabel: true,
         showMinLabel: false,
-        color: theme.chartLabel,
+        color: theme.tokens.content.muted,
         fontFamily: theme.text.family,
         inside: true,
         lineHeight: 12,

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -97,7 +97,7 @@ class ReleaseSessionsChart extends Component<Props> {
           scale: true,
           axisLabel: {
             formatter: (value: number) => displayCrashFreePercent(value),
-            color: theme.chartLabel,
+            color: theme.tokens.content.muted,
           },
         };
       case ReleaseComparisonChartType.HEALTHY_SESSIONS:
@@ -114,7 +114,7 @@ class ReleaseSessionsChart extends Component<Props> {
           scale: true,
           axisLabel: {
             formatter: (value: number) => `${round(value, 2)}%`,
-            color: theme.chartLabel,
+            color: theme.tokens.content.muted,
           },
         };
       case ReleaseComparisonChartType.SESSION_COUNT:

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -141,7 +141,7 @@ function ReleaseAdoption({
     max: 100,
     axisLabel: {
       formatter: (value: number) => `${value}%`,
-      color: theme.chartLabel,
+      color: theme.tokens.content.muted,
     },
   };
 

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -622,7 +622,7 @@ export function ProductUsageChart({
                 displayMode === 'usage'
                   ? t(`Plan Quota (%s)`, yAxisQuotaLineLabel)
                   : t('Max Spend'),
-              color: theme.chartLabel,
+              color: theme.tokens.content.muted,
               backgroundColor: theme.tokens.background.primary,
               borderRadius: 2,
               padding: 2,

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -1310,7 +1310,7 @@ const BaseRow = styled('div')`
 `;
 
 const SubText = styled('span')`
-  color: ${p => p.theme.chartLabel};
+  color: ${p => p.theme.tokens.content.muted};
   font-size: ${p => p.theme.fontSize.md};
 `;
 


### PR DESCRIPTION
[chartOther -> content.muted](https://github.com/getsentry/sentry/commit/bedb20371583f1a07daeb3391c8fe9ee15a74fe2)

[chartLabel -> content.muted](https://github.com/getsentry/sentry/commit/dc8db17718d9f5c97c15f7660287eff46a5d673f)

[chartLineColor -> colors.gray300](https://github.com/getsentry/sentry/commit/19f9948f8e960f6a62fe9a9fff924402cd49e83d) Note: This is not ideal but it’s a 1:1 replacement and we’ll take a look at _not_ using `theme.colors` later on, @Jesse-Box FYI