### PR TITLE
fix(ai): Re-order operation type matching values

### DIFF
--- a/src/sentry/relay/config/ai_operation_type_map.py
+++ b/src/sentry/relay/config/ai_operation_type_map.py
@@ -2,7 +2,15 @@ from typing import Literal, Required, TypedDict
 
 AI_OPERATION_TYPE_VALUE = Literal["agent", "ai_client", "tool", "handoff"]
 
+# Default catch all "*" -> ai_client mapping is defined explicitly in the code
+# so it doesn't take precedence over other mappings, while ai_client mappings
+# must be listed first to ensure they take precedence over less strict "agent"
+# mappings. (e.g. "ai.streamText.doStream*" -> ai_client, "ai.streamText*" -> agent)
 AI_OPERATION_TYPE_MAP: dict[AI_OPERATION_TYPE_VALUE, list[str]] = {
+    "ai_client": [
+        "ai.streamText.doStream*",
+        "ai.generateText.doGenerate*",
+    ],
     "agent": [
         "ai.run.generateText",
         "ai.run.generateObject",
@@ -19,7 +27,6 @@ AI_OPERATION_TYPE_MAP: dict[AI_OPERATION_TYPE_VALUE, list[str]] = {
     ],
     "tool": ["gen_ai.execute_tool", "execute_tool", "ai.toolCall*"],
     "handoff": ["gen_ai.handoff", "handoff"],
-    "ai_client": ["*"],  # default fallback
 }
 
 
@@ -34,6 +41,11 @@ def ai_operation_type_map_config() -> AIOperationTypeMap:
     for operation_type, operations in AI_OPERATION_TYPE_MAP.items():
         for operation in operations:
             operation_type_map[operation] = operation_type
+
+    # default catch all "*" -> ai_client mapping
+    # at the end of the map to ensure it doesn't
+    # takes precedence over other mappings
+    operation_type_map["*"] = "ai_client"
 
     return {
         "version": 1,


### PR DESCRIPTION
We need to re-order the mappings to be able to match following cases:
```
"ai.streamText" -> agent
"ai.streamText foo" -> agent
"ai.streamText.doStream" -> ai_client
"ai.streamText.doStream foo" -> ai_client
```

Also the catch-all `*` is now added at the end, to always be the last fuzzy matching option
