### PR TITLE
fix(preprod): Hide 'Span Evidence' section for preprod issues

### DIFF
--- a/static/app/utils/issueTypeConfig/preprodConfig.tsx
+++ b/static/app/utils/issueTypeConfig/preprodConfig.tsx
@@ -37,7 +37,7 @@ const preprodDetectedConfig: IssueCategoryConfigMapping = {
     mergedIssues: {enabled: false},
     similarIssues: {enabled: false},
     stacktrace: {enabled: false},
-    spanEvidence: {enabled: true},
+    spanEvidence: {enabled: false},
     evidence: null,
     usesIssuePlatform: true,
     issueSummary: {enabled: true},


### PR DESCRIPTION
Preprod issues don't have spans so the UI isn't useful.

Before:
<img width="1874" height="1724" alt="CleanShot 2025-12-18 at 18 08 39@2x" src="https://github.com/user-attachments/assets/4932789b-e0f9-4ccf-8664-51e1c7fbadd7" />

After:
<img width="1862" height="1668" alt="CleanShot 2025-12-18 at 18 08 55@2x" src="https://github.com/user-attachments/assets/f69b81b9-2ae6-4a3f-9df4-cdcd3f9dd424" />
