### PR TITLE
feat(seer settings): Onboarding wizard should only set org level options

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -10,7 +10,6 @@ import requests
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.db import router, transaction
 from django.utils import timezone
 from rest_framework.response import Response
 
@@ -23,7 +22,6 @@ from sentry.integrations.types import ExternalProviders
 from sentry.issues.grouptype import WebVitalsGroup
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.group import Group
-from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
@@ -593,36 +591,23 @@ def onboarding_seer_settings_update(
     """
     # Get organization and list of projects
     organization = Organization.objects.get(id=organization_id)
-    projects = Project.objects.filter(organization_id=organization_id, status=ObjectStatus.ACTIVE)
 
-    # If RCA is explicitly disabled, set the automation tuning to off for org and projects.
-    # If RCA is disabled then other settings don't matter.
-    if not is_rca_enabled:
-        # Ensure org and all projects are updated in a single transaction to maintain consistency
-        with transaction.atomic(using=router.db_for_write(OrganizationOption)):
-            organization.update_option(
-                "sentry:default_autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
-            )
-            for project in projects:
-                project.update_option(
-                    "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
-                )
-        logger.info(
-            "RCA is disabled for org and projects, setting automation tuning to off",
-            extra={
-                "organization_id": organization_id,
-                "org_slug": organization.slug,
-                "num_projects": len(projects),
-            },
-        )
-        return
+    # Set the default automation tuning for the org
+    if is_rca_enabled:
+        rca_default_tuning = AutofixAutomationTuningSettings.MEDIUM
+    else:
+        rca_default_tuning = AutofixAutomationTuningSettings.OFF
+    organization.update_option("sentry:default_autofix_automation_tuning", rca_default_tuning)
 
-    # Set the default stopping point for projects
-    stopping_point = AutofixStoppingPoint.CODE_CHANGES
+    # Set the default stopping point and auto open PRs for the org
     if is_auto_open_prs_enabled:
         stopping_point = AutofixStoppingPoint.OPEN_PR
+        organization.update_option("sentry:auto_open_prs", True)
+    else:
+        stopping_point = AutofixStoppingPoint.CODE_CHANGES
+        organization.update_option("sentry:auto_open_prs", False)
 
-    # Build preferences for each project with its repositories
+    # Update preferences for each project with its repositories
     preferences_to_set = []
     for project_id, repositories in project_repo_dict.items():
         preferences_to_set.append(

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -627,9 +627,9 @@ def onboarding_seer_settings_update(
         "onboarding_seer_settings_update for new org completed",
         extra={
             "organization_id": organization_id,
+            "default_autofix_automation_tuning": rca_default_tuning,
+            "auto_open_prs": is_auto_open_prs_enabled,
             "org_slug": organization.slug,
-            "is_rca_enabled": is_rca_enabled,
-            "is_auto_open_prs_enabled": is_auto_open_prs_enabled,
             "num_projects": len(project_repo_dict),
         },
     )

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1536,6 +1536,47 @@ class TestOnboardingSeerSettingsUpdate(TestCase):
         assert organization.get_option("sentry:auto_open_prs") is True
 
     @patch("sentry.seer.autofix.autofix.bulk_set_project_preferences")
+    def test_rca_disabled_with_auto_prs_and_project_sets_open_pr_stopping_point(
+        self, mock_bulk_set
+    ) -> None:
+        """Tests that when RCA is disabled but auto PRs enabled with a project, stopping point is OPEN_PR."""
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+
+        repo = SeerRepoDefinition(
+            provider="github",
+            owner="getsentry",
+            name="sentry",
+            external_id="789",
+        )
+
+        onboarding_seer_settings_update(
+            organization_id=organization.id,
+            is_rca_enabled=False,
+            is_auto_open_prs_enabled=True,
+            project_repo_dict={project.id: [repo]},
+        )
+
+        # Verify org-level options
+        organization.refresh_from_db()
+        assert (
+            organization.get_option("sentry:default_autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.OFF
+        )
+        assert organization.get_option("sentry:auto_open_prs") is True
+
+        # Verify bulk_set_project_preferences is called with OPEN_PR stopping point
+        mock_bulk_set.assert_called_once()
+        call_args = mock_bulk_set.call_args
+        assert call_args[0][0] == organization.id
+        preferences = call_args[0][1]
+        assert len(preferences) == 1
+        assert preferences[0]["organization_id"] == organization.id
+        assert preferences[0]["project_id"] == project.id
+        assert preferences[0]["automated_run_stopping_point"] == "open_pr"
+        assert len(preferences[0]["repositories"]) == 1
+
+    @patch("sentry.seer.autofix.autofix.bulk_set_project_preferences")
     def test_rca_enabled_without_auto_prs_sets_code_changes_stopping_point(
         self, mock_bulk_set
     ) -> None:


### PR DESCRIPTION
## PR Details
+ The toggles in (onboarding wizard step 4)[https://www.figma.com/design/GMZ2vapRoc1TcueKOjTyUY/Seer-Activation-Flow?node-id=1297-45994&t=4bV5U4gJ6fkSEn70-4] shouldn't change project defaults it should just change org defaults.
+ This PR makes that change.
+ UI in step 4 needs to be reworked too to make it clear to the user that these toggles will affect the behaviour of new projects and not exiting ones. It will serve as a template of new projects. 
