### PR TITLE
fix(dynamic grouping): Remove unnecessary `deprecatedRouteProps`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2664,7 +2664,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'dynamic-groups/',
       component: make(() => import('sentry/views/issueList/pages/dynamicGrouping')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'views/:viewId/',


### PR DESCRIPTION
Unnecessary `deprecatedRouteProps` - no legacy props here.