### PR TITLE
fix(scraps): do not spread all styles from theme.font onto button

### DIFF
--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -83,7 +83,10 @@ export function DO_NOT_USE_getChonkButtonStyles(
 
     background: 'none',
 
-    ...buttonSizes[p.size],
+    height: buttonSizes[p.size].height,
+    minHeight: buttonSizes[p.size].minHeight,
+    fontSize: buttonSizes[p.size].fontSize,
+    lineHeight: buttonSizes[p.size].lineHeight,
 
     '&::before': {
       content: '""',


### PR DESCRIPTION
we've recently widened `theme.form` to contain more information for better grouping, but spreading has a negative impact of adding things we don't want. In this case, buttons got a padding they shouldn't have. The fix is to just apply the props we want explicitly, even if that is a bit more code.