### PR TITLE
feat(ai-conversations): optimize endpoint performance

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -23,11 +23,86 @@ from sentry.snuba.spans_rpc import Spans
 logger = logging.getLogger("sentry.api.endpoints.organization_ai_conversations")
 
 
-class OrganizationAIConversationsSerializer(serializers.Serializer):
-    """Serializer for validating query parameters."""
+def _build_conversation_query(base_query: str, user_query: str) -> str:
+    if user_query and user_query.strip():
+        return f"{base_query} {user_query.strip()}"
+    return base_query
 
+
+def _extract_conversation_ids(results: dict[str, Any]) -> list[str]:
+    return [
+        conv_id for row in results.get("data", []) if (conv_id := row.get("gen_ai.conversation.id"))
+    ]
+
+
+def _compute_duration_ms(start_ts: float, finish_ts: float) -> int:
+    if finish_ts and start_ts:
+        return int((finish_ts - start_ts) * 1000)
+    return 0
+
+
+def _compute_timestamp_ms(finish_ts: float) -> int:
+    return int(finish_ts * 1000) if finish_ts else 0
+
+
+def _parse_messages(messages: str | list | None) -> list | None:
+    if not messages:
+        return None
+    if isinstance(messages, str):
+        try:
+            messages = json.loads(messages)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(messages, list):
+        return None
+    return messages
+
+
+def _extract_first_user_message(messages: str | list | None) -> str | None:
+    parsed = _parse_messages(messages)
+    if not parsed:
+        return None
+    for msg in parsed:
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            return msg.get("content")
+    return None
+
+
+def _build_conversation_response(
+    conv_id: str,
+    duration: int,
+    timestamp: int,
+    errors: int,
+    llm_calls: int,
+    tool_calls: int,
+    total_tokens: int,
+    total_cost: float,
+    trace_ids: list[str],
+    flow: list[str],
+    first_input: str | None,
+    last_output: str | None,
+) -> dict[str, Any]:
+    return {
+        "conversationId": conv_id,
+        "flow": flow,
+        "duration": duration,
+        "errors": errors,
+        "llmCalls": llm_calls,
+        "toolCalls": tool_calls,
+        "totalTokens": total_tokens,
+        "totalCost": total_cost,
+        "timestamp": timestamp,
+        "traceCount": len(trace_ids),
+        "traceIds": trace_ids,
+        "firstInput": first_input,
+        "lastOutput": last_output,
+    }
+
+
+class OrganizationAIConversationsSerializer(serializers.Serializer):
     sort = serializers.CharField(required=False, default="-timestamp")
     query = serializers.CharField(required=False, allow_blank=True)
+    useOptimizedQuery = serializers.BooleanField(required=False, default=False)
 
     def validate_sort(self, value):
         allowed_sorts = {
@@ -53,17 +128,12 @@ class OrganizationAIConversationsSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
-    """Endpoint for fetching AI agent conversation traces."""
-
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DATA_BROWSING
 
     def get(self, request: Request, organization: Organization) -> Response:
-        """
-        Retrieve AI conversation traces for an organization.
-        """
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
             return Response(status=404)
 
@@ -78,14 +148,13 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
         validated_data = serializer.validated_data
 
-        # Create paginator with data function
         def data_fn(offset: int, limit: int):
             return self._get_conversations(
                 snuba_params=snuba_params,
                 offset=offset,
                 limit=limit,
-                _sort=validated_data.get("sort", "-timestamp"),
-                _query=validated_data.get("query", ""),
+                user_query=validated_data.get("query", ""),
+                use_optimized=validated_data.get("useOptimizedQuery", False),
             )
 
         with handle_query_errors():
@@ -98,36 +167,35 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             )
 
     def _get_conversations(
-        self, snuba_params, offset: int, limit: int, _sort: str, _query: str
+        self,
+        snuba_params,
+        offset: int,
+        limit: int,
+        user_query: str,
+        use_optimized: bool = False,
     ) -> list[dict]:
