### PR TITLE
theme: use text variants

### DIFF
--- a/static/app/views/alerts/list/rules/alertRuleStatus.tsx
+++ b/static/app/views/alerts/list/rules/alertRuleStatus.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
 import {IconArrow, IconMute, IconNot} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import {hasActiveIncident} from 'sentry/views/alerts/list/rules/utils';
 import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
 import {
@@ -63,7 +63,7 @@ export default function AlertRuleStatus({rule}: Props) {
       ? criticalTrigger
       : (warningTrigger ?? criticalTrigger);
 
-  let iconColor: ColorOrAlias = 'successText';
+  let iconVariant: SVGIconProps['variant'] = 'success';
   let iconDirection: 'up' | 'down' | undefined;
   let thresholdTypeText =
     activeIncident && rule.thresholdType === AlertRuleThresholdType.ABOVE
@@ -74,12 +74,12 @@ export default function AlertRuleStatus({rule}: Props) {
   const statusLabel = activeIncident ? t('Critical') : t('Resolved');
 
   if (activeIncident) {
-    iconColor =
+    iconVariant =
       trigger?.label === AlertRuleTriggerType.CRITICAL
-        ? 'errorText'
+        ? 'danger'
         : trigger?.label === AlertRuleTriggerType.WARNING
-          ? 'warningText'
-          : 'successText';
+          ? 'warning'
+          : 'success';
     iconDirection = rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'up' : 'down';
   } else {
     // Use the Resolved threshold type, which is opposite of Critical
@@ -91,7 +91,7 @@ export default function AlertRuleStatus({rule}: Props) {
   return (
     <Flex align="center">
       {rule.detectionType !== AlertRuleComparisonType.DYNAMIC && (
-        <IconArrow color={iconColor} direction={iconDirection} />
+        <IconArrow color={iconVariant} direction={iconDirection} />
       )}
       {rule.detectionType === AlertRuleComparisonType.DYNAMIC ? (
         <TriggerText>{statusLabel}</TriggerText>

--- a/static/app/views/alerts/list/rules/alertRuleStatus.tsx
+++ b/static/app/views/alerts/list/rules/alertRuleStatus.tsx
@@ -91,7 +91,7 @@ export default function AlertRuleStatus({rule}: Props) {
   return (
     <Flex align="center">
       {rule.detectionType !== AlertRuleComparisonType.DYNAMIC && (
-        <IconArrow color={iconVariant} direction={iconDirection} />
+        <IconArrow variant={iconVariant} direction={iconDirection} />
       )}
       {rule.detectionType === AlertRuleComparisonType.DYNAMIC ? (
         <TriggerText>{statusLabel}</TriggerText>

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -9,6 +9,7 @@ import MarkLine from 'sentry/components/charts/components/markLine';
 import type {DateTimeObject} from 'sentry/components/charts/utils';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import LoadingError from 'sentry/components/loadingError';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {PanelTable} from 'sentry/components/panels/panelTable';
@@ -20,7 +21,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import toArray from 'sentry/utils/array/toArray';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
@@ -153,10 +153,10 @@ function TeamReleases({
     }
 
     return (
-      <SubText color={trend >= 0 ? 'successText' : 'errorText'}>
+      <Text variant={trend >= 0 ? 'success' : 'danger'}>
         {`${round(Math.abs(trend), 3)}`}
         <PaddedIconArrow direction={trend >= 0 ? 'up' : 'down'} size="xs" />
-      </SubText>
+      </Text>
     );
   }
 
@@ -334,8 +334,4 @@ const ScoreWrapper = styled('div')`
 
 const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
-`;
-
-const SubText = styled('div')<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
 `;

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -6,6 +6,7 @@ import round from 'lodash/round';
 import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import type {DateTimeObject} from 'sentry/components/charts/utils';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Text} from 'sentry/components/core/text';
 import LoadingError from 'sentry/components/loadingError';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {PanelTable} from 'sentry/components/panels/panelTable';
@@ -19,7 +20,6 @@ import type {Project} from 'sentry/types/project';
 import {formatFloat} from 'sentry/utils/number/formatFloat';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getCountSeries, getCrashFreeRate, getSeriesSum} from 'sentry/utils/sessions';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import {displayCrashFreePercent} from 'sentry/views/releases/utils';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
@@ -187,10 +187,10 @@ function TeamStability({
     }
 
     return (
-      <SubText color={trend >= 0 ? 'successText' : 'errorText'}>
+      <Text variant={trend >= 0 ? 'success' : 'danger'}>
         {`${round(Math.abs(trend), 3)}\u0025`}
         <PaddedIconArrow direction={trend >= 0 ? 'up' : 'down'} size="xs" />
-      </SubText>
+      </Text>
     );
   }
 
@@ -285,8 +285,4 @@ const ScoreWrapper = styled('div')`
 
 const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
-`;
-
-const SubText = styled('div')<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
 `;


### PR DESCRIPTION
The `ColorOrAlias` type is problematic since it creates a coupling between how the theme is structured and which colors are available. Along the same lines, organizing our theme with a flat key list isn't a scalable long term approach. 

Developers should use variants to encapsulate meanings or access colors directly on the theme if they need to.
