### PR TITLE
feat(uptime): Add task to process pending missed check backfills

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -925,6 +925,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.uptime.autodetect.tasks",
     "sentry.uptime.rdap.tasks",
     "sentry.uptime.subscriptions.tasks",
+    "sentry.uptime.tasks",
     "sentry.workflow_engine.tasks.delayed_workflows",
     "sentry.workflow_engine.tasks.workflows",
     "sentry.workflow_engine.tasks.actions",
@@ -971,6 +972,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     "monitors-detect-broken-monitor-envs": {
         "task": "crons:sentry.monitors.tasks.detect_broken_monitor_envs",
         "schedule": task_crontab("0", "15", "mon-fri", "*", "*"),
+    },
+    "uptime-write-pending-misses": {
+        "task": "uptime_tasks:sentry.uptime.tasks.write_pending_missed_checks",
+        "schedule": timedelta(minutes=1),
     },
     "clear-expired-snoozes": {
         "task": "issues:sentry.tasks.clear_expired_snoozes",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -973,10 +973,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "crons:sentry.monitors.tasks.detect_broken_monitor_envs",
         "schedule": task_crontab("0", "15", "mon-fri", "*", "*"),
     },
-    "uptime-write-pending-misses": {
-        "task": "uptime_tasks:sentry.uptime.tasks.write_pending_missed_checks",
-        "schedule": timedelta(minutes=1),
-    },
     "clear-expired-snoozes": {
         "task": "issues:sentry.tasks.clear_expired_snoozes",
         "schedule": task_crontab("*/5", "*", "*", "*", "*"),
@@ -1045,6 +1041,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     "uptime-broken-monitor-checker": {
         "task": "uptime:sentry.uptime.tasks.broken_monitor_checker",
         "schedule": task_crontab("0", "*/1", "*", "*", "*"),
+    },
+    "uptime-write-pending-misses": {
+        "task": "uptime_tasks:sentry.uptime.tasks.write_pending_missed_checks",
+        "schedule": timedelta(minutes=1),
     },
     "poll_tempest": {
         "task": "tempest:sentry.tempest.tasks.poll_tempest",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1043,7 +1043,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "schedule": task_crontab("0", "*/1", "*", "*", "*"),
     },
     "uptime-write-pending-misses": {
-        "task": "uptime_tasks:sentry.uptime.tasks.write_pending_missed_checks",
+        "task": "uptime:sentry.uptime.tasks.write_pending_missed_checks",
         "schedule": timedelta(minutes=1),
     },
     "poll_tempest": {

--- a/src/sentry/uptime/tasks.py
+++ b/src/sentry/uptime/tasks.py
@@ -45,7 +45,7 @@ def _write_pending_missed_checks():
     pending_misses_key = build_pending_misses_key()
     current_time_ms = datetime.now(timezone.utc).timestamp() * 1000
 
-    ready_entries = cluster.zrangebyscore(
+    ready_entries: list[tuple[str, float]] = cluster.zrangebyscore(
         pending_misses_key, "-inf", current_time_ms, withscores=True
     )
 

--- a/src/sentry/uptime/tasks.py
+++ b/src/sentry/uptime/tasks.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sentry.locks import locks
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import uptime_tasks
+from sentry.taskworker.retry import Retry
+from sentry.uptime.consumers.eap_producer import produce_eap_uptime_result
+from sentry.uptime.utils import build_pending_misses_key, get_cluster
+from sentry.utils import json, metrics
+from sentry.utils.locking import UnableToAcquireLock
+from sentry.workflow_engine.models.detector import Detector
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.uptime.tasks.write_pending_missed_checks",
+    namespace=uptime_tasks,
+    retry=Retry(times=3, delay=60),
+)
+def write_pending_missed_checks(**kwargs):
+    """
+    Background task that writes backfilled missed checks to EAP after their TTL expires.
+    This task runs periodically and processes pending misses.
+    """
+    lock = locks.get(
+        "uptime:write_pending_missed_checks",
+        duration=600,
+        routing_key=None,
+    )
+
+    try:
+        with lock.acquire():
+            _write_pending_missed_checks()
+    except UnableToAcquireLock:
+        logger.info("write_pending_missed_checks.unable_to_acquire_lock")
+        return
+
+
+def _write_pending_missed_checks():
+    cluster = get_cluster()
+    pending_misses_key = build_pending_misses_key()
+    current_time_ms = datetime.now(timezone.utc).timestamp() * 1000
+
+    ready_entries = cluster.zrangebyscore(
+        pending_misses_key, "-inf", current_time_ms, withscores=True
+    )
+
+    total_written = 0
+    total_skipped = 0
+
+    for backfill_key, write_time in ready_entries:
+        try:
+            parts = backfill_key.split(":")
+            detector_id = int(parts[2])
+            scheduled_time_ms = int(parts[3])
+        except (IndexError, ValueError):
+            logger.exception(
+                "write_pending_missed_checks.invalid_key_format",
+                extra={"backfill_key": backfill_key},
+            )
+            cluster.zrem(pending_misses_key, backfill_key)
+            continue
+
+        try:
+            detector = Detector.objects.select_related("project").get(id=detector_id)
+        except Detector.DoesNotExist:
+            logger.warning(
+                "write_pending_missed_checks.detector_not_found",
+                extra={"detector_id": detector_id, "backfill_key": backfill_key},
+            )
+            cluster.zrem(pending_misses_key, backfill_key)
+            cluster.delete(backfill_key)
+            continue
+
+        miss_data_json = cluster.get(backfill_key)
+
+        if miss_data_json is None:
+            logger.info(
+                "write_pending_missed_checks.miss_already_handled",
+                extra={
+                    "detector_id": detector_id,
+                    "scheduled_time_ms": scheduled_time_ms,
+                    "backfill_key": backfill_key,
+                },
+            )
+            total_skipped += 1
+        else:
+            try:
+                produce_eap_uptime_result(
+                    detector,
+                    json.loads(miss_data_json),
+                    {},
+                )
+                total_written += 1
+            except Exception:
+                logger.exception(
+                    "write_pending_missed_checks.write_failed",
+                    extra={
+                        "detector_id": detector_id,
+                        "scheduled_time_ms": scheduled_time_ms,
+                        "backfill_key": backfill_key,
+                    },
+                )
+
+            cluster.delete(backfill_key)
+
+        # Remove from sorted set
+        cluster.zrem(pending_misses_key, backfill_key)
+
+    if total_written > 0 or total_skipped > 0:
+        metrics.incr(
+            "uptime.write_pending_missed_checks.processed",
+            amount=total_written,
+            tags={"result": "written"},
+            sample_rate=1.0,
+        )
+        metrics.incr(
+            "uptime.write_pending_missed_checks.processed",
+            amount=total_skipped,
+            tags={"result": "skipped"},
+            sample_rate=1.0,
+        )

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -50,7 +50,7 @@ def test_taskworker_schedule_type(name: str, config: dict[str, Any], load_tasks)
     ), f"Schedule {name} has a schedule of type {type(schedule)}"
 
 
-def test_taskworker_schedule_parameters() -> None:
+def test_taskworker_schedule_parameters(load_tasks) -> None:
     for config in settings.TASKWORKER_SCHEDULES.values():
         (namespace, taskname) = config["task"].split(":")
         task = taskregistry.get_task(namespace, taskname)

--- a/tests/sentry/uptime/test_tasks.py
+++ b/tests/sentry/uptime/test_tasks.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+from unittest.mock import MagicMock
+
+from sentry.testutils.cases import TestCase
+from sentry.uptime.tasks import write_pending_missed_checks
+from sentry.uptime.utils import build_backfilled_miss_key, build_pending_misses_key, get_cluster
+from sentry.utils import json
+
+
+class WritePendingMissedChecksTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.subscription = self.create_uptime_subscription()
+        self.detector = self.create_uptime_detector(uptime_subscription=self.subscription)
+        self.cluster = get_cluster()
+
+    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    def test_writes_pending_misses(self, mock_produce: MagicMock) -> None:
+        """Test that pending misses are written to EAP when their write time has passed."""
+        with self.feature("organizations:uptime-upgrade-late-results"):
+            # Create a pending miss
+            scheduled_time_ms = int(
+                (datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp() * 1000
+            )
+            miss_result = {
+                "guid": "test-guid",
+                "subscription_id": str(self.subscription.subscription_id),
+                "status": "missed_window",
+                "status_reason": None,
+                "trace_id": "test-trace-id",
+                "span_id": "test-span-id",
+                "region": "us-west",
+                "scheduled_check_time_ms": scheduled_time_ms,
+                "actual_check_time_ms": scheduled_time_ms + 1000,
+                "duration_ms": 0,
+                "request_info": None,
+            }
+
+            # Store miss data
+            backfill_key = build_backfilled_miss_key(self.detector, scheduled_time_ms)
+            self.cluster.set(backfill_key, json.dumps(miss_result), ex=timedelta(minutes=5))
+
+            # Add backfill key to sorted set with write time in the past
+            write_time_ms = (datetime.now(timezone.utc) - timedelta(seconds=10)).timestamp() * 1000
+            self.cluster.zadd(build_pending_misses_key(), {backfill_key: write_time_ms})
+
+            # Run the task
+            write_pending_missed_checks()
+
+            # Verify miss was written to EAP
+            assert mock_produce.call_count == 1
+
+            # Verify cleanup
+            assert self.cluster.get(backfill_key) is None
+            assert self.cluster.zscore(build_pending_misses_key(), backfill_key) is None
+
+    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    def test_skips_future_misses(self, mock_produce: MagicMock) -> None:
+        """Test that misses with write time in the future are not written yet."""
+        with self.feature("organizations:uptime-upgrade-late-results"):
+            # Create a pending miss with write time in the future
+            scheduled_time_ms = int(
+                (datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp() * 1000
+            )
+            miss_result = {
+                "guid": "test-guid",
+                "subscription_id": str(self.subscription.subscription_id),
+                "status": "missed_window",
+                "status_reason": None,
+                "trace_id": "test-trace-id",
+                "span_id": "test-span-id",
+                "region": "us-west",
+                "scheduled_check_time_ms": scheduled_time_ms,
+                "actual_check_time_ms": scheduled_time_ms + 1000,
+                "duration_ms": 0,
+                "request_info": None,
+            }
+
+            # Store miss data
+            backfill_key = build_backfilled_miss_key(self.detector, scheduled_time_ms)
+            self.cluster.set(backfill_key, json.dumps(miss_result), ex=timedelta(minutes=5))
+
+            # Add backfill key to sorted set with future write time
+            write_time_ms = (datetime.now(timezone.utc) + timedelta(minutes=2)).timestamp() * 1000
+            self.cluster.zadd(build_pending_misses_key(), {backfill_key: write_time_ms})
+
+            # Run the task
+            write_pending_missed_checks()
+
+            # Verify miss was NOT written to EAP
+            assert mock_produce.call_count == 0
+
+            # Verify data still exists
+            assert self.cluster.get(backfill_key) is not None
+            assert self.cluster.zscore(build_pending_misses_key(), backfill_key) is not None
+
+    @mock.patch("sentry.uptime.consumers.eap_producer._eap_items_producer.produce")
+    def test_handles_missing_backfill_key(self, mock_produce: MagicMock) -> None:
+        """Test that task handles case where backfill key is missing (late result already handled it)."""
+        with self.feature("organizations:uptime-upgrade-late-results"):
+            # Create sorted set entry but NO backfill key (simulates late result upgrading the miss)
+            scheduled_time_ms = int(
+                (datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp() * 1000
+            )
+            backfill_key = build_backfilled_miss_key(self.detector, scheduled_time_ms)
+
+            # Add to sorted set with write time in the past, but don't create the backfill key
+            write_time_ms = (datetime.now(timezone.utc) - timedelta(seconds=10)).timestamp() * 1000
+            self.cluster.zadd(build_pending_misses_key(), {backfill_key: write_time_ms})
+
+            # Run the task
+            write_pending_missed_checks()
+
+            # Verify nothing was written to EAP
+            assert mock_produce.call_count == 0
+
+            # Verify cleanup still happened
+            assert self.cluster.zscore(build_pending_misses_key(), backfill_key) is None


### PR DESCRIPTION
This adds a task that runs every minute and processes pending miss backfills from the consumer.

<!-- Describe your PR here. -->