### PR TITLE
fix(tests): skip flaky tests

### DIFF
--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -552,7 +552,7 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
         if not self.dry_run:
             assert transaction_widget.dataset_source == DashboardDatasetSourcesTypes.FORCED.value
 
-    @pytest.mark.skip(reason="Flaky: non-deterministic set ordering causing failures. See #105124")
+    @pytest.mark.skip(reason="Flaky. See #105124")
     def test_unhandled_filter_sets_error_events_dataset(self) -> None:
         error_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -552,6 +552,7 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
         if not self.dry_run:
             assert transaction_widget.dataset_source == DashboardDatasetSourcesTypes.FORCED.value
 
+    @pytest.mark.skip(reason="Flaky: non-deterministic set ordering causing failures. See #105124")
     def test_unhandled_filter_sets_error_events_dataset(self) -> None:
         error_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,

--- a/tests/sentry/discover/test_dataset_split.py
+++ b/tests/sentry/discover/test_dataset_split.py
@@ -598,6 +598,7 @@ class DiscoverSavedQueryDatasetSplitTestCase(TestCase, SnubaTestCase):
         if not self.dry_run:
             assert transaction_query.dataset_source == DatasetSourcesTypes.FORCED.value
 
+    @pytest.mark.skip(reason="Flaky: non-deterministic set ordering causing failures. See #105124")
     def test_unhandled_filter_sets_error_events_dataset(self) -> None:
         error_query = DiscoverSavedQuery.objects.create(
             organization_id=self.organization.id,

--- a/tests/sentry/discover/test_dataset_split.py
+++ b/tests/sentry/discover/test_dataset_split.py
@@ -598,7 +598,7 @@ class DiscoverSavedQueryDatasetSplitTestCase(TestCase, SnubaTestCase):
         if not self.dry_run:
             assert transaction_query.dataset_source == DatasetSourcesTypes.FORCED.value
 
-    @pytest.mark.skip(reason="Flaky: non-deterministic set ordering causing failures. See #105124")
+    @pytest.mark.skip(reason="Flaky. See #105124")
     def test_unhandled_filter_sets_error_events_dataset(self) -> None:
         error_query = DiscoverSavedQuery.objects.create(
             organization_id=self.organization.id,

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pytest
 from sentry_protos.snuba.v1.request_common_pb2 import TRACE_ITEM_TYPE_OCCURRENCE
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue, KeyValue, KeyValueList
 
@@ -101,6 +102,7 @@ class ItemHelpersTest(TestCase):
         assert "group_id" not in result
         assert result["field"] == AnyValue(string_value="value")
 
+    @pytest.mark.skip(reason="Flaky: non-deterministic set ordering causing failures. See #105124")
     def test_encode_attributes_with_tags(self) -> None:
         event_data = {
             "field": "value",

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -102,7 +102,7 @@ class ItemHelpersTest(TestCase):
         assert "group_id" not in result
         assert result["field"] == AnyValue(string_value="value")
 
-    @pytest.mark.skip(reason="Flaky: non-deterministic set ordering causing failures. See #105124")
+    @pytest.mark.skip(reason="Flaky. See #105124")
     def test_encode_attributes_with_tags(self) -> None:
         event_data = {
             "field": "value",


### PR DESCRIPTION
These tests are failing intermittently in CI

Test run failures
- https://github.com/getsentry/sentry/actions/runs/20286235917/job/58260463227
- https://github.com/getsentry/sentry/actions/runs/20286235917/job/58260463258


Tests that are flaking:
- `tests/sentry/eventstream/test_item_helpers.py::test_encode_attributes_with_tags`
- `tests/sentry/discover/test_dashboard_widget_split.py::test_unhandled_filter_sets_error_events_dataset`  
- `tests/sentry/discover/test_dataset_split.py::test_unhandled_filter_sets_error_events_dataset`
