### PR TITLE
feat(onboarding): Add wrapFetchWithSentry to Tanstack Start onboarding

### DIFF
--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -159,6 +159,50 @@ Sentry.init({
           ],
         },
         {
+          type: 'conditional',
+          condition: params.isPerformanceSelected,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                'To enable tracing for server-side requests, you need to explicitly define a [serverEntryLink:server entry point] in your application and wrap your request handler with [code:wrapFetchWithSentry].',
+                {
+                  code: <code />,
+                  serverEntryLink: (
+                    <ExternalLink href="https://tanstack.com/start/latest/docs/framework/react/guide/server-entry-point" />
+                  ),
+                }
+              ),
+            },
+            {
+              type: 'text',
+              text: tct('Create a [code:src/server.ts] file in your project:', {
+                code: <code />,
+              }),
+            },
+            {
+              type: 'code',
+              tabs: [
+                {
+                  label: 'TypeScript',
+                  language: 'typescript',
+                  filename: 'src/server.ts',
+                  code: `import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
+import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+
+export default createServerEntry(
+  wrapFetchWithSentry({
+    fetch(request: Request) {
+      return handler.fetch(request);
+    },
+  })
+);`,
+                },
+              ],
+            },
+          ],
+        },
+        {
           type: 'text',
           text: tct(
             'For production monitoring, you need to move the Sentry server config file to your build output. Since [hostingLink:TanStack Start is designed to work with any hosting provider], the exact location will depend on where your build artifacts are deployed (for example, [code:/dist], [code:.output/server] or a platform-specific directory).',


### PR DESCRIPTION
We will release a new wrapFetchWithSentry API for the Tanstack Start SDK that adds support for server-side tracing. Later this will also handle server-side error monitoring, but that doesn't work yet.

PR should be merged after the next JS SDK release (10.32.0).
