### PR TITLE
feat(ILOC): update to more generic schema to support other Apple apps

### DIFF
--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -45,11 +45,11 @@ class OAuthAuthorizeView(AuthLoginView):
             final_uri = urlunparse(parts)
 
         # Django's HttpResponseRedirect blocks custom URL schemes for security.
-        # For OAuth redirects to the Sentry mobile agent, we need to support the
-        # sentry-mobile-agent:// scheme, so we use HttpResponse with a Location
+        # For OAuth redirects to Sentry Apple apps, we need to support the
+        # sentry-apple:// scheme, so we use HttpResponse with a Location
         # header directly.
         parsed_uri = urlparse(final_uri)
-        if parsed_uri.scheme == "sentry-mobile-agent":
+        if parsed_uri.scheme == "sentry-apple":
             response = HttpResponse(status=302)
             response["Location"] = final_uri
             return response

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -90,44 +90,44 @@ class ApiApplicationTest(TestCase):
         assert not app.is_valid_redirect_uri("http://127.0.0.1/callback")
 
     def test_is_valid_redirect_uri_custom_scheme(self) -> None:
-        # Test custom scheme for mobile apps (sentry-mobile-agent://)
+        # Test custom scheme for Apple apps (sentry-apple://)
         app = ApiApplication.objects.create(
             owner=self.user,
-            redirect_uris="sentry-mobile-agent://sentry.io/auth",
+            redirect_uris="sentry-apple://sentry.io/auth",
             version=0,  # legacy behavior
         )
 
         # Exact match should work
-        assert app.is_valid_redirect_uri("sentry-mobile-agent://sentry.io/auth")
+        assert app.is_valid_redirect_uri("sentry-apple://sentry.io/auth")
 
         # With trailing slash - depends on normalization
-        assert app.is_valid_redirect_uri("sentry-mobile-agent://sentry.io/auth/")
+        assert app.is_valid_redirect_uri("sentry-apple://sentry.io/auth/")
 
         # Prefix match should work in legacy mode
-        assert app.is_valid_redirect_uri("sentry-mobile-agent://sentry.io/auth/callback")
+        assert app.is_valid_redirect_uri("sentry-apple://sentry.io/auth/callback")
 
         # Different scheme should fail
         assert not app.is_valid_redirect_uri("https://sentry.io/auth")
 
         # Different host should fail
-        assert not app.is_valid_redirect_uri("sentry-mobile-agent://other.io/auth")
+        assert not app.is_valid_redirect_uri("sentry-apple://other.io/auth")
 
         # Different path should fail (not a prefix)
-        assert not app.is_valid_redirect_uri("sentry-mobile-agent://sentry.io/other")
+        assert not app.is_valid_redirect_uri("sentry-apple://sentry.io/other")
 
     def test_is_valid_redirect_uri_custom_scheme_strict(self) -> None:
         # Test custom scheme with strict validation (version 1)
         app = ApiApplication.objects.create(
             owner=self.user,
-            redirect_uris="sentry-mobile-agent://sentry.io/auth",
+            redirect_uris="sentry-apple://sentry.io/auth",
             version=1,  # strict mode
         )
 
         # Exact match should work
-        assert app.is_valid_redirect_uri("sentry-mobile-agent://sentry.io/auth")
+        assert app.is_valid_redirect_uri("sentry-apple://sentry.io/auth")
 
         # Prefix match should NOT work in strict mode
