### PR TITLE
fix(logs): Use replace for first page param init

### DIFF
--- a/static/app/views/explore/logs/usePersistentLogsPageParameters.spec.tsx
+++ b/static/app/views/explore/logs/usePersistentLogsPageParameters.spec.tsx
@@ -59,7 +59,8 @@ describe('usePersistentLogsPageParameters', () => {
           [LOGS_FIELDS_KEY]: ['message', 'sentry.message.parameters.0'],
           [LOGS_SORT_BYS_KEY]: ['sentry.message.parameters.0'],
         }),
-      })
+      }),
+      {replace: true}
     );
   });
 
@@ -87,5 +88,38 @@ describe('usePersistentLogsPageParameters', () => {
     render(<Main />);
 
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('uses replace to navigate only on the first render', () => {
+    (useLocation as jest.Mock).mockReturnValue({
+      pathname: '/logs/',
+      query: {},
+    });
+
+    (usePersistedLogsPageParams as jest.Mock).mockReturnValue([
+      {
+        fields: ['message'],
+        sortBys: [{field: 'message', order: 'desc'}],
+      },
+    ]);
+
+    function Main() {
+      usePersistentLogsPageParameters();
+      return <div>main</div>;
+    }
+
+    const {rerender} = render(<Main />);
+    expect(navigateMock).toHaveBeenCalledWith(expect.anything(), {replace: true});
+
+    // Change the fields and sort by props to retrigger navigation
+    (usePersistedLogsPageParams as jest.Mock).mockReturnValue([
+      {
+        fields: ['test'],
+        sortBys: [{field: 'test', order: 'desc'}],
+      },
+    ]);
+
+    rerender(<Main />);
+    expect(navigateMock).toHaveBeenCalledWith(expect.anything(), {replace: false});
   });
 });

--- a/static/app/views/explore/logs/usePersistentLogsPageParameters.tsx
+++ b/static/app/views/explore/logs/usePersistentLogsPageParameters.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import type {Location} from 'history';
 
 import {useLocation} from 'sentry/utils/useLocation';
@@ -20,6 +20,11 @@ export function usePersistentLogsPageParameters() {
   const location = useLocation();
   const navigate = useNavigate();
   const [persistedParams] = usePersistedLogsPageParams();
+
+  // The first render for setting these params in the URL should replace the current URL
+  // to avoid adding extra entries to the history stack that lead to a re-init state (i.e.
+  // a URL state where these props need to be re-applied, blocking back navigation)
+  const firstRender = useRef(true);
   useEffect(() => {
     let changedSomething = false;
     const target: Location = {...location, query: {...location.query}};
@@ -32,7 +37,8 @@ export function usePersistentLogsPageParameters() {
       changedSomething = !!target.query[LOGS_SORT_BYS_KEY];
     }
     if (changedSomething) {
-      navigate(target);
+      navigate(target, {replace: firstRender.current});
+      firstRender.current = false;
     }
   }, [location, navigate, persistedParams]);
 }


### PR DESCRIPTION
When a user navigates to logs, we initialize some base state and push it to the URL. That URL push messes up back-navigation because when a user immediately hits "back", they go to the base URL that needs initialization so it gets re-pushed and the user can't successfully navigate.

The solution is to replace the history rather than push onto the stack for the first initialization.