### PR TITLE
chore(llm-detector): Add deduplication of trace ids

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -234,6 +234,15 @@ def detect_llm_issues_for_project(project_id: int) -> None:
     if not evidence_traces:
         return
 
+    logger.info(
+        "Getting traces for detection",
+        extra={
+            "organization_id": organization_id,
+            "project_id": project_id,
+            "num_traces": len(evidence_traces),
+            "num_unique_traces": len({trace.trace_id for trace in evidence_traces}),
+        },
+    )
     # Shuffle to randomize order
     random.shuffle(evidence_traces)
     processed_traces = 0

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -242,6 +242,15 @@ def detect_llm_issues_for_project(project_id: int) -> None:
         if processed_traces >= NUM_TRANSACTIONS_TO_PROCESS:
             break
 
+        logger.info(
+            "Sending Seer Request for Detection",
+            extra={
+                "trace_id": trace.trace_id,
+                "transaction_name": trace.transaction_name,
+                "organization_id": organization_id,
+                "project_id": project_id,
+            },
+        )
         seer_request = IssueDetectionRequest(
             traces=[trace],
             organization_id=organization_id,

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -69,6 +69,7 @@ def get_project_top_transaction_traces_for_llm_detection(
 
     trace_metadata = []
     seen_names = set()
+    seen_trace_ids = set()
 
     for row in transactions_result.get("data", []):
         transaction_name = row.get("transaction")
@@ -101,6 +102,9 @@ def get_project_top_transaction_traces_for_llm_detection(
         if not trace_id:
             continue
 
+        if trace_id in seen_trace_ids:
+            continue
+
         trace_metadata.append(
             TraceMetadata(
                 trace_id=trace_id,
@@ -108,5 +112,6 @@ def get_project_top_transaction_traces_for_llm_detection(
             )
         )
         seen_names.add(normalized_name)
+        seen_trace_ids.add(trace_id)
 
     return trace_metadata


### PR DESCRIPTION
the way we are currently doing the lookup for traces could return the same trace id for two different transactions. adds in some logic to make sure the IDs are unique. adds some logs to confirm
