### PR TITLE
chore(api): Use new route structure for some admin endpoints

### DIFF
--- a/static/gsAdmin/components/addBillingMetricUsage.tsx
+++ b/static/gsAdmin/components/addBillingMetricUsage.tsx
@@ -134,7 +134,7 @@ function AddBillingMetricUsageModal({
       date: getDateString(date),
     };
 
-    api.request(`/_admin/${orgSlug}/record-usage/`, {
+    api.request(`/customers/${orgSlug}/record-usage/`, {
       method: 'POST',
       data,
       success: () => {

--- a/static/gsAdmin/components/addOrRemoveOrgModal.tsx
+++ b/static/gsAdmin/components/addOrRemoveOrgModal.tsx
@@ -19,7 +19,7 @@ function AddToOrgModal({Header, Body, userId, closeModal}: AddOrRemoveOrgModalPr
   const onSubmit = async (data: Record<string, any>) => {
     try {
       await api
-        .requestPromise(`/_admin/${data.organizationSlug}/users/${userId}/members/`, {
+        .requestPromise(`/customers/${data.organizationSlug}/users/${userId}/members/`, {
           method: 'POST',
           data: {
             orgRole: data.role,
@@ -78,7 +78,7 @@ function RemoveFromOrgModal({
   const onSubmit = async (data: Record<string, any>) => {
     try {
       await api
-        .requestPromise(`/_admin/${data.organizationSlug}/users/${userId}/members/`, {
+        .requestPromise(`/customers/${data.organizationSlug}/users/${userId}/members/`, {
           method: 'DELETE',
         })
         .then(() => {

--- a/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
@@ -139,7 +139,7 @@ describe('DeleteBillingMetricHistory', () => {
 
     // Mock the API endpoint for deleting billing metric history
     const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
-      url: `/api/0/_admin/${organization.slug}/delete-billing-metric-history/`,
+      url: `/api/0/customers/${organization.slug}/delete-billing-metric-history/`,
       method: 'POST',
       body: {},
     });
@@ -168,7 +168,7 @@ describe('DeleteBillingMetricHistory', () => {
 
     // Check that the API call was made with the correct parameters
     expect(deleteBillingMetricHistoryMock).toHaveBeenCalledWith(
-      `/api/0/_admin/${organization.slug}/delete-billing-metric-history/`,
+      `/api/0/customers/${organization.slug}/delete-billing-metric-history/`,
       expect.objectContaining({
         method: 'POST',
         data: {
@@ -216,7 +216,7 @@ describe('DeleteBillingMetricHistory', () => {
 
     // Mock the API endpoint to return an error
     const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
-      url: `/api/0/_admin/${organization.slug}/delete-billing-metric-history/`,
+      url: `/api/0/customers/${organization.slug}/delete-billing-metric-history/`,
       method: 'POST',
       statusCode: 400,
       body: {

--- a/static/gsAdmin/components/deleteBillingMetricHistory.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.tsx
@@ -76,7 +76,7 @@ function DeleteBillingMetricHistoryModal({
       return;
     }
 
-    api.request(`/api/0/_admin/${orgSlug}/delete-billing-metric-history/`, {
+    api.request(`/api/0/customers/${orgSlug}/delete-billing-metric-history/`, {
       method: 'POST',
       data: {
         data_category: dataCategory,

--- a/static/gsAdmin/components/refundVercelRequestModal.tsx
+++ b/static/gsAdmin/components/refundVercelRequestModal.tsx
@@ -39,7 +39,7 @@ function RefundVercelRequestModal({
       reason,
     };
 
-    api.request(`/_admin/${orgSlug}/refund-vercel/`, {
+    api.request(`/customers/${orgSlug}/refund-vercel/`, {
       method: 'POST',
       data,
       success: () => {

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1927,7 +1927,7 @@ describe('Customer Details', () => {
       await userEvent.type(screen.getByRole('textbox', {name: 'Reason'}), 'test');
 
       const apiMock = MockApiClient.addMockResponse({
-        url: `/_admin/${organization.slug}/refund-vercel/`,
+        url: `/customers/${organization.slug}/refund-vercel/`,
         method: 'POST',
         body: {},
       });
@@ -1936,7 +1936,7 @@ describe('Customer Details', () => {
 
       await waitFor(() =>
         expect(apiMock).toHaveBeenCalledWith(
-          `/_admin/${organization.slug}/refund-vercel/`,
+          `/customers/${organization.slug}/refund-vercel/`,
           expect.objectContaining({
             method: 'POST',
             data: {


### PR DESCRIPTION
New routes were added for these endpoints here: https://github.com/getsentry/getsentry/pull/19045

`_admin/<org>` was changed to `customers/<org>` per the new URL structure requirements (cellularization project)