-        assert not app.is_valid_redirect_uri("sentry-mobile-agent://sentry.io/auth/callback")
+        assert not app.is_valid_redirect_uri("sentry-apple://sentry.io/auth/callback")
 
     def test_get_default_redirect_uri(self) -> None:
         app = ApiApplication.objects.create(

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -341,10 +341,12 @@ class OAuthAuthorizeTokenTest(TestCase):
         assert location == "https://example.com"
         fragment_d = parse_qs(fragment)
         assert fragment_d["access_token"] == [token.token]
-        assert fragment_d["token_type"] == ["bearer"]
+        assert fragment_d["token_type"] == ["Bearer"]
         assert "refresh_token" not in fragment_d
+        # expires_in should be a positive integer number of seconds until expiry
         assert fragment_d["expires_in"]
-        assert fragment_d["token_type"] == ["bearer"]
+        assert int(fragment_d["expires_in"][0]) > 0
+        assert fragment_d["token_type"] == ["Bearer"]
 
     def test_minimal_params_code_deny_flow(self) -> None:
         self.login_as(self.user)
@@ -1098,9 +1100,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         """Test that redirect_uri is required when multiple custom schemes are registered."""
         self.login_as(self.user)
         # Update application to have multiple redirect URIs
-        self.application.redirect_uris = (
-            f"{self.custom_uri}\nsentry-apple://sentry.io/callback"
-        )
+        self.application.redirect_uris = f"{self.custom_uri}\nsentry-apple://sentry.io/callback"
         self.application.save()
 
         resp = self.client.get(

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -522,7 +522,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeTest(TestCase):
         self.owner = self.create_user(email="admin@test.com")
         self.create_member(user=self.owner, organization=self.organization, role="owner")
         self.another_organization = self.create_organization(owner=self.owner)
-        self.custom_uri = "sentry-mobile-agent://sentry.io/auth"
+        self.custom_uri = "sentry-apple://sentry.io/auth"
         self.application = ApiApplication.objects.create(
             owner=self.user,
             redirect_uris=self.custom_uri,
@@ -567,7 +567,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeTest(TestCase):
         assert grant.organization_id == self.organization.id
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
         assert "state=foo" in resp["Location"]
 
@@ -582,7 +582,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeTest(TestCase):
         )
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "error=invalid_scope" in resp["Location"]
         assert "state=foo" in resp["Location"]
         assert "code=" not in resp["Location"]
@@ -615,7 +615,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeTest(TestCase):
 
         grant = ApiGrant.objects.get(user=self.owner)
         assert grant.redirect_uri == self.custom_uri
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
 
         # There is only one ApiAuthorization for this user and app which is related to the right organization
         api_auth = ApiAuthorization.objects.get(user=self.owner, application=self.application)
@@ -669,7 +669,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeStrictTest(TestCase):
         self.owner = self.create_user(email="admin@test.com")
         self.create_member(user=self.owner, organization=self.organization, role="owner")
         self.another_organization = self.create_organization(owner=self.owner)
-        self.custom_uri = "sentry-mobile-agent://sentry.io/auth"
+        self.custom_uri = "sentry-apple://sentry.io/auth"
         self.application = ApiApplication.objects.create(
             owner=self.user,
             redirect_uris=self.custom_uri,
@@ -715,7 +715,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeStrictTest(TestCase):
         assert grant.organization_id == self.organization.id
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
         assert "state=foo" in resp["Location"]
 
@@ -730,7 +730,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeStrictTest(TestCase):
         )
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "error=invalid_scope" in resp["Location"]
         assert "state=foo" in resp["Location"]
         assert "code=" not in resp["Location"]
@@ -754,7 +754,7 @@ class OAuthAuthorizeOrgScopedCustomSchemeStrictTest(TestCase):
 
 @control_silo_test
 class OAuthAuthorizeCustomSchemeTest(TestCase):
-    """Tests for OAuth flows using custom URI schemes (sentry-mobile-agent://)."""
+    """Tests for OAuth flows using custom URI schemes (sentry-apple://)."""
 
     @cached_property
     def path(self) -> str:
@@ -762,7 +762,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.custom_uri = "sentry-mobile-agent://sentry.io/auth"
+        self.custom_uri = "sentry-apple://sentry.io/auth"
         self.application = ApiApplication.objects.create(
             owner=self.user, redirect_uris=self.custom_uri
         )
@@ -787,7 +787,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
 
         assert resp.status_code == 302
         # Verify custom scheme is used in Location header
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
 
     def test_code_flow_custom_scheme_deny(self) -> None:
@@ -802,7 +802,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         resp = self.client.post(self.path, {"op": "deny"})
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "error=access_denied" in resp["Location"]
         assert "code=" not in resp["Location"]
         assert not ApiGrant.objects.filter(user=self.user).exists()
@@ -826,7 +826,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
 
         assert resp.status_code == 302
         # Verify custom scheme is used with fragment for token
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "#" in resp["Location"]
         assert "access_token=" in resp["Location"]
 
@@ -842,7 +842,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         resp = self.client.post(self.path, {"op": "deny"})
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "#" in resp["Location"]
         assert "error=access_denied" in resp["Location"]
         assert "access_token=" not in resp["Location"]
@@ -862,7 +862,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
 
         grant = ApiGrant.objects.get(user=self.user)
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
         assert f"state={state}" in resp["Location"]
 
@@ -886,7 +886,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         assert grant.get_scopes() == ["org:read"]
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
         assert "state=foo" in resp["Location"]
 
@@ -906,7 +906,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         assert not grant.get_scopes()
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
 
     def test_code_flow_force_prompt_custom_scheme(self) -> None:
@@ -989,7 +989,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         assert not grant.get_scopes()
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
 
     def test_invalid_scope_custom_scheme(self) -> None:
@@ -1001,7 +1001,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         )
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "error=invalid_scope" in resp["Location"]
         assert "code=" not in resp["Location"]
         assert not ApiGrant.objects.filter(user=self.user).exists()
@@ -1026,7 +1026,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
 
         assert resp.status_code == 302
         location, fragment = resp["Location"].split("#", 1)
-        assert location.startswith("sentry-mobile-agent://")
+        assert location.startswith("sentry-apple://")
         fragment_d = parse_qs(fragment)
         assert fragment_d["access_token"] == [token.token]
         assert fragment_d["state"] == ["foo"]
@@ -1040,7 +1040,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         )
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "#" in resp["Location"]
         assert "error=invalid_scope" in resp["Location"]
         assert "access_token" not in resp["Location"]
