### PR TITLE
nit(preprod): Close button should be right aligned (EME-703)

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -76,33 +76,44 @@ function BuildButton({
         })
       }
     >
-      <Flex direction="column" gap="xs">
-        <Flex align="center" gap="sm">
-          {icon}
-          <Text size="sm" variant="accent" bold>
-            {label}
-          </Text>
-          {!buildNumber && (
-            <Text size="sm" variant="accent" bold>
-              {`#${buildId}`}
-            </Text>
-          )}
-          {sha && (
-            <Flex align="center" gap="xs">
-              <IconCommit size="xs" />
-              <Text size="sm" variant="accent" bold monospace>
-                {sha}
+      <ContentWrapper>
+        <ClippedContent>
+          <Flex direction="column" gap="xs">
+            <Flex align="center" gap="sm">
+              {icon}
+              <Text size="sm" variant="accent" bold>
+                {label}
+              </Text>
+              {!buildNumber && (
+                <Text size="sm" variant="accent" bold>
+                  {`#${buildId}`}
+                </Text>
+              )}
+              {sha && (
+                <Flex align="center" gap="xs">
+                  <IconCommit size="xs" />
+                  <Text size="sm" variant="accent" bold monospace>
+                    {sha}
+                  </Text>
+                </Flex>
+              )}
+              {branchName && (
+                <BuildBranch>
+                  <Text size="sm" variant="muted">
+                    {branchName}
+                  </Text>
+                </BuildBranch>
+              )}
+            </Flex>
+            <Flex align="center" gap="sm">
+              <Text size="sm" variant="muted">
+                {metadataParts.join(' • ')}
               </Text>
             </Flex>
-          )}
-          {branchName && (
-            <BuildBranch>
-              <Text size="sm" variant="muted">
-                {branchName}
-              </Text>
-            </BuildBranch>
-          )}
-          {onRemove && (
+          </Flex>
+        </ClippedContent>
+        {onRemove && (
+          <CloseButtonWrapper>
             <Button
               onClick={e => {
                 e.preventDefault();
@@ -115,14 +126,9 @@ function BuildButton({
               aria-label={t('Clear base build')}
               icon={<IconClose size="xs" color="purple400" />}
             />
-          )}
-        </Flex>
-        <Flex align="center" gap="sm">
-          <Text size="sm" variant="muted">
-            {metadataParts.join(' • ')}
-          </Text>
-        </Flex>
-      </Flex>
+          </CloseButtonWrapper>
+        )}
+      </ContentWrapper>
     </StyledLinkButton>
   );
 }
@@ -130,6 +136,28 @@ function BuildButton({
 const StyledLinkButton = styled(LinkButton)`
   height: auto;
   min-height: auto;
+
+  /* Override ButtonLabel overflow to allow close button to extend beyond */
+  > span:last-child {
+    overflow: visible;
+  }
+`;
+
+const ContentWrapper = styled('div')`
+  position: relative;
+  width: 100%;
+`;
+
+const ClippedContent = styled('div')`
+  overflow: hidden;
+`;
+
+const CloseButtonWrapper = styled('div')`
+  position: absolute;
+  top: 0;
+  right: -6px;
+  background-color: ${p => p.theme.colors.surface500};
+  border-radius: ${p => p.theme.radius.xs};
 `;
 
 const ComparisonContainer = styled(Flex)`


### PR DESCRIPTION
Improve UI layout for build removal button

Added a `Flex` container with `justify="end"` around the remove button in the `BuildButton` component to ensure proper alignment of the close icon. This pushes the remove button to the right side of the container, creating a more balanced and visually appealing layout.

## Before

![Screenshot 2025-12-18 at 11.49.31.png](https://app.graphite.com/user-attachments/assets/52a61918-1955-41c3-9fb4-73fc01ebbf30.png)

## After 

<img width="315" height="71" alt="Screenshot 2025-12-18 at 13 10 30" src="https://github.com/user-attachments/assets/8b087c69-6bf0-46f1-bab2-2ebe16ec68a4" />

## Hover 

Button is aligned outside the clipped container to ensure internal padding for button is not clipped but the icon is still visually right aligned.

<img width="324" height="76" alt="Screenshot 2025-12-18 at 13 10 36" src="https://github.com/user-attachments/assets/ebf59169-71fd-4d33-91ae-cf7f249a9bd7" />

## Mobile

On mobile the buttons stretch to fill their parent here the button can be seen right aligned.

<img width="599" height="76" alt="Screenshot 2025-12-18 at 13 10 52" src="https://github.com/user-attachments/assets/83c7397c-b6f7-4eab-a0ee-510f876dcb93" />

## Clipped 

On a constrained width environment the content is correctly clipped the close button remains unclipped and tappable, the button is also opaque so the icon is fully visible when overlapping clipped content.

<img width="224" height="68" alt="Screenshot 2025-12-18 at 13 11 05" src="https://github.com/user-attachments/assets/61b71905-7427-4a36-b3b7-42c291e9dc27" />

