### PR TITLE
fix(aci): Add option to disable using the issue stream detector in workflow evaluations

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3305,9 +3305,9 @@ register(
 )
 
 register(
-    "workflow_engine.use_only_preferred_detector",
+    "workflow_engine.exclude_issue_stream_detector",
     type=Bool,
-    default=True,
+    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3305,6 +3305,13 @@ register(
 )
 
 register(
+    "workflow_engine.use_only_preferred_detector",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "grouping.grouphash_metadata.ingestion_writes_enabled",
     type=Bool,
     default=True,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -500,7 +500,9 @@ def process_workflows(
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
 
-    workflows = _get_associated_workflows(event_detectors.detectors, environment, event_data)
+    workflows = _get_associated_workflows(
+        [event_detectors.preferred_detector], environment, event_data
+    )
     workflow_evaluation_data.workflows = workflows
 
     if not workflows:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from django.db import router, transaction
 from django.db.models import Q
 
-from sentry import features, options
+from sentry import features
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
@@ -500,14 +500,7 @@ def process_workflows(
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
 
-    # Use only preferred detector or all detectors based on option
-    use_only_preferred = options.get("workflow_engine.use_only_preferred_detector")
-    detectors_to_use: Collection[Detector] = (
-        [event_detectors.preferred_detector]
-        if use_only_preferred
-        else list(event_detectors.detectors)
-    )
-    workflows = _get_associated_workflows(detectors_to_use, environment, event_data)
+    workflows = _get_associated_workflows(event_detectors.detectors, environment, event_data)
     workflow_evaluation_data.workflows = workflows
 
     if not workflows:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from django.db import router, transaction
 from django.db.models import Q
 
-from sentry import features
+from sentry import features, options
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
@@ -500,9 +500,14 @@ def process_workflows(
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
 
-    workflows = _get_associated_workflows(
-        [event_detectors.preferred_detector], environment, event_data
+    # Use only preferred detector or all detectors based on option
+    use_only_preferred = options.get("workflow_engine.use_only_preferred_detector")
+    detectors_to_use: Collection[Detector] = (
+        [event_detectors.preferred_detector]
+        if use_only_preferred
+        else list(event_detectors.detectors)
     )
+    workflows = _get_associated_workflows(detectors_to_use, environment, event_data)
     workflow_evaluation_data.workflows = workflows
 
     if not workflows:

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -358,7 +358,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert WorkflowFireHistory.objects.count() == 3
         assert mock_trigger_action.call_count == 3
 
-    @override_options({"workflow_engine.use_only_preferred_detector": False})
+    @override_options({"workflow_engine.exclude_issue_stream_detector": False})
     def test_uses_issue_stream_workflows(self) -> None:
         issue_occurrence = self.build_occurrence()
         self.group_event.occurrence = issue_occurrence
@@ -379,7 +379,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert result.data.triggered_actions is not None
         assert len(result.data.triggered_actions) == 0
 
-    @override_options({"workflow_engine.use_only_preferred_detector": False})
+    @override_options({"workflow_engine.exclude_issue_stream_detector": False})
     def test_multiple_detectors(self) -> None:
         issue_stream_workflow, issue_stream_detector, _, _ = self.create_detector_and_workflow(
             name_prefix="issue_stream",

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -358,6 +358,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert WorkflowFireHistory.objects.count() == 3
         assert mock_trigger_action.call_count == 3
 
+    @override_options({"workflow_engine.use_only_preferred_detector": False})
     def test_uses_issue_stream_workflows(self) -> None:
         issue_occurrence = self.build_occurrence()
         self.group_event.occurrence = issue_occurrence
@@ -378,6 +379,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert result.data.triggered_actions is not None
         assert len(result.data.triggered_actions) == 0
 
+    @override_options({"workflow_engine.use_only_preferred_detector": False})
     def test_multiple_detectors(self) -> None:
         issue_stream_workflow, issue_stream_detector, _, _ = self.create_detector_and_workflow(
             name_prefix="issue_stream",


### PR DESCRIPTION
The issue stream detector is contributing to action over-triggering relative to user expectations.
This is fixable, but for now we want the ability to disable issue stream detector workflow triggering to reduce risk of additional difficulties while we sort things out.