### PR TITLE
ref(dashboards): Use dataset getter for search bar data

### DIFF
--- a/static/app/views/dashboards/hooks/useDatasetSearchBarData.tsx
+++ b/static/app/views/dashboards/hooks/useDatasetSearchBarData.tsx
@@ -8,45 +8,19 @@ import {WidgetType} from 'sentry/views/dashboards/types';
 export function useDatasetSearchBarData(): (widgetType: WidgetType) => SearchBarData {
   const {selection} = usePageFilters();
 
-  const errorsData = getDatasetConfig(WidgetType.ERRORS).useSearchBarDataProvider!({
-    pageFilters: selection,
-  });
-
-  const logsData = getDatasetConfig(WidgetType.LOGS).useSearchBarDataProvider!({
-    pageFilters: selection,
-  });
-
-  const spansData = getDatasetConfig(WidgetType.SPANS).useSearchBarDataProvider!({
-    pageFilters: selection,
-  });
-
-  const issuesData = getDatasetConfig(WidgetType.ISSUE).useSearchBarDataProvider!({
-    pageFilters: selection,
-  });
-
-  const releasesData = getDatasetConfig(WidgetType.RELEASE).useSearchBarDataProvider!({
-    pageFilters: selection,
-  });
-
   const getSearchBarData = (widgetType: WidgetType): SearchBarData => {
-    switch (widgetType) {
-      case WidgetType.ERRORS:
-        return errorsData;
-      case WidgetType.LOGS:
-        return logsData;
-      case WidgetType.SPANS:
-        return spansData;
-      case WidgetType.ISSUE:
-        return issuesData;
-      case WidgetType.RELEASE:
-        return releasesData;
-      default:
-        return {
-          getFilterKeySections: () => [],
-          getFilterKeys: () => ({}),
-          getTagValues: () => Promise.resolve([]),
-        };
+    const datasetConfig = getDatasetConfig(widgetType);
+    if (datasetConfig.useSearchBarDataProvider) {
+      return datasetConfig.useSearchBarDataProvider({
+        pageFilters: selection,
+      });
     }
+
+    return {
+      getFilterKeySections: () => [],
+      getFilterKeys: () => ({}),
+      getTagValues: () => Promise.resolve([]),
+    };
   };
 
   return getSearchBarData;


### PR DESCRIPTION
Small refactor to leverage the dataset getter to clean up some longer switch statements