### PR TITLE
ref(auth): Remove usage of `deprecatedRouteProps` for auth layout route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -146,7 +146,6 @@ function buildRoutes(): RouteObject[] {
     ? {
         path: '/auth/login/',
         component: errorHandler(AuthLayout),
-        deprecatedRouteProps: true,
         children: experimentalSpaChildRoutes,
       }
     : {};

--- a/static/app/views/auth/layout.tsx
+++ b/static/app/views/auth/layout.tsx
@@ -37,7 +37,7 @@ function AuthLayoutContent({children}: {children: React.ReactNode}) {
 }
 
 /**
- * Route component for auth pages (used in routes.tsx).
+ * Route component for auth pages.
  * Uses <Outlet /> for child routes.
  */
 export default function AuthLayout() {
@@ -49,7 +49,7 @@ export default function AuthLayout() {
 }
 
 /**
- * Wrapper component for auth-style layout (used directly in components like dataDownload).
+ * Wrapper component for auth-style layout with children to render.
  */
 export function AuthLayoutWrapper({children}: {children: React.ReactNode}) {
   return <AuthLayoutContent>{children}</AuthLayoutContent>;

--- a/static/app/views/auth/layout.tsx
+++ b/static/app/views/auth/layout.tsx
@@ -10,7 +10,10 @@ import {AppBodyContent} from 'sentry/views/app/appBodyContent';
 
 const BODY_CLASSES = ['narrow'];
 
-export default function Layout() {
+/**
+ * Shared auth layout structure - includes all wrapper elements.
+ */
+function AuthLayoutContent({children}: {children: React.ReactNode}) {
   useEffect(() => {
     document.body.classList.add(...BODY_CLASSES);
     return () => document.body.classList.remove(...BODY_CLASSES);
@@ -25,14 +28,31 @@ export default function Layout() {
             <AuthSidebar>
               <SentryButton />
             </AuthSidebar>
-            <div>
-              <Outlet />
-            </div>
+            <div>{children}</div>
           </AuthPanel>
         </AuthContainer>
       </AppBodyContent>
     </div>
   );
+}
+
+/**
+ * Route component for auth pages (used in routes.tsx).
+ * Uses <Outlet /> for child routes.
+ */
+export default function AuthLayout() {
+  return (
+    <AuthLayoutContent>
+      <Outlet />
+    </AuthLayoutContent>
+  );
+}
+
+/**
+ * Wrapper component for auth-style layout (used directly in components like dataDownload).
+ */
+export function AuthLayoutWrapper({children}: {children: React.ReactNode}) {
+  return <AuthLayoutContent>{children}</AuthLayoutContent>;
 }
 
 const AuthContainer = styled('div')`

--- a/static/app/views/auth/layout.tsx
+++ b/static/app/views/auth/layout.tsx
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {Link} from 'sentry/components/core/link';
@@ -9,7 +10,7 @@ import {AppBodyContent} from 'sentry/views/app/appBodyContent';
 
 const BODY_CLASSES = ['narrow'];
 
-function Layout({children}: {children: React.ReactNode}) {
+export default function Layout() {
   useEffect(() => {
     document.body.classList.add(...BODY_CLASSES);
     return () => document.body.classList.remove(...BODY_CLASSES);
@@ -24,7 +25,9 @@ function Layout({children}: {children: React.ReactNode}) {
             <AuthSidebar>
               <SentryButton />
             </AuthSidebar>
-            <div>{children}</div>
+            <div>
+              <Outlet />
+            </div>
           </AuthPanel>
         </AuthContainer>
       </AppBodyContent>
@@ -75,5 +78,3 @@ const SentryButton = styled(
     color: #fff;
   }
 `;
-
-export default Layout;

--- a/static/app/views/dataExport/dataDownload.tsx
+++ b/static/app/views/dataExport/dataDownload.tsx
@@ -15,7 +15,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
-import Layout from 'sentry/views/auth/layout';
+import {AuthLayoutWrapper as Layout} from 'sentry/views/auth/layout';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';


### PR DESCRIPTION
Migrates the `AuthLayout` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7