### PR TITLE
feat(trace-waterfall): Add trace count disagree info

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {
@@ -17,16 +16,16 @@ import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModel
 import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
 
 type MetaDataProps = {
-  bodyText: React.ReactNode;
+  children: React.ReactNode;
   headingText: string;
   rightAlignBody?: boolean;
 };
 
-function MetaSection({headingText, bodyText, rightAlignBody}: MetaDataProps) {
+function MetaSection({headingText, rightAlignBody, children}: MetaDataProps) {
   return (
     <HeaderInfo>
       <StyledSectionHeading>{headingText}</StyledSectionHeading>
-      <SectionBody alignment={rightAlignBody}>{bodyText}</SectionBody>
+      <SectionBody alignment={rightAlignBody}>{children}</SectionBody>
     </HeaderInfo>
   );
 }
@@ -43,7 +42,7 @@ const StyledSectionHeading = styled(SectionHeading)`
 const SectionBody = styled('div')<{alignment?: boolean}>`
   font-size: ${p => p.theme.fontSize.xl};
   text-align: ${p => (p.alignment ? 'right' : 'left')};
-  padding: ${space(0.5)} 0;
+  padding: ${p => p.theme.space.xs} 0;
   max-height: 32px;
 `;
 
@@ -94,54 +93,40 @@ export function Meta(props: MetaProps) {
 
   return (
     <MetaWrapper>
-      <MetaSection
-        headingText={t('Issues')}
-        bodyText={
-          uniqueIssuesCount && traceNode ? (
-            <TraceDrawerComponents.IssuesLink node={traceNode}>
-              {uniqueIssuesCount}
-            </TraceDrawerComponents.IssuesLink>
-          ) : (
-            uniqueIssuesCount
-          )
-        }
-      />
-      {hasSpans ? <MetaSection headingText={t('Spans')} bodyText={spansCount} /> : null}
+      <MetaSection headingText={t('Issues')}>
+        {uniqueIssuesCount && traceNode ? (
+          <TraceDrawerComponents.IssuesLink node={traceNode}>
+            {uniqueIssuesCount}
+          </TraceDrawerComponents.IssuesLink>
+        ) : (
+          uniqueIssuesCount
+        )}
+      </MetaSection>
+      {hasSpans ? <MetaSection headingText={t('Spans')}>{spansCount}</MetaSection> : null}
       {ageStartTimestamp ? (
-        <MetaSection
-          headingText={t('Age')}
-          bodyText={
-            <TimeSince
-              unitStyle="extraShort"
-              date={new Date(ageStartTimestamp)}
-              tooltipShowSeconds
-              suffix=""
-            />
-          }
-        />
+        <MetaSection headingText={t('Age')}>
+          <TimeSince
+            unitStyle="extraShort"
+            date={new Date(ageStartTimestamp)}
+            tooltipShowSeconds
+            suffix=""
+          />
+        </MetaSection>
       ) : null}
       {hasSpans ? (
-        <MetaSection
-          headingText={t('Root Duration')}
-          rightAlignBody
-          bodyText={
-            repEvent
-              ? OurLogKnownFieldKey.PROJECT_ID in repEvent
-                ? '\u2014' // Logs don't have a duration
-                : getRootDuration(repEvent)
-              : '\u2014'
-          }
-        />
+        <MetaSection headingText={t('Root Duration')} rightAlignBody>
+          {repEvent
+            ? OurLogKnownFieldKey.PROJECT_ID in repEvent
+              ? '\u2014' // Logs don't have a duration
+              : getRootDuration(repEvent)
+            : '\u2014'}
+        </MetaSection>
       ) : hasLogs ? (
-        <MetaSection
-          rightAlignBody
-          headingText={t('Logs')}
-          bodyText={
-            props.meta && 'logs' in props.meta
-              ? props.meta.logs
-              : (props.logs?.length ?? 0)
-          }
-        />
+        <MetaSection rightAlignBody headingText={t('Logs')}>
+          {props.meta && 'logs' in props.meta
+            ? props.meta.logs
+            : (props.logs?.length ?? 0)}
+        </MetaSection>
       ) : null}
     </MetaWrapper>
   );
@@ -150,7 +135,7 @@ export function Meta(props: MetaProps) {
 const MetaWrapper = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(2)};
+  gap: ${p => p.theme.space.xl};
 
   ${HeaderInfo} {
     min-height: 0;


### PR DESCRIPTION
This PR adds in a tooltip over the span count to inform users of the count of spans shown, and total spans for a given trace.

Ticket: EXP-654

<img width="252" height="95" alt="Screenshot 2025-12-15 at 12 25 43" src="https://github.com/user-attachments/assets/0514c538-e924-4881-8811-a694b6118bb8" />