### PR TITLE
ref(seer): Refactor useShowNewSeer() into showNewSeer() and put it inside of sentry, not gsApp

### DIFF
--- a/static/app/utils/seer/showNewSeer.ts
+++ b/static/app/utils/seer/showNewSeer.ts
@@ -1,4 +1,4 @@
-import useOrganization from 'sentry/utils/useOrganization';
+import type {Organization} from 'sentry/types/organization';
 
 /**
  * This hook determines if we should show the new Seer settings/onboarding or not.
@@ -9,9 +9,7 @@ import useOrganization from 'sentry/utils/useOrganization';
  *  - The organization is on the code-review-beta trial
  *  - If the new Seer billing is released
  */
-export function useShowNewSeer() {
-  const organization = useOrganization();
-
+export default function showNewSeer(organization: Organization) {
   // New seer plan
   if (organization.features.includes('seat-based-seer-enabled')) {
     return true;

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -121,7 +121,7 @@ function OrganizationSettingsForm({initialData, onSave}: Props) {
           </PoweredByCodecov>
         ),
       },
-      makePreventAiField(),
+      makePreventAiField(organization),
     ];
     return formsConfig;
   }, [access, organization]);

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -7,8 +7,10 @@ import type {FieldObject} from 'sentry/components/forms/types';
 import {IconLock} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
+import type {Organization} from 'sentry/types/organization';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
 
-export const makePreventAiField = (): FieldObject => {
+export const makePreventAiField = (organization: Organization): FieldObject => {
   const isSelfHosted = ConfigStore.get('isSelfHosted');
 
   const isDisabled = isSelfHosted;
@@ -43,6 +45,10 @@ export const makePreventAiField = (): FieldObject => {
       ),
     }),
     visible: ({model}) => {
+      if (showNewSeer(organization)) {
+        return false;
+      }
+
       // Show field when AI features are enabled (hideAiFeatures is false)
       const hideAiFeatures = model.getValue('hideAiFeatures');
       return hideAiFeatures;

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
@@ -9,6 +9,7 @@ import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -17,7 +18,6 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import SeerWizardSetupBanner from 'getsentry/views/seerAutomation/components/seerWizardSetupBanner';
 import SettingsPageTabs from 'getsentry/views/seerAutomation/components/settingsPageTabs';
 import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
-import {useShowNewSeer} from 'getsentry/views/seerAutomation/onboarding/hooks/useShowNewSeer';
 
 interface Props {
   children: React.ReactNode;
@@ -27,13 +27,12 @@ export default function SeerSettingsPageWrapper({children}: Props) {
   const navigate = useNavigate();
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
-  const showNewSeer = useShowNewSeer();
 
   useEffect(() => {
     // If the org is on the old-seer plan then they shouldn't be here on this new settings page
     // Or if we havn't launched the new seer yet.
     // Then they need to see old settings page, or get downgraded off old seer.
-    if (!showNewSeer) {
+    if (!showNewSeer(organization)) {
       navigate(normalizeUrl(`/organizations/${organization.slug}/settings/seer/`));
       return;
     }
@@ -45,7 +44,7 @@ export default function SeerSettingsPageWrapper({children}: Props) {
     }
 
     // Else you do have the new seer plan, then stay here and edit some settings.
-  }, [navigate, organization.features, organization.slug, showNewSeer]);
+  }, [navigate, organization.features, organization.slug, organization]);
 
   return (
     <Feature

--- a/static/gsApp/views/seerAutomation/onboarding/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboarding.tsx
@@ -1,4 +1,6 @@
-import {useShowNewSeer} from './hooks/useShowNewSeer';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
+import useOrganization from 'sentry/utils/useOrganization';
+
 import SeerOnboardingLegacy from './onboardingLegacy';
 import SeerOnboardingSeatBased from './onboardingSeatBased';
 
@@ -6,9 +8,9 @@ import SeerOnboardingSeatBased from './onboardingSeatBased';
  * Depending on user's billing, will show either the legacy onboarding, or the newer, seat-based onboarding.
  */
 export default function SeerOnboarding() {
-  const showNewSeer = useShowNewSeer();
+  const organization = useOrganization();
 
-  if (showNewSeer) {
+  if (showNewSeer(organization)) {
     return <SeerOnboardingSeatBased />;
   }
 

--- a/static/gsApp/views/seerAutomation/seerAutomation.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomation.tsx
@@ -6,20 +6,19 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {DataCategoryExact} from 'sentry/types/core';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import {SeerAutomationDefault} from 'getsentry/views/seerAutomation/components/seerAutomationDefault';
 import {SeerAutomationProjectList} from 'getsentry/views/seerAutomation/components/seerAutomationProjectList';
-import {useShowNewSeer} from 'getsentry/views/seerAutomation/onboarding/hooks/useShowNewSeer';
 import SeerAutomationSettings from 'getsentry/views/seerAutomation/settings';
 
 export default function SeerAutomation() {
   const organization = useOrganization();
-  const showNewSeer = useShowNewSeer();
 
-  if (showNewSeer) {
+  if (showNewSeer(organization)) {
     return <SeerAutomationSettings />;
   }
 

--- a/static/gsApp/views/seerAutomation/trial.tsx
+++ b/static/gsApp/views/seerAutomation/trial.tsx
@@ -19,12 +19,12 @@ import {Text} from '@sentry/scraps/text/text';
 
 import {IconUpgrade} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import useSubscription from 'getsentry/hooks/useSubscription';
 import {hasAccessToSubscriptionOverview} from 'getsentry/utils/billing';
-import {useShowNewSeer} from 'getsentry/views/seerAutomation/onboarding/hooks/useShowNewSeer';
 
 const BUTTONS = [
   {
@@ -53,7 +53,6 @@ export default function SeerAutomationTrial() {
   const navigate = useNavigate();
   const organization = useOrganization();
   const subscription = useSubscription();
-  const showNewSeer = useShowNewSeer();
 
   const canVisitSubscriptionPage = hasAccessToSubscriptionOverview(
     subscription,
@@ -63,7 +62,7 @@ export default function SeerAutomationTrial() {
   useEffect(() => {
     // If the org is on the old-seer plan then they shouldn't be here on this new settings page
     // they need to goto the old settings page, or get downgraded off old seer.
-    if (!showNewSeer) {
+    if (!showNewSeer(organization)) {
       navigate(normalizeUrl(`/organizations/${organization.slug}/settings/seer/`));
       return;
     }
@@ -75,7 +74,7 @@ export default function SeerAutomationTrial() {
     }
 
     // Else you don't yet have the new seer plan, then stay here and click to start a trial.
-  }, [navigate, organization.features, organization.slug, showNewSeer]);
+  }, [navigate, organization.features, organization.slug, organization]);
 
   return (
     <Fragment>


### PR DESCRIPTION
This also adds the check to the "Enable AI Code Review (beta)" button on /settings/organization/

That button will be visible if:
- `seer-user-billing` is disabled
- OR `seer-added` is enabled.