### PR TITLE
ref(seer billing): Don't create OrganizationContributors for bots or external contributors

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -789,6 +789,23 @@ class PullRequestEventWebhook(GitHubWebhook):
                 },
             )
 
+            if created:
+                logger.info(
+                    "github.webhook.pull_request.contributor_eligibility_check",
+                    extra={
+                        "organization_id": organization.id,
+                        "repository_id": repo.id,
+                        "pr_number": number,
+                        "user_id": user["id"],
+                        "user_login": user["login"],
+                        "user_type": user_type,
+                        "author_association": author_association,
+                        "is_eligible": is_contributor_eligible_for_seat_assignment(
+                            user_type, author_association
+                        ),
+                    },
+                )
+
             if created and is_contributor_eligible_for_seat_assignment(
                 user_type, author_association
             ):

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -800,7 +800,7 @@ class PullRequestEventWebhook(GitHubWebhook):
                 )
 
                 logger.info(
-                    "github.webhook.pull_request.contributor_eligibility_check",
+                    "github.webhook.organization_contributor.eligibility_check",
                     extra={
                         "pr_number": number,
                         "user_login": user["login"],

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -789,7 +789,9 @@ class PullRequestEventWebhook(GitHubWebhook):
                 },
             )
 
-            if created:
+            if created and is_contributor_eligible_for_seat_assignment(
+                user_type, author_association
+            ):
                 # Track AI contributor if eligible
                 contributor, _ = OrganizationContributors.objects.get_or_create(
                     organization_id=organization.id,
@@ -834,9 +836,6 @@ class PullRequestEventWebhook(GitHubWebhook):
 
                     if (
                         locked_contributor
-                        and is_contributor_eligible_for_seat_assignment(
-                            user_type, author_association
-                        )
                         and locked_contributor.num_actions
                         >= ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD
                     ):

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -793,10 +793,7 @@ class PullRequestEventWebhook(GitHubWebhook):
                 logger.info(
                     "github.webhook.pull_request.contributor_eligibility_check",
                     extra={
-                        "organization_id": organization.id,
-                        "repository_id": repo.id,
                         "pr_number": number,
-                        "user_id": user["id"],
                         "user_login": user["login"],
                         "user_type": user_type,
                         "author_association": author_association,

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -790,6 +790,15 @@ class PullRequestEventWebhook(GitHubWebhook):
             )
 
             if created:
+                metrics.incr(
+                    "github.webhook.pull_request.created",
+                    sample_rate=1.0,
+                    tags={
+                        "organization_id": organization.id,
+                        "repository_id": repo.id,
+                    },
+                )
+
                 logger.info(
                     "github.webhook.pull_request.contributor_eligibility_check",
                     extra={
@@ -803,66 +812,57 @@ class PullRequestEventWebhook(GitHubWebhook):
                     },
                 )
 
-            if created and is_contributor_eligible_for_seat_assignment(
-                user_type, author_association
-            ):
-                # Track AI contributor if eligible
-                contributor, _ = OrganizationContributors.objects.get_or_create(
-                    organization_id=organization.id,
-                    integration_id=integration.id,
-                    external_identifier=user["id"],
-                    defaults={
-                        "alias": user["login"],
-                    },
-                )
-
-                if should_create_or_increment_contributor_seat(organization, repo, contributor):
-                    metrics.incr(
-                        "github.webhook.organization_contributor.should_create",
-                        sample_rate=1.0,
-                        tags={
-                            "organization_id": organization.id,
-                            "repository_id": repo.id,
+                if is_contributor_eligible_for_seat_assignment(user_type, author_association):
+                    # Track AI contributor if eligible
+                    contributor, _ = OrganizationContributors.objects.get_or_create(
+                        organization_id=organization.id,
+                        integration_id=integration.id,
+                        external_identifier=user["id"],
+                        defaults={
+                            "alias": user["login"],
                         },
                     )
 
-                    locked_contributor = None
-                    with transaction.atomic(router.db_for_write(OrganizationContributors)):
-                        try:
-                            locked_contributor = (
-                                OrganizationContributors.objects.select_for_update().get(
-                                    organization_id=organization.id,
-                                    integration_id=integration.id,
-                                    external_identifier=user["id"],
+                    if should_create_or_increment_contributor_seat(organization, repo, contributor):
+                        metrics.incr(
+                            "github.webhook.organization_contributor.should_create",
+                            sample_rate=1.0,
+                            tags={
+                                "organization_id": organization.id,
+                                "repository_id": repo.id,
+                            },
+                        )
+
+                        locked_contributor = None
+                        with transaction.atomic(router.db_for_write(OrganizationContributors)):
+                            try:
+                                locked_contributor = (
+                                    OrganizationContributors.objects.select_for_update().get(
+                                        organization_id=organization.id,
+                                        integration_id=integration.id,
+                                        external_identifier=user["id"],
+                                    )
                                 )
-                            )
-                            locked_contributor.num_actions += 1
-                            locked_contributor.save(update_fields=["num_actions", "date_updated"])
-                        except OrganizationContributors.DoesNotExist:
-                            logger.exception(
-                                "github.webhook.organization_contributor.not_found",
-                                extra={
-                                    "organization_id": organization.id,
-                                    "integration_id": integration.id,
-                                    "external_identifier": user["id"],
-                                },
-                            )
+                                locked_contributor.num_actions += 1
+                                locked_contributor.save(
+                                    update_fields=["num_actions", "date_updated"]
+                                )
+                            except OrganizationContributors.DoesNotExist:
+                                logger.exception(
+                                    "github.webhook.organization_contributor.not_found",
+                                    extra={
+                                        "organization_id": organization.id,
+                                        "integration_id": integration.id,
+                                        "external_identifier": user["id"],
+                                    },
+                                )
 
-                    if (
-                        locked_contributor
-                        and locked_contributor.num_actions
-                        >= ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD
-                    ):
-                        assign_seat_to_organization_contributor.delay(locked_contributor.id)
-
-                metrics.incr(
-                    "github.webhook.pull_request.created",
-                    sample_rate=1.0,
-                    tags={
-                        "organization_id": organization.id,
-                        "repository_id": repo.id,
-                    },
-                )
+                        if (
+                            locked_contributor
+                            and locked_contributor.num_actions
+                            >= ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD
+                        ):
+                            assign_seat_to_organization_contributor.delay(locked_contributor.id)
 
         except IntegrityError:
             pass

--- a/src/sentry/tasks/organization_contributors.py
+++ b/src/sentry/tasks/organization_contributors.py
@@ -52,6 +52,16 @@ def assign_seat_to_organization_contributor(contributor_id) -> None:
         )
         return
 
+    logger.info(
+        "organization_contributors.assign_seat.start",
+        extra={
+            "organization_contributor_id": organization_contributor.id,
+            "organization_id": organization_contributor.organization_id,
+            "integration_id": organization_contributor.integration_id,
+            "external_identifier": organization_contributor.external_identifier,
+        },
+    )
+
     outcome = quotas.backend.assign_seat(DataCategory.SEER_USER, organization_contributor)
 
     if outcome != Outcome.ACCEPTED:

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -1126,7 +1126,7 @@ class PullRequestEventWebhook(APITestCase):
         "sentry.integrations.github.webhook.should_create_or_increment_contributor_seat",
         return_value=True,
     )
-    def test_seat_assignment_not_triggered_for_bot_contributor(
+    def test_no_contributor_tracking_for_bot_contributor(
         self,
         mock_should_create_or_increment_contributor_seat: MagicMock,
         mock_assign_seat: MagicMock,
@@ -1147,13 +1147,6 @@ class PullRequestEventWebhook(APITestCase):
                 metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
             )
             integration.add_organization(self.project.organization.id, self.user)
-
-        contributor = OrganizationContributors.objects.create(
-            organization_id=self.organization.id,
-            integration_id=integration.id,
-            external_identifier="6752317",
-            num_actions=1,
-        )
 
         body = json.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
         body["pull_request"]["user"]["type"] = "Bot"
@@ -1169,8 +1162,11 @@ class PullRequestEventWebhook(APITestCase):
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 
-        contributor.refresh_from_db()
-        assert contributor.num_actions == 2
+        assert not OrganizationContributors.objects.filter(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_identifier="6752317",
+        ).exists()
         mock_assign_seat.delay.assert_not_called()
 
     @patch("sentry.integrations.github.webhook.assign_seat_to_organization_contributor")
@@ -1178,7 +1174,7 @@ class PullRequestEventWebhook(APITestCase):
         "sentry.integrations.github.webhook.should_create_or_increment_contributor_seat",
         return_value=True,
     )
-    def test_seat_assignment_not_triggered_for_non_member_contributor(
+    def test_no_contributor_tracking_for_non_member_contributor(
         self,
         mock_should_create_or_increment_contributor_seat: MagicMock,
         mock_assign_seat: MagicMock,
@@ -1200,13 +1196,6 @@ class PullRequestEventWebhook(APITestCase):
             )
             integration.add_organization(self.project.organization.id, self.user)
 
-        contributor = OrganizationContributors.objects.create(
-            organization_id=self.organization.id,
-            integration_id=integration.id,
-            external_identifier="6752317",
-            num_actions=1,
-        )
-
         body = json.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
         body["pull_request"]["author_association"] = "COLLABORATOR"
         modified_body = json.dumps(body).encode("utf-8")
@@ -1221,8 +1210,11 @@ class PullRequestEventWebhook(APITestCase):
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),
         )
 
-        contributor.refresh_from_db()
-        assert contributor.num_actions == 2
+        assert not OrganizationContributors.objects.filter(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_identifier="6752317",
+        ).exists()
         mock_assign_seat.delay.assert_not_called()
 
 


### PR DESCRIPTION
Don't create OrganizationContributors for bots or external contributors.

Also, add a log to the `assign_seat_to_organization_contributor` task and to `webhook.py` for debugging purposes.