### PR TITLE
feat(occurrences on eap): Add retries and backoff for delete RPC requests sent to EAP

### DIFF
--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -78,6 +78,10 @@ class SnubaRPCError(SnubaError):
     pass
 
 
+class SnubaRPCRateLimitExceeded(SnubaRPCError):
+    pass
+
+
 class SnubaRPCRequest(Protocol):
     def SerializeToString(self, deterministic: bool = ...) -> bytes: ...
 
@@ -361,6 +365,8 @@ def _make_rpc_request(
                         log_snuba_info(f"{referrer}.error:\n{error}")
                     if http_resp.status == 404:
                         raise NotFound() from SnubaRPCError(error)
+                    if http_resp.status == 429:
+                        raise SnubaRPCRateLimitExceeded(error)
                     raise SnubaRPCError(error)
                 return http_resp
 


### PR DESCRIPTION
Resolves [SENTRY-5DCB](https://sentry.sentry.io/issues/7049009648?project=1). Resolves [SENTRY-5DCN](https://sentry.sentry.io/issues/7049508299?project=1).

This PR adds a retry policy & exponential backoff for delete RPC requests that we issue to EAP, to hopefully respond in a healthy way to Snuba rate-limiting.

We may also want to loosen the Snuba rate limit policy at some point in the future, since the number of delete requests we issued to start getting rate-limited wasn't excessive ([metrics](https://app.datadoghq.com/metric/explorer?fromUser=false&graph_layout=stacked&start=1765836199691&end=1765922599691&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyFoiBVgAdAJoiJIiGvUw2vjy9XAYPRWZ2RoawABUPPUYGk6Z+LUAFACUIHygkdG5sVgATInJCKnpeFk5eYiFxSDb5ZXVcLVxjXDNEo4dXXg9fT2CGBBoE5wcaTaazeYIZarAC6VFc7jwmFC4XhqkRGBipXiqwooFR6MxOl2MKoGjkzRkIHkGFeCDOUBwMFmSI0EEyiTQojgTjkinKOE5UA5XKc9CYyhEbg8aBxSQg9kwWB5CjOnJESh40J4fBACvEAGEpMIYCgRIi0DwgA)).