-        """
-        Fetch conversation data by querying spans grouped by gen_ai.conversation.id.
+        query_string = _build_conversation_query("has:gen_ai.conversation.id", user_query)
 
-        This is a two-step process:
-        1. Find conversation IDs that have spans in the time range (with pagination/sorting)
-        2. Get complete aggregations for those conversations (all spans, ignoring time filter)
+        conversation_ids_results = self._fetch_conversation_ids(
+            snuba_params, query_string, offset, limit
+        )
+        conversation_ids = _extract_conversation_ids(conversation_ids_results)
 
-        Args:
-            snuba_params: Snuba parameters including projects, time range, etc.
-            offset: Starting index for pagination
-            limit: Number of results to return
-            _sort: Sort field and direction (currently only supports timestamp sorting, unused for now)
-            _query: Search query (not yet implemented)
-        """
+        if not conversation_ids:
+            return []
 
-        # Build query string combining base filter with user query
-        base_query = "has:gen_ai.conversation.id"
-        if _query and _query.strip():
-            base_query = f"{base_query} {_query.strip()}"
+        if use_optimized:
+            return self._get_conversations_optimized(snuba_params, conversation_ids)
 
-        # Step 1: Find conversation IDs with spans in the time range
-        conversation_ids_results = Spans.run_table_query(
+        return self._get_conversations_default(snuba_params, conversation_ids)
+
+    def _fetch_conversation_ids(
+        self, snuba_params, query_string: str, offset: int, limit: int
+    ) -> dict[str, Any]:
+        return Spans.run_table_query(
             params=snuba_params,
-            query_string=base_query,
-            selected_columns=[
-                "gen_ai.conversation.id",
-                "max(precise.finish_ts)",
-            ],
+            query_string=query_string,
+            selected_columns=["gen_ai.conversation.id", "max(precise.finish_ts)"],
             orderby=["-max(precise.finish_ts)"],
             offset=offset,
             limit=limit,
@@ -136,231 +204,157 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             sampling_mode="NORMAL",
         )
 
-        logger.info(
-            "[ai-conversations] Got Conversation IDs results",
-            extra={"conversation_ids_results": conversation_ids_results},
-        )
-
-        conversation_ids: list[str] = [
-            conv_id
-            for row in conversation_ids_results.get("data", [])
-            if (conv_id := row.get("gen_ai.conversation.id"))
-        ]
-
-        if not conversation_ids:
-            return []
-
-        # Step 2, 3, 4: Run aggregation, enrichment, and first/last IO queries in parallel
+    def _get_conversations_default(self, snuba_params, conversation_ids: list[str]) -> list[dict]:
         with ThreadPoolExecutor(max_workers=3) as executor:
             future_aggregations = executor.submit(
-                self._get_aggregations, snuba_params, conversation_ids
+                self._fetch_aggregations, snuba_params, conversation_ids
             )
             future_enrichment = executor.submit(
-                self._get_enrichment_data, snuba_params, conversation_ids
+                self._fetch_enrichment_data, snuba_params, conversation_ids
             )
             future_first_last_io = executor.submit(
-                self._get_first_last_io, snuba_params, conversation_ids
+                self._fetch_first_last_io, snuba_params, conversation_ids
             )
 
-            results = future_aggregations.result()
+            aggregations = future_aggregations.result()
             enrichment_data = future_enrichment.result()
             first_last_io_data = future_first_last_io.result()
 
-        # Create a map of conversation data by ID
-        conversations_map = {}
-        for row in results.get("data", []):
-            start_ts = row.get("min(precise.start_ts)", 0)
-            finish_ts = row.get("max(precise.finish_ts)", 0)
-            duration_ms = int((finish_ts - start_ts) * 1000) if finish_ts and start_ts else 0
-            timestamp_ms = int(finish_ts * 1000) if finish_ts else 0
+        conversations_map = self._build_conversations_from_aggregations(aggregations)
+        self._apply_enrichment(conversations_map, enrichment_data)
+        self._apply_first_last_io(conversations_map, first_last_io_data)
 
-            conv_id = row.get("gen_ai.conversation.id", "")
-            conversations_map[conv_id] = {
-                "conversationId": conv_id,
-                "flow": [],
-                "duration": duration_ms,
-                "errors": int(row.get("failure_count()") or 0),
-                "llmCalls": int(row.get("count_if(gen_ai.operation.type,equals,ai_client)") or 0),
-                "toolCalls": int(
-                    row.get("count_if(gen_ai.operation.type,equals,execute_tool)") or 0
-                ),
-                "totalTokens": int(row.get("sum(gen_ai.usage.total_tokens)") or 0),
-                "totalCost": float(row.get("sum(gen_ai.usage.total_cost)") or 0),
-                "timestamp": timestamp_ms,
-                "traceCount": 0,  # Will be set in _apply_enrichment
-                "traceIds": [],
-                "firstInput": None,  # Will be set in _apply_first_last_io
-                "lastOutput": None,  # Will be set in _apply_first_last_io
-            }
-
-        logger.info(
-            "[ai-conversations] Got conversations map",
-            extra={"conversations_map": json.dumps(conversations_map)},
-        )
-
-        # Preserve the order from step 1
-        conversations = [
+        return [
             conversations_map[conv_id]
             for conv_id in conversation_ids
             if conv_id in conversations_map
         ]
 
-        if conversations:
-            self._apply_enrichment(conversations, enrichment_data)
-            self._apply_first_last_io(conversations, first_last_io_data)
-
-        return conversations
-
-    def _get_aggregations(self, snuba_params, conversation_ids: list[str]) -> dict[str, Any]:
-        """
-        Get aggregated metrics for conversations (query 2).
-        """
-        logger.info(
-            "[ai-conversations] Getting complete aggregations for conversations",
-            extra={"conversation_ids": conversation_ids},
-        )
-        results = Spans.run_table_query(
-            params=snuba_params,
-            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}]",
-            selected_columns=[
-                "gen_ai.conversation.id",
-                "failure_count()",
-                "count_if(gen_ai.operation.type,equals,ai_client)",
-                "count_if(gen_ai.operation.type,equals,execute_tool)",
-                "sum(gen_ai.usage.total_tokens)",
-                "sum(gen_ai.usage.total_cost)",
-                "min(precise.start_ts)",
-                "max(precise.finish_ts)",
-            ],
-            orderby=None,
-            offset=0,
-            limit=len(conversation_ids),
-            referrer=Referrer.API_AI_CONVERSATIONS_COMPLETE.value,
-            config=SearchResolverConfig(auto_fields=True),
-            sampling_mode="HIGHEST_ACCURACY",
+    def _fetch_aggregations(self, snuba_params, conversation_ids: list[str]) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            Spans.run_table_query(
+                params=snuba_params,
+                query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}]",
+                selected_columns=[
+                    "gen_ai.conversation.id",
+                    "failure_count()",
+                    "count_if(gen_ai.operation.type,equals,ai_client)",
+                    "count_if(gen_ai.operation.type,equals,execute_tool)",
+                    "sum(gen_ai.usage.total_tokens)",
+                    "sum(gen_ai.usage.total_cost)",
+                    "min(precise.start_ts)",
+                    "max(precise.finish_ts)",
+                ],
+                orderby=None,
+                offset=0,
+                limit=len(conversation_ids),
+                referrer=Referrer.API_AI_CONVERSATIONS_COMPLETE.value,
+                config=SearchResolverConfig(auto_fields=True),
+                sampling_mode="HIGHEST_ACCURACY",
+            ),
         )
 
