### PR TITLE
fix(trace-waterfall): Make Open in Explore button a link button

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
@@ -44,7 +44,7 @@ export function TraceOpenInExploreButton({trace_id, traceEventView}: Props) {
   return (
     <LinkButton
       size="xs"
-      to={target}
+      to={{pathname: target.pathname, query: target.query}}
       onClick={() => {
         traceAnalytics.trackExploreSearch(
           organization,

--- a/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
@@ -1,8 +1,8 @@
-import {Button} from 'sentry/components/core/button';
+import {LinkButton} from '@sentry/scraps/button/linkButton';
+
 import {t} from 'sentry/locale';
 import type EventView from 'sentry/utils/discover/eventView';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import {
@@ -19,15 +19,32 @@ export function TraceOpenInExploreButton({trace_id, traceEventView}: Props) {
   const organization = useOrganization();
   const hasExploreEnabled = organization.features.includes('visibility-explore-view');
   const location = useLocation();
-  const navigate = useNavigate();
 
   if (!hasExploreEnabled || !trace_id) {
     return null;
   }
 
+  const {start, end, statsPeriod} = traceEventView;
+  const target = getSearchInExploreTarget(
+    organization,
+    {
+      ...location,
+      query: {
+        start,
+        end,
+        statsPeriod: start && end ? null : statsPeriod, // We don't want statsPeriod to have precedence over start and end
+      },
+    },
+    '-1',
+    'trace',
+    trace_id ?? '',
+    TraceDrawerActionKind.INCLUDE
+  );
+
   return (
-    <Button
+    <LinkButton
       size="xs"
+      to={target}
       onClick={() => {
         traceAnalytics.trackExploreSearch(
           organization,
@@ -36,28 +53,9 @@ export function TraceOpenInExploreButton({trace_id, traceEventView}: Props) {
           TraceDrawerActionKind.INCLUDE,
           'toolbar_menu'
         );
-
-        const {start, end, statsPeriod} = traceEventView;
-        const target = getSearchInExploreTarget(
-          organization,
-          {
-            ...location,
-            query: {
-              start,
-              end,
-              statsPeriod: start && end ? null : statsPeriod, // We don't want statsPeriod to have precedence over start and end
-            },
-          },
-          '-1',
-          'trace',
-          trace_id ?? '',
-          TraceDrawerActionKind.INCLUDE
-        );
-
-        navigate(target);
       }}
     >
       {t('Open in Explore')}
-    </Button>
+    </LinkButton>
   );
 }


### PR DESCRIPTION
Quick fix to make the "Open in Explore" button, a `LinkButton` component so that it acts like a normal link, but it remains styled the same way.