### PR TITLE
feat(explore): Save case sensitivity and add multi-query case sensitive support

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -82,13 +82,13 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
 
   const spanSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps = useMemo(
     () => ({
+      ...props,
       itemType: TraceItemDataset.SPANS,
       numberAttributes,
       stringAttributes: stringAttributesWithSemver,
       numberSecondaryAliases,
       stringSecondaryAliases,
-      caseInsensitive: props.caseInsensitive ?? null,
-      ...props,
+      caseInsensitive: props.caseInsensitive ? true : undefined,
     }),
     [
       numberAttributes,
@@ -100,14 +100,14 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
   );
 
   const spanSearchQueryBuilderProviderProps = useTraceItemSearchQueryBuilderProps({
+    ...props,
     itemType: TraceItemDataset.SPANS,
     numberAttributes,
     stringAttributes: stringAttributesWithSemver,
     numberSecondaryAliases,
     stringSecondaryAliases,
-    caseInsensitive: props.caseInsensitive,
+    caseInsensitive: props.caseInsensitive ? true : undefined,
     onCaseInsensitiveClick: props.onCaseInsensitiveClick,
-    ...props,
   });
 
   return useMemo(

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -1,6 +1,8 @@
 import {useMemo} from 'react';
 
 import {STATIC_SEMVER_TAGS} from 'sentry/components/events/searchBarFieldConstants';
+import type {SearchQueryBuilderProps} from 'sentry/components/searchQueryBuilder';
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
 import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
@@ -33,10 +35,12 @@ export interface UseSpanSearchQueryBuilderProps {
   initialQuery: string;
   searchSource: string;
   autoFocus?: boolean;
+  caseInsensitive?: CaseInsensitive;
   datetime?: PageFilters['datetime'];
   disableLoadingTags?: boolean;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   onBlur?: (query: string, state: CallbackSearchState) => void;
+  onCaseInsensitiveClick?: SearchQueryBuilderProps['onCaseInsensitiveClick'];
   onChange?: (query: string, state: CallbackSearchState) => void;
   onSearch?: (query: string, state: CallbackSearchState) => void;
   placeholder?: string;
@@ -83,6 +87,7 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
       stringAttributes: stringAttributesWithSemver,
       numberSecondaryAliases,
       stringSecondaryAliases,
+      caseInsensitive: props.caseInsensitive ?? null,
       ...props,
     }),
     [
@@ -100,6 +105,8 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
     stringAttributes: stringAttributesWithSemver,
     numberSecondaryAliases,
     stringSecondaryAliases,
+    caseInsensitive: props.caseInsensitive,
+    onCaseInsensitiveClick: props.onCaseInsensitiveClick,
     ...props,
   });
 

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -12,10 +12,7 @@ import * as Sentry from '@sentry/react';
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import type {SearchQueryBuilderProps} from 'sentry/components/searchQueryBuilder';
-import type {
-  CaseInsensitive,
-  SetCaseInsensitive,
-} from 'sentry/components/searchQueryBuilder/hooks';
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {useHandleSearch} from 'sentry/components/searchQueryBuilder/hooks/useHandleSearch';
 import {
   useQueryBuilderState,
@@ -73,7 +70,7 @@ interface SearchQueryBuilderContextData {
   filterKeyAliases?: TagCollection;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   namespace?: string;
-  onCaseInsensitiveClick?: SetCaseInsensitive;
+  onCaseInsensitiveClick?: (value: CaseInsensitive) => void;
   placeholder?: string;
   /**
    * The element to render the combobox popovers into.

--- a/static/app/components/searchQueryBuilder/hooks.ts
+++ b/static/app/components/searchQueryBuilder/hooks.ts
@@ -12,5 +12,3 @@ export function useCaseInsensitivity() {
 }
 
 export type CaseInsensitive = ReturnType<typeof useCaseInsensitivity>[0];
-
-export type SetCaseInsensitive = ReturnType<typeof useCaseInsensitivity>[1];

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -11,10 +11,7 @@ import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilder,
 } from 'sentry/components/searchQueryBuilder/context';
-import type {
-  CaseInsensitive,
-  SetCaseInsensitive,
-} from 'sentry/components/searchQueryBuilder/hooks';
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {useOnChange} from 'sentry/components/searchQueryBuilder/hooks/useOnChange';
 import {PlainTextQueryInput} from 'sentry/components/searchQueryBuilder/plainTextQueryInput';
 import {TokenizedQueryGrid} from 'sentry/components/searchQueryBuilder/tokenizedQueryGrid';
@@ -141,7 +138,7 @@ export interface SearchQueryBuilderProps {
    * When passed, this will display the case sensitivity toggle, and will be called when
    * the user clicks on the case sensitivity button.
    */
-  onCaseInsensitiveClick?: SetCaseInsensitive;
+  onCaseInsensitiveClick?: (value: CaseInsensitive) => void;
   /**
    * Called when the query value changes
    */

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.spec.tsx
@@ -140,7 +140,7 @@ describe('useFetchEventsTimeSeries', () => {
           interval: '1h',
           query: 'span.op:db*',
           sampling: 'NORMAL',
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -194,7 +194,7 @@ describe('useFetchEventsTimeSeries', () => {
           project: [420],
           interval: '2h',
           sampling: 'NORMAL',
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -244,7 +244,7 @@ describe('useFetchEventsTimeSeries', () => {
           topEvents: 5,
           groupBy: ['span.category', 'transaction'],
           sort: '-p50(span.duration)',
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -169,7 +169,7 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
               ? '0'
               : '1'
             : undefined,
-          caseInsensitive: caseInsensitive ? 1 : 0,
+          caseInsensitive: caseInsensitive ? 1 : undefined,
           logQuery: logQueryParams,
           metricQuery: metricQueryParams,
           spanQuery: spanQueryParams,

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -1,11 +1,11 @@
 import {useMemo} from 'react';
 
 import type {SpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
-import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
-import type {
-  CaseInsensitive,
-  SetCaseInsensitive,
-} from 'sentry/components/searchQueryBuilder/hooks';
+import {
+  SearchQueryBuilder,
+  type SearchQueryBuilderProps,
+} from 'sentry/components/searchQueryBuilder';
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {t} from 'sentry/locale';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import type {AggregationKey} from 'sentry/utils/fields';
@@ -27,7 +27,7 @@ export type TraceItemSearchQueryBuilderProps = {
   disabled?: boolean;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   namespace?: string;
-  onCaseInsensitiveClick?: SetCaseInsensitive;
+  onCaseInsensitiveClick?: SearchQueryBuilderProps['onCaseInsensitiveClick'];
   replaceRawSearchKeys?: string[];
 } & Omit<SpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useMemo} from 'react';
 
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import type {DateString} from 'sentry/types/core';
 import type {User} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
@@ -40,6 +41,7 @@ type ReadableQuery = {
   // - `aggregateField` which contains a list of group bys and visualizes merged together
   // - `groupby` and `visualize` which contains the group bys and visualizes separately
   aggregateField?: Array<RawGroupBy | RawVisualize>;
+  caseInsensitive?: CaseInsensitive;
 
   groupby?: string[];
   // Only used for metrics dataset.
@@ -53,7 +55,7 @@ export class SavedQueryQuery {
   mode: Mode;
   orderby: string;
   query: string;
-
+  caseInsensitive?: CaseInsensitive;
   aggregateField: Array<RawGroupBy | RawVisualize>;
   groupby: string[];
   visualize: RawVisualize[];
@@ -66,7 +68,7 @@ export class SavedQueryQuery {
     this.mode = query.mode;
     this.orderby = query.orderby;
     this.query = query.query;
-
+    this.caseInsensitive = query.caseInsensitive;
     // for compatibility, we ensure that aggregate fields, group bys and visualizes are all populated
     // we ensure that group bys + visualizes = aggregate fields
     this.groupby =
@@ -107,6 +109,7 @@ export type ReadableSavedQuery = {
   projects: number[];
   query: [ReadableQuery, ...ReadableQuery[]];
   starred: boolean;
+  caseInsensitive?: CaseInsensitive;
   changedReason?: ExploreQueryChangedReason | null;
   createdBy?: User;
   end?: string;

--- a/static/app/views/explore/hooks/useSaveMultiQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveMultiQuery.tsx
@@ -50,6 +50,7 @@ export function useSaveMultiQuery() {
         orderby: q.sortBys[0] ? encodeSort(q.sortBys[0]) : undefined, // Explore only handles a single sort by
         query: q.query ?? '',
         mode: q.groupBys.length > 0 ? 'aggregate' : 'samples',
+        caseInsensitive: q.caseInsensitive ? '1' : undefined,
       })),
     };
   }, [title, start, end, period, interval, projects, environments, queries]);

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useMemo} from 'react';
 
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {DateString} from 'sentry/types/core';
 import {encodeSort} from 'sentry/utils/discover/eventView';
 import useApi from 'sentry/utils/useApi';
@@ -41,6 +42,7 @@ type ExploreSavedQueryRequest = {
     mode: Mode;
     aggregateField?: Array<{groupBy: string} | {yAxes: string[]; chartType?: number}>;
     aggregateOrderby?: string;
+    caseInsensitive?: '1';
     fields?: string[];
     groupby?: string[];
     orderby?: string;
@@ -60,6 +62,7 @@ function useSavedQueryForDataset(dataset: 'spans' | 'logs') {
   const queryParams = useQueryParams();
   const {id, title} = queryParams;
 
+  const [caseInsensitivity] = useCaseInsensitivity();
   const {saveQueryFromSavedQuery, updateQueryFromSavedQuery} = useFromSavedQuery();
 
   const requestData = useMemo((): ExploreSavedQueryRequest => {
@@ -69,8 +72,9 @@ function useSavedQueryForDataset(dataset: 'spans' | 'logs') {
       pageFilters,
       interval,
       title: title ?? '',
+      caseInsensitivity: caseInsensitivity ? '1' : undefined,
     });
-  }, [dataset, queryParams, pageFilters, interval, title]);
+  }, [dataset, queryParams, pageFilters, interval, title, caseInsensitivity]);
 
   const {saveQueryApi, updateQueryApi} = useCreateOrUpdateSavedQuery(id);
 
@@ -200,12 +204,14 @@ function convertQueryParamsToRequest({
   pageFilters,
   interval,
   title,
+  caseInsensitivity,
 }: {
   dataset: 'spans' | 'logs';
   interval: string;
   pageFilters: ReturnType<typeof usePageFilters>;
   queryParams: ReadableQueryParams;
   title: string;
+  caseInsensitivity?: '1';
 }): ExploreSavedQueryRequest {
   const {selection} = pageFilters;
   const {datetime, projects, environments} = selection;
@@ -253,6 +259,7 @@ function convertQueryParamsToRequest({
         query,
         mode,
         aggregateField: aggregateFields,
+        caseInsensitive: caseInsensitivity,
       },
     ],
   };

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -62,7 +62,7 @@ function useSavedQueryForDataset(dataset: 'spans' | 'logs') {
   const queryParams = useQueryParams();
   const {id, title} = queryParams;
 
-  const [caseInsensitivity] = useCaseInsensitivity();
+  const [caseInsensitive] = useCaseInsensitivity();
   const {saveQueryFromSavedQuery, updateQueryFromSavedQuery} = useFromSavedQuery();
 
   const requestData = useMemo((): ExploreSavedQueryRequest => {
@@ -72,9 +72,9 @@ function useSavedQueryForDataset(dataset: 'spans' | 'logs') {
       pageFilters,
       interval,
       title: title ?? '',
-      caseInsensitivity: caseInsensitivity ? '1' : undefined,
+      caseInsensitive: caseInsensitive ? '1' : undefined,
     });
-  }, [dataset, queryParams, pageFilters, interval, title, caseInsensitivity]);
+  }, [dataset, queryParams, pageFilters, interval, title, caseInsensitive]);
 
   const {saveQueryApi, updateQueryApi} = useCreateOrUpdateSavedQuery(id);
 
@@ -204,14 +204,14 @@ function convertQueryParamsToRequest({
   pageFilters,
   interval,
   title,
-  caseInsensitivity,
+  caseInsensitive,
 }: {
   dataset: 'spans' | 'logs';
   interval: string;
   pageFilters: ReturnType<typeof usePageFilters>;
   queryParams: ReadableQueryParams;
   title: string;
-  caseInsensitivity?: '1';
+  caseInsensitive?: '1';
 }): ExploreSavedQueryRequest {
   const {selection} = pageFilters;
   const {datetime, projects, environments} = selection;
@@ -259,7 +259,7 @@ function convertQueryParamsToRequest({
         query,
         mode,
         aggregateField: aggregateFields,
-        caseInsensitive: caseInsensitivity,
+        caseInsensitive,
       },
     ],
   };

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -214,7 +214,7 @@ describe('LogsPage', () => {
         `/organizations/${organization.slug}/events-timeseries/`,
         expect.objectContaining({
           query: expect.objectContaining({
-            caseInsensitive: 0,
+            caseInsensitive: undefined,
             dataset: 'ourlogs',
             disableAggregateExtrapolation: '0',
             environment: [],

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -195,7 +195,7 @@ describe('LogsTabContent', () => {
       `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         query: expect.objectContaining({
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
           dataset: 'ourlogs',
           disableAggregateExtrapolation: '0',
           environment: [],

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -4,7 +4,7 @@ import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as modal from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -104,7 +104,7 @@ describe('useSaveAsItems', () => {
   });
 
   it('should open save query modal when save as new query is clicked', () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSaveAsItems({
           visualizes: [new VisualizeFunction('count()')],
@@ -114,7 +114,7 @@ describe('useSaveAsItems', () => {
           search: new MutableSearch('message:"test error"'),
           sortBys: [{field: 'timestamp', kind: 'desc'}],
         }),
-      {wrapper: createWrapper()}
+      {additionalWrapper: createWrapper()}
     );
 
     const saveAsItems = result.current;
@@ -162,7 +162,7 @@ describe('useSaveAsItems', () => {
       })
     );
 
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSaveAsItems({
           visualizes: [new VisualizeFunction('count()')],
@@ -172,7 +172,7 @@ describe('useSaveAsItems', () => {
           search: new MutableSearch('message:"test"'),
           sortBys: [{field: 'timestamp', kind: 'desc'}],
         }),
-      {wrapper: createWrapper()}
+      {additionalWrapper: createWrapper()}
     );
 
     await waitFor(() => {
@@ -194,7 +194,7 @@ describe('useSaveAsItems', () => {
       })
     );
 
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSaveAsItems({
           visualizes: [new VisualizeFunction('count()')],
@@ -204,7 +204,7 @@ describe('useSaveAsItems', () => {
           search: new MutableSearch('message:"test"'),
           sortBys: [{field: 'timestamp', kind: 'desc'}],
         }),
-      {wrapper: createWrapper()}
+      {additionalWrapper: createWrapper()}
     );
 
     const saveAsItems = result.current;
@@ -214,7 +214,7 @@ describe('useSaveAsItems', () => {
   });
 
   it('should call saveQuery with correct parameters when modal saves', async () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSaveAsItems({
           visualizes: [new VisualizeFunction('count()')],
@@ -226,7 +226,7 @@ describe('useSaveAsItems', () => {
           search: new MutableSearch('message:"test error"'),
           sortBys: [{field: 'timestamp', kind: 'desc'}],
         }),
-      {wrapper: createWrapper()}
+      {additionalWrapper: createWrapper()}
     );
 
     const saveAsItems = result.current;

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -335,6 +335,7 @@ type BaseGetLogsUrlParams = {
   aggregateFields?: Array<GroupBy | BaseVisualize>;
   aggregateFn?: string;
   aggregateParam?: string;
+  caseInsensitive?: '1' | null;
   field?: string[];
   groupBy?: string[];
   id?: number;
@@ -366,6 +367,7 @@ export function getLogsUrl({
   aggregateFields,
   aggregateFn,
   aggregateParam,
+  caseInsensitive,
 }: BaseGetLogsUrlParams & {organization: Organization | string}) {
   const {start, end, period: statsPeriod, utc} = selection?.datetime ?? {};
   const {environments, projects} = selection ?? {};
@@ -390,6 +392,7 @@ export function getLogsUrl({
     [LOGS_AGGREGATE_FN_KEY]: aggregateFn,
     [LOGS_AGGREGATE_PARAM_KEY]: aggregateParam,
     title,
+    caseInsensitive,
   };
 
   const orgSlug = typeof organization === 'string' ? organization : organization.slug;
@@ -444,6 +447,7 @@ export function getLogsUrlFromSavedQueryUrl({
       environments: savedQuery.environment ? [...savedQuery.environment] : [],
       projects: savedQuery.projects ? [...savedQuery.projects] : [],
     },
+    caseInsensitive: firstQuery.caseInsensitive ? '1' : null,
   });
 }
 

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -680,6 +680,52 @@ describe('MultiQueryModeContent', () => {
     ]);
   });
 
+  it('allows changing case insensitivity', async () => {
+    let queries: any;
+    function Component() {
+      queries = useReadQueriesFromLocation();
+      return <MultiQueryModeContent />;
+    }
+
+    render(
+      <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+        <Component />
+      </TraceItemAttributeProvider>
+    );
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    await userEvent.click(screen.getByLabelText('Ignore case'));
+    expect(queries).toEqual([
+      {
+        caseInsensitive: '1',
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+  });
+
   it('allows adding a query', async () => {
     let queries: any;
     function Component() {

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -995,7 +995,7 @@ describe('MultiQueryModeContent', () => {
         `/organizations/${organization.slug}/events-timeseries/`,
         expect.objectContaining({
           query: expect.objectContaining({
-            caseInsensitive: 0,
+            caseInsensitive: undefined,
             dataset: 'spans',
             disableAggregateExtrapolation: '0',
             environment: [],
@@ -1049,7 +1049,7 @@ describe('MultiQueryModeContent', () => {
         `/organizations/${organization.slug}/events-timeseries/`,
         expect.objectContaining({
           query: expect.objectContaining({
-            caseInsensitive: 0,
+            caseInsensitive: undefined,
             dataset: 'spans',
             disableAggregateExtrapolation: '0',
             environment: [],

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
@@ -100,7 +100,13 @@ function useMultiQueryTableAggregateModeImpl({
   return {eventView, fields, result};
 }
 
-export function useMultiQueryTableSampleMode({query, yAxes, sortBys, enabled}: Props) {
+export function useMultiQueryTableSampleMode({
+  query,
+  yAxes,
+  sortBys,
+  enabled,
+  queryExtras,
+}: Props) {
   const canTriggerHighAccuracy = useCallback(
     (results: ReturnType<typeof useSpansQuery<any[]>>) => {
       const canGoToHigherAccuracyTier = results.meta?.dataScanned === 'partial';
@@ -111,7 +117,7 @@ export function useMultiQueryTableSampleMode({query, yAxes, sortBys, enabled}: P
   );
   return useProgressiveQuery({
     queryHookImplementation: useMultiQueryTableSampleModeImpl,
-    queryHookArgs: {query, yAxes, sortBys, enabled},
+    queryHookArgs: {query, yAxes, sortBys, enabled, queryExtras},
     queryOptions: {
       canTriggerHighAccuracy,
     },

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.tsx
@@ -29,6 +29,7 @@ interface UseMultiQueryTimeseriesResults {
 export function useMultiQueryTimeseries({
   enabled,
   index,
+  queryExtras,
 }: UseMultiQueryTimeseriesOptions) {
   const canTriggerHighAccuracy = useCallback(
     (results: ReturnType<typeof useMultiQueryTimeseriesImpl>['result']) => {
@@ -51,7 +52,7 @@ export function useMultiQueryTimeseries({
   );
   return useProgressiveQuery<typeof useMultiQueryTimeseriesImpl>({
     queryHookImplementation: useMultiQueryTimeseriesImpl,
-    queryHookArgs: {enabled, index},
+    queryHookArgs: {enabled, index, queryExtras},
     queryOptions: {
       canTriggerHighAccuracy,
     },

--- a/static/app/views/explore/multiQueryMode/locationUtils.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.tsx
@@ -28,6 +28,7 @@ export type ReadableExploreQueryParts = {
   query: string;
   sortBys: Sort[];
   yAxes: string[];
+  caseInsensitive?: '1' | null;
   chartType?: ChartType;
 };
 
@@ -104,6 +105,8 @@ function parseQuery(raw: string): ReadableExploreQueryParts {
     const parsedSortBys = decodeSorts(parsed.sortBys);
     const sortBys = validateSortBys(parsedSortBys, groupBys, fields, yAxes);
 
+    const caseInsensitive = parsed.caseInsensitive ?? undefined;
+
     return {
       yAxes,
       chartType,
@@ -111,6 +114,7 @@ function parseQuery(raw: string): ReadableExploreQueryParts {
       query: parsed.query ?? '',
       groupBys,
       fields,
+      caseInsensitive,
     };
   } catch (error) {
     return DEFAULT_QUERY;
@@ -136,6 +140,7 @@ export function useReadQueriesFromLocation(): ReadableExploreQueryParts[] {
 // Write utils begin
 
 type WritableExploreQueryParts = {
+  caseInsensitive?: '1' | null;
   chartType?: ChartType;
   fields?: string[];
   groupBys?: readonly string[];
@@ -148,6 +153,7 @@ function getQueriesAsUrlParam(queries: WritableExploreQueryParts[]): string[] {
   return queries.map(query =>
     JSON.stringify({
       chartType: query.chartType,
+      caseInsensitive: query.caseInsensitive,
       fields: query.fields,
       groupBys: query.groupBys,
       query: query.query,

--- a/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
@@ -1,5 +1,6 @@
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {useSpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {t} from 'sentry/locale';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
@@ -25,6 +26,10 @@ export function SearchBarSection({query, index}: Props) {
     initialQuery: query.query ?? '',
     onSearch: value => updateQuerySearch({query: value}),
     searchSource: 'explore',
+    caseInsensitive: query.caseInsensitive ? true : null,
+    onCaseInsensitiveClick: (value: CaseInsensitive) => {
+      updateQuerySearch({caseInsensitive: value ? '1' : null});
+    },
   });
 
   return (

--- a/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
@@ -28,7 +28,7 @@ export function SearchBarSection({query, index}: Props) {
     searchSource: 'explore',
     caseInsensitive: query.caseInsensitive ? true : null,
     onCaseInsensitiveClick: (value: CaseInsensitive) => {
-      updateQuerySearch({caseInsensitive: value ? '1' : null});
+      updateQuerySearch({caseInsensitive: value ? '1' : undefined});
     },
   });
 

--- a/static/app/views/explore/multiQueryMode/queryRow.tsx
+++ b/static/app/views/explore/multiQueryMode/queryRow.tsx
@@ -30,7 +30,7 @@ type Props = {
 };
 
 export function QueryRow({query: queryParts, index, totalQueryRows}: Props) {
-  const {groupBys, query, yAxes, sortBys} = queryParts;
+  const {groupBys, query, yAxes, sortBys, caseInsensitive} = queryParts;
   const mode = getQueryMode(groupBys);
 
   const aggregatesTableResult = useMultiQueryTableAggregateMode({
@@ -39,6 +39,9 @@ export function QueryRow({query: queryParts, index, totalQueryRows}: Props) {
     yAxes,
     sortBys,
     enabled: mode === Mode.AGGREGATE,
+    queryExtras: {
+      caseInsensitive: caseInsensitive ? true : undefined,
+    },
   });
 
   const spansTableResult = useMultiQueryTableSampleMode({
@@ -47,11 +50,17 @@ export function QueryRow({query: queryParts, index, totalQueryRows}: Props) {
     yAxes,
     sortBys,
     enabled: mode === Mode.SAMPLES,
+    queryExtras: {
+      caseInsensitive: caseInsensitive ? true : undefined,
+    },
   });
 
   const {result: timeseriesResult} = useMultiQueryTimeseries({
     index,
     enabled: true,
+    queryExtras: {
+      caseInsensitive: caseInsensitive ? true : undefined,
+    },
   });
 
   const [interval] = useChartInterval();

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -160,6 +160,7 @@ describe('SavedQueriesTable', () => {
             {
               visualize: [],
               groupby: [],
+              caseInsensitive: true,
             },
             {
               visualize: [],
@@ -174,7 +175,7 @@ describe('SavedQueriesTable', () => {
     });
     expect(await screen.findByText('Query Name')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/traces/compare/?environment=production&id=1&project=1&queries=%7B%22groupBys%22%3A%5B%5D%2C%22yAxes%22%3A%5B%5D%7D&queries=%7B%22groupBys%22%3A%5B%5D%2C%22yAxes%22%3A%5B%5D%7D&title=Query%20Name'
+      '/organizations/org-slug/explore/traces/compare/?environment=production&id=1&project=1&queries=%7B%22groupBys%22%3A%5B%5D%2C%22yAxes%22%3A%5B%5D%2C%22caseInsensitive%22%3A%221%22%7D&queries=%7B%22groupBys%22%3A%5B%5D%2C%22yAxes%22%3A%5B%5D%7D&title=Query%20Name'
     );
   });
 
@@ -198,6 +199,7 @@ describe('SavedQueriesTable', () => {
               query:
                 'message:"System time zone does not match user preferences time zone"',
               orderby: 'user.email',
+              caseInsensitive: true,
             },
           ],
           range: '1h',
@@ -211,7 +213,7 @@ describe('SavedQueriesTable', () => {
     });
     expect(await screen.findByText('Logs Query Name')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/logs/?aggregateField=%7B%22groupBy%22%3A%22message%22%7D&environment=production&id=1&interval=5m&logsFields=timestamp&logsFields=message&logsFields=user.email&logsQuery=message%3A%22System%20time%20zone%20does%20not%20match%20user%20preferences%20time%20zone%22&logsSortBys=user.email&mode=samples&project=1&statsPeriod=1h&title=Logs%20Query%20Name'
+      '/organizations/org-slug/explore/logs/?aggregateField=%7B%22groupBy%22%3A%22message%22%7D&caseInsensitive=1&environment=production&id=1&interval=5m&logsFields=timestamp&logsFields=message&logsFields=user.email&logsQuery=message%3A%22System%20time%20zone%20does%20not%20match%20user%20preferences%20time%20zone%22&logsSortBys=user.email&mode=samples&project=1&statsPeriod=1h&title=Logs%20Query%20Name'
     );
   });
 

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -13,6 +13,7 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -68,6 +69,7 @@ export function ToolbarSaveAs() {
     () => dedupeArray(visualizes.filter(isVisualizeFunction).map(v => v.yAxis)),
     [visualizes]
   );
+  const [caseInsensitive] = useCaseInsensitivity();
 
   const sortBys = mode === Mode.SAMPLES ? sampleSortBys : aggregateSortBys;
 
@@ -314,6 +316,7 @@ export function ToolbarSaveAs() {
                 sortBys,
                 yAxes: [visualizeYAxes[0]!],
                 chartType: visualizes[0]!.chartType,
+                caseInsensitive: caseInsensitive ? '1' : undefined,
               },
             ],
           })}

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -6,6 +6,7 @@ import {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {isTokenFunction} from 'sentry/components/arithmeticBuilder/token';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {getTooltipText as getAnnotatedTooltipText} from 'sentry/components/events/meta/annotatedText/utils';
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
@@ -68,9 +69,11 @@ export function getExploreUrl({
   table,
   title,
   referrer,
+  caseInsensitive,
 }: {
   organization: Organization;
   aggregateField?: Array<GroupBy | BaseVisualize>;
+  caseInsensitive?: CaseInsensitive;
   field?: string[];
   groupBy?: string[];
   id?: number;
@@ -105,6 +108,7 @@ export function getExploreUrl({
     table,
     title,
     referrer,
+    caseInsensitive: caseInsensitive ? '1' : undefined,
   };
 
   return (
@@ -143,6 +147,7 @@ function getExploreUrlFromSavedQueryUrl({
           yAxes: (visualize?.yAxes ?? []).slice(),
           groupBys: groupBys ?? [],
           sortBys: decodeSorts(q.orderby),
+          caseInsensitive: q.caseInsensitive ? '1' : null,
         };
       }),
       title: savedQuery.name,
@@ -158,6 +163,7 @@ function getExploreUrlFromSavedQueryUrl({
       },
     });
   }
+
   return getExploreUrl({
     organization,
     ...savedQuery,
@@ -210,15 +216,17 @@ export function getExploreMultiQueryUrl({
     start,
     end,
     interval,
-    queries: queries.map(({chartType, fields, groupBys, query, sortBys, yAxes}) =>
-      JSON.stringify({
-        chartType,
-        fields,
-        groupBys,
-        query,
-        sortBys: sortBys[0] ? encodeSort(sortBys[0]) : undefined, // Explore only handles a single sort by
-        yAxes,
-      })
+    queries: queries.map(
+      ({chartType, fields, groupBys, query, sortBys, yAxes, caseInsensitive}) =>
+        JSON.stringify({
+          chartType,
+          fields,
+          groupBys,
+          query,
+          sortBys: sortBys[0] ? encodeSort(sortBys[0]) : undefined, // Explore only handles a single sort by
+          yAxes,
+          caseInsensitive: caseInsensitive ? '1' : undefined,
+        })
     ),
     title,
     id,

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -95,7 +95,7 @@ describe('CacheLandingPage', () => {
           referrer: 'api.insights.cache.landing-cache-throughput-chart',
           statsPeriod: '10d',
           yAxis: ['epm()'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -141,7 +141,7 @@ describe('DatabaseLandingPage', () => {
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: ['epm()'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -167,7 +167,7 @@ describe('DatabaseLandingPage', () => {
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: ['avg(span.self_time)'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -260,7 +260,7 @@ describe('DatabaseLandingPage', () => {
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: ['epm()'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -286,7 +286,7 @@ describe('DatabaseLandingPage', () => {
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: ['avg(span.self_time)'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -261,7 +261,7 @@ describe('DatabaseSpanSummaryPage', () => {
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: ['epm()'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -287,7 +287,7 @@ describe('DatabaseSpanSummaryPage', () => {
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: ['avg(span.self_time)'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -240,7 +240,7 @@ describe('HTTPSamplesPanel', () => {
             statsPeriod: '10d',
             topEvents: 5,
             yAxis: ['count()'],
-            caseInsensitive: 0,
+            caseInsensitive: undefined,
           },
         })
       );
@@ -397,7 +397,7 @@ describe('HTTPSamplesPanel', () => {
             referrer: 'api.insights.http.samples-panel-duration-chart',
             statsPeriod: '10d',
             yAxis: ['avg(span.self_time)'],
-            caseInsensitive: 0,
+            caseInsensitive: undefined,
           }),
         })
       );

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -207,7 +207,7 @@ describe('HTTPDomainSummaryPage', () => {
             referrer: 'api.insights.http.domain-summary-throughput-chart',
             statsPeriod: '10d',
             yAxis: ['epm()'],
-            caseInsensitive: 0,
+            caseInsensitive: undefined,
           },
         })
       );
@@ -231,7 +231,7 @@ describe('HTTPDomainSummaryPage', () => {
           referrer: 'api.insights.http.domain-summary-duration-chart',
           statsPeriod: '10d',
           yAxis: ['avg(span.self_time)'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -258,7 +258,7 @@ describe('HTTPDomainSummaryPage', () => {
             'http_response_rate(4)',
             'http_response_rate(5)',
           ],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -261,7 +261,7 @@ describe('HTTPLandingPage', () => {
           referrer: 'api.insights.http.landing-throughput-chart',
           statsPeriod: '10d',
           yAxis: ['epm()'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -303,7 +303,7 @@ describe('HTTPLandingPage', () => {
           referrer: 'api.insights.http.landing-duration-chart',
           statsPeriod: '10d',
           yAxis: ['avg(span.self_time)'],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );
@@ -330,7 +330,7 @@ describe('HTTPLandingPage', () => {
             'http_response_rate(4)',
             'http_response_rate(5)',
           ],
-          caseInsensitive: 0,
+          caseInsensitive: undefined,
         },
       })
     );


### PR DESCRIPTION
This PR adds in the ability for saved queries to pass along the case sensitive param so that users can store that state. 

This PR also adds in support for case insensitive search to the compare queries page.

Tickets: EXP-661, EXP-669