### PR TITLE
feat(security): adjustments to GitHub secret scanning endpoint

### DIFF
--- a/src/sentry/api/endpoints/secret_scanning/github.py
+++ b/src/sentry/api/endpoints/secret_scanning/github.py
@@ -118,7 +118,7 @@ class SecretScanningGitHubEndpoint(View):
                     # TODO: revoke token
                     pass
 
-                # Send an email
+                # Send an email notification
                 url_prefix = options.get("system.url-prefix")
                 if isinstance(token, ApiToken):
                     # for personal token, send an alert to the token owner
@@ -160,7 +160,12 @@ class SecretScanningGitHubEndpoint(View):
                     type="user.secret-scanning-alert",
                     context=context,
                 )
-                msg.send_async([u.username for u in users])
+
+                # only send email to users in the allowlist
+                allowed_emails = options.get("secret-scanning.github.notifications.email-allowlist")
+                recipients = [u.email for u in users if u.email in allowed_emails]
+                if recipients:
+                    msg.send_async(recipients)
 
                 response.append(
                     {

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3441,6 +3441,13 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Secret Scanning. Email allowlist for notifications.
+register(
+    "secret-scanning.github.notifications.email-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Rate limiting for the occurrence consumer
 register(


### PR DESCRIPTION
Continuation of https://github.com/getsentry/sentry/pull/78386 and preparing for getting secret exposure notifications from GitHub. Fixes in this PR:
* Update naming according to https://github.com/getsentry/sentry-docs/pull/13914
* Gate the email notification feature (send emails only to special users for now)
* Provide feedback to GitHub on true positives (when their detection was correct)