### PR TITLE
feat(preprod): Add v0 of size issues

### DIFF
--- a/src/sentry/preprod/size_analysis/issues.py
+++ b/src/sentry/preprod/size_analysis/issues.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+from sentry.issues.grouptype import PreprodDeltaGroupType
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.preprod.size_analysis.models import SizeMetricDiffItem
+
+
+def diff_to_occurrence(
+    project_id: int, size: Literal["install", "download"], diff: SizeMetricDiffItem
+) -> tuple[IssueOccurrence, dict[str, Any]]:
+
+    id = uuid4().hex
+    event_id = uuid4().hex
+    fingerprint = [uuid4().hex]
+    current_timestamp = datetime.now(timezone.utc)
+
+    # TODO(EME-80): Unclear if/what we should put in the event_data:
+    event_data = {
+        "event_id": event_id,
+        "project_id": project_id,
+        "platform": "other",
+        "received": current_timestamp.timestamp(),
+        "timestamp": current_timestamp.timestamp(),
+    }
+
+    evidence_display = [
+        IssueEvidence("some_evidence_name", "some_evidence_data", False),
+    ]
+
+    match size:
+        case "download":
+            delta = diff.head_download_size - diff.base_download_size
+        case "install":
+            delta = diff.head_install_size - diff.base_install_size
+        case _:
+            assert False, f"Unknown size {size}"
+
+    occurrence = IssueOccurrence(
+        id=id,
+        event_id=event_id,
+        # TODO(EME-80): Should format title better:
+        issue_title=f"{delta} byte {size} size regression",
+        subtitle="",
+        project_id=project_id,
+        fingerprint=fingerprint,
+        type=PreprodDeltaGroupType,
+        detection_time=current_timestamp,
+        evidence_data={},
+        evidence_display=evidence_display,
+        # TODO(EME-80): Unclear what we should set these to:
+        level="error",
+        resource_id=None,
+        culprit="",
+    )
+
+    return occurrence, event_data

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -6,6 +6,8 @@ from io import BytesIO
 from django.db import router, transaction
 from django.utils import timezone
 
+from sentry import features
+from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.files.file import File
 from sentry.preprod.models import (
     PreprodArtifact,
@@ -13,7 +15,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
 )
 from sentry.preprod.size_analysis.compare import compare_size_analysis
-from sentry.preprod.size_analysis.models import SizeAnalysisResults
+from sentry.preprod.size_analysis.models import ComparisonResults, SizeAnalysisResults
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
@@ -21,6 +23,8 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import attachments_tasks
 from sentry.utils import metrics
 from sentry.utils.json import dumps_htmlsafe
+
+from .issues import diff_to_occurrence
 
 logger = logging.getLogger(__name__)
 
