### PR TITLE
fix(spans-migration): fix threshold button styling on extrapolation mode banner

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -3,8 +3,6 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
-import {Button} from '@sentry/scraps/button/button';
-
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import type {Client} from 'sentry/api';
@@ -13,7 +11,7 @@ import {
   OnDemandWarningIcon,
 } from 'sentry/components/alerts/onDemandMetricAlert';
 import {Alert} from 'sentry/components/core/alert';
-import {ExternalLink} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import {Select} from 'sentry/components/core/select';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {
@@ -613,14 +611,16 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 'The thresholds on this chart may look off. This is because, once saved, alerts will now take into account [samplingLink:sampling rate]. Before clicking save, take the time to update your [thresholdsLink:thresholds]. Click cancel to continue running this alert in compatibility mode.',
                 {
                   thresholdsLink: (
-                    // had to use a button and style it as a link because you can't use onClick on a link element
-                    <LinkStyledButton
-                      priority="link"
+                    <Link
                       aria-label="Go to thresholds"
+                      to="#thresholds-warning-icon"
+                      preventScrollReset
                       onClick={() => {
-                        document
-                          .getElementById('thresholds-warning-icon')
-                          ?.scrollIntoView({behavior: 'smooth'});
+                        requestAnimationFrame(() => {
+                          document
+                            .getElementById('thresholds-warning-icon')
+                            ?.scrollIntoView({behavior: 'smooth'});
+                        });
                       }}
                     />
                   ),
@@ -889,12 +889,6 @@ const StyledListTitle = styled('div')`
   span {
     margin-left: ${space(1)};
   }
-`;
-
-const LinkStyledButton = styled(Button)`
-  padding: 0;
-  font-weight: normal;
-  text-decoration: underline;
 `;
 
 // This is a temporary hacky solution to hide list items without changing the numbering of the rest of the list

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -613,7 +613,8 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 'The thresholds on this chart may look off. This is because, once saved, alerts will now take into account [samplingLink:sampling rate]. Before clicking save, take the time to update your [thresholdsLink:thresholds]. Click cancel to continue running this alert in compatibility mode.',
                 {
                   thresholdsLink: (
-                    <Button
+                    // had to use a button and style it as a link because you can't use onClick on a link element
+                    <LinkStyledButton
                       priority="link"
                       aria-label="Go to thresholds"
                       onClick={() => {
@@ -888,6 +889,12 @@ const StyledListTitle = styled('div')`
   span {
     margin-left: ${space(1)};
   }
+`;
+
+const LinkStyledButton = styled(Button)`
+  padding: 0;
+  font-weight: normal;
+  text-decoration: underline;
 `;
 
 // This is a temporary hacky solution to hide list items without changing the numbering of the rest of the list

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -640,7 +640,7 @@ function MigratedAlertWarningListener() {
                 />
               ),
               thresholdsLink: (
-                <Button
+                <LinkStyledButton
                   priority="link"
                   aria-label="Go to thresholds"
                   onClick={() => {
@@ -670,6 +670,12 @@ function WarningIcon({id, tooltipProps}: {id: string; tooltipProps?: TooltipProp
 
 const StyledIconWarning = styled(IconWarning)`
   animation: ${() => pulse(1.15)} 1s ease infinite;
+`;
+
+const LinkStyledButton = styled(Button)`
+  padding: 0;
+  font-weight: normal;
+  text-decoration: underline;
 `;
 
 const HeadingContainer = styled('div')`

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -640,6 +640,7 @@ function MigratedAlertWarningListener() {
                 />
               ),
               thresholdsLink: (
+                // had to use a button and style it as a link because you can't use onClick on a link element
                 <LinkStyledButton
                   priority="link"
                   aria-label="Go to thresholds"

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -4,8 +4,7 @@ import styled from '@emotion/styled';
 import toNumber from 'lodash/toNumber';
 
 import {Alert} from '@sentry/scraps/alert/alert';
-import {Button} from '@sentry/scraps/button/button';
-import {ExternalLink} from '@sentry/scraps/link/link';
+import {ExternalLink, Link} from '@sentry/scraps/link/link';
 
 import {Disclosure} from 'sentry/components/core/disclosure';
 import {Flex, Stack} from 'sentry/components/core/layout';
@@ -26,6 +25,7 @@ import {PriorityLevel} from 'sentry/types/group';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import type {Detector, MetricDetectorConfig} from 'sentry/types/workflowEngine/detectors';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
 import {
   AlertRuleSensitivity,
   AlertRuleThresholdType,
@@ -625,6 +625,7 @@ function MigratedAlertWarningListener() {
     dataset,
     extrapolationMode,
   });
+  const location = useLocation();
 
   if (isMigratedExtrapolation) {
     return (
@@ -640,14 +641,16 @@ function MigratedAlertWarningListener() {
                 />
               ),
               thresholdsLink: (
-                // had to use a button and style it as a link because you can't use onClick on a link element
-                <LinkStyledButton
-                  priority="link"
+                <Link
                   aria-label="Go to thresholds"
+                  preventScrollReset
+                  to={{...location, hash: '#thresholds-warning-icon'}}
                   onClick={() => {
-                    document
-                      .getElementById('thresholds-warning-icon')
-                      ?.scrollIntoView({behavior: 'smooth'});
+                    requestAnimationFrame(() => {
+                      document
+                        .getElementById('thresholds-warning-icon')
+                        ?.scrollIntoView({behavior: 'smooth'});
+                    });
                   }}
                 />
               ),
@@ -671,12 +674,6 @@ function WarningIcon({id, tooltipProps}: {id: string; tooltipProps?: TooltipProp
 
 const StyledIconWarning = styled(IconWarning)`
   animation: ${() => pulse(1.15)} 1s ease infinite;
-`;
-
-const LinkStyledButton = styled(Button)`
-  padding: 0;
-  font-weight: normal;
-  text-decoration: underline;
 `;
 
 const HeadingContainer = styled('div')`


### PR DESCRIPTION
I noticed the threshold button padding changed recently so i created my own styling for it to match the link styling.
| Before | <img width="1084" height="522" alt="image" src="https://github.com/user-attachments/assets/e6a428d6-a308-473a-83cb-aa6471b00b3c" /> |
|--------|--------|
| **After** | <img width="1183" height="576" alt="image" src="https://github.com/user-attachments/assets/de800ed7-c8f8-4412-949f-dd28b7233c41" /> | 