### PR TITLE
ref(events-search): update doc about query param

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -740,7 +740,11 @@ class EventParams:
         name="query",
         location=OpenApiParameter.QUERY,
         type=OpenApiTypes.STR,
-        description="An optional search query for filtering events.",
+        description=(
+            "An optional search query for filtering events. "
+            "See [search syntax](https://docs.sentry.io/concepts/search/) and queryable event properties at "
+            "[Sentry Search Documentation](https://docs.sentry.io/concepts/search/searchable-properties/events/) for more information. An example query might be `query=transaction:foo AND release:abc`"
+        ),
         required=False,
     )
 


### PR DESCRIPTION
add links to search syntax, as right now its not clear how to use this field.