### PR TITLE
replay: use icon variant

### DIFF
--- a/static/app/views/replays/selectors/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/selectors/deadRageSelectorCards.tsx
@@ -9,10 +9,10 @@ import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconCursorArrow, IconSearch} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelectors';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import {
   HeaderContainer,
@@ -95,12 +95,12 @@ function AccordionWidget({
   });
   const location = useLocation();
   const filteredData = data.filter(d => (d[clickType] ?? 0) > 0);
-  const clickColor = deadOrRage === 'dead' ? 'yellow300' : 'red300';
+  const iconVariant = deadOrRage === 'dead' ? 'warning' : 'danger';
 
   return (
     <StyledWidgetContainer data-test-id="selector-widget">
       <StyledHeaderContainer>
-        <IconCursorArrow color={clickColor} />
+        <IconCursorArrow variant={iconVariant} />
         {header}
       </StyledHeaderContainer>
       {isLoading ? (
@@ -139,7 +139,7 @@ function AccordionWidget({
                   <AccordionItemHeader
                     count={d[clickType] ?? 0}
                     selector={d.dom_element.selector}
-                    clickColor={clickColor}
+                    iconVariant={iconVariant}
                     selectorQuery={selectorQuery}
                     id={d.project_id}
                   />
@@ -163,20 +163,20 @@ function AccordionWidget({
 
 function AccordionItemHeader({
   count,
-  clickColor,
+  iconVariant,
   selector,
   selectorQuery,
   id,
 }: {
-  clickColor: ColorOrAlias;
   count: number;
+  iconVariant: SVGIconProps['variant'];
   id: number;
   selector: string;
   selectorQuery: string;
 }) {
   const clickCount = (
     <ClickCount>
-      <IconCursorArrow size="xs" color={clickColor} />
+      <IconCursorArrow size="xs" variant={iconVariant} />
       {count}
     </ClickCount>
   );


### PR DESCRIPTION
The `ColorOrAlias` type is problematic since it creates a coupling between how the theme is structured and which colors are available. Along the same lines, organizing our theme with a flat key list isn't a scalable long term approach. 

Developers should use variants to encapsulate meanings or access colors directly on the theme if they need to.
