### PR TITLE
ref(grouplist): Refactor GroupList to FC

### DIFF
--- a/static/app/components/issues/groupList.spec.tsx
+++ b/static/app/components/issues/groupList.spec.tsx
@@ -1,0 +1,185 @@
+import * as qs from 'query-string';
+import {GroupFixture} from 'sentry-fixture/group';
+import {MemberFixture} from 'sentry-fixture/member';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import GroupStore from 'sentry/stores/groupStore';
+import {RELATED_ISSUES_BOOLEAN_QUERY_ERROR} from 'sentry/views/alerts/rules/metric/details/relatedIssuesNotAvailable';
+
+import GroupList from './groupList';
+
+describe('GroupList', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const group = GroupFixture();
+  const membersUrl = `/organizations/${organization.slug}/users/`;
+  const issuesUrl = `/organizations/${organization.slug}/issues/`;
+  const defaultQueryParams = {query: '', sort: 'new', limit: '50'};
+  const issuesUrlWithDefaultQuery = `${issuesUrl}?${qs.stringify(defaultQueryParams)}`;
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/issues/`,
+      query: defaultQueryParams,
+    },
+    route: '/organizations/:orgId/issues/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    GroupStore.reset();
+
+    MockApiClient.addMockResponse({url: membersUrl, body: [MemberFixture()]});
+    MockApiClient.addMockResponse({
+      url: issuesUrlWithDefaultQuery,
+      method: 'GET',
+      body: [group],
+    });
+  });
+
+  afterEach(() => {
+    GroupStore.reset();
+  });
+
+  it('renders the group list', async () => {
+    render(<GroupList numPlaceholderRows={1} queryParams={defaultQueryParams} />, {
+      organization,
+      initialRouterConfig,
+    });
+
+    expect(await screen.findByText('RequestError')).toBeInTheDocument();
+    expect(screen.getByText(group.shortId)).toBeInTheDocument();
+    expect(screen.getByText(group.culprit)).toBeInTheDocument();
+    // Event count
+    expect(screen.getByText('327k')).toBeInTheDocument();
+    // Users
+    expect(screen.getByText('35k')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no groups are returned', async () => {
+    MockApiClient.addMockResponse({url: membersUrl, body: []});
+    MockApiClient.addMockResponse({
+      url: issuesUrlWithDefaultQuery,
+      method: 'GET',
+      body: [],
+    });
+
+    render(<GroupList numPlaceholderRows={1} queryParams={defaultQueryParams} />, {
+      organization,
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByText("There don't seem to be any events fitting the query.")
+    ).toBeInTheDocument();
+  });
+
+  it('renders custom error when query has boolean logic', async () => {
+    const renderErrorMessage = jest.fn(() => <div>custom error</div>);
+    const issuesRequest = MockApiClient.addMockResponse({
+      url: `${issuesUrl}?${qs.stringify({...defaultQueryParams, query: 'issue.id:1'})}`,
+      method: 'GET',
+      body: [],
+    });
+
+    render(
+      <GroupList
+        numPlaceholderRows={1}
+        queryParams={{...defaultQueryParams, query: 'foo OR bar'}}
+        renderErrorMessage={renderErrorMessage}
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {...defaultQueryParams, query: 'foo OR bar'},
+          },
+        },
+      }
+    );
+
+    expect(await screen.findByText('custom error')).toBeInTheDocument();
+    expect(renderErrorMessage).toHaveBeenCalledWith(
+      {detail: RELATED_ISSUES_BOOLEAN_QUERY_ERROR},
+      expect.any(Function)
+    );
+    expect(issuesRequest).not.toHaveBeenCalled();
+  });
+
+  it('invokes onFetchSuccess with correct arguments', async () => {
+    const onFetchSuccess = jest.fn();
+    MockApiClient.addMockResponse({url: membersUrl, body: []});
+    const linkHeader = '<https://sentry.io/?cursor=next>; rel="next"';
+    MockApiClient.addMockResponse({
+      url: issuesUrlWithDefaultQuery,
+      method: 'GET',
+      body: [group],
+      headers: {Link: linkHeader},
+    });
+
+    render(
+      <GroupList
+        numPlaceholderRows={1}
+        queryParams={defaultQueryParams}
+        onFetchSuccess={onFetchSuccess}
+      />,
+      {
+        organization,
+        initialRouterConfig,
+      }
+    );
+
+    expect(await screen.findByText('RequestError')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(onFetchSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: false,
+          errorData: null,
+          groups: [group],
+          loading: false,
+          pageLinks: linkHeader,
+          memberList: undefined,
+        }),
+        expect.any(Function)
+      )
+    );
+  });
+
+  it('renders pagination and navigates on next click', async () => {
+    const pageLinks =
+      '<https://sentry.io/?cursor=prev:0:0>; rel="previous"; results="false"; cursor="prev:0:0", ' +
+      '<https://sentry.io/?cursor=next:0:0>; rel="next"; results="true"; cursor="next:0:0"';
+
+    MockApiClient.addMockResponse({url: membersUrl, body: []});
+    MockApiClient.addMockResponse({
+      url: issuesUrlWithDefaultQuery,
+      method: 'GET',
+      body: [GroupFixture()],
+      headers: {Link: pageLinks},
+    });
+
+    const {router} = render(
+      <GroupList numPlaceholderRows={1} queryParams={defaultQueryParams} />,
+      {
+        organization,
+        initialRouterConfig,
+      }
+    );
+
+    expect(await screen.findByTestId('pagination')).toBeInTheDocument();
+    const prev = screen.getByRole('button', {name: 'Previous'});
+    const next = screen.getByRole('button', {name: 'Next'});
+    expect(prev).toBeDisabled();
+    expect(next).toBeEnabled();
+
+    await userEvent.click(next);
+
+    await waitFor(() => {
+      expect(router.location.query.cursor).toBe('next:0:0');
+    });
+
+    expect(router.location.query.page).toBe('1');
+  });
+});

--- a/static/app/components/issues/groupList.spec.tsx
+++ b/static/app/components/issues/groupList.spec.tsx
@@ -11,7 +11,7 @@ import {RELATED_ISSUES_BOOLEAN_QUERY_ERROR} from 'sentry/views/alerts/rules/metr
 import GroupList from './groupList';
 
 describe('GroupList', () => {
-  const organization = OrganizationFixture({slug: 'org-slug'});
+  const organization = OrganizationFixture();
   const group = GroupFixture();
   const membersUrl = `/organizations/${organization.slug}/users/`;
   const issuesUrl = `/organizations/${organization.slug}/issues/`;

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -1,11 +1,10 @@
-import {Component, Fragment} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import * as qs from 'query-string';
 
 import {fetchOrgMembers, indexMembersByProject} from 'sentry/actionCreators/members';
-import type {Client} from 'sentry/api';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import LoadingError from 'sentry/components/loadingError';
 import Pagination from 'sentry/components/pagination';
@@ -21,24 +20,14 @@ import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
-import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
-import withApi from 'sentry/utils/withApi';
-import withOrganization from 'sentry/utils/withOrganization';
-// eslint-disable-next-line no-restricted-imports
-import withSentryRouter from 'sentry/utils/withSentryRouter';
+import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
 import {RELATED_ISSUES_BOOLEAN_QUERY_ERROR} from 'sentry/views/alerts/rules/metric/details/relatedIssuesNotAvailable';
 
 import GroupListHeader from './groupListHeader';
-
-const defaultProps = {
-  canSelectGroups: true,
-  withChart: true,
-  withPagination: true,
-  useFilteredStats: true,
-  useTintRow: true,
-};
 
 export type GroupListColumn =
   | 'graph'
@@ -50,14 +39,13 @@ export type GroupListColumn =
   | 'firstSeen'
   | 'lastSeen';
 
-type Props = WithRouterProps & {
-  api: Client;
+type Props = {
   /**
    * Number of placeholder rows to show during loading
    */
   numPlaceholderRows: number;
-  organization: Organization;
   queryParams: Record<string, number | string | string[] | undefined | null>;
+  canSelectGroups?: boolean;
   customStatsPeriod?: TimePeriodType;
   /**
    * Defaults to `/organizations/${orgSlug}/issues/`
@@ -81,8 +69,12 @@ type Props = WithRouterProps & {
   renderErrorMessage?: (props: {detail: string}, retry: () => void) => React.ReactNode;
   // where the group list is rendered
   source?: string;
+  useFilteredStats?: boolean;
+  useTintRow?: boolean;
+  withChart?: boolean;
   withColumns?: GroupListColumn[];
-} & Partial<typeof defaultProps>;
+  withPagination?: boolean;
+};
 
 type State = {
   error: boolean;
@@ -93,69 +85,120 @@ type State = {
   memberList?: ReturnType<typeof indexMembersByProject>;
 };
 
-class GroupList extends Component<Props, State> {
-  static defaultProps = defaultProps;
+const DEFAULT_COLUMNS: GroupListColumn[] = ['graph', 'event', 'users', 'assignee'];
 
-  state: State = {
-    loading: true,
-    error: false,
-    errorData: null,
-    groups: [],
-    pageLinks: null,
-  };
+function GroupList({
+  queryParams,
+  endpointPath,
+  onFetchSuccess,
+  renderEmptyMessage,
+  renderErrorMessage,
+  customStatsPeriod,
+  queryFilterDescription,
+  source,
+  query,
+  numPlaceholderRows,
+  withColumns = DEFAULT_COLUMNS,
+  withChart = true,
+  withPagination = true,
+  canSelectGroups = true,
+  useFilteredStats = true,
+  useTintRow = true,
+}: Props) {
+  const api = useApi();
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
 
-  componentDidMount() {
-    this.fetchData();
-  }
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [errorData, setErrorData] = useState<{detail: string} | null>(null);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [pageLinks, setPageLinks] = useState<string | null>(null);
+  const [memberList, setMemberList] = useState<
+    ReturnType<typeof indexMembersByProject> | undefined
+  >(undefined);
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
-    return (
-      !isEqual(this.state, nextState) ||
-      nextProps.endpointPath !== this.props.endpointPath ||
-      nextProps.query !== this.props.query ||
-      !isEqual(nextProps.queryParams, this.props.queryParams)
+  const previousPropsRef = useRef<
+    | {
+        orgSlug: string;
+        endpointPath?: string;
+        query?: string;
+        queryParams?: Record<string, number | string | string[] | undefined | null>;
+      }
+    | undefined
+  >(undefined);
+
+  const getQueryParams = useCallback(() => {
+    const queryParamsFromLocation = {...location.query};
+    queryParamsFromLocation.limit = '50';
+    queryParamsFromLocation.sort = 'new';
+    queryParamsFromLocation.query = query;
+
+    return queryParamsFromLocation;
+  }, [location.query, query]);
+
+  const computedQueryParams = useMemo(
+    () => queryParams ?? getQueryParams(),
+    [getQueryParams, queryParams]
+  );
+
+  const getGroupListEndpoint = useCallback(() => {
+    // TODO: Split up the query parameters and the URL. This will make it much easier to mock the endpoint.
+    const path = endpointPath ?? `/organizations/${organization.slug}/issues/`;
+
+    return `${path}?${qs.stringify(computedQueryParams)}`;
+  }, [computedQueryParams, endpointPath, organization.slug]);
+
+  const handleCursorChange = useCallback(
+    (
+      cursor: string | undefined,
+      path: string,
+      queryParam: Record<string, any>,
+      pageDiff: number
+    ) => {
+      const queryPageInt = parseInt(queryParam.page, 10);
+      let nextPage: number | undefined = isNaN(queryPageInt)
+        ? pageDiff
+        : queryPageInt + pageDiff;
+
+      // unset cursor and page when we navigate back to the first page
+      // also reset cursor if somehow the previous button is enabled on
+      // first page and user attempts to go backwards
+      if (nextPage <= 0) {
+        cursor = undefined;
+        nextPage = undefined;
+      }
+
+      navigate({
+        pathname: path,
+        query: {...queryParam, cursor, page: nextPage},
+      });
+    },
+    [navigate]
+  );
+
+  const onGroupChange = useCallback(() => {
+    const storeGroups = GroupStore.getAllItems() as Group[];
+    setGroups(prevGroups =>
+      isEqual(storeGroups, prevGroups) ? prevGroups : storeGroups
     );
-  }
+  }, []);
 
-  componentDidUpdate(prevProps: Props) {
-    const ignoredQueryParams = ['end'];
-
-    if (
-      prevProps.organization.slug !== this.props.organization.slug ||
-      prevProps.endpointPath !== this.props.endpointPath ||
-      prevProps.query !== this.props.query ||
-      !isEqual(
-        omit(prevProps.queryParams, ignoredQueryParams),
-        omit(this.props.queryParams, ignoredQueryParams)
-      )
-    ) {
-      this.fetchData();
-    }
-  }
-
-  componentWillUnmount() {
-    GroupStore.reset();
-    this.listener?.();
-  }
-
-  listener = GroupStore.listen(() => this.onGroupChange(), undefined);
-
-  fetchData = async () => {
+  const fetchData = useCallback(async () => {
     GroupStore.loadInitialData([]);
-    const {api, organization, queryParams} = this.props;
     api.clear();
 
-    this.setState({loading: true, error: false, errorData: null});
+    setLoading(true);
+    setError(false);
+    setErrorData(null);
 
     fetchOrgMembers(api, organization.slug).then(members => {
-      this.setState({memberList: indexMembersByProject(members)});
+      setMemberList(indexMembersByProject(members));
     });
 
-    const endpoint = this.getGroupListEndpoint();
-
-    const parsedQuery = parseSearch(
-      (queryParams ?? this.getQueryParams()).query as string
-    );
+    const endpoint = getGroupListEndpoint();
+    const parsedQuery = parseSearch(String(computedQueryParams.query ?? ''));
     const hasLogicBoolean = parsedQuery
       ? treeResultLocator<boolean>({
           tree: parsedQuery,
@@ -169,11 +212,9 @@ class GroupList extends Component<Props, State> {
     // Check if the alert rule query has AND or OR
     // logic queries haven't been implemented for issue search yet
     if (hasLogicBoolean) {
-      this.setState({
-        error: true,
-        errorData: {detail: RELATED_ISSUES_BOOLEAN_QUERY_ERROR},
-        loading: false,
-      });
+      setError(true);
+      setErrorData({detail: RELATED_ISSUES_BOOLEAN_QUERY_ERROR});
+      setLoading(false);
       return;
     }
 
@@ -183,173 +224,156 @@ class GroupList extends Component<Props, State> {
       });
 
       GroupStore.add(data);
+      const nextGroups = GroupStore.getAllItems() as Group[];
+      const nextPageLinks = jqXHR?.getResponseHeader('Link') ?? null;
 
-      this.setState(
+      setGroups(prevGroups =>
+        isEqual(prevGroups, nextGroups) ? prevGroups : nextGroups
+      );
+      setError(false);
+      setErrorData(null);
+      setLoading(false);
+      setPageLinks(nextPageLinks);
+
+      onFetchSuccess?.(
         {
           error: false,
           errorData: null,
+          groups: nextGroups,
           loading: false,
-          pageLinks: jqXHR?.getResponseHeader('Link') ?? null,
+          pageLinks: nextPageLinks,
+          memberList,
         },
-        () => {
-          this.props.onFetchSuccess?.(this.state, this.handleCursorChange);
-        }
+        handleCursorChange
       );
-    } catch (error: any) {
-      this.setState({error: true, errorData: error.responseJSON, loading: false});
+    } catch (fetchError: any) {
+      setError(true);
+      setErrorData(fetchError.responseJSON);
+      setLoading(false);
     }
-  };
+  }, [
+    api,
+    computedQueryParams.query,
+    getGroupListEndpoint,
+    handleCursorChange,
+    memberList,
+    onFetchSuccess,
+    organization.slug,
+  ]);
 
-  getGroupListEndpoint() {
-    // TODO: Split up the query parameters and the URL. This will make it much easier to mock the endpoint.
-    const {organization, endpointPath, queryParams} = this.props;
-    const path = endpointPath ?? `/organizations/${organization.slug}/issues/`;
-    const queryParameters = queryParams ?? this.getQueryParams();
-
-    return `${path}?${qs.stringify(queryParameters)}`;
-  }
-
-  getQueryParams() {
-    const {location, query} = this.props;
-
-    const queryParams = location.query;
-    queryParams.limit = 50;
-    queryParams.sort = 'new';
-    queryParams.query = query;
-
-    return queryParams;
-  }
-
-  handleCursorChange = (
-    cursor: string | undefined,
-    path: string,
-    query: Record<string, any>,
-    pageDiff: number
-  ) => {
-    const queryPageInt = parseInt(query.page, 10);
-    let nextPage: number | undefined = isNaN(queryPageInt)
-      ? pageDiff
-      : queryPageInt + pageDiff;
-
-    // unset cursor and page when we navigate back to the first page
-    // also reset cursor if somehow the previous button is enabled on
-    // first page and user attempts to go backwards
-    if (nextPage <= 0) {
-      cursor = undefined;
-      nextPage = undefined;
-    }
-
-    this.props.router.push({
-      pathname: path,
-      query: {...query, cursor, page: nextPage},
-    });
-  };
-
-  onGroupChange() {
-    const groups = GroupStore.getAllItems() as Group[];
-    if (!isEqual(groups, this.state.groups)) {
-      this.setState({groups});
-    }
-  }
-
-  render() {
-    const {
-      canSelectGroups,
-      withChart,
-      withColumns = ['graph', 'event', 'users', 'assignee'],
-      renderEmptyMessage,
-      renderErrorMessage,
-      withPagination,
-      useFilteredStats,
-      useTintRow,
-      customStatsPeriod,
-      queryParams,
-      queryFilterDescription,
-      source,
-      query,
-      numPlaceholderRows,
-    } = this.props;
-    const {loading, error, errorData, groups, memberList, pageLinks} = this.state;
-
-    const columns: GroupListColumn[] = [
-      ...withColumns,
-      'firstSeen' as const,
-      'lastSeen' as const,
-    ];
-
-    if (error) {
-      if (typeof renderErrorMessage === 'function' && errorData) {
-        return renderErrorMessage(errorData, this.fetchData);
-      }
-
-      return <LoadingError onRetry={this.fetchData} />;
-    }
-
-    if (!loading && groups.length === 0) {
-      if (typeof renderEmptyMessage === 'function') {
-        return renderEmptyMessage();
-      }
-      return (
-        <Panel>
-          <PanelBody>
-            <EmptyStateWarning>
-              <p>{t("There don't seem to be any events fitting the query.")}</p>
-            </EmptyStateWarning>
-          </PanelBody>
-        </Panel>
+  useEffect(() => {
+    const ignoredQueryParams = ['end'];
+    const prev = previousPropsRef.current;
+    const queryChanged =
+      !prev ||
+      !isEqual(
+        omit(prev.queryParams ?? {}, ignoredQueryParams),
+        omit(computedQueryParams ?? {}, ignoredQueryParams)
       );
+    const shouldFetch =
+      !prev ||
+      prev.orgSlug !== organization.slug ||
+      prev.endpointPath !== endpointPath ||
+      prev.query !== query ||
+      queryChanged;
+
+    if (shouldFetch) {
+      fetchData();
+      previousPropsRef.current = {
+        orgSlug: organization.slug,
+        endpointPath,
+        query,
+        queryParams: computedQueryParams,
+      };
+    }
+  }, [computedQueryParams, endpointPath, fetchData, organization.slug, query]);
+
+  useEffect(() => {
+    const unsubscribe = GroupStore.listen(onGroupChange, undefined);
+
+    return () => {
+      unsubscribe();
+      GroupStore.reset();
+    };
+  }, [onGroupChange]);
+
+  const columns: GroupListColumn[] = useMemo(
+    () => [...withColumns, 'firstSeen', 'lastSeen'],
+    [withColumns]
+  );
+
+  if (error) {
+    if (typeof renderErrorMessage === 'function' && errorData) {
+      return renderErrorMessage(errorData, fetchData);
     }
 
-    const statsPeriod =
-      queryParams?.groupStatsPeriod === 'auto'
-        ? queryParams?.groupStatsPeriod
-        : DEFAULT_STREAM_GROUP_STATS_PERIOD;
+    return <LoadingError onRetry={fetchData} />;
+  }
 
+  if (!loading && groups.length === 0) {
+    if (typeof renderEmptyMessage === 'function') {
+      return renderEmptyMessage();
+    }
     return (
-      <Fragment>
-        <PanelContainer>
-          <GroupListHeader withChart={!!withChart} withColumns={columns} />
-          <PanelBody>
-            {loading
-              ? [...new Array(numPlaceholderRows)].map((_, i) => (
-                  <GroupPlaceholder key={i}>
-                    <Placeholder height="50px" />
-                  </GroupPlaceholder>
-                ))
-              : groups.map(({id, project}) => {
-                  const members = memberList?.hasOwnProperty(project.slug)
-                    ? memberList[project.slug]
-                    : undefined;
-
-                  return (
-                    <StreamGroup
-                      key={id}
-                      id={id}
-                      canSelect={canSelectGroups}
-                      withChart={withChart}
-                      withColumns={columns}
-                      memberList={members}
-                      useFilteredStats={useFilteredStats}
-                      useTintRow={useTintRow}
-                      customStatsPeriod={customStatsPeriod}
-                      statsPeriod={statsPeriod}
-                      queryFilterDescription={queryFilterDescription}
-                      source={source}
-                      query={query}
-                    />
-                  );
-                })}
-          </PanelBody>
-        </PanelContainer>
-        {withPagination && (
-          <Pagination pageLinks={pageLinks} onCursor={this.handleCursorChange} />
-        )}
-      </Fragment>
+      <Panel>
+        <PanelBody>
+          <EmptyStateWarning>
+            <p>{t("There don't seem to be any events fitting the query.")}</p>
+          </EmptyStateWarning>
+        </PanelBody>
+      </Panel>
     );
   }
+
+  const statsPeriod =
+    computedQueryParams?.groupStatsPeriod === 'auto'
+      ? computedQueryParams?.groupStatsPeriod
+      : DEFAULT_STREAM_GROUP_STATS_PERIOD;
+
+  return (
+    <Fragment>
+      <PanelContainer>
+        <GroupListHeader withChart={!!withChart} withColumns={columns} />
+        <PanelBody>
+          {loading
+            ? [...new Array(numPlaceholderRows)].map((_, i) => (
+                <GroupPlaceholder key={i}>
+                  <Placeholder height="50px" />
+                </GroupPlaceholder>
+              ))
+            : groups.map(({id, project}) => {
+                const members = memberList?.hasOwnProperty(project.slug)
+                  ? memberList[project.slug]
+                  : undefined;
+
+                return (
+                  <StreamGroup
+                    key={id}
+                    id={id}
+                    canSelect={canSelectGroups}
+                    withChart={withChart}
+                    withColumns={columns}
+                    memberList={members}
+                    useFilteredStats={useFilteredStats}
+                    useTintRow={useTintRow}
+                    customStatsPeriod={customStatsPeriod}
+                    statsPeriod={statsPeriod}
+                    queryFilterDescription={queryFilterDescription}
+                    source={source}
+                    query={query}
+                  />
+                );
+              })}
+        </PanelBody>
+      </PanelContainer>
+      {withPagination && (
+        <Pagination pageLinks={pageLinks} onCursor={handleCursorChange} />
+      )}
+    </Fragment>
+  );
 }
 
-export default withOrganization(withApi(withSentryRouter(GroupList)));
+export default GroupList;
 
 const GroupPlaceholder = styled('div')`
   padding: ${space(1)};


### PR DESCRIPTION
GroupList is used in a few different places around the app (such as project details, release details, and others) to display a list of matching issues. I would like to start using React Query here instead of GroupStore, so the first step is to convert it to an FC

<img width="835" height="526" alt="CleanShot 2025-12-15 at 09 43 27" src="https://github.com/user-attachments/assets/1b7bf5cf-10bc-4f45-84e7-c3a89ad518bf" />