-        logger.info(
-            "[ai-conversations] Got complete aggregations for conversations",
-            extra={"results": json.dumps(results)},
-        )
-        return cast(dict[str, Any], results)
-
-    def _get_enrichment_data(self, snuba_params, conversation_ids: list[str]) -> dict[str, Any]:
-        """
-        Get enrichment data (flows and trace IDs) for conversations (query 3).
-        """
-        logger.info(
-            "[ai-conversations] Enriching conversations",
-            extra={"conversation_ids": conversation_ids},
-        )
-        all_spans_results = Spans.run_table_query(
-            params=snuba_params,
-            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}]",
-            selected_columns=[
-                "gen_ai.conversation.id",
-                "gen_ai.operation.type",
-                "gen_ai.agent.name",
-                "trace",
-                "precise.start_ts",
-            ],
-            orderby=["precise.start_ts"],
-            offset=0,
-            limit=10000,
-            referrer=Referrer.API_AI_CONVERSATIONS_ENRICHMENT.value,
-            config=SearchResolverConfig(auto_fields=True),
-            sampling_mode="HIGHEST_ACCURACY",
-        )
-        logger.info(
-            "[ai-conversations] Got all spans results",
-            extra={"all_spans_results": json.dumps(all_spans_results)},
-        )
-        return cast(dict[str, Any], all_spans_results)
-
-    def _get_first_last_io(self, snuba_params, conversation_ids: list[str]) -> dict[str, Any]:
-        """
-        Get first input and last output for conversations (query 4).
-
-        Fetches ai_client spans ordered by timestamp to determine:
-        - firstInput: first user message content from earliest ai_client span per conversation
-        - lastOutput: gen_ai.response.text from latest ai_client span per conversation
-        """
-        logger.info(
-            "[ai-conversations] Getting first input / last output",
-            extra={"conversation_ids": conversation_ids},
+    def _fetch_enrichment_data(self, snuba_params, conversation_ids: list[str]) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            Spans.run_table_query(
+                params=snuba_params,
+                query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}]",
+                selected_columns=[
+                    "gen_ai.conversation.id",
+                    "gen_ai.operation.type",
+                    "gen_ai.agent.name",
+                    "trace",
+                    "precise.start_ts",
+                ],
+                orderby=["precise.start_ts"],
+                offset=0,
+                limit=10000,
+                referrer=Referrer.API_AI_CONVERSATIONS_ENRICHMENT.value,
+                config=SearchResolverConfig(auto_fields=True),
+                sampling_mode="HIGHEST_ACCURACY",
+            ),
         )
 
