### PR TITLE
feat(Replay): Write User Attributes to EAP Trace Item

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -86,6 +86,14 @@ class EventContext(TypedDict):
     trace_id: str | None
     replay_id: str
     segment_id: int
+    user_id: str | None
+    user_email: str | None
+    user_name: str | None
+    user_ip: str | None
+    user_geo_city: str | None
+    user_geo_country_code: str | None
+    user_geo_region: str | None
+    user_geo_subdivision: str | None
 
 
 @sentry_sdk.trace
@@ -367,6 +375,31 @@ def as_trace_item(
     # eventually use the trace_id in its rightful position.
     trace_item_context["attributes"]["replay_id"] = context["replay_id"]
     trace_item_context["attributes"]["segment_id"] = context["segment_id"]
+
+    user_id = context.get("user_id")
+    if user_id is not None:
+        trace_item_context["attributes"]["user_id"] = user_id
+    user_email = context.get("user_email")
+    if user_email is not None:
+        trace_item_context["attributes"]["user_email"] = user_email
+    user_name = context.get("user_name")
+    if user_name is not None:
+        trace_item_context["attributes"]["user_name"] = user_name
+    user_ip = context.get("user_ip")
+    if user_ip is not None:
+        trace_item_context["attributes"]["user_ip"] = user_ip
+    user_geo_city = context.get("user_geo_city")
+    if user_geo_city is not None:
+        trace_item_context["attributes"]["user_geo_city"] = user_geo_city
+    user_geo_country_code = context.get("user_geo_country_code")
+    if user_geo_country_code is not None:
+        trace_item_context["attributes"]["user_geo_country_code"] = user_geo_country_code
+    user_geo_region = context.get("user_geo_region")
+    if user_geo_region is not None:
+        trace_item_context["attributes"]["user_geo_region"] = user_geo_region
+    user_geo_subdivision = context.get("user_geo_subdivision")
+    if user_geo_subdivision is not None:
+        trace_item_context["attributes"]["user_geo_subdivision"] = user_geo_subdivision
 
     return new_trace_item(
         {

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -1810,6 +1810,14 @@ def test_as_trace_item() -> None:
         "trace_id": "trace-123",
         "replay_id": "replay-456",
         "segment_id": 1,
+        "user_id": "user-123",
+        "user_email": "test@example.com",
+        "user_name": "Test User",
+        "user_ip": "192.168.1.1",
+        "user_geo_city": "San Francisco",
+        "user_geo_country_code": "US",
+        "user_geo_region": "California",
+        "user_geo_subdivision": "CA",
     }
 
     event = {
@@ -1835,6 +1843,16 @@ def test_as_trace_item() -> None:
     assert result.attributes["to"].string_value == "/new-page"
     assert result.attributes["replay_id"].string_value == "replay-456"  # Should be added
 
+    # User attributes
+    assert result.attributes["user_id"].string_value == "user-123"
+    assert result.attributes["user_email"].string_value == "test@example.com"
+    assert result.attributes["user_name"].string_value == "Test User"
+    assert result.attributes["user_ip"].string_value == "192.168.1.1"
+    assert result.attributes["user_geo_city"].string_value == "San Francisco"
+    assert result.attributes["user_geo_country_code"].string_value == "US"
+    assert result.attributes["user_geo_region"].string_value == "California"
+    assert result.attributes["user_geo_subdivision"].string_value == "CA"
+
 
 def test_as_trace_item_with_no_trace_id() -> None:
     context: EventContext = {
@@ -1845,6 +1863,14 @@ def test_as_trace_item_with_no_trace_id() -> None:
         "trace_id": None,
         "replay_id": "replay-456",
         "segment_id": 1,
+        "user_id": None,
+        "user_email": None,
+        "user_name": None,
+        "user_ip": None,
+        "user_geo_city": None,
+        "user_geo_country_code": None,
+        "user_geo_region": None,
+        "user_geo_subdivision": None,
     }
 
     event = {
@@ -1871,6 +1897,14 @@ def test_as_trace_item_returns_none_for_unsupported_event() -> None:
         "trace_id": "trace-123",
         "replay_id": "replay-456",
         "segment_id": 1,
+        "user_id": None,
+        "user_email": None,
+        "user_name": None,
+        "user_ip": None,
+        "user_geo_city": None,
+        "user_geo_country_code": None,
+        "user_geo_region": None,
+        "user_geo_subdivision": None,
     }
 
     event: dict[str, Any] = {"data": {"payload": {}}}
@@ -1891,6 +1925,14 @@ def test_parse_events(options_get: mock.MagicMock) -> None:
             "retention_days": 1,
             "segment_id": 1,
             "trace_id": None,
+            "user_id": None,
+            "user_email": None,
+            "user_name": None,
+            "user_ip": None,
+            "user_geo_city": None,
+            "user_geo_country_code": None,
+            "user_geo_region": None,
+            "user_geo_subdivision": None,
         },
         [
             {
@@ -1949,6 +1991,14 @@ def test_parse_events_disabled(options_get: mock.MagicMock) -> None:
             "retention_days": 1,
             "segment_id": 1,
             "trace_id": None,
+            "user_id": None,
+            "user_email": None,
+            "user_name": None,
+            "user_ip": None,
+            "user_geo_city": None,
+            "user_geo_country_code": None,
+            "user_geo_region": None,
+            "user_geo_subdivision": None,
         },
         [
             {


### PR DESCRIPTION
Currently, the replay EAP trace items do not include user data in the attributes dictionary. As a result, when opening a replay under the eap flag, the replay details page displays "Anonymous User". This PR writes the user data to the attributes dictionary, and asserts it with respective unit tests.