### PR TITLE
Added `device_type` to tag mapping

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -183,7 +183,11 @@ class AppContextType(ContextType):
 @contexttype
 class DeviceContextType(ContextType):
     type = "device"
-    context_to_tag_mapping = {"": "{model}", "family": "{family}"}
+    context_to_tag_mapping = {
+        "": "{model}",
+        "family": "{family}",
+        "device_type": "{device_type}",
+    }
     # model_id, arch
 
 

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_device.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_device.pysnap
@@ -7,9 +7,12 @@ errors: null
 tags:
 - - device
   - iPad
+- - device.device_type
+  - Handheld
 to_json:
   device:
     arch: arm64
+    device_type: Handheld
     model: iPad
     model_id: 1234AB
     name: My iPad

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -73,6 +73,7 @@ def test_device(make_ctx_snapshot) -> None:
                 "model_id": "1234AB",
                 "version": "1.2.3",
                 "arch": "arm64",
+                "device_type": "Handheld",
             }
         }
     )


### PR DESCRIPTION
Followup on https://github.com/getsentry/sentry/pull/104956

The `device_type` is especially relevant in cross platform context, like the game engines, and resolves to `Unknown`, `Handheld`, `Console`, `Desktop`.
