### PR TITLE
fix(pr-review): Fix register seer launch ffs

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -451,9 +451,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable public RPC endpoint for local seer development
     manager.add("organizations:seer-public-rpc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Organizations on the old usage-based (v0) Seer plan
-    manager.add("organizations:seer-added", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:seer-added", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Organizations on the new seat-based Seer plan
-    manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable new SentryApp webhook request endpoint
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable standalone span ingestion


### PR DESCRIPTION
Match the register feature flags in getsentry
https://github.com/getsentry/getsentry/blob/71b4389f491e36904324213863a0d4baf0f732ce/getsentry/features.py#L2427C1-L2428C125
These are implemented in internal [here](https://github.com/getsentry/getsentry/blob/61aa8051ebce1e1eaab6e5b0dc29343df8c99b53/getsentry/features.py#L1955-L1980) and should be made available to frontend


A similar pattern to other example `projects:similarity-embeddings` registered in sentry, and implementation of handler is in getsentry
https://github.com/getsentry/sentry/blob/74a33eb749ab7858561c58c927ca7770710f800b/src/sentry/features/temporary.py#L667
https://github.com/getsentry/getsentry/blob/1549095c37e4756b6d919d388a3893182dfca42e/getsentry/features.py#L1878
