### PR TITLE
fix(releases): Allow project:releases scope for org releases endpoint

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -22,6 +22,7 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
 from sentry.exceptions import InvalidParams
 from sentry.models.apikey import is_api_key_auth
+from sentry.models.apitoken import is_api_token_auth
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.orgauthtoken import is_org_auth_token_auth
@@ -669,13 +670,13 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
                 return []
             has_valid_api_key = request.auth.has_scope("org:ci")
 
-        # Check if authenticated user has appropriate release scopes
+        # Check if authenticated via API token (used by Sentry CLI) with appropriate release scopes.
         # This ensures consistency with the project releases endpoint which allows
-        # users with project:releases or org:ci scopes to create releases even if
-        # they're not direct team members of the project.
-        if not has_valid_api_key and request.user and request.user.is_authenticated:
-            if request.access.has_scope("project:releases") or request.access.has_scope("org:ci"):
-                has_valid_api_key = True
+        # API tokens with project:releases scope to create releases even if the user
+        # is not a direct team member of the project.
+        has_valid_api_key = has_valid_api_key or (
+            is_api_token_auth(request.auth) and request.auth.has_scope("project:releases")
+        )
 
         if not (
             has_valid_api_key or (getattr(request, "user", None) and request.user.is_authenticated)

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -669,6 +669,14 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
                 return []
             has_valid_api_key = request.auth.has_scope("org:ci")
 
+        # Check if authenticated user has appropriate release scopes
+        # This ensures consistency with the project releases endpoint which allows
+        # users with project:releases or org:ci scopes to create releases even if
+        # they're not direct team members of the project.
+        if not has_valid_api_key and request.user and request.user.is_authenticated:
+            if request.access.has_scope("project:releases") or request.access.has_scope("org:ci"):
+                has_valid_api_key = True
+
         if not (
             has_valid_api_key or (getattr(request, "user", None) and request.user.is_authenticated)
         ):

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -675,7 +675,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         # API tokens with project:releases scope to create releases even if the user
         # is not a direct team member of the project.
         has_valid_api_key = has_valid_api_key or (
-            is_api_token_auth(request.auth) and request.auth.has_scope("project:releases")
+            is_api_token_auth(request.auth) and request.access.has_scope("project:releases")
         )
 
         if not (

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2163,7 +2163,6 @@ class OrganizationReleaseCreateTest(APITestCase):
         team1 = self.create_team(organization=org)
         team2 = self.create_team(organization=org)
 
-        # User is only a member of team1
         project1 = self.create_project(name="project1", organization=org, teams=[team1])
         project2 = self.create_project(name="project2", organization=org, teams=[team2])
 


### PR DESCRIPTION
## Changes

- Add authorization logic to allow users with `project:releases` or `org:ci` scopes to create releases via the organization releases endpoint, even if they're not direct team members of the project
- Ensures consistency with the project releases endpoint behavior
- Add test case to verify users with `project:releases` token can create releases for projects they're not team members of
- Fix test to use proper silo mode context (`assume_test_silo_mode(SiloMode.CONTROL)`) for `ApiToken` creation

## Context

Previously, the organization releases endpoint only allowed release creation if the user was either a member of the project or was using an org Auth Token with `org:ci` scope. This change extends that check to also include users with `project:releases` scope, matching the behavior of the project releases endpoint and providing consistency across the API.

## Issues

- Fixes [BE-611](https://linear.app/getsentry/issue/BE-611/fix-error-with-user-auth-tokens)
- Ref #105038