### PR TITLE
fix(dynamic-sampling): don't query snuba for empty sets in boost_low_volume_projects

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -284,7 +284,7 @@ def query_project_counts_by_org(
 
     Yields chunks of result rows, to allow timeouts to be handled in the caller.
     """
-    if not org_ids:
+    if not org_ids and options.get("dynamic-sampling.skip_snuba_query_for_empty_orgs"):
         return
 
     if query_interval is None:

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -300,10 +300,6 @@ def query_project_counts_by_org(
         amount=len(org_ids),
         tags={"measure": str(measure.value)},
     )
-    metrics.incr(
-        "dynamic_sampling.query_project_counts_by_org.invocations",
-        tags={"measure": str(measure.value), "empty_org_ids": str(len(org_ids) == 0)},
-    )
 
     org_ids = list(org_ids)
     project_ids = list(

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -284,6 +284,9 @@ def query_project_counts_by_org(
 
     Yields chunks of result rows, to allow timeouts to be handled in the caller.
     """
+    if not org_ids:
+        return
+
     if query_interval is None:
         query_interval = timedelta(hours=1)
 
@@ -296,6 +299,10 @@ def query_project_counts_by_org(
         "dynamic_sampling.query_project_counts_by_org.count",
         amount=len(org_ids),
         tags={"measure": str(measure.value)},
+    )
+    metrics.incr(
+        "dynamic_sampling.query_project_counts_by_org.invocations",
+        tags={"measure": str(measure.value), "empty_org_ids": str(len(org_ids) == 0)},
     )
 
     org_ids = list(org_ids)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2232,6 +2232,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Skip Snuba query when there are no orgs to query for. This is a rollout flag for a fix
+# that prevents unnecessary Snuba queries.
+register(
+    "dynamic-sampling.skip_snuba_query_for_empty_orgs",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # === Hybrid cloud subsystem options ===
 # UI rollout
 register(

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
@@ -374,19 +374,20 @@ class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase,
     def now(self) -> datetime:
         return MOCK_DATETIME
 
-    def test_query_skips_for_empty_org_ids(self) -> None:
+    def test_query_skips_for_empty_org_ids_when_option_enabled(self) -> None:
         """
         Confirms that query_project_counts_by_org does NOT make a Snuba query
-        when called with an empty org_ids list.
+        when called with an empty org_ids list and the option is enabled.
         """
-        with patch(
-            "sentry.dynamic_sampling.tasks.boost_low_volume_projects.raw_snql_query"
-        ) as mock_query:
-            mock_query.return_value = {"data": []}
+        with self.options({"dynamic-sampling.skip_snuba_query_for_empty_orgs": True}):
+            with patch(
+                "sentry.dynamic_sampling.tasks.boost_low_volume_projects.raw_snql_query"
+            ) as mock_query:
+                mock_query.return_value = {"data": []}
 
-            list(query_project_counts_by_org([], SamplingMeasure.TRANSACTIONS))
+                list(query_project_counts_by_org([], SamplingMeasure.TRANSACTIONS))
 
-            assert mock_query.call_count == 0
+                assert mock_query.call_count == 0
 
     def test_fetch_projects_only_queries_measures_with_orgs(self) -> None:
         """
@@ -415,6 +416,7 @@ class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase,
                 {
                     "dynamic-sampling.check_span_feature_flag": True,
                     "dynamic-sampling.measure.spans": [org.id],
+                    "dynamic-sampling.skip_snuba_query_for_empty_orgs": True,
                 }
             ):
                 partitioned = partition_by_measure([org.id])
@@ -448,6 +450,7 @@ class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase,
                 {
                     "dynamic-sampling.check_span_feature_flag": True,
                     "dynamic-sampling.measure.spans": [org1.id, org2.id],
+                    "dynamic-sampling.skip_snuba_query_for_empty_orgs": True,
                 }
             ):
                 batches = [[org1.id], [org2.id]]


### PR DESCRIPTION
- We've been wondering why we see the same amount of queries for both measures in boost_low_volume_projects
- Decided to go deep into the code, found that we query for empty org lists - this PR fixes that by returning an empty list early, and adds tests to verify it
- For the record: tests failed before making the change, so we know that this was causing the behaviour

Closes TET-1342