### PR TITLE
chore (aci): gate new metric alert charts with UI rollout flag

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -219,7 +219,7 @@ def build_metric_alert_chart(
     query_type = SnubaQuery.Type(snuba_query.type)
     is_crash_free_alert = query_type == SnubaQuery.Type.CRASH_RATE
     using_new_charts = features.has(
-        "organizations:new-metric-issue-charts",
+        "organizations:workflow-engine-ui",
         organization,
     )
     if is_crash_free_alert:

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -149,7 +149,7 @@ def fetch_metric_issue_open_periods(
             open_period_identifier = alert_rule_detector.alert_rule_id
 
         if features.has(
-            "organizations:new-metric-issue-charts",
+            "organizations:workflow-engine-ui",
             organization,
         ):
             resp = client.get(
@@ -250,7 +250,7 @@ def build_metric_alert_chart(
             "end": timezone.now().strftime(TIME_FORMAT),
         }
     if features.has(
-        "organizations:new-metric-issue-charts",
+        "organizations:workflow-engine-ui",
         organization,
     ):
         # TODO(mifu67): create detailed serializer for open period, pass here.

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -180,7 +180,7 @@ class FetchOpenPeriodsTest(BaseMetricIssueTest):
 
     @freeze_time(frozen_time)
     @with_feature("organizations:incidents")
-    @with_feature("organizations:new-metric-issue-charts")
+    @with_feature("organizations:workflow-engine-ui")
     def test_use_open_period_serializer(self) -> None:
         detector = self.create_detector(project=self.project)
         group = self.create_group(type=MetricIssue.type_id, priority=PriorityLevel.HIGH)
@@ -213,7 +213,7 @@ class FetchOpenPeriodsTest(BaseMetricIssueTest):
 
     @freeze_time(frozen_time)
     @with_feature("organizations:incidents")
-    @with_feature("organizations:new-metric-issue-charts")
+    @with_feature("organizations:workflow-engine-ui")
     def test_use_open_period_serializer_with_offset(self) -> None:
         group = self.create_group(type=MetricIssue.type_id, priority=PriorityLevel.HIGH)
 


### PR DESCRIPTION
These charts should be gated by the UI flag, because they reference open periods.