### PR TITLE
fix(agents): Read messages length from attribute

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -244,7 +244,7 @@ export function AIInputSection({
           key={node.id}
           messages={messages}
           originalLength={
-            originalMessagesLength ? Number(originalMessagesLength) : undefined
+            defined(originalMessagesLength) ? Number(originalMessagesLength) : undefined
           }
         />
       ) : null}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -12,10 +12,7 @@ import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import usePrevious from 'sentry/utils/usePrevious';
-import type {
-  TraceItemDetailsMeta,
-  TraceItemResponseAttribute,
-} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   getIsAiNode,
   getTraceNodeAttribute,
@@ -178,17 +175,19 @@ function useInvalidRoleDetection(roles: string[]) {
 export function AIInputSection({
   node,
   attributes,
-  attributesMeta,
   event,
 }: {
   node: EapSpanNode | SpanNode | TransactionNode;
   attributes?: TraceItemResponseAttribute[];
-  attributesMeta?: TraceItemDetailsMeta;
   event?: EventTransaction;
 }) {
   const shouldRender = getIsAiNode(node) && hasAIInputAttribute(node, attributes, event);
-  const messagesMeta = attributesMeta?.['gen_ai.request.messages']?.meta as any;
-  const originalMessagesLength: number | undefined = messagesMeta?.['']?.len;
+  const originalMessagesLength = getTraceNodeAttribute(
+    'gen_ai.request.messages.original_length',
+    node,
+    event,
+    attributes
+  );
 
   let promptMessages = shouldRender
     ? getTraceNodeAttribute('gen_ai.request.messages', node, event, attributes)
@@ -244,7 +243,9 @@ export function AIInputSection({
         <MessagesArrayRenderer
           key={node.id}
           messages={messages}
-          originalLength={originalMessagesLength}
+          originalLength={
+            originalMessagesLength ? Number(originalMessagesLength) : undefined
+          }
         />
       ) : null}
       {toolArgs ? (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -444,7 +444,6 @@ function EAPSpanNodeDetailsContent({
   traceItemData: TraceItemDetailsResponse;
 }) {
   const attributes = traceItemData.attributes;
-  const attributesMeta = traceItemData.meta;
   const links = traceItemData.links;
   const isTransaction = node.value.is_transaction && !!eventTransaction;
 
@@ -521,11 +520,7 @@ function EAPSpanNodeDetailsContent({
           hideNodeActions={hideNodeActions}
         />
         <AIIOAlert node={node} attributes={attributes} />
-        <AIInputSection
-          node={node}
-          attributes={attributes}
-          attributesMeta={attributesMeta}
-        />
+        <AIInputSection node={node} attributes={attributes} />
         <AIOutputSection node={node} attributes={attributes} />
         <MCPInputSection node={node} attributes={attributes} />
         <MCPOutputSection node={node} attributes={attributes} />


### PR DESCRIPTION
Using the len meta is not a viable option for storing the original amount of messages in the request messages as there are other mechanisms using it for different data (e.g. relay setting char count).
This PR switches over the UI logic to a new attribute `gen_ai.request.messages.original_length`, which will be sent by SDKs in the future.

- closes [TET-1622: Fix messages len message](https://linear.app/getsentry/issue/TET-1622/fix-messages-len-message)