### PR TITLE
fix(preprod): use separate producer for preprod EAP

### DIFF
--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -19,13 +19,13 @@ from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_topic_definition
 
 
-def write_preprod_size_metric_to_eap(
+def produce_preprod_size_metric_to_eap(
     size_metric: PreprodArtifactSizeMetrics,
     organization_id: int,
     project_id: int,
 ) -> None:
     """
-    Write a PreprodArtifactSizeMetrics to EAP as a TRACE_ITEM_TYPE_PREPROD trace item.
+    Write a PreprodArtifactSizeMetrics to EAP topic as a TRACE_ITEM_TYPE_PREPROD trace item.
 
     NOTE: EAP is append-only, so this function should only be called after the size metric has been successfully committed
     since we cannot update fields later on. EAP does support ReplacingMergeTree deduplication,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -15,7 +15,7 @@ from sentry.constants import DataCategory
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.preprod.eap.write import write_preprod_size_metric_to_eap
+from sentry.preprod.eap.write import produce_preprod_size_metric_to_eap
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeComparison,
@@ -477,7 +477,7 @@ def _assemble_preprod_artifact_size_analysis(
             organization = preprod_artifact.project.organization
             if features.has("organizations:preprod-size-metrics-eap-write", organization):
                 for size_metric in size_metrics_updated:
-                    write_preprod_size_metric_to_eap(
+                    produce_preprod_size_metric_to_eap(
                         size_metric=size_metric,
                         organization_id=org_id,
                         project_id=project.id,

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -16,7 +16,7 @@ from sentry.testutils.cases import TestCase
 
 
 class WritePreprodSizeMetricToEAPTest(TestCase):
-    @patch("sentry.preprod.eap.write.eap_producer.produce")
+    @patch("sentry.preprod.eap.write._eap_producer.produce")
     def test_write_preprod_size_metric_encodes_all_fields_correctly(self, mock_produce):
         commit_comparison = CommitComparison.objects.create(
             organization_id=self.organization.id,
@@ -117,7 +117,7 @@ class WritePreprodSizeMetricToEAPTest(TestCase):
         assert attrs["git_base_ref"].string_value == "main"
         assert attrs["git_pr_number"].int_value == 42
 
-    @patch("sentry.preprod.eap.write.eap_producer.produce")
+    @patch("sentry.preprod.eap.write._eap_producer.produce")
     def test_write_preprod_size_metric_handles_optional_fields(self, mock_produce):
         artifact = self.create_preprod_artifact(
             project=self.project,

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -6,7 +6,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.models.commitcomparison import CommitComparison
-from sentry.preprod.eap.write import write_preprod_size_metric_to_eap
+from sentry.preprod.eap.write import produce_preprod_size_metric_to_eap
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeMetrics,
@@ -61,7 +61,7 @@ class WritePreprodSizeMetricToEAPTest(TestCase):
             analysis_file_id=123,
         )
 
-        write_preprod_size_metric_to_eap(
+        produce_preprod_size_metric_to_eap(
             size_metric=size_metric,
             organization_id=self.organization.id,
             project_id=self.project.id,
@@ -130,7 +130,7 @@ class WritePreprodSizeMetricToEAPTest(TestCase):
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
 
-        write_preprod_size_metric_to_eap(
+        produce_preprod_size_metric_to_eap(
             size_metric=size_metric,
             organization_id=self.organization.id,
             project_id=self.project.id,

--- a/tests/snuba/preprod/eap/test_preprod_eap_integration.py
+++ b/tests/snuba/preprod/eap/test_preprod_eap_integration.py
@@ -3,11 +3,14 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    ComparisonFilter,
+    TraceItemFilter,
+)
 
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.eap.read import query_preprod_size_metrics
-from sentry.preprod.eap.write import write_preprod_size_metric_to_eap
+from sentry.preprod.eap.write import produce_preprod_size_metric_to_eap
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeMetrics,
@@ -58,7 +61,7 @@ class PreprodEAPIntegrationTest(SnubaTestCase):
             analysis_file_id=123,
         )
 
-        write_preprod_size_metric_to_eap(
+        produce_preprod_size_metric_to_eap(
             size_metric=size_metric,
             organization_id=self.organization.id,
             project_id=self.project.id,
@@ -153,13 +156,13 @@ class PreprodEAPIntegrationTest(SnubaTestCase):
             max_install_size=1000,
         )
 
-        write_preprod_size_metric_to_eap(
+        produce_preprod_size_metric_to_eap(
             size_metric=size_metric_main,
             organization_id=self.organization.id,
             project_id=self.project.id,
         )
 
-        write_preprod_size_metric_to_eap(
+        produce_preprod_size_metric_to_eap(
             size_metric=size_metric_watch,
             organization_id=self.organization.id,
             project_id=self.project.id,

--- a/tests/snuba/preprod/eap/test_preprod_eap_integration.py
+++ b/tests/snuba/preprod/eap/test_preprod_eap_integration.py
@@ -3,10 +3,7 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
-    ComparisonFilter,
-    TraceItemFilter,
-)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.eap.read import query_preprod_size_metrics


### PR DESCRIPTION
Realized I accidentally piggy-backed off Replay's Kafka producer, so this creates our own named producer. I also renamed `produce_preprod_size_metric_to_eap` to make it more obvious it goes through Kafka and therefore not a synchronous write.