### PR TITLE
feat(explore-attr-breakdowns): Selection CTA should be dismissed upon first box draw

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -25,7 +25,7 @@ import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 
 import {Chart} from './attributeDistributionChart';
-import {CHARTS_PER_PAGE} from './constants';
+import {CHART_SELECTION_ALERT_KEY, CHARTS_PER_PAGE} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
 
 export type AttributeDistribution = Array<{
@@ -217,7 +217,7 @@ export function AttributeDistribution() {
 
 function ChartSelectionAlert() {
   const {dismiss, isDismissed} = useDismissAlert({
-    key: 'attribute-breakdowns-chart-selection-alert-dismissed',
+    key: CHART_SELECTION_ALERT_KEY,
   });
 
   if (isDismissed) {

--- a/static/app/views/explore/components/attributeBreakdowns/constants.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/constants.tsx
@@ -5,3 +5,6 @@ export const CHART_MAX_SERIES_LENGTH = 40;
 
 export const CHARTS_COLUMN_COUNT = 3;
 export const CHARTS_PER_PAGE = CHARTS_COLUMN_COUNT * 4;
+
+export const CHART_SELECTION_ALERT_KEY =
+  'attribute-breakdowns-chart-selection-alert-dismissed';

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -9,11 +9,13 @@ import {space} from 'sentry/styles/space';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useChartSelection} from 'sentry/views/explore/components/attributeBreakdowns/chartSelectionContext';
+import {CHART_SELECTION_ALERT_KEY} from 'sentry/views/explore/components/attributeBreakdowns/constants';
 import {FloatingTrigger} from 'sentry/views/explore/components/attributeBreakdowns/floatingTrigger';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
@@ -164,6 +166,12 @@ function Chart({
   const organization = useOrganization();
   const {chartSelection, setChartSelection} = useChartSelection();
   const [interval, setInterval, intervalOptions] = useChartInterval();
+  const {
+    dismiss: dismissChartSelectionAlert,
+    isDismissed: isChartSelectionAlertDismissed,
+  } = useDismissAlert({
+    key: CHART_SELECTION_ALERT_KEY,
+  });
 
   const chartHeight = visualize.visible ? CHART_HEIGHT : 50;
 
@@ -270,6 +278,11 @@ function Chart({
               chartRef={chartRef}
               chartXRangeSelection={{
                 initialSelection: initialChartSelection,
+                onSelectionEnd: () => {
+                  if (!isChartSelectionAlertDismissed) {
+                    dismissChartSelectionAlert();
+                  }
+                },
                 onInsideSelectionClick: params => {
                   if (!params.selectionState) return;
 


### PR DESCRIPTION
<img width="1120" height="481" alt="Screenshot 2025-12-18 at 12 33 51 PM" src="https://github.com/user-attachments/assets/41a0a305-0b8f-4a5a-a094-cd15829e9983" />
