### PR TITLE
feat(seer): Implement a page to set repo-specific seer settings

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1234,6 +1234,10 @@ function buildRoutes(): RouteObject[] {
           component: make(() => import('getsentry/views/seerAutomation/repos')),
         },
         {
+          path: 'repos/:repoId/',
+          component: make(() => import('getsentry/views/seerAutomation/repoDetails')),
+        },
+        {
           path: 'onboarding/',
           name: t('Setup Wizard'),
           component: make(

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -42,6 +42,7 @@ type ParamKeys =
   | 'release'
   | 'relocationUuid'
   | 'replaySlug'
+  | 'repoId'
   | 'ruleId'
   | 'scrubbingId'
   | 'searchId'

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -1,0 +1,81 @@
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import {t} from 'sentry/locale';
+import {
+  DEFAULT_CODE_REVIEW_TRIGGERS,
+  type RepositoryWithSettings,
+} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+
+import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
+import {type RepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
+
+interface Props {
+  organization: Organization;
+  repoWithSettings: RepositoryWithSettings;
+}
+
+export default function RepoDetailsForm({organization, repoWithSettings}: Props) {
+  const canWrite = useCanWriteSettings();
+
+  return (
+    <Form
+      allowUndo
+      saveOnBlur
+      apiMethod="PUT"
+      apiEndpoint={`/organizations/${organization.slug}/repos/settings/`}
+      initialData={
+        {
+          enabledCodeReview:
+            repoWithSettings?.settings?.enabledCodeReview ??
+            organization.autoEnableCodeReview ??
+            true,
+          codeReviewTriggers:
+            repoWithSettings?.settings?.codeReviewTriggers ??
+            organization.defaultCodeReviewTriggers ??
+            DEFAULT_CODE_REVIEW_TRIGGERS,
+          repositoryIds: [repoWithSettings.id],
+        } satisfies RepositorySettings
+      }
+    >
+      <JsonForm
+        disabled={!canWrite}
+        forms={[
+          {
+            title: t('AI Code Review'),
+            fields: [
+              {
+                name: 'enabledCodeReview',
+                label: t('Enable Code Review'),
+                help: t('Seer will review your PRs and flag potential bugs.'),
+                type: 'boolean',
+                getData: data => ({
+                  enabledCodeReview: data.enabledCodeReview,
+                  repositoryIds: [repoWithSettings.id],
+                }),
+              },
+              {
+                name: 'codeReviewTriggers',
+                label: t('Code Review Triggers'),
+                help: t(
+                  'Reviews can run on demand, whenever a PR is opened, or after each commit is pushed to a PR.'
+                ),
+                type: 'choice',
+                multiple: true,
+                choices: [
+                  ['on_command_phrase', t('On Command Phrase')],
+                  ['on_ready_for_review', t('On Ready for Review')],
+                  ['on_new_commit', t('On New Commit')],
+                ],
+                getData: data => ({
+                  codeReviewTriggers: data.codeReviewTriggers,
+                  repositoryIds: [repoWithSettings.id],
+                }),
+              },
+            ],
+          },
+        ]}
+      />
+    </Form>
+  );
+}

--- a/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureCodeReviewStep.tsx
@@ -15,6 +15,7 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
+import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
 
 import {useSeerOnboardingContext} from 'getsentry/views/seerAutomation/onboarding/hooks/seerOnboardingContext';
 import {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
@@ -24,11 +25,6 @@ import {RepositorySelector} from './repositorySelector';
 
 // This is the max # of repos that we will allow to be pre-selected.
 const MAX_REPOSITORIES_TO_PRESELECT = 10;
-const DEFAULT_CODE_REVIEW_TRIGGERS = [
-  'on_command_phrase',
-  'on_new_commit',
-  'on_ready_for_review',
-];
 
 export function ConfigureCodeReviewStep() {
   const {currentStep, setCurrentStep} = useGuidedStepsContext();

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
@@ -9,7 +9,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import {getRepositoryWithSettingsQueryKey} from 'getsentry/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings';
 
-type RepositorySettings =
+export type RepositorySettings =
   | {
       enabledCodeReview: boolean;
       repositoryIds: string[];
@@ -43,7 +43,8 @@ export function useBulkUpdateRepositorySettings(
         data,
       });
     },
-    onSettled: data => {
+    ...options,
+    onSettled: (data, error, variables, context) => {
       queryClient.invalidateQueries({
         queryKey: [`/organizations/${organization.slug}/repos/`],
       });
@@ -52,7 +53,7 @@ export function useBulkUpdateRepositorySettings(
           queryKey: getRepositoryWithSettingsQueryKey(organization, repo.id),
         });
       });
+      options?.onSettled?.(data, error, variables, context);
     },
-    ...options,
   });
 }

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -4,8 +4,6 @@ import {Alert} from '@sentry/scraps/alert/alert';
 import {LinkButton} from '@sentry/scraps/button/linkButton';
 
 import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
