### PR TITLE
theme: deprecate ColorOrAlias

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -587,6 +587,11 @@ const commonTheme = {
 
 export type Color = keyof ReturnType<typeof deprecatedColorMappings>;
 type Aliases = typeof lightAliases;
+/**
+ * Do not use this type. Use direct colors access via theme.colors or encapsulate
+ * colors into human readable variants that signify the color's purpose.
+ * @deprecated
+ */
 export type ColorOrAlias = keyof Aliases | Color;
 export interface SentryTheme extends Omit<typeof lightThemeDefinition, 'chart'> {
   chart: {


### PR DESCRIPTION
This type is problematic as it creates a dependency on the theme shape. We will be removing it in favor of using variants or direct theme color access