### PR TITLE
ref(uptime): Remove usage of `deprecatedRouteProps` from uptime route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1526,7 +1526,6 @@ function buildRoutes(): RouteObject[] {
         {
           path: 'uptime/',
           component: make(() => import('sentry/views/alerts/rules/uptime')),
-          deprecatedRouteProps: true,
           children: [
             {
               path: ':projectId/:detectorId/details/',

--- a/static/app/views/alerts/rules/uptime/index.tsx
+++ b/static/app/views/alerts/rules/uptime/index.tsx
@@ -1,16 +1,20 @@
+import {Outlet} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export default function UptimeContainer({children}: {children: React.ReactNode}) {
+export default function UptimeContainer() {
   const organization = useOrganization();
 
   return (
     <Feature features={['uptime']} organization={organization} renderDisabled={NoAccess}>
       <NoProjectMessage organization={organization}>
-        <PageFiltersContainer>{children}</PageFiltersContainer>
+        <PageFiltersContainer>
+          <Outlet />
+        </PageFiltersContainer>
       </NoProjectMessage>
     </Feature>
   );


### PR DESCRIPTION
Migrates an uptime route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7