### PR TITLE
feat: Update bulk update endpoint to also allow sending repo mapping object

### DIFF
--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -181,6 +181,12 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
             )
 
             for proj_id, project in projects_by_id.items():
+                has_stopping_point_update = automated_run_stopping_point is not None
+                has_repo_update = proj_id in filtered_repo_mappings
+
+                if not has_stopping_point_update and not has_repo_update:
+                    continue
+
                 project_id_str = str(proj_id)
                 existing_pref = existing_preferences.get(project_id_str, {})
 
@@ -191,10 +197,10 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
                     "project_id": proj_id,
                 }
 
-                if automated_run_stopping_point:
+                if has_stopping_point_update:
                     pref_update["automated_run_stopping_point"] = automated_run_stopping_point
 
-                if proj_id in filtered_repo_mappings:
+                if has_repo_update:
                     repos_data = filtered_repo_mappings[proj_id]
                     pref_update["repositories"] = [
                         SeerRepoDefinition(**repo_data).dict() for repo_data in repos_data

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -24,6 +24,8 @@ from sentry.seer.autofix.utils import (
     bulk_set_project_preferences,
     default_seer_project_preference,
 )
+from sentry.seer.endpoints.organization_seer_onboarding import ProjectRepoMappingField
+from sentry.seer.models import SeerRepoDefinition
 
 
 class SeerAutofixSettingGetResponseSerializer(serializers.Serializer):
@@ -47,6 +49,22 @@ class SeerAutofixSettingsPostSerializer(SeerAutofixSettingsSerializer):
         max_length=1000,
         help_text="List of project IDs to create/update settings for.",
     )
+    projectRepoMappings = ProjectRepoMappingField(
+        required=False,
+        allow_null=True,
+        help_text="Optional mapping of project IDs to repository configurations. If provided, updates the repository list for each specified project.",
+    )
+
+    def validate(self, data):
+        if (
+            "autofixAutomationTuning" not in data
+            and "automatedRunStoppingPoint" not in data
+            and "projectRepoMappings" not in data
+        ):
+            raise serializers.ValidationError(
+                "At least one of 'autofixAutomationTuning', 'automatedRunStoppingPoint', or 'projectRepoMappings' must be provided."
+            )
+        return data
 
 
 @region_silo_endpoint
@@ -143,38 +161,67 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         project_ids = set[int](serializer.validated_data["projectIds"] or [])
         autofix_automation_tuning = serializer.validated_data.get("autofixAutomationTuning")
         automated_run_stopping_point = serializer.validated_data.get("automatedRunStoppingPoint")
+        project_repo_mappings = serializer.validated_data.get("projectRepoMappings")
 
-        projects = self.get_projects(request, organization, project_ids=project_ids)
+        all_project_ids = set(project_ids)
+        if project_repo_mappings:
+            all_project_ids.update(project_repo_mappings.keys())
+
+        projects = self.get_projects(request, organization, project_ids=all_project_ids)
+        projects_by_id = {project.id: project for project in projects}
+
+        validated_project_ids = set(projects_by_id.keys())
+        validated_project_ids_for_settings = project_ids & validated_project_ids
+        validated_project_ids_for_repos = (
+            set(project_repo_mappings.keys()) & validated_project_ids
+            if project_repo_mappings
+            else set()
+        )
 
         preferences_to_set: list[dict[str, Any]] = []
-        if automated_run_stopping_point:
-            project_ids_list = [project.id for project in projects]
-            existing_preferences = bulk_get_project_preferences(organization.id, project_ids_list)
+        project_ids_needing_preferences: set[int] = set()
 
-            for project in projects:
-                project_id_str = str(project.id)
+        if automated_run_stopping_point:
+            project_ids_needing_preferences.update(validated_project_ids_for_settings)
+        if project_repo_mappings:
+            project_ids_needing_preferences.update(validated_project_ids_for_repos)
+
+        if project_ids_needing_preferences:
+            existing_preferences = bulk_get_project_preferences(
+                organization.id, list(project_ids_needing_preferences)
+            )
+
+            for proj_id in project_ids_needing_preferences:
+                project = projects_by_id[proj_id]
+                project_id_str = str(proj_id)
                 existing_pref = existing_preferences.get(project_id_str, {})
 
-                preferences_to_set.append(
-                    {
-                        **default_seer_project_preference(project).dict(),
-                        **existing_pref,
-                        "organization_id": organization.id,
-                        "project_id": project.id,
-                        "automated_run_stopping_point": automated_run_stopping_point,
-                    }
-                )
+                pref_update: dict[str, Any] = {
+                    **default_seer_project_preference(project).dict(),
+                    **existing_pref,
+                    "organization_id": organization.id,
+                    "project_id": proj_id,
+                }
+
+                if automated_run_stopping_point and proj_id in validated_project_ids_for_settings:
+                    pref_update["automated_run_stopping_point"] = automated_run_stopping_point
+
+                if proj_id in validated_project_ids_for_repos:
+                    repos_data = project_repo_mappings[proj_id]
+                    pref_update["repositories"] = [
+                        SeerRepoDefinition(**repo_data).dict() for repo_data in repos_data
+                    ]
+
+                preferences_to_set.append(pref_update)
 
         # Wrap DB writes and Seer API call in a transaction.
         # If Seer API fails, DB changes are rolled back.
         with transaction.atomic(router.db_for_write(ProjectOption)):
             if autofix_automation_tuning:
