### PR TITLE
fix(seer): Fix stale query data after using wizard

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
@@ -49,9 +49,9 @@ export function useBulkUpdateRepositorySettings(
         queryKey: [`/organizations/${organization.slug}/repos/`],
       });
       (data ?? []).forEach(repo => {
-        queryClient.invalidateQueries({
-          queryKey: getRepositoryWithSettingsQueryKey(organization, repo.id),
-        });
+        const queryKey = getRepositoryWithSettingsQueryKey(organization, repo.id);
+        queryClient.invalidateQueries({queryKey});
+        queryClient.setQueryData(queryKey, [repo, undefined, undefined]);
       });
       options?.onSettled?.(data, error, variables, context);
     },


### PR DESCRIPTION
This fixes stale data after the Code Review step in the wizard. To reproduce:

* Load new Seer --> Repos settings, ensure Code Review is off for all of them
* Open Wizard (without reloading page)
* Enable at least one repo from Code Review step
* Click next to save
* Nav back to Seer --> Repos

Observe that the checkbox will be unselected.
