### PR TITLE
theme: remove theme.iconSizes

### DIFF
--- a/static/app/components/alerts/onDemandMetricAlert.tsx
+++ b/static/app/components/alerts/onDemandMetricAlert.tsx
@@ -5,6 +5,7 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconClose, IconWarning} from 'sentry/icons';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import type {Color} from 'sentry/utils/theme';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
@@ -86,7 +87,7 @@ const InfoAlert = styled(Alert)`
 `;
 
 const HoverableIconWarning = styled(IconWarning)`
-  min-width: ${p => p.theme.iconSizes.sm};
+  min-width: ${() => SvgIcon.ICON_SIZES.sm};
   &:hover {
     cursor: pointer;
   }

--- a/static/app/components/alerts/pageBanner.tsx
+++ b/static/app/components/alerts/pageBanner.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import Panel from 'sentry/components/panels/panel';
 import {IconClose} from 'sentry/icons';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
@@ -71,8 +72,8 @@ const CloseButton = styled(Button)`
   top: -${space(1)};
   right: -${space(1)};
   border-radius: 50%;
-  height: ${p => p.theme.iconSizes.lg};
-  width: ${p => p.theme.iconSizes.lg};
+  height: ${() => SvgIcon.ICON_SIZES.lg};
+  width: ${() => SvgIcon.ICON_SIZES.lg};
   z-index: 1;
 `;
 

--- a/static/app/components/commandPalette/ui/content.tsx
+++ b/static/app/components/commandPalette/ui/content.tsx
@@ -10,6 +10,7 @@ import {COMMAND_PALETTE_GROUP_KEY_CONFIG} from 'sentry/components/commandPalette
 import {CommandPaletteList} from 'sentry/components/commandPalette/ui/list';
 import {useCommandPaletteState} from 'sentry/components/commandPalette/ui/useCommandPaletteState';
 import type {MenuListItemProps} from 'sentry/components/core/menuListItem';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {unreachable} from 'sentry/utils/unreachable';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -134,6 +135,6 @@ export function CommandPaletteContent() {
 }
 
 const IconWrap = styled(Flex)`
-  width: ${p => p.theme.iconSizes.md};
-  height: ${p => p.theme.iconSizes.md};
+  width: ${() => SvgIcon.ICON_SIZES.md};
+  height: ${() => SvgIcon.ICON_SIZES.md};
 `;

--- a/static/app/components/core/layout/index.tsx
+++ b/static/app/components/core/layout/index.tsx
@@ -1,4 +1,4 @@
-export {Container} from './container';
+export {Container, type ContainerProps} from './container';
 export {Flex, type FlexProps} from './flex';
 export {Grid} from './grid';
 export {Stack} from './stack';

--- a/static/app/components/core/layout/index.tsx
+++ b/static/app/components/core/layout/index.tsx
@@ -1,4 +1,4 @@
-export {Container, type ContainerProps} from './container';
+export {Container} from './container';
 export {Flex, type FlexProps} from './flex';
 export {Grid} from './grid';
 export {Stack} from './stack';

--- a/static/app/components/errors/detailedError.tsx
+++ b/static/app/components/errors/detailedError.tsx
@@ -6,6 +6,7 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {IconFlag} from 'sentry/icons';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
@@ -83,7 +84,7 @@ const ErrorHeading = styled('h4')`
   display: flex;
   gap: ${space(1.5)};
   align-items: center;
-  margin-left: calc(-1 * (${p => p.theme.iconSizes.md} + ${space(1.5)}));
+  margin-left: calc(-1 * (${() => SvgIcon.ICON_SIZES.md} + ${space(1.5)}));
 `;
 
 const ErrorFooter = styled('div')`

--- a/static/app/components/events/contexts/contextIcon.tsx
+++ b/static/app/components/events/contexts/contextIcon.tsx
@@ -1,4 +1,4 @@
-import {css, useTheme} from '@emotion/react';
+import {css} from '@emotion/react';
 import logoAmazon from 'sentry-logos/logo-amazon.svg';
 import logoAmd from 'sentry-logos/logo-amd.svg';
 import logoAndroidPhone from 'sentry-logos/logo-android-phone.svg';