-        results = Spans.run_table_query(
-            params=snuba_params,
-            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}] gen_ai.operation.type:ai_client",
-            selected_columns=[
-                "gen_ai.conversation.id",
-                "gen_ai.request.messages",
-                "gen_ai.response.text",
-                "precise.start_ts",
-                "precise.finish_ts",
-            ],
-            orderby=["precise.start_ts"],
-            offset=0,
-            limit=10000,
-            referrer=Referrer.API_AI_CONVERSATIONS_FIRST_LAST_IO.value,
-            config=SearchResolverConfig(auto_fields=True),
-            sampling_mode="HIGHEST_ACCURACY",
+    def _fetch_first_last_io(self, snuba_params, conversation_ids: list[str]) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            Spans.run_table_query(
+                params=snuba_params,
+                query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}] gen_ai.operation.type:ai_client",
+                selected_columns=[
+                    "gen_ai.conversation.id",
+                    "gen_ai.request.messages",
+                    "gen_ai.response.text",
+                    "precise.start_ts",
+                    "precise.finish_ts",
+                ],
+                orderby=["precise.start_ts"],
+                offset=0,
+                limit=10000,
+                referrer=Referrer.API_AI_CONVERSATIONS_FIRST_LAST_IO.value,
+                config=SearchResolverConfig(auto_fields=True),
+                sampling_mode="HIGHEST_ACCURACY",
+            ),
         )
 
-        logger.info(
-            "[ai-conversations] Got first input / last output results",
-            extra={"results_count": len(results.get("data", []))},
-        )
+    def _build_conversations_from_aggregations(
+        self, aggregations: dict[str, Any]
+    ) -> dict[str, dict[str, Any]]:
+        conversations_map: dict[str, dict[str, Any]] = {}
 
-        return cast(dict[str, Any], results)
+        for row in aggregations.get("data", []):
+            conv_id = row.get("gen_ai.conversation.id", "")
+            start_ts = row.get("min(precise.start_ts)", 0)
+            finish_ts = row.get("max(precise.finish_ts)", 0)
 
-    def _apply_enrichment(self, conversations: list[dict], enrichment_data: dict) -> None:
-        """
-        Apply enrichment data (flows and trace IDs) to conversations.
-        """
-        flows_by_conversation = defaultdict(list)
-        traces_by_conversation = defaultdict(set)
-        logger.info(
-            "[ai-conversations] Collecting traces and flows",
-            extra={"enrichment_data": json.dumps(enrichment_data)},
-        )
+            conversations_map[conv_id] = _build_conversation_response(
+                conv_id=conv_id,
+                duration=_compute_duration_ms(start_ts, finish_ts),
+                timestamp=_compute_timestamp_ms(finish_ts),
+                errors=int(row.get("failure_count()") or 0),
+                llm_calls=int(row.get("count_if(gen_ai.operation.type,equals,ai_client)") or 0),
+                tool_calls=int(row.get("count_if(gen_ai.operation.type,equals,execute_tool)") or 0),
+                total_tokens=int(row.get("sum(gen_ai.usage.total_tokens)") or 0),
+                total_cost=float(row.get("sum(gen_ai.usage.total_cost)") or 0),
+                trace_ids=[],
+                flow=[],
+                first_input=None,
+                last_output=None,
+            )
+
+        return conversations_map
+
+    def _apply_enrichment(
+        self, conversations_map: dict[str, dict[str, Any]], enrichment_data: dict[str, Any]
+    ) -> None:
+        flows_by_conversation: dict[str, list[str]] = defaultdict(list)
+        traces_by_conversation: dict[str, set[str]] = defaultdict(set)
+
         for row in enrichment_data.get("data", []):
             conv_id = row.get("gen_ai.conversation.id", "")
             if not conv_id:
                 continue
 
