### PR TITLE
fix(security): IDOR in OrganizationEventsStatsEndpoint - scope DashboardWidget by organization

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -366,7 +366,9 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                     )
 
                 try:
-                    widget = DashboardWidget.objects.get(id=dashboard_widget_id)
+                    widget = DashboardWidget.objects.get(
+                        id=dashboard_widget_id, dashboard__organization_id=organization.id
+                    )
                     does_widget_have_split = widget.discover_widget_split is not None
 
                     if does_widget_have_split:

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1272,28 +1272,6 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         assert response.status_code == 200
         assert all([interval[1][0]["count"] == 0 for interval in response.data["data"]])
 
-    def test_idor_dashboard_widget_from_different_org(self) -> None:
-        """Regression test: Cannot access dashboard widgets from other organizations (IDOR)."""
-        other_org = self.create_organization()
-        other_dashboard = self.create_dashboard(organization=other_org)
-        other_widget = self.create_dashboard_widget(dashboard=other_dashboard)
-
-        # Request with cross-org widget ID should not use that widget's configuration
-        response = self.do_request(
-            {
-                "start": self.day_ago,
-                "end": self.day_ago + timedelta(hours=2),
-                "interval": "1h",
-                "dashboardWidgetId": other_widget.id,
-            },
-        )
-        # Should still return 200 (falls back to default behavior)
-        assert response.status_code == 200
-        # Should NOT have discoverSplitDecision from the cross-org widget
-        meta = response.data.get("meta", {})
-        assert "discoverSplitDecision" not in meta
-
-
 class OrganizationEventsStatsTopNEventsSpans(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1272,6 +1272,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         assert response.status_code == 200
         assert all([interval[1][0]["count"] == 0 for interval in response.data["data"]])
 
+
 class OrganizationEventsStatsTopNEventsSpans(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -962,6 +962,43 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
         assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 
+    def test_idor_dashboard_widget_from_different_org(self) -> None:
+        """Regression test: Cannot access dashboard widgets from other organizations (IDOR)."""
+        # Create a widget in a DIFFERENT organization with discover_widget_split set
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        _, other_widget, __ = create_widget(
+            ["count()"],
+            "",
+            other_project,
+            discover_widget_split=DashboardWidgetTypes.ERROR_EVENTS,
+        )
+
+        # Request with cross-org widget ID should NOT use that widget's configuration
+        # The widget should be ignored because it belongs to a different organization
+        response = self.do_request(
+            {
+                "field": ["count()"],
+                "query": "",
+                "dataset": "metricsEnhanced",
+                "per_page": 50,
+                "dashboardWidgetId": other_widget.id,
+            }
+        )
+
+        # Request should succeed (the widget query fails silently and falls back)
+        assert response.status_code == 200, response.content
+        # The cross-org widget had ERROR_EVENTS split, but since it's not accessible,
+        # the response should NOT have the split decision from that widget.
+        # The fallback behavior (without a valid widget) runs the split detection logic
+        # which will either return no split decision or a different one based on the current org's data.
+        meta = response.data.get("meta", {})
+        # The key assertion: the response should NOT show ERROR_EVENTS from the other org's widget
+        # Since we have no error events in our org, it should be TRANSACTION_LIKE or not present
+        assert meta.get("discoverSplitDecision") != DashboardWidgetTypes.get_type_name(
+            DashboardWidgetTypes.ERROR_EVENTS
+        )
+
     def test_inp_percentile(self) -> None:
         for hour in range(6):
             timestamp = self.day_ago + timedelta(hours=hour, minutes=30)


### PR DESCRIPTION
## Summary
Fixes IDOR vulnerability in `OrganizationEventsStatsEndpoint` where `DashboardWidget` was queried without organization scoping, allowing users to potentially access dashboard widget configurations from other organizations via the `dashboardWidgetId` query parameter.

## Changes
- Added `dashboard__organization_id=organization.id` to `DashboardWidget.objects.get()` query

## Security Impact
Before this fix, an attacker could:
1. Pass a `dashboardWidgetId` from another organization
2. Have the endpoint use that widget's `discover_widget_split` configuration

Now the query is scoped to the current organization, so widgets from other orgs will not be found.

## Note
The existing exception handler (lines 499-510) catches `DashboardWidget.DoesNotExist` and falls back to default behavior, so this doesn't change the API response for invalid widget IDs. The fix prevents the more subtle information leakage through widget configuration access.

## Test plan
- [ ] Existing tests pass (CI will verify)
- The Snuba-dependent tests in `tests/snuba/api/endpoints/test_organization_events_stats.py` will verify the endpoint still works correctly