### PR TITLE
theme: migrate surface theme usage

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -241,7 +241,7 @@ const InnerLabel = styled(TextOverflow)`
 
 const InputWrapper = styled('div')<{isEmpty: boolean}>`
   display: inline-block;
-  background: ${p => p.theme.surface200};
+  background: ${p => p.theme.colors.surface300};
   border-radius: ${p => p.theme.radius.md};
   margin: -${space(0.5)} -${space(1)};
   padding: ${space(0.5)} ${space(1)};

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -402,7 +402,8 @@ const DefaultLine = styled('div')<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: ${p => (p.isSubFrame ? `${p.theme.surface100}` : `${p.theme.surface200}`)};
+  background: ${p =>
+    p.isSubFrame ? `${p.theme.colors.surface200}` : `${p.theme.colors.surface300}`};
   min-height: 40px;
   word-break: break-word;
   padding: ${space(0.75)} ${space(1.5)};

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -323,7 +323,7 @@ const StyledList = styled(List)`
 `;
 
 const Suggestions = styled('div')`
-  background-color: ${p => p.theme.surface100};
+  background-color: ${p => p.theme.colors.surface200};
   border-radius: ${p => p.theme.radius.md};
   padding: ${space(1)} ${space(1)} ${space(1)} ${space(2)};
 `;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -549,7 +549,7 @@ const RowHeader = styled('span')<{
   column-gap: ${space(1)};
   background-color: ${p =>
     !p.isInAppFrame && p.isSubFrame
-      ? `${p.theme.surface100}`
+      ? `${p.theme.colors.surface200}`
       : `${p.theme.bodyBackground}`};
   font-size: ${p => p.theme.fontSize.sm};
   padding: ${space(1)};

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -174,7 +174,7 @@ const Title = styled('div')`
 const StreamlinedPanel = styled(Panel)`
   position: relative;
   background: ${p => p.theme.tokens.background.primary}
-    linear-gradient(to right, rgba(245, 243, 247, 0), ${p => p.theme.surface100});
+    linear-gradient(to right, rgba(245, 243, 247, 0), ${p => p.theme.colors.surface200});
   overflow: hidden;
   margin-bottom: 0;
   width: 100%;

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -362,7 +362,7 @@ const InteractionOverlayCanvas = styled('canvas')`
 `;
 
 const WireframeCanvas = styled('canvas')`
-  background-color: ${p => p.theme.surface100};
+  background-color: ${p => p.theme.colors.surface200};
   width: 100%;
   height: 100%;
 `;

--- a/static/app/components/notificationActions/notificationActionItem.tsx
+++ b/static/app/components/notificationActions/notificationActionItem.tsx
@@ -360,7 +360,8 @@ const StyledCard = styled(Card)<{isEditing: boolean}>`
   align-items: center;
   justify-content: space-between;
   margin-bottom: ${space(1)};
-  background-color: ${props => (props.isEditing ? props.theme.surface200 : 'inherit')};
+  background-color: ${props =>
+    props.isEditing ? props.theme.colors.surface300 : 'inherit'};
 `;
 
 const IconContainer = styled('div')`

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -526,7 +526,7 @@ const FrameBar = styled('div')<{withoutBorders?: boolean}>`
   overflow: auto;
   width: 100%;
   position: relative;
-  background-color: ${p => p.theme.surface200};
+  background-color: ${p => p.theme.colors.surface300};
   ${p => !p.withoutBorders && `border-top: 1px solid ${p.theme.border};`}
   flex: 1 1 100%;
 `;

--- a/static/app/components/profiling/flamegraph/callTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/callTreeTable.tsx
@@ -66,7 +66,7 @@ export const CallTreeTable = styled('div')`
     }
 
     &[data-hovered='true']:not([tabindex='0']) {
-      background: ${p => p.theme.surface200};
+      background: ${p => p.theme.colors.surface300};
     }
   }
 
@@ -231,7 +231,7 @@ export const CallTreeTableHeaderButton = styled('button')`
   justify-content: space-between;
   padding: 0 ${space(1)};
   border: none;
-  background-color: ${props => props.theme.surface200};
+  background-color: ${props => props.theme.colors.surface300};
   transition: background-color 100ms ease-in-out;
   line-height: 29px;
 

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/differentialFlamegraphDrawer.tsx
@@ -351,7 +351,7 @@ const ProfilingDetailsFrameTabs = styled('ul')`
   padding: 0 ${space(1)};
   margin: 0;
   border-top: 1px solid ${prop => prop.theme.border};
