### PR TITLE
ref(projects): Remove usages of `deprecatedRouteProps` from projects children routes

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1350,17 +1350,14 @@ function buildRoutes(): RouteObject[] {
     {
       path: ':projectId/',
       component: make(() => import('sentry/views/projectDetail')),
-      deprecatedRouteProps: true,
     },
     {
       path: ':projectId/events/:eventId/',
       component: errorHandler(ProjectEventRedirect),
-      deprecatedRouteProps: true,
     },
     {
       path: ':projectId/getting-started/',
       component: make(() => import('sentry/views/projectInstall/gettingStarted')),
-      deprecatedRouteProps: true,
     },
   ];
   const projectsRoutes: SentryRouteObject = {

--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -1,17 +1,13 @@
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
-import withOrganization from 'sentry/utils/withOrganization';
 
 import ProjectDetail from './projectDetail';
 
-function ProjectDetailContainer(
-  props: Omit<
-    React.ComponentProps<typeof ProjectDetail>,
-    'projects' | 'loadingProjects' | 'selection'
-  >
-) {
+export default function ProjectDetailContainer() {
+  const params = useParams<{projectId: string}>();
   const {projects} = useProjects();
-  const project = projects.find(p => p.slug === props.params.projectId);
+  const project = projects.find(p => p.slug === params.projectId);
 
   useRouteAnalyticsParams(
     project
@@ -22,7 +18,5 @@ function ProjectDetailContainer(
       : {}
   );
 
-  return <ProjectDetail {...props} />;
+  return <ProjectDetail />;
 }
-
-export default withOrganization(ProjectDetailContainer);

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -23,14 +23,17 @@ import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
+import useRouter from 'sentry/utils/useRouter';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 import {ERRORS_BASIC_CHART_PERIODS} from './charts/projectErrorsBasicChart';
@@ -43,29 +46,25 @@ import ProjectLatestReleases from './projectLatestReleases';
 import ProjectQuickLinks from './projectQuickLinks';
 import ProjectTeamAccess from './projectTeamAccess';
 
-type RouteParams = {
-  orgId: string;
-  projectId: string;
-};
-
-type Props = RouteComponentProps<RouteParams> & {
-  organization: Organization;
-};
-
-export default function ProjectDetail({router, location, organization}: Props) {
+export default function ProjectDetail() {
   const api = useApi();
-  const params = useParams();
+  const params = useParams<{orgId: string; projectId: string}>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const router = useRouter();
   const {projects, fetching: loadingProjects} = useProjects();
   const {selection} = usePageFilters();
   const project = projects.find(p => p.slug === params.projectId);
-  const {query} = location.query;
+  const query = decodeScalar(location.query.query, '');
+  const projectQueryParam = decodeScalar(location.query.project);
   const hasPerformance = organization.features.includes('performance-view');
   const hasDiscover = organization.features.includes('discover-basic');
   const hasTransactions = hasPerformance && project?.firstTransactionEvent;
   const projectId = project?.id;
   const isProjectStabilized =
     defined(project?.id) &&
-    project.id === location.query.project &&
+    project.id === projectQueryParam &&
     project.id === String(selection.projects[0]);
   const hasSessions = project?.hasSessions ?? null;
   const hasOnlyBasicChart = !hasPerformance && !hasDiscover && !hasSessions;
@@ -82,20 +81,23 @@ export default function ProjectDetail({router, location, organization}: Props) {
   }, [hasTransactions, hasSessions]);
 
   const onRetryProjects = useCallback(() => {
-    fetchOrganizationDetails(api, params.orgId!);
+    fetchOrganizationDetails(api, params.orgId);
   }, [api, params.orgId]);
 
   const handleSearch = useCallback(
     (searchQuery: string) => {
-      router.replace({
-        pathname: location.pathname,
-        query: {
-          ...location.query,
-          query: searchQuery,
+      navigate(
+        {
+          pathname: location.pathname,
+          query: {
+            ...location.query,
+            query: searchQuery,
+          },
         },
-      });
+        {replace: true}
+      );
     },
-    [router, location.query, location.pathname]
+    [navigate, location.query, location.pathname]
   );
 
   const tagValueLoader = useCallback(
@@ -105,22 +107,22 @@ export default function ProjectDetail({router, location, organization}: Props) {
         orgSlug: organization.slug,
         tagKey: key,
         search,
-        projectIds: location.query.project ? [location.query.project] : undefined,
+        projectIds: projectQueryParam ? [projectQueryParam] : undefined,
         endpointParams: location.query,
       });
     },
-    [api, organization.slug, location.query]
+    [api, organization.slug, location.query, projectQueryParam]
   );
 
   useEffect(() => {
     function syncProjectWithSlug() {
-      if (projectId && projectId !== location.query.project) {
+      if (projectId && projectId !== projectQueryParam) {
         // if someone visits /organizations/sentry/projects/javascript/ (without ?project=XXX) we need to update URL and globalSelection with the right project ID
         updateProjects([Number(projectId)], router);
       }
     }
     syncProjectWithSlug();
-  }, [location.query.project, router, projectId]);
+  }, [projectQueryParam, router, projectId]);
 
   if (!loadingProjects && !project) {
     return (
@@ -263,14 +265,14 @@ export default function ProjectDetail({router, location, organization}: Props) {
                 <Feature features="incidents" organization={organization}>
                   <ProjectLatestAlerts
                     organization={organization}
-                    projectSlug={params.projectId!}
+                    projectSlug={params.projectId}
                     location={location}
                     isProjectStabilized={isProjectStabilized}
                   />
                 </Feature>
                 <ProjectLatestReleases
                   organization={organization}
-                  projectSlug={params.projectId!}
+                  projectSlug={params.projectId}
                   location={location}
                   isProjectStabilized={isProjectStabilized}
                   project={project}

--- a/static/app/views/projectEventRedirect.tsx
+++ b/static/app/views/projectEventRedirect.tsx
@@ -3,10 +3,8 @@ import {useEffect, useState} from 'react';
 import DetailedError from 'sentry/components/errors/detailedError';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
-
-type Props = RouteComponentProps;
 
 /**
  * This component performs a client-side redirect to Event Details given only
@@ -18,10 +16,10 @@ type Props = RouteComponentProps;
  * See:
  * https://github.com/getsentry/sentry/blob/824c03089907ad22a9282303a5eaca33989ce481/src/sentry/web/urls.py#L578
  */
-function ProjectEventRedirect({router}: Props) {
+export default function ProjectEventRedirect() {
   const [error, setError] = useState<string | null>(null);
-
-  const params = useParams();
+  const navigate = useNavigate();
+  const params = useParams<{eventId: string; orgId: string; projectId: string}>();
 
   useEffect(() => {
     // This presumes that _this_ React view/route is only reachable at
@@ -55,7 +53,7 @@ function ProjectEventRedirect({router}: Props) {
       // this redirect business.
       const url = new URL(xhr.responseURL);
       if (url.origin === window.location.origin) {
-        router.replace(url.pathname);
+        navigate(url.pathname, {replace: true});
       } else {
         // If the origin has changed, we cannot do a simple replace with the router.
         // Instead, we opt to do a full redirect.
@@ -65,7 +63,7 @@ function ProjectEventRedirect({router}: Props) {
     xhr.onerror = () => {
       setError(t('Could not load the requested event'));
     };
-  }, [params, router]);
+  }, [params, navigate]);
 
   return error ? (
     <DetailedError heading={t('Not found')} message={error} hideSupportLinks />
@@ -73,5 +71,3 @@ function ProjectEventRedirect({router}: Props) {
     <Layout.Page withPadding />
   );
 }
-
-export default ProjectEventRedirect;

--- a/static/app/views/projectInstall/gettingStarted.spec.tsx
+++ b/static/app/views/projectInstall/gettingStarted.spec.tsx
@@ -1,13 +1,12 @@
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 
-import PlatformOrIntegration from './gettingStarted';
+import GettingStarted from './gettingStarted';
 
 type ProjectWithBadPlatform = Omit<Project, 'platform'> & {
   platform: string;
@@ -54,20 +53,18 @@ describe('ProjectInstallPlatform', () => {
   it('should render getting started docs for correct platform', async () => {
     const project = ProjectFixture({platform: 'javascript'});
 
-    const {routerProps} = initializeOrg({
-      router: {
-        params: {
-          projectId: project.slug,
-          platform: 'python',
-        },
-      },
-    });
-
     ProjectsStore.loadInitialData([project]);
 
     mockProjectApiResponses([project]);
 
-    render(<PlatformOrIntegration {...routerProps} />);
+    render(<GettingStarted />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/org-slug/projects/${project.slug}/getting-started/`,
+        },
+        route: '/organizations/:orgId/projects/:projectId/getting-started/',
+      },
+    });
 
     expect(
       await screen.findByRole('heading', {

--- a/static/app/views/projectInstall/gettingStarted.tsx
+++ b/static/app/views/projectInstall/gettingStarted.tsx
@@ -5,17 +5,16 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Redirect from 'sentry/components/redirect';
 import allPlatforms from 'sentry/data/platforms';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 import {ProjectInstallPlatform} from './platform';
 
-type Props = RouteComponentProps<{projectId: string}>;
-
-function GettingStarted({params}: Props) {
+export default function GettingStarted() {
   const organization = useOrganization();
+  const params = useParams<{projectId: string}>();
 
   const {projects, initiallyLoaded} = useProjects({
     slugs: [params.projectId],
@@ -53,5 +52,3 @@ const GettingStartedLayout = styled(Layout.Page)`
   background: ${p => p.theme.tokens.background.primary};
   padding-top: ${space(3)};
 `;
-
-export default GettingStarted;


### PR DESCRIPTION
Migrates Projects children views off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7