### PR TITLE
fix(seer): Improve the empty-search-results state for Org level Seer Project&Repo lists

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -172,9 +172,11 @@ export default function SeerProjectTable() {
         updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
       >
         <SimpleTable.Empty>
-          {tct('No projects found matching [searchTerm].', {
-            searchTerm: <code>{searchTerm}</code>,
-          })}
+          {searchTerm
+            ? tct('No projects found matching [searchTerm]', {
+                searchTerm: <code>{searchTerm}</code>,
+              })
+            : t('No projects found')}
         </SimpleTable.Empty>
       </ProjectTable>
     );

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -14,7 +14,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconSearch} from 'sentry/icons/iconSearch';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Sort} from 'sentry/utils/discover/fields';
@@ -156,6 +156,25 @@ export default function SeerProjectTable() {
       >
         <SimpleTable.Empty>
           <LoadingError />
+        </SimpleTable.Empty>
+      </ProjectTable>
+    );
+  }
+
+  if (filteredProjects.length === 0) {
+    return (
+      <ProjectTable
+        projects={filteredProjects}
+        onSortClick={setSort}
+        sort={sort}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
+      >
+        <SimpleTable.Empty>
+          {tct('No projects found matching [searchTerm].', {
+            searchTerm: <code>{searchTerm}</code>,
+          })}
         </SimpleTable.Empty>
       </ProjectTable>
     );

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -10,7 +10,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconSearch} from 'sentry/icons/iconSearch';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {RepositoryWithSettings} from 'sentry/types/integrations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
@@ -142,6 +142,25 @@ export default function SeerRepoTable() {
       >
         <SimpleTable.Empty>
           <LoadingError />
+        </SimpleTable.Empty>
+      </RepoTable>
+    );
+  }
+
+  if (filteredRepositories.length === 0) {
+    return (
+      <RepoTable
+        mutateRepositorySettings={mutateRepositorySettings}
+        onSortClick={setSort}
+        repositories={filteredRepositories}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        sort={sort}
+      >
+        <SimpleTable.Empty>
+          {tct('No repositories found matching [searchTerm].', {
+            searchTerm: <code>{searchTerm}</code>,
+          })}
         </SimpleTable.Empty>
       </RepoTable>
     );

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -158,9 +158,11 @@ export default function SeerRepoTable() {
         sort={sort}
       >
         <SimpleTable.Empty>
-          {tct('No repositories found matching [searchTerm].', {
-            searchTerm: <code>{searchTerm}</code>,
-          })}
+          {searchTerm
+            ? tct('No repositories found matching [searchTerm]', {
+                searchTerm: <code>{searchTerm}</code>,
+              })
+            : t('No repositories found')}
         </SimpleTable.Empty>
       </RepoTable>
     );


### PR DESCRIPTION
<img width="1218" height="500" alt="SCR-20251217-mmqq" src="https://github.com/user-attachments/assets/fde99554-6012-4f98-88b7-54a9b7355d1b" />
<img width="1216" height="526" alt="SCR-20251217-mmpi" src="https://github.com/user-attachments/assets/4d17a664-6f26-477f-ab04-72f42c8e2637" />
