### PR TITLE
feat(issues): Match breadcrumb absolute format to logs etc

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -94,10 +94,10 @@ describe('BreadcrumbsDataSection', () => {
     );
 
     // From virtual crumb
-    expect(screen.getByText('06:01:48.762 PM')).toBeInTheDocument();
+    expect(screen.getByText('May 21, 2019 6:01:48.762 PM UTC')).toBeInTheDocument();
     expect(screen.queryByText('0ms')).not.toBeInTheDocument();
     // From event breadcrumb
-    expect(screen.getByText('06:00:48.760 PM')).toBeInTheDocument();
+    expect(screen.getByText('May 21, 2019 6:00:48.760 PM UTC')).toBeInTheDocument();
     expect(screen.queryByText('-1min 2ms')).not.toBeInTheDocument();
 
     const timeControl = screen.getByRole('button', {
@@ -106,16 +106,16 @@ describe('BreadcrumbsDataSection', () => {
     await userEvent.click(timeControl);
 
     expect(screen.getByText('0ms')).toBeInTheDocument();
-    expect(screen.queryByText('06:01:48.762 PM')).not.toBeInTheDocument();
+    expect(screen.queryByText('May 21, 2019 6:01:48.762 PM UTC')).not.toBeInTheDocument();
     expect(screen.getByText('-1min 2ms')).toBeInTheDocument();
-    expect(screen.queryByText('06:00:48.760 PM')).not.toBeInTheDocument();
+    expect(screen.queryByText('May 21, 2019 6:00:48.760 PM UTC')).not.toBeInTheDocument();
 
     await userEvent.click(timeControl);
 
     expect(screen.queryByText('0ms')).not.toBeInTheDocument();
-    expect(screen.getByText('06:01:48.762 PM')).toBeInTheDocument();
+    expect(screen.getByText('May 21, 2019 6:01:48.762 PM UTC')).toBeInTheDocument();
     expect(screen.queryByText('-1min 2ms')).not.toBeInTheDocument();
-    expect(screen.getByText('06:00:48.760 PM')).toBeInTheDocument();
+    expect(screen.getByText('May 21, 2019 6:00:48.760 PM UTC')).toBeInTheDocument();
   });
 
   it('opens the drawer and focuses search when the search button is pressed', async () => {

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
@@ -66,9 +66,9 @@ describe('BreadcrumbsDrawer', () => {
       expect(within(drawerScreen).getByText(level)).toBeInTheDocument();
       expect(within(drawerScreen).getByText(message)).toBeInTheDocument();
     }
-    expect(within(drawerScreen).getAllByText('06:00:48.760 PM')).toHaveLength(
-      MOCK_BREADCRUMBS.length
-    );
+    expect(
+      within(drawerScreen).getAllByText('May 21, 2019 6:00:48.760 PM UTC')
+    ).toHaveLength(MOCK_BREADCRUMBS.length);
   });
 
   it('allows search to affect displayed crumbs', async () => {
@@ -158,9 +158,9 @@ describe('BreadcrumbsDrawer', () => {
 
   it('allows time display dropdown to change all displayed crumbs', async () => {
     const drawerScreen = await renderBreadcrumbDrawer();
-    expect(within(drawerScreen).getAllByText('06:00:48.760 PM')).toHaveLength(
-      MOCK_BREADCRUMBS.length
-    );
+    expect(
+      within(drawerScreen).getAllByText('May 21, 2019 6:00:48.760 PM UTC')
+    ).toHaveLength(MOCK_BREADCRUMBS.length);
     expect(within(drawerScreen).queryByText('-1min 2ms')).not.toBeInTheDocument();
     const timeControl = within(drawerScreen).getByRole('button', {
       name: 'Change Time Format for All Breadcrumbs',
@@ -168,7 +168,9 @@ describe('BreadcrumbsDrawer', () => {
     await userEvent.click(timeControl);
     await userEvent.click(within(drawerScreen).getByRole('option', {name: 'Relative'}));
 
-    expect(within(drawerScreen).queryByText('06:00:48.760 PM')).not.toBeInTheDocument();
+    expect(
+      within(drawerScreen).queryByText('May 21, 2019 6:00:48.760 PM UTC')
+    ).not.toBeInTheDocument();
     expect(within(drawerScreen).getAllByText('-1min 2ms')).toHaveLength(
       MOCK_BREADCRUMBS.length
     );
@@ -176,9 +178,9 @@ describe('BreadcrumbsDrawer', () => {
     await userEvent.click(timeControl);
     await userEvent.click(within(drawerScreen).getByRole('option', {name: 'Absolute'}));
 
-    expect(within(drawerScreen).getAllByText('06:00:48.760 PM')).toHaveLength(
-      MOCK_BREADCRUMBS.length
-    );
+    expect(
+      within(drawerScreen).getAllByText('May 21, 2019 6:00:48.760 PM UTC')
+    ).toHaveLength(MOCK_BREADCRUMBS.length);
     expect(within(drawerScreen).queryByText('-1min 2ms')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawer.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawer.tsx
@@ -120,6 +120,9 @@ export function BreadcrumbsDrawer({
       </InputGroup>
       <CompactSelect
         size="xs"
+        multiple
+        clearable
+        menuTitle={t('Filter by')}
         value={filters}
         onChange={options => {
           const newFilters = options.map(({value}) => value);
@@ -129,7 +132,6 @@ export function BreadcrumbsDrawer({
             organization,
           });
         }}
-        multiple
         options={filterOptions}
         maxMenuHeight={400}
         trigger={props => (
@@ -138,6 +140,7 @@ export function BreadcrumbsDrawer({
             borderless
             icon={<IconFilter />}
             aria-label={t('Filter All Breadcrumbs')}
+            title={t('Filter')}
             {...props}
             {...getFocusProps(BreadcrumbControlOptions.FILTER)}
           >
@@ -153,6 +156,7 @@ export function BreadcrumbsDrawer({
             borderless
             icon={<IconSort />}
             aria-label={t('Sort All Breadcrumbs')}
+            title={t('Sort')}
             {...props}
             {...getFocusProps(BreadcrumbControlOptions.SORT)}
           />
@@ -182,6 +186,7 @@ export function BreadcrumbsDrawer({
               )
             }
             aria-label={t('Change Time Format for All Breadcrumbs')}
+            title={t('Time Format')}
             {...props}
           />
         )}

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+import {Link} from 'react-router-dom';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import moment from 'moment-timezone';
@@ -9,11 +11,40 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import BreadcrumbItemContent from 'sentry/components/events/breadcrumbs/breadcrumbItemContent';
 import type {EnhancedCrumb} from 'sentry/components/events/breadcrumbs/utils';
 import {Timeline} from 'sentry/components/timeline';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import isValidDate from 'sentry/utils/date/isValidDate';
-import {shouldUse24Hours} from 'sentry/utils/dates';
+
+function BreadcrumbTimestampTooltipBody({timestamp}: {timestamp: Date}) {
+  const currentTimezone = useTimezone();
+  const isUTCLocalTimezone = currentTimezone === 'UTC';
+
+  return (
+    <DescriptionList>
+      <dt>{t('Occurred')}</dt>
+      <dd>
+        <TimestampValues>
+          <DateTime date={timestamp} seconds milliseconds timeZone />
+          {!isUTCLocalTimezone && (
+            <DateTime date={timestamp} seconds milliseconds timeZone utc />
+          )}
+        </TimestampValues>
+      </dd>
+      {isUTCLocalTimezone && (
+        <Fragment>
+          <dt />
+          <dd>
+            <TimezoneLink to="/settings/account/details/#timezone">
+              {t('Add your local timezone')}
+            </TimezoneLink>
+          </dd>
+        </Fragment>
+      )}
+    </DescriptionList>
+  );
+}
 
 interface BreadcrumbsTimelineProps {
   breadcrumbs: EnhancedCrumb[];
@@ -74,24 +105,24 @@ export default function BreadcrumbsTimeline({
       breadcrumbs[virtualizedRow.index]!;
     const isVirtualCrumb = !defined(raw);
 
-    const timeDate = new Date(breadcrumb.timestamp ?? '');
+    const timestamp = new Date(breadcrumb.timestamp ?? '');
     const startTimeDate = new Date(startTimeString ?? '');
 
-    const absoluteFormat = shouldUse24Hours() ? 'HH:mm:ss.SSS' : 'hh:mm:ss.SSS A';
-    const timestampComponent = isValidDate(timeDate) ? (
+    const timestampComponent = isValidDate(timestamp) ? (
       <Timestamp>
         <Tooltip
-          title={<DateTime date={timeDate} format={`ll - ${absoluteFormat} (z)`} />}
+          title={<BreadcrumbTimestampTooltipBody timestamp={timestamp} />}
           isHoverable
+          maxWidth={400}
         >
           {isValidDate(startTimeDate) ? (
             <Duration
-              seconds={moment(timeDate).diff(moment(startTimeDate), 's', true)}
+              seconds={moment(timestamp).diff(moment(startTimeDate), 's', true)}
               exact
               abbreviation
             />
           ) : (
-            <DateTime date={timeDate} format={absoluteFormat} />
+            <DateTime date={timestamp} seconds milliseconds timeZone />
           )}
         </Tooltip>
       </Timestamp>
@@ -195,4 +226,23 @@ const BreadcrumbItem = styled(Timeline.Item)`
       )
       100% 1;
   }
+`;
+
+const DescriptionList = styled('dl')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: ${space(0.75)} ${space(1)};
+  text-align: left;
+  margin: 0;
+`;
+
+const TimestampValues = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.25)};
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+const TimezoneLink = styled(Link)`
+  line-height: 0.8;
 `;

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -1,8 +1,9 @@
 import {Fragment} from 'react';
-import {Link} from 'react-router-dom';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import moment from 'moment-timezone';
+
+import {Link} from '@sentry/scraps/link';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {DateTime} from 'sentry/components/dateTime';


### PR DESCRIPTION
Logs and metrics have consolidated on a style of tooltip and absolute date format. This makes issue breadcrumbs more closely match.

Adds some missing tooltips to these breadcrumb control buttons that only have icons.

before

<img width="324" height="133" alt="image" src="https://github.com/user-attachments/assets/009c7e02-da88-49e9-b7b3-0e8fde544ddc" />

after

<img width="371" height="125" alt="image" src="https://github.com/user-attachments/assets/ea9935ba-72d1-4621-9a8d-1b31ecec8b94" />
