### PR TITLE
fix(uptime): Use simple uuid format

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -353,15 +353,15 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 synthetic_metric_tags["status"] = CHECKSTATUS_MISSED_WINDOW
                 for i in range(0, num_missed_checks):
                     missed_result: CheckResult = {
-                        "guid": str(uuid.uuid4()),
+                        "guid": uuid.uuid4().hex,
                         "subscription_id": result["subscription_id"],
                         "status": CHECKSTATUS_MISSED_WINDOW,
                         "status_reason": {
                             "type": "miss_backfill",
                             "description": "Miss was never reported for this scheduled check_time",
                         },
-                        "trace_id": str(uuid.uuid4()),
-                        "span_id": str(uuid.uuid4()),
+                        "trace_id": uuid.uuid4().hex,
+                        "span_id": uuid.uuid4().hex,
                         "region": result["region"],
                         "scheduled_check_time_ms": last_update_ms
                         + ((i + 1) * subscription_interval_ms),

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -450,6 +450,11 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 == "Miss was never reported for this scheduled check_time"
             )
 
+            # Verify backfilled misses use UUIDs without dashes (simple format)
+            assert "-" not in synth_1.attributes["guid"].string_value
+            assert "-" not in synth_1.trace_id
+            assert "-" not in synth_1.attributes["span_id"].string_value
+
             assert (
                 synth_1.attributes["scheduled_check_time_us"].int_value
                 == (last_update_time + 300 * 1000) * 1000


### PR DESCRIPTION
This matches what we do in the uptime checker, no dashes in the UUIDs