### PR TITLE
ref(suspect tags): Use `Referrer` enum values when querying Snuba

### DIFF
--- a/src/sentry/issues/suspect_tags.py
+++ b/src/sentry/issues/suspect_tags.py
@@ -5,6 +5,7 @@ import sentry_sdk
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
 
 from sentry.seer.workflows.compare import KeyedValueCount, keyed_kl_score
+from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
 
@@ -121,7 +122,7 @@ def query_baseline_set(
 
     response = raw_snql_query(
         snuba_request,
-        referrer="issues.suspect_tags.query_baseline_set",
+        referrer=Referrer.ISSUES_SUSPECT_TAGS_QUERY_BASELINE_SET.value,
         use_cache=True,
     )
 
@@ -197,7 +198,7 @@ def query_selection_set(
 
     response = raw_snql_query(
         snuba_request,
-        referrer="issues.suspect_tags.query_selection_set",
+        referrer=Referrer.ISSUES_SUSPECT_TAGS_QUERY_SELECTION_SET.value,
         use_cache=True,
     )
 
@@ -259,7 +260,7 @@ def query_error_counts(
 
     response = raw_snql_query(
         snuba_request,
-        referrer="issues.suspect_tags.query_error_counts",
+        referrer=Referrer.ISSUES_SUSPECT_TAGS_QUERY_ERROR_COUNTS.value,
         use_cache=True,
     )
 

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -679,6 +679,9 @@ class Referrer(StrEnum):
     IS_ESCALATING_GROUP = "sentry.issues.escalating.is_escalating"
     ISSUE_DETAILS_STREAMLINE_GRAPH = "issue_details.streamline_graph"
     ISSUE_DETAILS_STREAMLINE_LIST = "issue_details.streamline_list"
+    ISSUES_SUSPECT_TAGS_QUERY_BASELINE_SET = "issues.suspect_tags.query_baseline_set"
+    ISSUES_SUSPECT_TAGS_QUERY_SELECTION_SET = "issues.suspect_tags.query_selection_set"
+    ISSUES_SUSPECT_TAGS_QUERY_ERROR_COUNTS = "issues.suspect_tags.query_error_counts"
 
     INSIGHTS_MOBILE_HAS_TTFDCONFIGURED = "insights.mobile.hasTTFDConfigured"
     INSIGHTS_TIME_SPENT_TOTAL_TIME = "insights.time_spent.total_time"


### PR DESCRIPTION
Switch from hard-coded values to values from the `Referrer` enum for Snuba queries during suspect tags calculation.