### PR TITLE
ref(discover): Migrate `TableView` component off of `browserHistory.push` to `navigate`

### DIFF
--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import * as Sentry from '@Sentry/react';
+import * as Sentry from '@sentry/react';
 import type {Location, LocationDescriptorObject} from 'history';
 
 import {openModal} from 'sentry/actionCreators/modal';

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
+import * as Sentry from '@Sentry/react';
 import type {Location, LocationDescriptorObject} from 'history';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -16,7 +16,6 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
 import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -46,6 +45,7 @@ import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useProjects from 'sentry/utils/useProjects';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {appendQueryDatasetParam, hasDatasetSelector} from 'sentry/views/dashboards/utils';
@@ -102,8 +102,9 @@ type TableViewProps = {
  * In most cases, the new EventView object differs from the previous EventView
  * object. The new EventView object is pushed to the location object.
  */
-function TableView(props: TableViewProps) {
+export default function TableView(props: TableViewProps) {
   const theme = useTheme();
+  const navigate = useNavigate();
   const {projects} = useProjects();
   const routes = useRoutes();
   const replayLinkGenerator = generateReplayLink(routes);
@@ -544,7 +545,7 @@ function TableView(props: TableViewProps) {
             return project.slug === dataRow.project;
           });
 
-          browserHistory.push(
+          navigate(
             normalizeUrl({
               pathname: makeReleasesPathname({
                 organization,
@@ -572,7 +573,7 @@ function TableView(props: TableViewProps) {
             function: ['count', '', undefined, undefined],
           });
 
-          browserHistory.push(
+          navigate(
             normalizeUrl(
               nextView.getResultsViewUrlTarget(
                 organization,
@@ -610,7 +611,7 @@ function TableView(props: TableViewProps) {
       );
       // Get yAxis from location
       target.query.yAxis = decodeList(location.query.yAxis);
-      browserHistory.push(normalizeUrl(target));
+      navigate(normalizeUrl(target));
     };
   }
 
@@ -633,7 +634,7 @@ function TableView(props: TableViewProps) {
     resultsViewUrlTarget.query.yAxis = previousYAxis.filter(yAxis =>
       nextView.getYAxisOptions().find(({value}) => value === yAxis)
     );
-    browserHistory.push(normalizeUrl(resultsViewUrlTarget));
+    navigate(normalizeUrl(resultsViewUrlTarget));
   }
 
   function renderHeaderButtons() {
@@ -725,5 +726,3 @@ export const TransactionLink = styled(Link)`
 const StyledIcon = styled(IconStack)`
   vertical-align: middle;
 `;
-
-export default TableView;


### PR DESCRIPTION
Migrating this component to modern navigation. Going to update tests & migrate them off `deprecatedRouterMocks` in a follow-up PR.