### PR TITLE
fix(security): IDOR in OrganizationEventsEndpoint - scope DashboardWidget by organization

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -289,7 +289,9 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             dashboard_widget_id: str,
         ):
             try:
-                widget = DashboardWidget.objects.get(id=dashboard_widget_id)
+                widget = DashboardWidget.objects.get(
+                    id=dashboard_widget_id, dashboard__organization_id=organization.id
+                )
                 does_widget_have_split = widget.discover_widget_split is not None
 
                 if does_widget_have_split:

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6019,26 +6019,6 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert "meta" not in response.data
         assert "debug_info" not in response.data
 
-    def test_idor_dashboard_widget_from_different_org(self) -> None:
-        """Regression test: Cannot access dashboard widgets from other organizations (IDOR)."""
-        other_org = self.create_organization()
-        other_dashboard = self.create_dashboard(organization=other_org)
-        other_widget = self.create_dashboard_widget(dashboard=other_dashboard)
-
-        # Request with cross-org widget ID should not use that widget's configuration
-        response = self.do_request(
-            {
-                "field": ["count()"],
-                "project": [self.project.id],
-                "dashboardWidgetId": other_widget.id,
-            },
-        )
-        # Should still return 200 (falls back to default behavior)
-        assert response.status_code == 200
-        # Should NOT have discoverSplitDecision from the cross-org widget
-        meta = response.data.get("meta", {})
-        assert "discoverSplitDecision" not in meta
-
 
 class OrganizationEventsProfilesDatasetEndpointTest(OrganizationEventsEndpointTestBase):
     @mock.patch("sentry.search.events.builder.base.raw_snql_query")

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6019,6 +6019,26 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert "meta" not in response.data
         assert "debug_info" not in response.data
 
+    def test_idor_dashboard_widget_from_different_org(self) -> None:
+        """Regression test: Cannot access dashboard widgets from other organizations (IDOR)."""
+        other_org = self.create_organization()
+        other_dashboard = self.create_dashboard(organization=other_org)
+        other_widget = self.create_dashboard_widget(dashboard=other_dashboard)
+
+        # Request with cross-org widget ID should not use that widget's configuration
+        response = self.do_request(
+            {
+                "field": ["count()"],
+                "project": [self.project.id],
+                "dashboardWidgetId": other_widget.id,
+            },
+        )
+        # Should still return 200 (falls back to default behavior)
+        assert response.status_code == 200
+        # Should NOT have discoverSplitDecision from the cross-org widget
+        meta = response.data.get("meta", {})
+        assert "discoverSplitDecision" not in meta
+
 
 class OrganizationEventsProfilesDatasetEndpointTest(OrganizationEventsEndpointTestBase):
     @mock.patch("sentry.search.events.builder.base.raw_snql_query")

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -4077,18 +4077,21 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
     def test_idor_dashboard_widget_from_different_org(self) -> None:
         """Regression test: Cannot access dashboard widgets from other organizations (IDOR)."""
-        # Create a widget in a DIFFERENT organization with discover_widget_split set
+        # Create a widget in a DIFFERENT organization with discover_widget_split=None
+        # This means if the widget IS accessed, the split detection would run and UPDATE it
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)
         _, other_widget, __ = create_widget(
             ["count()"],
             "",
             other_project,
-            discover_widget_split=DashboardWidgetTypes.ERROR_EVENTS,
+            discover_widget_split=None,  # Not yet split - would be updated if accessed
         )
 
-        # Request with cross-org widget ID should NOT use that widget's configuration
-        # The widget should be ignored because it belongs to a different organization
+        # Verify initial state
+        assert other_widget.discover_widget_split is None
+
+        # Request with cross-org widget ID should NOT access that widget
         response = self.do_request(
             {
                 "field": ["count()"],
@@ -4101,12 +4104,14 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
         # Request should succeed (the widget query fails silently and falls back)
         assert response.status_code == 200, response.content
-        # The cross-org widget had ERROR_EVENTS split, but since it's not accessible,
-        # the response should NOT have the split decision from that widget.
-        meta = response.data.get("meta", {})
-        # The key assertion: the response should NOT show ERROR_EVENTS from the other org's widget
-        assert meta.get("discoverSplitDecision") != DashboardWidgetTypes.get_type_name(
-            DashboardWidgetTypes.ERROR_EVENTS
+
+        # KEY ASSERTION: The cross-org widget should NOT have been modified
+        # Without IDOR fix: widget is found, split detection runs, discover_widget_split gets set
+        # With IDOR fix: widget not found (wrong org), widget stays unchanged
+        other_widget.refresh_from_db()
+        assert other_widget.discover_widget_split is None, (
+            "Cross-org widget was modified - IDOR vulnerability! "
+            "The widget should not be accessible from a different organization."
         )
 
 


### PR DESCRIPTION
## Summary
Fixes IDOR vulnerability in `OrganizationEventsEndpoint` where `DashboardWidget` was queried without organization scoping, allowing users to potentially access dashboard widget configurations from other organizations via the `dashboardWidgetId` query parameter.

## Changes
- Added `dashboard__organization_id=organization.id` to `DashboardWidget.objects.get()` query

## Security Impact
Before this fix, an attacker could:
1. Pass a `dashboardWidgetId` from another organization
2. Have the endpoint use that widget's `discover_widget_split` configuration

Now the query is scoped to the current organization.

## Note
This is the same fix pattern as PR #104986 for `organization_events_stats.py`.

## Test plan
- [ ] Existing tests pass (CI will verify)