### PR TITLE
ref(occurrences on eap): Rename EAP RPC class for Occurrences

### DIFF
--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -10,10 +10,10 @@ from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolv
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
 
-logger = logging.getLogger("sentry.snuba.occurrences_rpc")
+logger = logging.getLogger(__name__)
 
 
-class OccurrencesRPC(rpc_dataset_common.RPCBase):
+class Occurrences(rpc_dataset_common.RPCBase):
     DEFINITIONS = OCCURRENCE_DEFINITIONS
 
     @classmethod

--- a/tests/sentry/snuba/test_rpc_dataset_common.py
+++ b/tests/sentry/snuba/test_rpc_dataset_common.py
@@ -5,7 +5,7 @@ from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageCon
 
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
-from sentry.snuba.occurrences_rpc import OccurrencesRPC
+from sentry.snuba.occurrences_rpc import Occurrences
 from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.rpc_dataset_common import RPCBase, TableQuery
 from sentry.snuba.spans_rpc import Spans
@@ -110,7 +110,7 @@ trace_id_test_cases = (
     [
         pytest.param(Spans, id="spans"),
         pytest.param(OurLogs, id="ourlogs"),
-        pytest.param(OccurrencesRPC, id="occurrences"),
+        pytest.param(Occurrences, id="occurrences"),
     ],
 )
 @pytest.mark.parametrize(trace_id_test_cases[0], trace_id_test_cases[1])
@@ -136,7 +136,7 @@ def test_force_sampling_mode_in_table(dataset, query, mode):
     [
         pytest.param(Spans, id="spans"),
         pytest.param(OurLogs, id="ourlogs"),
-        pytest.param(OccurrencesRPC, id="occurrences"),
+        pytest.param(Occurrences, id="occurrences"),
     ],
 )
 @pytest.mark.parametrize(trace_id_test_cases[0], trace_id_test_cases[1])


### PR DESCRIPTION
Renaming this class from `OccurrencesRPC` to `Occurrences` to be in line with the classes for other datasets (e.g. `Spans`, `OurLogs`).