### PR TITLE
fix(insights): Update supported browsers for web vitals

### DIFF
--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -38,7 +38,13 @@ export const vitalStateIcons: Record<VitalState, React.ReactNode> = {
 };
 
 export const vitalSupportedBrowsers: Partial<Record<WebVital, Browser[]>> = {
-  [WebVital.LCP]: [Browser.CHROME, Browser.EDGE, Browser.OPERA, Browser.FIREFOX],
+  [WebVital.LCP]: [
+    Browser.CHROME,
+    Browser.EDGE,
+    Browser.OPERA,
+    Browser.FIREFOX,
+    Browser.SAFARI,
+  ],
   [WebVital.FID]: [
     Browser.CHROME,
     Browser.EDGE,
@@ -64,5 +70,11 @@ export const vitalSupportedBrowsers: Partial<Record<WebVital, Browser[]>> = {
     Browser.SAFARI,
     Browser.IE,
   ],
-  [WebVital.INP]: [Browser.CHROME, Browser.EDGE, Browser.OPERA],
+  [WebVital.INP]: [
+    Browser.CHROME,
+    Browser.EDGE,
+    Browser.OPERA,
+    Browser.FIREFOX,
+    Browser.SAFARI,
+  ],
 };


### PR DESCRIPTION
- Safari [released](https://web.dev/blog/lcp-and-inp-are-now-baseline-newly-available?hl=en) support for INP and LCP with version `26.2` in December
- Firefox [released](https://blog.mozilla.org/performance/2025/10/15/firefox-144-ships-interactionid-for-inp/) support for INP in versino `144` in october

This PR updates our supported/not supported list in our insight detail panels:

before:
<img width="866" height="283" alt="image" src="https://github.com/user-attachments/assets/962f291f-3c54-44bd-b4ae-81fe6a164731" />
<img width="838" height="185" alt="image" src="https://github.com/user-attachments/assets/ff7083d3-d93d-4c64-afd2-61cf9e41c1bf" />


after:
<img width="855" height="206" alt="image" src="https://github.com/user-attachments/assets/f78825c2-ea44-4f68-9e7f-7fd4ca1c7b8f" />
<img width="849" height="185" alt="image" src="https://github.com/user-attachments/assets/42ed0370-c79c-4d13-82be-64b0267bcbcb" />
