### PR TITLE
fix(preprod): Fix insight savings formatting

### DIFF
--- a/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
@@ -7,9 +7,9 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import type {DiffItem, InsightDiffItem} from 'sentry/views/preprod/types/appSizeTypes';
 import {getInsightConfig} from 'sentry/views/preprod/utils/insightProcessing';
+import {formattedSizeDiff} from 'sentry/views/preprod/utils/labelUtils';
 
 interface InsightDiffRowProps {
   children: React.ReactNode;
@@ -84,7 +84,7 @@ export function InsightDiffRow({
                   <Text>
                     {t(
                       'Potential savings: %s',
-                      formatBytesBase10(insight.total_savings_change)
+                      formattedSizeDiff(insight.total_savings_change)
                     )}{' '}
                     <Text
                       variant={insight.total_savings_change > 0 ? 'danger' : 'success'}


### PR DESCRIPTION
Before
<img width="405" height="164" alt="Screenshot 2025-12-17 at 12 11 26 PM" src="https://github.com/user-attachments/assets/c74fa355-1735-453e-b6dc-b08c0b2cd85b" />

After
<img width="342" height="156" alt="Screenshot 2025-12-17 at 12 11 08 PM" src="https://github.com/user-attachments/assets/a6e866ee-a1a3-4467-b7fe-6c683ac2496f" />