### PR TITLE
Issue details email copy

### DIFF
--- a/static/app/components/events/contexts/knownContext/user.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/user.spec.tsx
@@ -37,18 +37,20 @@ const MOCK_REDACTION = {
 describe('UserContext', () => {
   it('returns values and according to the parameters', () => {
     const result = getUserContextData({data: MOCK_USER_CONTEXT});
-    
+
     // Extract the actionButton from the email item for comparison
     const emailItem = result.find(item => item.key === 'email');
     const {actionButton, ...emailItemWithoutButton} = emailItem || {};
-    
-    expect(result.map(item => {
-      if (item.key === 'email') {
-        const {actionButton: _, ...rest} = item;
-        return rest;
-      }
-      return item;
-    })).toEqual([
+
+    expect(
+      result.map(item => {
+        if (item.key === 'email') {
+          const {actionButton: _, ...rest} = item;
+          return rest;
+        }
+        return item;
+      })
+    ).toEqual([
       {
         key: 'email',
         subject: 'Email',
@@ -77,7 +79,7 @@ describe('UserContext', () => {
         meta: undefined,
       },
     ]);
-    
+
     // Verify actionButton exists for email
     expect(actionButton).toBeDefined();
   });
@@ -116,12 +118,7 @@ describe('UserContext', () => {
 
     const event = EventFixture();
     render(
-      <ContextCard
-        event={event}
-        type="default"
-        alias="user"
-        value={MOCK_USER_CONTEXT}
-      />
+      <ContextCard event={event} type="default" alias="user" value={MOCK_USER_CONTEXT} />
     );
 
     const copyButton = screen.getByRole('button', {name: 'Copy email to clipboard'});

--- a/static/app/components/events/contexts/knownContext/user.tsx
+++ b/static/app/components/events/contexts/knownContext/user.tsx
@@ -1,7 +1,12 @@
+import {useCallback} from 'react';
+
+import {Button} from 'sentry/components/core/button';
 import {getContextKeys} from 'sentry/components/events/contexts/utils';
+import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {KeyValueListData} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 
 enum UserContextKeys {
   ID = 'id',
@@ -104,6 +109,9 @@ export function getUserContextData({
                     ? `mailto:${data.email}`
                     : undefined,
               },
+              actionButton: defined(data.email) ? (
+                <CopyEmailButton email={data.email} />
+              ) : undefined,
             };
           case UserContextKeys.GEO:
             return {
@@ -123,5 +131,29 @@ export function getUserContextData({
       // Since user context is generated separately from the rest, it has all known keys with those
       // unset appearing as `null`. We want to omit those unless they have annotations.
       .filter(item => defined(item.value) || defined(meta?.[item.key]))
+  );
+}
+
+function CopyEmailButton({email}: {email: string}) {
+  const {copy} = useCopyToClipboard();
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      copy(email, {successMessage: t('Email copied to clipboard')});
+    },
+    [copy, email]
+  );
+
+  return (
+    <Button
+      aria-label={t('Copy email to clipboard')}
+      title={t('Copy email to clipboard')}
+      borderless
+      size="zero"
+      icon={<IconCopy size="xs" />}
+      onClick={handleCopy}
+    />
   );
 }

--- a/static/app/views/issueDetails/participantList.spec.tsx
+++ b/static/app/views/issueDetails/participantList.spec.tsx
@@ -44,4 +44,24 @@ describe('ParticipantList', () => {
 
     expect(screen.queryByText('Individuals (2)')).not.toBeInTheDocument();
   });
+
+  it('copies email to clipboard when email is clicked', async () => {
+    const mockCopy = jest.fn().mockResolvedValue('');
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: mockCopy,
+      },
+    });
+
+    render(
+      <ParticipantList teams={[]} users={users} description="Participants">
+        Click Me
+      </ParticipantList>
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Click Me'}));
+    await waitFor(() => expect(screen.getByText('John Doe')).toBeVisible());
+    const email = screen.getByText('john.doe@example.com');
+    await userEvent.click(email);
+    expect(mockCopy).toHaveBeenCalledWith('john.doe@example.com');
+  });
 });

--- a/static/app/views/issueDetails/participantList.tsx
+++ b/static/app/views/issueDetails/participantList.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
@@ -10,6 +10,7 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Team} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 
 interface ParticipantScrollboxProps {
   teams: Team[];
@@ -17,6 +18,16 @@ interface ParticipantScrollboxProps {
 }
 
 function ParticipantScrollbox({users, teams}: ParticipantScrollboxProps) {
+  const {copy} = useCopyToClipboard();
+
+  const handleCopyEmail = useCallback(
+    (email: string, event: React.MouseEvent) => {
+      event.stopPropagation();
+      copy(email, {successMessage: t('Email copied to clipboard')});
+    },
+    [copy]
+  );
+
   if (!users.length && !teams.length) {
     return null;
   }
@@ -41,7 +52,14 @@ function ParticipantScrollbox({users, teams}: ParticipantScrollboxProps) {
           <UserAvatar user={user} size={28} />
           <div>
             {user.name}
-            <SubText>{user.email}</SubText>
+            {user.email === user.name ? null : (
+              <ClickableEmail
+                onClick={e => handleCopyEmail(user.email, e)}
+                title={t('Click to copy email')}
+              >
+                {user.email}
+              </ClickableEmail>
+            )}
           </div>
         </UserRow>
       ))}
@@ -152,4 +170,11 @@ const UserRow = styled('div')`
 const SubText = styled('div')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSize.xs};
+`;
+
+const ClickableEmail = styled(SubText)`
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/participantList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.spec.tsx
@@ -69,4 +69,19 @@ describe('ParticipantList', () => {
     expect(await screen.findByText('#team-1')).toBeInTheDocument();
     expect(await screen.findByText('#team-2')).toBeInTheDocument();
   });
+
+  it('copies email to clipboard when email is clicked', async () => {
+    const mockCopy = jest.fn().mockResolvedValue('');
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: mockCopy,
+      },
+    });
+
+    render(<ParticipantList users={users} />);
+    await userEvent.click(screen.getByText('JD'), {skipHover: true});
+    const email = await screen.findByText('john.doe@example.com');
+    await userEvent.click(email);
+    expect(mockCopy).toHaveBeenCalledWith('john.doe@example.com');
+  });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -13,6 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {Team} from 'sentry/types/organization';
 import type {AvatarUser, User} from 'sentry/types/user';
 import {userDisplayName} from 'sentry/utils/formatters';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import useOverlay from 'sentry/utils/useOverlay';
 
 interface DropdownListProps {
@@ -34,6 +35,15 @@ export default function ParticipantList({
 
   const theme = useTheme();
   const showHeaders = users.length > 0 && teams && teams.length > 0;
+  const {copy} = useCopyToClipboard();
+
+  const handleCopyEmail = useCallback(
+    (email: string, event: React.MouseEvent) => {
+      event.stopPropagation();
+      copy(email, {successMessage: t('Email copied to clipboard')});
+    },
+    [copy]
+  );
 
   return (
     <div>
@@ -83,7 +93,12 @@ export default function ParticipantList({
                   <NameWrapper>
                     <div>{user.name}</div>
                     {user.email === user.name ? null : (
-                      <SmallText>{user.email}</SmallText>
+                      <ClickableEmail
+                        onClick={e => handleCopyEmail(user.email, e)}
+                        title={t('Click to copy email')}
+                      >
+                        {user.email}
+                      </ClickableEmail>
                     )}
                     {!hideTimestamp && <LastSeen date={(user as AvatarUser).lastSeen} />}
                   </NameWrapper>
@@ -142,6 +157,13 @@ const NameWrapper = styled('div')`
 
 const SmallText = styled('div')`
   font-size: ${p => p.theme.fontSize.xs};
+`;
+
+const ClickableEmail = styled(SmallText)`
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 const StyledAvatarList = styled(AvatarList)`


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds click-to-copy functionality for user emails on the issue details page.

Users can now click on an email in the participant list to copy it to their clipboard, improving workflow and aligning with existing Sentry UI patterns.

This was implemented by:
- Utilizing the `useCopyToClipboard` hook.
- Creating a `ClickableEmail` component with appropriate styling (pointer cursor, underline on hover) and a tooltip.
- Updating both streamline and non-streamline versions of `participantList.tsx`.
- Adding comprehensive tests to verify the functionality.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/CDXAKMGTU/p1766084635338949?thread_ts=1766084635.338949&cid=CDXAKMGTU)

<a href="https://cursor.com/background-agent?bcId=bc-ba40155c-6c69-492a-ad39-3865503dc263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba40155c-6c69-492a-ad39-3865503dc263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

