### PR TITLE
ref(explore): Migrate `SchemaHintsList` component tests off of `deprecatedRouterMocks`

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -115,10 +115,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const stringTag1Hint = screen.getByText('stringTag1');
@@ -137,10 +134,7 @@ describe('SchemaHintsList', () => {
 
   it('should render loading indicator when isLoading is true', () => {
     render(
-      <Subject stringTags={{}} numberTags={{}} supportedAggregates={[]} isLoading />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      <Subject stringTags={{}} numberTags={{}} supportedAggregates={[]} isLoading />
     );
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();


### PR DESCRIPTION
Migrating the tests for the `SchemaHintsList` component off of `deprecatedRouterMocks`.