### PR TITLE
fix(agents): Restore 'agent-monitoring.page-view' analytic event

### DIFF
--- a/static/app/views/insights/agentModels/views/modelsLandingPage.tsx
+++ b/static/app/views/insights/agentModels/views/modelsLandingPage.tsx
@@ -24,6 +24,7 @@ import {ModelsTable} from 'sentry/views/insights/pages/agents/components/modelsT
 import {WidgetGrid} from 'sentry/views/insights/pages/agents/components/styles';
 import TokenTypesWidget from 'sentry/views/insights/pages/agents/components/tokenTypesWidget';
 import TokenUsageWidget from 'sentry/views/insights/pages/agents/components/tokenUsageWidget';
+import {useAgentMonitoringTrackPageView} from 'sentry/views/insights/pages/agents/hooks/useAgentMonitoringTrackPageView';
 import {useAgentSpanSearchProps} from 'sentry/views/insights/pages/agents/hooks/useAgentSpanSearchProps';
 import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
@@ -39,6 +40,8 @@ function AgentModelsLandingPage({datePageFilterProps}: AgentModelsLandingPagePro
   useDefaultToAllProjects();
 
   const agentSpanSearchProps = useAgentSpanSearchProps();
+
+  useAgentMonitoringTrackPageView();
 
   return (
     <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>

--- a/static/app/views/insights/agentTools/views/toolsLandingPage.tsx
+++ b/static/app/views/insights/agentTools/views/toolsLandingPage.tsx
@@ -23,6 +23,7 @@ import {TwoColumnWidgetGrid} from 'sentry/views/insights/pages/agents/components
 import ToolUsageWidget from 'sentry/views/insights/pages/agents/components/toolCallsWidget';
 import ToolErrorsWidget from 'sentry/views/insights/pages/agents/components/toolErrorsWidget';
 import {ToolsTable} from 'sentry/views/insights/pages/agents/components/toolsTable';
+import {useAgentMonitoringTrackPageView} from 'sentry/views/insights/pages/agents/hooks/useAgentMonitoringTrackPageView';
 import {useAgentSpanSearchProps} from 'sentry/views/insights/pages/agents/hooks/useAgentSpanSearchProps';
 import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
@@ -38,6 +39,8 @@ function AgentToolsLandingPage({datePageFilterProps}: AgentToolsLandingPageProps
   useDefaultToAllProjects();
 
   const agentSpanSearchProps = useAgentSpanSearchProps();
+
+  useAgentMonitoringTrackPageView();
 
   return (
     <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>

--- a/static/app/views/insights/aiGenerations/views/overview.tsx
+++ b/static/app/views/insights/aiGenerations/views/overview.tsx
@@ -19,13 +19,10 @@ import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {IconChevron, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
-import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import SchemaHintsList from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
 import {TableActionButton} from 'sentry/views/explore/components/tableActionButton';
@@ -44,22 +41,12 @@ import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/componen
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
+import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 const DISABLE_AGGREGATES: never[] = [];
-
-function useShowOnboarding() {
-  const {projects} = useProjects();
-  const pageFilters = usePageFilters();
-  const selectedProjects = getSelectedProjectList(
-    pageFilters.selection.projects,
-    projects
-  );
-
-  return !selectedProjects.some(p => p.hasInsightsAgentMonitoring);
-}
 
 interface AIGenerationsPageProps {
   datePageFilterProps: DatePageFilterProps;
@@ -68,7 +55,7 @@ interface AIGenerationsPageProps {
 function AIGenerationsPage({datePageFilterProps}: AIGenerationsPageProps) {
   const organization = useOrganization();
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const showOnboarding = useShowOnboarding();
+  const showOnboarding = useShowAgentOnboarding();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
 
   const [searchQuery, setSearchQuery] = useQueryState(

--- a/static/app/views/insights/aiGenerations/views/overview.tsx
+++ b/static/app/views/insights/aiGenerations/views/overview.tsx
@@ -41,6 +41,7 @@ import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/componen
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
+import {useAgentMonitoringTrackPageView} from 'sentry/views/insights/pages/agents/hooks/useAgentMonitoringTrackPageView';
 import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
@@ -57,6 +58,8 @@ function AIGenerationsPage({datePageFilterProps}: AIGenerationsPageProps) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const showOnboarding = useShowAgentOnboarding();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
+
+  useAgentMonitoringTrackPageView();
 
   const [searchQuery, setSearchQuery] = useQueryState(
     'query',

--- a/static/app/views/insights/pages/agents/hooks/useAgentMonitoringTrackPageView.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAgentMonitoringTrackPageView.tsx
@@ -1,0 +1,17 @@
+import {useEffect} from 'react';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
+
+export function useAgentMonitoringTrackPageView() {
+  const showOnboarding = useShowAgentOnboarding();
+  const organization = useOrganization();
+
+  useEffect(() => {
+    trackAnalytics('agent-monitoring.page-view', {
+      organization,
+      isOnboarding: showOnboarding,
+    });
+  }, [organization, showOnboarding]);
+}

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -11,12 +11,9 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {DataCategory} from 'sentry/types/core';
-import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -40,6 +37,7 @@ import TokenUsageWidget from 'sentry/views/insights/pages/agents/components/toke
 import ToolUsageWidget from 'sentry/views/insights/pages/agents/components/toolCallsWidget';
 import {TracesTable} from 'sentry/views/insights/pages/agents/components/tracesTable';
 import {useAgentSpanSearchProps} from 'sentry/views/insights/pages/agents/hooks/useAgentSpanSearchProps';
+import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
 import {getAgentRunsFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
@@ -47,24 +45,13 @@ import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 
-function useShowOnboarding() {
-  const {projects} = useProjects();
-  const pageFilters = usePageFilters();
-  const selectedProjects = getSelectedProjectList(
-    pageFilters.selection.projects,
-    projects
-  );
-
-  return !selectedProjects.some(p => p.hasInsightsAgentMonitoring);
-}
-
 interface AgentsOverviewPageProps {
   datePageFilterProps: DatePageFilterProps;
 }
 
 function AgentsOverviewPage({datePageFilterProps}: AgentsOverviewPageProps) {
   const organization = useOrganization();
-  const showOnboarding = useShowOnboarding();
+  const showOnboarding = useShowAgentOnboarding();
   useDefaultToAllProjects();
 
   const {value: conversationTable} = useConversationsTableSwitch();

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -36,6 +36,7 @@ import {WidgetGrid} from 'sentry/views/insights/pages/agents/components/styles';
 import TokenUsageWidget from 'sentry/views/insights/pages/agents/components/tokenUsageWidget';
 import ToolUsageWidget from 'sentry/views/insights/pages/agents/components/toolCallsWidget';
 import {TracesTable} from 'sentry/views/insights/pages/agents/components/tracesTable';
+import {useAgentMonitoringTrackPageView} from 'sentry/views/insights/pages/agents/hooks/useAgentMonitoringTrackPageView';
 import {useAgentSpanSearchProps} from 'sentry/views/insights/pages/agents/hooks/useAgentSpanSearchProps';
 import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
@@ -58,6 +59,7 @@ function AgentsOverviewPage({datePageFilterProps}: AgentsOverviewPageProps) {
   const agentSpanSearchProps = useAgentSpanSearchProps();
 
   useOverviewPageTrackPageload();
+  useAgentMonitoringTrackPageView();
 
   // Fire a request to check if there are any agent runs
   // If there are, we show the count/duration of agent runs


### PR DESCRIPTION
- Add the event to all pages inside Insights / Agents ✅
- The types for the event properties in the code base are still valid (see isOnboarding) ✅

contributes to https://linear.app/getsentry/issue/TET-1610/restore-agent-monitoringpage-view-event