### PR TITLE
fix(replay): Format access update notification

### DIFF
--- a/static/app/data/forms/organizationMembershipSettings.tsx
+++ b/static/app/data/forms/organizationMembershipSettings.tsx
@@ -130,6 +130,7 @@ const formGroups: JsonFormObject[] = [
         label: t('Replay Access Members'),
         help: t('Select the members who will have access to replay data.'),
         multiple: true,
+        formatMessageValue: false,
         visible: ({model, features}) =>
           features.has('granular-replay-permissions') &&
           model.getValue('hasGranularReplayPermissions'),


### PR DESCRIPTION
**Before**
<img width="574" height="106" alt="Screenshot 2025-12-16 at 12 42 47" src="https://github.com/user-attachments/assets/e0daa093-480f-4c87-8bc3-8d6fadbd58b3" />


**After**
<img width="574" height="106" alt="Screenshot 2025-12-16 at 12 43 12" src="https://github.com/user-attachments/assets/a5e538a3-c071-4d88-8390-f37e0d4ac6a9" />
