### PR TITLE
feat(explore-attr-breakdowns): Adding attr breakdowns as a separate result_mode

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -44,7 +44,7 @@ export type TracingEventParameters = {
     query_status: 'success' | 'error' | 'pending';
     result_length: number;
     result_missing_root: number;
-    result_mode: 'trace samples' | 'span samples' | 'aggregates';
+    result_mode: 'trace samples' | 'span samples' | 'aggregates' | 'attribute breakdowns';
     sample_counts: number[];
     title: string;
     user_queries: string;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -205,8 +205,14 @@ function SpanTabContentSection({
     'traces-page-cross-event-querying'
   );
 
-  const queryType: 'aggregate' | 'samples' | 'traces' =
-    tab === Mode.AGGREGATE ? 'aggregate' : tab === Tab.TRACE ? 'traces' : 'samples';
+  const queryType =
+    tab === Mode.AGGREGATE
+      ? 'aggregate'
+      : tab === Tab.TRACE
+        ? 'traces'
+        : tab === Tab.ATTRIBUTE_BREAKDOWNS
+          ? 'attribute_breakdowns'
+          : 'samples';
 
   const limit = 50;
 
@@ -265,7 +271,6 @@ function SpanTabContentSection({
   const [interval] = useChartInterval();
 
   useAnalytics({
-    tab,
     queryType,
     aggregatesTableResult,
     spansTableResult,

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -1,6 +1,8 @@
 import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 
+import {Badge} from '@sentry/scraps/badge/badge';
+
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
@@ -98,6 +100,7 @@ export function ExploreTables(props: ExploreTablesProps) {
             {attributeBreakdownsEnabled ? (
               <TabList.Item key={Tab.ATTRIBUTE_BREAKDOWNS}>
                 {t('Attribute Breakdowns')}
+                <Badge type="beta">Beta</Badge>
               </TabList.Item>
             ) : null}
           </TabList>

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -91,7 +91,7 @@ export function ExploreTables(props: ExploreTablesProps) {
 
   return (
     <Fragment>
-      <SamplesTableHeader>
+      <SamplesTableHeader data-explore-chart-selection-region>
         <Tabs value={props.tab} onChange={props.setTab} size="sm">
           <TabList hideBorder variant="floating">
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -92,21 +92,19 @@ export function ExploreTables(props: ExploreTablesProps) {
   return (
     <Fragment>
       <SamplesTableHeader>
-        <ChartSelectionRegion data-explore-chart-selection-region>
-          <Tabs value={props.tab} onChange={props.setTab} size="sm">
-            <TabList hideBorder variant="floating">
-              <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
-              <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
-              <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
-              {attributeBreakdownsEnabled ? (
-                <TabList.Item key={Tab.ATTRIBUTE_BREAKDOWNS}>
-                  {t('Attribute Breakdowns')}
-                  <Badge type="beta">Beta</Badge>
-                </TabList.Item>
-              ) : null}
-            </TabList>
-          </Tabs>
-        </ChartSelectionRegion>
+        <Tabs value={props.tab} onChange={props.setTab} size="sm">
+          <TabList hideBorder variant="floating">
+            <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
+            <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
+            <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
+            {attributeBreakdownsEnabled ? (
+              <TabList.Item key={Tab.ATTRIBUTE_BREAKDOWNS}>
+                {t('Attribute Breakdowns')}
+                <Badge type="beta">Beta</Badge>
+              </TabList.Item>
+            ) : null}
+          </TabList>
+        </Tabs>
         {props.tab === Tab.SPAN ? (
           <Button onClick={openColumnEditor} icon={<IconTable />} size="sm">
             {t('Edit Table')}
@@ -142,8 +140,4 @@ const SamplesTableHeader = styled('div')`
   flex-direction: row;
   justify-content: space-between;
   margin-bottom: ${space(1)};
-`;
-
-const ChartSelectionRegion = styled('div')`
-  width: 100%;
 `;

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -91,20 +91,22 @@ export function ExploreTables(props: ExploreTablesProps) {
 
   return (
     <Fragment>
-      <SamplesTableHeader data-explore-chart-selection-region>
-        <Tabs value={props.tab} onChange={props.setTab} size="sm">
-          <TabList hideBorder variant="floating">
-            <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
-            <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
-            <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
-            {attributeBreakdownsEnabled ? (
-              <TabList.Item key={Tab.ATTRIBUTE_BREAKDOWNS}>
-                {t('Attribute Breakdowns')}
-                <Badge type="beta">Beta</Badge>
-              </TabList.Item>
-            ) : null}
-          </TabList>
-        </Tabs>
+      <SamplesTableHeader>
+        <ChartSelectionRegion data-explore-chart-selection-region>
+          <Tabs value={props.tab} onChange={props.setTab} size="sm">
+            <TabList hideBorder variant="floating">
+              <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
+              <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
+              <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
+              {attributeBreakdownsEnabled ? (
+                <TabList.Item key={Tab.ATTRIBUTE_BREAKDOWNS}>
+                  {t('Attribute Breakdowns')}
+                  <Badge type="beta">Beta</Badge>
+                </TabList.Item>
+              ) : null}
+            </TabList>
+          </Tabs>
+        </ChartSelectionRegion>
         {props.tab === Tab.SPAN ? (
           <Button onClick={openColumnEditor} icon={<IconTable />} size="sm">
             {t('Edit Table')}
@@ -140,4 +142,8 @@ const SamplesTableHeader = styled('div')`
   flex-direction: row;
   justify-content: space-between;
   margin-bottom: ${space(1)};
+`;
+
+const ChartSelectionRegion = styled('div')`
+  width: 100%;
 `;


### PR DESCRIPTION
Prep for GA:
- Added a beta badge to the tab
- Added attribute_breakdowns as a separate result_mode in the explore query analytics
<img width="653" height="204" alt="Screenshot 2025-12-15 at 1 24 35 PM" src="https://github.com/user-attachments/assets/ca7ad85b-80db-457f-9b71-a850a2dbfb74" />
