### PR TITLE
chore(ACI): Add back upsampled tests

### DIFF
--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -2,15 +2,14 @@ import copy
 from datetime import timedelta
 from functools import cached_property
 from unittest.mock import MagicMock, call, patch
+from uuid import uuid4
 
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
 from sentry.incidents.subscription_processor import SubscriptionProcessor
-from sentry.snuba.dataset import Dataset
-from uuid import uuid4
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
-from sentry.snuba.dataset import EntityKey
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.models import QuerySubscription
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
@@ -23,7 +22,7 @@ from tests.sentry.incidents.subscription_processor.test_subscription_processor_b
 
 class ProcessUpdateTest(ProcessUpdateBaseClass):
     """
-    Test early return scenarios + simple cases.
+    Test early return scenarios and simple cases.
     """
 
     def test_simple(self) -> None:

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from sentry.constants import ObjectStatus
 from sentry.incidents.subscription_processor import SubscriptionProcessor
 from sentry.snuba.dataset import Dataset
+from uuid import uuid4
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -415,3 +416,96 @@ class ProcessUpdateComparisonAlertTest(ProcessUpdateBaseClass):
         # Check that we successfully resolve
         self.send_update(6, timedelta(minutes=-5))
         assert self.get_detector_state(detector) == DetectorPriorityLevel.OK
+
+
+class ProcessUpdateUpsampledCountTest(ProcessUpdateBaseClass):
+    """Test that upsampled_count() aggregate works correctly with sample weight data"""
+
+    @cached_property
+    def upsampled_detector(self):
+        """Create a detector that uses upsampled_count() aggregate function"""
+        detector = self.metric_detector
+        snuba_query = self.get_snuba_query(detector)
+        snuba_query.update(
+            time_window=3600,
+            aggregate="upsampled_count()",
+            resolution=60,
+        )
+        snuba_query.save()
+
+        DataCondition.objects.filter(condition_group=detector.workflow_condition_group).delete()
+        self.set_up_data_conditions(
+            detector=detector,
+            threshold_type=Condition.GREATER,
+            critical_threshold=20,
+            resolve_threshold=10,
+        )
+        return detector
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.detector = self.upsampled_detector
+
+    def build_upsampled_subscription_update(
+        self, subscription, upsampled_count=1.0, time_delta=None
+    ):
+        """Build a subscription update that simulates upsampled_count() query results"""
+        if time_delta is not None:
+            timestamp = timezone.now() + time_delta
+        else:
+            timestamp = timezone.now()
+        timestamp = timestamp.replace(microsecond=0)
+
+        # Create subscription update with the aggregation value
+        data = {"upsampled_count": upsampled_count}
+        values = {"data": [data]}
+        return {
+            "subscription_id": subscription.subscription_id if subscription else uuid4().hex,
+            "values": values,
+            "timestamp": timestamp,
+            "interval": 1,
+            "partition": 1,
+            "offset": 1,
+        }
+
+    def send_upsampled_update(self, upsampled_count, time_delta=None):
+        """Send a subscription update simulating upsampled_count() query results"""
+        if time_delta is None:
+            time_delta = timedelta()
+
+        processor = SubscriptionProcessor(self.sub)
+        message = self.build_upsampled_subscription_update(
+            self.sub, upsampled_count=upsampled_count, time_delta=time_delta
+        )
+        with (
+            self.feature("organizations:incidents"),
+            self.feature("organizations:performance-view"),
+        ):
+            processor.process_update(message)
+        return processor
+
+    def test_upsampled_count_no_detector_below_threshold(self) -> None:
+        """Test that the detector is not triggered when upsampled count is below threshold"""
+        # Send update with upsampled_count below threshold (1 < 20)
+        self.send_upsampled_update(upsampled_count=1.0)
+
+        # Verify detector was not triggered (1 < 20 threshold)
+        assert self.get_detector_state(self.upsampled_detector) == DetectorPriorityLevel.OK
+
+    def test_upsampled_count_detector_above_threshold(self) -> None:
+        """Test that detector is triggered when upsampled count exceeds threshold"""
+        # Send update with upsampled_count above threshold (30 > 20)
+        self.send_upsampled_update(upsampled_count=30.0)
+
+        # Verify detector was triggered (30 > 20 threshold)
+        assert self.get_detector_state(self.upsampled_detector) == DetectorPriorityLevel.HIGH
+
+    def test_upsampled_count_detector_and_resolve(self) -> None:
+        """Test detector triggering and resolving with upsampled count"""
+        # First, trigger the detector with high upsampled_count
+        self.send_upsampled_update(upsampled_count=30.0)
+        assert self.get_detector_state(self.upsampled_detector) == DetectorPriorityLevel.HIGH
+
+        # Then resolve it with low upsampled_count (below resolve threshold of 10)
+        self.send_upsampled_update(upsampled_count=5.0, time_delta=timedelta(minutes=1))
+        assert self.get_detector_state(self.upsampled_detector) == DetectorPriorityLevel.OK


### PR DESCRIPTION
Another companion to https://github.com/getsentry/sentry/pull/105113 to add back the upsampled alerts subscription processor tests but updates them for ACI. 