### PR TITLE
fix(scraps): turn of focus-visible styles for LinkButton applied by link

### DIFF
--- a/static/app/components/core/button/linkButton.tsx
+++ b/static/app/components/core/button/linkButton.tsx
@@ -94,6 +94,9 @@ const StyledLinkButton = styled(
   }
 )<LinkButtonProps>`
   ${p => getChonkLinkButtonStyles(p)}
+  &:focus-visible {
+    box-shadow: none;
+  }
 `;
 
 const getChonkLinkButtonStyles = (p: LinkButtonProps) => {


### PR DESCRIPTION
`LinkButton` gets created with styles from our Button component, which applies a `focus-visible` style to the `::after` pseudo-element of the button.

However, we essentially render a `Link` at the end, and the styles of the link add a `focus-visible` to the actual element itself. That creates two focus styles.

I’m not sure if this is the right fix though, as it only tackles the symptom. I think we actually want an unstyled version of our `Link` because we apply different styles (from a button) to it. `getLinkStyles` currently doesn’t do much, but if we add more things here, it might break the `LinkButton` again.

https://github.com/getsentry/sentry/blob/3f3093fe4cae18d2f6e6d6995ab5591fb3a8d504/static/app/components/core/link/link.tsx#L35-L56

before:

<img width="628" height="134" alt="Screenshot 2025-12-15 at 15 32 28" src="https://github.com/user-attachments/assets/4c8dc850-06e7-4d43-8e6c-e73928089c79" />

after:

<img width="624" height="134" alt="Screenshot 2025-12-15 at 15 31 41" src="https://github.com/user-attachments/assets/9ad0cebd-a11e-426c-8839-15e4e4f029c3" />
