### PR TITLE
fix(replay-permissions): Grant superuser access

### DIFF
--- a/static/app/utils/replays/hooks/useHasReplayAccess.tsx
+++ b/static/app/utils/replays/hooks/useHasReplayAccess.tsx
@@ -9,7 +9,7 @@ export function useHasReplayAccess() {
   const user = useUser();
   const hasFeature = organization.features.includes('granular-replay-permissions');
 
-  if (!hasFeature || !organization.hasGranularReplayPermissions) {
+  if (user.isSuperuser || !hasFeature || !organization.hasGranularReplayPermissions) {
     return true;
   }
 


### PR DESCRIPTION
Superuser should have access to replays, independent of the allowlist.