### PR TITLE
feat: SelectTrigger.IconButton

### DIFF
--- a/static/app/components/core/button/types.tsx
+++ b/static/app/components/core/button/types.tsx
@@ -67,11 +67,11 @@ interface BaseButtonProps extends DO_NOT_USE_CommonButtonProps, ButtonElementPro
   ref?: React.Ref<HTMLButtonElement>;
 }
 
-interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
+export interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
   children: React.ReactNode;
 }
 
-interface ButtonPropsWithAriaLabel extends BaseButtonProps {
+export interface ButtonPropsWithAriaLabel extends BaseButtonProps {
   'aria-label': string;
   children?: never;
 }

--- a/static/app/components/core/button/types.tsx
+++ b/static/app/components/core/button/types.tsx
@@ -67,11 +67,11 @@ interface BaseButtonProps extends DO_NOT_USE_CommonButtonProps, ButtonElementPro
   ref?: React.Ref<HTMLButtonElement>;
 }
 
-export interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
+interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
   children: React.ReactNode;
 }
 
-export interface ButtonPropsWithAriaLabel extends BaseButtonProps {
+interface ButtonPropsWithAriaLabel extends BaseButtonProps {
   'aria-label': string;
   children?: never;
 }

--- a/static/app/components/core/compactSelect/trigger.tsx
+++ b/static/app/components/core/compactSelect/trigger.tsx
@@ -19,7 +19,7 @@ export type ButtonTriggerProps = DistributedOmit<DropdownButtonProps, 'ref'> & {
   ref?: React.Ref<TriggerEl>;
 };
 
-export type IconButtonTriggerProps = SetRequired<
+type IconButtonTriggerProps = SetRequired<
   DistributedOmit<DropdownButtonProps, 'ref' | 'showChevron'>,
   'aria-label' | 'icon'
 > & {

--- a/static/app/components/core/compactSelect/trigger.tsx
+++ b/static/app/components/core/compactSelect/trigger.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type {DistributedOmit} from 'type-fest';
+import type {DistributedOmit, SetRequired} from 'type-fest';
 
 import DropdownButton, {type DropdownButtonProps} from 'sentry/components/dropdownButton';
 
@@ -15,23 +15,48 @@ export type SelectTriggerProps = React.HTMLAttributes<TriggerEl> & {
   ref?: React.Ref<TriggerEl>;
 };
 
-export type ButtonTriggerProps = DistributedOmit<DropdownButtonProps, 'ref'> & {
+export type ButtonTriggerProps = SetRequired<
+  DistributedOmit<DropdownButtonProps, 'ref'>,
+  'children'
+> & {
   ref?: React.Ref<TriggerEl>;
+};
+
+export type IconButtonTriggerProps = SetRequired<
+  DistributedOmit<DropdownButtonProps, 'ref' | 'showChevron'>,
+  'aria-label' | 'icon'
+> & {
+  ref?: React.Ref<TriggerEl>;
+};
+
+const useContextProps = () => {
+  const selectContext = React.useContext(SelectContext);
+  return {
+    size: selectContext.size,
+    isOpen: selectContext.overlayIsOpen,
+    disabled: selectContext.disabled,
+  };
 };
 
 export const SelectTrigger = {
   Button({ref, ...props}: ButtonTriggerProps) {
-    const selectContext = React.useContext(SelectContext);
-    const contextProps = {
-      size: selectContext.size,
-      isOpen: selectContext.overlayIsOpen,
-      disabled: selectContext.disabled,
-    };
-
     return (
       <DropdownButton
-        {...contextProps}
+        {...useContextProps()}
         {...props}
+        ref={ref as React.Ref<HTMLButtonElement>}
+      />
+    );
+  },
+
+  // omit children prop to prevent usage of children in IconButton
+  // we still need children on type level to allow ergonomic object spreading of triggerProps
+  IconButton({ref, children: _, ...props}: IconButtonTriggerProps) {
+    return (
+      <DropdownButton
+        {...useContextProps()}
+        {...props}
+        showChevron={false}
         ref={ref as React.Ref<HTMLButtonElement>}
       />
     );

--- a/static/app/components/core/compactSelect/trigger.tsx
+++ b/static/app/components/core/compactSelect/trigger.tsx
@@ -15,10 +15,7 @@ export type SelectTriggerProps = React.HTMLAttributes<TriggerEl> & {
   ref?: React.Ref<TriggerEl>;
 };
 
-export type ButtonTriggerProps = SetRequired<
-  DistributedOmit<DropdownButtonProps, 'ref'>,
-  'children'
-> & {
+export type ButtonTriggerProps = DistributedOmit<DropdownButtonProps, 'ref'> & {
   ref?: React.Ref<TriggerEl>;
 };
 

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -118,7 +118,6 @@ function OverflowMenu({state, overflowMenuItems, disabled}: any) {
           <OverflowMenuTrigger
             {...triggerProps}
             borderless
-            showChevron={false}
             icon={<IconEllipsis />}
             aria-label={t('More tabs')}
           />
@@ -351,7 +350,7 @@ const TabListOverflowWrap = withChonk(
   ChonkStyledTabListOverflowWrap
 );
 
-const OverflowMenuTrigger = styled(SelectTrigger.Button)`
+const OverflowMenuTrigger = styled(SelectTrigger.IconButton)`
   padding-left: ${space(1)};
   padding-right: ${space(1)};
   color: ${p => p.theme.tokens.component.link.muted.default};

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawer.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawer.tsx
@@ -152,8 +152,7 @@ export function BreadcrumbsDrawer({
       <CompactSelect
         size="xs"
         trigger={props => (
-          <SelectTrigger.Button
-            showChevron={false}
+          <SelectTrigger.IconButton
             borderless
             icon={<IconSort />}
             aria-label={t('Sort All Breadcrumbs')}
@@ -176,8 +175,7 @@ export function BreadcrumbsDrawer({
       <CompactSelect
         size="xs"
         trigger={props => (
-          <SelectTrigger.Button
-            showChevron={false}
+          <SelectTrigger.IconButton
             borderless
             icon={
               timeDisplay === BreadcrumbTimeDisplay.ABSOLUTE ? (

--- a/static/app/components/events/featureFlags/featureFlagSort.tsx
+++ b/static/app/components/events/featureFlags/featureFlagSort.tsx
@@ -36,11 +36,10 @@ export default function FeatureFlagSort({
   return (
     <CompositeSelect
       trigger={triggerProps => (
-        <SelectTrigger.Button
+        <SelectTrigger.IconButton
           {...triggerProps}
           aria-label={t('Sort Flags')}
           size="xs"
-          showChevron={false}
           icon={<IconSort />}
           title={t('Sort Flags')}
         />

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -47,9 +47,8 @@ export default function ReplayPreferenceDropdown({
       size="sm"
       disabled={isLoading}
       trigger={triggerProps => (
-        <SelectTrigger.Button
+        <SelectTrigger.IconButton
           {...triggerProps}
-          showChevron={false}
           title={t('Settings')}
           aria-label={t('Settings')}
           icon={<IconSettings />}

--- a/static/app/utils/discover/teamKeyTransactionField.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.tsx
@@ -56,11 +56,10 @@ function TeamKeyTransactionField({
               : null
           }
         >
-          <SelectTrigger.Button
+          <SelectTrigger.IconButton
             {...triggerProps}
             disabled={disabled}
             borderless
-            showChevron={false}
             size="zero"
             icon={
               <IconStar

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -190,9 +190,8 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
       }
       menuFooter={isSelectingFilterKey && filterOptionsMenuFooter}
       trigger={triggerProps => (
-        <SelectTrigger.Button
+        <SelectTrigger.IconButton
           {...triggerProps}
-          showChevron={false}
           aria-label={t('Add Global Filter')}
           icon={<IconAdd size="sm" />}
         />

--- a/static/app/views/insights/common/components/releasesSort.tsx
+++ b/static/app/views/insights/common/components/releasesSort.tsx
@@ -27,9 +27,8 @@ export function ReleasesSort({environments, sortBy, onChange}: Props) {
   return (
     <CompositeSelect
       trigger={triggerProps => (
-        <SelectTrigger.Button
+        <SelectTrigger.IconButton
           {...triggerProps}
-          showChevron={false}
           size="xs"
           icon={<IconSort />}
           title={t('Sort Releases')}

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -350,11 +350,10 @@ function WidgetContainerActions({
   return (
     <CompositeSelect
       trigger={triggerProps => (
-        <SelectTrigger.Button
+        <SelectTrigger.IconButton
           {...triggerProps}
           size="xs"
           borderless
-          showChevron={false}
           aria-label={t('More')}
           icon={<IconEllipsis />}
         />

--- a/static/app/views/replays/list/replayIndexTimestampPrefPicker.tsx
+++ b/static/app/views/replays/list/replayIndexTimestampPrefPicker.tsx
@@ -24,9 +24,8 @@ export default function ReplayIndexTimestampPrefPicker() {
         },
       ]}
       trigger={triggerProps => (
-        <SelectTrigger.Button
+        <SelectTrigger.IconButton
           {...triggerProps}
-          showChevron={false}
           icon={<IconSettings />}
           aria-label={t('Configure timestamp settings')}
         />


### PR DESCRIPTION
This PR creates a dedicated `SelectTrigger.IconButton`, which:

- always hides the `chevron`
- makes `icon` and `aria-label` required
- disallows `children` at runtime. `children` are still kept at compile time because spreading `...triggerProps` can contain children, but an `IconButton` should never show children. This will make it possible to completely remove `triggerProps` from `compactSelect` in the next PR because we can then always render a `<SelectTrigger>`and have `triggerProps` contain the `defaultLabel`, which we want for `SelectTrigger.Button` but not for `SelectTrigger.IconButton`. Without this, we would have to `omit` children coming from `triggerProps` when rendering only an `icon`.

ref: https://linear.app/getsentry/issue/DE-668/streamline-compactselect-triggers