### PR TITLE
fix(security): IDOR in OrganizationCodeMappingsEndpoint - scope Project by organization

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -215,7 +215,9 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
             return self.respond("Missing param: integrationId", status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            project = Project.objects.get(id=request.data["projectId"])
+            project = Project.objects.get(
+                id=request.data["projectId"], organization_id=organization.id
+            )
         except ValueError as exc:
             if "invalid literal for int() with base 10" in str(exc):
                 return self.respond(


### PR DESCRIPTION
## Summary
Fixes IDOR vulnerability in `OrganizationCodeMappingsEndpoint.post()` where `Project` was queried without organization scoping, allowing users to potentially access/probe projects from other organizations by guessing project IDs.

## Changes
- Added `organization_id=organization.id` to `Project.objects.get()` query in the POST handler
- Updated test to verify cross-org project access returns 404 (not 403) to prevent ID enumeration

## Security Impact
Before this fix, an attacker could:
1. Probe for valid project IDs from any organization
2. Receive different responses (403 vs 404) that leaked information about valid project IDs

## Test plan
- [x] Regression test `test_idor_project_from_different_org` added to verify cross-org access is blocked
- [ ] Existing tests pass (CI will verify)