### PR TITLE
feat(occurrences): Add tagname attr to eap

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -49,7 +49,7 @@ def _encode_value(value: Any) -> AnyValue:
         return AnyValue(int_value=value)
     elif isinstance(value, float):
         return AnyValue(double_value=value)
-    elif isinstance(value, list) or isinstance(value, tuple):
+    elif isinstance(value, list) or isinstance(value, tuple) or isinstance(value, set):
         # Not yet processed on EAP side
         return AnyValue(
             array_value=ArrayValue(values=[_encode_value(v) for v in value if v is not None])
@@ -85,9 +85,16 @@ def encode_attributes(
     if event.group_id:
         attributes["group_id"] = AnyValue(int_value=event.group_id)
 
+    format_tag_key = lambda key: f"tags[{key}]"
+
+    tag_keys = set()
     for key, value in event_data["tags"]:
         if value is None:
             continue
-        attributes[f"tags[{key}]"] = _encode_value(value)
+        formatted_key = format_tag_key(key)
+        attributes[formatted_key] = _encode_value(value)
+        tag_keys.add(formatted_key)
+
+    attributes["tag_keys"] = _encode_value(tag_keys)
 
     return attributes

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -122,6 +122,15 @@ class ItemHelpersTest(TestCase):
         assert result["tags[environment]"] == AnyValue(string_value="production")
         assert result["tags[release]"] == AnyValue(string_value="1.0.0")
         assert result["tags[level]"] == AnyValue(string_value="error")
+        assert result["tag_keys"] == AnyValue(
+            array_value=ArrayValue(
+                values=[
+                    AnyValue(string_value="tags[environment]"),
+                    AnyValue(string_value="tags[level]"),
+                    AnyValue(string_value="tags[release]"),
+                ]
+            )
+        )
 
     def test_encode_attributes_with_empty_tags(self) -> None:
         event_data = {"field": "value", "tags": []}
@@ -137,6 +146,7 @@ class ItemHelpersTest(TestCase):
         assert result["field"] == AnyValue(string_value="value")
         # No tags[] keys should be present
         assert not any(key.startswith("tags[") for key in result.keys())
+        assert result["tag_keys"] == AnyValue(array_value=ArrayValue(values=[]))
 
     def test_encode_attributes_with_integer_tag_values(self) -> None:
         event_data = {
@@ -166,7 +176,7 @@ class ItemHelpersTest(TestCase):
 
         # "tags" field itself gets encoded as a non-scalar value in the loop
         # Then tags are processed separately, but empty list adds no tag attributes
-        assert len(result) == 1
+        assert len(result) == 2
         assert result["tags"] == AnyValue(array_value=ArrayValue(values=[]))
 
     def test_encode_attributes_with_complex_types(self) -> None:


### PR DESCRIPTION
Currently, when we look to get all tags from EAP we run a `TraceItemAttributeNamesRequest`. The problem there is that that request only performs "best effort" filtering, which means we might over-fetch tags for a given group_id. Instead, let's add the tag names as their own attrs to occurrences so that we can draw & use those directly.