### PR TITLE
ref(alerts): Remove usage of `deprecatedRouteProps` for `AlertRulesList` route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1480,7 +1480,6 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/alerts/list/rules/alertRulesList')),
-          deprecatedRouteProps: true,
         },
         {
           path: 'details/:ruleId/',

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -29,8 +29,8 @@ import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAna
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import useRouter from 'sentry/utils/useRouter';
 import FilterBar from 'sentry/views/alerts/filterBar';
 import AlertHeader from 'sentry/views/alerts/list/header';
 import type {CombinedAlerts} from 'sentry/views/alerts/types';
@@ -59,9 +59,9 @@ const DataConsentBanner = HookOrDefault({
   defaultComponent: null,
 });
 
-function AlertRulesList() {
+export default function AlertRulesList() {
   const location = useLocation();
-  const router = useRouter();
+  const navigate = useNavigate();
   const api = useApi();
   const queryClient = useQueryClient();
   const organization = useOrganization();
@@ -89,7 +89,7 @@ function AlertRulesList() {
 
   const handleChangeFilter = (activeFilters: string[]) => {
     const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
-    router.push({
+    navigate({
       pathname: location.pathname,
       query: {
         ...currentQuery,
@@ -100,7 +100,7 @@ function AlertRulesList() {
 
   const handleChangeSearch = (name: string) => {
     const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
-    router.push({
+    navigate({
       pathname: location.pathname,
       query: {
         ...currentQuery,
@@ -111,7 +111,7 @@ function AlertRulesList() {
 
   const handleChangeType = (alertType: CombinedAlertType[]) => {
     const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
-    router.push({
+    navigate({
       pathname: location.pathname,
       query: {
         ...currentQuery,
@@ -307,7 +307,7 @@ function AlertRulesList() {
                   team = '';
                 }
 
-                router.push({
+                navigate({
                   pathname: path,
                   query: {...currentQuery, team, cursor},
                 });
@@ -319,8 +319,6 @@ function AlertRulesList() {
     </Fragment>
   );
 }
-
-export default AlertRulesList;
 
 const StyledLoadingError = styled(LoadingError)`
   grid-column: 1 / -1;


### PR DESCRIPTION
Migrates an alerts route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7