### PR TITLE
fix(frontend): Overflow issue on streamlinedExternalIssueList #105050

### DIFF
--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -89,7 +89,7 @@ export function StreamlinedExternalIssueList({
   }
 
   return (
-    <Flex direction="row" gap="md">
+    <Flex direction="row" gap="md" wrap="wrap">
       {linkedIssues.length > 0 && (
         <IssueActionWrapper>
           {linkedIssues.map(linkedIssue => (


### PR DESCRIPTION
(Fixes #105050)

<!-- Describe your PR here. -->
Added wrap="wrap" to the <Flex> wrapper in `streamlinedExternalIssueList.tsx`
I believe this is all that's needed to fix this overflow:
<img width="528" height="390" alt="image" src="https://github.com/user-attachments/assets/a8be9886-7186-4349-9861-188a18913d45" />


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
