### PR TITLE
feat(explore-attr-breakdowns): Hiding action menu on click outside selected region in chart

### DIFF
--- a/static/app/components/charts/useChartXRangeSelection.spec.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.spec.tsx
@@ -833,7 +833,7 @@ describe('useChartXRangeSelection', () => {
       });
     });
 
-    it('should not call onOutsideSelectionClick when clicking on an action menu item', async () => {
+    it('should not call onOutsideSelectionClick when clicking on an action menu item', () => {
       const onOutsideSelectionClick = jest.fn();
 
       const mockEchartsInstance = {

--- a/static/app/components/charts/useChartXRangeSelection.spec.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.spec.tsx
@@ -670,27 +670,42 @@ describe('useChartXRangeSelection', () => {
     });
   });
 
-  describe('onChartClick handler', () => {
-    it('should call onChartClick when chart is clicked', async () => {
-      const onChartClick = jest.fn();
-      let clickHandler: ((event: MouseEvent) => void) | null = null;
-
-      const mockDom = {
-        getBoundingClientRect: jest.fn().mockReturnValue({
-          left: 50,
-          top: 100,
-        }),
-        addEventListener: jest.fn((event, handler) => {
-          if (event === 'click') {
-            clickHandler = handler;
-          }
-        }),
-        removeEventListener: jest.fn(),
-      };
+  describe('click callbacks', () => {
+    it('should call onInsideSelectionClick when clicking inside the selection box', async () => {
+      const onInsideSelectionClick = jest.fn();
 
       const mockEchartsInstance = {
         ...mockChartInstance,
-        getDom: jest.fn().mockReturnValue(mockDom),
+        getModel: jest.fn().mockReturnValue({
+          getComponent: jest.fn((type: string) => {
+            if (type === 'xAxis') {
+              return {
+                axis: {scale: {getExtent: () => [0, 100]}},
+              };
+            }
+            if (type === 'yAxis') {
+              return {
+                axis: {scale: {getExtent: () => [0, 50]}},
+              };
+            }
+            return mockAxis;
+          }),
+        }),
+        convertToPixel: jest.fn((_config, value) => {
+          // Selection range pixels: xMin=50, xMax=150
+          // yMin pixel = 200
+          if (value === 100) return 200; // xMax extent
+          if (value === 0) return 200; // yMin extent
+          if (value === 10) return 50; // selection xMin
+          if (value === 90) return 150; // selection xMax
+          return 100;
+        }),
+        getDom: jest.fn().mockReturnValue({
+          getBoundingClientRect: jest.fn().mockReturnValue({
+            left: 0,
+            top: 0,
+          }),
+        }),
         dispatchAction: jest.fn(),
       } as any;
 
@@ -698,33 +713,204 @@ describe('useChartXRangeSelection', () => {
         getEchartsInstance: () => mockEchartsInstance,
       } as unknown as EChartsReact;
 
-      renderHook(() =>
+      const {result} = renderHook(() =>
         useChartXRangeSelection({
           chartRef: mockChartRef,
-          onChartClick,
+          onInsideSelectionClick,
         })
       );
 
-      await waitFor(() => {
-        expect(mockDom.addEventListener).toHaveBeenCalledWith(
-          'click',
-          expect.any(Function)
+      // Create a selection first
+      act(() => {
+        result.current.onBrushEnd(
+          {areas: [{coordRange: [10, 90], panelId: 'test-panel-id'}]} as any,
+          mockEchartsInstance
         );
       });
 
-      // Simulate click event
-      const mockEvent = {preventDefault: jest.fn()} as unknown as MouseEvent;
-      act(() => {
-        clickHandler?.(mockEvent);
+      // Simulate a click inside the selection box (clientX=100 is between 50 and 150)
+      const clickEvent = new MouseEvent('click', {
+        clientX: 100,
+        clientY: 100,
+        bubbles: true,
       });
 
-      expect(onChartClick).toHaveBeenCalledWith(
-        expect.objectContaining({
-          selectionState: null,
-          setSelectionState: expect.any(Function),
-          clearSelection: expect.any(Function),
+      act(() => {
+        document.body.dispatchEvent(clickEvent);
+      });
+
+      await waitFor(() => {
+        expect(onInsideSelectionClick).toHaveBeenCalledWith(
+          expect.objectContaining({
+            selectionState: expect.objectContaining({
+              selection: expect.objectContaining({
+                range: [10, 90],
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('should call onOutsideSelectionClick when clicking outside the selection box', async () => {
+      const onOutsideSelectionClick = jest.fn();
+
+      const mockEchartsInstance = {
+        ...mockChartInstance,
+        getModel: jest.fn().mockReturnValue({
+          getComponent: jest.fn((type: string) => {
+            if (type === 'xAxis') {
+              return {
+                axis: {scale: {getExtent: () => [0, 100]}},
+              };
+            }
+            if (type === 'yAxis') {
+              return {
+                axis: {scale: {getExtent: () => [0, 50]}},
+              };
+            }
+            return mockAxis;
+          }),
+        }),
+        convertToPixel: jest.fn((_config, value) => {
+          // Selection range pixels: xMin=50, xMax=150
+          // yMin pixel = 200
+          if (value === 100) return 200; // xMax extent
+          if (value === 0) return 200; // yMin extent
+          if (value === 10) return 50; // selection xMin
+          if (value === 90) return 150; // selection xMax
+          return 100;
+        }),
+        getDom: jest.fn().mockReturnValue({
+          getBoundingClientRect: jest.fn().mockReturnValue({
+            left: 0,
+            top: 0,
+          }),
+        }),
+        dispatchAction: jest.fn(),
+      } as any;
+
+      mockChartRef.current = {
+        getEchartsInstance: () => mockEchartsInstance,
+      } as unknown as EChartsReact;
+
+      const {result} = renderHook(() =>
+        useChartXRangeSelection({
+          chartRef: mockChartRef,
+          onOutsideSelectionClick,
         })
       );
+
+      // Create a selection first
+      act(() => {
+        result.current.onBrushEnd(
+          {areas: [{coordRange: [10, 90], panelId: 'test-panel-id'}]} as any,
+          mockEchartsInstance
+        );
+      });
+
+      // Simulate a click outside the selection box (clientX=200 is > 150)
+      const clickEvent = new MouseEvent('click', {
+        clientX: 200,
+        clientY: 100,
+        bubbles: true,
+      });
+
+      act(() => {
+        document.body.dispatchEvent(clickEvent);
+      });
+
+      await waitFor(() => {
+        expect(onOutsideSelectionClick).toHaveBeenCalledWith(
+          expect.objectContaining({
+            selectionState: expect.objectContaining({
+              selection: expect.objectContaining({
+                range: [10, 90],
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('should not call onOutsideSelectionClick when clicking on an action menu item', async () => {
+      const onOutsideSelectionClick = jest.fn();
+
+      const mockEchartsInstance = {
+        ...mockChartInstance,
+        getModel: jest.fn().mockReturnValue({
+          getComponent: jest.fn((type: string) => {
+            if (type === 'xAxis') {
+              return {
+                axis: {scale: {getExtent: () => [0, 100]}},
+              };
+            }
+            if (type === 'yAxis') {
+              return {
+                axis: {scale: {getExtent: () => [0, 50]}},
+              };
+            }
+            return mockAxis;
+          }),
+        }),
+        convertToPixel: jest.fn((_config, value) => {
+          if (value === 100) return 200;
+          if (value === 0) return 200;
+          if (value === 10) return 50;
+          if (value === 90) return 150;
+          return 100;
+        }),
+        getDom: jest.fn().mockReturnValue({
+          getBoundingClientRect: jest.fn().mockReturnValue({
+            left: 0,
+            top: 0,
+          }),
+        }),
+        dispatchAction: jest.fn(),
+      } as any;
+
+      mockChartRef.current = {
+        getEchartsInstance: () => mockEchartsInstance,
+      } as unknown as EChartsReact;
+
+      const {result} = renderHook(() =>
+        useChartXRangeSelection({
+          chartRef: mockChartRef,
+          onOutsideSelectionClick,
+        })
+      );
+
+      // Create a selection first
+      act(() => {
+        result.current.onBrushEnd(
+          {areas: [{coordRange: [10, 90], panelId: 'test-panel-id'}]} as any,
+          mockEchartsInstance
+        );
+      });
+
+      // Create an action menu element with the data attribute
+      const actionMenuElement = document.createElement('div');
+      actionMenuElement.dataset.chartXRangeSelectionActionMenu = '';
+      const menuButton = document.createElement('button');
+      actionMenuElement.appendChild(menuButton);
+      document.body.appendChild(actionMenuElement);
+
+      // Simulate a click on the menu button (child of action menu)
+      const clickEvent = new MouseEvent('click', {
+        clientX: 200, // Outside selection box
+        clientY: 100,
+        bubbles: true,
+      });
+      Object.defineProperty(clickEvent, 'target', {value: menuButton});
+
+      act(() => {
+        document.body.dispatchEvent(clickEvent);
+      });
+
+      // onOutsideSelectionClick should NOT be called because click was on action menu
+      expect(onOutsideSelectionClick).not.toHaveBeenCalled();
+
+      document.body.removeChild(actionMenuElement);
     });
   });
 });

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -110,14 +110,19 @@ export type ChartXRangeSelectionProps = {
   initialSelection?: Selection;
 
   /**
-   * The callback that is called when the chart is clicked.
-   */
-  onChartClick?: (params: SelectionCallbackParams) => void;
-
-  /**
    * The callback that is called when the selection is cleared.
    */
   onClearSelection?: (params: SelectionCallbackParams) => void;
+
+  /**
+   * The callback that is called when the chart is clicked inside the selection box.
+   */
+  onInsideSelectionClick?: (params: SelectionCallbackParams) => void;
+
+  /**
+   * The callback that is called when the chart is clicked outside the selection box and the action menu.
+   */
+  onOutsideSelectionClick?: (params: SelectionCallbackParams) => void;
 
   /**
    * The callback that is called when the selection/dragging ends.
@@ -134,8 +139,9 @@ export function useChartXRangeSelection({
   chartRef,
   onSelectionEnd,
   onSelectionStart,
-  onChartClick,
   onClearSelection,
+  onInsideSelectionClick,
+  onOutsideSelectionClick,
   actionMenuRenderer,
   chartsGroupName,
   initialSelection,
@@ -305,30 +311,70 @@ export function useChartXRangeSelection({
     disabled,
   ]);
 
-  // This effect sets up the listener for clicks anywhere on the chart to trigger the
-  // onChartClick callback if it is passed in. The params to it include state management functions,
-  // giving the consumer full control over the selection state.
   useEffect(() => {
-    if (disabled) return;
+    if (disabled || !selectionState?.selection) return;
 
     const chartInstance = chartRef.current?.getEchartsInstance();
     if (!chartInstance) return;
 
-    const dom = chartInstance.getDom();
-
-    const handleClickAnywhere = (event: MouseEvent) => {
+    const handleInsideSelectionClick = (event: MouseEvent) => {
       event.preventDefault();
 
-      onChartClick?.(callbackParams);
+      const [selectedMin, selectedMax] = selectionState.selection.range;
+
+      const xMinPixel = chartInstance.convertToPixel({xAxisIndex: 0}, selectedMin);
+      const xMaxPixel = chartInstance.convertToPixel({xAxisIndex: 0}, selectedMax);
+
+      // @ts-expect-error TODO Abdullah Khan: chartInstance.getModel is a private method, but we access it to get the axis extremes
+      // could not find a better way, this works out perfectly for now. Passing down the entire series data to the hook is more gross.
+      const yAxis = chartInstance.getModel()?.getComponent?.('yAxis', 0);
+      if (!yAxis) return;
+
+      const yMin = yAxis.axis.scale.getExtent()[0];
+      const yMinPixel = chartInstance.convertToPixel({yAxisIndex: 0}, yMin);
+
+      const chartRect = chartInstance.getDom().getBoundingClientRect();
+
+      const left = chartRect.left + xMinPixel;
+      const right = chartRect.left + xMaxPixel;
+      const top = chartRect.top;
+      const bottom = chartRect.top + yMinPixel;
+
+      const {clientX, clientY} = event;
+
+      if (clientX >= left && clientX <= right && clientY >= top && clientY <= bottom) {
+        onInsideSelectionClick?.(callbackParams);
+        return;
+      }
+
+      // Check if the click was on an element that is a child of the action menu
+      // to prevent triggering the onOutsideSelectionClick callback. The action menu items
+      // have their own onClick handlers.
+      let el = event.target as HTMLElement | null;
+      while (el) {
+        if (el.dataset?.chartXRangeSelectionActionMenu !== undefined) {
+          return;
+        }
+        el = el.parentElement;
+      }
+
+      onOutsideSelectionClick?.(callbackParams);
     };
 
-    dom.addEventListener('click', handleClickAnywhere);
+    document.body.addEventListener('click', handleInsideSelectionClick, true);
 
     // eslint-disable-next-line consistent-return
     return () => {
-      dom.removeEventListener('click', handleClickAnywhere);
+      document.body.removeEventListener('click', handleInsideSelectionClick, true);
     };
-  }, [enableBrushMode, callbackParams, chartRef, onChartClick, disabled]);
+  }, [
+    disabled,
+    selectionState,
+    chartRef,
+    onInsideSelectionClick,
+    onOutsideSelectionClick,
+    callbackParams,
+  ]);
 
   // This effect fires whenever state changes. It:
   // - Re-draws the selection box in the chart on state change enforcing persistence.
@@ -438,6 +484,7 @@ export function useChartXRangeSelection({
 
     return createPortal(
       <div
+        data-chart-x-range-selection-action-menu
         style={{
           position: 'absolute',
           transform,

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -318,8 +318,6 @@ export function useChartXRangeSelection({
     if (!chartInstance) return;
 
     const handleInsideSelectionClick = (event: MouseEvent) => {
-      event.preventDefault();
-
       const [selectedMin, selectedMax] = selectionState.selection.range;
 
       const xMinPixel = chartInstance.convertToPixel({xAxisIndex: 0}, selectedMin);

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -25,7 +25,7 @@ import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 
 import {Chart} from './attributeDistributionChart';
-import {CHARTS_PER_PAGE} from './constants';
+import {CHART_SELECTION_ALERT_KEY, CHARTS_PER_PAGE} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
 
 export type AttributeDistribution = Array<{
@@ -217,7 +217,7 @@ export function AttributeDistribution() {
 
 function ChartSelectionAlert() {
   const {dismiss, isDismissed} = useDismissAlert({
-    key: 'attribute-breakdowns-chart-selection-alert-dismissed',
+    key: CHART_SELECTION_ALERT_KEY,
   });
 
   if (isDismissed) {

--- a/static/app/views/explore/components/attributeBreakdowns/constants.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/constants.tsx
@@ -5,3 +5,6 @@ export const CHART_MAX_SERIES_LENGTH = 40;
 
 export const CHARTS_COLUMN_COUNT = 3;
 export const CHARTS_PER_PAGE = CHARTS_COLUMN_COUNT * 4;
+
+export const CHART_SELECTION_ALERT_KEY =
+  'attribute-breakdowns-chart-selection-alert-dismissed';

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -270,13 +270,24 @@ function Chart({
               chartRef={chartRef}
               chartXRangeSelection={{
                 initialSelection: initialChartSelection,
-                onChartClick: params => {
+                onInsideSelectionClick: params => {
                   if (!params.selectionState) return;
 
-                  // Always show the action menu when the chart is clicked.
                   params.setSelectionState({
                     ...params.selectionState,
                     isActionMenuVisible: true,
+                  });
+                },
+                onOutsideSelectionClick: params => {
+                  if (
+                    !params.selectionState ||
+                    !params.selectionState.isActionMenuVisible
+                  )
+                    return;
+
+                  params.setSelectionState({
+                    ...params.selectionState,
+                    isActionMenuVisible: false,
                   });
                 },
                 onClearSelection: () => {

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -9,11 +9,13 @@ import {space} from 'sentry/styles/space';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useChartSelection} from 'sentry/views/explore/components/attributeBreakdowns/chartSelectionContext';
+import {CHART_SELECTION_ALERT_KEY} from 'sentry/views/explore/components/attributeBreakdowns/constants';
 import {FloatingTrigger} from 'sentry/views/explore/components/attributeBreakdowns/floatingTrigger';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
@@ -164,6 +166,12 @@ function Chart({
   const organization = useOrganization();
   const {chartSelection, setChartSelection} = useChartSelection();
   const [interval, setInterval, intervalOptions] = useChartInterval();
+  const {
+    dismiss: dismissChartSelectionAlert,
+    isDismissed: isChartSelectionAlertDismissed,
+  } = useDismissAlert({
+    key: CHART_SELECTION_ALERT_KEY,
+  });
 
   const chartHeight = visualize.visible ? CHART_HEIGHT : 50;
 
@@ -270,6 +278,11 @@ function Chart({
               chartRef={chartRef}
               chartXRangeSelection={{
                 initialSelection: initialChartSelection,
+                onSelectionEnd: () => {
+                  if (!isChartSelectionAlertDismissed) {
+                    dismissChartSelectionAlert();
+                  }
+                },
                 onInsideSelectionClick: params => {
                   if (!params.selectionState) return;
 

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -279,11 +279,7 @@ function Chart({
                   });
                 },
                 onOutsideSelectionClick: params => {
-                  if (
-                    !params.selectionState ||
-                    !params.selectionState.isActionMenuVisible
-                  )
-                    return;
+                  if (!params.selectionState?.isActionMenuVisible) return;
 
                   params.setSelectionState({
                     ...params.selectionState,


### PR DESCRIPTION
- Echarts doesn't provide a callback for this usecase so we use coordinate mapping manually
- Also, this is explore attribute breakdowns behaviour. Added inside/outside selected region click handlers to decouple the generic selection hook from this logic. 