### PR TITLE
chore(search-bar): Move case sensitive to custom parser

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks.spec.tsx
@@ -23,7 +23,7 @@ describe('useCaseSensitivity', () => {
       () => useCaseInsensitivity(),
       {initialRouterConfig: {location: {pathname: '/', query: {caseInsensitive: '1'}}}}
     );
-    expect(caseSensitivityTrue.current[0]).toBe(1);
+    expect(caseSensitivityTrue.current[0]).toBe(true);
   });
 
   it('should set the case sensitivity', async () => {
@@ -33,7 +33,7 @@ describe('useCaseSensitivity', () => {
 
     const [, setCaseSensitivity] = result.current;
 
-    await act(() => setCaseSensitivity(1));
+    await act(() => setCaseSensitivity(true));
     await waitFor(() => expect(router.location.query.caseInsensitive).toBe('1'));
 
     await act(() => setCaseSensitivity(null));

--- a/static/app/components/searchQueryBuilder/hooks.ts
+++ b/static/app/components/searchQueryBuilder/hooks.ts
@@ -1,9 +1,11 @@
-import {parseAsNumberLiteral, useQueryState} from 'nuqs';
+import {useQueryState} from 'nuqs';
+
+import {parseAsBooleanLiteral} from 'sentry/utils/url/parseAsBooleanLiteral';
 
 export function useCaseInsensitivity() {
   const [caseInsensitive, setCaseInsensitive] = useQueryState(
     'caseInsensitive',
-    parseAsNumberLiteral([1])
+    parseAsBooleanLiteral
   );
 
   return [caseInsensitive, setCaseInsensitive] as const;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4248,7 +4248,7 @@ describe('SearchQueryBuilder', () => {
       render(
         <SearchQueryBuilder
           {...defaultProps}
-          caseInsensitive={1}
+          caseInsensitive
           onCaseInsensitiveClick={() => Promise.resolve(new URLSearchParams())}
         />
       );

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -716,7 +716,7 @@ export default Storybook.story('SearchQueryBuilder', story => {
   });
 
   story('Case sensitivity', () => {
-    const [caseInsensitive, setCaseInsensitive] = useState<1 | null>(null);
+    const [caseInsensitive, setCaseInsensitive] = useState<true | null>(null);
 
     return (
       <Fragment>

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -50,7 +50,7 @@ export interface SearchQueryBuilderProps {
   autoFocus?: boolean;
   /**
    * Controls the state of the case sensitivity toggle.
-   * - `1` = case insensitive
+   * - `true` = case insensitive
    * - `null` = case sensitive
    */
   caseInsensitive?: CaseInsensitive;
@@ -202,7 +202,7 @@ function ActionButtons({
     return null;
   }
 
-  const isCaseInsensitive = caseInsensitive === 1;
+  const isCaseInsensitive = caseInsensitive === true;
   const caseInsensitiveLabel = isCaseInsensitive ? t('Match case') : t('Ignore case');
 
   return (
@@ -218,7 +218,7 @@ function ActionButtons({
             borderless
             active={!isCaseInsensitive}
             onClick={() => {
-              onCaseInsensitiveClick?.(isCaseInsensitive ? null : 1);
+              onCaseInsensitiveClick?.(isCaseInsensitive ? null : true);
             }}
           />
         </Tooltip>

--- a/static/app/utils/url/parseAsBooleanLiteral.tsx
+++ b/static/app/utils/url/parseAsBooleanLiteral.tsx
@@ -1,0 +1,6 @@
+import {createParser} from 'nuqs';
+
+export const parseAsBooleanLiteral = createParser({
+  parse: v => (v === '1' ? true : null),
+  serialize: () => '1',
+});

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -107,7 +107,7 @@ export function useTraces({
       per_page: limit,
       cursor,
       breakdownSlices: BREAKDOWN_SLICES,
-      caseInsensitive,
+      caseInsensitive: caseInsensitive ? '1' : undefined,
       ...(Array.isArray(logQuery) && logQuery.length > 0 ? {logQuery} : {}),
       ...(Array.isArray(metricQuery) && metricQuery.length > 0 ? {metricQuery} : {}),
       ...(Array.isArray(spanQuery) && spanQuery.length > 0 ? {spanQuery} : {}),

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -290,7 +290,7 @@ describe('LogsTabContent', () => {
           field: [...AlwaysPresentLogFields, 'message', 'sentry.message.parameters.0'],
           sort: 'sentry.message.parameters.0',
           query: 'severity:error',
-          caseInsensitive: 1,
+          caseInsensitive: '1',
         }),
       })
     );

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -141,7 +141,7 @@ function useLogsQueryKey({
       per_page: limit ? limit : undefined,
       referrer,
       sampling: highFidelity ? SAMPLING_MODE.FLEX_TIME : SAMPLING_MODE.NORMAL,
-      caseInsensitive,
+      caseInsensitive: caseInsensitive ? '1' : undefined,
     },
     pageFiltersReady,
     eventView,

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -161,7 +161,7 @@ function useMetricsQueryKey({
       per_page: limit,
       referrer,
       sampling: queryExtras?.samplingMode ?? SAMPLING_MODE.NORMAL,
-      caseInsensitive: queryExtras?.caseInsensitive,
+      caseInsensitive: queryExtras?.caseInsensitive ? 1 : undefined,
       disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation
         ? '1'
         : undefined,

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -161,7 +161,7 @@ function useMetricsQueryKey({
       per_page: limit,
       referrer,
       sampling: queryExtras?.samplingMode ?? SAMPLING_MODE.NORMAL,
-      caseInsensitive: queryExtras?.caseInsensitive ? 1 : undefined,
+      caseInsensitive: queryExtras?.caseInsensitive ? '1' : undefined,
       disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation
         ? '1'
         : undefined,

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -306,8 +306,8 @@ function useWrappedDiscoverQueryBase<T>({
     }
   }
 
-  if (typeof caseInsensitive === 'number') {
-    queryExtras.caseInsensitive = caseInsensitive.toString();
+  if (typeof caseInsensitive === 'boolean' && caseInsensitive) {
+    queryExtras.caseInsensitive = '1';
   }
 
   if (Array.isArray(logQuery) && logQuery.length > 0) {


### PR DESCRIPTION
This PR updates the `useCaseInsensitivity` to use a new custom nuqs parser.