@@ -474,7 +478,81 @@ def _run_size_analysis_comparison(
         comparison.state = PreprodArtifactSizeComparison.State.SUCCESS
         comparison.save()
 
+    maybe_emit_issues(
+        comparison_results=comparison_results,
+        head_metric=head_size_metric,
+        base_metric=base_size_metric,
+    )
+
     logger.info(
         "preprod.size_analysis.compare.success",
         extra={"comparison_id": comparison.id},
+    )
+
+
+def maybe_emit_issues(
+    comparison_results: ComparisonResults,
+    head_metric: PreprodArtifactSizeMetrics,
+    base_metric: PreprodArtifactSizeMetrics,
+) -> None:
+    try:
+        _maybe_emit_issues(
+            comparison_results=comparison_results, head_metric=head_metric, base_metric=base_metric
+        )
+    except Exception:
+        logger.exception("Error emitting issues")
+
+
+def _maybe_emit_issues(
+    comparison_results: ComparisonResults,
+    head_metric: PreprodArtifactSizeMetrics,
+    base_metric: PreprodArtifactSizeMetrics,
+) -> None:
+    project = head_metric.preprod_artifact.project
+    project_id = project.id
+    organization_id = project.organization.id
+
+    if not features.has("organizations:preprod-issues", project.organization):
+        logger.info(
+            "preprod.size_analysis.compare.issues.disabled",
+            extra={
+                "project_id": project_id,
+                "organization_id": organization_id,
+            },
+        )
+        return
+
+    # TODO(EME-80): Make threshold configurable:
+    arbitrary_threshold = 100 * 1024
+    diff = comparison_results.size_metric_diff_item
+    download_delta = diff.head_download_size - diff.base_download_size
+    install_delta = diff.head_install_size - diff.base_install_size
+
+    issue_count = 0
+
+    if download_delta >= arbitrary_threshold:
+        occurrence, event_data = diff_to_occurrence(project_id, "download", diff)
+        produce_occurrence_to_kafka(
+            payload_type=PayloadType.OCCURRENCE,
+            occurrence=occurrence,
+            event_data=event_data,
+        )
+        issue_count += 1
+
+    if install_delta >= arbitrary_threshold:
+        occurrence, event_data = diff_to_occurrence(project_id, "install", diff)
+        produce_occurrence_to_kafka(
+            payload_type=PayloadType.OCCURRENCE,
+            occurrence=occurrence,
+            event_data=event_data,
+        )
+        issue_count += 1
+
+    logger.info(
+        "preprod.size_analysis.compare.issues",
+        extra={
+            "project_id": project_id,
+            "organization_id": organization_id,
+            "issue_count": issue_count,
+        },
     )

--- a/tests/sentry/preprod/size_analysis/test_issues.py
+++ b/tests/sentry/preprod/size_analysis/test_issues.py
@@ -1,0 +1,58 @@
+from sentry.issues.grouptype import PreprodDeltaGroupType
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+from sentry.preprod.size_analysis.issues import diff_to_occurrence
+from sentry.preprod.size_analysis.models import SizeMetricDiffItem
+
+
+def test_diff_to_occurrence_install():
+
+    diff = SizeMetricDiffItem(
+        metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        identifier=None,
+        base_install_size=100,
+        head_install_size=150,
+        base_download_size=300,
+        head_download_size=400,
+    )
+
+    occurrence, event = diff_to_occurrence(42, "install", diff)
+
+    assert occurrence.project_id == 42
+    assert occurrence.issue_title == "50 byte install size regression"
+    assert occurrence.type == PreprodDeltaGroupType
+
+    # Event has some required feilds which should match issue:
+    assert occurrence.event_id == event["event_id"]
+    assert occurrence.project_id == event["project_id"]
+    # event has timestamp as string, occurrence as object
+    assert occurrence.detection_time.timestamp() == event["timestamp"]
+
+    # Event has some required fields which need to be set correctly:
+    assert event["platform"] == "other"
+
+
+def test_diff_to_occurrence_download():
+
+    diff = SizeMetricDiffItem(
+        metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        identifier=None,
+        base_install_size=100,
+        head_install_size=150,
+        base_download_size=300,
+        head_download_size=500,
+    )
+
+    occurrence, event = diff_to_occurrence(43, "download", diff)
+
+    assert occurrence.project_id == 43
+    assert occurrence.issue_title == "200 byte download size regression"
+    assert occurrence.type == PreprodDeltaGroupType
+
+    # Event has some required feilds which should match the occurrence:
+    assert occurrence.event_id == event["event_id"]
+    assert occurrence.project_id == event["project_id"]
+    # event has timestamp as string, occurrence as object
+    assert occurrence.detection_time.timestamp() == event["timestamp"]
+
+    # Event has some required fields which need to be set correctly:
+    assert event["platform"] == "other"


### PR DESCRIPTION
This adds V0 of preprod size issues to Sentry.
The logic is behind a feature flag (`organizations:preprod-issues`)
In this initial version:
- The issue text/metadata is very minimal
- The limit is hardcoded