### PR TITLE
ref(integrations): Remove usage of `deprecatedRouteProps` for `SentryAppExternalInstallation` component

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -186,7 +186,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/sentry-apps/:sentryAppSlug/external-install/',
       component: make(() => import('sentry/views/sentryAppExternalInstallation')),
-      deprecatedRouteProps: true,
     },
     {
       path: '/account/',


### PR DESCRIPTION
Removes unnecessary `deprecatedRouteProps` for `SentryAppExternalInstallation` component. The props themselves were already removed in https://github.com/getsentry/sentry/pull/97237.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7