### PR TITLE
feat(seer): Add "org defaults" step for seer onboarding

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -1,11 +1,11 @@
-import {Fragment, useCallback, useState} from 'react';
+import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import configureCodeReviewImg from 'sentry-images/spot/seer-config-check.svg';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
-import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {
@@ -15,20 +15,11 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
-import {useUpdateOrganization} from 'sentry/utils/useUpdateOrganization';
 
 import {useSeerOnboardingContext} from 'getsentry/views/seerAutomation/onboarding/hooks/seerOnboardingContext';
 import {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
 
-import {
-  Field,
-  FieldDescription,
-  FieldLabel,
-  MaxWidthPanel,
-  PanelDescription,
-  StepContent,
-} from './common';
+import {MaxWidthPanel, PanelDescription, StepContent} from './common';
 import {RepositorySelector} from './repositorySelector';
 
 // This is the max # of repos that we will allow to be pre-selected.
@@ -40,17 +31,12 @@ const DEFAULT_CODE_REVIEW_TRIGGERS = [
 ];
 
 export function ConfigureCodeReviewStep() {
-  const organization = useOrganization();
   const {currentStep, setCurrentStep} = useGuidedStepsContext();
   const {
     clearRootCauseAnalysisRepositories,
     selectedCodeReviewRepositories,
     unselectedCodeReviewRepositories,
   } = useSeerOnboardingContext();
-
-  const [enableCodeReview, setEnableCodeReview] = useState(
-    organization.autoEnableCodeReview ?? true
-  );
 
   const {mutate: updateRepositorySettings, isPending: isUpdateRepositorySettingsPending} =
     useBulkUpdateRepositorySettings();
@@ -140,13 +126,6 @@ export function ConfigureCodeReviewStep() {
     updateRepositorySettings,
   ]);
 
-  const handleChangeCodeReview = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setEnableCodeReview(e.target.checked);
-    },
-    [setEnableCodeReview]
-  );
-
   return (
     <Fragment>
       <StepContentWithBackground>
@@ -155,31 +134,14 @@ export function ConfigureCodeReviewStep() {
             <PanelDescription>
               <p>{t(`You've successfully connected to GitHub!`)}</p>
 
+              <Text bold>{t('AI Code Review')}</Text>
               <p>
                 {t(
-                  `Now, select which repositories you would like to run Seer’s AI Code Review on.`
+                  `For all selected repositories below, Seer's AI Code Review will be run to review your PRs and flag potential bugs. `
                 )}
               </p>
             </PanelDescription>
-
-            <Field>
-              <Flex direction="column" flex="1" gap="xs">
-                <FieldLabel>{t('Enable AI Code Review')}</FieldLabel>
-                <FieldDescription>
-                  <p>
-                    {t(
-                      'For all checked repositories below, Seer will review your PRs and flag potential bugs. '
-                    )}
-                  </p>
-                </FieldDescription>
-              </Flex>
-              <Switch
-                size="lg"
-                checked={enableCodeReview}
-                onChange={handleChangeCodeReview}
-              />
-            </Field>
-            <RepositorySelector disabled={!enableCodeReview} />
+            <RepositorySelector />
           </PanelBody>
         </MaxWidthPanel>
 

--- a/static/gsApp/views/seerAutomation/onboarding/configureDefaultsStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureDefaultsStep.tsx
@@ -1,0 +1,180 @@
+import {Fragment, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
+
+import configureRootCauseAnalysisImg from 'sentry-images/spot/seer-config-connect-2.svg';
+
+import {Button} from '@sentry/scraps/button';
+import {Text} from '@sentry/scraps/text';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {Flex} from 'sentry/components/core/layout/flex';
+import {Switch} from 'sentry/components/core/switch';
+import {
+  GuidedSteps,
+  useGuidedStepsContext,
+} from 'sentry/components/guidedSteps/guidedSteps';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PanelBody from 'sentry/components/panels/panelBody';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useUpdateOrganization} from 'sentry/utils/useUpdateOrganization';
+
+import {useSeerOnboardingContext} from './hooks/seerOnboardingContext';
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+  MaxWidthPanel,
+  PanelDescription,
+  StepContent,
+} from './common';
+
+export function ConfigureDefaultsStep() {
+  const organization = useOrganization();
+  const [proposeFixesEnabled, setProposeFixesEnabled] = useState(
+    organization.defaultAutofixAutomationTuning !== 'off'
+  );
+  const [autoCreatePREnabled, setAutoCreatePREnabled] = useState(
+    organization.autoOpenPrs ?? false
+  );
+  const [enableCodeReview, setEnableCodeReview] = useState(
+    organization.autoEnableCodeReview ?? true
+  );
+
+  const {currentStep, setCurrentStep} = useGuidedStepsContext();
+
+  const {mutate: updateOrganization, isPending: isUpdateOrganizationPending} =
+    useUpdateOrganization(organization);
+
+  const handlePreviousStep = useCallback(() => {
+    setCurrentStep(currentStep - 1);
+  }, [setCurrentStep, currentStep]);
+
+  const handleNextStep = useCallback(() => {
+    updateOrganization(
+      {
+        defaultAutofixAutomationTuning: proposeFixesEnabled ? 'medium' : 'off',
+        autoOpenPrs: autoCreatePREnabled,
+        autoEnableCodeReview: enableCodeReview,
+      },
+      {
+        onSuccess: () => {
+          setCurrentStep(currentStep + 1);
+          addSuccessMessage(t('Seer default settings updated successfully'));
+        },
+        onError: () => {
+          addErrorMessage(
+            t('Failed to update Seer default settings, reload and try again')
+          );
+        },
+      }
+    );
+  }, [
+    autoCreatePREnabled,
+    enableCodeReview,
+    proposeFixesEnabled,
+    updateOrganization,
+    currentStep,
+    setCurrentStep,
+  ]);
+
+  return (
+    <Fragment>
+      <StepContentWithBackground>
+        <MaxWidthPanel>
+          <PanelBody>
+            <PanelDescription>
+              <p>
+                {t(
+                  `Create default settings for all future projects and repositories. If you don’t turn this defaults on now, you can always manage them from the Seer Settings Page.`
+                )}
+              </p>
+              <p>
+                {t(
+                  `This will not effect the configuration of the repos and projects on the previous two steps.`
+                )}
+              </p>
+            </PanelDescription>
+
+            <Field>
+              <Field>
+                <Flex direction="column" flex="1" gap="xs">
+                  <FieldLabel>{t('Enable AI Code Review')}</FieldLabel>
+                  <FieldDescription>
+                    {t(
+                      'For all NEW projects, Seer will review your PRs and flag potential bugs.'
+                    )}
+                  </FieldDescription>
+                </Flex>
+                <Switch
+                  size="lg"
+                  checked={enableCodeReview}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setEnableCodeReview(e.target.checked)
+                  }
+                />
+              </Field>
+              <Flex direction="column" flex="1" gap="xs">
+                <FieldLabel>{t('Enable Root Cause Analysis')}</FieldLabel>
+                <FieldDescription>
+                  <Text>
+                    {t(
+                      'For all NEW projects, Seer will automatically analyze highly actionable issues, create a root cause analysis, and propose a solution. '
+                    )}
+                  </Text>
+                </FieldDescription>
+              </Flex>
+              <Switch
+                size="lg"
+                checked={proposeFixesEnabled}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setProposeFixesEnabled(e.target.checked)
+                }
+              />
+            </Field>
+            <Field>
+              <Flex direction="column" flex="1" gap="xs">
+                <FieldLabel>{t('Automatic PR Creation')}</FieldLabel>
+                <FieldDescription>
+                  {t('For all NEW projects, Seer will be able to create a pull request.')}
+                </FieldDescription>
+              </Flex>
+              <Switch
+                size="lg"
+                checked={autoCreatePREnabled}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setAutoCreatePREnabled(e.target.checked)
+                }
+              />
+            </Field>
+          </PanelBody>
+        </MaxWidthPanel>
+      </StepContentWithBackground>
+
+      <GuidedSteps.ButtonWrapper>
+        <Button size="md" onClick={handlePreviousStep} aria-label={t('Previous Step')}>
+          {t('Previous Step')}
+        </Button>
+        <Button
+          size="md"
+          onClick={handleNextStep}
+          priority="primary"
+          disabled={isUpdateOrganizationPending}
+          aria-label={t('Last Step')}
+        >
+          {t('Last Step')}
+        </Button>
+        {isUpdateOrganizationPending && <InlineLoadingIndicator size={20} />}
+      </GuidedSteps.ButtonWrapper>
+    </Fragment>
+  );
+}
+
+const StepContentWithBackground = styled(StepContent)`
+  background: url(${configureRootCauseAnalysisImg}) no-repeat 638px 0;
+  background-size: 200px 256px;
+`;
+
+const InlineLoadingIndicator = styled(LoadingIndicator)`
+  margin: 0;
+`;

