### PR TITLE
fix(preprod): Align buttons

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -136,6 +136,7 @@ function BuildButton({
 const StyledLinkButton = styled(LinkButton)`
   height: auto;
   min-height: auto;
+  align-self: stretch;
 
   /* Override ButtonLabel overflow to allow close button to extend beyond */
   > span:last-child {
@@ -162,15 +163,13 @@ const CloseButtonWrapper = styled('div')`
 
 const ComparisonContainer = styled(Flex)`
   flex-wrap: wrap;
-  align-items: stretch;
+  align-items: center;
   justify-content: center;
   gap: ${p => p.theme.space.lg};
   width: 100%;
 
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     flex-direction: column;
-    gap: ${p => p.theme.space.md};
-    padding-bottom: ${p => p.theme.space.lg};
 
     > * {
       min-width: 0;
@@ -210,9 +209,7 @@ export function SizeCompareSelectedBuilds({
         projectType={projectType}
       />
 
-      <Flex align="center">
-        <Text>{t('vs')}</Text>
-      </Flex>
+      <Text>{t('vs')}</Text>
 
       {baseBuildDetails ? (
         <BuildButton
@@ -224,11 +221,9 @@ export function SizeCompareSelectedBuilds({
           projectType={projectType}
         />
       ) : (
-        <Flex align="center">
-          <SelectBuild>
-            <Text size="sm">{t('Select a build')}</Text>
-          </SelectBuild>
-        </Flex>
+        <SelectBuild>
+          <Text size="sm">{t('Select a build')}</Text>
+        </SelectBuild>
       )}
 
       {onTriggerComparison && (


### PR DESCRIPTION
Wide before/after:
<img width="2458" height="420" alt="CleanShot 2025-12-18 at 14 54 19@2x" src="https://github.com/user-attachments/assets/633bc41f-2fc3-4e37-b9d5-a085cefd5fd4" />
<img width="2450" height="342" alt="CleanShot 2025-12-18 at 14 53 42@2x" src="https://github.com/user-attachments/assets/d5e05c19-99e9-4eff-b998-6224d0c443ad" />



Mobile before/after:
<img width="1308" height="658" alt="CleanShot 2025-12-18 at 14 54 33@2x" src="https://github.com/user-attachments/assets/d9d21e02-d723-4822-9e26-1033f1a29724" />
<img width="1278" height="708" alt="CleanShot 2025-12-18 at 14 50 41@2x" src="https://github.com/user-attachments/assets/d5c47179-9371-491d-9dbb-00576b61dc3f" />

