### PR TITLE
chore(seer settings): Replace old project level UI settings flag with new one

### DIFF
--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -545,9 +545,9 @@ describe('ProjectSeer', () => {
     }
   });
 
-  it('hides Scan Issues toggle when triage-signals-v0 feature flag is enabled', async () => {
+  it('hides Scan Issues toggle when seer-user-billing feature flag is enabled', async () => {
     const projectWithFeatureFlag = ProjectFixture({
-      features: ['triage-signals-v0'],
+      features: ['seer-user-billing'],
       autofixAutomationTuning: 'medium', // Already enabled, so no auto-enable PUT
     });
 
@@ -567,7 +567,7 @@ describe('ProjectSeer', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows Scan Issues toggle when triage-signals-v0 feature flag is disabled', async () => {
+  it('shows Scan Issues toggle when seer-user-billing feature flag is disabled', async () => {
     render(<ProjectSeer />, {
       organization,
       outletContext: {project},
@@ -580,10 +580,10 @@ describe('ProjectSeer', () => {
     expect(toggle).toBeInTheDocument();
   });
 
-  describe('Auto-Trigger Fixes with triage-signals-v0', () => {
+  describe('Auto-Trigger Fixes with seer-user-billing', () => {
     it('shows as toggle when flag enabled, dropdown when disabled', async () => {
       const projectWithFlag = ProjectFixture({
-        features: ['triage-signals-v0'],
+        features: ['seer-user-billing'],
         seerScannerAutomation: true,
         autofixAutomationTuning: 'medium', // Already enabled, so no auto-enable PUT
       });
@@ -622,14 +622,14 @@ describe('ProjectSeer', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('toggle is always checked when triage-signals-v0 flag is enabled', async () => {
+    it('toggle is always checked when seer-user-billing flag is enabled', async () => {
       // When flag is on, the toggle is always checked regardless of stored value
       // because we default to ON for triage signals users
       render(<ProjectSeer />, {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             seerScannerAutomation: true,
             autofixAutomationTuning: 'medium',
           }),
@@ -652,7 +652,7 @@ describe('ProjectSeer', () => {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             seerScannerAutomation: true,
             autofixAutomationTuning: 'medium', // Start with enabled so no auto-enable
           }),
@@ -688,7 +688,7 @@ describe('ProjectSeer', () => {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             seerScannerAutomation: true,
             autofixAutomationTuning: 'off', // Existing org with it disabled
           }),
@@ -706,7 +706,7 @@ describe('ProjectSeer', () => {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             seerScannerAutomation: true,
             autofixAutomationTuning: undefined, // New org
           }),
@@ -1226,13 +1226,13 @@ describe('ProjectSeer', () => {
     });
   });
 
-  describe('Auto-open PR and Cursor Handoff toggles with triage-signals-v0', () => {
+  describe('Auto-open PR and Cursor Handoff toggles with seer-user-billing', () => {
     it('shows Auto-open PR toggle when Auto-Trigger is ON', async () => {
       render(<ProjectSeer />, {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },
@@ -1247,7 +1247,7 @@ describe('ProjectSeer', () => {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'off',
           }),
         },
@@ -1298,7 +1298,7 @@ describe('ProjectSeer', () => {
         organization: orgWithCursor,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },
@@ -1315,7 +1315,7 @@ describe('ProjectSeer', () => {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },
@@ -1343,7 +1343,7 @@ describe('ProjectSeer', () => {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },
@@ -1415,7 +1415,7 @@ describe('ProjectSeer', () => {
         organization: orgWithCursor,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },
@@ -1480,7 +1480,7 @@ describe('ProjectSeer', () => {
         organization: orgWithCursor,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },
@@ -1514,7 +1514,7 @@ describe('ProjectSeer', () => {
         organization,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },
@@ -1587,7 +1587,7 @@ describe('ProjectSeer', () => {
         organization: orgWithCursor,
         outletContext: {
           project: ProjectFixture({
-            features: ['triage-signals-v0'],
+            features: ['seer-user-billing'],
             autofixAutomationTuning: 'medium',
           }),
         },

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -200,7 +200,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
   const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
   const {data: codingAgentIntegrations} = useCodingAgentIntegrations();
 
-  const isTriageSignalsFeatureOn = project.features.includes('triage-signals-v0');
+  const isTriageSignalsFeatureOn = project.features.includes('seer-user-billing');
   const canWriteProject = hasEveryAccess(['project:read'], {organization, project});
 
   const cursorIntegrations =
@@ -294,7 +294,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     [preference, updateProjectSeerPreferences]
   );
 
-  // Handler for Auto-open PR toggle (triage-signals-v0)
+  // Handler for Auto-open PR toggle (seer-user-billing)
   // Controls whether Seer auto-opens PRs
   // OFF = stop at code_changes, ON = stop at open_pr
   const handleAutoOpenPrChange = useCallback(
@@ -327,7 +327,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     ]
   );
 
-  // Handler for Cursor handoff toggle (triage-signals-v0)
+  // Handler for Cursor handoff toggle (seer-user-billing)
   // When ON: stops at root_cause and hands off to Cursor
   // When OFF: defaults to code_changes (user can then enable auto-open PR if desired)
   const handleCursorHandoffChange = useCallback(
@@ -459,7 +459,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     },
   } satisfies FieldObject;
 
-  // For triage-signals-v0: Simple toggle for Auto-open PR
+  // For seer-user-billing: Simple toggle for Auto-open PR
   // OFF = stop at code_changes, ON = stop at open_pr
   const autoOpenPrToggleField = {
     name: 'autoOpenPr',
@@ -479,7 +479,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     disabled: ({model}) => model?.getValue('cursorHandoff') === true,
   } satisfies FieldObject;
 
-  // For triage-signals-v0: Simple toggle for Cursor handoff
+  // For seer-user-billing: Simple toggle for Cursor handoff
   // When ON: stops at root_cause and hands off to Cursor
   const cursorHandoffToggleField = {
     name: 'cursorHandoff',
@@ -565,7 +565,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
           automated_run_stopping_point: preference?.automation_handoff
             ? 'cursor_handoff'
             : (preference?.automated_run_stopping_point ?? 'root_cause'),
-          // For triage-signals-v0 mode (toggles) - only include when flag is on
+          // For seer-user-billing mode (toggles) - only include when flag is on
           ...(isTriageSignalsFeatureOn && {
             autoOpenPr: preference?.automated_run_stopping_point === 'open_pr',
             cursorHandoff: Boolean(preference?.automation_handoff),


### PR DESCRIPTION
## PR Details
+ Replaces the old `triage-signals-v0` project level flag with new `seer-user-billing` flag. This new flag is the feature flag used for all ui related changes for the new Seer pricing launch. 
+ Slack thread: https://sentry.slack.com/archives/C08U3M9KCVB/p1765916992908719