### PR TITLE
fix(autofix): Full width summary loading placeholder

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -2,6 +2,8 @@ import {isValidElement, useEffect, useLayoutEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
+import {Container} from '@sentry/scraps/layout';
+
 import {AiPrivacyTooltip} from 'sentry/components/aiPrivacyTooltip';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
@@ -390,7 +392,7 @@ function GroupSummaryFull({
   ];
 
   return (
-    <div data-testid="group-summary">
+    <Container data-testid="group-summary" width="100%">
       {isError ? <div>{t('Error loading summary')}</div> : null}
       <Content>
         <InsightGrid>
@@ -438,7 +440,7 @@ function GroupSummaryFull({
           </ResummarizeWrapper>
         )}
       </Content>
-    </div>
+    </Container>
   );
 }
 


### PR DESCRIPTION
# Screenshots

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="759" height="340" alt="image" src="https://github.com/user-attachments/assets/4913cbdb-53b3-4935-998e-5d3f89058aa6" />
 <td><img width="759" height="340" alt="image" src="https://github.com/user-attachments/assets/109b66d6-6136-49ee-af03-e237f86b4a5e" />
</table>

Fixes AIML-2122