### PR TITLE
ref(seer): Change `onboarding_seer_settings_update` to not configure org details

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -597,15 +597,12 @@ def onboarding_seer_settings_update(
         rca_default_tuning = AutofixAutomationTuningSettings.MEDIUM
     else:
         rca_default_tuning = AutofixAutomationTuningSettings.OFF
-    organization.update_option("sentry:default_autofix_automation_tuning", rca_default_tuning)
 
     # Set the default stopping point and auto open PRs for the org
     if is_auto_open_prs_enabled:
         stopping_point = AutofixStoppingPoint.OPEN_PR
-        organization.update_option("sentry:auto_open_prs", True)
     else:
         stopping_point = AutofixStoppingPoint.CODE_CHANGES
-        organization.update_option("sentry:auto_open_prs", False)
 
     # Update preferences for each project with its repositories
     preferences_to_set = []
@@ -627,7 +624,7 @@ def onboarding_seer_settings_update(
         "onboarding_seer_settings_update for new org completed",
         extra={
             "organization_id": organization_id,
-            "default_autofix_automation_tuning": rca_default_tuning,
+            "autofix_automation_tuning": rca_default_tuning,
             "auto_open_prs": is_auto_open_prs_enabled,
             "org_slug": organization.slug,
             "num_projects": len(project_repo_dict),

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1476,13 +1476,18 @@ class TestGetLogsForEvent(TestCase):
 
 @pytest.mark.django_db
 class TestOnboardingSeerSettingsUpdate(TestCase):
-    def test_rca_disabled_sets_automation_tuning_off(self) -> None:
-        """Tests that when RCA is disabled, automation tuning is set to OFF for org."""
+    def test_does_not_set_org_options_when_rca_enabled(self) -> None:
+        """Tests that org options are not set"""
         organization = self.create_organization()
+
+        assert (
+            organization.get_option("sentry:default_autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.OFF
+        )
 
         onboarding_seer_settings_update(
             organization_id=organization.id,
-            is_rca_enabled=False,
+            is_rca_enabled=True,
             is_auto_open_prs_enabled=False,
             project_repo_dict={},
         )
@@ -1493,47 +1498,6 @@ class TestOnboardingSeerSettingsUpdate(TestCase):
             organization.get_option("sentry:default_autofix_automation_tuning")
             == AutofixAutomationTuningSettings.OFF
         )
-        # Verify auto_open_prs is set to False
-        assert organization.get_option("sentry:auto_open_prs") is False
-
-    def test_rca_enabled_sets_automation_tuning_medium(self) -> None:
-        """Tests that when RCA is enabled, automation tuning is set to MEDIUM for org."""
-        organization = self.create_organization()
-
-        onboarding_seer_settings_update(
-            organization_id=organization.id,
-            is_rca_enabled=True,
-            is_auto_open_prs_enabled=False,
-            project_repo_dict={},
-        )
-
-        # Verify org-level option is set to MEDIUM
-        organization.refresh_from_db()
-        assert (
-            organization.get_option("sentry:default_autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.MEDIUM
-        )
-        # Verify auto_open_prs is set to False
-        assert organization.get_option("sentry:auto_open_prs") is False
-
-    def test_auto_open_prs_enabled_sets_org_option(self) -> None:
-        """Tests that when auto_open_prs is enabled, the org option is set to True."""
-        organization = self.create_organization()
-
-        onboarding_seer_settings_update(
-            organization_id=organization.id,
-            is_rca_enabled=True,
-            is_auto_open_prs_enabled=True,
-            project_repo_dict={},
-        )
-
-        # Verify org-level options
-        organization.refresh_from_db()
-        assert (
-            organization.get_option("sentry:default_autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.MEDIUM
-        )
-        assert organization.get_option("sentry:auto_open_prs") is True
 
     @patch("sentry.seer.autofix.autofix.bulk_set_project_preferences")
     def test_rca_disabled_with_auto_prs_and_project_sets_open_pr_stopping_point(
@@ -1559,11 +1523,6 @@ class TestOnboardingSeerSettingsUpdate(TestCase):
 
         # Verify org-level options
         organization.refresh_from_db()
-        assert (
-            organization.get_option("sentry:default_autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.OFF
-        )
-        assert organization.get_option("sentry:auto_open_prs") is True
 
         # Verify bulk_set_project_preferences is called with OPEN_PR stopping point
         mock_bulk_set.assert_called_once()

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -19,7 +19,6 @@ from sentry.seer.autofix.autofix import (
     onboarding_seer_settings_update,
     trigger_autofix,
 )
-from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
 from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
@@ -1480,10 +1479,7 @@ class TestOnboardingSeerSettingsUpdate(TestCase):
         """Tests that org options are not set"""
         organization = self.create_organization()
 
-        assert (
-            organization.get_option("sentry:default_autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.OFF
-        )
+        assert organization.get_option("sentry:default_autofix_automation_tuning") is None
 
         onboarding_seer_settings_update(
             organization_id=organization.id,
@@ -1494,10 +1490,7 @@ class TestOnboardingSeerSettingsUpdate(TestCase):
 
         # Verify org-level option is set to OFF
         organization.refresh_from_db()
-        assert (
-            organization.get_option("sentry:default_autofix_automation_tuning")
-            == AutofixAutomationTuningSettings.OFF
-        )
+        assert organization.get_option("sentry:default_autofix_automation_tuning") is None
 
     @patch("sentry.seer.autofix.autofix.bulk_set_project_preferences")
     def test_rca_disabled_with_auto_prs_and_project_sets_open_pr_stopping_point(


### PR DESCRIPTION
No longer needed on this endpoint (in fact, this API will be removed soon).
