### PR TITLE
ref(dynamic-sampling): remove logging statements for log-project-config

### DIFF
--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
 
-from sentry import features, quotas
+from sentry import quotas
 from sentry.constants import TARGET_SAMPLE_RATE_DEFAULT
 from sentry.db.models import Model
 from sentry.dynamic_sampling.rules.biases.base import Bias
@@ -128,21 +128,6 @@ def generate_rules(project: Project) -> list[PolymorphicRule]:
         rules = _get_rules_of_enabled_biases(
             project, base_sample_rate, enabled_user_biases, combined_biases
         )
-        if features.has("organizations:log-project-config", organization, actor=None):
-            try:
-                logger.info(
-                    "log-project-config - generate_rules: Generated %s rules for project %s in org %s.",
-                    len(rules),
-                    project.id,
-                    organization.id,
-                    extra={
-                        "enabled_user_biases": enabled_user_biases,
-                        "base_sample_rate": base_sample_rate,
-                        "num_rules": len(rules),
-                    },
-                )
-            except Exception as e:
-                sentry_sdk.capture_exception(e)
 
     except Exception as e:
         sentry_sdk.capture_exception(e)

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -21,7 +21,7 @@ from snuba_sdk import (
     Request,
 )
 
-from sentry import features, options, quotas
+from sentry import options, quotas
 from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.models.common import RebalancedItem, guarded_run
 from sentry.dynamic_sampling.models.projects_rebalancing import (
@@ -218,25 +218,11 @@ def boost_low_volume_projects_of_org(
     organization ID. Transaction counts and rates have to be provided.
     """
 
-    org = Organization.objects.get_from_cache(id=org_id)
-    if features.has("organizations:log-project-config", org):
-        logger.info(
-            "log-project-config: Starting boost_low_volume_projects_of_org for org %s",
-            org_id,
-            extra={"org_id": org_id},
-        )
-
     try:
         rebalanced_projects = calculate_sample_rates_of_projects(
             org_id, projects_with_tx_count_and_rates
         )
     except Exception as e:
-        if features.has("organizations:log-project-config", org):
-            logger.info(
-                "log-project-config: Error calculating sample rates of for org %s",
-                org_id,
-                extra={"org_id": org_id},
-            )
         sentry_sdk.capture_exception(e)
         raise
 
@@ -432,24 +418,10 @@ def calculate_sample_rates_of_projects(
     # issues.
 
     default_sample_rate = quotas.backend.get_blended_sample_rate(organization_id=org_id)
-    should_log_project_config = features.has("organizations:log-project-config", organization)
-
     sample_rate, success = get_org_sample_rate(
         org_id=org_id,
         default_sample_rate=default_sample_rate,
     )
-
-    if should_log_project_config:
-        logger.info(
-            "log-project-config: calculate_sample_rates_of_projects for org %s",
-            org_id,
-            extra={
-                "org": org_id,
-                "target_sample_rate": sample_rate,
-                "success": success,
-                "default_sample_rate": default_sample_rate,
-            },
-        )
 
     if success:
         sample_function(
@@ -483,13 +455,6 @@ def calculate_sample_rates_of_projects(
         project_id: count_per_root for project_id, count_per_root, _, _ in projects_with_tx_count
     }
 
-    if should_log_project_config:
-        logger.info(
-            "log-project-config: calculate_sample_rates_of_projects for org %s",
-            org_id,
-            extra={"projects_with_counts": projects_with_counts, "sample_rate": sample_rate},
-        )
-
     # The rebalancing will not work (or would make sense) when we have only projects with zero-counts.
     if not any(projects_with_counts.values()):
         return None
@@ -522,26 +487,6 @@ def calculate_sample_rates_of_projects(
     rebalanced_projects: list[RebalancedItem] | None = guarded_run(
         model, ProjectsRebalancingInput(classes=projects, sample_rate=sample_rate)
     )
-    if should_log_project_config:
-        logger.info(
-            "log-project-config: rebalanced_projects for org %s",
-            org_id,
-            extra={
-                "rebalanced_projects": (
-                    [
-                        {
-                            "id": project.id,
-                            "count": project.count,
-                            "new_sample_rate": project.new_sample_rate,
-                        }
-                        for project in rebalanced_projects
-                    ]
-                    if rebalanced_projects
-                    else None
-                ),
-                "sample_rate": sample_rate,
-            },
-        )
 
     return rebalanced_projects
 

--- a/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sample_rate.py
@@ -32,16 +32,6 @@ def get_org_sample_rate(
     has_dynamic_sampling_custom = features.has("organizations:dynamic-sampling-custom", org)
     if has_dynamic_sampling_custom:
         sample_rate = org.get_option("sentry:target_sample_rate") if org else None
-        if features.has("organizations:log-project-config", org):
-            logger.info(
-                "log-project-config: org.get_option: %s",
-                sample_rate,
-                extra={
-                    "org": org.id if org else None,
-                    "target_sample_rate": sample_rate,
-                    "default_sample_rate": default_sample_rate,
-                },
-            )
         if sample_rate is not None:
             return float(sample_rate), True
         if default_sample_rate is not None:
@@ -50,16 +40,6 @@ def get_org_sample_rate(
 
     # fallback to sliding window calculation
     sample_rate, is_custom = _get_sliding_window_org_sample_rate(org_id, default_sample_rate)
-    if features.has("organizations:log-project-config", org):
-        logger.info(
-            "log-project-config: _get_sliding_window_org_sample_rate for org %s",
-            org_id,
-            extra={
-                "sample_rate": sample_rate,
-                "is_custom": is_custom,
-                "default_sample_rate": default_sample_rate,
-            },
-        )
     return sample_rate, is_custom
 
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -16,9 +16,6 @@ from sentry.constants import (
     ObjectStatus,
 )
 from sentry.dynamic_sampling import generate_rules
-from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
-    get_boost_low_volume_projects_sample_rate,
-)
 from sentry.grouping.api import get_grouping_config_dict_for_project
 from sentry.ingest.inbound_filters import (
     FilterStatKeys,
@@ -1186,65 +1183,6 @@ def _get_project_config(
     with sentry_sdk.start_span(op="get_all_quotas"):
         if quotas_config := get_quotas(project, keys=project_keys):
             config["quotas"] = quotas_config
-
-    if features.has("organizations:log-project-config", project.organization):
-        try:
-            logger.info(
-                "log-project-config - get_project_config: Logging sampling feature flags for project %s in org %s.",
-                project.id,
-                project.organization.id,
-                extra={
-                    "project_id": str(project.id),
-                    "org_id": str(project.organization.id),
-                    "sampling_rule_count": (
-                        len(config["sampling"]["rules"]) if "sampling" in config else None
-                    ),
-                    "dynamic_sampling_feature_flag": features.has(
-                        "organizations:dynamic-sampling", project.organization
-                    ),
-                    "dynamic_sampling_custom_feature_flag": features.has(
-                        "organizations:dynamic-sampling-custom", project.organization
-                    ),
-                    "dynamic_sampling_mode": project.organization.get_option(
-                        "sentry:sampling_mode", None
-                    ),
-                    "dynamic_sampling_org_target_rate": project.organization.get_option(
-                        "sentry:target_sample_rate", None
-                    ),
-                    "dynamic_sampling_biases": project.get_option(
-                        "sentry:dynamic_sampling_biases", None
-                    ),
-                    "low_volume_projects_sample_rate": get_boost_low_volume_projects_sample_rate(
-                        org_id=project.organization.id,
-                        project_id=project.id,
-                        error_sample_rate_fallback=None,
-                    ),
-                },
-            )
-            logger.info(
-                "log-project-config - get_project_config: Logging project sampling config for project %s in org %s.",
-                project.id,
-                project.organization.id,
-                extra={
-                    "project_sampling_config": config["sampling"] if "sampling" in config else None,
-                    "project_id": str(project.id),
-                    "org_id": str(project.organization.id),
-                    "dynamic_sampling_feature_flag": features.has(
-                        "organizations:dynamic-sampling", project.organization
-                    ),
-                    "dynamic_sampling_custom_feature_flag": features.has(
-                        "organizations:dynamic-sampling-custom", project.organization
-                    ),
-                    "dynamic_sampling_mode": project.organization.get_option(
-                        "sentry:sampling_mode", None
-                    ),
-                    "dynamic_sampling_org_target_rate": project.organization.get_option(
-                        "sentry:target_sample_rate", None
-                    ),
-                },
-            )
-        except Exception:
-            capture_exception()
 
     return ProjectConfig(project, **cfg)
 


### PR DESCRIPTION
- We needed these logging statements for debugging in summer 2025
- We left them after the fix, in case something else would happen down the line
- It is now clear that the problem is fixed, so we can remove the logging statements