### PR TITLE
fix(seer billing): add collaborator to allowed author associations

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -84,7 +84,7 @@ def is_contributor_eligible_for_seat_assignment(
 ) -> bool:
     """
     Determine if a contributor is eligible for seat assignment based on their user type and author association.
-    - Contributor must be MEMBER or OWNER of the repo
+    - Contributor must be MEMBER or OWNER of the parent org, or COLLABORATOR on the repo
     - Contributor cannot be a bot
     """
     return user_type != "Bot" and author_association in (
@@ -797,6 +797,21 @@ class PullRequestEventWebhook(GitHubWebhook):
                     tags={
                         "organization_id": organization.id,
                         "repository_id": repo.id,
+                    },
+                )
+
+                logger.info(
+                    "github.webhook.organization_contributor.eligibility_check",
+                    extra={
+                        "organization_id": organization.id,
+                        "repository_id": repo.id,
+                        "pr_number": number,
+                        "user_login": user["login"],
+                        "user_type": user_type,
+                        "author_association": author_association,
+                        "is_eligible": is_contributor_eligible_for_seat_assignment(
+                            user_type, author_association
+                        ),
                     },
                 )
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -90,6 +90,7 @@ def is_contributor_eligible_for_seat_assignment(
     return user_type != "Bot" and author_association in (
         AuthorAssociation.MEMBER,
         AuthorAssociation.OWNER,
+        AuthorAssociation.COLLABORATOR,
     )
 
 
@@ -796,19 +797,6 @@ class PullRequestEventWebhook(GitHubWebhook):
                     tags={
                         "organization_id": organization.id,
                         "repository_id": repo.id,
-                    },
-                )
-
-                logger.info(
-                    "github.webhook.organization_contributor.eligibility_check",
-                    extra={
-                        "pr_number": number,
-                        "user_login": user["login"],
-                        "user_type": user_type,
-                        "author_association": author_association,
-                        "is_eligible": is_contributor_eligible_for_seat_assignment(
-                            user_type, author_association
-                        ),
                     },
                 )
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -50,7 +50,7 @@ class IsContributorEligibleForSeatAssignmentTest(TestCase):
         assert is_contributor_eligible_for_seat_assignment("User", "OWNER")
 
     def test_user_with_collaborator_association_is_eligible(self):
-        assert not is_contributor_eligible_for_seat_assignment("User", "COLLABORATOR")
+        assert is_contributor_eligible_for_seat_assignment("User", "COLLABORATOR")
 
     def test_user_with_contributor_association_is_not_eligible(self):
         assert not is_contributor_eligible_for_seat_assignment("User", "CONTRIBUTOR")

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -49,7 +49,7 @@ class IsContributorEligibleForSeatAssignmentTest(TestCase):
     def test_user_with_owner_association_is_eligible(self):
         assert is_contributor_eligible_for_seat_assignment("User", "OWNER")
 
-    def test_user_with_collaborator_association_is_not_eligible(self):
+    def test_user_with_collaborator_association_is_eligible(self):
         assert not is_contributor_eligible_for_seat_assignment("User", "COLLABORATOR")
 
     def test_user_with_contributor_association_is_not_eligible(self):

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -1174,7 +1174,7 @@ class PullRequestEventWebhook(APITestCase):
         "sentry.integrations.github.webhook.should_create_or_increment_contributor_seat",
         return_value=True,
     )
-    def test_no_contributor_tracking_for_non_member_contributor(
+    def test_no_contributor_tracking_for_non_collaborator_contributor(
         self,
         mock_should_create_or_increment_contributor_seat: MagicMock,
         mock_assign_seat: MagicMock,
@@ -1197,7 +1197,7 @@ class PullRequestEventWebhook(APITestCase):
             integration.add_organization(self.project.organization.id, self.user)
 
         body = json.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
-        body["pull_request"]["author_association"] = "COLLABORATOR"
+        body["pull_request"]["author_association"] = "CONTRIBUTOR"
         modified_body = json.dumps(body).encode("utf-8")
 
         self.client.post(


### PR DESCRIPTION
We added a log to see why the contributor eligibility check was failing so often. It turns out that the vast majority of PRs opened are done by `COLLABORATOR`s or `CONTRIBUTOR`s, whereas our eligibility check is only allowing `MEMBER` and `OWNER`. Here we add `COLLABORATOR` as an allowed author association.

The distinction between `COLLABORATOR` and `MEMBER` is that an org member has access at the organization level, whereas a collaborator is not a member of the org but has access to specific repos. A user must accept the invite to collaborate before they are considered a collaborator, contrary to the github docs.