### PR TITLE
feat(tracemetrics): Add PHP and Laravel to metrics allowlist

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -454,6 +454,7 @@ export const limitedMetricsSupportPrefixes: Set<string> = new Set([
   'javascript',
   'node',
   'python',
+  'php',
 ]);
 
 export const profiling: PlatformKey[] = [


### PR DESCRIPTION
We have metrics support for PHP, so expose the metrics tab for users.