@@ -1085,7 +1085,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         self.login_as(self.user)
 
         # Try to use a different custom scheme that's not registered
-        invalid_uri = "sentry-mobile-agent://different.com/auth"
+        invalid_uri = "sentry-apple://different.com/auth"
         resp = self.client.get(
             f"{self.path}?response_type=code&redirect_uri={invalid_uri}&client_id={self.application.client_id}"
         )
@@ -1099,7 +1099,7 @@ class OAuthAuthorizeCustomSchemeTest(TestCase):
         self.login_as(self.user)
         # Update application to have multiple redirect URIs
         self.application.redirect_uris = (
-            f"{self.custom_uri}\nsentry-mobile-agent://sentry.io/callback"
+            f"{self.custom_uri}\nsentry-apple://sentry.io/callback"
         )
         self.application.save()
 
@@ -1123,7 +1123,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.custom_uri = "sentry-mobile-agent://sentry.io/auth"
+        self.custom_uri = "sentry-apple://sentry.io/auth"
         self.application = ApiApplication.objects.create(
             owner=self.user, redirect_uris=self.custom_uri, version=1  # Strict mode
         )
@@ -1147,7 +1147,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
         assert grant.application == self.application
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
 
     def test_prefix_match_fails_strict_mode(self) -> None:
@@ -1183,7 +1183,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
         assert token.application == self.application
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "#" in resp["Location"]
         assert "access_token=" in resp["Location"]
 
@@ -1201,7 +1201,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
 
         grant = ApiGrant.objects.get(user=self.user)
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
         assert f"state={state}" in resp["Location"]
 
@@ -1225,7 +1225,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
         assert grant.get_scopes() == ["org:read"]
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]
         assert "state=bar" in resp["Location"]
 
@@ -1241,7 +1241,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
         resp = self.client.post(self.path, {"op": "deny"})
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "error=access_denied" in resp["Location"]
         assert "code=" not in resp["Location"]
         assert not ApiGrant.objects.filter(user=self.user).exists()
@@ -1258,7 +1258,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
         resp = self.client.post(self.path, {"op": "deny"})
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "#" in resp["Location"]
         assert "error=access_denied" in resp["Location"]
         assert "access_token=" not in resp["Location"]
@@ -1273,7 +1273,7 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
         )
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert "error=invalid_scope" in resp["Location"]
         assert "code=" not in resp["Location"]
         assert not ApiGrant.objects.filter(user=self.user).exists()
@@ -1307,5 +1307,5 @@ class OAuthAuthorizeCustomSchemeStrictTest(TestCase):
         assert grant.application == self.application
 
         assert resp.status_code == 302
-        assert resp["Location"].startswith("sentry-mobile-agent://")
+        assert resp["Location"].startswith("sentry-apple://")
         assert f"code={grant.code}" in resp["Location"]


### PR DESCRIPTION
We originally did this for a mobile app, but we may now also be adding a mac app, so this should be more generic (the old name was already out of date anyways)