### PR TITLE
fix(issues): Fix autogenerated received timestamp

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -249,7 +249,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "level": occurrence_data["level"],
                     "project_id": event_payload.get("project_id"),
                     "platform": event_payload.get("platform"),
-                    "received": event_payload.get("received", timezone.now()),
+                    "received": event_payload.get("received", timezone.now().isoformat()),
                     "tags": event_payload.get("tags"),
                     "timestamp": event_payload.get("timestamp"),
                 }

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -32,7 +32,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.snuba.backend import SnubaEventStorage
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.group import PriorityLevel
@@ -600,6 +600,20 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         message["assignee"] = ""
         kwargs = _get_kwargs(message)
         assert kwargs["occurrence_data"]["assignee"] is None
+
+    def test_handles_missing_received(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        message["event"].pop("received", None)
+        self.run_test(message)
+
+    @freeze_time("2024-07-11 00:00:00")
+    def test_missing_received_fills_with_current_time(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        message["event"].pop("received", None)
+
+        kwargs = _get_kwargs(message)
+
+        assert kwargs["event_data"]["received"] == "2024-07-11T00:00:00+00:00"
 
     @mock.patch("sentry.issues.occurrence_consumer._process_message")
     def test_validate_cache(self, mock_process_message: mock.MagicMock) -> None:


### PR DESCRIPTION
In `process_occurrence_message` if the "received" timestamp on the
event is unset we try to backfill it:
```
"received": event_payload.get("received", timezone.now()),
```

Later in this function we validate this data:
```
try:
    jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)
except jsonschema.exceptions.ValidationError:
    metrics.incr(
        "occurrence_ingest.event_payload_invalid",
        sample_rate=1.0,
        tags={"occurrence_type": occurrence_data["type"]},
    )
    logger.exception(
        "Error validating event payload, falling back to legacy validation"
    )
    try:
        jsonschema.validate(event_data, LEGACY_EVENT_PAYLOAD_SCHEMA)
    except jsonschema.exceptions.ValidationError:
        metrics.incr(
            "occurrence_ingest.legacy_event_payload_invalid",
            sample_rate=1.0,
            tags={"occurrence_type": occurrence_data["type"]},
        )
        raise
```

We try two schemas:
- EVENT_PAYLOAD_SCHEMA
- LEGACY_EVENT_PAYLOAD_SCHEMA

In EVENT_PAYLOAD_SCHEMA `received` is defined as:
```
The format is either a string as defined in RFC 3339 or a numeric
(integer or float) value representing the number of seconds that have
elapsed since the Unix epoch.
```

In `LEGACY_EVENT_PAYLOAD_SCHEMA` it's defined like:
```
"received": {"type": "string", "format": "date-time"},
```

Which is only the isoformat:
https://json-schema.org/understanding-json-schema/reference/type

I belive neither of these handle the `timezone.now()` datetime object
correctly. Since both the legacy and current schemas handle ISO strings
update the code to do:
```
"received": event_payload.get("received", timezone.now().isoformat()),
```

instead.
