### PR TITLE
fix(loader): adhere to CSP, unflag feature check

### DIFF
--- a/src/sentry/templates/sentry/partial/loader.html
+++ b/src/sentry/templates/sentry/partial/loader.html
@@ -4,131 +4,353 @@
   <div class="loading-mask"></div>
 
   <div class="loading-indicator" data-test-id="loading-indicator">
-      <svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <style>
-            :root {
-                --delay: 0ms;
-                --duration: 900ms;
-                --stagger: 50ms;
-            }
-            path {
-                stroke-dashoffset: 1150;
-                stroke-dasharray: 1150;
-                animation: draw calc(var(--duration) + (var(--i) * var(--stagger)) + (1.3s - var(--delay))) calc(var(--delay) + ((3 - var(--i)) * var(--stagger))) ease-out;
-            }
-            [data-index="0"] {
-                stroke: #F0369A;
-            }
-            [data-index="1"] {
-                stroke: #67C800;
-            }
-            [data-index="2"] {
-                stroke: #7553FF;
-            }
-            @keyframes draw {
-                0% {
-                    stroke-dashoffset: 1150;
-                }
-                40% {
-                    stroke-dashoffset: 0;
-                }
-                100% {
-                    stroke-dashoffset: -1150;
-                }
-            }
-            @media (prefers-reduced-motion: reduce) {
-              path {
-                animation: none;
-                stroke-dashoffset: 0;
-              }
-            }
-        </style>
-        <script>
-            const host = document.currentScript.closest('svg');
-            host.addEventListener('animationend', (event) => {
-                event.target.style.animationName = 'none';
-                setTimeout(() => {
-                    event.target.style.animationName = '';
-                }, 0);
-            })
-        </script>
-        <defs>
-            <filter id="goo">
-                <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
-                <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 34 -6" result="goo" />
-                <feComposite in="SourceGraphic" in2="goo" operator="atop"/>
-            </filter>
-        </defs>
-        <mask id="loader-mask" width="300" height="265" x="50" y="72" maskUnits="userSpaceOnUse" style="mask-type:alpha">
-            <path fill="#000" d="M223.687 85.56a28.02 28.02 0 0 0-24-13.559 28.02 28.02 0 0 0-24 13.559l-39.48 67.62a193.26 193.26 0 0 1 106.5 159.96h-27.72a166.07 166.07 0 0 0-92.76-136.32L85.687 240a95.52 95.52 0 0 1 55.38 73.02h-63.66a4.55 4.55 0 0 1-3.659-2.325 4.56 4.56 0 0 1-.06-4.335l17.64-30a64.4 64.4 0 0 0-20.16-11.4l-17.46 30a27.24 27.24 0 0 0 2.023 30.435 27.2 27.2 0 0 0 8.116 7.005 27.96 27.96 0 0 0 13.56 3.6h87.18a116.41 116.41 0 0 0-48-103.86l13.86-24a143.22 143.22 0 0 1 61.8 127.86h73.86a215.28 215.28 0 0 0-98.46-190.8l28.02-48a4.62 4.62 0 0 1 6.3-1.62c3.18 1.74 121.74 208.62 123.96 211.02a4.562 4.562 0 0 1-4.08 6.78h-28.56q.54 11.46 0 22.86h28.68a27.54 27.54 0 0 0 27.72-27.66 26.94 26.94 0 0 0-3.72-13.68z"/>
-        </mask>
-        <g id="root" mask="url(#loader-mask)" filter="url('#goo')">
-            <path stroke="#F0369A" stroke-width="4" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-            <g data-index="0" style="--delay:0s;" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-                <path style="--i: 1;" d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"/>
-                <path style="--i: 0;" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-                <path style="--i: 2;" d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"/>
-            </g>
-            <g data-index="1" style="--delay:180ms;" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-                <path style="--i: 2;" d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"/>
-                <path style="--i: 0;" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-                <path style="--i: 1;" d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"/>
-            </g>
-            <g data-index="2" style="--delay:400ms;" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-                <path style="--i: 0;" d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"/>
-                <path style="--i: 3;" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-                <path style="--i: 1;" d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"/>
-            </g>
+    <svg
+      width="256"
+      height="256"
+      viewBox="0 0 400 400"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <style>
+        .theme-light #base {
+          fill: #f0f0f2;
+        }
+        .theme-dark #base {
+          fill: #24202b;
+        }
+        :root {
+          --loop: 2350ms;
+        }
+
+        g[data-index] path {
+          stroke-dasharray: 1150;
+          stroke-dashoffset: 1150;
+          animation-duration: var(--loop);
+          animation-iteration-count: infinite;
+          animation-fill-mode: both;
+          animation-timing-function: linear;
+        }
+
+        [data-index='0'] {
+          stroke: #f0369a;
+        }
+        [data-index='1'] {
+          stroke: #67c800;
+        }
+        [data-index='2'] {
+          stroke: #7553ff;
+        }
+
+        g[data-index='0'] > path:nth-of-type(1) {
+          animation-name: draw_g0_p1;
+        } /* i=1 */
+        g[data-index='0'] > path:nth-of-type(2) {
+          animation-name: draw_g0_p0;
+        } /* i=0 */
+        g[data-index='0'] > path:nth-of-type(3) {
+          animation-name: draw_g0_p2;
+        } /* i=2 */
+
+        g[data-index='1'] > path:nth-of-type(1) {
+          animation-name: draw_g1_p2;
+        } /* i=2 */
+        g[data-index='1'] > path:nth-of-type(2) {
+          animation-name: draw_g1_p0;
+        } /* i=0 */
+        g[data-index='1'] > path:nth-of-type(3) {
+          animation-name: draw_g1_p1;
+        } /* i=1 */
+
+        g[data-index='2'] > path:nth-of-type(1) {
+          animation-name: draw_g2_p0;
+        } /* i=0 */
+        g[data-index='2'] > path:nth-of-type(2) {
+          animation-name: draw_g2_p3;
+        } /* i=3 */
+        g[data-index='2'] > path:nth-of-type(3) {
+          animation-name: draw_g2_p1;
+        } /* i=1 */
+
+        /*
+          Each baked timeline:
+          - Hold at 1150 until its start %
+          - Ease-out into 0 by its 40% point
+          - Ease-out to -1150 by end of loop
+          - Snap back to 1150 at 100% so the loop repeats cleanly
+        */
+        @keyframes draw_g0_p2 {
+          /* start=  50ms =>  2.127660%, 40% point=41.276596% */
+          0%,
+          2.127660% {
+            stroke-dashoffset: 1150;
+          }
+          2.127660% {
+            animation-timing-function: ease-out;
+          }
+          41.276596% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g0_p1 {
+          /* start= 100ms =>  4.255319%, 40% point=42.553191% */
+          0%,
+          4.255319% {
+            stroke-dashoffset: 1150;
+          }
+          4.255319% {
+            animation-timing-function: ease-out;
+          }
+          42.553191% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g0_p0 {
+          /* start= 150ms =>  6.382979%, 40% point=43.829787% */
+          0%,
+          6.382979% {
+            stroke-dashoffset: 1150;
+          }
+          6.382979% {
+            animation-timing-function: ease-out;
+          }
+          43.829787% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+
+        @keyframes draw_g1_p2 {
+          /* start= 230ms =>  9.787234%, 40% point=45.872340% */
+          0%,
+          9.787234% {
+            stroke-dashoffset: 1150;
+          }
+          9.787234% {
+            animation-timing-function: ease-out;
+          }
+          45.872340% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g1_p1 {
+          /* start= 280ms => 11.914894%, 40% point=47.148936% */
+          0%,
+          11.914894% {
+            stroke-dashoffset: 1150;
+          }
+          11.914894% {
+            animation-timing-function: ease-out;
+          }
+          47.148936% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g1_p0 {
+          /* start= 330ms => 14.042553%, 40% point=48.425532% */
+          0%,
+          14.042553% {
+            stroke-dashoffset: 1150;
+          }
+          14.042553% {
+            animation-timing-function: ease-out;
+          }
+          48.425532% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+
+        @keyframes draw_g2_p3 {
+          /* start= 400ms => 17.021277%, 40% point=50.212766% */
+          0%,
+          17.021277% {
+            stroke-dashoffset: 1150;
+          }
+          17.021277% {
+            animation-timing-function: ease-out;
+          }
+          50.212766% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g2_p1 {
+          /* start= 500ms => 21.276596%, 40% point=52.765957% */
+          0%,
+          21.276596% {
+            stroke-dashoffset: 1150;
+          }
+          21.276596% {
+            animation-timing-function: ease-out;
+          }
+          52.765957% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g2_p0 {
+          /* start= 550ms => 23.404255%, 40% point=54.042553% */
+          0%,
+          23.404255% {
+            stroke-dashoffset: 1150;
+          }
+          23.404255% {
+            animation-timing-function: ease-out;
+          }
+          54.042553% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          g[data-index] path {
+            animation: none;
+            stroke-dashoffset: 0;
+          }
+        }
+      </style>
+
+      <defs>
+        <filter id="goo">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur" />
+          <feColorMatrix
+            in="blur"
+            mode="matrix"
+            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 36 -4"
+            result="goo"
+          />
+          <feComposite in="SourceGraphic" in2="goo" operator="atop" />
+        </filter>
+      </defs>
+
+      <mask
+        id="loader-mask"
+        width="300"
+        height="265"
+        x="50"
+        y="72"
+        maskUnits="userSpaceOnUse"
+        style="mask-type: alpha"
+      >
+        <path
+          fill="#24202B"
+          d="M223.687 85.56a28.02 28.02 0 0 0-24-13.559 28.02 28.02 0 0 0-24 13.559l-39.48 67.62a193.26 193.26 0 0 1 106.5 159.96h-27.72a166.07 166.07 0 0 0-92.76-136.32L85.687 240a95.52 95.52 0 0 1 55.38 73.02h-63.66a4.55 4.55 0 0 1-3.659-2.325 4.56 4.56 0 0 1-.06-4.335l17.64-30a64.4 64.4 0 0 0-20.16-11.4l-17.46 30a27.24 27.24 0 0 0 2.023 30.435 27.2 27.2 0 0 0 8.116 7.005 27.96 27.96 0 0 0 13.56 3.6h87.18a116.41 116.41 0 0 0-48-103.86l13.86-24a143.22 143.22 0 0 1 61.8 127.86h73.86a215.28 215.28 0 0 0-98.46-190.8l28.02-48a4.62 4.62 0 0 1 6.3-1.62c3.18 1.74 121.74 208.62 123.96 211.02a4.562 4.562 0 0 1-4.08 6.78h-28.56q.54 11.46 0 22.86h28.68a27.54 27.54 0 0 0 27.72-27.66 26.94 26.94 0 0 0-3.72-13.68z"
+        />
+      </mask>
+
+      <path
+        id="base"
+        fill="#F0F0F2"
+        d="M223.687 85.56a28.02 28.02 0 0 0-24-13.559 28.02 28.02 0 0 0-24 13.559l-39.48 67.62a193.26 193.26 0 0 1 106.5 159.96h-27.72a166.07 166.07 0 0 0-92.76-136.32L85.687 240a95.52 95.52 0 0 1 55.38 73.02h-63.66a4.55 4.55 0 0 1-3.659-2.325 4.56 4.56 0 0 1-.06-4.335l17.64-30a64.4 64.4 0 0 0-20.16-11.4l-17.46 30a27.24 27.24 0 0 0 2.023 30.435 27.2 27.2 0 0 0 8.116 7.005 27.96 27.96 0 0 0 13.56 3.6h87.18a116.41 116.41 0 0 0-48-103.86l13.86-24a143.22 143.22 0 0 1 61.8 127.86h73.86a215.28 215.28 0 0 0-98.46-190.8l28.02-48a4.62 4.62 0 0 1 6.3-1.62c3.18 1.74 121.74 208.62 123.96 211.02a4.562 4.562 0 0 1-4.08 6.78h-28.56q.54 11.46 0 22.86h28.68a27.54 27.54 0 0 0 27.72-27.66 26.94 26.94 0 0 0-3.72-13.68z"
+      />
+      <g
+        id="root"
+        mask="url(#loader-mask)"
+        filter="url('#goo')"
+        stroke-width="5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <g data-index="0">
+          <path
+            d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"
+          />
+          <path
+            d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"
+          />
+          <path
+            d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"
+          />
         </g>
+
+        <g data-index="1">
+          <path
+            d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"
+          />
+          <path
+            d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"
+          />
+          <path
+            d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"
+          />
+        </g>
+
+        <g data-index="2">
+          <path
+            d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"
+          />
+          <path
+            d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"
+          />
+          <path
+            d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"
+          />
+        </g>
+      </g>
     </svg>
   </div>
 
   <div class="loading-message">
     <p>{% loading_message %}</p>
     <p><small>You may need to disable adblocking extensions to load Sentry.</small></p>
-    <script>
-      function randomFrom(arr) {
-        return arr[Math.floor(Math.random() * arr.length)];
-      }
-      function randomBetween(min, max) {
-        return Math.floor(Math.random() * (max - min - 1) + min);
-      }
-      customElements.define('scraps-bleep', class extends HTMLElement {
-        constructor() {
-          super();
-          this.shapes = '◆●▴▪×'.split('');
-          this.chars = '@#$%&*!+'.split('');
-          this.length = this.textContent.trim().length;
-        }
-        random() {
-          const set = new Set();
-          let hasShape = false;
-          while (set.size < this.length) {
-            if (!hasShape && Math.random() > 0.75) {
-              set.add(randomFrom(this.shapes));
-              hasShape = true;
-            } else {
-              set.add(randomFrom(this.chars));
-            }
-          }
-          return Array.from(set.values()).join('');
-        }
-        shuffle() {
-          this.raf = requestAnimationFrame(() => {
-            this.textContent = this.random();
-            this.timeout = setTimeout(() => this.shuffle(), randomBetween(50, 250));
-          })
-        }
-        connectedCallback() {
-          if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-            this.shuffle();
-          }
-        }
-        disconnectedCallback() {
-          cancelAnimationFrame(this.raf);
-          clearTimeout(this.timeout);
-        }
-      })
-    </script>
   </div>
 </div>

--- a/src/sentry/templates/sentry/partial/loader.html
+++ b/src/sentry/templates/sentry/partial/loader.html
@@ -43,33 +43,33 @@
 
         g[data-index='0'] > path:nth-of-type(1) {
           animation-name: draw_g0_p1;
-        } /* i=1 */
+        }
         g[data-index='0'] > path:nth-of-type(2) {
           animation-name: draw_g0_p0;
-        } /* i=0 */
+        }
         g[data-index='0'] > path:nth-of-type(3) {
           animation-name: draw_g0_p2;
-        } /* i=2 */
+        }
 
         g[data-index='1'] > path:nth-of-type(1) {
           animation-name: draw_g1_p2;
-        } /* i=2 */
+        }
         g[data-index='1'] > path:nth-of-type(2) {
           animation-name: draw_g1_p0;
-        } /* i=0 */
+        }
         g[data-index='1'] > path:nth-of-type(3) {
           animation-name: draw_g1_p1;
-        } /* i=1 */
+        }
 
         g[data-index='2'] > path:nth-of-type(1) {
           animation-name: draw_g2_p0;
-        } /* i=0 */
+        }
         g[data-index='2'] > path:nth-of-type(2) {
           animation-name: draw_g2_p3;
-        } /* i=3 */
+        }
         g[data-index='2'] > path:nth-of-type(3) {
           animation-name: draw_g2_p1;
-        } /* i=1 */
+        }
 
         /*
           Each baked timeline:
@@ -79,19 +79,19 @@
           - Snap back to 1150 at 100% so the loop repeats cleanly
         */
         @keyframes draw_g0_p2 {
-          /* start=  50ms =>  2.127660%, 40% point=41.276596% */
+          /* start=  50ms =>  2.1%, 40% point=41.3% */
           0%,
-          2.127660% {
+          2.1% {
             stroke-dashoffset: 1150;
           }
-          2.127660% {
+          2.1% {
             animation-timing-function: ease-out;
           }
-          41.276596% {
+          41.3% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -99,19 +99,19 @@
           }
         }
         @keyframes draw_g0_p1 {
-          /* start= 100ms =>  4.255319%, 40% point=42.553191% */
+          /* start= 100ms => 4.3%, 40% point=42.6% */
           0%,
-          4.255319% {
+          4.3% {
             stroke-dashoffset: 1150;
           }
-          4.255319% {
+          4.3% {
             animation-timing-function: ease-out;
           }
-          42.553191% {
+          42.6% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -119,19 +119,19 @@
           }
         }
         @keyframes draw_g0_p0 {
-          /* start= 150ms =>  6.382979%, 40% point=43.829787% */
+          /* start= 150ms =>  6.4%, 40% point=43.8% */
           0%,
-          6.382979% {
+          6.4% {
             stroke-dashoffset: 1150;
           }
-          6.382979% {
+          6.4% {
             animation-timing-function: ease-out;
           }
-          43.829787% {
+          43.8% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -140,19 +140,19 @@
         }
 
         @keyframes draw_g1_p2 {
-          /* start= 230ms =>  9.787234%, 40% point=45.872340% */
+          /* start= 230ms =>  9.8%, 40% point=45.9% */
           0%,
-          9.787234% {
+          9.8% {
             stroke-dashoffset: 1150;
           }
-          9.787234% {
+          9.8% {
             animation-timing-function: ease-out;
           }
-          45.872340% {
+          45.9% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -160,19 +160,19 @@
           }
         }
         @keyframes draw_g1_p1 {
-          /* start= 280ms => 11.914894%, 40% point=47.148936% */
+          /* start= 280ms => 11.9%, 40% point=47.1% */
           0%,
-          11.914894% {
+          11.9% {
             stroke-dashoffset: 1150;
           }
-          11.914894% {
+          11.9% {
             animation-timing-function: ease-out;
           }
-          47.148936% {
+          47.1% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -180,19 +180,19 @@
           }
         }
         @keyframes draw_g1_p0 {
-          /* start= 330ms => 14.042553%, 40% point=48.425532% */
+          /* start= 330ms => 14%, 40% point=48.4% */
           0%,
-          14.042553% {
+          14% {
             stroke-dashoffset: 1150;
           }
-          14.042553% {
+          14% {
             animation-timing-function: ease-out;
           }
-          48.425532% {
+          48.4% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -201,19 +201,19 @@
         }
 
         @keyframes draw_g2_p3 {
-          /* start= 400ms => 17.021277%, 40% point=50.212766% */
+          /* start= 400ms => 17%, 40% point=50.2% */
           0%,
-          17.021277% {
+          17% {
             stroke-dashoffset: 1150;
           }
-          17.021277% {
+          17% {
             animation-timing-function: ease-out;
           }
-          50.212766% {
+          50.2% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -221,19 +221,19 @@
           }
         }
         @keyframes draw_g2_p1 {
-          /* start= 500ms => 21.276596%, 40% point=52.765957% */
+          /* start= 500ms => 21.3%, 40% point=52.8% */
           0%,
-          21.276596% {
+          21.3% {
             stroke-dashoffset: 1150;
           }
-          21.276596% {
+          21.3% {
             animation-timing-function: ease-out;
           }
-          52.765957% {
+          52.8% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -241,19 +241,19 @@
           }
         }
         @keyframes draw_g2_p0 {
-          /* start= 550ms => 23.404255%, 40% point=54.042553% */
+          /* start= 550ms => 23.4%, 40% point=54% */
           0%,
-          23.404255% {
+          23.4% {
             stroke-dashoffset: 1150;
           }
-          23.404255% {
+          23.4% {
             animation-timing-function: ease-out;
           }
-          54.042553% {
+          54% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {

--- a/src/sentry/templates/sentry/partial/loader.html
+++ b/src/sentry/templates/sentry/partial/loader.html
@@ -18,6 +18,13 @@
         .theme-dark #base {
           fill: #24202b;
         }
+        .theme-system {
+          @media (prefers-color-scheme: dark) {
+            #base {
+              fill: #24202b;
+            }
+          }
+        }
         :root {
           --loop: 2350ms;
         }

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -47,83 +47,349 @@
       <div class="splash-loader">
         <div class="loading-mask"></div>
         <div class="loading-indicator" data-test-id="loading-indicator">
-            <svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <style>
-                  :root {
-                      --delay: 0ms;
-                      --duration: 900ms;
-                      --stagger: 50ms;
-                  }
-                  path {
-                      stroke-dashoffset: 1150;
-                      stroke-dasharray: 1150;
-                      animation: draw calc(var(--duration) + (var(--i) * var(--stagger)) + (1.3s - var(--delay))) calc(var(--delay) + ((3 - var(--i)) * var(--stagger))) ease-out;
-                  }
-                  [data-index="0"] {
-                      stroke: #F0369A;
-                  }
-                  [data-index="1"] {
-                      stroke: #67C800;
-                  }
-                  [data-index="2"] {
-                      stroke: #7553FF;
-                  }
-                  @keyframes draw {
-                      0% {
-                          stroke-dashoffset: 1150;
-                      }
-                      40% {
-                          stroke-dashoffset: 0;
-                      }
-                      100% {
-                          stroke-dashoffset: -1150;
-                      }
-                  }
-                  @media (prefers-reduced-motion: reduce) {
-                    path {
-                      animation: none;
-                      stroke-dashoffset: 0;
-                    }
-                  }
-              </style>
-              <script>
-                  const host = document.currentScript.closest('svg');
-                  host.addEventListener('animationend', (event) => {
-                      event.target.style.animationName = 'none';
-                      setTimeout(() => {
-                          event.target.style.animationName = '';
-                      }, 0);
-                  })
-              </script>
-              <defs>
-                  <filter id="goo">
-                      <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
-                      <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 34 -6" result="goo" />
-                      <feComposite in="SourceGraphic" in2="goo" operator="atop"/>
-                  </filter>
-              </defs>
-              <mask id="loader-mask" width="300" height="265" x="50" y="72" maskUnits="userSpaceOnUse" style="mask-type:alpha">
-                  <path fill="#000" d="M223.687 85.56a28.02 28.02 0 0 0-24-13.559 28.02 28.02 0 0 0-24 13.559l-39.48 67.62a193.26 193.26 0 0 1 106.5 159.96h-27.72a166.07 166.07 0 0 0-92.76-136.32L85.687 240a95.52 95.52 0 0 1 55.38 73.02h-63.66a4.55 4.55 0 0 1-3.659-2.325 4.56 4.56 0 0 1-.06-4.335l17.64-30a64.4 64.4 0 0 0-20.16-11.4l-17.46 30a27.24 27.24 0 0 0 2.023 30.435 27.2 27.2 0 0 0 8.116 7.005 27.96 27.96 0 0 0 13.56 3.6h87.18a116.41 116.41 0 0 0-48-103.86l13.86-24a143.22 143.22 0 0 1 61.8 127.86h73.86a215.28 215.28 0 0 0-98.46-190.8l28.02-48a4.62 4.62 0 0 1 6.3-1.62c3.18 1.74 121.74 208.62 123.96 211.02a4.562 4.562 0 0 1-4.08 6.78h-28.56q.54 11.46 0 22.86h28.68a27.54 27.54 0 0 0 27.72-27.66 26.94 26.94 0 0 0-3.72-13.68z"/>
-              </mask>
-              <g id="root" mask="url(#loader-mask)">
-                  <path stroke="#F0369A" stroke-width="4" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-                  <g filter="url('#goo')" data-index="0" style="--delay:0s;" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-                      <path style="--i: 1;" d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"/>
-                      <path style="--i: 0;" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-                      <path style="--i: 2;" d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"/>
-                  </g>
-                  <g filter="url('#goo')" data-index="1" style="--delay:180ms;" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-                      <path style="--i: 2;" d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"/>
-                      <path style="--i: 0;" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-                      <path style="--i: 1;" d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"/>
-                  </g>
-                  <g filter="url('#goo')" data-index="2" style="--delay:800ms;" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-                      <path style="--i: 0;" d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"/>
-                      <path style="--i: 3;" d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"/>
-                      <path style="--i: 1;" d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"/>
-                  </g>
-              </g>
-          </svg>
+            <svg
+      width="256"
+      height="256"
+      viewBox="0 0 400 400"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <style>
+        .theme-light #base {
+          fill: #f0f0f2;
+        }
+        .theme-dark #base {
+          fill: #24202b;
+        }
+        :root {
+          --loop: 2350ms;
+        }
+
+        g[data-index] path {
+          stroke-dasharray: 1150;
+          stroke-dashoffset: 1150;
+          animation-duration: var(--loop);
+          animation-iteration-count: infinite;
+          animation-fill-mode: both;
+          animation-timing-function: linear;
+        }
+
+        [data-index='0'] {
+          stroke: #f0369a;
+        }
+        [data-index='1'] {
+          stroke: #67c800;
+        }
+        [data-index='2'] {
+          stroke: #7553ff;
+        }
+
+        g[data-index='0'] > path:nth-of-type(1) {
+          animation-name: draw_g0_p1;
+        } /* i=1 */
+        g[data-index='0'] > path:nth-of-type(2) {
+          animation-name: draw_g0_p0;
+        } /* i=0 */
+        g[data-index='0'] > path:nth-of-type(3) {
+          animation-name: draw_g0_p2;
+        } /* i=2 */
+
+        g[data-index='1'] > path:nth-of-type(1) {
+          animation-name: draw_g1_p2;
+        } /* i=2 */
+        g[data-index='1'] > path:nth-of-type(2) {
+          animation-name: draw_g1_p0;
+        } /* i=0 */
+        g[data-index='1'] > path:nth-of-type(3) {
+          animation-name: draw_g1_p1;
+        } /* i=1 */
+
+        g[data-index='2'] > path:nth-of-type(1) {
+          animation-name: draw_g2_p0;
+        } /* i=0 */
+        g[data-index='2'] > path:nth-of-type(2) {
+          animation-name: draw_g2_p3;
+        } /* i=3 */
+        g[data-index='2'] > path:nth-of-type(3) {
+          animation-name: draw_g2_p1;
+        } /* i=1 */
+
+        /*
+      Each baked timeline:
+      - Hold at 1150 until its start %
+      - Ease-out into 0 by its 40% point
+      - Ease-out to -1150 by end of loop
+      - Snap back to 1150 at 100% so the loop repeats cleanly
+    */
+        @keyframes draw_g0_p2 {
+          /* start=  50ms =>  2.127660%, 40% point=41.276596% */
+          0%,
+          2.127660% {
+            stroke-dashoffset: 1150;
+          }
+          2.127660% {
+            animation-timing-function: ease-out;
+          }
+          41.276596% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g0_p1 {
+          /* start= 100ms =>  4.255319%, 40% point=42.553191% */
+          0%,
+          4.255319% {
+            stroke-dashoffset: 1150;
+          }
+          4.255319% {
+            animation-timing-function: ease-out;
+          }
+          42.553191% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g0_p0 {
+          /* start= 150ms =>  6.382979%, 40% point=43.829787% */
+          0%,
+          6.382979% {
+            stroke-dashoffset: 1150;
+          }
+          6.382979% {
+            animation-timing-function: ease-out;
+          }
+          43.829787% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+
+        @keyframes draw_g1_p2 {
+          /* start= 230ms =>  9.787234%, 40% point=45.872340% */
+          0%,
+          9.787234% {
+            stroke-dashoffset: 1150;
+          }
+          9.787234% {
+            animation-timing-function: ease-out;
+          }
+          45.872340% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g1_p1 {
+          /* start= 280ms => 11.914894%, 40% point=47.148936% */
+          0%,
+          11.914894% {
+            stroke-dashoffset: 1150;
+          }
+          11.914894% {
+            animation-timing-function: ease-out;
+          }
+          47.148936% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g1_p0 {
+          /* start= 330ms => 14.042553%, 40% point=48.425532% */
+          0%,
+          14.042553% {
+            stroke-dashoffset: 1150;
+          }
+          14.042553% {
+            animation-timing-function: ease-out;
+          }
+          48.425532% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+
+        @keyframes draw_g2_p3 {
+          /* start= 400ms => 17.021277%, 40% point=50.212766% */
+          0%,
+          17.021277% {
+            stroke-dashoffset: 1150;
+          }
+          17.021277% {
+            animation-timing-function: ease-out;
+          }
+          50.212766% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g2_p1 {
+          /* start= 500ms => 21.276596%, 40% point=52.765957% */
+          0%,
+          21.276596% {
+            stroke-dashoffset: 1150;
+          }
+          21.276596% {
+            animation-timing-function: ease-out;
+          }
+          52.765957% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+        @keyframes draw_g2_p0 {
+          /* start= 550ms => 23.404255%, 40% point=54.042553% */
+          0%,
+          23.404255% {
+            stroke-dashoffset: 1150;
+          }
+          23.404255% {
+            animation-timing-function: ease-out;
+          }
+          54.042553% {
+            stroke-dashoffset: 0;
+            animation-timing-function: ease-out;
+          }
+          99.999% {
+            stroke-dashoffset: -1150;
+          }
+          100% {
+            stroke-dashoffset: 1150;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          g[data-index] path {
+            animation: none;
+            stroke-dashoffset: 0;
+          }
+        }
+      </style>
+
+      <defs>
+        <filter id="goo">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur" />
+          <feColorMatrix
+            in="blur"
+            mode="matrix"
+            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 36 -4"
+            result="goo"
+          />
+          <feComposite in="SourceGraphic" in2="goo" operator="atop" />
+        </filter>
+      </defs>
+
+      <mask
+        id="loader-mask"
+        width="300"
+        height="265"
+        x="50"
+        y="72"
+        maskUnits="userSpaceOnUse"
+        style="mask-type: alpha"
+      >
+        <path
+          fill="#24202B"
+          d="M223.687 85.56a28.02 28.02 0 0 0-24-13.559 28.02 28.02 0 0 0-24 13.559l-39.48 67.62a193.26 193.26 0 0 1 106.5 159.96h-27.72a166.07 166.07 0 0 0-92.76-136.32L85.687 240a95.52 95.52 0 0 1 55.38 73.02h-63.66a4.55 4.55 0 0 1-3.659-2.325 4.56 4.56 0 0 1-.06-4.335l17.64-30a64.4 64.4 0 0 0-20.16-11.4l-17.46 30a27.24 27.24 0 0 0 2.023 30.435 27.2 27.2 0 0 0 8.116 7.005 27.96 27.96 0 0 0 13.56 3.6h87.18a116.41 116.41 0 0 0-48-103.86l13.86-24a143.22 143.22 0 0 1 61.8 127.86h73.86a215.28 215.28 0 0 0-98.46-190.8l28.02-48a4.62 4.62 0 0 1 6.3-1.62c3.18 1.74 121.74 208.62 123.96 211.02a4.562 4.562 0 0 1-4.08 6.78h-28.56q.54 11.46 0 22.86h28.68a27.54 27.54 0 0 0 27.72-27.66 26.94 26.94 0 0 0-3.72-13.68z"
+        />
+      </mask>
+
+      <path
+        id="base"
+        fill="#F0F0F2"
+        d="M223.687 85.56a28.02 28.02 0 0 0-24-13.559 28.02 28.02 0 0 0-24 13.559l-39.48 67.62a193.26 193.26 0 0 1 106.5 159.96h-27.72a166.07 166.07 0 0 0-92.76-136.32L85.687 240a95.52 95.52 0 0 1 55.38 73.02h-63.66a4.55 4.55 0 0 1-3.659-2.325 4.56 4.56 0 0 1-.06-4.335l17.64-30a64.4 64.4 0 0 0-20.16-11.4l-17.46 30a27.24 27.24 0 0 0 2.023 30.435 27.2 27.2 0 0 0 8.116 7.005 27.96 27.96 0 0 0 13.56 3.6h87.18a116.41 116.41 0 0 0-48-103.86l13.86-24a143.22 143.22 0 0 1 61.8 127.86h73.86a215.28 215.28 0 0 0-98.46-190.8l28.02-48a4.62 4.62 0 0 1 6.3-1.62c3.18 1.74 121.74 208.62 123.96 211.02a4.562 4.562 0 0 1-4.08 6.78h-28.56q.54 11.46 0 22.86h28.68a27.54 27.54 0 0 0 27.72-27.66 26.94 26.94 0 0 0-3.72-13.68z"
+      />
+      <g
+        id="root"
+        mask="url(#loader-mask)"
+        filter="url('#goo')"
+        stroke-width="5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <g data-index="0">
+          <path
+            d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"
+          />
+          <path
+            d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"
+          />
+          <path
+            d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"
+          />
+        </g>
+
+        <g data-index="1">
+          <path
+            d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"
+          />
+          <path
+            d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"
+          />
+          <path
+            d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"
+          />
+        </g>
+
+        <g data-index="2">
+          <path
+            d="m82.8 253.5-12.7 22-12.5 21.2-.2.3v.1l-.2.2v.3a24 24 0 00.3 22.4l.3.6A24 24 0 0076.4 332h87l-3.2-21.8A115 115 0 00112 233l17.6-30.4a147 147 0 0166.8 112l1.3 17.5h65.6l-1.3-20.2a212 212 0 00-99.3-165.8l29.6-50.8a9 9 0 013.3-3.1 9 9 0 0112.1 3.1l122.2 209.2h.1a8 8 0 011 4v.2a8.5 8.5 0 01-8.6 8.5h-38.9"
+          />
+          <path
+            d="M92.5 268.7 88 276.6 71.4 305v.1a8 8 0 000 7.2l.2.4a8 8 0 006 3.4h67.3l-.6-3.4A99 99 0 0097.2 242.5l-6.8-4 33.4-57.8 6.9 4a163 163 0 0181.6 128.8l.2 2.7h33.7L246 313A196 196 0 00147.8 155.7l-7-4L178.6 87v-.1a25 25 0 0133-9.1l.8.3a25 25 0 019 8.9h.1v.2L343.7 296.4a24 24 0 013.3 12v.4a24.5 24.5 0 01-24.6 24.4H291.5"
+          />
+          <path
+            d="M85.7 264.5l-8.7 15-12.5 21.3-.1.2-.1.3A15.6 15.6 0 0076.9 324h77.2l-1.8-12.6a107 107 0 00-51-75.8l25.5-44.1A155 155 0 01204.3 314l.8 10.1h49.7l-.8-11.7A204 204 0 00151.8 148.9l33.6-57.7a17 17 0 0129.2 0L336.8 300.4a16 16 0 012.2 8.2 16.5 16.5 0 01-16.6 16.6H291.5"
+          />
+        </g>
+      </g>
+    </svg>
         </div>
 
         <div class="loading-message">

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -86,55 +86,55 @@
 
         g[data-index='0'] > path:nth-of-type(1) {
           animation-name: draw_g0_p1;
-        } /* i=1 */
+        }
         g[data-index='0'] > path:nth-of-type(2) {
           animation-name: draw_g0_p0;
-        } /* i=0 */
+        }
         g[data-index='0'] > path:nth-of-type(3) {
           animation-name: draw_g0_p2;
-        } /* i=2 */
+        }
 
         g[data-index='1'] > path:nth-of-type(1) {
           animation-name: draw_g1_p2;
-        } /* i=2 */
+        }
         g[data-index='1'] > path:nth-of-type(2) {
           animation-name: draw_g1_p0;
-        } /* i=0 */
+        }
         g[data-index='1'] > path:nth-of-type(3) {
           animation-name: draw_g1_p1;
-        } /* i=1 */
+        }
 
         g[data-index='2'] > path:nth-of-type(1) {
           animation-name: draw_g2_p0;
-        } /* i=0 */
+        }
         g[data-index='2'] > path:nth-of-type(2) {
           animation-name: draw_g2_p3;
-        } /* i=3 */
+        }
         g[data-index='2'] > path:nth-of-type(3) {
           animation-name: draw_g2_p1;
-        } /* i=1 */
+        }
 
         /*
-      Each baked timeline:
-      - Hold at 1150 until its start %
-      - Ease-out into 0 by its 40% point
-      - Ease-out to -1150 by end of loop
-      - Snap back to 1150 at 100% so the loop repeats cleanly
-    */
+          Each baked timeline:
+          - Hold at 1150 until its start %
+          - Ease-out into 0 by its 40% point
+          - Ease-out to -1150 by end of loop
+          - Snap back to 1150 at 100% so the loop repeats cleanly
+        */
         @keyframes draw_g0_p2 {
-          /* start=  50ms =>  2.127660%, 40% point=41.276596% */
+          /* start=  50ms =>  2.1%, 40% point=41.3% */
           0%,
-          2.127660% {
+          2.1% {
             stroke-dashoffset: 1150;
           }
-          2.127660% {
+          2.1% {
             animation-timing-function: ease-out;
           }
-          41.276596% {
+          41.3% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -142,19 +142,19 @@
           }
         }
         @keyframes draw_g0_p1 {
-          /* start= 100ms =>  4.255319%, 40% point=42.553191% */
+          /* start= 100ms => 4.3%, 40% point=42.6% */
           0%,
-          4.255319% {
+          4.3% {
             stroke-dashoffset: 1150;
           }
-          4.255319% {
+          4.3% {
             animation-timing-function: ease-out;
           }
-          42.553191% {
+          42.6% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -162,19 +162,19 @@
           }
         }
         @keyframes draw_g0_p0 {
-          /* start= 150ms =>  6.382979%, 40% point=43.829787% */
+          /* start= 150ms =>  6.4%, 40% point=43.8% */
           0%,
-          6.382979% {
+          6.4% {
             stroke-dashoffset: 1150;
           }
-          6.382979% {
+          6.4% {
             animation-timing-function: ease-out;
           }
-          43.829787% {
+          43.8% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -183,19 +183,19 @@
         }
 
         @keyframes draw_g1_p2 {
-          /* start= 230ms =>  9.787234%, 40% point=45.872340% */
+          /* start= 230ms =>  9.8%, 40% point=45.9% */
           0%,
-          9.787234% {
+          9.8% {
             stroke-dashoffset: 1150;
           }
-          9.787234% {
+          9.8% {
             animation-timing-function: ease-out;
           }
-          45.872340% {
+          45.9% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -203,19 +203,19 @@
           }
         }
         @keyframes draw_g1_p1 {
-          /* start= 280ms => 11.914894%, 40% point=47.148936% */
+          /* start= 280ms => 11.9%, 40% point=47.1% */
           0%,
-          11.914894% {
+          11.9% {
             stroke-dashoffset: 1150;
           }
-          11.914894% {
+          11.9% {
             animation-timing-function: ease-out;
           }
-          47.148936% {
+          47.1% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -223,19 +223,19 @@
           }
         }
         @keyframes draw_g1_p0 {
-          /* start= 330ms => 14.042553%, 40% point=48.425532% */
+          /* start= 330ms => 14%, 40% point=48.4% */
           0%,
-          14.042553% {
+          14% {
             stroke-dashoffset: 1150;
           }
-          14.042553% {
+          14% {
             animation-timing-function: ease-out;
           }
-          48.425532% {
+          48.4% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -244,19 +244,19 @@
         }
 
         @keyframes draw_g2_p3 {
-          /* start= 400ms => 17.021277%, 40% point=50.212766% */
+          /* start= 400ms => 17%, 40% point=50.2% */
           0%,
-          17.021277% {
+          17% {
             stroke-dashoffset: 1150;
           }
-          17.021277% {
+          17% {
             animation-timing-function: ease-out;
           }
-          50.212766% {
+          50.2% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -264,19 +264,19 @@
           }
         }
         @keyframes draw_g2_p1 {
-          /* start= 500ms => 21.276596%, 40% point=52.765957% */
+          /* start= 500ms => 21.3%, 40% point=52.8% */
           0%,
-          21.276596% {
+          21.3% {
             stroke-dashoffset: 1150;
           }
-          21.276596% {
+          21.3% {
             animation-timing-function: ease-out;
           }
-          52.765957% {
+          52.8% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {
@@ -284,19 +284,19 @@
           }
         }
         @keyframes draw_g2_p0 {
-          /* start= 550ms => 23.404255%, 40% point=54.042553% */
+          /* start= 550ms => 23.4%, 40% point=54% */
           0%,
-          23.404255% {
+          23.4% {
             stroke-dashoffset: 1150;
           }
-          23.404255% {
+          23.4% {
             animation-timing-function: ease-out;
           }
-          54.042553% {
+          54% {
             stroke-dashoffset: 0;
             animation-timing-function: ease-out;
           }
-          99.999% {
+          99.99% {
             stroke-dashoffset: -1150;
           }
           100% {

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -61,6 +61,13 @@
         .theme-dark #base {
           fill: #24202b;
         }
+        .theme-system {
+          @media (prefers-color-scheme: dark) {
+            #base {
+              fill: #24202b;
+            }
+          }
+        }
         :root {
           --loop: 2350ms;
         }

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -395,50 +395,6 @@
         <div class="loading-message">
           <p>Loading a <scraps-bleep>$#!%</scraps-bleep>-ton of JavaScript&hellip;</p>
           <p><small>You may need to disable adblocking extensions to load Sentry.</small></p>
-          <script>
-            function randomFrom(arr) {
-              return arr[Math.floor(Math.random() * arr.length)];
-            }
-            function randomBetween(min, max) {
-              return Math.floor(Math.random() * (max - min - 1) + min);
-            }
-            customElements.define('scraps-bleep', class extends HTMLElement {
-              constructor() {
-                super();
-                this.shapes = '◆●▴▪×'.split('');
-                this.chars = '@#$%&*!+'.split('');
-                this.length = this.textContent.trim().length;
-              }
-              random() {
-                const set = new Set();
-                let hasShape = false;
-                while (set.size < this.length) {
-                  if (!hasShape && Math.random() > 0.75) {
-                    set.add(randomFrom(this.shapes));
-                    hasShape = true;
-                  } else {
-                    set.add(randomFrom(this.chars));
-                  }
-                }
-                return Array.from(set.values()).join('');
-              }
-              shuffle() {
-                this.raf = requestAnimationFrame(() => {
-                  this.textContent = this.random();
-                  this.timeout = setTimeout(() => this.shuffle(), randomBetween(50, 250));
-                })
-              }
-              connectedCallback() {
-                if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-                  this.shuffle();
-                }
-              }
-              disconnectedCallback() {
-                cancelAnimationFrame(this.raf);
-                clearTimeout(this.timeout);
-              }
-            })
-          </script>
         </div>
       </div>
     </div>

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -24,8 +24,8 @@ body {
   margin: 0;
   font-size: 87.5%;
   line-height: 1.4;
-  color: @gray-darker;
-  background: @white-dark;
+  color: #3E3B46;
+  background: #FFF;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
@@ -35,16 +35,16 @@ body {
 // Applied to body
 body.theme-dark {
   // theme.tokens.background.primary
-  background: #272433;
+  background: #2F2937;
   // theme.tokens.content.primary
-  color: #F6F5FA;
+  color: #E9E5EB;
 }
 body.theme-system {
   @media (prefers-color-scheme: dark) {
     // theme.tokens.background.primary
-    background: #272433;
+    background: #2F2937;
     // theme.content.primary
-    color: #F6F5FA;
+    color: #E9E5EB;
   }
 }
 

--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -552,6 +552,7 @@ table.table.key-value {
   .loading-indicator {
     height: 256px;
     width: 256px;
+    transform: scale(0.75);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -601,6 +602,45 @@ body.theme-system {
       opacity: 0.8;
     }
   }
+}
+scraps-bleep {
+  position: relative;
+  display: inline-block;
+  color: transparent;
+}
+scraps-bleep::before {
+  content: '$#!%';
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  animation: bleep 1.3s steps(1) infinite;
+  color: #3E3B46;
+}
+@media (prefers-reduced-motion: reduce) {
+  scraps-bleep::before {
+    animation: none;
+  }
+}
+body.theme-dark scraps-bleep::before {
+  // theme.tokens.content.primary
+  color: #E9E5EB;
+}
+body.theme-system scraps-bleep::before {
+  @media (prefers-color-scheme: dark) {
+    // theme.content.primary
+    color: #E9E5EB;
+  }
+}
+@keyframes bleep {
+  0% { content: '$#!%'; }
+  12% { content: '&*#%'; }
+  25% { content: '$◆*+'; }
+  37% { content: '!@#&'; }
+  50% { content: '%*$◆'; }
+  62% { content: '@+!#'; }
+  75% { content: '*&#$'; }
+  87% { content: '+%@*'; }
 }
 
 /**


### PR DESCRIPTION
Refactors the [Splash Loader (#101654)](https://github.com/getsentry/sentry/pull/101654) to address a few common feedback points:

- before, animation restart was triggered by inline JS (blocked by CSP) -> now animation + delays are baked into precomputed CSS keyframes so `animation-iteration-count: infinite` works
- before, `scraps-bleep` was a web component with inline JS (blocked by CSP) to randomize the text shuffle -> now shuffle animation uses CSS keyframes
- background colors updated again to match new color scheme (see #103886)
- `prefers_chonk_ui` preference check removed from Django view since UI2 has been fully rolled out

Closes DE-563

## Result

Functionally identical, but zero JS.


https://github.com/user-attachments/assets/b535f5df-0d5a-45fa-9b3c-42280c7baaa2


https://github.com/user-attachments/assets/f55313cc-7c03-4d67-a738-4372afde9466