-  background-color: ${props => props.theme.surface200};
+  background-color: ${props => props.theme.colors.surface300};
   user-select: none;
   grid-area: tabs;
 `;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -365,7 +365,7 @@ export const ProfilingDetailsFrameTabs = styled('ul')`
   padding: 0 ${space(1)};
   margin: 0;
   border-top: 1px solid ${prop => prop.theme.border};
-  background-color: ${props => props.theme.surface200};
+  background-color: ${props => props.theme.colors.surface300};
   user-select: none;
   grid-area: tabs;
 `;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -391,7 +391,7 @@ const FrameBar = styled('div')`
   overflow: auto;
   width: 100%;
   position: relative;
-  background-color: ${p => p.theme.surface200};
+  background-color: ${p => p.theme.colors.surface300};
   border-top: 1px solid ${p => p.theme.border};
   flex: 1 1 100%;
   grid-area: table;

--- a/static/app/stories/apiReference.tsx
+++ b/static/app/stories/apiReference.tsx
@@ -361,7 +361,7 @@ const StoryTypesTable = styled('table')`
   table-layout: fixed;
 
   th {
-    background-color: ${p => p.theme.surface200};
+    background-color: ${p => p.theme.colors.surface300};
   }
 
   tr:not(:last-child) {
@@ -380,13 +380,13 @@ const StoryTypesTable = styled('table')`
 
 const StoryTypesTableHeader = styled('thead')`
   tr {
-    background-color: ${p => p.theme.surface200};
+    background-color: ${p => p.theme.colors.surface300};
     border-bottom: 1px solid ${p => p.theme.border};
   }
 `;
 
 const StoryTypesTableHeaderCell = styled('th')`
-  background-color: ${p => p.theme.surface200};
+  background-color: ${p => p.theme.colors.surface300};
   padding: ${p => p.theme.space.md};
 `;
 
@@ -398,7 +398,7 @@ const StoryTypesTableCell = styled('td')`
 const StoryTypesTableDefinitionCell = styled('td')`
   padding: ${p => p.theme.space.md};
   padding-left: 0;
