### PR TITLE
Typing error resolution

### DIFF
--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -6,7 +6,7 @@ import weakref
 from collections.abc import Callable, Collection, Generator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
 from enum import IntEnum, auto
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from django.conf import settings
 from django.db import models, router
@@ -68,12 +68,7 @@ def make_key(model: Any, prefix: str, kwargs: Mapping[str, Model | int | str]) -
     return f"{prefix}:{model.__name__}:{md5_text(kwargs_bits_str).hexdigest()}"
 
 
-if TYPE_CHECKING:
-    # For type checkers, we want to use DjangoBaseManager directly. This preserves the
-    # generic type parameters.
-    _base_manager_base = DjangoBaseManager
-else:
-    _base_manager_base = DjangoBaseManager.from_queryset(BaseQuerySet, "_base_manager_base")
+_base_manager_base = DjangoBaseManager.from_queryset(BaseQuerySet, "_base_manager_base")
 
 
 class BaseManager(_base_manager_base[M]):


### PR DESCRIPTION
Resolves new type errors where `mypy` failed to recognize `BaseQuerySet`-proxied methods on `Model.objects` (e.g., `using_replica`).

Previously, `BaseManager` conditionally inherited from a plain Django `Manager` under `TYPE_CHECKING`, causing `mypy` to miss these methods. This change ensures `BaseManager` always derives from `DjangoBaseManager.from_queryset(BaseQuerySet)`, providing `mypy` with the correct manager shape.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-c09a2c38-d31d-4920-99f7-1f9fb9f36bf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c09a2c38-d31d-4920-99f7-1f9fb9f36bf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

