### PR TITLE
fix(trace-waterfall): Truncate subtitle text

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -90,9 +90,9 @@ function ContextBadges({rootEventResults}: Pick<TitleProps, 'rootEventResults'>)
     ? findSpanAttributeValue(rootEventResults.data.attributes, FieldKey.REPLAY_ID)
     : rootEventResults.data.contexts.replay?.[ReplayContextKey.REPLAY_ID];
 
-  if (!replayId) {
-    return null;
-  }
+  // if (!replayId) {
+  //   return null;
+  // }
 
   return (
     <Fragment>
@@ -126,15 +126,17 @@ export function Title({representativeEvent, rootEventResults}: TitleProps) {
 
   if (traceTitle) {
     return (
-      <Stack align="start" gap="md" width="80%">
+      <Stack align="start" width="75%">
         <Text size="xl" bold ellipsis>
           {traceTitle.title}
         </Text>
         {traceTitle.subtitle && (
-          <Text size="md" ellipsis variant="muted">
-            {traceTitle.subtitle}
+          <Flex align="center" gap="sm" width="100%">
+            <Text size="md" ellipsis variant="muted">
+              {traceTitle.subtitle}
+            </Text>
             <ContextBadges rootEventResults={rootEventResults} />
-          </Text>
+          </Flex>
         )}
       </Stack>
     );

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -90,9 +90,9 @@ function ContextBadges({rootEventResults}: Pick<TitleProps, 'rootEventResults'>)
     ? findSpanAttributeValue(rootEventResults.data.attributes, FieldKey.REPLAY_ID)
     : rootEventResults.data.contexts.replay?.[ReplayContextKey.REPLAY_ID];
 
-  // if (!replayId) {
-  //   return null;
-  // }
+  if (!replayId) {
+    return null;
+  }
 
   return (
     <Fragment>

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -1,10 +1,12 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {ReplayContextKey} from 'sentry/types/event';
 import {FieldKey} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -122,41 +124,25 @@ const ReplayButton = styled(LinkButton)`
 export function Title({representativeEvent, rootEventResults}: TitleProps) {
   const traceTitle = getTitle(representativeEvent);
 
+  if (traceTitle) {
+    return (
+      <Stack align="start" gap="md" width="80%">
+        <Text size="xl" bold>
+          {traceTitle.title}
+        </Text>
+        {traceTitle.subtitle && (
+          <Text size="md" ellipsis variant="muted">
+            {traceTitle.subtitle}
+            <ContextBadges rootEventResults={rootEventResults} />
+          </Text>
+        )}
+      </Stack>
+    );
+  }
+
   return (
-    <div>
-      {traceTitle ? (
-        <TitleWrapper>
-          <TitleText>{traceTitle.title}</TitleText>
-          {traceTitle.subtitle && (
-            <SubtitleText>
-              {traceTitle.subtitle}
-              <ContextBadges rootEventResults={rootEventResults} />
-            </SubtitleText>
-          )}
-        </TitleWrapper>
-      ) : (
-        <TitleText>{t('Trace')}</TitleText>
-      )}
-    </div>
+    <Text bold size="xl">
+      {t('Trace')}
+    </Text>
   );
 }
-
-const TitleWrapper = styled('div')`
-  display: flex;
-  align-items: flex-start;
-  flex-direction: column;
-`;
-
-const TitleText = styled('div')`
-  font-weight: ${p => p.theme.fontWeight.bold};
-  font-size: ${p => p.theme.fontSize.xl};
-  ${p => p.theme.overflowEllipsis};
-`;
-
-const SubtitleText = styled('div')`
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.subText};
-  display: flex;
-  align-items: center;
-  gap: ${space(1)};
-`;

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -127,7 +127,7 @@ export function Title({representativeEvent, rootEventResults}: TitleProps) {
   if (traceTitle) {
     return (
       <Stack align="start" gap="md" width="80%">
-        <Text size="xl" bold>
+        <Text size="xl" bold ellipsis>
           {traceTitle.title}
         </Text>
         {traceTitle.subtitle && (


### PR DESCRIPTION
This PR fixes a truncation issue with the subtitle for the trace waterfall title

Resolves: JAVASCRIPT-35N4

Example:

<img width="1630" height="64" alt="Screenshot 2025-12-15 at 14 27 29" src="https://github.com/user-attachments/assets/20901e52-ceff-4255-9e8a-3ba198e2fdb1" />

---

<img width="1218" height="44" alt="Screenshot 2025-12-15 at 14 50 00" src="https://github.com/user-attachments/assets/99f35c7a-361d-4228-895a-8c22b7d629b8" />