-            # Collect trace IDs
             trace_id = row.get("trace", "")
             if trace_id:
                 traces_by_conversation[conv_id].add(trace_id)
 
-            # Collect agent flow (only from invoke_agent spans)
             if row.get("gen_ai.operation.type") == "invoke_agent":
                 agent_name = row.get("gen_ai.agent.name", "")
                 if agent_name:
                     flows_by_conversation[conv_id].append(agent_name)
 
-        for conversation in conversations:
-            conv_id = conversation["conversationId"]
+        for conv_id, conversation in conversations_map.items():
             traces = traces_by_conversation.get(conv_id, set())
             conversation["flow"] = flows_by_conversation.get(conv_id, [])
             conversation["traceIds"] = list(traces)
             conversation["traceCount"] = len(traces)
 
-        logger.info(
-            "[ai-conversations] Enriched conversations",
-            extra={"conversations": json.dumps(conversations)},
-        )
-
-    def _apply_first_last_io(self, conversations: list[dict], first_last_io_data: dict) -> None:
-        """
-        Apply first input and last output to conversations.
-
-        - firstInput: first user message content from the FIRST ai_client span (by start_ts)
-        - lastOutput: gen_ai.response.text from the LAST ai_client span (by finish_ts)
-        """
-        # Track first input and last output per conversation
+    def _apply_first_last_io(
+        self, conversations_map: dict[str, dict[str, Any]], first_last_io_data: dict[str, Any]
+    ) -> None:
         first_input_by_conv: dict[str, str] = {}
         last_output_by_conv: dict[str, tuple[float, str]] = {}
 
@@ -373,48 +367,182 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             response_text = row.get("gen_ai.response.text")
             finish_ts = row.get("precise.finish_ts", 0)
 
-            # First input: extract first user message from first span per conversation
-            # Data is ordered by start_ts, so first occurrence is the earliest span
             if conv_id not in first_input_by_conv and messages:
-                first_user_content = self._extract_first_user_message(messages)
+                first_user_content = _extract_first_user_message(messages)
                 if first_user_content:
                     first_input_by_conv[conv_id] = first_user_content
 
-            # Last output: track gen_ai.response.text from span with latest finish_ts
             if response_text:
                 current = last_output_by_conv.get(conv_id)
                 if current is None or finish_ts > current[0]:
                     last_output_by_conv[conv_id] = (finish_ts, response_text)
 
-        for conversation in conversations:
-            conv_id = conversation["conversationId"]
+        for conv_id, conversation in conversations_map.items():
             conversation["firstInput"] = first_input_by_conv.get(conv_id)
             last_tuple = last_output_by_conv.get(conv_id)
             conversation["lastOutput"] = last_tuple[1] if last_tuple else None
 
-    def _extract_first_user_message(self, messages: str | list | None) -> str | None:
-        """
-        Extract the content of the first user message from messages.
+    def _get_conversations_optimized(self, snuba_params, conversation_ids: list[str]) -> list[dict]:
+        all_spans = self._fetch_all_spans(snuba_params, conversation_ids)
+        return self._aggregate_spans(conversation_ids, all_spans)
 
-        Messages can be a JSON string or a list of message objects.
-        Each message object has 'role' and 'content' fields.
-        """
-        if not messages:
-            return None
+    def _fetch_all_spans(self, snuba_params, conversation_ids: list[str]) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            Spans.run_table_query(
+                params=snuba_params,
+                query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}]",
+                selected_columns=[
+                    "gen_ai.conversation.id",
+                    "precise.start_ts",
+                    "precise.finish_ts",
+                    "span.status",
+                    "gen_ai.operation.type",
+                    "gen_ai.usage.total_tokens",
+                    "gen_ai.usage.total_cost",
+                    "trace",
+                    "gen_ai.agent.name",
+                    "gen_ai.request.messages",
+                    "gen_ai.response.text",
+                ],
+                orderby=["precise.start_ts"],
+                offset=0,
+                limit=10000,
+                referrer=Referrer.API_AI_CONVERSATIONS_COMPLETE.value,
+                config=SearchResolverConfig(auto_fields=True),
+                sampling_mode="HIGHEST_ACCURACY",
+            ),
+        )
 
