### PR TITLE
Theme color direct access

### DIFF
--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -161,12 +161,13 @@ const generateThemeUtils = (
   colors: ReturnType<typeof deprecatedColorMappings>,
   aliases: Aliases
 ) => ({
-  tooltipUnderline: (underlineColor: ColorOrAlias = 'gray300') => ({
+  tooltipUnderline: (underlineColor: ColorOrAlias | string = 'gray300') => ({
     textDecoration: 'underline' as const,
     textDecorationThickness: '0.75px',
     textUnderlineOffset: '1.25px',
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    textDecorationColor: colors[underlineColor] ?? aliases[underlineColor],
+    textDecorationColor:
+      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      colors[underlineColor] ?? aliases[underlineColor] ?? underlineColor,
     textDecorationStyle: 'dotted' as const,
   }),
   overflowEllipsis: css`

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -137,7 +137,7 @@ interface UseHoverOverlayProps {
   /**
    * Color of the dotted underline, if available. See also: showUnderline.
    */
-  underlineColor?: ColorOrAlias;
+  underlineColor?: ColorOrAlias | string;
 }
 
 export function isOverflown(el: Element): boolean {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useMemo, useState, type PropsWithChildren} from 'react';
 import {css, useTheme} from '@emotion/react';
+import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useHover} from '@react-aria/interactions';
 import type {LocationDescriptor} from 'history';
@@ -54,7 +55,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import type {Color} from 'sentry/utils/theme';
-import type {Theme} from '@emotion/react';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -297,11 +297,7 @@ const getDurationComparison = (
   const colors = makeDurationComparisonStatusColors(theme);
 
   const formattedBaseDuration = (
-    <Tooltip
-      title={baseDescription}
-      showUnderline
-      underlineColor={colors[status].normal}
-    >
+    <Tooltip title={baseDescription} showUnderline underlineColor={colors[status].normal}>
       {getDuration(baseline, 2, true)}
     </Tooltip>
   );


### PR DESCRIPTION
The ColorOrAlias type is problematic since it creates a coupling between how the theme is structured and which colors are available. Along the same lines, organizing our theme with a flat key list isn't a scalable long term approach.

Developers _should_ use variants to encapsulate different color meanings or access colors directly on the theme.