### PR TITLE
fix(api): Accept project IDs as strings in organization releases endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -710,6 +710,8 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
             for project in projects_from_request:
                 allowed_projects[project.slug] = project
                 allowed_projects[project.id] = project
+                # Also accept project IDs as strings (Sentry CLI serializes project IDs as strings)
+                allowed_projects[str(project.id)] = project
 
             projects: list[Project] = []
             for id_or_slug in result["projects"]:

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2101,6 +2101,54 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert response.status_code == 400
         assert response.data == {"refs": ["Invalid repository names: not_a_repo"]}
 
+    def test_project_ids_as_strings(self) -> None:
+        """
+        Test that project IDs can be passed as strings (common in JSON payloads).
+        This ensures compatibility with clients that serialize numeric IDs as strings.
+        """
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        project = self.create_project(name="test-project", organization=org, teams=[team])
+
+        self.create_member(teams=[team], user=user, organization=org)
+
+        # Create a token with project:releases scope
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=user, scope_list=["project:releases"])
+
+        url = reverse(
+            "sentry-api-0-organization-releases",
+            kwargs={"organization_id_or_slug": org.slug},
+        )
+
+        # Test with project ID as string (common in JSON)
+        response = self.client.post(
+            url,
+            data={"version": "1.0.0", "projects": [str(project.id)]},
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+        assert response.status_code == 201, response.content
+        assert Release.objects.filter(version="1.0.0", organization_id=org.id).exists()
+
+        # Test with project ID as integer
+        response = self.client.post(
+            url,
+            data={"version": "2.0.0", "projects": [project.id]},
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+        assert response.status_code == 201, response.content
+        assert Release.objects.filter(version="2.0.0", organization_id=org.id).exists()
+
+        # Test with project slug
+        response = self.client.post(
+            url,
+            data={"version": "3.0.0", "projects": [project.slug]},
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+        assert response.status_code == 201, response.content
+        assert Release.objects.filter(version="3.0.0", organization_id=org.id).exists()
+
 
 class OrganizationReleaseCommitRangesTest(SetRefsTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Fixes an issue where the Sentry CLI serializes project IDs as strings, but the API only accepted them as integers.

I have manually tested this change locally using Sentry CLI and the fix works as intended.

## Changes

**Bug Fix:**
- Modified the organization releases endpoint to accept project IDs in string format in addition to integers and slugs
- Added test coverage to verify project IDs can be passed as strings, integers, or slugs

This improves compatibility with the Sentry CLI and other clients that serialize numeric IDs as strings in JSON payloads.

Fixes [BE-612](https://linear.app/getsentry/issue/BE-612/fix-for-project-ids)
See #105038 