### PR TITLE
ref(projects): Remove usage of `deprecatedRouteProps` for project routes parent

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1368,7 +1368,6 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/projects/')),
     withOrgPath: true,
     children: projectsChildren,
-    deprecatedRouteProps: true,
   };
 
   const traceView: SentryRouteObject = {

--- a/static/app/views/projects/index.tsx
+++ b/static/app/views/projects/index.tsx
@@ -1,11 +1,9 @@
+import {Outlet} from 'react-router-dom';
+
 import Redirect from 'sentry/components/redirect';
 import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
-type Props = {
-  children: React.ReactNode;
-};
-
-export default function Projects({children}: Props) {
+export default function Projects() {
   const redirectPath = useRedirectNavV2Routes({
     oldPathPrefix: '/projects/',
     newPathPrefix: '/insights/projects/',
@@ -15,5 +13,5 @@ export default function Projects({children}: Props) {
     return <Redirect to={redirectPath} />;
   }
 
-  return children;
+  return <Outlet />;
 }


### PR DESCRIPTION
Migrates project routes parent off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7