### PR TITLE
fix(eap): Fix item helpers test

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -49,7 +49,7 @@ def _encode_value(value: Any) -> AnyValue:
         return AnyValue(int_value=value)
     elif isinstance(value, float):
         return AnyValue(double_value=value)
-    elif isinstance(value, list) or isinstance(value, tuple) or isinstance(value, set):
+    elif isinstance(value, list) or isinstance(value, tuple):
         # Not yet processed on EAP side
         return AnyValue(
             array_value=ArrayValue(values=[_encode_value(v) for v in value if v is not None])
@@ -95,6 +95,6 @@ def encode_attributes(
         attributes[formatted_key] = _encode_value(value)
         tag_keys.add(formatted_key)
 
-    attributes["tag_keys"] = _encode_value(tag_keys)
+    attributes["tag_keys"] = _encode_value(sorted(tag_keys))
 
     return attributes

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import pytest
 from sentry_protos.snuba.v1.request_common_pb2 import TRACE_ITEM_TYPE_OCCURRENCE
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue, KeyValue, KeyValueList
 
@@ -102,7 +101,6 @@ class ItemHelpersTest(TestCase):
         assert "group_id" not in result
         assert result["field"] == AnyValue(string_value="value")
 
-    @pytest.mark.skip(reason="Flaky. See #105124")
     def test_encode_attributes_with_tags(self) -> None:
         event_data = {
             "field": "value",


### PR DESCRIPTION
Removes set support from item_helpers. Better to be sure of being unordered.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
