### PR TITLE
chore(ACI): Add back subscription processor crash rate detector test coverage

### DIFF
--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -4,20 +4,40 @@ from functools import cached_property
 from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
 
+import orjson
+import pytest
 from django.utils import timezone
+from urllib3.response import HTTPResponse
 
 from sentry.constants import ObjectStatus
 from sentry.incidents.subscription_processor import SubscriptionProcessor
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.models import QuerySubscription
+from sentry.incidents.subscription_processor import SubscriptionProcessor
+from sentry.seer.anomaly_detection.types import (
+    AnomalyDetectionSeasonality,
+    AnomalyDetectionSensitivity,
+    AnomalyDetectionThresholdType,
+    AnomalyType,
+    DetectAnomaliesResponse,
+)
+from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.utils import resolve_tag_key
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery
+from sentry.testutils.cases import BaseMetricsTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
+from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.subscription_processor.test_subscription_processor_base import (
     ProcessUpdateBaseClass,
 )
+
+EMPTY = object()
+pytestmark = [pytest.mark.sentry_metrics]
 
 
 class ProcessUpdateTest(ProcessUpdateBaseClass):
@@ -515,3 +535,447 @@ class ProcessUpdateUpsampledCountTest(ProcessUpdateBaseClass):
         # Then resolve it with low upsampled_count (below resolve threshold of 10)
         self.send_upsampled_update(upsampled_count=5.0, time_delta=timedelta(minutes=1))
         assert self.get_detector_state(self.upsampled_detector) == DetectorPriorityLevel.OK
