### PR TITLE
ref(preprod): Use case-sensitive exact match for app_id and build_configuration filters

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
@@ -96,7 +96,7 @@ class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
         if not release_version_parsed:
             app_id = params.get("app_id")
             if app_id:
-                queryset = queryset.filter(app_id__iexact=app_id)
+                queryset = queryset.filter(app_id__exact=app_id)
 
             build_version = params.get("build_version")
             if build_version:
@@ -133,7 +133,7 @@ class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
 
         build_configuration = params.get("build_configuration")
         if build_configuration:
-            queryset = queryset.filter(build_configuration__name__iexact=build_configuration)
+            queryset = queryset.filter(build_configuration__name__exact=build_configuration)
 
         platform = params.get("platform")
         if platform:

--- a/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_list_builds.py
@@ -96,7 +96,7 @@ class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
         if not release_version_parsed:
             app_id = params.get("app_id")
             if app_id:
-                queryset = queryset.filter(app_id__icontains=app_id)
+                queryset = queryset.filter(app_id__iexact=app_id)
 
             build_version = params.get("build_version")
             if build_version:
@@ -133,7 +133,7 @@ class ProjectPreprodListBuildsEndpoint(ProjectEndpoint):
 
         build_configuration = params.get("build_configuration")
         if build_configuration:
-            queryset = queryset.filter(build_configuration__name__icontains=build_configuration)
+            queryset = queryset.filter(build_configuration__name__iexact=build_configuration)
 
         platform = params.get("platform")
         if platform:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
@@ -668,7 +668,6 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         """App ID filter uses case-sensitive exact match (no partial matches, no case variants)."""
         url = self._get_url()
 
-        # Different case should not match
         response = self.client.get(
             f"{url}?app_id=COM.EXAMPLE.APP",
             format="json",
@@ -677,7 +676,6 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert len(response.json()["builds"]) == 0
 
-        # Partial match should not work
         response = self.client.get(
             f"{url}?app_id=com.example",
             format="json",
@@ -740,7 +738,6 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
 
         url = self._get_url()
 
-        # Exact case match: "Release" only finds "Release"
         response = self.client.get(
             f"{url}?build_configuration=Release",
             format="json",
@@ -751,7 +748,6 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         assert len(resp_data["builds"]) == 1
         assert resp_data["builds"][0]["app_info"]["build_configuration"] == "Release"
 
-        # Different case: "RELEASE" only finds "RELEASE"
         response = self.client.get(
             f"{url}?build_configuration=RELEASE",
             format="json",
@@ -761,7 +757,6 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         assert len(response.json()["builds"]) == 1
         assert response.json()["builds"][0]["app_info"]["build_configuration"] == "RELEASE"
 
-        # Partial match: "Release" does not match "ReleaseProduction"
         response = self.client.get(
             f"{url}?build_configuration=Release",
             format="json",
@@ -769,4 +764,4 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         )
         assert response.status_code == 200
         matched_configs = {b["app_info"]["build_configuration"] for b in response.json()["builds"]}
-        assert matched_configs == {"Release"}  # Does not include "ReleaseProduction"
+        assert matched_configs == {"Release"}


### PR DESCRIPTION
## Summary

Changes `app_id` and `build_configuration` query filters from `contains` to `exact` to ensure exact matching while remaining case-sensitive.

We cannot compare the builds if the case doesn't match.

This makes the filtering more precise and aligns with the comparison selection UI behavior:

**Before**: `app_id=com.example` would match `com.example.app`, `com.example.app2`, `com.example.app3`, etc.  
**After**: `app_id=com.example.app` only matches exactly `com.example.app` (case-insensitive)

Same goes for build_configuration, before `release` would match `playStoreRelease`. Now it only matches `release`.

 ## Usage of ProjectPreprodListBuildsEndpoint

  This endpoint is used in 5 places but only one of them uses the `app_id` and `build_configuration`:

  1. **Build Comparison Selection** (`static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx:92`)
     - Params: `app_id`, `build_configuration`, `state`, `per_page`, `query`
     - Impact: **Directly affected by this change** - ensures only exact matches are selectable for comparison

  2. **Build List Page** (`static/app/views/preprod/buildList/buildList.tsx:40`)
     - Params: `per_page`, `cursor`
     - Impact: No filters, unaffected

  3. **Releases List - Mobile Builds Tab** (`static/app/views/releases/list/mobileBuilds.tsx:59`)
     - Params: `per_page`, `query`, date filters
     - Impact: Only uses search query, unaffected

  4. **Release Detail - Preprod Builds Tab** (`static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx:86`)
     - Params: `release_version`, `per_page`, `query`
     - Impact: not affected by this change