### PR TITLE
monitor: use color variants

### DIFF
--- a/static/app/components/core/text/index.tsx
+++ b/static/app/components/core/text/index.tsx
@@ -1,3 +1,4 @@
+export type {TextProps} from './text';
 export {Text} from './text';
 export {Heading} from './heading';
 export {Prose} from './prose';

--- a/static/app/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {
   IconCheckmark,
@@ -11,7 +12,6 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import {
   MonitorStatus,
   type MonitorEnvironment,
@@ -24,21 +24,21 @@ interface Props {
 
 const statusIconColorMap: Record<MonitorStatus, StatusNotice> = {
   ok: {
-    icon: <IconCheckmark color="successText" />,
-    color: 'successText',
+    icon: <IconCheckmark variant="success" />,
+    variant: 'success',
   },
   error: {
-    icon: <IconFire color="errorText" />,
-    color: 'errorText',
+    icon: <IconFire variant="danger" />,
+    variant: 'danger',
   },
   active: {
-    icon: <IconTimer color="subText" />,
-    color: 'subText',
+    icon: <IconTimer variant="muted" />,
+    variant: 'muted',
     label: t('Waiting For Check-In'),
   },
   disabled: {
-    icon: <IconUnsubscribed color="subText" size="xs" />,
-    color: 'subText',
+    icon: <IconUnsubscribed variant="muted" size="xs" />,
+    variant: 'muted',
     label: t('Muted'),
   },
 };
@@ -47,16 +47,16 @@ const userNotifiedDisplay: StatusNotice = {
   label: t(
     'This environment is likely broken due to being in an error state for multiple days.'
   ),
-  icon: <IconFix color="subText" />,
-  color: 'subText',
+  icon: <IconFix variant="muted" />,
+  variant: 'muted',
 };
 
 const envMutedDisplay: StatusNotice = {
   label: t(
     'This environment is likely broken due to being in an error state for multiple days. It has been automatically muted.'
   ),
-  icon: <IconMute color="subText" />,
-  color: 'subText',
+  icon: <IconMute variant="muted" />,
+  variant: 'muted',
 };
 
 export default function MonitorEnvironmentLabel({monitorEnv}: Props) {
@@ -64,7 +64,7 @@ export default function MonitorEnvironmentLabel({monitorEnv}: Props) {
   const {userNotifiedTimestamp, environmentMutedTimestamp} =
     activeIncident?.brokenNotice ?? {};
   const envStatus = isMuted ? MonitorStatus.DISABLED : status;
-  const {label, icon, color} = environmentMutedTimestamp
+  const {label, icon, variant} = environmentMutedTimestamp
     ? envMutedDisplay
     : userNotifiedTimestamp
       ? userNotifiedDisplay
@@ -73,7 +73,9 @@ export default function MonitorEnvironmentLabel({monitorEnv}: Props) {
   return (
     <EnvWithStatus>
       <Tooltip skipWrapper showOnlyOnOverflow title={name}>
-        <MonitorEnvLabel color={color}>{name}</MonitorEnvLabel>
+        <MonitorEnvLabel>
+          <Text variant={variant}>{name}</Text>
+        </MonitorEnvLabel>
       </Tooltip>
       <Tooltip disabled={!label} title={label} skipWrapper>
         {icon}
@@ -90,12 +92,11 @@ const EnvWithStatus = styled('div')`
   opacity: var(--disabled-opacity);
 `;
 
-const MonitorEnvLabel = styled('div')<{color: ColorOrAlias}>`
+const MonitorEnvLabel = styled('div')`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
   min-width: 0;
 
-  color: ${p => p.theme[p.color]};
   opacity: var(--disabled-opacity);
 `;

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -1,6 +1,6 @@
+import type {TextProps} from 'sentry/components/core/text';
 import type {Actor, ObjectStatus} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 
 /**
  * Some old monitor configurations do NOT have a schedule_type
@@ -206,8 +206,8 @@ export type MonitorBucket = [timestamp: number, envData: MonitorBucketEnvMapping
  * timeline view
  */
 export interface StatusNotice {
-  color: ColorOrAlias;
   icon: React.ReactNode;
+  variant: TextProps<any>['variant'];
   label?: React.ReactNode;
 }
 


### PR DESCRIPTION
The `ColorOrAlias` type is problematic since it creates a coupling between how the theme is structured and which colors are available. Along the same lines, organizing our theme with a flat key list isn't a scalable long term approach. 
Developers should use variants to encapsulate meanings or access colors directly on the theme if they need to.
