### PR TITLE
feat(uptime): Store backfilled misses in Redis for delayed writing

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -512,6 +512,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:view-hierarchy-scrubbing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable email notifications when auto-detected uptime monitors graduate from onboarding
     manager.add("organizations:uptime-auto-detected-monitor-emails", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable tracking and upgrading of late uptime check results
+    manager.add("organizations:uptime-upgrade-late-results", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable endpoint and frontend for AI-powered UF summaries
     manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -14,6 +14,14 @@ def build_last_seen_interval_key(detector: Detector) -> str:
     return f"project-sub-last-seen-interval:detector:{detector.id}"
 
 
+def build_backfilled_miss_key(detector: Detector, scheduled_check_time_ms: int) -> str:
+    return f"uptime:backfilled_miss:{detector.id}:{scheduled_check_time_ms}"
+
+
+def build_pending_misses_key() -> str:
+    return "uptime:pending_misses"
+
+
 def build_detector_fingerprint_component(detector: Detector) -> str:
     return f"uptime-detector:{detector.id}"
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -1407,7 +1407,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             assert miss_data["subscription_id"] == self.subscription.subscription_id
             assert miss_data["status"] == CHECKSTATUS_MISSED_WINDOW
 
-            pending_misses_key = build_pending_misses_key(self.detector)
+            pending_misses_key = build_pending_misses_key()
             pending_misses = cluster.zrange(pending_misses_key, 0, -1)
             assert len(pending_misses) == 1
             assert backfill_key in [


### PR DESCRIPTION
This commit changes the backfill logic to defer writing MISSED_WINDOW results to EAP. Instead, backfilled misses are stored in Redis with their full CheckResult JSON and scheduled for later writing via a sorted set.

This will enable us to implement late results, where we mark a result as late if it arrives after a later event and we have already detected a miss.