-        # Parse if it's a JSON string
-        if isinstance(messages, str):
-            try:
-                messages = json.loads(messages)
-            except (json.JSONDecodeError, TypeError):
-                return None
+    def _aggregate_spans(
+        self, conversation_ids: list[str], all_spans: dict[str, Any]
+    ) -> list[dict]:
+        accumulators = self._init_accumulators(conversation_ids)
+        self._process_spans(accumulators, all_spans)
+        return self._build_results_from_accumulators(conversation_ids, accumulators)
 
-        if not isinstance(messages, list):
-            return None
+    def _init_accumulators(self, conversation_ids: list[str]) -> dict[str, dict[str, Any]]:
+        return {
+            conv_id: {
+                "min_start_ts": float("inf"),
+                "max_finish_ts": 0.0,
+                "failure_count": 0,
+                "ai_client_count": 0,
+                "execute_tool_count": 0,
+                "total_tokens": 0,
+                "total_cost": 0.0,
+                "traces": set(),
+                "flow": [],
+                "first_input": None,
+                "first_input_ts": float("inf"),
+                "last_output": None,
+                "last_output_ts": 0.0,
+            }
+            for conv_id in conversation_ids
+        }
 
-        # Find first message with role "user"
-        for msg in messages:
-            if isinstance(msg, dict) and msg.get("role") == "user":
-                return msg.get("content")
+    def _process_spans(
+        self, accumulators: dict[str, dict[str, Any]], all_spans: dict[str, Any]
+    ) -> None:
+        for row in all_spans.get("data", []):
+            conv_id = row.get("gen_ai.conversation.id", "")
+            if conv_id not in accumulators:
+                continue
 
