### PR TITLE
feat(dashboards): Remove secondary release selection from all Mobile insights

### DIFF
--- a/static/app/views/insights/colors.tsx
+++ b/static/app/views/insights/colors.tsx
@@ -1,5 +1,4 @@
 import type {Theme} from '@emotion/react';
-import Color from 'color';
 
 export const COUNT_COLOR = (theme: Theme) => theme.chart.getColorPalette(0)[0];
 export const THROUGHPUT_COLOR = (theme: Theme) => theme.chart.getColorPalette(3)[3];
@@ -10,7 +9,4 @@ export const HTTP_RESPONSE_3XX_COLOR = '#F2B712';
 export const HTTP_RESPONSE_4XX_COLOR = '#F58C46';
 export const HTTP_RESPONSE_5XX_COLOR = '#E9626E';
 
-const COLD_START_COLOR = '#3C74DD';
-
 export const PRIMARY_RELEASE_COLOR = '#3C74DD'; // COLD_START_COLOR
-export const SECONDARY_RELEASE_COLOR = Color(COLD_START_COLOR).lighten(0.4).string();

--- a/static/app/views/insights/common/components/releaseSelector.spec.tsx
+++ b/static/app/views/insights/common/components/releaseSelector.spec.tsx
@@ -20,7 +20,6 @@ jest.mock('sentry/views/insights/common/queries/useReleases', () => ({
   }),
   useReleaseSelection: () => ({
     primaryRelease: undefined,
-    secondaryRelease: undefined,
     isLoading: false,
   }),
 }));

