### PR TITLE
feat(uptime): Write late results to EAP

### DIFF
--- a/src/sentry/uptime/consumers/eap_converter.py
+++ b/src/sentry/uptime/consumers/eap_converter.py
@@ -61,6 +61,7 @@ def convert_uptime_request_to_trace_item(
     request_sequence: int,
     item_id: bytes,
     incident_status: IncidentStatus,
+    is_late: bool = False,
 ) -> TraceItem:
     """
     Convert an individual request to a denormalized UptimeResult TraceItem.
@@ -77,6 +78,7 @@ def convert_uptime_request_to_trace_item(
     attributes["check_status"] = _anyvalue(result["status"])
     if "region" in result:
         attributes["region"] = _anyvalue(result["region"])
+    attributes["late"] = _anyvalue(is_late)
 
     attributes["scheduled_check_time_us"] = _anyvalue(ms_to_us(result["scheduled_check_time_ms"]))
     attributes["actual_check_time_us"] = _anyvalue(ms_to_us(result["actual_check_time_ms"]))
@@ -149,6 +151,7 @@ def convert_uptime_result_to_trace_items(
     project: Project,
     result: CheckResult,
     incident_status: IncidentStatus,
+    is_late: bool = False,
 ) -> list[TraceItem]:
     """
     Convert a complete uptime result to a list of denormalized TraceItems.
@@ -172,7 +175,7 @@ def convert_uptime_result_to_trace_items(
         item_id = int(uuid.uuid5(UPTIME_NAMESPACE, name).hex, 16).to_bytes(16, "little")
 
         request_item = convert_uptime_request_to_trace_item(
-            project, result, request_info, sequence, item_id, incident_status
+            project, result, request_info, sequence, item_id, incident_status, is_late=is_late
         )
         trace_items.append(request_item)
 

--- a/src/sentry/uptime/consumers/eap_producer.py
+++ b/src/sentry/uptime/consumers/eap_producer.py
@@ -35,6 +35,7 @@ def produce_eap_uptime_result(
     detector: Detector,
     result: CheckResult,
     metric_tags: dict[str, str],
+    is_late: bool = False,
 ) -> None:
     """
     Produces TraceItems to the EAP topic for uptime check results.
@@ -50,7 +51,7 @@ def produce_eap_uptime_result(
             incident_status = IncidentStatus.NO_INCIDENT
 
         trace_items = convert_uptime_result_to_trace_items(
-            detector.project, result, incident_status
+            detector.project, result, incident_status, is_late=is_late
         )
         topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
 


### PR DESCRIPTION
If we get a result that has a `scheduled_check_time_ms` that is lower than `last_update_ms` we usually exit out early. We've now started tracking when we backfill misses. We we have a pending backfilled miss, if we get a result for the same scheduled time we can write a late result instead. This is a cross between a miss and the usual results - it won't send notifications, but it'll give users more info in the ui.