-import Form from 'sentry/components/forms/form';
-import JsonForm from 'sentry/components/forms/jsonForm';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -16,12 +14,11 @@ import {IconGitlab} from 'sentry/icons/iconGitlab';
 import {IconOpen} from 'sentry/icons/iconOpen';
 import {IconVsts} from 'sentry/icons/iconVsts';
 import {t, tct} from 'sentry/locale';
-import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
-import {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
+import RepoDetailsForm from 'getsentry/views/seerAutomation/components/repoDetails/repoDetailsForm';
 import useRepositoryWithSettings from 'getsentry/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings';
 
 const PROVIDER_ICONS = {
@@ -40,16 +37,12 @@ export default function SeerRepoDetails() {
   const {repoId} = useParams<{repoId: string}>();
   const organization = useOrganization();
 
-  const canWrite = true;
-
   const {
     data: repoWithSettings,
     error,
     isPending,
     refetch,
   } = useRepositoryWithSettings({repositoryId: repoId});
-
-  const {mutate: mutateRepositorySettings} = useBulkUpdateRepositorySettings();
 
   if (isPending) {
     return <LoadingIndicator />;
@@ -90,63 +83,10 @@ export default function SeerRepoDetails() {
       />
 
       {isSupportedAutofixProvider(repoWithSettings?.provider) ? (
-        <Form
-          saveOnBlur
-          apiMethod="PUT"
-          apiEndpoint={`/organizations/${organization.slug}/`}
-          allowUndo
-          initialData={{
-            autoEnableCodeReview:
-              repoWithSettings?.settings?.enabledCodeReview ??
-              organization.autoEnableCodeReview ??
-              true,
-            defaultCodeReviewTriggers:
-              repoWithSettings?.settings?.codeReviewTriggers ??
-              organization.defaultCodeReviewTriggers ??
-              DEFAULT_CODE_REVIEW_TRIGGERS,
-          }}
-        >
-          <JsonForm
-            disabled={!canWrite}
-            forms={[
-              {
-                title: t('AI Code Review'),
-                fields: [
-                  {
-                    name: 'autoEnableCodeReview',
-                    label: t('Enable Code Review'),
-                    help: t('Seer will review your PRs and flag potential bugs.'),
-                    type: 'boolean',
-                    onChange: value =>
-                      mutateRepositorySettings({
-                        enabledCodeReview: value,
-                        repositoryIds: [repoId],
-                      }),
-                  },
-                  {
-                    name: 'defaultCodeReviewTriggers',
-                    label: t('Code Review Triggers'),
-                    help: t(
-                      'Reviews can run on demand, whenever a PR is opened, or after each commit is pushed to a PR.'
-                    ),
-                    type: 'choice',
-                    multiple: true,
-                    choices: [
-                      ['on_command_phrase', t('On Command Phrase')],
-                      ['on_ready_for_review', t('On Ready for Review')],
-                      ['on_new_commit', t('On New Commit')],
-                    ],
-                    onChange: value =>
-                      mutateRepositorySettings({
-                        codeReviewTriggers: value,
-                        repositoryIds: [repoId],
-                      }),
-                  },
-                ],
-              },
-            ]}
-          />
-        </Form>
+        <RepoDetailsForm
+          organization={organization}
+          repoWithSettings={repoWithSettings}
+        />
       ) : (
         <Alert type="warning">{t('Seer is not supported for this repository.')}</Alert>
       )}

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -1,0 +1,155 @@
+import {Fragment} from 'react';
+
+import {Alert} from '@sentry/scraps/alert/alert';
+import {LinkButton} from '@sentry/scraps/button/linkButton';
+
+import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {IconBitbucket} from 'sentry/icons/iconBitbucket';
+import {IconGithub} from 'sentry/icons/iconGithub';
+import {IconGitlab} from 'sentry/icons/iconGitlab';
+import {IconOpen} from 'sentry/icons/iconOpen';
+import {IconVsts} from 'sentry/icons/iconVsts';
+import {t, tct} from 'sentry/locale';
+import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+
+import {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
+import useRepositoryWithSettings from 'getsentry/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings';
+
+const PROVIDER_ICONS = {
+  github: IconGithub,
+  'integrations:github': IconGithub,
+  'integrations:github_enterprise': IconGithub,
+  bitbucket: IconBitbucket,
+  'integrations:bitbucket': IconBitbucket,
+  visualstudio: IconVsts,
+  'integrations:vsts': IconVsts,
+  gitlab: IconGitlab,
+  'integrations:gitlab': IconGitlab,
+};
+
+export default function SeerRepoDetails() {
+  const {repoId} = useParams<{repoId: string}>();
+  const organization = useOrganization();
+
+  const canWrite = true;
+
+  const {
+    data: repoWithSettings,
+    error,
+    isPending,
+    refetch,
+  } = useRepositoryWithSettings({repositoryId: repoId});
+
+  const {mutate: mutateRepositorySettings} = useBulkUpdateRepositorySettings();
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (error) {
+    return <LoadingError onRetry={refetch} />;
+  }
+
+  const ProviderIcon =
+    PROVIDER_ICONS[repoWithSettings?.provider?.id as keyof typeof PROVIDER_ICONS] ??
+    IconOpen;
+
+  return (
+    <Fragment>
+      <SentryDocumentTitle
+        title={t('Repository Seer Settings')}
+        projectSlug={repoWithSettings?.name}
+      />
+      <SettingsPageHeader
+        title={tct('Seer Settings for [repoName] [providerLink]', {
+          repoName: <code>{repoWithSettings?.name}</code>,
+          providerLink: (
+            <ExternalLink href={repoWithSettings?.url}>
+              <ProviderIcon size="md" />
+            </ExternalLink>
+          ),
+        })}
+        subtitle={t('Choose how Seer automatically reviews your pull requests.')}
+        action={
+          <LinkButton
+            href="https://docs.sentry.io/product/ai-in-sentry/ai-code-review/"
+            external
+          >
+            {t('Read the docs')}
+          </LinkButton>
+        }
+      />
+
+      {isSupportedAutofixProvider(repoWithSettings?.provider) ? (
+        <Form
+          saveOnBlur
+          apiMethod="PUT"
+          apiEndpoint={`/organizations/${organization.slug}/`}
+          allowUndo
+          initialData={{
+            autoEnableCodeReview:
+              repoWithSettings?.settings?.enabledCodeReview ??
+              organization.autoEnableCodeReview ??
+              true,
+            defaultCodeReviewTriggers:
+              repoWithSettings?.settings?.codeReviewTriggers ??
+              organization.defaultCodeReviewTriggers ??
+              DEFAULT_CODE_REVIEW_TRIGGERS,
+          }}
+        >
+          <JsonForm
+            disabled={!canWrite}
+            forms={[
+              {
+                title: t('AI Code Review'),
+                fields: [
+                  {
+                    name: 'autoEnableCodeReview',
+                    label: t('Enable Code Review'),
+                    help: t('Seer will review your PRs and flag potential bugs.'),
+                    type: 'boolean',
+                    onChange: value =>
+                      mutateRepositorySettings({
+                        enabledCodeReview: value,
+                        repositoryIds: [repoId],
+                      }),
+                  },
+                  {
+                    name: 'defaultCodeReviewTriggers',
+                    label: t('Code Review Triggers'),
+                    help: t(
+                      'Reviews can run on demand, whenever a PR is opened, or after each commit is pushed to a PR.'
+                    ),
+                    type: 'choice',
+                    multiple: true,
+                    choices: [
+                      ['on_command_phrase', t('On Command Phrase')],
+                      ['on_ready_for_review', t('On Ready for Review')],
+                      ['on_new_commit', t('On New Commit')],
+                    ],
+                    onChange: value =>
+                      mutateRepositorySettings({
+                        codeReviewTriggers: value,
+                        repositoryIds: [repoId],
+                      }),
+                  },
+                ],
+              },
+            ]}
+          />
+        </Form>
+      ) : (
+        <Alert type="warning">{t('Seer is not supported for this repository.')}</Alert>
+      )}
+    </Fragment>
+  );
+}


### PR DESCRIPTION
New page to control repo-specific code-review settings.

| State | Img |
| --- | --- |
| Loading | <img width="1061" height="744" alt="SCR-20251217-mjex" src="https://github.com/user-attachments/assets/3d98ad56-8ffe-4af3-8659-1d41a6965a67" />
| Error to fetch | <img width="1061" height="744" alt="SCR-20251217-mjgh" src="https://github.com/user-attachments/assets/f27ce63c-6abe-4b80-ba8e-e3ceb40ba6fb" />
| Repo is not supported | <img width="1061" height="744" alt="SCR-20251217-mjhx" src="https://github.com/user-attachments/assets/feac4711-15b9-42e2-a43e-1f016888bf70" />
| The form | <img width="1061" height="744" alt="SCR-20251217-mjja" src="https://github.com/user-attachments/assets/0d11bb86-c7ad-4442-9cb9-269dd509197b" />
