### PR TITLE
Add generic AppIcon component for rendering app icon or fallback placeholder

### DIFF
--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -67,15 +67,16 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
         </Flex>
         <Heading as="h1">Build comparison</Heading>
         <Flex gap="lg" wrap="wrap" align="center">
-          <Flex gap="sm" align="center">
-            {buildDetails.app_info.name && (
+          {buildDetails.app_info.name && (
+            <Flex gap="sm" align="center">
               <AppIcon
                 appName={buildDetails.app_info.name}
                 appIconId={buildDetails.app_info.app_icon_id}
                 projectId={projectId}
               />
-            )}
-          </Flex>
+              <Text>{buildDetails.app_info.name}</Text>
+            </Flex>
+          )}
           <Flex gap="sm" align="center">
             <InfoIcon>
               {buildDetails.app_info.platform ? (

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -13,6 +13,7 @@ import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {IconCode, IconDownload, IconJson, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {AppIcon} from 'sentry/views/preprod/components/appIcon';
 import {
   isSizeInfoCompleted,
   type BuildDetailsApiResponse,
@@ -67,12 +68,13 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
         <Heading as="h1">Build comparison</Heading>
         <Flex gap="lg" wrap="wrap" align="center">
           <Flex gap="sm" align="center">
-            <AppIcon>
-              <AppIconPlaceholder>
-                {buildDetails.app_info.name?.charAt(0) || ''}
-              </AppIconPlaceholder>
-            </AppIcon>
-            <Text>{buildDetails.app_info.name}</Text>
+            {buildDetails.app_info.name && (
+              <AppIcon
+                appName={buildDetails.app_info.name}
+                appIconId={buildDetails.app_info.app_icon_id}
+                projectId={projectId}
+              />
+            )}
           </Flex>
           <Flex gap="sm" align="center">
             <InfoIcon>
@@ -136,23 +138,6 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
     </Flex>
   );
 }
-
-const AppIcon = styled('div')`
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
-  background: ${p => p.theme.purple400};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-`;
-
-const AppIconPlaceholder = styled('div')`
-  color: white;
-  font-weight: ${p => p.theme.fontWeight.bold};
-  font-size: ${p => p.theme.fontSize.sm};
-`;
 
 const InfoIcon = styled('div')`
   width: 24px;

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
@@ -11,7 +11,7 @@ import Feature from 'sentry/components/acl/feature';
 import {IconClock, IconFile, IconJson, IconLink, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getFormat, getFormattedDate, getUtcToSystem} from 'sentry/utils/dates';
-import useOrganization from 'sentry/utils/useOrganization';
+import {AppIcon} from 'sentry/views/preprod/components/appIcon';
 import {openInstallModal} from 'sentry/views/preprod/components/installModal';
 import {type BuildDetailsAppInfo} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
@@ -29,36 +29,26 @@ interface BuildDetailsSidebarAppInfoProps {
 }
 
 export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProps) {
-  const organization = useOrganization();
   const labels = getLabels(props.appInfo.platform ?? undefined);
-  const [imageError, setImageError] = useState(false);
 
   const datetimeFormat = getFormat({
     seconds: true,
     timeZone: true,
   });
 
-  let iconUrl = null;
-  if (props.appInfo.app_icon_id) {
-    iconUrl = `/api/0/projects/${organization.slug}/${props.projectId}/files/images/${props.appInfo.app_icon_id}/`;
-  }
-
   return (
     <Flex direction="column" gap="xl">
       <Flex align="center" gap="sm">
-        {iconUrl && !imageError && (
-          <AppIcon
-            src={iconUrl}
-            alt="App Icon"
-            width={24}
-            height={24}
-            onError={() => setImageError(true)}
-          />
+        {props.appInfo.name && (
+          <Fragment>
+            <AppIcon
+              appName={props.appInfo.name}
+              appIconId={props.appInfo.app_icon_id}
+              projectId={props.projectId}
+            />
+            <Heading as="h3">{props.appInfo.name}</Heading>
+          </Fragment>
         )}
-        {(!iconUrl || imageError) && (
-          <AppIconPlaceholder>{props.appInfo.name?.charAt(0) || ''}</AppIconPlaceholder>
-        )}
-        {props.appInfo.name && <Heading as="h3">{props.appInfo.name}</Heading>}
       </Flex>
 
       <Flex wrap="wrap" gap="md">
@@ -150,24 +140,6 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
     </Flex>
   );
 }
-
-const AppIcon = styled('img')`
-  border-radius: 4px;
-`;
-
-const AppIconPlaceholder = styled('div')`
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: ${p => p.theme.purple400};
-  color: ${p => p.theme.white};
-  font-weight: ${p => p.theme.fontWeight.bold};
-  font-size: ${p => p.theme.fontSize.sm};
-`;
 
 const InfoIcon = styled('div')`
   width: 24px;

--- a/static/app/views/preprod/components/appIcon.tsx
+++ b/static/app/views/preprod/components/appIcon.tsx
@@ -1,0 +1,55 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface AppIconProps {
+  appName: string;
+  appIconId?: string | null;
+  projectId?: string | null;
+}
+
+export function AppIcon({appName, appIconId, projectId}: AppIconProps) {
+  const organization = useOrganization();
+  const [imageError, setImageError] = useState(false);
+
+  let iconUrl = undefined;
+  if (appIconId && projectId) {
+    iconUrl = `/api/0/projects/${organization.slug}/${projectId}/files/images/${appIconId}/`;
+  }
+
+  return (
+    <Fragment>
+      {iconUrl && !imageError && (
+        <AppIconImg
+          src={iconUrl}
+          alt="App Icon"
+          width={24}
+          height={24}
+          onError={() => setImageError(true)}
+        />
+      )}
+      {(!iconUrl || imageError) && (
+        <AppIconPlaceholder>{appName.charAt(0)}</AppIconPlaceholder>
+      )}
+    </Fragment>
+  );
+}
+
+const AppIconImg = styled('img')`
+  border-radius: 4px;
+`;
+
+const AppIconPlaceholder = styled('div')`
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: ${p => p.theme.purple400};
+  color: ${p => p.theme.white};
+  font-weight: ${p => p.theme.fontWeight.bold};
+  font-size: ${p => p.theme.fontSize.sm};
+`;


### PR DESCRIPTION
Adds a generic `<AppIcon>` component that will load & display the app icon, or fallback to a placeholder (first letter of app + purple BG).

Also adds icon to compare page with app name.

Compare page
<img width="603" height="154" alt="Screenshot 2025-12-17 at 12 44 04 PM" src="https://github.com/user-attachments/assets/75d53171-ffa0-4acb-a838-d7e1576756b1" />

App size page (icon present)
<img width="262" height="252" alt="Screenshot 2025-12-17 at 12 41 20 PM" src="https://github.com/user-attachments/assets/ac05be5e-fcea-4783-ad63-fdde099d469b" />


App size page (fallback)
<img width="254" height="226" alt="Screenshot 2025-12-17 at 12 47 35 PM" src="https://github.com/user-attachments/assets/bbc8a39d-4aa4-43e3-b409-0295daa21bfe" />
