### PR TITLE
ref(crons): Remove usages of `deprecatedRouteProps` from crons routes

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1551,12 +1551,10 @@ function buildRoutes(): RouteObject[] {
         {
           path: 'crons/',
           component: make(() => import('sentry/views/alerts/rules/crons')),
-          deprecatedRouteProps: true,
           children: [
             {
               path: ':projectId/:monitorSlug/details/',
               component: make(() => import('sentry/views/alerts/rules/crons/details')),
-              deprecatedRouteProps: true,
             },
           ],
         },

--- a/static/app/views/alerts/rules/crons/details.spec.tsx
+++ b/static/app/views/alerts/rules/crons/details.spec.tsx
@@ -1,16 +1,23 @@
 import {CheckinProcessingErrorFixture} from 'sentry-fixture/checkinProcessingError';
 import {MonitorFixture} from 'sentry-fixture/monitor';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import MonitorDetails from 'sentry/views/alerts/rules/crons/details';
 
 describe('Monitor Details', () => {
-  const monitor = MonitorFixture();
-  const {organization, project, routerProps} = initializeOrg({
-    router: {params: {monitorSlug: monitor.slug, projectId: monitor.project.slug}},
-  });
+  const organization = OrganizationFixture();
+  const project = ProjectFixture({organization});
+  const monitor = MonitorFixture({project});
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/alerts/rules/crons/${project.slug}/${monitor.slug}/details/`,
+    },
+    route: '/alerts/rules/crons/:projectId/:monitorSlug/details/',
+  };
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -41,7 +48,7 @@ describe('Monitor Details', () => {
   });
 
   it('renders', async () => {
-    render(<MonitorDetails {...routerProps} />);
+    render(<MonitorDetails />, {organization, initialRouterConfig});
     expect(await screen.findByText(monitor.slug, {exact: false})).toBeInTheDocument();
 
     // Doesn't show processing errors
@@ -58,7 +65,7 @@ describe('Monitor Details', () => {
       statusCode: 404,
     });
 
-    render(<MonitorDetails {...routerProps} />);
+    render(<MonitorDetails />, {organization, initialRouterConfig});
     expect(
       await screen.findByText('The monitor you were looking for was not found.')
     ).toBeInTheDocument();
@@ -70,7 +77,7 @@ describe('Monitor Details', () => {
       body: [CheckinProcessingErrorFixture()],
     });
 
-    render(<MonitorDetails {...routerProps} />);
+    render(<MonitorDetails />, {organization, initialRouterConfig});
     expect(
       await screen.findByText(
         'Errors were encountered while ingesting check-ins for this monitor'

--- a/static/app/views/alerts/rules/crons/details.tsx
+++ b/static/app/views/alerts/rules/crons/details.tsx
@@ -14,10 +14,11 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {TimezoneProvider, useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import {DetailsSidebar} from 'sentry/views/insights/crons/components/detailsSidebar';
 import {DetailsTimeline} from 'sentry/views/insights/crons/components/detailsTimeline';
 import {MonitorCheckIns} from 'sentry/views/insights/crons/components/monitorCheckIns';
@@ -33,17 +34,16 @@ import {makeMonitorDetailsQueryKey} from 'sentry/views/insights/crons/utils';
 
 import {getMonitorRefetchInterval, getNextCheckInEnv} from './utils';
 
-type Props = RouteComponentProps<{monitorSlug: string; projectId: string}>;
-
 function hasLastCheckIn(monitor: Monitor) {
   return monitor.environments.some(e => e.lastCheckIn);
 }
 
-function MonitorDetails({params, location}: Props) {
+export default function MonitorDetails() {
   const api = useApi();
-
   const organization = useOrganization();
   const queryClient = useQueryClient();
+  const params = useParams<{monitorSlug: string; projectId: string}>();
+  const location = useLocation();
 
   const queryKey = makeMonitorDetailsQueryKey(
     organization,
@@ -202,5 +202,3 @@ const MainActions = styled('div')`
 const StyledPageFilterBar = styled(PageFilterBar)`
   margin-bottom: ${space(2)};
 `;
-
-export default MonitorDetails;

--- a/static/app/views/alerts/rules/crons/index.tsx
+++ b/static/app/views/alerts/rules/crons/index.tsx
@@ -1,13 +1,17 @@
+import {Outlet} from 'react-router-dom';
+
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export default function CronsContainer({children}: {children: React.ReactNode}) {
+export default function CronsContainer() {
   const organization = useOrganization();
 
   return (
     <NoProjectMessage organization={organization}>
-      <PageFiltersContainer>{children}</PageFiltersContainer>
+      <PageFiltersContainer>
+        <Outlet />
+      </PageFiltersContainer>
     </NoProjectMessage>
   );
 }


### PR DESCRIPTION
Migrates crons routes off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7