### PR TITLE
feat(explore): Adds caseInsensitive param to explore saved queries serializer

### DIFF
--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -131,6 +131,11 @@ class QuerySerializer(serializers.Serializer):
         allow_null=True,
         help_text="The metric configuration (only used for metrics dataset).",
     )
+    caseInsensitive = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Whether the query should be case insensitive.",
+    )
 
 
 class ExploreSavedQuerySerializer(serializers.Serializer):
@@ -200,6 +205,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
             "aggregateField",
             "aggregateOrderby",
             "metric",
+            "caseInsensitive",
         ]
 
         for key in query_keys:

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1161,7 +1161,6 @@ class ExploreSavedQueriesTest(APITestCase):
                     "dataset": "metrics",
                     "query": [
                         {
-                            "caseInsensitive": False,
                             "fields": ["avg()"],
                             "mode": "aggregate",
                             "metric": {
@@ -1179,6 +1178,7 @@ class ExploreSavedQueriesTest(APITestCase):
         assert data["dataset"] == "metrics"
         assert data["query"] == [
             {
+                "caseInsensitive": False,
                 "fields": ["avg()"],
                 "mode": "aggregate",
                 "metric": {

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1287,3 +1287,25 @@ class ExploreSavedQueriesTest(APITestCase):
         data = response.data
         assert data["start"] is not None
         assert data["end"] is not None
+
+    def test_save_with_case_insensitive(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Case insensitive query",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                            "caseInsensitive": True,
+                        }
+                    ],
+                    "range": "24h",
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["query"][0]["caseInsensitive"] is True

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -58,6 +58,7 @@ class ExploreSavedQueriesTest(APITestCase):
         assert "range" not in response.data[0]
         assert response.data[0]["query"] == [
             {
+                "caseInsensitive": False,
                 "fields": [
                     "id",
                     "span.op",
@@ -618,6 +619,7 @@ class ExploreSavedQueriesTest(APITestCase):
         assert data["environment"] == ["dev"]
         assert data["query"] == [
             {
+                "caseInsensitive": False,
                 "fields": ["span.op", "count(span.duration)"],
                 "mode": "samples",
                 "query": "span.op:pageload",
@@ -1139,6 +1141,7 @@ class ExploreSavedQueriesTest(APITestCase):
         assert data["dataset"] == "metrics"
         assert data["query"] == [
             {
+                "caseInsensitive": False,
                 "fields": ["count()"],
                 "mode": "aggregate",
                 "metric": {
@@ -1158,6 +1161,7 @@ class ExploreSavedQueriesTest(APITestCase):
                     "dataset": "metrics",
                     "query": [
                         {
+                            "caseInsensitive": False,
                             "fields": ["avg()"],
                             "mode": "aggregate",
                             "metric": {
@@ -1300,7 +1304,7 @@ class ExploreSavedQueriesTest(APITestCase):
                         {
                             "fields": ["span.op"],
                             "mode": "samples",
-                            "caseInsensitive": True,
+                            "caseInsensitive": 1,
                         }
                     ],
                     "range": "24h",

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -144,7 +144,7 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
                 {
                     "name": "New query",
                     "projects": self.project_ids,
-                    "query": [{"fields": [], "mode": "samples"}],
+                    "query": [{"caseInsensitive": False, "fields": [], "mode": "samples"}],
                     "range": "24h",
                     "orderby": "-timestamp",
                 },
@@ -153,7 +153,9 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(self.query_id)
         assert set(response.data["projects"]) == set(self.project_ids)
-        assert response.data["query"] == [{"fields": [], "mode": "samples"}]
+        assert response.data["query"] == [
+            {"caseInsensitive": False, "fields": [], "mode": "samples"}
+        ]
 
     def test_put_with_interval(self) -> None:
         with self.feature(self.feature_name):
@@ -176,7 +178,11 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["interval"] == "10m"
         assert response.data["query"] == [
-            {"fields": ["span.op", "count(span.duration)"], "mode": "samples"}
+            {
+                "caseInsensitive": False,
+                "fields": ["span.op", "count(span.duration)"],
+                "mode": "samples",
+            }
         ]
 
     def test_put_query_without_access(self) -> None:


### PR DESCRIPTION
Allows saving `caseInsensitive` on the explore saved query `query` object