-                autofix_automation_tuning_value = (
-                    autofix_automation_tuning or AutofixAutomationTuningSettings.OFF.value
-                )
-                for project in projects:
+                for proj_id in validated_project_ids_for_settings:
+                    project = projects_by_id[proj_id]
                     project.update_option(
-                        "sentry:autofix_automation_tuning", autofix_automation_tuning_value
+                        "sentry:autofix_automation_tuning", autofix_automation_tuning
                     )
 
             if preferences_to_set:

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -118,13 +118,11 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         List projects with their autofix automation settings.
 
         :pparam string organization_id_or_slug: the id or slug of the organization.
-        :qparam list[int] projectIds: Optional list of project IDs to filter by.
         :qparam string query: Optional search query to filter by project name or slug.
         :auth: required
         """
         serializer = SeerAutofixSettingGetResponseSerializer(
             data={
-                "projectIds": request.GET.getlist("projectIds") or None,
                 "query": request.GET.get("query"),
             }
         )

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -149,6 +149,8 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         """
         Bulk create/update the autofix automation settings of projects in a single request.
 
+        NOTE: When ProjectRepoMappings are provided, it will overwrite the existing repositories for that project.
+
         :pparam string organization_id_or_slug: the id or slug of the organization.
         :auth: required
         """

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -304,3 +304,153 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             },
         )
         assert response.status_code == 403
+
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
+    )
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    def test_post_updates_project_repo_mappings(
+        self, mock_bulk_get_preferences, mock_bulk_set_preferences
+    ):
+        project = self.create_project(organization=self.organization)
+
+        mock_bulk_get_preferences.return_value = {}
+
+        repo_data = {
+            "provider": "github",
+            "owner": "test-org",
+            "name": "test-repo",
+            "externalId": "12345",
+        }
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project.id],
+                "projectRepoMappings": {
+                    str(project.id): [repo_data],
+                },
+            },
+        )
+        assert response.status_code == 204
+
+        mock_bulk_set_preferences.assert_called_once()
+        call_args = mock_bulk_set_preferences.call_args
+        preferences = call_args[0][1]
+        assert len(preferences) == 1
+        assert preferences[0]["project_id"] == project.id
+        assert len(preferences[0]["repositories"]) == 1
+        assert preferences[0]["repositories"][0]["name"] == "test-repo"
+        assert preferences[0]["repositories"][0]["owner"] == "test-org"
+        assert preferences[0]["repositories"][0]["external_id"] == "12345"
+
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
+    )
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    def test_post_updates_repo_mappings_with_other_settings(
+        self, mock_bulk_get_preferences, mock_bulk_set_preferences
+    ):
+        project = self.create_project(organization=self.organization)
+
+        mock_bulk_get_preferences.return_value = {}
+
+        repo_data = {
+            "provider": "github",
+            "owner": "test-org",
+            "name": "test-repo",
+            "externalId": "12345",
+        }
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project.id],
+                "autofixAutomationTuning": AutofixAutomationTuningSettings.MEDIUM.value,
+                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
+                "projectRepoMappings": {
+                    str(project.id): [repo_data],
+                },
+            },
+        )
+        assert response.status_code == 204
+
+        project.refresh_from_db()
+        assert (
+            project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.MEDIUM.value
+        )
+
+        mock_bulk_set_preferences.assert_called_once()
+        call_args = mock_bulk_set_preferences.call_args
+        preferences = call_args[0][1]
+        assert len(preferences) == 1
+        assert preferences[0]["project_id"] == project.id
+        assert preferences[0]["automated_run_stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
+        assert len(preferences[0]["repositories"]) == 1
+
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    def test_post_rejects_repo_mappings_for_projects_not_in_organization(
+        self, mock_bulk_get_preferences
+    ):
+        project = self.create_project(organization=self.organization)
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+
+        repo_data = {
+            "provider": "github",
+            "owner": "test-org",
+            "name": "test-repo",
+            "externalId": "12345",
+        }
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project.id],
+                "projectRepoMappings": {
+                    str(other_project.id): [repo_data],
+                },
+            },
+        )
+        assert response.status_code == 403
+
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
+    )
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    def test_post_clears_repos_with_empty_list(
+        self, mock_bulk_get_preferences, mock_bulk_set_preferences
+    ):
+        project = self.create_project(organization=self.organization)
+
+        mock_bulk_get_preferences.return_value = {
+            str(project.id): {
+                "repositories": [{"name": "old-repo", "owner": "old-owner"}],
+            }
+        }
+
+        response = self.client.post(
+            self.url,
+            {
+                "projectIds": [project.id],
+                "projectRepoMappings": {
+                    str(project.id): [],
+                },
+            },
+        )
+        assert response.status_code == 204
+
+        mock_bulk_set_preferences.assert_called_once()
+        call_args = mock_bulk_set_preferences.call_args
+        preferences = call_args[0][1]
+        assert len(preferences) == 1
+        assert preferences[0]["repositories"] == []


### PR DESCRIPTION
This PR aims to update the bulk update automation settings endpoint to also include the project: repo[] mapping parameter to also update those fields, if they exist.

This can be used to clear out repos as well.



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
