### PR TITLE
fix: forward triggerProps id to custom trigger

### DIFF
--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -477,7 +477,10 @@ export function Control({
     <SelectContext value={contextValue}>
       <ControlWrap {...wrapperProps}>
         {trigger ? (
-          trigger(mergeProps(triggerKeyboardProps, overlayTriggerProps), overlayIsOpen)
+          trigger(
+            mergeProps({id: triggerProps.id}, triggerKeyboardProps, overlayTriggerProps),
+            overlayIsOpen
+          )
         ) : (
           <DropdownButton
             size={size}


### PR DESCRIPTION
while we shouldn't provide `triggerProps` _and_ `trigger` to a `CompactSelect`, we do create an `id` that we label the `ul` by, so this id must be put onto the trigger.

This does happen for the default trigger, but not if you provide your own. This PR fixes this by passing the id to the props that will eventually get spread onto the trigger.

ref: https://linear.app/getsentry/issue/DE-668/streamline-compactselect-triggers