### PR TITLE
fix(replays): restrict to active staff instead of superuser with user-based replay permissions

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -85,7 +85,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
         """
         if not features.has("organizations:session-replay", organization, actor=request.user):
             return Response(status=404)
-        if not has_replay_permission(organization, request.user):
+        if not has_replay_permission(request, organization):
             return Response(status=403)
 
         try:

--- a/src/sentry/replays/endpoints/organization_replay_endpoint.py
+++ b/src/sentry/replays/endpoints/organization_replay_endpoint.py
@@ -24,5 +24,5 @@ class OrganizationReplayEndpoint(OrganizationEndpoint):
         if not features.has("organizations:session-replay", organization, actor=request.user):
             raise NotFound()
 
-        if not has_replay_permission(organization, request.user):
+        if not has_replay_permission(request, organization):
             raise PermissionDenied()

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -54,7 +54,7 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsEndpointBase):
         if not features.has("organizations:session-replay", organization, actor=request.user):
             return Response(status=404)
 
-        if not has_replay_permission(organization, request.user):
+        if not has_replay_permission(request, organization):
             return Response(status=403)
 
         try:

--- a/src/sentry/replays/endpoints/project_replay_endpoint.py
+++ b/src/sentry/replays/endpoints/project_replay_endpoint.py
@@ -26,5 +26,5 @@ class ProjectReplayEndpoint(ProjectEndpoint):
         ):
             raise NotFound()
 
-        if not has_replay_permission(project.organization, request.user):
+        if not has_replay_permission(request, project.organization):
             raise PermissionDenied()

--- a/src/sentry/replays/endpoints/project_replay_jobs_delete.py
+++ b/src/sentry/replays/endpoints/project_replay_jobs_delete.py
@@ -69,7 +69,7 @@ class ProjectReplayDeletionJobsIndexEndpoint(ProjectEndpoint):
         """
         Retrieve a collection of replay delete jobs.
         """
-        if not has_replay_permission(project.organization, request.user):
+        if not has_replay_permission(request, project.organization):
             return Response(status=403)
 
         queryset = ReplayDeletionJobModel.objects.filter(
@@ -90,7 +90,7 @@ class ProjectReplayDeletionJobsIndexEndpoint(ProjectEndpoint):
         """
         Create a new replay deletion job.
         """
-        if not has_replay_permission(project.organization, request.user):
+        if not has_replay_permission(request, project.organization):
             return Response(status=403)
 
         serializer = ReplayDeletionJobCreateSerializer(data=request.data)

--- a/tests/sentry/replays/endpoints/test_replay_granular_permissions.py
+++ b/tests/sentry/replays/endpoints/test_replay_granular_permissions.py
@@ -197,10 +197,10 @@ class TestReplayGranularPermissions(APITestCase):
             response = self.client.get(url)
             assert response.status_code == 200
 
-    def test_superuser_always_has_access(self) -> None:
-        """Superuser can access replay data even when not in allowlist"""
-        superuser = self.create_user(is_superuser=True)
-        self.create_member(organization=self.organization, user=superuser)
+    def test_staff_always_has_access(self) -> None:
+        """Staff can access replay data even when not in allowlist"""
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(organization=self.organization, user=staff_user)
 
         with self.feature(
             ["organizations:session-replay", "organizations:granular-replay-permissions"]
@@ -210,22 +210,22 @@ class TestReplayGranularPermissions(APITestCase):
                 organizationmember=self.member_with_access
             )
 
-            self.login_as(superuser, superuser=True)
+            self.login_as(staff_user, staff=True)
             url = f"/api/0/organizations/{self.organization.slug}/replays/"
             response = self.client.get(url)
             assert response.status_code == 200
 
-    def test_superuser_access_with_empty_allowlist(self) -> None:
-        """Superuser can access replay data even when allowlist is empty"""
-        superuser = self.create_user(is_superuser=True)
-        self.create_member(organization=self.organization, user=superuser)
+    def test_staff_access_with_empty_allowlist(self) -> None:
+        """Staff can access replay data even when allowlist is empty"""
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(organization=self.organization, user=staff_user)
 
         with self.feature(
             ["organizations:session-replay", "organizations:granular-replay-permissions"]
         ):
             self._enable_granular_permissions()
 
-            self.login_as(superuser, superuser=True)
+            self.login_as(staff_user, staff=True)
             url = f"/api/0/organizations/{self.organization.slug}/replays/"
             response = self.client.get(url)
             assert response.status_code == 200


### PR DESCRIPTION
- in granular replay permissions, currently the check for superuser is true even when not in staff mode
- move the permission to only apply when staff mode is active, i.e. a superuser is logged in as staff