### PR TITLE
ref(llm-detection): Replace custom exception with logger calls

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -5,7 +5,6 @@ import random
 from datetime import UTC, datetime
 from uuid import uuid4
 
-import sentry_sdk
 from django.conf import settings
 from pydantic import BaseModel, ValidationError
 from urllib3 import Retry
@@ -69,10 +68,6 @@ class IssueDetectionRequest(BaseModel):
     traces: list[TraceMetadata]
     organization_id: int
     project_id: int
-
-
-class LLMIssueDetectionError(Exception):
-    pass
 
 
 def get_base_platform(platform: str | None) -> str | None:
@@ -272,52 +267,40 @@ def detect_llm_issues_for_project(project_id: int) -> None:
                 path=SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
                 body=json.dumps(seer_request.dict()).encode("utf-8"),
             )
-        except Exception as network_error:
-            e = LLMIssueDetectionError("Seer network error")
-            sentry_sdk.set_context(
-                "error_details",
-                {
+        except Exception:
+            logger.exception(
+                "Seer network error",
+                extra={
                     "project_id": project_id,
                     "organization_id": organization_id,
-                    "status": None,
-                    "response_data": None,
-                    "error_message": str(network_error),
                 },
             )
-            sentry_sdk.capture_exception(e)
             continue
 
         if response.status < 200 or response.status >= 300:
-            e = LLMIssueDetectionError("Seer HTTP error")
-            sentry_sdk.set_context(
-                "error_details",
-                {
+            logger.error(
+                "Seer HTTP error",
+                extra={
                     "project_id": project_id,
                     "organization_id": organization_id,
                     "status": response.status,
                     "response_data": response.data.decode("utf-8"),
                 },
             )
-            sentry_sdk.capture_exception(e)
             continue
 
         try:
             raw_response_data = response.json()
             response_data = IssueDetectionResponse.parse_obj(raw_response_data)
-        except (ValueError, TypeError, ValidationError) as parse_error:
-            e = LLMIssueDetectionError("Seer response parsing error")
-            sentry_sdk.set_context(
-                "error_details",
-                {
+        except (ValueError, TypeError, ValidationError):
+            logger.exception(
+                "Seer response parsing error",
+                extra={
                     "project_id": project_id,
                     "organization_id": organization_id,
                     "status": response.status,
                     "response_data": response.data.decode("utf-8"),
-                    "error_message": str(parse_error),
                 },
-            )
-            sentry_sdk.capture_exception(
-                e,
             )
             continue
 
@@ -355,17 +338,13 @@ def detect_llm_issues_for_project(project_id: int) -> None:
                         "verification_reason": detected_issue.verification_reason,
                     },
                 )
-            except Exception as issue_creation_exception:
-                e = LLMIssueDetectionError("Error creating issue occurrence")
-                sentry_sdk.set_context(
-                    "error_details",
-                    {
+            except Exception:
+                logger.exception(
+                    "Error creating issue occurrence",
+                    extra={
                         "project_id": project_id,
                         "organization_id": organization_id,
-                        "status": None,
-                        "response_data": detected_issue.title,
-                        "error_message": str(issue_creation_exception),
+                        "issue_title": detected_issue.title,
                     },
                 )
-                sentry_sdk.capture_exception(e)
                 continue

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -273,6 +273,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
                 extra={
                     "project_id": project_id,
                     "organization_id": organization_id,
+                    "trace_id": trace.trace_id,
                 },
             )
             continue
@@ -285,6 +286,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
                     "organization_id": organization_id,
                     "status": response.status,
                     "response_data": response.data.decode("utf-8"),
+                    "trace_id": trace.trace_id,
                 },
             )
             continue
@@ -300,6 +302,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
                     "organization_id": organization_id,
                     "status": response.status,
                     "response_data": response.data.decode("utf-8"),
+                    "trace_id": trace.trace_id,
                 },
             )
             continue
@@ -336,6 +339,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
                         "category": detected_issue.category,
                         "subcategory": detected_issue.subcategory,
                         "verification_reason": detected_issue.verification_reason,
+                        "trace_id": trace.trace_id,
                     },
                 )
             except Exception:
@@ -345,6 +349,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
                         "project_id": project_id,
                         "organization_id": organization_id,
                         "issue_title": detected_issue.title,
+                        "trace_id": trace.trace_id,
                     },
                 )
                 continue

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -264,10 +264,10 @@ class LLMIssueDetectionTest(TestCase):
     @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     @patch("sentry.tasks.llm_issue_detection.trace_data.Spans.run_table_query")
     @patch("sentry.tasks.llm_issue_detection.detection.random.shuffle")
-    @patch("sentry.tasks.llm_issue_detection.detection.sentry_sdk.capture_exception")
+    @patch("sentry.tasks.llm_issue_detection.detection.logger.error")
     def test_detect_llm_issues_continues_on_seer_error(
         self,
-        mock_capture_exception,
+        mock_logger_error,
         mock_shuffle,
         mock_spans_query,
         mock_seer_request,
@@ -317,7 +317,7 @@ class LLMIssueDetectionTest(TestCase):
         detect_llm_issues_for_project(self.project.id)
 
         assert mock_seer_request.call_count == 2
-        assert mock_capture_exception.call_count == 1
+        assert mock_logger_error.call_count == 1
         assert mock_produce_occurrence.call_count == 1
 
         occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]


### PR DESCRIPTION
The LLM issue detection task was using a custom exception class (`LLMIssueDetectionError`) with `sentry_sdk.capture_exception()` for error handling. Instead let's use `logger.exception()` for actual exceptions (network errors, parsing errors, issue creation errors) and `logger.error()` for HTTP error responses where no exception exists.
