### PR TITLE
ref(explorer): wrap tool call text

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -555,10 +555,8 @@ const ToolCallTextContainer = styled('div')`
 `;
 
 const ToolCallText = styled(Text)<{isHighlighted?: boolean}>`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+  white-space: normal;
+  overflow: visible;
   text-decoration: underline;
   text-decoration-color: transparent;
   ${p =>


### PR DESCRIPTION
Many tool calls are currently cut off w ...

<img width="686" height="60" alt="Screenshot 2025-12-18 at 2 56 47 PM" src="https://github.com/user-attachments/assets/14191268-50fa-4ca3-8e72-90b7503d6395" />
