### PR TITLE
fix(seer): Do not use singleLineRenderer unnecessarily

### DIFF
--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -30,7 +30,6 @@ import {space} from 'sentry/styles/space';
 import {DataCategoryExact} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {setApiQueryData} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -650,13 +649,7 @@ function ProjectSeer({
       />
       <SettingsPageHeader
         title={tct('Seer Settings for [projectName]', {
-          projectName: (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: singleLineRenderer(`\`${project.slug}\``),
-              }}
-            />
-          ),
+          projectName: <code>{project.slug}</code>,
         })}
       />
       <ProjectSeerGeneralForm project={project} />


### PR DESCRIPTION
`project.slug` will not have markdown inside it; we don't need to `dangerouslySetInnerHTML` here because tct will handle it.

<img width="452" height="156" alt="SCR-20251217-kjns" src="https://github.com/user-attachments/assets/33e45584-1290-4963-b03f-bf9eabcc2914" />