--- a/static/gsApp/views/seerAutomation/onboarding/configureDefaultsStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureDefaultsStep.tsx
@@ -19,7 +19,6 @@ import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateOrganization} from 'sentry/utils/useUpdateOrganization';
 
-import {useSeerOnboardingContext} from './hooks/seerOnboardingContext';
 import {
   Field,
   FieldDescription,

--- a/static/gsApp/views/seerAutomation/onboarding/configureDefaultsStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureDefaultsStep.tsx
@@ -1,13 +1,14 @@
 import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
-import configureRootCauseAnalysisImg from 'sentry-images/spot/seer-config-connect-2.svg';
+import defaultsImg from 'sentry-images/spot/seer-config-error.svg';
 
 import {Button} from '@sentry/scraps/button';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Flex} from 'sentry/components/core/layout/flex';
+import {Link} from 'sentry/components/core/link';
 import {Switch} from 'sentry/components/core/switch';
 import {
   GuidedSteps,
@@ -15,7 +16,7 @@ import {
 } from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelBody from 'sentry/components/panels/panelBody';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateOrganization} from 'sentry/utils/useUpdateOrganization';
 
@@ -84,8 +85,11 @@ export function ConfigureDefaultsStep() {
           <PanelBody>
             <PanelDescription>
               <p>
-                {t(
-                  `Create default settings for all future projects and repositories. If you don’t turn this defaults on now, you can always manage them from the Seer Settings Page.`
+                {tct(
+                  `Create default settings for all future projects and repositories. If you don’t turn this defaults on now, you can always manage them from the [link:Seer Settings Page].`,
+                  {
+                    link: <Link to={`/settings/${organization.slug}/seer/`} />,
+                  }
                 )}
               </p>
               <p>
@@ -96,23 +100,23 @@ export function ConfigureDefaultsStep() {
             </PanelDescription>
 
             <Field>
-              <Field>
-                <Flex direction="column" flex="1" gap="xs">
-                  <FieldLabel>{t('Enable AI Code Review')}</FieldLabel>
-                  <FieldDescription>
-                    {t(
-                      'For all NEW projects, Seer will review your PRs and flag potential bugs.'
-                    )}
-                  </FieldDescription>
-                </Flex>
-                <Switch
-                  size="lg"
-                  checked={enableCodeReview}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setEnableCodeReview(e.target.checked)
-                  }
-                />
-              </Field>
+              <Flex direction="column" flex="1" gap="xs">
+                <FieldLabel>{t('Enable AI Code Review')}</FieldLabel>
+                <FieldDescription>
+                  {t(
+                    'For all NEW projects, Seer will review your PRs and flag potential bugs.'
+                  )}
+                </FieldDescription>
+              </Flex>
+              <Switch
+                size="lg"
+                checked={enableCodeReview}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setEnableCodeReview(e.target.checked)
+                }
+              />
+            </Field>
+            <Field>
               <Flex direction="column" flex="1" gap="xs">
                 <FieldLabel>{t('Enable Root Cause Analysis')}</FieldLabel>
                 <FieldDescription>
@@ -170,8 +174,8 @@ export function ConfigureDefaultsStep() {
 }
 
 const StepContentWithBackground = styled(StepContent)`
-  background: url(${configureRootCauseAnalysisImg}) no-repeat 638px 0;
-  background-size: 200px 256px;
+  background: url(${defaultsImg}) no-repeat 638px 0;
+  background-size: 192px 168px;
 `;
 
 const InlineLoadingIndicator = styled(LoadingIndicator)`

--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -130,7 +130,8 @@ export function ConfigureRootCauseAnalysisStep() {
     // Only submit if RCA is disabled (empty mapping is fine) or there are valid mappings
     const hasMappings = Object.keys(projectRepoMapping).length > 0;
     if (!hasMappings) {
-      addErrorMessage(t('At least one repository must be mapped to a project'));
+      // Otherwise, there is nothing mapped so nothing to do here, can advance to the next step.
+      setCurrentStep(currentStep + 1);
       return;
     }
 

--- a/static/gsApp/views/seerAutomation/onboarding/nextStepsStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/nextStepsStep.tsx
@@ -1,10 +1,9 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import nextStepsImg from 'sentry-images/spot/seer-config-error.svg';
+import nextStepsImg from 'sentry-images/spot/seer-config-bug-2.svg';
 
 import {LinkButton} from '@sentry/scraps/button/linkButton';
-import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -12,18 +11,10 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {t, tct} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import {useSeerOnboardingContext} from './hooks/seerOnboardingContext';
 import {ActionSection, MaxWidthPanel, PanelDescription, StepContent} from './common';
 
 export function NextStepsStep() {
-  const {selectedCodeReviewRepositories, selectedRootCauseAnalysisRepositories} =
-    useSeerOnboardingContext();
-
   const organization = useOrganization();
-  const totalRepositories = new Set([
-    ...selectedCodeReviewRepositories.map(repo => repo.id),
-    ...selectedRootCauseAnalysisRepositories.map(repo => repo.id),
-  ]).size;
 
   return (
     <Fragment>
@@ -55,30 +46,6 @@ export function NextStepsStep() {
                 )}
               </Text>
             </PanelDescription>
-            <PanelDescription>
-              <Flex direction="column" gap="md">
-                <Text bold>{t('Predicted spend')}</Text>
-                <Text>
-                  {t(`Based on the activity in your Seer-connected repositories
-              over the last month, this is an estimate of what you would owe at the end of
-              your trial:`)}
-                </Text>
-                <Well>
-                  <WellContent>
-                    <CellTitle>{t('Connected Repos')}</CellTitle>
-                    <Text>{totalRepositories}</Text>
-                  </WellContent>
-                  <WellContent>
-                    <CellTitle>{t('Active Contributors')}</CellTitle>
-                    <Text>??</Text>
-                  </WellContent>
-                  <WellContent>
-                    <CellTitle>{t('Predicted Spend')}</CellTitle>
-                    <Text>$4,000</Text>
-                  </WellContent>
-                </Well>
-              </Flex>
-            </PanelDescription>
           </PanelBody>
         </MaxWidthPanel>
 
@@ -98,29 +65,9 @@ export function NextStepsStep() {
 
 const StepContentWithBackground = styled(StepContent)`
   background: url(${nextStepsImg}) no-repeat 638px 0;
-  background-size: 192px 168px;
+  background-size: 233px 212px;
 `;
 
 const NextStepsList = styled('ul')`
   margin: ${p => p.theme.space.xl} 0;
-`;
-
-const Well = styled(Flex)`
-  background: ${p => p.theme.backgroundSecondary};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.radius.md};
-`;
-const WellContent = styled(Flex)`
-  flex-direction: column;
-  border-right: 1px solid ${p => p.theme.border};
-  padding: ${p => p.theme.space.lg};
-
-  &:last-child {
-    border-right: none;
-  }
-`;
-const CellTitle = styled(Text)`
-  color: ${p => p.theme.subText};
-  font-weight: ${p => p.theme.fontWeight.bold};
-  text-transform: uppercase;
 `;

--- a/static/gsApp/views/seerAutomation/onboarding/stepsManager.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/stepsManager.tsx
@@ -77,7 +77,7 @@ export function StepsManager() {
         <ConfigureDefaultsStep />
       </GuidedSteps.Step>
 
-      <GuidedSteps.Step stepKey={Steps.NEXT_STEPS} title={t('Next Steps')}>
+      <GuidedSteps.Step stepKey={Steps.NEXT_STEPS} title={t('Wrap Up')}>
         <NextStepsStep />
       </GuidedSteps.Step>
     </Fragment>

--- a/static/gsApp/views/seerAutomation/onboarding/stepsManager.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/stepsManager.tsx
@@ -13,6 +13,7 @@ import {useSeerOnboardingContext} from 'getsentry/views/seerAutomation/onboardin
 import {Steps} from 'getsentry/views/seerAutomation/onboarding/types';
 
 import {ConfigureCodeReviewStep} from './configureCodeReviewStep';
+import {ConfigureDefaultsStep} from './configureDefaultsStep';
 import {ConfigureRootCauseAnalysisStep} from './configureRootCauseAnalysisStep';
 import {ConnectGithubStep} from './connectGithubStep';
 import {NextStepsStep} from './nextStepsStep';
@@ -70,6 +71,10 @@ export function StepsManager() {
         title={t('Set Up AI Root Cause Analysis')}
       >
         <ConfigureRootCauseAnalysisStep />
+      </GuidedSteps.Step>
+
+      <GuidedSteps.Step stepKey={Steps.SETUP_DEFAULTS} title={t('Set Up Defaults')}>
+        <ConfigureDefaultsStep />
       </GuidedSteps.Step>
 
       <GuidedSteps.Step stepKey={Steps.NEXT_STEPS} title={t('Next Steps')}>

--- a/static/gsApp/views/seerAutomation/onboarding/types.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/types.tsx
@@ -2,5 +2,6 @@ export enum Steps {
   CONNECT_GITHUB = 'connect-github',
   SETUP_CODE_REVIEW = 'setup-code-review',
   SETUP_ROOT_CAUSE_ANALYSIS = 'setup-root-cause-analysis',
+  SETUP_DEFAULTS = 'setup-defaults',
   NEXT_STEPS = 'next-steps',
 }


### PR DESCRIPTION
Implements new design changes that splits org default into a new step.

## Code Review

<img width="965" height="747" alt="image" src="https://github.com/user-attachments/assets/82b5a9ee-0101-4350-949e-1f912a9e8bbc" />

## RCA
<img width="971" height="777" alt="image" src="https://github.com/user-attachments/assets/45f7af60-2e71-48fc-a033-d86d34fc309f" />

## *new* Defaults
<img width="916" height="491" alt="image" src="https://github.com/user-attachments/assets/d798270b-779a-4007-a5a8-e414e2efadba" />

## Wrap Up
<img width="954" height="375" alt="image" src="https://github.com/user-attachments/assets/09d67053-166b-4f06-b5ea-f09f554ad3b3" />

