### PR TITLE
refactor(preprod): update build details to use "Build Metadata" instead of "Git details" and add base build row logic (EME-679)

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -129,7 +129,7 @@ describe('BuildDetails', () => {
     await waitFor(() => expect(appSizeMock).toHaveBeenCalledTimes(1));
 
     expect(await screen.findByText('v1.0.0 (123)')).toBeInTheDocument();
-    expect(await screen.findByText('Git details')).toBeInTheDocument();
+    expect(await screen.findByText('Build Metadata')).toBeInTheDocument();
   });
 
   it('shows "Your app is still being analyzed..." text when size analysis is processing', async () => {

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -5,6 +5,7 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import {Link} from 'sentry/components/core/link';
 import {
   KeyValueData,
   type KeyValueDataContentProps,
@@ -12,9 +13,14 @@ import {
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import {BuildDetailsSidebarAppInfo} from 'sentry/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  formatBuildName,
+  getBaseBuildUrl,
+} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   getBranchUrl,
   getPrUrl,
@@ -31,6 +37,7 @@ interface BuildDetailsSidebarContentProps {
 
 export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProps) {
   const {buildDetailsData, isBuildDetailsPending = false, artifactId, projectId} = props;
+  const organization = useOrganization();
 
   if (isBuildDetailsPending || !buildDetailsData) {
     return <SidebarLoadingSkeleton data-testid="sidebar-loading-skeleton" />;
@@ -78,6 +85,37 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
         ),
       },
     },
+    ...(vcsInfo.base_sha
+      ? [
+          {
+            item: {
+              key: 'Base Build',
+              subject: 'Base Build',
+              value: (() => {
+                if (!buildDetailsData.base_build_info) {
+                  return '-';
+                }
+                const buildName = formatBuildName(
+                  buildDetailsData.base_build_info.version,
+                  buildDetailsData.base_build_info.build_number
+                );
+                const baseBuildUrl =
+                  buildDetailsData.base_artifact_id && projectId
+                    ? getBaseBuildUrl({
+                        baseArtifactId: buildDetailsData.base_artifact_id,
+                        organizationSlug: organization.slug,
+                        projectId,
+                      })
+                    : null;
+                if (!baseBuildUrl || !buildName) {
+                  return '-';
+                }
+                return <Link to={baseBuildUrl}>{buildName}</Link>;
+              })(),
+            },
+          },
+        ]
+      : []),
     {
       item: {
         key: 'PR Number',
@@ -145,7 +183,7 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
 
       {/* VCS info */}
       {hasVcsInfo ? (
-        <KeyValueData.Card title="Git details" contentItems={vcsInfoContentItems} />
+        <KeyValueData.Card title="Build Metadata" contentItems={vcsInfoContentItems} />
       ) : (
         <Container
           border="primary"

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -10,6 +10,7 @@ export interface BuildDetailsApiResponse {
   vcs_info: BuildDetailsVcsInfo;
   size_info?: BuildDetailsSizeInfo;
   base_artifact_id?: string | null;
+  base_build_info?: BuildDetailsAppInfo | null;
 }
 
 export interface BuildDetailsAppInfo {

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -1,0 +1,31 @@
+interface BuildLinkParams {
+  baseArtifactId: string | null | undefined;
+  organizationSlug: string;
+  projectId: string;
+}
+
+export function getBaseBuildUrl(params: BuildLinkParams): string | null {
+  const {organizationSlug, projectId, baseArtifactId} = params;
+
+  if (!baseArtifactId) {
+    return null;
+  }
+
+  return `/organizations/${organizationSlug}/preprod/${projectId}/${baseArtifactId}/`;
+}
+
+export function formatBuildName(
+  version: string | number | null | undefined,
+  buildNumber: string | number | null | undefined
+): string | null {
+  if (
+    version === undefined ||
+    version === null ||
+    buildNumber === undefined ||
+    buildNumber === null
+  ) {
+    return null;
+  }
+
+  return `v${version} (${buildNumber})`;
+}


### PR DESCRIPTION
This commit introduces new functionality to render a "Base Build" row based on the presence of base build information, enhancing the clarity and usability of the build details display. New utility functions for formatting build names and generating base build URLs have also been added. Additionally replaced the title "Git details" with "Build Metadata" in the build details sidebar and related tests.

## No Base Build

<img width="343" height="215" alt="Screenshot 2025-12-18 at 10 33 22" src="https://github.com/user-attachments/assets/4dbed582-24aa-4477-9eea-4be60e1d8b7c" />

## No Base Artefact

<img width="345" height="259" alt="Screenshot 2025-12-17 at 14 50 55" src="https://github.com/user-attachments/assets/0bd92126-2048-4c45-8d4b-0ac090cd19b4" />

## With Base Artefact

<img width="351" height="256" alt="Screenshot 2025-12-18 at 09 59 05" src="https://github.com/user-attachments/assets/b317b03e-7c1e-4c7f-b9b3-fb9dd99aeb3c" />

## Testing

Manual tested and updated and also added integration tests for all three states.

## Merging

Requires https://github.com/getsentry/sentry/pull/105145 to be merged first then this branch will be rebased onto `master` which will remove the API changes shown in this PR. For review please just review the frontend changes, backend changes should be reviewed as part of the above linked PR.