### PR TITLE
fix(checkout): Adjust padding for error alert

### DIFF
--- a/static/gsApp/views/amCheckout/components/cart.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.tsx
@@ -7,7 +7,7 @@ import moment from 'moment-timezone';
 import {Alert} from 'sentry/components/core/alert';
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
-import {Flex, Stack} from 'sentry/components/core/layout';
+import {Container, Flex, Stack} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Placeholder from 'sentry/components/placeholder';
@@ -946,7 +946,11 @@ function Cart({
           </Stack>
           {summaryIsOpen && (
             <Flex direction="column" gap="lg" data-test-id="plan-summary" width="100%">
-              {errorMessage && <Alert type="error">{errorMessage}</Alert>}
+              {errorMessage && (
+                <Container>
+                  <Alert type="error">{errorMessage}</Alert>
+                </Container>
+              )}
               <ItemsSummary activePlan={activePlan} formData={formData} />
             </Flex>
           )}


### PR DESCRIPTION
# before
<img width="418" height="175" alt="Screenshot 2025-12-18 at 11 33 08 AM" src="https://github.com/user-attachments/assets/a7acf0d8-f7ef-4af1-b1c8-f61191cec3c7" />

# after
<img width="395" height="156" alt="Screenshot 2025-12-18 at 11 32 51 AM" src="https://github.com/user-attachments/assets/10aad83e-698e-49cc-a7af-430ef190cbdc" />
