### PR TITLE
fix(uptime): Enforce environment requirement

### DIFF
--- a/static/app/views/detectors/components/forms/detectorBaseFields.tsx
+++ b/static/app/views/detectors/components/forms/detectorBaseFields.tsx
@@ -13,10 +13,14 @@ import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/co
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 interface DetectorBaseFieldsProps {
+  envFieldProps?: Partial<React.ComponentProps<typeof SelectField>>;
   noEnvironment?: boolean;
 }
 
-export function DetectorBaseFields({noEnvironment}: DetectorBaseFieldsProps) {
+export function DetectorBaseFields({
+  noEnvironment,
+  envFieldProps,
+}: DetectorBaseFieldsProps) {
   const {setHasSetDetectorName} = useDetectorFormContext();
 
   return (
@@ -43,7 +47,7 @@ export function DetectorBaseFields({noEnvironment}: DetectorBaseFieldsProps) {
       </Layout.Title>
       <Flex gap="md">
         <ProjectField />
-        {!noEnvironment && <EnvironmentField />}
+        {!noEnvironment && <EnvironmentField {...envFieldProps} />}
       </Flex>
     </Flex>
   );
@@ -85,7 +89,7 @@ function ProjectField() {
   );
 }
 
-function EnvironmentField() {
+function EnvironmentField(props: Partial<React.ComponentProps<typeof SelectField>>) {
   const {projects} = useProjects();
   const projectId = useFormField<string>('projectId')!;
 
@@ -104,6 +108,7 @@ function EnvironmentField() {
       placeholder={t('Environment')}
       aria-label={t('Select Environment')}
       size="sm"
+      {...props}
     />
   );
 }

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -23,6 +23,7 @@ type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
   detector: TDetector;
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   savedDetectorToFormData: (detector: TDetector) => TFormData;
+  envFieldProps?: React.ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
   mapFormErrors?: (error: any) => any;
   noEnvironment?: boolean;
   previewChart?: React.ReactNode;
@@ -40,6 +41,7 @@ export function EditDetectorLayout<
   savedDetectorToFormData,
   mapFormErrors,
   noEnvironment,
+  envFieldProps,
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
@@ -73,7 +75,10 @@ export function EditDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields noEnvironment={noEnvironment} />
+          <DetectorBaseFields
+            noEnvironment={noEnvironment}
+            envFieldProps={envFieldProps}
+          />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -22,6 +22,7 @@ type NewDetectorLayoutProps<TFormData, TUpdatePayload> = {
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   initialFormData: Partial<TFormData>;
   disabledCreate?: string;
+  envFieldProps?: React.ComponentProps<typeof DetectorBaseFields>['envFieldProps'];
   mapFormErrors?: (error: any) => any;
   noEnvironment?: boolean;
   previewChart?: React.ReactNode;
@@ -37,6 +38,7 @@ export function NewDetectorLayout<
   disabledCreate,
   mapFormErrors,
   noEnvironment,
+  envFieldProps,
   previewChart,
   detectorType,
 }: NewDetectorLayoutProps<TFormData, TUpdatePayload>) {
@@ -85,7 +87,10 @@ export function NewDetectorLayout<
         </div>
 
         <EditLayout.HeaderFields>
-          <DetectorBaseFields noEnvironment={noEnvironment} />
+          <DetectorBaseFields
+            noEnvironment={noEnvironment}
+            envFieldProps={envFieldProps}
+          />
           {previewChart ?? <div />}
         </EditLayout.HeaderFields>
       </EditLayout.Header>

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -56,6 +56,7 @@ export function NewUptimeDetectorForm() {
       detectorType="uptime_domain_failure"
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       initialFormData={{}}
+      envFieldProps={{required: true}}
     >
       <UptimeDetectorForm />
     </NewDetectorLayout>
@@ -68,6 +69,7 @@ export function EditExistingUptimeDetectorForm({detector}: {detector: UptimeDete
       detector={detector}
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       savedDetectorToFormData={uptimeSavedDetectorToFormData}
+      envFieldProps={{required: true}}
     >
       <UptimeDetectorForm />
     </EditDetectorLayout>

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -8,6 +8,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
 
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -774,6 +775,8 @@ describe('DetectorEdit', () => {
         'https://uptime.example.com'
       );
 
+      await selectEvent.select(screen.getByLabelText('Select Environment'), 'production');
+
       await userEvent.click(screen.getByRole('button', {name: 'Create Monitor'}));
 
       await waitFor(() => {
@@ -786,7 +789,7 @@ describe('DetectorEdit', () => {
           data: expect.objectContaining({
             config: {
               downtimeThreshold: 3,
-              environment: null,
+              environment: 'production',
               mode: 1,
               recoveryThreshold: 1,
             },
@@ -825,6 +828,8 @@ describe('DetectorEdit', () => {
         'https://uptime-custom.example.com'
       );
 
+      await selectEvent.select(screen.getByLabelText('Select Environment'), 'production');
+
       await userEvent.clear(screen.getByRole('spinbutton', {name: 'Failure Threshold'}));
       await userEvent.type(
         screen.getByRole('spinbutton', {name: 'Failure Threshold'}),
@@ -849,7 +854,7 @@ describe('DetectorEdit', () => {
           data: expect.objectContaining({
             config: {
               downtimeThreshold: '5',
-              environment: null,
+              environment: 'production',
               mode: 1,
               recoveryThreshold: '4',
             },


### PR DESCRIPTION
Enforces that a environment must be selected when creating or editing an uptime monitor.

This is ONLY enforced on the front end for now, since it is currently possible to have a uptime monitor created without an environment.

Fixes [NEW-649: It should not be possible to create an uptime monitor without an environment](https://linear.app/getsentry/issue/NEW-649/it-should-not-be-possible-to-create-an-uptime-monitor-without-an)