@@ -48,9 +48,9 @@ import logoVercel from 'sentry-logos/logo-vercel.svg';
 import logoWindows from 'sentry-logos/logo-windows.svg';
 import logoXbox from 'sentry-logos/logo-xbox.svg';
 
+import {SvgIcon, type SVGIconProps} from 'sentry/icons/svgIcon';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {IconSize} from 'sentry/utils/theme';
 
 const LOGO_MAPPING = {
   'android-phone': logoAndroidPhone,
@@ -162,17 +162,15 @@ export function getLogoImage(name: string) {
 
 export interface ContextIconProps {
   name: string;
-  size?: IconSize;
+  size?: SVGIconProps['size'];
 }
 
 export function ContextIcon({name, size: providedSize = 'xl'}: ContextIconProps) {
-  const theme = useTheme();
-  const size = theme.iconSizes[providedSize];
+  const size = SvgIcon.ICON_SIZES[providedSize];
 
   // Apply darkmode CSS to icon when in darkmode
   const isDarkmode = useLegacyStore(ConfigStore).theme === 'dark';
   const extraCass = isDarkmode && INVERT_IN_DARKMODE.includes(name) ? darkCss : null;
-
   const imageName = getLogoImage(name);
 
   return <img height={size} width={size} css={extraCass} src={imageName} />;

--- a/static/app/components/events/contexts/platformContext/utils.tsx
+++ b/static/app/components/events/contexts/platformContext/utils.tsx
@@ -5,9 +5,9 @@ import {getReactContextData} from 'sentry/components/events/contexts/platformCon
 import {getSpringContextData} from 'sentry/components/events/contexts/platformContext/spring';
 import {getUnityContextData} from 'sentry/components/events/contexts/platformContext/unity';
 import {getContextKeys} from 'sentry/components/events/contexts/utils';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import type {KeyValueListData} from 'sentry/types/group';
-import type {IconSize} from 'sentry/utils/theme';
 
 enum PlatformContextKeys {
   LARAVEL = 'laravel',
@@ -38,7 +38,7 @@ export function getPlatformContextIcon({
   size = 'sm',
 }: {
   platform: string;
-  size?: IconSize;
+  size?: SVGIconProps['size'];
 }) {
   let platformIconName = '';
   switch (platform) {

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -36,6 +36,7 @@ import {
 } from 'sentry/components/events/contexts/platformContext/utils';
 import {userContextToActor} from 'sentry/components/events/interfaces/utils';
 import StructuredEventData from 'sentry/components/structuredEventData';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -318,7 +319,6 @@ export function getContextIcon({
   type,
   value = {},
   contextIconProps = {},
-  theme,
 }: {
   alias: string;
   theme: Theme;
@@ -349,7 +349,7 @@ export function getContextIcon({
       break;
     case 'user': {
       const user = userContextToActor(value);
-      const iconSize = theme.iconSizes[contextIconProps?.size ?? 'xl'];
+      const iconSize = SvgIcon.ICON_SIZES[contextIconProps?.size ?? 'xl'];
       return <UserAvatar user={user} size={parseInt(iconSize, 10)} gravatar={false} />;
     }
     case 'gpu':

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -28,6 +28,7 @@ import {IconChevron} from 'sentry/icons';
 import {IconFileBroken} from 'sentry/icons/iconFileBroken';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
 import {IconWarning} from 'sentry/icons/iconWarning';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
@@ -573,7 +574,7 @@ const StackTraceFrame = styled('li')`
 `;
 
 const SymbolicatorIcon = styled('div')`
-  width: ${p => p.theme.iconSizes.sm};
+  width: ${() => SvgIcon.ICON_SIZES.sm};
 `;
 
 const ShowHideButton = styled(Button)`

--- a/static/app/components/iconCircledNumber.tsx
+++ b/static/app/components/iconCircledNumber.tsx
@@ -1,23 +1,20 @@
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import type {IconSize} from 'sentry/utils/theme';
+import {SvgIcon, type SVGIconProps} from 'sentry/icons/svgIcon';
 
 type IconCircledNumberProps = {
   number: number;
-  size?: IconSize;
+  size?: SVGIconProps['size'];
 };
 
 export function IconCircledNumber({number, size = 'md'}: IconCircledNumberProps) {
-  const theme = useTheme();
-
   return (
     <Circle
       role="img"
-      size={theme.iconSizes[size]}
+      size={SvgIcon.ICON_SIZES[size]}
       aria-label={`circled number ${number}`}
     >
-      <Number size={theme.iconSizes[size]}>{number}</Number>
+      <Number size={SvgIcon.ICON_SIZES[size]}>{number}</Number>
     </Circle>
   );
 }

--- a/static/app/components/questionTooltip.tsx
+++ b/static/app/components/questionTooltip.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import type {TooltipProps} from 'sentry/components/core/tooltip';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconInfo, IconQuestion} from 'sentry/icons';
-import type {IconSize} from 'sentry/utils/theme';
+import {SvgIcon, type SVGIconProps} from 'sentry/icons/svgIcon';
 
 interface QuestionProps
   extends Partial<
@@ -22,7 +22,7 @@ interface QuestionProps
    *
    * Remember to keep the size relative to the text or content it is near.
    */
-  size: IconSize;
+  size: NonNullable<SVGIconProps['size']>;
   /**
    * The message to show in the question icons tooltip.
    */
@@ -53,8 +53,8 @@ function QuestionTooltip({
 
 const QuestionIconContainer = styled('span')<Pick<QuestionProps, 'size' | 'className'>>`
   display: inline-block;
-  height: ${p => p.theme.iconSizes[p.size]};
-  line-height: ${p => p.theme.iconSizes[p.size]};
+  height: ${p => SvgIcon.ICON_SIZES[p.size]};
+  line-height: ${p => SvgIcon.ICON_SIZES[p.size]};
 
   & svg {
     transition: 120ms opacity;

--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -18,7 +18,7 @@ export interface SVGIconProps extends React.SVGAttributes<SVGSVGElement> {
    */
   legacySize?: string;
   ref?: React.Ref<SVGSVGElement>;
-  size?: keyof typeof ICON_SIZES;
+  size?: Exclude<Size, '2xs'>;
   variant?: keyof Theme['tokens']['content'];
 }
 

--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -1,6 +1,6 @@
 import {useTheme, type Theme} from '@emotion/react';
 
-import type {ColorOrAlias, IconSize} from 'sentry/utils/theme';
+import type {ColorOrAlias, Size} from 'sentry/utils/theme';
 
 import {useIconDefaults} from './useIconDefaults';
 
@@ -18,14 +18,14 @@ export interface SVGIconProps extends React.SVGAttributes<SVGSVGElement> {
    */
   legacySize?: string;
   ref?: React.Ref<SVGSVGElement>;
-  size?: IconSize;
+  size?: keyof typeof ICON_SIZES;
   variant?: keyof Theme['tokens']['content'];
 }
 
 export function SvgIcon(props: SVGIconProps) {
   const theme = useTheme();
   const iconProps = useIconDefaults(props);
-  const size = iconProps.legacySize ?? theme.iconSizes[iconProps.size ?? 'sm'];
+  const size = iconProps.legacySize ?? ICON_SIZES[iconProps.size ?? 'sm'];
 
   const {
     variant: _variant,
@@ -74,3 +74,21 @@ const ICON_DIRECTION_TO_ROTATION_ANGLE = {
 } as const;
 
 SvgIcon.ICON_DIRECTION_TO_ROTATION_ANGLE = ICON_DIRECTION_TO_ROTATION_ANGLE;
+
+/**
+ * @TODO(jonasbadalic): There are other icons that either already use or should use this size map.
+ * Our icon implementation is specialized for SVGs, but this is not always the case for other icons that
+ * might be img or div elements, and we should instead provide a container implementation that implements
+ * a common icon size interface and handles the resolution. With some small changes to the types, this
+ * could be achieved via a small wrapper around the Container component.
+ */
+const ICON_SIZES: Record<Exclude<Size, '2xs'>, string> = {
+  xs: '12px',
+  sm: '14px',
+  md: '18px',
+  lg: '24px',
+  xl: '32px',
+  '2xl': '72px',
+} as const;
+
+SvgIcon.ICON_SIZES = ICON_SIZES;

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -13,6 +13,7 @@ import {
   IconSentry,
   IconVsts,
 } from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
 import type {Hooks} from 'sentry/types/hooks';
@@ -33,8 +34,6 @@ import type {
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {capitalize} from 'sentry/utils/string/capitalize';
 import {POPULARITY_WEIGHT} from 'sentry/views/settings/organizationIntegrations/constants';
-
-import type {IconSize} from './theme';
 
 /**
  * TODO: remove alias once all usages are updated
@@ -192,7 +191,7 @@ export const safeGetQsParam = (param: string) => {
 
 export const getIntegrationIcon = (
   integrationType?: string,
-  iconSize: IconSize = 'md'
+  iconSize: SVGIconProps['size'] = 'md'
 ) => {
   switch (integrationType) {
     case 'asana':
@@ -277,7 +276,7 @@ export const getIntegrationSourceUrl = (
 
 export function getCodeOwnerIcon(
   provider: CodeOwner['provider'],
-  iconSize: IconSize = 'md'
+  iconSize: SVGIconProps['size'] = 'md'
 ) {
   switch (provider ?? '') {
     case 'github':

--- a/static/app/utils/theme/index.tsx
+++ b/static/app/utils/theme/index.tsx
@@ -2,7 +2,7 @@ export type {
   Color,
   ColorOrAlias,
   FormSize,
-  IconSize,
+  Size,
   StrictCSSObject,
   SentryTheme as Theme,
 } from './theme';

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -417,25 +417,14 @@ type ButtonColors = Record<
   }
 >;
 
-type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
-
+export type Size = '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 /**
  * Unless you are implementing a new component in the `sentry/components/core`
  * directory, use `ComponentProps['size']` instead.
  * @internal
  */
 export type FormSize = 'xs' | 'sm' | 'md';
-
 export type Space = keyof typeof space;
-
-const iconSizes: Record<Size, string> = {
-  xs: '12px',
-  sm: '14px',
-  md: '18px',
-  lg: '24px',
-  xl: '32px',
-  '2xl': '72px',
-} as const;
 
 const legacyTypography = {
   fontSize: typography.font.size,
@@ -519,9 +508,6 @@ const commonTheme = {
   size,
   motion: generateMotion(),
 
-  // Icons
-  iconSizes,
-
   // Try to keep these ordered plz
   zIndex: {
     // Generic z-index when you hope your component is isolated and
@@ -596,7 +582,6 @@ const commonTheme = {
 };
 
 export type Color = keyof ReturnType<typeof deprecatedColorMappings>;
-export type IconSize = keyof typeof iconSizes;
 type Aliases = typeof lightAliases;
 export type ColorOrAlias = keyof Aliases | Color;
 export interface SentryTheme extends Omit<typeof lightThemeDefinition, 'chart'> {

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -20,6 +20,7 @@ import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconEllipsis, IconUser} from 'sentry/icons';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types/core';
@@ -399,7 +400,7 @@ const IconContainer = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${p => p.theme.iconSizes.lg};
+  width: ${() => SvgIcon.ICON_SIZES.lg};
   flex-shrink: 0;
 `;
 

--- a/static/app/views/releases/detail/commitsAndFiles/fileIcon.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/fileIcon.tsx
@@ -1,7 +1,7 @@
-import {useTheme} from '@emotion/react';
 import {PlatformIcon} from 'platformicons';
 
 import {IconFile} from 'sentry/icons';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {fileExtensionToPlatform, getFileExtension} from 'sentry/utils/fileExtension';
 
 interface FileIconProps {
@@ -11,13 +11,12 @@ interface FileIconProps {
 function FileIcon({fileName}: FileIconProps) {
   const fileExtension = getFileExtension(fileName);
   const iconName = fileExtension ? fileExtensionToPlatform(fileExtension) : null;
-  const theme = useTheme();
 
   if (!iconName) {
     return <IconFile size="sm" />;
   }
 
-  return <PlatformIcon platform={iconName} size={theme.iconSizes.sm} />;
+  return <PlatformIcon platform={iconName} size={SvgIcon.ICON_SIZES.sm} />;
 }
 
 export default FileIcon;

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -17,12 +17,12 @@ import {extractSelectionParameters} from 'sentry/components/organizations/pageFi
 import PanelItem from 'sentry/components/panels/panelItem';
 import Placeholder from 'sentry/components/placeholder';
 import {IconCheckmark, IconFire, IconWarning} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Release, ReleaseProject} from 'sentry/types/release';
 import {defined} from 'sentry/utils';
-import type {IconSize} from 'sentry/utils/theme';
 import {ReleasesDisplayOption} from 'sentry/views/releases/list/releasesDisplayOptions';
 import type {ReleasesRequestRenderProps} from 'sentry/views/releases/list/releasesRequest';
 import {
@@ -47,7 +47,10 @@ import {
 const CRASH_FREE_DANGER_THRESHOLD = 98;
 const CRASH_FREE_WARNING_THRESHOLD = 99.5;
 
-function getCrashFreeIcon(crashFreePercent: number, iconSize: IconSize = 'sm') {
+function getCrashFreeIcon(
+  crashFreePercent: number,
+  iconSize: SVGIconProps['size'] = 'sm'
+) {
   if (crashFreePercent < CRASH_FREE_DANGER_THRESHOLD) {
     return <IconFire color="errorText" size={iconSize} />;
   }

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -2,12 +2,12 @@ import moment from 'moment-timezone';
 
 import type {PromptData} from 'sentry/actionCreators/prompts';
 import {IconBuilding, IconGroup, IconSeer, IconUser} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
-import type {IconSize} from 'sentry/utils/theme';
 
 import {
   BILLION,
@@ -601,7 +601,7 @@ export function getPlanIcon(plan: Plan) {
   return <IconUser />;
 }
 
-export function getProductIcon(product: AddOnCategory, size?: IconSize) {
+export function getProductIcon(product: AddOnCategory, size?: SVGIconProps['size']) {
   if ([AddOnCategory.LEGACY_SEER, AddOnCategory.SEER].includes(product)) {
     return <IconSeer size={size} />;
   }

--- a/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
+++ b/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
@@ -2,26 +2,24 @@ import styled from '@emotion/styled';
 
 import {ExternalLink} from 'sentry/components/core/link';
 import {IconBusiness, IconCheckmark} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {IconSize} from 'sentry/utils/theme/theme';
 
 type Props = {
   color?: string;
-  /**
-   * To match power icon
-   */
-  iconSize?: string;
+  iconSize?: SVGIconProps['size'];
   isNewCheckout?: boolean;
+  legacySize?: SVGIconProps['legacySize'];
 };
 
-function MoreFeaturesLink({color, iconSize, isNewCheckout}: Props) {
+function MoreFeaturesLink({color, legacySize, isNewCheckout}: Props) {
   return (
     <MoreLink href="https://sentry.io/pricing" color={color}>
       {isNewCheckout ? (
-        <IconCheckmark size={(iconSize as IconSize) ?? 'sm'} />
+        <IconCheckmark legacySize={legacySize} />
       ) : (
-        <IconBusiness legacySize={iconSize} />
+        <IconBusiness legacySize={legacySize} />
       )}
       {t('And more...')}
     </MoreLink>

--- a/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
+++ b/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
@@ -8,7 +8,6 @@ import {space} from 'sentry/styles/space';
 
 type Props = {
   color?: string;
-  iconSize?: SVGIconProps['size'];
   isNewCheckout?: boolean;
   legacySize?: SVGIconProps['legacySize'];
 };

--- a/static/gsApp/views/amCheckout/components/planSelectRow.tsx
+++ b/static/gsApp/views/amCheckout/components/planSelectRow.tsx
@@ -155,7 +155,7 @@ function PlanSelectRow({
                         </Feature>
                       ))}
                     {/* custom to match text size */}
-                    {hasMoreLink && <MoreFeaturesLink iconSize="14px" />}
+                    {hasMoreLink && <MoreFeaturesLink legacySize="14px" />}
                   </FeatureList>
                 ) : (
                   <FeatureList>
@@ -167,7 +167,7 @@ function PlanSelectRow({
                       </Feature>
                     ))}
                     {/* custom to match text size */}
-                    {hasMoreLink && <MoreFeaturesLink iconSize="14px" />}
+                    {hasMoreLink && <MoreFeaturesLink legacySize="14px" />}
                   </FeatureList>
                 ))}
             </PlanDetails>


### PR DESCRIPTION
We probably need to provide a unified icon container for the different types of icons (see comment next to SvgIcon size mapping)

Fix DE-308