-        return None
+            acc = accumulators[conv_id]
+            self._update_timestamps(acc, row)
+            self._update_counts(acc, row)
+            self._update_tokens_and_cost(acc, row)
+            self._update_traces(acc, row)
+            self._update_first_last_io(acc, row)
+
+    def _update_timestamps(self, acc: dict[str, Any], row: dict[str, Any]) -> None:
+        start_ts = row.get("precise.start_ts") or 0
+        finish_ts = row.get("precise.finish_ts") or 0
+
+        if start_ts and start_ts < acc["min_start_ts"]:
+            acc["min_start_ts"] = start_ts
+        if finish_ts and finish_ts > acc["max_finish_ts"]:
+            acc["max_finish_ts"] = finish_ts
+
+    def _update_counts(self, acc: dict[str, Any], row: dict[str, Any]) -> None:
+        status = row.get("span.status", "")
+        op_type = row.get("gen_ai.operation.type", "")
+
+        if status and status != "ok":
+            acc["failure_count"] += 1
+
+        if op_type == "ai_client":
+            acc["ai_client_count"] += 1
+        elif op_type == "execute_tool":
+            acc["execute_tool_count"] += 1
+        elif op_type == "invoke_agent":
+            agent_name = row.get("gen_ai.agent.name", "")
+            if agent_name:
+                acc["flow"].append(agent_name)
+
+    def _update_tokens_and_cost(self, acc: dict[str, Any], row: dict[str, Any]) -> None:
+        tokens = row.get("gen_ai.usage.total_tokens")
+        if tokens:
+            acc["total_tokens"] += int(tokens)
+
+        cost = row.get("gen_ai.usage.total_cost")
+        if cost:
+            acc["total_cost"] += float(cost)
+
+    def _update_traces(self, acc: dict[str, Any], row: dict[str, Any]) -> None:
+        trace_id = row.get("trace", "")
+        if trace_id:
+            acc["traces"].add(trace_id)
+
+    def _update_first_last_io(self, acc: dict[str, Any], row: dict[str, Any]) -> None:
+        op_type = row.get("gen_ai.operation.type", "")
+        if op_type != "ai_client":
+            return
+
+        start_ts = row.get("precise.start_ts") or 0
+        finish_ts = row.get("precise.finish_ts") or 0
+        messages = row.get("gen_ai.request.messages")
+        response_text = row.get("gen_ai.response.text")
+
+        if start_ts and start_ts < acc["first_input_ts"] and messages:
+            first_user = _extract_first_user_message(messages)
+            if first_user:
+                acc["first_input"] = first_user
+                acc["first_input_ts"] = start_ts
+
+        if finish_ts and finish_ts > acc["last_output_ts"] and response_text:
+            acc["last_output"] = response_text
+            acc["last_output_ts"] = finish_ts
+
+    def _build_results_from_accumulators(
+        self, conversation_ids: list[str], accumulators: dict[str, dict[str, Any]]
+    ) -> list[dict]:
+        result = []
+
+        for conv_id in conversation_ids:
+            if conv_id not in accumulators:
+                continue
+
+            acc = accumulators[conv_id]
+            min_ts = acc["min_start_ts"] if acc["min_start_ts"] != float("inf") else 0
+            max_ts = acc["max_finish_ts"]
+
+            result.append(
+                _build_conversation_response(
+                    conv_id=conv_id,
+                    duration=_compute_duration_ms(min_ts, max_ts),
+                    timestamp=_compute_timestamp_ms(max_ts),
+                    errors=acc["failure_count"],
+                    llm_calls=acc["ai_client_count"],
+                    tool_calls=acc["execute_tool_count"],
+                    total_tokens=acc["total_tokens"],
+                    total_cost=acc["total_cost"],
+                    trace_ids=list(acc["traces"]),
+                    flow=acc["flow"],
+                    first_input=acc["first_input"],
+                    last_output=acc["last_output"],
+                )
+            )
+
+        return result

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -632,3 +632,92 @@ class OrganizationAIConversationsEndpointTest(BaseSpansTestCase, SpanTestCase, A
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["conversationId"] == conversation_id_1
+
+    def test_optimized_query_produces_same_results(self) -> None:
+        """Test that useOptimizedQuery=true produces the same results as the default path"""
+        now = before_now(days=25).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        first_messages = [{"role": "user", "content": "What's the weather?"}]
+        last_response_text = "It's sunny today"
+
+        # Create a conversation with various span types
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=4),
+            op="gen_ai.invoke_agent",
+            operation_type="invoke_agent",
+            agent_name="Weather Agent",
+            trace_id=trace_id,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=3),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            tokens=100,
+            cost=0.001,
+            trace_id=trace_id,
+            messages=first_messages,
+            response_text="Let me check",
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.execute_tool",
+            operation_type="execute_tool",
+            trace_id=trace_id,
+        )
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.chat",
+            status="internal_error",
+            operation_type="ai_client",
+            tokens=50,
+            cost=0.0005,
+            trace_id=trace_id,
+            messages=[{"role": "user", "content": "Thanks"}],
+            response_text=last_response_text,
+        )
+
+        base_query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        # Get results from default path
+        default_response = self.do_request(base_query)
+        assert default_response.status_code == 200
+        assert len(default_response.data) == 1
+
+        # Get results from optimized path
+        optimized_query = {**base_query, "useOptimizedQuery": "true"}
+        optimized_response = self.do_request(optimized_query)
+        assert optimized_response.status_code == 200
+        assert len(optimized_response.data) == 1
+
+        # Compare results - they should be identical
+        default_conv = default_response.data[0]
+        optimized_conv = optimized_response.data[0]
+
+        assert optimized_conv["conversationId"] == default_conv["conversationId"]
+        assert optimized_conv["errors"] == default_conv["errors"]
+        assert optimized_conv["llmCalls"] == default_conv["llmCalls"]
+        assert optimized_conv["toolCalls"] == default_conv["toolCalls"]
+        assert optimized_conv["totalTokens"] == default_conv["totalTokens"]
+        assert optimized_conv["totalCost"] == default_conv["totalCost"]
+        assert optimized_conv["traceCount"] == default_conv["traceCount"]
+        assert optimized_conv["flow"] == default_conv["flow"]
+        assert optimized_conv["firstInput"] == default_conv["firstInput"]
+        assert optimized_conv["lastOutput"] == default_conv["lastOutput"]
+        # Duration and timestamp may have minor differences due to timing, but should be close
+        assert optimized_conv["duration"] == default_conv["duration"]
+        assert optimized_conv["timestamp"] == default_conv["timestamp"]
+        # traceIds may be in different order, compare as sets
+        assert set(optimized_conv["traceIds"]) == set(default_conv["traceIds"])


### PR DESCRIPTION
Closes [TET-1614: Conversations endpoint performance](https://linear.app/getsentry/issue/TET-1614/conversations-endpoint-performance)

Adds a code path behind `useOptimizedQuery` parameter that performs 2 queries and aggregates data in code instead of the existing behavior (running 4 queries).