### PR TITLE
feat: check repo public/private status metric

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -785,7 +785,7 @@ class PullRequestEventWebhook(GitHubWebhook):
 
                 try:
                     pr_repo_private = pull_request["head"]["repo"]["private"]
-                except (KeyError, AttributeError):
+                except (KeyError, AttributeError, TypeError):
                     pr_repo_private = False
 
                 metrics.incr(

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -708,7 +708,6 @@ class PullRequestEventWebhook(GitHubWebhook):
         number = pull_request["number"]
         title = pull_request["title"]
         body = pull_request["body"]
-        author_association = pull_request["author_association"]
         user = pull_request["user"]
         user_type = user.get("type")
         action = event["action"]
@@ -783,12 +782,19 @@ class PullRequestEventWebhook(GitHubWebhook):
             )
 
             if created:
+
+                try:
+                    pr_repo_private = pull_request["head"]["repo"]["private"]
+                except (KeyError, AttributeError):
+                    pr_repo_private = False
+
                 metrics.incr(
                     "github.webhook.pull_request.created",
                     sample_rate=1.0,
                     tags={
                         "organization_id": organization.id,
                         "repository_id": repo.id,
+                        "is_private": pr_repo_private,
                     },
                 )
 
@@ -800,7 +806,6 @@ class PullRequestEventWebhook(GitHubWebhook):
                         "pr_number": number,
                         "user_login": user["login"],
                         "user_type": user_type,
-                        "author_association": author_association,
                         "is_eligible": is_contributor_eligible_for_seat_assignment(user_type),
                     },
                 )


### PR DESCRIPTION
Adds another tag to the metric if the repo associated with the PR is private/public.

Will help inform the ratio of PRs generated belonging to public vs. private repos


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
