### PR TITLE
fix(autofix): Stop fetching autofix on completion

### DIFF
--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -124,7 +124,9 @@ const isPolling = (
 
   if (
     !hasSolutionStep &&
-    ![AutofixStatus.ERROR, AutofixStatus.CANCELLED].includes(autofixData.status)
+    ![AutofixStatus.ERROR, AutofixStatus.CANCELLED, AutofixStatus.COMPLETED].includes(
+      autofixData.status
+    )
   ) {
     // we want to keep polling until we have a solution step because that's a stopping point
     // we need this explicit check in case we get a state for a fraction of a second where the root cause is complete and there is no step after it started


### PR DESCRIPTION
Even if there is no solution step, stop polling when autofix status is completed.