--- a/static/app/views/insights/common/components/releaseSelector.tsx
+++ b/static/app/views/insights/common/components/releaseSelector.tsx
@@ -56,7 +56,7 @@ function ReleaseSelector({
 }: Props) {
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
   const {data, isLoading} = useReleases(searchTerm, sortBy);
-  const {primaryRelease, secondaryRelease} = useReleaseSelection();
+  const {primaryRelease} = useReleaseSelection();
 
   const options: Array<SelectOption<string> & {count?: number}> = [];
 
@@ -91,7 +91,7 @@ function ReleaseSelector({
   }
 
   data
-    ?.filter(({version}) => ![primaryRelease, secondaryRelease].includes(version))
+    ?.filter(({version}) => primaryRelease !== version)
     .forEach(release => {
       const option = {
         value: release.version,

--- a/static/app/views/insights/common/components/releaseSelector.tsx
+++ b/static/app/views/insights/common/components/releaseSelector.tsx
@@ -31,9 +31,6 @@ import {
 import {formatVersionAndCenterTruncate} from 'sentry/views/insights/common/utils/formatVersionAndCenterTruncate';
 import type {ModuleName} from 'sentry/views/insights/types';
 
-export const PRIMARY_RELEASE_ALIAS = 'R1';
-export const SECONDARY_RELEASE_ALIAS = 'R2';
-
 type Props = {
   allOptionDescription: string;
   allOptionTitle: string;

--- a/static/app/views/insights/common/components/releaseSelector.tsx
+++ b/static/app/views/insights/common/components/releaseSelector.tsx
@@ -192,14 +192,10 @@ function getReleasesSortBy(
 
 type ReleaseComparisonSelectorProps = {
   moduleName: ModuleName;
-  primaryOnly?: boolean;
 };
 
-export function ReleaseComparisonSelector({
-  primaryOnly = false,
-  moduleName,
-}: ReleaseComparisonSelectorProps) {
-  const {primaryRelease, secondaryRelease} = useReleaseSelection();
+export function ReleaseComparisonSelector({moduleName}: ReleaseComparisonSelectorProps) {
+  const {primaryRelease} = useReleaseSelection();
   const location = useLocation();
   const navigate = useNavigate();
   const {selection} = usePageFilters();
@@ -254,10 +250,6 @@ export function ReleaseComparisonSelector({
     ? formatVersionAndCenterTruncate(primaryRelease, 16)
     : 'All';
 
-  const secondaryTriggerLabelContent = secondaryRelease
-    ? formatVersionAndCenterTruncate(secondaryRelease, 16)
-    : 'None';
-
   return (
     <StyledPageSelector condensed>
       <ReleaseSelector
@@ -276,9 +268,6 @@ export function ReleaseComparisonSelector({
             primaryRelease: newValue.value as string,
           };
 
-          if (!defined(newValue.value) || newValue.value === '') {
-            delete updatedQuery.secondaryRelease;
-          }
           navigate({
             ...location,
             query: updatedQuery,
@@ -287,46 +276,10 @@ export function ReleaseComparisonSelector({
         selectorValue={primaryRelease}
         selectorName={t('Release 1')}
         key="primaryRelease"
-        triggerLabelPrefix={
-          secondaryRelease
-            ? PRIMARY_RELEASE_ALIAS
-            : primaryRelease
-              ? t('Release')
-              : t('Releases')
-        }
+        triggerLabelPrefix={primaryRelease ? t('Release') : t('Releases')}
         triggerLabel={primaryTriggerLabelContent}
         sortBy={sortReleasesBy}
       />
-      {primaryOnly === false && primaryRelease && (
-        <ReleaseSelector
-          allOptionDescription={t('No comparison.')}
-          allOptionTitle={t('None')}
-          onChange={newValue => {
-            trackAnalytics('insights.release.select_release', {
-              organization,
-              filtered: defined(newValue.value) && newValue.value !== '',
-              type: 'secondary',
-              moduleName,
-            });
-
-            const updatedQuery: Record<string, string> = {
-              ...location.query,
-              secondaryRelease: newValue.value as string,
-            };
-
-            navigate({
-              ...location,
-              query: updatedQuery,
-            });
-          }}
-          selectorName={t('Release 2')}
-          selectorValue={secondaryRelease}
-          key="secondaryRelease"
-          triggerLabelPrefix={secondaryRelease ? SECONDARY_RELEASE_ALIAS : t('Compare')}
-          triggerLabel={secondaryTriggerLabelContent}
-          sortBy={sortReleasesBy}
-        />
-      )}
       <ReleasesSort
         sortBy={sortReleasesBy}
         environments={selection.environments}

--- a/static/app/views/insights/common/queries/useHasTtfdConfigured.tsx
+++ b/static/app/views/insights/common/queries/useHasTtfdConfigured.tsx
@@ -5,11 +5,7 @@ import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseCo
 import {useSpans} from './useDiscover';
 
 export function useTTFDConfigured(additionalFilters?: string[]) {
-  const {
-    primaryRelease,
-    secondaryRelease,
-    isLoading: isReleasesLoading,
-  } = useReleaseSelection();
+  const {primaryRelease, isLoading: isReleasesLoading} = useReleaseSelection();
 
   const query = new MutableSearch([
     'is_transaction:true',
@@ -17,7 +13,7 @@ export function useTTFDConfigured(additionalFilters?: string[]) {
     ...(additionalFilters ?? []),
   ]);
 
-  const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
+  const queryString = appendReleaseFilters(query, primaryRelease);
 
   const result = useSpans(
     {

--- a/static/app/views/insights/common/queries/useReleases.tsx
+++ b/static/app/views/insights/common/queries/useReleases.tsx
@@ -125,23 +125,15 @@ export function useReleases(
 export function useReleaseSelection(): {
   isLoading: boolean;
   primaryRelease: string | undefined;
-  secondaryRelease: string | undefined;
 } {
   const location = useLocation();
 
   const {isLoading} = useReleases(undefined, undefined);
 
-  // Get release values from query parameters
   const primaryReleaseFromQuery = decodeScalar(location.query.primaryRelease);
-  const secondaryReleaseFromQuery = decodeScalar(location.query.secondaryRelease);
 
   const primaryRelease =
     primaryReleaseFromQuery === '' ? undefined : primaryReleaseFromQuery;
 
-  const secondaryRelease =
-    primaryRelease === undefined || secondaryReleaseFromQuery === ''
-      ? undefined
-      : secondaryReleaseFromQuery;
-
-  return {primaryRelease, secondaryRelease, isLoading};
+  return {primaryRelease, isLoading};
 }

--- a/static/app/views/insights/common/utils/releaseComparison.spec.tsx
+++ b/static/app/views/insights/common/utils/releaseComparison.spec.tsx
@@ -9,44 +9,8 @@ describe('appendReleaseFilters', () => {
     query = new MutableSearch('transaction.op:ui.load');
   });
 
-  it('adds both releases when both are provided and different', () => {
-    const result = appendReleaseFilters(query, 'v1.0.0', 'v2.0.0');
-
-    expect(result).toBe('transaction.op:ui.load ( release:v1.0.0 OR release:v2.0.0 )');
-  });
-
-  it('adds only primary release when only primary is provided', () => {
-    const result = appendReleaseFilters(query, 'v1.0.0', undefined);
-
-    expect(result).toBe('transaction.op:ui.load release:v1.0.0');
-  });
-
-  it('adds only primary release when both releases are the same', () => {
-    const result = appendReleaseFilters(query, 'v1.0.0', 'v1.0.0');
-
-    expect(result).toBe('transaction.op:ui.load release:v1.0.0');
-  });
-
-  it('returns original query when no primary release provided', () => {
-    const result = appendReleaseFilters(query, undefined, 'v2.0.0');
-
-    expect(result).toBe('transaction.op:ui.load');
-  });
-
-  it('returns original query when both releases are undefined', () => {
-    const result = appendReleaseFilters(query, undefined, undefined);
-
-    expect(result).toBe('transaction.op:ui.load');
-  });
-
-  it('returns original query when primary release is empty string', () => {
-    const result = appendReleaseFilters(query, '', 'v2.0.0');
-
-    expect(result).toBe('transaction.op:ui.load');
-  });
-
-  it('handles secondary release when primary is provided', () => {
-    const result = appendReleaseFilters(query, 'v1.0.0', '');
+  it('appends primary release', () => {
+    const result = appendReleaseFilters(query, 'v1.0.0');
 
     expect(result).toBe('transaction.op:ui.load release:v1.0.0');
   });

--- a/static/app/views/insights/common/utils/releaseComparison.tsx
+++ b/static/app/views/insights/common/utils/releaseComparison.tsx
@@ -3,26 +3,14 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 export function appendReleaseFilters(
   query: MutableSearch,
-  primaryRelease: string | undefined,
-  secondaryRelease?: string
+  primaryRelease: string | undefined
 ) {
   // Treat empty strings as undefined
   const validPrimary =
     primaryRelease && primaryRelease !== '' ? primaryRelease : undefined;
-  const validSecondary =
-    secondaryRelease && secondaryRelease !== '' ? secondaryRelease : undefined;
 
   let queryString: string = query.formatString();
-  if (
-    defined(validPrimary) &&
-    defined(validSecondary) &&
-    validPrimary !== validSecondary
-  ) {
-    queryString = query
-      .copy()
-      .addDisjunctionFilterValues('release', [validPrimary, validSecondary])
-      .formatString();
-  } else if (defined(validPrimary)) {
+  if (defined(validPrimary)) {
     queryString = query.copy().addStringFilter(`release:${validPrimary}`).formatString();
   }
   return queryString;

--- a/static/app/views/insights/mobile/appStarts/components/charts/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/charts/deviceClassBreakdownBarChart.tsx
@@ -19,10 +19,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-import {
-  PRIMARY_RELEASE_COLOR,
-  SECONDARY_RELEASE_COLOR,
-} from 'sentry/views/insights/colors';
+import {PRIMARY_RELEASE_COLOR} from 'sentry/views/insights/colors';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {ChartActionDropdown} from 'sentry/views/insights/common/components/chartActionDropdown';
 import {
@@ -55,11 +52,7 @@ function DeviceClassBreakdownBarChart({
   const theme = useTheme();
   const location = useLocation();
   const {query: locationQuery} = location;
-  const {
-    primaryRelease,
-    secondaryRelease,
-    isLoading: isReleasesLoading,
-  } = useReleaseSelection();
+  const {primaryRelease, isLoading: isReleasesLoading} = useReleaseSelection();
   const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const startType =
@@ -78,9 +71,7 @@ function DeviceClassBreakdownBarChart({
   }
   query.addFilterValue('is_transaction', 'true');
 
-  const search = new MutableSearch(
-    appendReleaseFilters(query, primaryRelease, secondaryRelease)
-  );
+  const search = new MutableSearch(appendReleaseFilters(query, primaryRelease));
   const referrer = Referrer.DEVICE_CLASS_BREAKDOWN_BAR_CHART;
   const appStartMetric: SpanProperty =
     startType === COLD_START_TYPE
@@ -88,7 +79,7 @@ function DeviceClassBreakdownBarChart({
       : 'avg(measurements.app_start_warm)';
 
   const groupBy: SpanProperty[] = [SpanFields.DEVICE_CLASS];
-  if (defined(primaryRelease) || defined(secondaryRelease)) {
+  if (defined(primaryRelease)) {
     groupBy.push(SpanFields.RELEASE);
   }
   groupBy.push(appStartMetric);
@@ -110,7 +101,6 @@ function DeviceClassBreakdownBarChart({
     data: startupDataByDeviceClass,
     yAxes: YAXES,
     primaryRelease,
-    secondaryRelease,
     theme,
   });
 
@@ -153,7 +143,7 @@ function DeviceClassBreakdownBarChart({
         right: 12,
       }}
       autoHeightResize
-      colors={[PRIMARY_RELEASE_COLOR, SECONDARY_RELEASE_COLOR]}
+      colors={[PRIMARY_RELEASE_COLOR]}
       series={
         data.map(series => ({
           ...series,
@@ -163,10 +153,7 @@ function DeviceClassBreakdownBarChart({
               : {
                   ...datum,
                   itemStyle: {
-                    color:
-                      series.seriesName === 'all' || series.seriesName === primaryRelease
-                        ? PRIMARY_RELEASE_COLOR
-                        : SECONDARY_RELEASE_COLOR,
+                    color: PRIMARY_RELEASE_COLOR,
                   },
                 }
           ),

--- a/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
@@ -5,7 +5,6 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {EventSamples} from 'sentry/views/insights/mobile/appStarts/components/eventSamples';
 import {
   MobileCursors,
@@ -35,11 +34,6 @@ describe('ScreenLoadEventSamples', () => {
         },
       })
     );
-    jest.mocked(useReleaseSelection).mockReturnValue({
-      primaryRelease: 'com.example.vu.android@2.10.5',
-      isLoading: false,
-      secondaryRelease: 'com.example.vu.android@2.10.3+42',
-    });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/events/`,
       method: 'GET',
@@ -65,11 +59,6 @@ describe('ScreenLoadEventSamples', () => {
           id: 970136705,
           version: 'com.example.vu.android@2.10.5',
           dateCreated: '2023-12-19T21:37:53.895495Z',
-        },
-        {
-          id: 969902997,
-          version: 'com.example.vu.android@2.10.3+42',
-          dateCreated: '2023-12-19T18:04:06.953025Z',
         },
       ],
     });
@@ -132,7 +121,7 @@ describe('ScreenLoadEventSamples', () => {
     );
 
     // Check that headers are set properly
-    expect(screen.getByRole('columnheader', {name: 'Event ID (R1)'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Event ID'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Duration'})).toBeInTheDocument();
 

--- a/static/app/views/insights/mobile/appStarts/components/eventSamples.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/eventSamples.tsx
@@ -1,6 +1,5 @@
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -8,12 +7,7 @@ import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {
-  PRIMARY_RELEASE_ALIAS,
-  SECONDARY_RELEASE_ALIAS,
-} from 'sentry/views/insights/common/components/releaseSelector';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {COLD_START_TYPE} from 'sentry/views/insights/mobile/appStarts/components/startTypeSelector';
 import {EventSamplesTable} from 'sentry/views/insights/mobile/screenload/components/tables/eventSamplesTable';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -40,7 +34,6 @@ export function EventSamples({
 }: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
-  const {primaryRelease} = useReleaseSelection();
   const cursor = decodeScalar(location.query?.[cursorName]);
 
   const deviceClass = decodeScalar(location.query[SpanFields.DEVICE_CLASS]) ?? '';
@@ -63,12 +56,7 @@ export function EventSamples({
   const sort = decodeSorts(location.query[sortKey])[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
-    'transaction.span_id': defined(release)
-      ? t(
-          'Event ID (%s)',
-          release === primaryRelease ? PRIMARY_RELEASE_ALIAS : SECONDARY_RELEASE_ALIAS
-        )
-      : t('Event ID'),
+    'transaction.span_id': t('Event ID'),
     profile_id: t('Profile'),
     'span.duration': t('Duration'),
   };

--- a/static/app/views/insights/mobile/appStarts/components/samples.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/samples.tsx
@@ -5,7 +5,6 @@ import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
@@ -25,39 +24,11 @@ const SPANS = 'spans';
 
 export function SamplesTables({transactionName}: any) {
   const [sampleType, setSampleType] = useState<typeof EVENT | typeof SPANS>(SPANS);
-  const {primaryRelease, secondaryRelease} = useReleaseSelection();
+  const {primaryRelease} = useReleaseSelection();
   const organization = useOrganization();
 
   const content = useMemo(() => {
     if (sampleType === EVENT) {
-      if (defined(primaryRelease) && defined(secondaryRelease)) {
-        return (
-          <EventSplitContainer>
-            <ErrorBoundary mini>
-              <div>
-                <EventSamples
-                  cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  release={primaryRelease}
-                  transaction={transactionName}
-                  footerAlignedPagination
-                />
-              </div>
-            </ErrorBoundary>
-            <ErrorBoundary mini>
-              <div>
-                <EventSamples
-                  cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-                  sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-                  release={secondaryRelease}
-                  transaction={transactionName}
-                  footerAlignedPagination
-                />
-              </div>
-            </ErrorBoundary>
-          </EventSplitContainer>
-        );
-      }
       return (
         <ErrorBoundary mini>
           <EventSamples
@@ -76,11 +47,10 @@ export function SamplesTables({transactionName}: any) {
         <SpanOperationTable
           transaction={transactionName}
           primaryRelease={primaryRelease}
-          secondaryRelease={secondaryRelease}
         />
       </ErrorBoundary>
     );
-  }, [primaryRelease, sampleType, secondaryRelease, transactionName]);
+  }, [primaryRelease, sampleType, transactionName]);
 
   return (
     <div>
@@ -90,7 +60,6 @@ export function SamplesTables({transactionName}: any) {
             <SpanOpSelector
               primaryRelease={primaryRelease}
               transaction={transactionName}
-              secondaryRelease={secondaryRelease}
             />
           )}
           <DeviceClassSelector
@@ -119,12 +88,6 @@ export function SamplesTables({transactionName}: any) {
     </div>
   );
 }
-
-const EventSplitContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: ${space(1.5)};
-`;
 
 const Controls = styled('div')`
   display: flex;

--- a/static/app/views/insights/mobile/appStarts/components/spanOpSelector.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/spanOpSelector.spec.tsx
@@ -55,13 +55,7 @@ describe('SpanOpSelector', () => {
   });
 
   it('lists all span operations that are stored', async () => {
-    render(
-      <SpanOpSelector
-        primaryRelease="release1"
-        secondaryRelease="release2"
-        transaction="foo-bar"
-      />
-    );
+    render(<SpanOpSelector primaryRelease="release1" transaction="foo-bar" />);
 
     expect(await screen.findByText('All')).toBeInTheDocument();
 

--- a/static/app/views/insights/mobile/appStarts/components/spanOpSelector.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/spanOpSelector.tsx
@@ -25,11 +25,10 @@ export const APP_START_SPANS = [
 
 type Props = {
   primaryRelease?: string;
-  secondaryRelease?: string;
   transaction?: string;
 };
 
-export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: Props) {
+export function SpanOpSelector({transaction, primaryRelease}: Props) {
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
@@ -59,11 +58,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     searchQuery.addFilterValue('os.name', selectedPlatform);
   }
 
-  const queryStringPrimary = appendReleaseFilters(
-    searchQuery,
-    primaryRelease,
-    secondaryRelease
-  );
+  const queryStringPrimary = appendReleaseFilters(searchQuery, primaryRelease);
 
   const {data} = useSpans(
     {

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
@@ -29,11 +29,7 @@ interface Props {
 
 function StartDurationWidget({additionalFilters}: Props) {
   const location = useLocation();
-  const {
-    primaryRelease,
-    secondaryRelease,
-    isLoading: isReleasesLoading,
-  } = useReleaseSelection();
+  const {primaryRelease, isLoading: isReleasesLoading} = useReleaseSelection();
   const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const startType =
@@ -48,11 +44,10 @@ function StartDurationWidget({additionalFilters}: Props) {
     query.addFilterValue('os.name', selectedPlatform);
   }
 
-  const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
+  const queryString = appendReleaseFilters(query, primaryRelease);
   const search = new MutableSearch(queryString);
   const referrer = Referrer.MOBILE_APP_STARTS_DURATION_CHART;
-  const groupBy =
-    primaryRelease || secondaryRelease ? SpanFields.RELEASE : SpanFields.TRANSACTION;
+  const groupBy = primaryRelease ? SpanFields.RELEASE : SpanFields.TRANSACTION;
   const yAxis: SpanProperty = 'avg(span.duration)';
 
   const {

--- a/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
@@ -54,10 +54,8 @@ describe('SpanOpSelector', () => {
             'span.op': 'string',
             'span.description': 'string',
             'span.group': 'string',
-            'avg_if(span.self_time,release,equals,release1)': 'duration',
-            'avg_compare(span.self_time,release,release1,release2)': 'percent_change',
+            'avg(span.self_time)': 'duration',
             'count()': 'integer',
-            'avg_if(span.self_time,release,equals,release2)': 'duration',
             'sum(span.self_time)': 'duration',
           },
         },
@@ -67,10 +65,8 @@ describe('SpanOpSelector', () => {
             'span.op': 'app.start.warm',
             'span.description': 'Application Init',
             'span.group': '7f4be68f08c0455f',
-            'avg_if(span.self_time,release,equals,release1)': 22.549867,
-            'avg_compare(span.self_time,release,release1,release2)': 0.5,
+            'avg(span.self_time)': 22.549867,
             'count()': 14,
-            'avg_if(span.self_time,release,equals,release2)': 12504.931908384617,
             'sum(span.self_time)': 162586.66467600001,
           },
         ],
@@ -79,76 +75,20 @@ describe('SpanOpSelector', () => {
   });
 
   it('renders data properly', async () => {
-    render(
-      <SpanOperationTable
-        transaction="foo-bar"
-        primaryRelease="release1"
-        secondaryRelease="release2"
-      />
-    );
+    render(<SpanOperationTable transaction="foo-bar" primaryRelease="release1" />);
 
     expect(await screen.findByRole('link', {name: 'Operation'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Span Description'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Avg Duration (R1)'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Avg Duration (R2)'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Change'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Avg Duration'})).toBeInTheDocument();
 
     expect(await screen.findByRole('cell', {name: 'app.start.warm'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: 'Application Init'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '22.55ms'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '12.50s'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '+50%'})).toBeInTheDocument();
 
     expect(screen.getByRole('link', {name: 'Application Init'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/insights/mobile/mobile-vitals/details/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&spanOp=app.start.warm&transaction=foo-bar'
     );
-  });
-
-  it('displays the infinity symbol for new spans with null percent change', async () => {
-    mockEventsRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      body: {
-        meta: {
-          fields: {
-            'project.id': 'integer',
-            'span.op': 'string',
-            'span.description': 'string',
-            'span.group': 'string',
-            'avg_if(span.self_time,release,equals,release1)': 'duration',
-            'avg_compare(span.self_time,release,release1,release2)': 'percent_change',
-            'count()': 'integer',
-            'avg_if(span.self_time,release,equals,release2)': 'duration',
-            'sum(span.self_time)': 'duration',
-          },
-        },
-        data: [
-          {
-            'project.id': parseInt(project.id, 10),
-            'span.op': 'app.start.warm',
-            'span.description': 'Application Init',
-            'span.group': '7f4be68f08c0455f',
-            'count()': 14,
-            'sum(span.self_time)': 162586.66467600001,
-
-            // simulate a scenario where a span was added in release 2
-            'avg_if(span.self_time,release,equals,release1)': 0,
-            'avg_if(span.self_time,release,equals,release2)': 12504.931908384617,
-            'avg_compare(span.self_time,release,release1,release2)': null,
-          },
-        ],
-      },
-    });
-
-    render(
-      <SpanOperationTable
-        transaction="foo-bar"
-        primaryRelease="release1"
-        secondaryRelease="release2"
-      />
-    );
-
-    expect(await screen.findByRole('cell', {name: '+∞%'})).toBeInTheDocument();
   });
 
   it('modifies the request to events when a span operation is selected', async () => {
@@ -184,13 +124,7 @@ describe('SpanOpSelector', () => {
       ],
     });
 
-    render(
-      <SpanOperationTable
-        transaction="foo-bar"
-        primaryRelease="release1"
-        secondaryRelease="release2"
-      />
-    );
+    render(<SpanOperationTable transaction="foo-bar" primaryRelease="release1" />);
 
     await waitFor(() => {
       expect(mockEventsRequest).toHaveBeenCalledWith(

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
@@ -19,7 +19,6 @@ describe('Screen Summary', () => {
         project: project.id,
         transaction: 'MainActivity',
         primaryRelease: 'com.example.vu.android@2.10.5',
-        secondaryRelease: 'com.example.vu.android@2.10.3+42',
         [SpanFields.APP_START_TYPE]: 'cold',
       },
     },
@@ -80,11 +79,7 @@ describe('Screen Summary', () => {
             {
               'span.op': 'app.start.cold',
               'avg_if(span.duration,release,equals,com.example.vu.android@2.10.5)': 1000,
-              'avg_if(span.duration,release,equals,com.example.vu.android@2.10.3+42)': 2000,
-              'avg_compare(span.duration,release,com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42)':
-                -0.5,
               'count_if(release,equals,com.example.vu.android@2.10.5)': 20,
-              'count_if(release,equals,com.example.vu.android@2.10.3+42)': 10,
             },
           ],
         },
@@ -103,19 +98,14 @@ describe('Screen Summary', () => {
       });
 
       const blocks = [
-        {header: 'Avg Cold Start (R1)', value: '1.00s'},
-        {header: 'Avg Cold Start (R2)', value: '2.00s'},
-        {header: 'Change', value: '-50%'},
-        {header: 'Count (R1)', value: '20'},
-        {header: 'Count (R2)', value: '10'},
+        {header: 'Avg Cold Start', value: '1.00s'},
+        {header: 'Count', value: '20'},
       ];
 
       for (const block of blocks) {
         const blockEl = screen.getByRole('heading', {name: block.header}).closest('div');
         await within(blockEl!).findByText(block.value);
       }
-
-      expect(screen.getByText('-50%')).toHaveAttribute('data-rating', 'good');
     });
   });
 });

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -11,11 +11,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
-import {
-  PRIMARY_RELEASE_ALIAS,
-  ReleaseComparisonSelector,
-  SECONDARY_RELEASE_ALIAS,
-} from 'sentry/views/insights/common/components/releaseSelector';
+import {ReleaseComparisonSelector} from 'sentry/views/insights/common/components/releaseSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
@@ -34,7 +30,6 @@ type Query = {
   'device.class': string;
   primaryRelease: string;
   project: string;
-  secondaryRelease: string;
   spanDescription: string;
   spanGroup: string;
   spanOp: string;
@@ -51,9 +46,7 @@ export function ScreenSummaryContentPage() {
     [SpanFields.APP_START_TYPE]: appStartType,
   } = location.query;
 
-  const {primaryRelease, secondaryRelease} = useReleaseSelection();
-
-  const showComparison = defined(primaryRelease) && defined(secondaryRelease);
+  const {primaryRelease} = useReleaseSelection();
 
   useEffect(() => {
     // Default the start type to cold start if not present
@@ -93,15 +86,7 @@ export function ScreenSummaryContentPage() {
   });
 
   let fields: SpanProperty[] = [];
-  if (showComparison) {
-    fields = [
-      `avg_if(span.duration,release,equals,${primaryRelease})`,
-      `avg_if(span.duration,release,equals,${secondaryRelease})`,
-      `avg_compare(span.duration,release,${primaryRelease},${secondaryRelease})`,
-      `count_if(release,equals,${primaryRelease})`,
-      `count_if(release,equals,${secondaryRelease})`,
-    ];
-  } else if (defined(primaryRelease)) {
+  if (defined(primaryRelease)) {
     fields = [
       `avg_if(span.duration,release,equals,${primaryRelease})`,
       `count_if(release,equals,${primaryRelease})`,
@@ -129,65 +114,26 @@ export function ScreenSummaryContentPage() {
             ')',
           ]}
           fields={fields}
-          blocks={
-            showComparison
-              ? [
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    allowZero: false,
-                    title:
-                      appStartType === COLD_START_TYPE
-                        ? t('Avg Cold Start (%s)', PRIMARY_RELEASE_ALIAS)
-                        : t('Avg Warm Start (%s)', PRIMARY_RELEASE_ALIAS),
-                    dataKey: `avg_if(span.duration,release,equals,${primaryRelease})`,
-                  },
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    allowZero: false,
-                    title:
-                      appStartType === COLD_START_TYPE
-                        ? t('Avg Cold Start (%s)', SECONDARY_RELEASE_ALIAS)
-                        : t('Avg Warm Start (%s)', SECONDARY_RELEASE_ALIAS),
-                    dataKey: `avg_if(span.duration,release,equals,${secondaryRelease})`,
-                  },
-                  {
-                    unit: 'percent_change',
-                    title: t('Change'),
-                    dataKey: `avg_compare(span.duration,release,${primaryRelease},${secondaryRelease})`,
-                    preferredPolarity: '-',
-                  },
-                  {
-                    unit: 'count',
-                    title: t('Count (%s)', PRIMARY_RELEASE_ALIAS),
-                    dataKey: `count_if(release,equals,${primaryRelease})`,
-                  },
-                  {
-                    unit: 'count',
-                    title: t('Count (%s)', SECONDARY_RELEASE_ALIAS),
-                    dataKey: `count_if(release,equals,${secondaryRelease})`,
-                  },
-                ]
-              : [
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    allowZero: false,
-                    title:
-                      appStartType === COLD_START_TYPE
-                        ? t('Avg Cold Start')
-                        : t('Avg Warm Start'),
-                    dataKey: primaryRelease
-                      ? `avg_if(span.duration,release,equals,${primaryRelease})`
-                      : 'avg(span.duration)',
-                  },
-                  {
-                    unit: 'count',
-                    title: t('Count'),
-                    dataKey: primaryRelease
-                      ? `count_if(release,equals,${primaryRelease})`
-                      : 'count()',
-                  },
-                ]
-          }
+          blocks={[
+            {
+              unit: DurationUnit.MILLISECOND,
+              allowZero: false,
+              title:
+                appStartType === COLD_START_TYPE
+                  ? t('Avg Cold Start')
+                  : t('Avg Warm Start'),
+              dataKey: primaryRelease
+                ? `avg_if(span.duration,release,equals,${primaryRelease})`
+                : 'avg(span.duration)',
+            },
+            {
+              unit: 'count',
+              title: t('Count'),
+              dataKey: primaryRelease
+                ? `count_if(release,equals,${primaryRelease})`
+                : 'count()',
+            },
+          ]}
           referrer="api.insights.mobile-startup-totals"
         />
       </HeaderContainer>

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanel.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanel.tsx
@@ -27,7 +27,6 @@ type Props = {
 };
 
 const PRIMARY_SPAN_QUERY_KEY = 'primarySpanSearchQuery';
-const SECONDARY_SPAN_QUERY_KEY = 'secondarySpanSearchQuery';
 
 export function SpanSamplesPanel({groupId, moduleName, transactionRoute}: Props) {
   const organization = useOrganization();
@@ -58,7 +57,7 @@ export function SpanSamplesPanel({groupId, moduleName, transactionRoute}: Props)
 
   transactionRoute ??= getTransactionSummaryBaseUrl(organization, view);
 
-  const {primaryRelease, secondaryRelease} = useReleaseSelection();
+  const {primaryRelease} = useReleaseSelection();
 
   const {query} = useLocation();
   const {project} = useCrossPlatformProject();
@@ -99,34 +98,19 @@ export function SpanSamplesPanel({groupId, moduleName, transactionRoute}: Props)
         </HeaderContainer>
         <PageAlert />
         <ChartsContainer>
-          <ChartsContainerItem key="release1">
+          <ChartsContainerItem>
             <SpanSamplesContainer
               groupId={groupId}
               moduleName={moduleName}
               transactionName={transactionName}
               transactionMethod={transactionMethod}
               release={primaryRelease}
-              sectionTitle={t('Release 1')}
+              sectionTitle={t('Release')}
               searchQueryKey={PRIMARY_SPAN_QUERY_KEY}
               spanOp={spanOp}
               additionalFilters={additionalFilters}
             />
           </ChartsContainerItem>
-          {secondaryRelease && (
-            <ChartsContainerItem key="release2">
-              <SpanSamplesContainer
-                groupId={groupId}
-                moduleName={moduleName}
-                transactionName={transactionName}
-                transactionMethod={transactionMethod}
-                release={secondaryRelease}
-                sectionTitle={t('Release 2')}
-                searchQueryKey={SECONDARY_SPAN_QUERY_KEY}
-                spanOp={spanOp}
-                additionalFilters={additionalFilters}
-              />
-            </ChartsContainerItem>
-          )}
         </ChartsContainer>
       </SampleDrawerBody>
     </PageAlertProvider>

--- a/static/app/views/insights/mobile/common/components/tables/samplesTables.spec.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/samplesTables.spec.tsx
@@ -8,7 +8,6 @@ jest.mock('sentry/views/insights/common/queries/useReleases');
 jest.mocked(useReleaseSelection).mockReturnValue({
   primaryRelease: 'com.example.vu.android@2.10.5-alpha.1+42',
   isLoading: false,
-  secondaryRelease: 'com.example.vu.android@2.10.3+42',
 });
 
 describe('SamplesTables', () => {
@@ -72,18 +71,12 @@ describe('SamplesTables', () => {
         'This is a custom Event Samples table for release: com.example.vu.android@2.10.5-alpha.1+42'
       )
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'This is a custom Event Samples table for release: com.example.vu.android@2.10.3+42'
-      )
-    ).toBeInTheDocument();
   });
 
   it('renders single event table when only primary release provided', async () => {
     jest.mocked(useReleaseSelection).mockReturnValue({
       primaryRelease: 'com.example.vu.android@2.10.5-alpha.1+42',
       isLoading: false,
-      secondaryRelease: undefined,
     });
 
     render(
@@ -104,18 +97,12 @@ describe('SamplesTables', () => {
         'Event table for release: com.example.vu.android@2.10.5-alpha.1+42'
       )
     ).toBeInTheDocument();
-
-    // Should not render secondary release table
-    expect(
-      screen.queryByText('Event table for release: com.example.vu.android@2.10.3+42')
-    ).not.toBeInTheDocument();
   });
 
   it('renders single event table when no releases provided', async () => {
     jest.mocked(useReleaseSelection).mockReturnValue({
       primaryRelease: undefined,
       isLoading: false,
-      secondaryRelease: undefined,
     });
 
     render(
@@ -132,36 +119,5 @@ describe('SamplesTables', () => {
 
     // Should render single event table with no release
     expect(await screen.findByText('Event table for release: none')).toBeInTheDocument();
-  });
-
-  it('renders single event table when both releases are the same', async () => {
-    jest.mocked(useReleaseSelection).mockReturnValue({
-      primaryRelease: 'com.example.vu.android@2.10.5-alpha.1+42',
-      isLoading: false,
-      secondaryRelease: 'com.example.vu.android@2.10.5-alpha.1+42',
-    });
-
-    render(
-      <SamplesTables
-        EventSamples={({release}) => (
-          <div>{`Event table for release: ${release || 'none'}`}</div>
-        )}
-        SpanOperationTable={_props => <div>Span Operation table</div>}
-        transactionName=""
-      />
-    );
-
-    await userEvent.click(screen.getByRole('radio', {name: 'By Event'}));
-
-    // Should render single event table, not side-by-side comparison
-    expect(
-      await screen.findByText(
-        'Event table for release: com.example.vu.android@2.10.5-alpha.1+42'
-      )
-    ).toBeInTheDocument();
-
-    // Should not render a second table since releases are the same
-    const eventTables = screen.getAllByText(/Event table for release:/);
-    expect(eventTables).toHaveLength(1);
   });
 });

--- a/static/app/views/insights/mobile/common/components/tables/samplesTables.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/samplesTables.tsx
@@ -28,7 +28,6 @@ interface EventSamplesProps {
 export interface SpanOperationTableProps {
   transaction: string;
   primaryRelease?: string;
-  secondaryRelease?: string;
 }
 
 interface SamplesTablesProps {
@@ -43,42 +42,10 @@ export function SamplesTables({
   SpanOperationTable,
 }: SamplesTablesProps) {
   const [sampleType, setSampleType] = useState<typeof EVENT | typeof SPANS>(SPANS);
-  const {primaryRelease, secondaryRelease} = useReleaseSelection();
-
-  // Only show comparison when we have two different releases selected
-  const showComparison =
-    primaryRelease && secondaryRelease && primaryRelease !== secondaryRelease;
+  const {primaryRelease} = useReleaseSelection();
 
   const content = useMemo(() => {
     if (sampleType === EVENT) {
-      if (showComparison) {
-        return (
-          <EventSplitContainer>
-            <ErrorBoundary mini>
-              {EventSamples && (
-                <EventSamples
-                  cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  release={primaryRelease}
-                  transaction={transactionName}
-                  footerAlignedPagination
-                />
-              )}
-            </ErrorBoundary>
-            <ErrorBoundary mini>
-              {EventSamples && (
-                <EventSamples
-                  cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-                  sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-                  release={secondaryRelease}
-                  transaction={transactionName}
-                  footerAlignedPagination
-                />
-              )}
-            </ErrorBoundary>
-          </EventSplitContainer>
-        );
-      }
       return (
         <ErrorBoundary mini>
           {EventSamples && (
@@ -99,19 +66,10 @@ export function SamplesTables({
         <SpanOperationTable
           transaction={transactionName}
           primaryRelease={primaryRelease}
-          secondaryRelease={secondaryRelease}
         />
       </ErrorBoundary>
     );
-  }, [
-    EventSamples,
-    SpanOperationTable,
-    primaryRelease,
-    sampleType,
-    secondaryRelease,
-    transactionName,
-    showComparison,
-  ]);
+  }, [EventSamples, SpanOperationTable, primaryRelease, sampleType, transactionName]);
 
   return (
     <div>
@@ -121,7 +79,6 @@ export function SamplesTables({
             <SpanOpSelector
               primaryRelease={primaryRelease}
               transaction={transactionName}
-              secondaryRelease={secondaryRelease}
             />
           )}
           <DeviceClassSelector size="md" clearSpansTableCursor />
@@ -146,12 +103,6 @@ export function SamplesTables({
     </div>
   );
 }
-
-const EventSplitContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: ${space(1.5)};
-`;
 
 const Controls = styled('div')`
   display: flex;

--- a/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
@@ -42,14 +42,10 @@ export function ScreensBarChart({
   chartProps?: BaseChartProps;
 }) {
   const theme = useTheme();
-  const {
-    isLoading: isReleasesLoading,
-    primaryRelease,
-    secondaryRelease,
-  } = useReleaseSelection();
+  const {isLoading: isReleasesLoading, primaryRelease} = useReleaseSelection();
 
   const groupBy: SpanProperty[] = [SpanFields.DEVICE_CLASS];
-  if (defined(primaryRelease) || defined(secondaryRelease)) {
+  if (defined(primaryRelease)) {
     groupBy.push(SpanFields.RELEASE);
   }
   const breakdownMetric: SpanProperty =
@@ -77,7 +73,6 @@ export function ScreensBarChart({
   const transformedEvents = transformDeviceClassEvents({
     yAxes: [type === 'ttid' ? YAxis.TTID : YAxis.TTFD],
     primaryRelease,
-    secondaryRelease,
     data: deviceClassEvents,
     theme,
   });

--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -49,11 +49,7 @@ export function ScreenCharts({additionalFilters}: Props) {
   const colorPalette = theme.chart.getColorPalette(4);
   const {isProjectCrossPlatform, selectedPlatform: platform} = useCrossPlatformProject();
 
-  const {
-    primaryRelease,
-    secondaryRelease,
-    isLoading: isReleasesLoading,
-  } = useReleaseSelection();
+  const {primaryRelease, isLoading: isReleasesLoading} = useReleaseSelection();
 
   const queryString = useMemo(() => {
     const query = new MutableSearch([
@@ -68,14 +64,8 @@ export function ScreenCharts({additionalFilters}: Props) {
 
     query.addFilterValue('is_transaction', 'true');
 
-    return appendReleaseFilters(query, primaryRelease, secondaryRelease);
-  }, [
-    additionalFilters,
-    isProjectCrossPlatform,
-    platform,
-    primaryRelease,
-    secondaryRelease,
-  ]);
+    return appendReleaseFilters(query, primaryRelease);
+  }, [additionalFilters, isProjectCrossPlatform, platform, primaryRelease]);
 
   const query = new MutableSearch(queryString);
   const groupBy = defined(primaryRelease) ? SpanFields.RELEASE : SpanFields.TRANSACTION;

--- a/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
@@ -38,7 +38,6 @@ describe('ScreenLoadEventSamples', () => {
     jest.mocked(useReleaseSelection).mockReturnValue({
       primaryRelease: 'com.example.vu.android@2.10.5',
       isLoading: false,
-      secondaryRelease: 'com.example.vu.android@2.10.3+42',
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/events/`,

--- a/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
@@ -129,7 +129,7 @@ describe('ScreenLoadEventSamples', () => {
     );
 
     // Check that headers are set properly
-    expect(screen.getByRole('columnheader', {name: 'Event ID (R1)'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Event ID'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'TTID'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'TTFD'})).toBeInTheDocument();

--- a/static/app/views/insights/mobile/screenload/components/eventSamples.tsx
+++ b/static/app/views/insights/mobile/screenload/components/eventSamples.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -10,12 +9,7 @@ import {decodeList, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {
-  PRIMARY_RELEASE_ALIAS,
-  SECONDARY_RELEASE_ALIAS,
-} from 'sentry/views/insights/common/components/releaseSelector';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {EventSamplesTable} from 'sentry/views/insights/mobile/screenload/components/tables/eventSamplesTable';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -41,7 +35,6 @@ export function ScreenLoadEventSamples({
 }: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
-  const {primaryRelease} = useReleaseSelection();
   const cursor = decodeScalar(location.query?.[cursorName]);
   const {selectedPlatform: platform, isProjectCrossPlatform} = useCrossPlatformProject();
 
@@ -84,12 +77,7 @@ export function ScreenLoadEventSamples({
   const sort = decodeSorts(location.query[sortKey])[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
-    id: defined(release)
-      ? t(
-          'Event ID (%s)',
-          release === primaryRelease ? PRIMARY_RELEASE_ALIAS : SECONDARY_RELEASE_ALIAS
-        )
-      : t('Event ID'),
+    id: t('Event ID'),
     'profile.id': t('Profile'),
     'measurements.time_to_initial_display': t('TTID'),
     'measurements.time_to_full_display': t('TTFD'),

--- a/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
+++ b/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
@@ -38,11 +38,7 @@ export function MobileMetricsRibbon({
   referrer: string;
   filters?: string[];
 }) {
-  const {
-    primaryRelease,
-    secondaryRelease,
-    isLoading: isReleasesLoading,
-  } = useReleaseSelection();
+  const {primaryRelease, isLoading: isReleasesLoading} = useReleaseSelection();
 
   const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
@@ -53,14 +49,8 @@ export function MobileMetricsRibbon({
       searchQuery.addFilterValue('os.name', selectedPlatform);
     }
 
-    return appendReleaseFilters(searchQuery, primaryRelease, secondaryRelease);
-  }, [
-    filters,
-    isProjectCrossPlatform,
-    primaryRelease,
-    secondaryRelease,
-    selectedPlatform,
-  ]);
+    return appendReleaseFilters(searchQuery, primaryRelease);
+  }, [filters, isProjectCrossPlatform, primaryRelease, selectedPlatform]);
 
   const {isPending, data, meta} = useSpans(
     {

--- a/static/app/views/insights/mobile/screenload/components/spanOpSelector.tsx
+++ b/static/app/views/insights/mobile/screenload/components/spanOpSelector.tsx
@@ -25,11 +25,10 @@ export const TTID_CONTRIBUTING_SPAN_OPS = [
 
 type Props = {
   primaryRelease?: string;
-  secondaryRelease?: string;
   transaction?: string;
 };
 
-export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: Props) {
+export function SpanOpSelector({transaction, primaryRelease}: Props) {
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
@@ -41,11 +40,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     `span.op:[${TTID_CONTRIBUTING_SPAN_OPS.join(',')}]`,
     'has:span.description',
   ]);
-  const queryStringPrimary = appendReleaseFilters(
-    searchQuery,
-    primaryRelease,
-    secondaryRelease
-  );
+  const queryStringPrimary = appendReleaseFilters(searchQuery, primaryRelease);
 
   const {data} = useSpans(
     {

--- a/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
@@ -34,7 +34,6 @@ describe('ScreenLoadSpansTable', () => {
       <ScreenLoadSpansTable
         transaction="MainActivity"
         primaryRelease="io.sentry.samples.android@7.0.0+2"
-        secondaryRelease="io.sentry.samples.android@6.27.0+2"
       />,
       {
         organization,
@@ -66,13 +65,12 @@ describe('ScreenLoadSpansTable', () => {
             'ttfd_contribution_rate()',
             'count()',
             'sum(span.self_time)',
-            'avg_if(span.self_time,release,equals,io.sentry.samples.android@7.0.0+2)',
-            'avg_if(span.self_time,release,equals,io.sentry.samples.android@6.27.0+2)',
+            'avg(span.self_time)',
           ],
           per_page: 25,
           project: [],
           query:
-            'transaction.op:[ui.load,navigation] transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,navigation,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] ( release:io.sentry.samples.android@7.0.0+2 OR release:io.sentry.samples.android@6.27.0+2 )',
+            'transaction.op:[ui.load,navigation] transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,navigation,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] release:io.sentry.samples.android@7.0.0+2',
           referrer: 'api.insights.mobile-span-table',
           sort: '-sum(span.self_time)',
           statsPeriod: '14d',
@@ -82,7 +80,7 @@ describe('ScreenLoadSpansTable', () => {
 
     const header = await screen.findAllByTestId('grid-head-row');
     const headerCells = within(header[0]!).getAllByTestId('grid-head-cell');
-    const headerCell = headerCells[4];
+    const headerCell = headerCells[3];
     expect(headerCell).toHaveTextContent('Affects');
     expect(await screen.findByRole('link', {name: 'Affects'})).toHaveAttribute(
       'href',
@@ -95,7 +93,6 @@ describe('ScreenLoadSpansTable', () => {
       <ScreenLoadSpansTable
         transaction="MainActivity"
         primaryRelease="io.sentry.samples.android@7.0.0+2"
-        secondaryRelease="io.sentry.samples.android@6.27.0+2"
       />,
       {
         organization,
@@ -111,7 +108,7 @@ describe('ScreenLoadSpansTable', () => {
 
     const header = await screen.findAllByTestId('grid-head-row');
     const headerCells = within(header[0]!).getAllByTestId('grid-head-cell');
-    const headerCell = headerCells[4];
+    const headerCell = headerCells[3];
     expect(headerCell).toHaveTextContent('Affects');
     expect(await screen.findByRole('link', {name: 'Affects'})).toHaveAttribute(
       'href',
@@ -119,7 +116,7 @@ describe('ScreenLoadSpansTable', () => {
     );
   });
 
-  it('renders single duration column when only primary release provided', async () => {
+  it('renders single duration column', async () => {
     render(
       <ScreenLoadSpansTable
         transaction="MainActivity"
@@ -142,8 +139,6 @@ describe('ScreenLoadSpansTable', () => {
     // Should show single "Avg Duration" column, not comparison columns
     const headerTexts = headerCells.map(cell => cell.textContent);
     expect(headerTexts).toContain('Avg Duration');
-    expect(headerTexts).not.toContain('Avg Duration (Primary)');
-    expect(headerTexts).not.toContain('Avg Duration (Secondary)');
 
     // Verify API call uses single avg field, not comparison fields
     expect(eventsMock).toHaveBeenCalledWith(
@@ -166,44 +161,6 @@ describe('ScreenLoadSpansTable', () => {
         },
       },
     });
-
-    const header = await screen.findAllByTestId('grid-head-row');
-    const headerCells = within(header[0]!).getAllByTestId('grid-head-cell');
-
-    // Should show single "Avg Duration" column, not comparison columns
-    const headerTexts = headerCells.map(cell => cell.textContent);
-    expect(headerTexts).toContain('Avg Duration');
-    expect(headerTexts).not.toContain('Avg Duration (Primary)');
-    expect(headerTexts).not.toContain('Avg Duration (Secondary)');
-
-    // Verify API call uses single avg field, not comparison fields
-    expect(eventsMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.objectContaining({
-          field: expect.arrayContaining(['avg(span.self_time)']),
-        }),
-      })
-    );
-  });
-
-  it('renders single duration column when both releases are the same', async () => {
-    render(
-      <ScreenLoadSpansTable
-        transaction="MainActivity"
-        primaryRelease="io.sentry.samples.android@7.0.0+2"
-        secondaryRelease="io.sentry.samples.android@7.0.0+2"
-      />,
-      {
-        organization,
-        initialRouterConfig: {
-          route: '/organizations/:orgId/performance/mobile/screens/',
-          location: {
-            pathname: '/organizations/org-slug/performance/mobile/screens/',
-          },
-        },
-      }
-    );
 
     const header = await screen.findAllByTestId('grid-head-row');
     const headerCells = within(header[0]!).getAllByTestId('grid-head-cell');

--- a/static/app/views/insights/mobile/screenload/utils.tsx
+++ b/static/app/views/insights/mobile/screenload/utils.tsx
@@ -14,7 +14,6 @@ export function isCrossPlatform(project: Project) {
 export function transformDeviceClassEvents({
   yAxes,
   primaryRelease,
-  secondaryRelease,
   data,
   theme,
 }: {
@@ -22,7 +21,6 @@ export function transformDeviceClassEvents({
   yAxes: YAxis[];
   data?: Array<Partial<SpanResponse> & Pick<SpanResponse, 'device.class'>>;
   primaryRelease?: string;
-  secondaryRelease?: string;
 }): Record<string, Record<string, Series>> {
   const transformedData = yAxes.reduce(
     (acc, yAxis) => ({...acc, [YAXIS_COLUMNS[yAxis]]: {}}),
@@ -38,17 +36,7 @@ export function transformDeviceClassEvents({
         seriesName: primaryRelease,
         data: new Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
       };
-    }
-    if (secondaryRelease) {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      transformedData[YAXIS_COLUMNS[val]][secondaryRelease] = {
-        seriesName: secondaryRelease,
-        data: new Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
-      };
-    }
-
-    // all option
-    if (!primaryRelease && !secondaryRelease) {
+    } else {
       // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       transformedData[YAXIS_COLUMNS[val]].all = {
         seriesName: 'all',

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -166,7 +166,6 @@ export function ScreenLoadSpansContent() {
                 transaction={transactionName}
               />
             </SampleContainerItem>
-            )
           </SampleContainer>
         )}
         {sampleType === SPANS && (

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -11,11 +11,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useRouter from 'sentry/utils/useRouter';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
-import {
-  PRIMARY_RELEASE_ALIAS,
-  ReleaseComparisonSelector,
-  SECONDARY_RELEASE_ALIAS,
-} from 'sentry/views/insights/common/components/releaseSelector';
+import {ReleaseComparisonSelector} from 'sentry/views/insights/common/components/releaseSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
@@ -38,7 +34,6 @@ import {ModuleName} from 'sentry/views/insights/types';
 type Query = {
   primaryRelease: string;
   project: string;
-  secondaryRelease: string;
   spanGroup: string;
   transaction: string;
   [QueryParameterNames.SPANS_SORT]: string;
@@ -54,11 +49,7 @@ export function ScreenLoadSpansContent() {
   const [sampleType, setSampleType] = useState<typeof EVENT | typeof SPANS>(SPANS);
 
   const {spanGroup, transaction: transactionName} = location.query;
-  const {primaryRelease, secondaryRelease} = useReleaseSelection();
-
-  // Only show comparison when we have two different releases selected
-  const showComparison =
-    primaryRelease && secondaryRelease && primaryRelease !== secondaryRelease;
+  const {primaryRelease} = useReleaseSelection();
 
   useSamplesDrawer({
     Component: (
@@ -93,86 +84,40 @@ export function ScreenLoadSpansContent() {
             'transaction.op:[ui.load,navigation]',
             `transaction:${transactionName}`,
           ]}
-          fields={
-            showComparison
-              ? [
-                  `avg_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`,
-                  `avg_if(measurements.time_to_initial_display,release,equals,${secondaryRelease})`,
-                  `avg_if(measurements.time_to_full_display,release,equals,${primaryRelease})`,
-                  `avg_if(measurements.time_to_full_display,release,equals,${secondaryRelease})`,
-                  `count_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`,
-                  `count_if(measurements.time_to_initial_display,release,equals,${secondaryRelease})`,
-                ]
-              : [
-                  primaryRelease
-                    ? `avg_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
-                    : 'avg(measurements.time_to_initial_display)',
-                  primaryRelease
-                    ? `avg_if(measurements.time_to_full_display,release,equals,${primaryRelease})`
-                    : 'avg(measurements.time_to_full_display)',
-                  primaryRelease
-                    ? `count_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
-                    : 'count()',
-                ]
-          }
-          blocks={
-            showComparison
-              ? [
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    dataKey: `avg_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`,
-                    title: t('Avg TTID (%s)', PRIMARY_RELEASE_ALIAS),
-                  },
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    dataKey: `avg_if(measurements.time_to_initial_display,release,equals,${secondaryRelease})`,
-                    title: t('Avg TTID (%s)', SECONDARY_RELEASE_ALIAS),
-                  },
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    dataKey: `avg_if(measurements.time_to_full_display,release,equals,${primaryRelease})`,
-                    title: t('Avg TTFD (%s)', PRIMARY_RELEASE_ALIAS),
-                  },
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    dataKey: `avg_if(measurements.time_to_full_display,release,equals,${secondaryRelease})`,
-                    title: t('Avg TTFD (%s)', SECONDARY_RELEASE_ALIAS),
-                  },
-                  {
-                    unit: 'count',
-                    dataKey: `count_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`,
-                    title: t('Total Count (%s)', PRIMARY_RELEASE_ALIAS),
-                  },
-                  {
-                    unit: 'count',
-                    dataKey: `count_if(measurements.time_to_initial_display,release,equals,${secondaryRelease})`,
-                    title: t('Total Count (%s)', SECONDARY_RELEASE_ALIAS),
-                  },
-                ]
-              : [
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    dataKey: primaryRelease
-                      ? `avg_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
-                      : 'avg(measurements.time_to_initial_display)',
-                    title: t('Avg TTID'),
-                  },
-                  {
-                    unit: DurationUnit.MILLISECOND,
-                    dataKey: primaryRelease
-                      ? `avg_if(measurements.time_to_full_display,release,equals,${primaryRelease})`
-                      : 'avg(measurements.time_to_full_display)',
-                    title: t('Avg TTFD'),
-                  },
-                  {
-                    unit: 'count',
-                    dataKey: primaryRelease
-                      ? `count_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
-                      : 'count()',
-                    title: t('Total Count'),
-                  },
-                ]
-          }
+          fields={[
+            primaryRelease
+              ? `avg_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
+              : 'avg(measurements.time_to_initial_display)',
+            primaryRelease
+              ? `avg_if(measurements.time_to_full_display,release,equals,${primaryRelease})`
+              : 'avg(measurements.time_to_full_display)',
+            primaryRelease
+              ? `count_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
+              : 'count()',
+          ]}
+          blocks={[
+            {
+              unit: DurationUnit.MILLISECOND,
+              dataKey: primaryRelease
+                ? `avg_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
+                : 'avg(measurements.time_to_initial_display)',
+              title: t('Avg TTID'),
+            },
+            {
+              unit: DurationUnit.MILLISECOND,
+              dataKey: primaryRelease
+                ? `avg_if(measurements.time_to_full_display,release,equals,${primaryRelease})`
+                : 'avg(measurements.time_to_full_display)',
+              title: t('Avg TTFD'),
+            },
+            {
+              unit: 'count',
+              dataKey: primaryRelease
+                ? `count_if(measurements.time_to_initial_display,release,equals,${primaryRelease})`
+                : 'count()',
+              title: t('Total Count'),
+            },
+          ]}
           referrer="api.insights.mobile-screen-totals"
         />
       </HeaderContainer>
@@ -188,7 +133,6 @@ export function ScreenLoadSpansContent() {
               <SpanOpSelector
                 primaryRelease={primaryRelease}
                 transaction={transactionName}
-                secondaryRelease={secondaryRelease}
               />
             )}
             {sampleType === EVENT && (
@@ -214,42 +158,21 @@ export function ScreenLoadSpansContent() {
         </Controls>
         {sampleType === EVENT && (
           <SampleContainer>
-            {showComparison ? (
-              <React.Fragment>
-                <SampleContainerItem>
-                  <ScreenLoadEventSamples
-                    release={primaryRelease}
-                    sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-                    cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-                    transaction={transactionName}
-                  />
-                </SampleContainerItem>
-                <SampleContainerItem>
-                  <ScreenLoadEventSamples
-                    release={secondaryRelease}
-                    sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-                    cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-                    transaction={transactionName}
-                  />
-                </SampleContainerItem>
-              </React.Fragment>
-            ) : (
-              <SampleContainerItem>
-                <ScreenLoadEventSamples
-                  release={primaryRelease}
-                  sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  transaction={transactionName}
-                />
-              </SampleContainerItem>
-            )}
+            <SampleContainerItem>
+              <ScreenLoadEventSamples
+                release={primaryRelease}
+                sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+                cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+                transaction={transactionName}
+              />
+            </SampleContainerItem>
+            )
           </SampleContainer>
         )}
         {sampleType === SPANS && (
           <ScreenLoadSpansTable
             transaction={transactionName}
             primaryRelease={primaryRelease}
-            secondaryRelease={secondaryRelease}
           />
         )}
       </ErrorBoundary>

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -276,7 +276,7 @@ function ScreensLandingPage() {
                       <DatePageFilter {...datePageFilterProps} />
                     </PageFilterBar>
                     <PageFilterBar condensed>
-                      <ReleaseComparisonSelector primaryOnly moduleName={moduleName} />
+                      <ReleaseComparisonSelector moduleName={moduleName} />
                     </PageFilterBar>
                   </ToolRibbon>
                 </Container>

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -61,7 +61,7 @@ function ScreensLandingPage() {
       {
         ...location,
         query: {
-          ...omit(location.query, ['primaryRelease', 'secondaryRelease']),
+          ...omit(location.query, ['primaryRelease']),
         },
       },
       {replace: true}

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.spec.tsx
@@ -18,24 +18,9 @@ describe('SpanOperationTable', () => {
       match: [MockApiClient.matchQuery({referrer: Referrer.SPAN_OPERATION_TABLE})],
     });
 
-    render(
-      <SpanOperationTable
-        transaction="transaction"
-        primaryRelease="foo"
-        secondaryRelease="bar"
-      />
-    );
+    render(<SpanOperationTable transaction="transaction" primaryRelease="foo" />);
 
-    [
-      'Operation',
-      'Span Description',
-      'Slow (R1)',
-      'Slow (R2)',
-      'Frozen (R1)',
-      'Frozen (R2)',
-      'Delay (R1)',
-      'Delay (R2)',
-    ].forEach(header => {
+    ['Operation', 'Span Description', 'Slow', 'Frozen', 'Delay'].forEach(header => {
       expect(screen.getByRole('columnheader', {name: header})).toBeInTheDocument();
     });
 
@@ -50,13 +35,9 @@ describe('SpanOperationTable', () => {
             'span.op',
             'span.group',
             'span.description',
-            'division_if(mobile.slow_frames,mobile.total_frames,release,equals,foo)',
-            'division_if(mobile.slow_frames,mobile.total_frames,release,equals,bar)',
-            'division_if(mobile.frozen_frames,mobile.total_frames,release,equals,foo)',
-            'division_if(mobile.frozen_frames,mobile.total_frames,release,equals,bar)',
-            'avg_if(mobile.frames_delay,release,equals,foo)',
-            'avg_if(mobile.frames_delay,release,equals,bar)',
-            'avg_compare(mobile.frames_delay,release,foo,bar)',
+            'division(mobile.slow_frames,mobile.total_frames)',
+            'division(mobile.frozen_frames,mobile.total_frames)',
+            'avg(mobile.frames_delay)',
           ],
         }),
       })

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
@@ -5,7 +5,6 @@ import {Link} from 'sentry/components/core/link';
 import Duration from 'sentry/components/duration';
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -13,10 +12,6 @@ import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {
-  PRIMARY_RELEASE_ALIAS,
-  SECONDARY_RELEASE_ALIAS,
-} from 'sentry/views/insights/common/components/releaseSelector';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/insights/common/utils/constants';
@@ -36,7 +31,6 @@ const VALID_SPAN_OPS = APP_START_SPANS;
 export function SpanOperationTable({
   transaction,
   primaryRelease,
-  secondaryRelease,
 }: SpanOperationTableProps) {
   const moduleURL = useModuleURL('mobile-vitals');
   const location = useLocation();
@@ -61,42 +55,17 @@ export function SpanOperationTable({
       ? [`${SpanFields.USER_GEO_SUBREGION}:[${subregions.join(',')}]`]
       : []),
   ]);
-  const queryStringPrimary = appendReleaseFilters(
-    searchQuery,
-    primaryRelease,
-    secondaryRelease
-  );
-
-  // Only show comparison when we have two different releases selected
-  const showComparison =
-    defined(primaryRelease) &&
-    defined(secondaryRelease) &&
-    primaryRelease !== secondaryRelease;
+  const queryStringPrimary = appendReleaseFilters(searchQuery, primaryRelease);
 
   const orderby = decodeScalar(location.query.sort, '');
 
   const baseFields = [PROJECT_ID, SPAN_OP, SPAN_GROUP, SPAN_DESCRIPTION];
-  let fields: any;
-
-  if (showComparison) {
-    fields = [
-      ...baseFields,
-      `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${primaryRelease})`,
-      `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${secondaryRelease})`,
-      `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${primaryRelease})`,
-      `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${secondaryRelease})`,
-      `avg_if(mobile.frames_delay,release,equals,${primaryRelease})`,
-      `avg_if(mobile.frames_delay,release,equals,${secondaryRelease})`,
-      `avg_compare(mobile.frames_delay,release,${primaryRelease},${secondaryRelease})`,
-    ] as any;
-  } else {
-    fields = [
-      ...baseFields,
-      'division(mobile.slow_frames,mobile.total_frames)',
-      'division(mobile.frozen_frames,mobile.total_frames)',
-      'avg(mobile.frames_delay)',
-    ] as any;
-  }
+  const fields: any = [
+    ...baseFields,
+    'division(mobile.slow_frames,mobile.total_frames)',
+    'division(mobile.frozen_frames,mobile.total_frames)',
+    'avg(mobile.frames_delay)',
+  ] as any;
 
   const newQuery: NewQuery = {
     name: '',
@@ -127,67 +96,16 @@ export function SpanOperationTable({
   };
   const columnTooltipMap: Record<string, string> = {};
 
-  if (showComparison) {
-    columnNameMap[
-      `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${primaryRelease})`
-    ] = t('Slow (%s)', PRIMARY_RELEASE_ALIAS);
-    columnNameMap[
-      `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${secondaryRelease})`
-    ] = t('Slow (%s)', SECONDARY_RELEASE_ALIAS);
-    columnNameMap[
-      `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${primaryRelease})`
-    ] = t('Frozen (%s)', PRIMARY_RELEASE_ALIAS);
-    columnNameMap[
-      `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${secondaryRelease})`
-    ] = t('Frozen (%s)', SECONDARY_RELEASE_ALIAS);
-    columnNameMap[`avg_if(mobile.frames_delay,release,equals,${primaryRelease})`] = t(
-      'Delay (%s)',
-      PRIMARY_RELEASE_ALIAS
-    );
-    columnNameMap[`avg_if(mobile.frames_delay,release,equals,${secondaryRelease})`] = t(
-      'Delay (%s)',
-      SECONDARY_RELEASE_ALIAS
-    );
-    columnNameMap[
-      `avg_compare(mobile.frames_delay,release,${primaryRelease},${secondaryRelease})`
-    ] = t('Change');
+  columnNameMap['division(mobile.slow_frames,mobile.total_frames)'] = t('Slow');
+  columnNameMap['division(mobile.frozen_frames,mobile.total_frames)'] = t('Frozen');
+  columnNameMap['avg(mobile.frames_delay)'] = t('Delay');
 
-    columnTooltipMap[
-      `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${primaryRelease})`
-    ] = t(
-      'The number of slow frames divided by total frames (%s)',
-      PRIMARY_RELEASE_ALIAS
-    );
-    columnTooltipMap[
-      `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${secondaryRelease})`
-    ] = t(
-      'The number of slow frames divided by total frames (%s)',
-      SECONDARY_RELEASE_ALIAS
-    );
-    columnTooltipMap[
-      `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${primaryRelease})`
-    ] = t(
-      'The number of frozen frames divided by total frames (%s)',
-      PRIMARY_RELEASE_ALIAS
-    );
-    columnTooltipMap[
-      `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${secondaryRelease})`
-    ] = t(
-      'The number of frozen frames divided by total frames (%s)',
-      SECONDARY_RELEASE_ALIAS
-    );
-  } else {
-    columnNameMap['division(mobile.slow_frames,mobile.total_frames)'] = t('Slow');
-    columnNameMap['division(mobile.frozen_frames,mobile.total_frames)'] = t('Frozen');
-    columnNameMap['avg(mobile.frames_delay)'] = t('Delay');
-
-    columnTooltipMap['division(mobile.slow_frames,mobile.total_frames)'] = t(
-      'The number of slow frames divided by total frames'
-    );
-    columnTooltipMap['division(mobile.frozen_frames,mobile.total_frames)'] = t(
-      'The number of frozen frames divided by total frames'
-    );
-  }
+  columnTooltipMap['division(mobile.slow_frames,mobile.total_frames)'] = t(
+    'The number of slow frames divided by total frames'
+  );
+  columnTooltipMap['division(mobile.frozen_frames,mobile.total_frames)'] = t(
+    'The number of frozen frames divided by total frames'
+  );
 
   function renderBodyCell(column: any, row: any) {
     if (column.key === SPAN_DESCRIPTION) {
@@ -226,39 +144,20 @@ export function SpanOperationTable({
     return null;
   }
 
-  const columnOrder = showComparison
-    ? [
-        String(SPAN_OP),
-        String(SPAN_DESCRIPTION),
-        `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${primaryRelease})`,
-        `division_if(mobile.slow_frames,mobile.total_frames,release,equals,${secondaryRelease})`,
-        `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${primaryRelease})`,
-        `division_if(mobile.frozen_frames,mobile.total_frames,release,equals,${secondaryRelease})`,
-        `avg_if(mobile.frames_delay,release,equals,${primaryRelease})`,
-        `avg_if(mobile.frames_delay,release,equals,${secondaryRelease})`,
-        `avg_compare(mobile.frames_delay,release,${primaryRelease},${secondaryRelease})`,
-      ]
-    : [
-        String(SPAN_OP),
-        String(SPAN_DESCRIPTION),
-        'division(mobile.slow_frames,mobile.total_frames)',
-        'division(mobile.frozen_frames,mobile.total_frames)',
-        'avg(mobile.frames_delay)',
-      ];
+  const columnOrder = [
+    String(SPAN_OP),
+    String(SPAN_DESCRIPTION),
+    'division(mobile.slow_frames,mobile.total_frames)',
+    'division(mobile.frozen_frames,mobile.total_frames)',
+    'avg(mobile.frames_delay)',
+  ];
 
-  const defaultSort = showComparison
-    ? [
-        {
-          key: `avg_compare(mobile.frames_delay,release,${primaryRelease},${secondaryRelease})`,
-          order: 'desc' as const,
-        },
-      ]
-    : [
-        {
-          key: 'avg(mobile.frames_delay)',
-          order: 'desc' as const,
-        },
-      ];
+  const defaultSort = [
+    {
+      key: 'avg(mobile.frames_delay)',
+      order: 'desc' as const,
+    },
+  ];
 
   return (
     <ScreensTable

--- a/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
@@ -19,7 +19,6 @@ type Query = {
   'device.class': string;
   primaryRelease: string;
   project: string;
-  secondaryRelease: string;
   spanDescription: string;
   spanGroup: string;
   spanOp: string;

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -104,11 +104,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
   const theme = useTheme();
   const pageFilter = usePageFilters();
   const mepSetting = useMEPSettingContext();
-  const {
-    isLoading: isLoadingReleases,
-    primaryRelease,
-    secondaryRelease,
-  } = useReleaseSelection();
+  const {isLoading: isLoadingReleases, primaryRelease} = useReleaseSelection();
   const location = useLocation();
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const {InteractiveTitle} = props;
@@ -124,7 +120,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
     () => ({
       fields: field,
       component: provided => {
-        if (isLoadingReleases || (!primaryRelease && !secondaryRelease)) {
+        if (isLoadingReleases || !primaryRelease) {
           return null;
         }
 
@@ -159,11 +155,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
         // Update query
         const mutableSearch = new MutableSearch(eventView.query);
         mutableSearch.addFilterValue(segmentOp, 'ui.load');
-        eventView.query = appendReleaseFilters(
-          mutableSearch,
-          primaryRelease,
-          secondaryRelease
-        );
+        eventView.query = appendReleaseFilters(mutableSearch, primaryRelease);
 
         return (
           <DiscoverQuery
@@ -180,7 +172,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
       transform: transformDiscoverToList,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [props.chartSetting, mepSetting.memoizationKey, primaryRelease, secondaryRelease]
+    [props.chartSetting, mepSetting.memoizationKey, primaryRelease]
   );
 
   const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
@@ -223,11 +215,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
           eventView.fields = [{field}, {field: 'release'}];
           const mutableSearch = new MutableSearch(eventView.query);
           mutableSearch.addFilterValue(segmentOp, 'ui.load');
-          eventView.query = appendReleaseFilters(
-            mutableSearch,
-            primaryRelease,
-            secondaryRelease
-          );
+          eventView.query = appendReleaseFilters(mutableSearch, primaryRelease);
           eventView.interval = getInterval(
             pageFilter.selection.datetime,
             STARFISH_CHART_INTERVAL_FIDELITY
@@ -257,13 +245,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      props.chartSetting,
-      selectedListIndex,
-      mepSetting.memoizationKey,
-      primaryRelease,
-      secondaryRelease,
-    ]
+    [props.chartSetting, selectedListIndex, mepSetting.memoizationKey, primaryRelease]
   );
 
   const Queries = {
@@ -355,7 +337,6 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
                 project: listItem['project.id'],
                 transaction,
                 primaryRelease,
-                secondaryRelease,
                 ...normalizeDateTimeParams(location.query),
                 ...targetQueryParams,
               },
@@ -404,7 +385,6 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
               ...normalizeDateTimeParams(pageFilter),
               ...targetQueryParams,
               primaryRelease,
-              secondaryRelease,
             },
           })}
           size="sm"


### PR DESCRIPTION
Mobile Vitals module allows selecting both a primary release and an optional secondary release for comparison. We've decided to remove this functionality both because users tend to find it confusing, and because we want to get ready for conversion of the Mobile Vitals modules to Dashboards, and Dashboards don't support this feature.

**e.g.,**

This PR removes the concept of "secondary release" completely from the codebase. It's no longer possible to select a secondary release, and the secondary release in the URL won't affect the UI. The product behaves as if secondary releases don't exist.

## Changes

There are many removals, but they rhyme:

- all usage of `secondaryRelease` via `useReleaseSelection` has been removed
- any code that runs when "comparison" is enabled has been inlined and there aren't any more conditionals
- any UI that annotated the release as R1 or R2 is removed
- all tests that tested comparison UIs are removed

In follow-up PRs I'll probably be doing more cleaning, potentially renaming "primary release" to "release", since there's no such thing as secondary anymore.
