### PR TITLE
fix(eventstream): Sort tag_keys to prevent flaky test failures

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -95,6 +95,6 @@ def encode_attributes(
         attributes[formatted_key] = _encode_value(value)
         tag_keys.add(formatted_key)
 
-    attributes["tag_keys"] = _encode_value(tag_keys)
+    attributes["tag_keys"] = _encode_value(sorted(tag_keys))
 
     return attributes


### PR DESCRIPTION
Fixes flaky test failures caused by non-deterministic set ordering when encoding tag keys to arrays
