### PR TITLE
feat(seer settings): Add default where should seer stop value for new projects [feature flagged]

### DIFF
--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -31,6 +31,7 @@ from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.seer.similarity.utils import (
     project_is_seer_eligible,
+    set_default_project_auto_open_prs,
     set_default_project_autofix_automation_tuning,
     set_default_project_seer_scanner_automation,
 )
@@ -55,6 +56,7 @@ def apply_default_project_settings(organization: Organization, project: Project)
 
     set_default_project_autofix_automation_tuning(organization, project)
     set_default_project_seer_scanner_automation(organization, project)
+    set_default_project_auto_open_prs(organization, project)
 
 
 class ProjectPostSerializer(serializers.Serializer):

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -207,6 +207,22 @@ def get_project_seer_preferences(project_id: int) -> SeerRawPreferenceResponse:
     raise SeerApiError(response.data.decode("utf-8"), response.status)
 
 
+def set_project_preference(preference: SeerProjectPreference) -> None:
+    """Set Seer project preference for a single project."""
+    path = "/v1/project-preference/set"
+    body = orjson.dumps({"preference": preference.dict()})
+
+    response = make_signed_seer_api_request(
+        autofix_connection_pool,
+        path,
+        body=body,
+        timeout=15,
+    )
+
+    if response.status >= 400:
+        raise SeerApiError(response.data.decode("utf-8"), response.status)
+
+
 def has_project_connected_repos(organization_id: int, project_id: int) -> bool:
     """
     Check if a project has connected repositories for Seer automation.

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -207,7 +207,7 @@ def get_project_seer_preferences(project_id: int) -> SeerRawPreferenceResponse:
     raise SeerApiError(response.data.decode("utf-8"), response.status)
 
 
-def set_project_preference(preference: SeerProjectPreference) -> None:
+def set_project_seer_preference(preference: SeerProjectPreference) -> None:
     """Set Seer project preference for a single project."""
     path = "/v1/project-preference/set"
     body = orjson.dumps({"preference": preference.dict()})

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -549,6 +549,7 @@ def set_default_project_auto_open_prs(organization: Organization, project: Proje
         if organization.get_option("sentry:auto_open_prs"):
             stopping_point = AutofixStoppingPoint.OPEN_PR
 
+        # We need to make an API call to Seer to set this preference
         preference = SeerProjectPreference(
             organization_id=organization.id,
             project_id=project.id,

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -544,22 +544,24 @@ def set_default_project_seer_scanner_automation(
 
 def set_default_project_auto_open_prs(organization: Organization, project: Project) -> None:
     """Called once at project creation time to set the initial auto open PRs."""
-    if is_seer_seat_based_tier_enabled(organization):
-        stopping_point = AutofixStoppingPoint.CODE_CHANGES
-        if organization.get_option("sentry:auto_open_prs"):
-            stopping_point = AutofixStoppingPoint.OPEN_PR
+    if not is_seer_seat_based_tier_enabled(organization):
+        return
 
-        # We need to make an API call to Seer to set this preference
-        preference = SeerProjectPreference(
-            organization_id=organization.id,
-            project_id=project.id,
-            repositories=[],
-            automated_run_stopping_point=stopping_point,
-        )
-        try:
-            set_project_seer_preference(preference)
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
+    stopping_point = AutofixStoppingPoint.CODE_CHANGES
+    if organization.get_option("sentry:auto_open_prs"):
+        stopping_point = AutofixStoppingPoint.OPEN_PR
+
+    # We need to make an API call to Seer to set this preference
+    preference = SeerProjectPreference(
+        organization_id=organization.id,
+        project_id=project.id,
+        repositories=[],
+        automated_run_stopping_point=stopping_point,
+    )
+    try:
+        set_project_seer_preference(preference)
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
 
 
 def report_token_count_metric(

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -17,7 +17,12 @@ from sentry.killswitches import killswitch_matches_context
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
-from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
+from sentry.seer.autofix.utils import (
+    AutofixStoppingPoint,
+    is_seer_seat_based_tier_enabled,
+    set_project_preference,
+)
+from sentry.seer.models import SeerProjectPreference
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
@@ -535,6 +540,25 @@ def set_default_project_seer_scanner_automation(
         org_default = organization.get_option("sentry:default_seer_scanner_automation")
         if org_default is not None:
             project.update_option("sentry:seer_scanner_automation", org_default)
+
+
+def set_default_project_auto_open_prs(organization: Organization, project: Project) -> None:
+    """Called once at project creation time to set the initial auto open PRs."""
+    if is_seer_seat_based_tier_enabled(organization):
+        stopping_point = AutofixStoppingPoint.CODE_CHANGES
+        if organization.get_option("sentry:auto_open_prs"):
+            stopping_point = AutofixStoppingPoint.OPEN_PR
+
+        preference = SeerProjectPreference(
+            organization_id=organization.id,
+            project_id=project.id,
+            repositories=[],
+            automated_run_stopping_point=stopping_point,
+        )
+        try:
+            set_project_preference(preference)
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
 
 
 def report_token_count_metric(

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -20,7 +20,7 @@ from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     is_seer_seat_based_tier_enabled,
-    set_project_preference,
+    set_project_seer_preference,
 )
 from sentry.seer.models import SeerProjectPreference
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -557,7 +557,7 @@ def set_default_project_auto_open_prs(organization: Organization, project: Proje
             automated_run_stopping_point=stopping_point,
         )
         try:
-            set_project_preference(preference)
+            set_project_seer_preference(preference)
         except Exception as e:
             sentry_sdk.capture_exception(e)
 


### PR DESCRIPTION
## PR Details
+ We use `sentry:auto_open_prs` as a org level default template for what new projects should have. If it's set to True then new projects' stopping point should be open PR, if not it is code changes. 
+ This change only applies to the new seat based only.
+ TBD: I have put the actual API call in a try catch. If I remove it then if this function fails then new project creation will fail too. As this is an external I expect higher failure rates. If this preference is not set for the project it will be set to code changes by the first autofix run. 
