### PR TITLE
fix(tracemetrics): Hide hidden fields in fields that display attributes

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -36,6 +36,7 @@ import {
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -82,9 +83,17 @@ function TraceMetricsSearchBar({
   };
 
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
-    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
+    useTraceItemAttributesWithConfig(
+      traceItemAttributeConfig,
+      'string',
+      HiddenTraceMetricGroupByFields
+    );
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
-    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
+    useTraceItemAttributesWithConfig(
+      traceItemAttributeConfig,
+      'number',
+      HiddenTraceMetricGroupByFields
+    );
 
   return (
     <TraceItemSearchQueryBuilder

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -36,7 +36,7 @@ import {
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
+import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -86,13 +86,13 @@ function TraceMetricsSearchBar({
     useTraceItemAttributesWithConfig(
       traceItemAttributeConfig,
       'string',
-      HiddenTraceMetricGroupByFields
+      HiddenTraceMetricSearchFields
     );
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceItemAttributesWithConfig(
       traceItemAttributeConfig,
       'number',
-      HiddenTraceMetricGroupByFields
+      HiddenTraceMetricSearchFields
     );
 
   return (

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
@@ -202,4 +202,44 @@ describe('WidgetBuilderGroupBySelector', () => {
     const selectInput = await screen.findByRole('textbox');
     expect(selectInput).toBeEnabled();
   });
+
+  it('hides group by fields that are hidden in the trace metrics dataset', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {
+          key: 'metric.name',
+          name: 'metric.name',
+        },
+      ],
+    });
+
+    render(
+      <WidgetBuilderProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.TRACEMETRICS} enabled>
+          <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
+        </TraceItemAttributeProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {
+              dataset: WidgetType.TRACEMETRICS,
+              displayType: DisplayType.LINE,
+            },
+          },
+        },
+      }
+    );
+
+    expect(await screen.findByText('Group by')).toBeInTheDocument();
+    expect(await screen.findByText('Select group')).toBeInTheDocument();
+    expect(await screen.findByText('+ Add Group')).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByText('Select group'));
+
+    expect(screen.queryByText('metric.name')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -15,6 +15,7 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {useDisableTransactionWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useDisableTransactionWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 
 interface WidgetBuilderGroupBySelectorProps {
   validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
@@ -29,8 +30,13 @@ function WidgetBuilderGroupBySelector({
   const organization = useOrganization();
 
   const tags: TagCollection = useTags();
-  const {tags: numericSpanTags} = useTraceItemTags('number');
-  const {tags: stringSpanTags} = useTraceItemTags('string');
+
+  let hiddenKeys: string[] = [];
+  if (state.dataset === WidgetType.TRACEMETRICS) {
+    hiddenKeys = HiddenTraceMetricGroupByFields;
+  }
+  const {tags: numericSpanTags} = useTraceItemTags('number', hiddenKeys);
+  const {tags: stringSpanTags} = useTraceItemTags('string', hiddenKeys);
 
   const groupByOptions = useMemo(() => {
     const datasetConfig = getDatasetConfig(state.dataset);

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -26,6 +26,7 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/utils';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 
 function WidgetBuilderSortBySelector() {
   const {state, dispatch} = useWidgetBuilderContext();
@@ -37,8 +38,12 @@ function WidgetBuilderSortBySelector() {
   const datasetConfig = getDatasetConfig(state.dataset);
 
   let tags: TagCollection = useTags();
-  const {tags: numericSpanTags} = useTraceItemTags('number');
-  const {tags: stringSpanTags} = useTraceItemTags('string');
+  let hiddenKeys: string[] = [];
+  if (state.dataset === WidgetType.TRACEMETRICS) {
+    hiddenKeys = HiddenTraceMetricGroupByFields;
+  }
+  const {tags: numericSpanTags} = useTraceItemTags('number', hiddenKeys);
+  const {tags: stringSpanTags} = useTraceItemTags('string', hiddenKeys);
   if (
     state.dataset === WidgetType.SPANS ||
     state.dataset === WidgetType.LOGS ||

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -63,6 +63,7 @@ import {validateColumnTypes} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 
 export const NONE = 'none';
 
@@ -282,8 +283,12 @@ function Visualize({error, setError}: VisualizeProps) {
   const isChartWidget = isChartDisplayType(state.displayType);
   const isBigNumberWidget = state.displayType === DisplayType.BIG_NUMBER;
   const isTableWidget = state.displayType === DisplayType.TABLE;
-  const {tags: numericSpanTags} = useTraceItemTags('number');
-  const {tags: stringSpanTags} = useTraceItemTags('string');
+  let hiddenKeys: string[] = [];
+  if (state.dataset === WidgetType.TRACEMETRICS) {
+    hiddenKeys = HiddenTraceMetricSearchFields;
+  }
+  const {tags: numericSpanTags} = useTraceItemTags('number', hiddenKeys);
+  const {tags: stringSpanTags} = useTraceItemTags('string', hiddenKeys);
 
   // Span column options are explicitly defined and bypass all of the
   // fieldOptions filtering and logic used for showing options for

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -1,7 +1,10 @@
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 
-export function useTraceItemTags(type?: 'number' | 'string') {
-  const {attributes, isLoading, secondaryAliases} = useTraceItemAttributes(type);
+export function useTraceItemTags(type?: 'number' | 'string', hiddenKeys?: string[]) {
+  const {attributes, isLoading, secondaryAliases} = useTraceItemAttributes(
+    type,
+    hiddenKeys
+  );
   return {
     tags: attributes,
     isLoading,


### PR DESCRIPTION
The filter bar, group by, and sort fields should all use the hidden trace metrics fields arrays to filter out specific values like `metric.name`, `metric.type`, etc.