### PR TITLE
Revert "ref(span-buffer): Emit outcome for dropped spans"

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -74,27 +74,10 @@ if #sunionstore_args > 0 then
     redis.call("zunionstore", set_key, #sunionstore_args + 1, set_key, unpack(sunionstore_args))
     redis.call("unlink", unpack(sunionstore_args))
 
-    -- Merge ingested count keys for merged spans
-    local ingested_count_key = string.format("span-buf:ic:%s", set_key)
-    for i = 1, #sunionstore_args do
-        local merged_key = sunionstore_args[i]
-        local merged_ic_key = string.format("span-buf:ic:%s", merged_key)
-        local merged_count = redis.call("get", merged_ic_key)
-        if merged_count then
-            redis.call("incrby", ingested_count_key, merged_count)
-        end
-        redis.call("del", merged_ic_key)
-    end
-
     while (redis.call("memory", "usage", set_key) or 0) > max_segment_bytes do
         redis.call("zpopmin", set_key)
     end
 end
-
--- Track total number of spans ingested for this segment
-local ingested_count_key = string.format("span-buf:ic:%s", set_key)
-redis.call("incrby", ingested_count_key, num_spans)
-redis.call("expire", ingested_count_key, set_timeout)
 
 redis.call("expire", set_key, set_timeout)
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -59,7 +59,6 @@ Glossary for types of keys:
     * span-buf:q:* -- the priority queue, used to determine which segments are ready to be flushed.
     * span-buf:hrs:* -- simple bool key to flag a segment as "has root span" (HRS)
     * span-buf:sr:* -- redirect mappings so that each incoming span ID can be mapped to the right span-buf:z: set.
-    * span-buf:ic:* -- ingested count, tracks total number of spans originally ingested for a segment (used to calculate dropped spans for outcome tracking)
 """
 
 from __future__ import annotations
@@ -77,12 +76,9 @@ from django.utils.functional import cached_property
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry import options
-from sentry.constants import DataCategory
-from sentry.models.project import Project
 from sentry.processing.backpressure.memory import ServiceMemory, iter_cluster_memory_usage
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.utils import metrics, redis
-from sentry.utils.outcomes import Outcome, track_outcome
 
 # SegmentKey is an internal identifier used by the redis buffer that is also
 # directly used as raw redis key. the format is
@@ -490,9 +486,9 @@ class SpansBuffer:
                         p.sscan(key, cursor=cursor, count=page_size)
                     current_keys.append(key)
 
-                scan_results = p.execute()
+                results = p.execute()
 
-            for key, (cursor, scan_values) in zip(current_keys, scan_results):
+            for key, (cursor, scan_values) in zip(current_keys, results):
                 decompressed_spans = []
 
                 for scan_value in scan_values:
@@ -514,43 +510,6 @@ class SpansBuffer:
                 else:
                     cursors[key] = cursor
 
-        # Fetch ingested counts for all segments to calculate dropped spans
-        with self.client.pipeline(transaction=False) as p:
-            for key in segment_keys:
-                ingested_count_key = b"span-buf:ic:" + key
-                p.get(ingested_count_key)
-
-            ingested_count_results = p.execute()
-
-        # Calculate dropped counts: total ingested - successfully loaded
-        for key, ingested_count in zip(segment_keys, ingested_count_results):
-            if ingested_count:
-                total_ingested = int(ingested_count)
-                successfully_loaded = len(payloads.get(key, []))
-                dropped = total_ingested - successfully_loaded
-                if dropped <= 0:
-                    continue
-
-                project_id_bytes, _, _ = parse_segment_key(key)
-                project_id = int(project_id_bytes)
-                try:
-                    project = Project.objects.get_from_cache(id=project_id)
-                except Project.DoesNotExist:
-                    logger.warning(
-                        "Project does not exist for segment with dropped spans",
-                        extra={"project_id": project_id},
-                    )
-                else:
-                    track_outcome(
-                        org_id=project.organization_id,
-                        project_id=project_id,
-                        key_id=None,
-                        outcome=Outcome.INVALID,
-                        reason="segment_too_large",
-                        category=DataCategory.SPAN_INDEXED,
-                        quantity=dropped,
-                    )
-
         for key, spans in payloads.items():
             if not spans:
                 # This is a bug, most likely the input topic is not
@@ -567,7 +526,6 @@ class SpansBuffer:
             with self.client.pipeline(transaction=False) as p:
                 for segment_key, flushed_segment in segment_keys.items():
                     p.delete(b"span-buf:hrs:" + segment_key)
-                    p.delete(b"span-buf:ic:" + segment_key)
                     p.unlink(segment_key)
                     p.zrem(flushed_segment.queue_key, segment_key)
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -632,14 +632,7 @@ def test_compression_functionality(compression_level) -> None:
         assert_clean(buffer.client)
 
 
-@mock.patch("sentry.spans.buffer.Project")
-def test_max_segment_spans_limit(mock_project_model, buffer: SpansBuffer) -> None:
-    # Mock the project lookup to avoid database access
-    mock_project = mock.Mock()
-    mock_project.id = 1
-    mock_project.organization_id = 100
-    mock_project_model.objects.get_from_cache.return_value = mock_project
-
+def test_max_segment_spans_limit(buffer: SpansBuffer) -> None:
     batch1 = [
         Span(
             payload=_payload("c" * 16),
@@ -706,109 +699,6 @@ def test_max_segment_spans_limit(mock_project_model, buffer: SpansBuffer) -> Non
     # NB: We currently accept that we leak redirect keys when we limit segments.
     # buffer.done_flush_segments(rv)
     # assert_clean(buffer.client)
-
-
-@mock.patch("sentry.spans.buffer.Project")
-@mock.patch("sentry.spans.buffer.track_outcome")
-def test_dropped_spans_emit_outcomes(
-    mock_track_outcome, mock_project_model, buffer: SpansBuffer
-) -> None:
-    """Test that outcomes are emitted when Redis drops spans due to size limit."""
-    from sentry.constants import DataCategory
-    from sentry.utils.outcomes import Outcome
-
-    # Mock the project lookup
-    mock_project = mock.Mock()
-    mock_project.id = 1
-    mock_project.organization_id = 100
-    mock_project_model.objects.get_from_cache.return_value = mock_project
-
-    # Create a segment with many spans that will exceed the Redis memory limit
-    batch1 = [
-        Span(
-            payload=_payload("b" * 16),
-            trace_id="a" * 32,
-            span_id="b" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-            end_timestamp=1700000000.0,
-        ),
-        Span(
-            payload=_payload("c" * 16),
-            trace_id="a" * 32,
-            span_id="c" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-            end_timestamp=1700000001.0,
-        ),
-        Span(
-            payload=_payload("d" * 16),
-            trace_id="a" * 32,
-            span_id="d" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-            end_timestamp=1700000002.0,
-        ),
-    ]
-    batch2 = [
-        Span(
-            payload=_payload("e" * 16),
-            trace_id="a" * 32,
-            span_id="e" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-            end_timestamp=1700000003.0,
-        ),
-        Span(
-            payload=_payload("f" * 16),
-            trace_id="a" * 32,
-            span_id="f" * 16,
-            parent_span_id="a" * 16,
-            segment_id=None,
-            project_id=1,
-            end_timestamp=1700000004.0,
-        ),
-        Span(
-            payload=_payload("a" * 16),
-            trace_id="a" * 32,
-            span_id="a" * 16,
-            parent_span_id=None,
-            project_id=1,
-            segment_id=None,
-            is_segment_span=True,
-            end_timestamp=1700000005.0,
-        ),
-    ]
-
-    # Set a very small max-segment-bytes to force Redis to drop spans
-    with override_options({"spans.buffer.max-segment-bytes": 200}):
-        buffer.process_spans(batch1, now=0)
-        buffer.process_spans(batch2, now=0)
-        buffer.flush_segments(now=11)
-
-    # Verify that track_outcome was called
-    assert mock_track_outcome.called, "track_outcome should be called when spans are dropped"
-
-    # Find the call with INVALID outcome
-    outcome_calls = [
-        call
-        for call in mock_track_outcome.call_args_list
-        if call.kwargs.get("outcome") == Outcome.INVALID
-    ]
-    assert len(outcome_calls) > 0, "Should have at least one INVALID outcome"
-
-    # Verify the outcome details
-    outcome_call = outcome_calls[0]
-    assert outcome_call.kwargs["org_id"] == 100
-    assert outcome_call.kwargs["project_id"] == 1
-    assert outcome_call.kwargs["outcome"] == Outcome.INVALID
-    assert outcome_call.kwargs["reason"] == "segment_too_large"
-    assert outcome_call.kwargs["category"] == DataCategory.SPAN_INDEXED
-    assert outcome_call.kwargs["quantity"] > 0, "Should have dropped at least some spans"
 
 
 def test_kafka_slice_id(buffer: SpansBuffer) -> None:


### PR DESCRIPTION
Reverts getsentry/sentry#104323

This added logic might be causing slowdowns when the max segments is hit.