### PR TITLE
chore(ai-ml): Correct flag name on tooltip

### DIFF
--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -681,7 +681,7 @@ export default function ProjectSeerContainer() {
   if (!organization.features.includes('autofix-seer-preferences')) {
     return (
       <FeatureDisabled
-        features={['autofix-seer-preferences']}
+        features={['organizations:autofix-seer-preferences']}
         hideHelpToggle
         message={t('Autofix is not enabled for this organization.')}
         featureName={t('Autofix')}


### PR DESCRIPTION
Small thing found while setting this up locally, this is incorrect

<img width="906" height="214" alt="image" src="https://github.com/user-attachments/assets/c6712fa0-bcc7-478d-97bd-6633a3d22e84" />
