### PR TITLE
chore(seer): Rename Seer settings button to match page title

### DIFF
--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -182,7 +182,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
         },
         {
           path: `${organizationSettingsPathPrefix}/seer/`,
-          title: t('Seer Automation'),
+          title: t('Seer'),
           description: t(
             "Manage settings for Seer's automated analysis across your organization"
           ),


### PR DESCRIPTION
[Org Settings](https://github.com/getsentry/sentry/blob/master/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx#L183-L191) and [Project settings](https://github.com/getsentry/sentry/blob/master/static/app/views/settings/project/navigationConfiguration.tsx#L64-L68) both should have the same button. `Seer` seems like the right thing at this time.

Sorting is something we should also look at coming up.

<img width="194" height="596" alt="SCR-20251217-jxxm" src="https://github.com/user-attachments/assets/8d335f4d-0911-4917-8b83-27aa19143ce8" />
<img width="185" height="411" alt="SCR-20251217-jxyl" src="https://github.com/user-attachments/assets/d5734b3c-ee30-4a85-a0e7-d90df053d433" />
