### PR TITLE
feat(build-comparison): Synchronizes the hide small changes switch with a url query param to ensure state is preserved in browser history

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -1,5 +1,6 @@
 import {useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
+import {parseAsBoolean, useQueryState} from 'nuqs';
 
 import {Button} from '@sentry/scraps/button';
 import {InputGroup} from '@sentry/scraps/input/inputGroup';
@@ -48,7 +49,10 @@ export function SizeCompareMainContent() {
   const navigate = useNavigate();
   const theme = useTheme();
   const [isFilesExpanded, setIsFilesExpanded] = useState(true);
-  const [hideSmallChanges, setHideSmallChanges] = useState(true);
+  const [hideSmallChanges, setHideSmallChanges] = useQueryState(
+    'hideSmallChanges',
+    parseAsBoolean.withDefault(true)
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const {baseArtifactId, headArtifactId, projectId} = useParams<{
     baseArtifactId: string;
@@ -314,7 +318,7 @@ export function SizeCompareMainContent() {
               <SizeCompareItemDiffTable
                 diffItems={filteredDiffItems}
                 originalItemCount={comparisonDataQuery.data?.diff_items.length ?? 0}
-                disableHideSmallChanges={() => setHideSmallChanges(!hideSmallChanges)}
+                disableHideSmallChanges={() => setHideSmallChanges(false)}
               />
             </Stack>
           )}


### PR DESCRIPTION
This pull request updates the `SizeCompareMainContent` component to improve how the "hide small changes" state is managed and synchronized with the URL. The changes ensure that the state persists in the URL, allowing for better navigation and sharing of filtered views.

State management and URL synchronization improvements:

* Replaced the local `useState` for `hideSmallChanges` with `useQueryState` from `nuqs`, synchronizing the state with the URL query parameter and providing a default value of `true`. [[1]](diffhunk://#diff-3bedf9ecc117b9b42a4854bad0624fe904f0778587d1a04c0836d1ed3f6e9ca3R3) [[2]](diffhunk://#diff-3bedf9ecc117b9b42a4854bad0624fe904f0778587d1a04c0836d1ed3f6e9ca3L51-R55)
* Updated the `disableHideSmallChanges` handler to explicitly set `hideSmallChanges` to `false`, ensuring consistent behavior with the new state management approach.