### PR TITLE
fix(ai): Add vercel operation names to operation type mapping

### DIFF
--- a/src/sentry/relay/config/ai_operation_type_map.py
+++ b/src/sentry/relay/config/ai_operation_type_map.py
@@ -14,8 +14,10 @@ AI_OPERATION_TYPE_MAP: dict[AI_OPERATION_TYPE_VALUE, list[str]] = {
         "gen_ai.create_agent",
         "invoke_agent",
         "create_agent",
+        "ai.streamText*",
+        "ai.generateText*",
     ],
-    "tool": ["gen_ai.execute_tool", "execute_tool"],
+    "tool": ["gen_ai.execute_tool", "execute_tool", "ai.toolCall*"],
     "handoff": ["gen_ai.handoff", "handoff"],
     "ai_client": ["*"],  # default fallback
 }


### PR DESCRIPTION
In our Vercel integration we report some more posibilites for `agent` and `tool` so this adds them for a proper mapping
