### PR TITLE
ref(top-issues): make 'disable filtering' work

### DIFF
--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -832,9 +832,7 @@ function DynamicGrouping() {
     const clusterData = customClusterData ?? topIssuesResponse?.data ?? [];
 
     if (isUsingCustomData && disableFilters) {
-      return clusterData.filter(
-        cluster => cluster.error_type && cluster.impact && cluster.location
-      );
+      return clusterData;
     }
 
     // Apply project filter and require structured fields


### PR DESCRIPTION
Disabling filters doesn't actually disable all filters right now, since it filters out clusters without the high-level tags. Making this work so that copy pasting data is a little less painful.