### PR TITLE
ref(seer): Use isSupportedAutofixProvider consistently

### DIFF
--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -185,11 +185,7 @@ export function hasPullRequest(autofixData: AutofixData | null | undefined): boo
 }
 
 const supportedProviders = ['integrations:github', 'integrations:github_enterprise'];
-
-export const isSupportedAutofixProvider = (provider?: {id: string; name: string}) => {
-  if (!provider) {
-    return false;
-  }
+export const isSupportedAutofixProvider = (provider: {id: string; name: string}) => {
   return supportedProviders.includes(provider.id);
 };
 

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -184,7 +184,11 @@ export function hasPullRequest(autofixData: AutofixData | null | undefined): boo
   return Boolean(changesStep?.changes?.some(change => change.pull_request));
 }
 
-const supportedProviders = ['integrations:github', 'integrations:github_enterprise'];
+const supportedProviders = [
+  'github',
+  'integrations:github',
+  'integrations:github_enterprise',
+];
 export const isSupportedAutofixProvider = (provider: {id: string; name: string}) => {
   return supportedProviders.includes(provider.id);
 };

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -6,6 +6,7 @@ import {InputGroup} from '@sentry/scraps/input/inputGroup';
 import {Stack} from '@sentry/scraps/layout/stack';
 
 import {useOrganizationRepositoriesWithSettings} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
@@ -23,12 +24,6 @@ import SeerRepoTableRow from 'getsentry/views/seerAutomation/components/repoTabl
 import {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
 import {getRepositoryWithSettingsQueryKey} from 'getsentry/views/seerAutomation/onboarding/hooks/useRepositoryWithSettings';
 
-const SUPPORTED_PROVIDERS = [
-  'github',
-  'integrations:github',
-  'integrations:github_enterprise',
-];
-
 export default function SeerRepoTable() {
   const queryClient = useQueryClient();
   const organization = useOrganization();
@@ -41,7 +36,7 @@ export default function SeerRepoTable() {
   const supportedRepositories = useMemo(
     () =>
       repositoriesWithSettings.filter(repository =>
-        SUPPORTED_PROVIDERS.includes(repository.provider.id)
+        isSupportedAutofixProvider(repository.provider)
       ),
     [repositoriesWithSettings]
   );


### PR DESCRIPTION
`github` is listed in some older code here: https://github.com/getsentry/sentry/blob/master/static/app/components/commitLink.tsx#L24

So i added it to the list of supported integration ids. If it's not a valid id then we can remove it from here and commitLink and https://github.com/getsentry/sentry/blob/f68047619171532894101b41ce07668a61fa5fb7/static/gsApp/views/seerAutomation/repoDetails.tsx#L28-L30