+
+class MetricsCrashRateDetectorProcessUpdateTest(ProcessUpdateBaseClass, BaseMetricsTestCase):
+    @pytest.fixture(autouse=True)
+    def _setup_metrics_patcher(self):
+        with patch("sentry.snuba.entity_subscription.metrics") as self.entity_subscription_metrics:
+            yield
+
+    @cached_property
+    def crash_rate_detector(self):
+        detector = self.metric_detector
+        DataCondition.objects.filter(condition_group=detector.workflow_condition_group).delete()
+        self.set_up_data_conditions(
+            detector=detector,
+            threshold_type=Condition.LESS,
+            critical_threshold=80,
+            warning_threshold=90,
+        )
+        snuba_query = self.get_snuba_query(detector)
+        snuba_query.update(
+            type=SnubaQuery.Type.CRASH_RATE.value,
+            time_window=3600,
+            dataset=Dataset.Metrics.value,
+            aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+            resolution=60,
+        )
+        snuba_query.save()
+        return detector
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.detector = self.crash_rate_detector
+
+        for status in ["exited", "crashed"]:
+            self.store_session(
+                self.build_session(
+                    status=status,
+                )
+            )
+
+    def send_crash_rate_detector_update(self, value, subscription, time_delta=None, count=EMPTY):
+        if time_delta is None:
+            time_delta = timedelta()
+        processor = SubscriptionProcessor(subscription)
+
+        if time_delta is not None:
+            timestamp = timezone.now() + time_delta
+        else:
+            timestamp = timezone.now()
+        timestamp = timestamp.replace(microsecond=0)
+
+        with (
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.capture_on_commit_callbacks(execute=True),
+        ):
+            if value is None:
+                numerator, denominator = 0, 0
+            else:
+                if count is EMPTY:
+                    numerator, denominator = value.as_integer_ratio()
+                else:
+                    denominator = count
+                    numerator = int(value * denominator)
+            processor.process_update(
+                {
+                    "entity": "entity",
+                    "subscription_id": (
+                        subscription.subscription_id if subscription else uuid4().hex
+                    ),
+                    "values": {
+                        "data": [
+                            {
+                                "project_id": 8,
+                                "count": denominator,
+                                "crashed": numerator,
+                            },
+                        ]
+                    },
+                    "timestamp": timestamp,
+                }
+            )
+        return processor
+
+    def test_crash_rate_detector_for_sessions_with_auto_resolve_critical(self) -> None:
+        """
+        Test that ensures that a detector is triggered when `crash_free_percentage` falls
+        below the critical threshold and then is resolved once `crash_free_percentage` goes above
+        the threshold (when no resolve_threshold is set)
+        """
+
+        # Send critical Update
+        update_value = (1 - self.critical_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-2),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+        # Send resolve update
+        update_value = (1 - self.warning_threshold / 100) - 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-1),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
+    )
+    def test_dynamic_crash_rate_detector_for_sessions_with_auto_resolve_critical(
+        self, mock_seer_request
+    ):
+        """
+        Test that ensures that a dynamic critical monitor is triggered when `crash_free_percentage` falls
+        below the critical threshold and then is resolved once `crash_free_percentage` goes above
+        the threshold (when no resolve_threshold is set)
+        """
+
+        # update the detector to be dynamic
+        detector = self.crash_rate_detector
+        detector.update(config={"detection_type": "dynamic", "comparison_delta": None})
+        detector.save()
+
+        critical_detector_trigger = DataCondition.objects.get(
+            condition_group=detector.workflow_condition_group,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        critical_detector_trigger.update(
+            type=Condition.ANOMALY_DETECTION,
+            comparison={
+                "sensitivity": AnomalyDetectionSensitivity.MEDIUM,
+                "seasonality": AnomalyDetectionSeasonality.AUTO,
+                "threshold_type": AnomalyDetectionThresholdType.ABOVE_AND_BELOW,
+            },
+        )
+        critical_detector_trigger.save()
+        snuba_query = self.get_snuba_query(detector)
+        snuba_query.update(time_window=15 * 60)
+        snuba_query.save()
+
+        # send critical update
+        seer_return_value: DetectAnomaliesResponse = {
+            "success": True,
+            "timeseries": [
+                {
+                    "anomaly": {
+                        "anomaly_score": 0.7,
+                        "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
+                    },
+                    "timestamp": 1,
+                    "value": 10,
+                }
+            ],
+        }
+
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        update_value = (1 - 0 / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-2),
+            subscription=self.sub,
+        )
+        assert mock_seer_request.call_count == 1
+        assert self.get_detector_state(detector) == DetectorPriorityLevel.HIGH
+
+        # resolve the detector
+        seer_return_value2: DetectAnomaliesResponse = {
+            "success": True,
+            "timeseries": [
+                {
+                    "anomaly": {
+                        "anomaly_score": 0.2,
+                        "anomaly_type": AnomalyType.NONE.value,
+                    },
+                    "timestamp": 1,
+                    "value": 5,
+                }
+            ],
+        }
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value2), status=200)
+        update_value = (1 - 0 / 100) - 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-1),
+            subscription=self.sub,
+        )
+        assert mock_seer_request.call_count == 2
+        assert self.get_detector_state(detector) == DetectorPriorityLevel.OK
+
+    def test_crash_rate_detector_for_sessions_with_auto_resolve_warning(self) -> None:
+        """
+        Test that ensures that a detector is triggered when `crash_free_percentage` falls
+        below the warning data condition threshold and then is resolved once `crash_free_percentage` goes above
+        the threshold (when no resolve_threshold is set)
+        """
+
+        # Send warning update
+        update_value = (1 - self.warning_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-3),
+            subscription=self.sub,
+        )
+
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.MEDIUM
+
+        update_value = (1 - self.warning_threshold / 100) - 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-1),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
+
+    def test_crash_rate_detector_for_sessions_with_critical_warning_then_resolved(self) -> None:
+        """
+        Test the behavior going from critical status to warning status to resolved
+        for crash rate monitors
+        """
+
+        # Send Critical Update
+        update_value = (1 - self.critical_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-10),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+        # Send Warning Update
+        update_value = (1 - self.warning_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-3),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.MEDIUM
+
+        # Send update higher than warning threshold
+        update_value = (1 - self.warning_threshold / 100) - 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-1),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
+
+    def test_crash_rate_detector_for_sessions_with_triggers_lower_than_resolve_threshold(
+        self,
+    ) -> None:
+        """
+        Test that ensures that when `crash_rate_percentage` goes above the warning threshold but
+        lower than the resolve threshold, detector is not resolved
+        """
+        self.update_threshold(self.detector, DetectorPriorityLevel.OK, 95)
+
+        # Send Critical Update
+        update_value = (1 - self.critical_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-10),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+        # Send Warning Update
+        update_value = (1 - self.warning_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-3),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.MEDIUM
+
+        # Send update higher than warning threshold but lower than resolve threshold
+        update_value = (1 - self.warning_threshold / 100) - 0.04
+
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-1),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.MEDIUM
+
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
+    def test_crash_rate_detector_for_sessions_with_no_sessions_data(
+        self, helper_metrics: MagicMock
+    ) -> None:
+        """
+        Test that ensures we skip the crash rate detector processing if we have no sessions data
+        """
+
+        self.send_crash_rate_detector_update(
+            value=None,
+            subscription=self.sub,
+        )
+        helper_metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.ignore_update_no_session_data"),
+            ]
+        )
+        self.metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ]
+        )
+
+    @patch("sentry.incidents.utils.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
+    def test_crash_rate_detector_when_session_count_is_lower_than_minimum_threshold(
+        self, helper_metrics
+    ):
+        # Send Critical Update
+        update_value = (1 - self.critical_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            count=10,
+            time_delta=timedelta(minutes=-10),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
+        helper_metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.ignore_update_count_lower_than_min_threshold"),
+            ]
+        )
+        self.metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ]
+        )
+
+    @patch("sentry.incidents.utils.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
+    def test_crash_rate_detector_when_session_count_is_higher_than_minimum_threshold(self) -> None:
+
+        # Send Critical Update
+        update_value = (1 - self.critical_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            count=31,
+            time_delta=timedelta(minutes=-10),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
+    def test_multiple_threshold_trigger_is_reset_when_no_sessions_data(
+        self, helper_metrics: MagicMock
+    ) -> None:
+
+        update_value = (1 - self.critical_threshold / 100) + 0.05
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-2),
+            subscription=self.sub,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+        self.send_crash_rate_detector_update(
+            value=None,
+            time_delta=timedelta(minutes=-1),
+            subscription=self.sub,
+        )
+        helper_metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.ignore_update_no_session_data"),
+            ],
+        )
+        self.metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ]
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+    @patch("sentry.incidents.utils.process_update_helpers.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
+    def test_multiple_threshold_trigger_is_reset_when_count_is_lower_than_min_threshold(
+        self, helper_metrics
+    ):
+        update_value = (1 - self.critical_threshold / 100) + 0.05
+        subscription = self.sub
+
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            time_delta=timedelta(minutes=-2),
+            subscription=subscription,
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+        self.send_crash_rate_detector_update(
+            value=update_value,
+            count=1,
+            time_delta=timedelta(minutes=-1),
+            subscription=subscription,
+        )
+        helper_metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.ignore_update_count_lower_than_min_threshold"),
+            ],
+        )
+        self.metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ],
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.HIGH
+
+    @patch("sentry.incidents.utils.process_update_helpers.metrics")
+    def test_ensure_case_when_no_metrics_index_not_found_is_handled_gracefully(
+        self, helper_metrics
+    ):
+        processor = SubscriptionProcessor(self.sub)
+        processor.process_update(
+            {
+                "entity": "entity",
+                "subscription_id": self.sub.subscription_id,
+                "values": {
+                    # 1001 is a random int that doesn't map to anything in the indexer
+                    "data": [
+                        {
+                            resolve_tag_key(
+                                UseCaseKey.RELEASE_HEALTH, self.organization.id, "session.status"
+                            ): 1001
+                        }
+                    ]
+                },
+                "timestamp": timezone.now(),
+            }
+        )
+        assert self.get_detector_state(self.detector) == DetectorPriorityLevel.OK
+        helper_metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.ignore_update_no_session_data"),
+            ]
+        )
+
+        self.metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ]
+        )


### PR DESCRIPTION
Companion PR to https://github.com/getsentry/sentry/pull/105113 that adds back the crash rate alert tests and updates them with ACI models. I removed a couple that have to do with resolve thresholds higher than 1 since we don't actually let users set those, but everything else remains. 