### PR TITLE
Revert "fix(ui): Button's label clipped (#104849)"

### DIFF
--- a/static/app/components/core/button/button.tsx
+++ b/static/app/components/core/button/button.tsx
@@ -78,6 +78,7 @@ const ButtonLabel = styled('span', {
     isPropValid(prop) &&
     !['size', 'borderless'].includes(prop),
 })<Pick<CommonButtonProps, 'size' | 'borderless'>>`
+  height: 100%;
   min-width: 0;
   display: flex;
   align-items: center;

--- a/static/app/components/core/button/linkButton.tsx
+++ b/static/app/components/core/button/linkButton.tsx
@@ -115,6 +115,7 @@ const ButtonLabel = styled('span', {
     isPropValid(prop) &&
     !['size', 'borderless'].includes(prop),
 })<Pick<CommonButtonProps, 'size' | 'borderless'>>`
+  height: 100%;
   min-width: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION
The root cause of the issue was addressed in https://github.com/getsentry/sentry/pull/104976 so this change should be reverted as it is causing the layout to be cutoff on the help button

Fixes DE-664