### PR TITLE
feat(replays): allow org:write to change granular replay permission settings instead of org:admin

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -500,7 +500,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         if not features.has("organizations:granular-replay-permissions", organization):
             raise NotFound("This feature is not enabled for your organization.")
 
-        if not request.access.has_scope("org:admin"):
+        if not request.access.has_scope("org:write"):
             raise PermissionDenied(
                 "You do not have permission to modify granular replay permissions."
             )


### PR DESCRIPTION
- Allow `org:write` to change the granular replay permission settings instead of `org:admin`
- Add tests to make sure we correctly gate this