-  background-color: ${p => p.theme.surface200};
+  background-color: ${p => p.theme.colors.surface300};
 
   button {
     margin-left: ${p => p.theme.space['2xs']};

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
@@ -32,7 +32,7 @@ function updateGhostRow({
   element.style.height = `${rowHeight}px`;
   element.style.position = 'absolute';
   element.style.backgroundColor =
-    interaction === 'clicked' ? theme.blue300 : theme.surface200;
+    interaction === 'clicked' ? theme.blue300 : theme.colors.surface300;
   element.style.pointerEvents = 'none';
   element.style.willChange = 'transform, opacity';
   element.style.transform = `translateY(${rowHeight * selectedNodeIndex - scrollTop}px)`;

--- a/static/app/views/alerts/rules/issue/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/issue/details/sidebar.tsx
@@ -228,7 +228,7 @@ const Badge = styled('span')`
 
 const ConditionsBadge = styled('span')`
   display: block;
-  background-color: ${p => p.theme.surface200};
+  background-color: ${p => p.theme.colors.surface300};
   padding: 0 ${space(0.75)};
   border-radius: ${p => p.theme.radius.md};
   color: ${p => p.theme.tokens.content.primary};

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -414,7 +414,7 @@ const TriggerActions = styled('div')`
 
 const TriggerText = styled('span')`
   display: block;
-  background-color: ${p => p.theme.surface200};
+  background-color: ${p => p.theme.colors.surface300};
   padding: ${space(0.25)} ${space(0.75)};
   border-radius: ${p => p.theme.radius.md};
   color: ${p => p.theme.tokens.content.primary};

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -793,7 +793,7 @@ function LoadingScreen({
 const LoadingPlaceholder = styled(({className}: PlaceholderProps) => (
   <Placeholder height="200px" className={className} />
 ))`
-  background-color: ${p => p.theme.surface300};
+  background-color: ${p => p.theme.colors.surface400};
 `;
 
 const BigNumberResizeWrapper = styled('div')<{noPadding?: boolean}>`

--- a/static/app/views/dashboards/widgetCard/toolbar.tsx
+++ b/static/app/views/dashboards/widgetCard/toolbar.tsx
@@ -118,7 +118,7 @@ const ToolbarPanel = styled('div')`
   justify-content: flex-end;
   align-items: flex-start;
 
-  background-color: ${p => color(p.theme.surface300).alpha(0.7).string()};
+  background-color: ${p => color(p.theme.colors.surface400).alpha(0.7).string()};
   border-radius: calc(${p => p.theme.radius.md} - 1px);
 `;
 

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -171,7 +171,7 @@ const OptionLabel = styled('label')<{disabled?: boolean}>`
   grid-template-columns: 1fr;
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid ${p => p.theme.border};
-  background-color: ${p => p.theme.surface400};
+  background-color: ${p => p.theme.colors.surface500};
   font-weight: ${p => p.theme.fontWeight.normal};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
   overflow: hidden;

--- a/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
@@ -89,7 +89,7 @@ const FrameContainer = styled('div')`
 
   border-top: 1px solid ${p => p.theme.border};
 
-  background: ${p => p.theme.surface200};
+  background: ${p => p.theme.colors.surface300};
 `;
 
 const ProjectAvatarContainer = styled('div')`

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -200,7 +200,7 @@ const TagBarBackground = styled('div')<{widthPercent: string}>`
   top: 0;
   bottom: 0;
   left: 0;
-  background: ${p => p.theme.surface100};
+  background: ${p => p.theme.colors.surface200};
   border-radius: ${p => p.theme.radius.md};
   width: ${p => p.widthPercent};
 `;

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -188,7 +188,7 @@ const EventItemRoot = styled(Link)`
   font-size: ${p => p.theme.fontSize.sm};
 
   &:hover {
-    background-color: ${p => p.theme.surface200};
+    background-color: ${p => p.theme.colors.surface300};
     color: ${p => p.theme.tokens.content.primary};
   }
 `;

--- a/static/app/views/nav/mobileTopbar.tsx
+++ b/static/app/views/nav/mobileTopbar.tsx
@@ -131,7 +131,7 @@ const Topbar = styled('header')<{showSuperuserWarning: boolean}>`
   padding-left: ${space(1.5)};
   padding-right: ${space(1.5)};
   border-bottom: 1px solid ${p => p.theme.translucentGray200};
-  background: ${p => p.theme.surface300};
+  background: ${p => p.theme.colors.surface400};
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -155,7 +155,7 @@ const NavigationOverlay = styled('nav')`
   left: 0;
   display: flex;
   flex-direction: column;
-  background: ${p => p.theme.surface200};
+  background: ${p => p.theme.colors.surface300};
   z-index: ${p => p.theme.zIndex.modal};
   --color: ${p => p.theme.tokens.content.primary};
   --color-hover: ${p => p.theme.activeText};

--- a/static/app/views/nav/secondary/secondaryMobile.tsx
+++ b/static/app/views/nav/secondary/secondaryMobile.tsx
@@ -52,7 +52,7 @@ const GroupHeader = styled('h2')`
   position: sticky;
   top: 0;
   z-index: 1;
-  background: ${p => p.theme.surface200};
+  background: ${p => p.theme.colors.surface300};
   display: flex;
   align-items: center;
   padding: ${space(2)} ${space(1)};

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewItem.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewItem.tsx
@@ -257,7 +257,7 @@ const UnsavedChangesIndicator = styled('div')<{isActive: boolean}>`
 
   border-radius: 50%;
   background: ${p => p.theme.purple400};
-  border: solid 2px ${p => p.theme.surface200};
+  border: solid 2px ${p => p.theme.colors.surface300};
   position: absolute;
   width: 10px;
   height: 10px;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
@@ -73,7 +73,7 @@ export function IssueViewQueryCount({view, isActive}: IssueViewQueryCountProps) 
     <QueryCountBubble
       animate={{
         backgroundColor: isFetching
-          ? [theme.surface400, theme.surface100, theme.surface400]
+          ? [theme.colors.surface500, theme.colors.surface200, theme.colors.surface500]
           : `#00000000`,
       }}
       transition={{

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1092,8 +1092,8 @@ const TraceStylingWrapper = styled('div')`
 
       /* hardcoded until new color scales are added to theme */
       &.missing_instrumentation {
-        --pattern-odd: ${p => p.theme.surface100};
-        --pattern-even: ${p => p.theme.surface300};
+        --pattern-odd: ${p => p.theme.colors.surface200};
+        --pattern-even: ${p => p.theme.colors.surface400};
       }
 
       &.error,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -785,7 +785,7 @@ const TableValueRow = styled('div')`
   gap: ${space(1)};
 
   border-radius: 4px;
-  background-color: ${p => p.theme.surface200};
+  background-color: ${p => p.theme.colors.surface300};
   margin: 2px;
 `;
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -291,13 +291,13 @@ const BuildItemContainer = styled(Flex)<{isSelected: boolean}>`
   cursor: pointer;
 
   &:hover {
-    background-color: ${p => p.theme.surface100};
+    background-color: ${p => p.theme.colors.surface200};
   }
 
   ${p =>
     p.isSelected &&
     `
-      background-color: ${p.theme.surface200};
+      background-color: ${p.theme.colors.surface300};
     `}
 `;
 

--- a/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeCategories.tsx
@@ -52,7 +52,7 @@ export function AppSizeCategories(props: AppSizeCategoriesProps) {
       avoidLabelOverlap: false,
       itemStyle: {
         borderRadius: 6,
-        borderColor: theme.surface100,
+        borderColor: theme.colors.surface200,
         borderWidth: 2,
       },
       label: {
@@ -88,7 +88,7 @@ export function AppSizeCategories(props: AppSizeCategoriesProps) {
   const tooltip: TooltipOption = {
     trigger: 'item',
     borderWidth: 0,
-    backgroundColor: theme.surface100,
+    backgroundColor: theme.colors.surface200,
     hideDelay: 0,
     transitionDuration: 0,
     padding: 12,

--- a/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
@@ -271,7 +271,7 @@ const LegendItem = styled('div')<{isActive: boolean}>`
     background-color 0.2s ease;
 
   &:hover {
-    background-color: ${p => p.theme.surface100};
+    background-color: ${p => p.theme.colors.surface200};
     opacity: ${p => (p.isActive ? 1 : 0.6)};
   }
 `;

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -222,7 +222,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
         top: '0',
         emphasis: {
           itemStyle: {
-            color: theme.surface100,
+            color: theme.colors.surface200,
             textStyle: {
               fontSize: 12,
               fontWeight: 'bold',

--- a/static/app/views/relocation/components/wrapper.tsx
+++ b/static/app/views/relocation/components/wrapper.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: ${p => p.theme.surface400};
+  background-color: ${p => p.theme.colors.surface500};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -147,7 +147,7 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: ${p => p.theme.surface400};
+  background-color: ${p => p.theme.colors.surface500};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -187,7 +187,7 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: ${p => p.theme.surface400};
+  background-color: ${p => p.theme.colors.surface500};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;
@@ -236,7 +236,7 @@ const UploadWell = styled('div')<{draggedOver: boolean}>`
   border-radius: 3px;
   border: 1px ${props => (props.draggedOver ? 'solid' : 'dashed')} ${p => p.theme.border};
   background: ${props =>
-    props.draggedOver ? p => p.theme.purple100 : p => p.theme.surface400};
+    props.draggedOver ? p => p.theme.purple100 : p => p.theme.colors.surface500};
 
   .upload-icon {
     color: ${p => p.theme.gray500};

--- a/static/app/views/replays/detail/network/details/tabs.tsx
+++ b/static/app/views/replays/detail/network/details/tabs.tsx
@@ -48,7 +48,7 @@ const StyledNetworkDetailsTabs = styled(NetworkDetailsTabs)`
   & > li {
     margin-right: 0;
     padding-right: ${space(3)};
-    background: ${p => p.theme.surface400};
+    background: ${p => p.theme.colors.surface500};
     z-index: ${p => p.theme.zIndex.initial};
   }
   & > li:first-child {

--- a/static/app/views/settings/projectSeer/selectableRepoItem.tsx
+++ b/static/app/views/settings/projectSeer/selectableRepoItem.tsx
@@ -75,10 +75,10 @@ const RepoListItemContainer = styled('div')<{
   ${p =>
     p.selected &&
     css`
-      background-color: ${p.theme.surface100};
+      background-color: ${p.theme.colors.surface200};
 
       &:hover {
-        background-color: ${p.theme.surface100};
+        background-color: ${p.theme.colors.surface200};
       }
     `}
 `;


### PR DESCRIPTION
Migrate gray color scale usage away from the legacy mapping.

surface100 → surface200
surface200 → surface300
surface300 → surface400
surface400 → surface500
surface500 → surface500

We cannot remove the actual keys from the theme yet due to the ColorOrAlias usages.