### PR TITLE
feat(Unity): Add Unity context type tag mapping

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -236,6 +236,15 @@ class OtelContextType(ContextType):
     context_to_tag_mapping = {}
 
 
+@contexttype
+class UnityContextType(ContextType):
+    type = "unity"
+    context_to_tag_mapping = {
+        "is_main_thread": "{is_main_thread}",
+        "install_mode": "{install_mode}",
+    }
+
+
 class Contexts(Interface):
     """
     This interface stores context specific information.

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_unity.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_unity.pysnap
@@ -1,0 +1,18 @@
+---
+source: tests/sentry/event_manager/interfaces/test_contexts.py
+---
+errors: null
+tags:
+- - unity.install_mode
+  - Store
+- - unity.is_main_thread
+  - 'yes'
+to_json:
+  unity:
+    active_scene_name: MainScene
+    editor_version: 2022.3.1f1
+    install_mode: Store
+    is_main_thread: true
+    rendering_threading_mode: MultiThreaded
+    target_frame_rate: '60'
+    type: unity

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -183,3 +183,18 @@ def test_large_nested_numbers() -> None:
         "type": "default",
     }
     assert ctx_data == expected_data
+
+
+def test_unity(make_ctx_snapshot) -> None:
+    make_ctx_snapshot(
+        {
+            "unity": {
+                "active_scene_name": "MainScene",
+                "editor_version": "2022.3.1f1",
+                "install_mode": "Store",
+                "is_main_thread": True,
+                "rendering_threading_mode": "MultiThreaded",
+                "target_frame_rate": "60",
+            }
+        }
+    )


### PR DESCRIPTION
Followup on https://github.com/getsentry/sentry/pull/104952

The Unity SDK adds a Unity specific context to events. Some of these context should be promoted to tags. Previously, this was done by the SDK itself, see https://github.com/getsentry/sentry-unity/pull/2459

The tags are:
- `is_main_thread` - bool, Whether the event comes from the main thread or not
- `install_mode` - enum, `Unknown`, `Store`, `DeveloperBuild`, `Adhoc`, `Enterprise`, `Editor`, see Unity [docs](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/ApplicationInstallMode.html)