### PR TITLE
tracing: fix devserver error

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
@@ -266,6 +266,8 @@ export function mockSpansResponse(
   project_slug: string,
   event_id: string
 ): jest.Mock<any, any> {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore MockApiClient is not defined in the global scope
   return MockApiClient.addMockResponse({
     url: `/organizations/org-slug/events/${project_slug}:${event_id}/?averageColumn=span.self_time&averageColumn=span.duration`,
     method: 'GET',


### PR DESCRIPTION
Fixes devserver type checking error

```
TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
    267 |   event_id: string
    268 | ): jest.Mock<any, any> {
  > 269 |   return global.MockApiClient.addMockResponse({
        |                 ^^^^^^^^^^^^^
    270 |     url: `/organizations/org-slug/events/${project_slug}:${event_id}/?averageColumn=span.self_time&averageColumn=span.duration`,
    271 |     method: 'GET',
    272 |     body: makeEventTransaction({
 ```