### PR TITLE
chore(preprod): fix alignment + color on build details cards

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -197,7 +197,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
           }
         >
           <Stack gap="xs">
-            <Flex align="end" gap="sm" wrap="wrap">
+            <Flex align="center" gap="sm" wrap="wrap">
               <Heading as="h3">
                 {card.watchBreakdown ? (
                   <Tooltip
@@ -225,8 +225,8 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                   return (
                     <LinkButton
                       to={card.comparisonUrl}
-                      size="xs"
-                      priority="link"
+                      size="zero"
+                      priority="transparent"
                       aria-label={t('Compare builds')}
                     >
                       <Flex align="center" gap="xs">

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -226,11 +226,11 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                     <LinkButton
                       to={card.comparisonUrl}
                       size="zero"
-                      priority="transparent"
+                      priority="link"
                       aria-label={t('Compare builds')}
                     >
                       <Flex align="center" gap="xs">
-                        {icon}
+                        <IconWrapper>{icon}</IconWrapper>
                         <Text
                           as="span"
                           variant={variant}
@@ -353,4 +353,10 @@ const MetricValue = styled('span')<{$interactive?: boolean}>`
     cursor: help;
   `
       : ''}
+`;
+
+const IconWrapper = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  color: ${p => p.theme.tokens.content.primary};
 `;

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -1,4 +1,5 @@
 import type {ReactNode} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button/linkButton';
@@ -81,6 +82,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
   } = props;
 
   const organization = useOrganization();
+  const theme = useTheme();
 
   if (!isSizeInfoCompleted(sizeInfo)) {
     return null;
@@ -230,7 +232,14 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                       aria-label={t('Compare builds')}
                     >
                       <Flex align="center" gap="xs">
-                        <IconWrapper>{icon}</IconWrapper>
+                        <Flex
+                          as="span"
+                          display="inline-flex"
+                          align="center"
+                          style={{color: theme.tokens.content.primary}}
+                        >
+                          {icon}
+                        </Flex>
                         <Text
                           as="span"
                           variant={variant}
@@ -353,10 +362,4 @@ const MetricValue = styled('span')<{$interactive?: boolean}>`
     cursor: help;
   `
       : ''}
-`;
-
-const IconWrapper = styled('span')`
-  display: inline-flex;
-  align-items: center;
-  color: ${p => p.theme.tokens.content.primary};
 `;


### PR DESCRIPTION
Fix
<img width="1336" height="252" alt="CleanShot 2025-12-15 at 12 17 11@2x" src="https://github.com/user-attachments/assets/6fbaa6d9-464f-49ab-a6c2-b4da6b06bc82" />


current on prod
(see diff padding)
<img width="1370" height="278" alt="CleanShot 2025-12-15 at 12 17 27@2x" src="https://github.com/user-attachments/assets/8d88890c-f110-41cc-b3a3-f46a31c00761" />
