### PR TITLE
ref(explorer): default rpc statsperiod of 7d

### DIFF
--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -183,9 +183,7 @@ def get_event_filter_keys(
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     # Treat empty projects as a query for all projects.
     if not project_ids:
@@ -254,9 +252,7 @@ def get_event_filter_key_values(
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     # Treat empty projects as a query for all projects.
     if not project_ids:

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -446,9 +446,7 @@ def get_issue_filter_keys(
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     api_key = ApiKey(organization_id=organization.id, scope_list=API_KEY_SCOPES)
 
@@ -562,9 +560,7 @@ def get_filter_key_values(
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     # Check if this is a built-in field first
     # For 'has' field, we need to get tag keys first
@@ -698,9 +694,7 @@ def execute_issues_query(
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     api_key = ApiKey(organization_id=organization.id, scope_list=API_KEY_SCOPES)
 
@@ -771,9 +765,7 @@ def get_issues_stats(
         logger.warning("Organization not found", extra={"org_id": org_id})
         return None
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     if not issue_ids:
         return []

--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -115,9 +115,7 @@ def get_attribute_names(
     """
     organization = Organization.objects.get(id=org_id)
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     api_key = ApiKey(organization_id=org_id, scope_list=API_KEY_SCOPES)
 
@@ -188,9 +186,7 @@ def get_attribute_values_with_substring(
 
     organization = Organization.objects.get(id=org_id)
 
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     api_key = ApiKey(organization_id=org_id, scope_list=API_KEY_SCOPES)
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -372,9 +372,7 @@ def get_attributes_and_values(
     """
     Fetches all string attributes and the corresponding values with counts for a given period.
     """
-    stats_period, start, end = validate_date_params(
-        stats_period, start, end, default_stats_period="7d"
-    )
+    stats_period, start, end = validate_date_params(stats_period, start, end)
 
     if stats_period:
         period = parse_stats_period(stats_period) or datetime.timedelta(days=7)

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -34,7 +34,7 @@ def validate_date_params(
     stats_period: str | None,
     start: str | None,
     end: str | None,
-    default_stats_period: str | None = None,
+    default_stats_period: str = "7d",
     allow_none: bool = False,
 ) -> tuple[str | None, str | None, str | None]:
     """


### PR DESCRIPTION
alternative to https://github.com/getsentry/seer/pull/4277. Stay consistent with where we define the defaults (always 7d atm)