### PR TITLE
fix(code-review): Update legacy feature enablement switch

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -297,7 +297,7 @@ describe('OrganizationSettingsForm', () => {
       {
         organization: {
           ...organization,
-          features: ['gen-ai-features'],
+          features: ['gen-ai-features', 'seer-added'],
         },
       }
     );
@@ -356,7 +356,7 @@ describe('OrganizationSettingsForm', () => {
       {
         organization: {
           ...organization,
-          features: ['gen-ai-features'],
+          features: ['gen-ai-features', 'seer-added'],
         },
       }
     );
@@ -379,7 +379,7 @@ describe('OrganizationSettingsForm', () => {
       {
         organization: {
           ...organization,
-          features: ['gen-ai-features'],
+          features: ['gen-ai-features', 'seer-added'],
         },
       }
     );
@@ -421,7 +421,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['gen-ai-features'],
+            features: ['gen-ai-features', 'seer-added'],
           },
         }
       );
@@ -436,7 +436,7 @@ describe('OrganizationSettingsForm', () => {
       expect(screen.queryByTestId('prevent-ai-disabled-tag')).not.toBeInTheDocument();
     });
 
-    it('is disabled when feature flag is off', async () => {
+    it('is hidden when seer-added or code-review-beta feature flag is off', async () => {
       jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
         name: 'us',
         displayName: 'United States of America (US)',
@@ -459,13 +459,11 @@ describe('OrganizationSettingsForm', () => {
 
       await waitFor(() => expect(membersRequest).toHaveBeenCalled());
 
-      const preventAiField = screen.getByRole('checkbox', {
-        name: /Enable AI Code Review/i,
-      });
-      expect(preventAiField).toBeInTheDocument();
-      expect(preventAiField).toBeEnabled();
-
-      expect(screen.queryByTestId('prevent-ai-disabled-tag')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('checkbox', {
+          name: /Enable AI Code Review/i,
+        })
+      ).not.toBeInTheDocument();
     });
 
     it('is enabled when EU region', async () => {
@@ -484,7 +482,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['gen-ai-features'],
+            features: ['gen-ai-features', 'seer-added'],
           },
         }
       );
@@ -518,7 +516,7 @@ describe('OrganizationSettingsForm', () => {
           organization: {
             ...organization,
             access: ['org:write'],
-            features: ['gen-ai-features'],
+            features: ['gen-ai-features', 'seer-added'],
           },
         }
       );
@@ -552,7 +550,7 @@ describe('OrganizationSettingsForm', () => {
           organization: {
             ...organization,
             access: ['org:read'],
-            features: ['gen-ai-features'],
+            features: ['gen-ai-features', 'seer-added'],
           },
         }
       );
@@ -580,7 +578,7 @@ describe('OrganizationSettingsForm', () => {
           organization: {
             ...organization,
             access: ['org:write'],
-            features: ['gen-ai-features'],
+            features: ['gen-ai-features', 'seer-added'],
           },
         }
       );
@@ -598,6 +596,36 @@ describe('OrganizationSettingsForm', () => {
       expect(
         await screen.findByText('This feature is not available for self-hosted instances')
       ).toBeInTheDocument();
+    });
+
+    it('is hidden when seat-based-seer-enabled feature is on', async () => {
+      jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
+        name: 'us',
+        displayName: 'United States of America (US)',
+        url: 'https://sentry.example.com',
+      });
+
+      render(
+        <OrganizationSettingsForm
+          {...routerProps}
+          initialData={OrganizationFixture({hideAiFeatures: true})}
+          onSave={onSave}
+        />,
+        {
+          organization: {
+            ...organization,
+            features: ['gen-ai-features', 'seer-added', 'seat-based-seer-enabled'],
+          },
+        }
+      );
+
+      await waitFor(() => expect(membersRequest).toHaveBeenCalled());
+
+      expect(
+        screen.queryByRole('checkbox', {
+          name: /Enable AI Code Review/i,
+        })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -8,7 +8,6 @@ import {IconLock} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
-import showNewSeer from 'sentry/utils/seer/showNewSeer';
 
 export const makePreventAiField = (organization: Organization): FieldObject => {
   const isSelfHosted = ConfigStore.get('isSelfHosted');
@@ -45,13 +44,19 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       ),
     }),
     visible: ({model}) => {
-      if (showNewSeer(organization)) {
+      if (organization.features.includes('seat-based-seer-enabled')) {
         return false;
       }
 
-      // Show field when AI features are enabled (hideAiFeatures is false)
-      const hideAiFeatures = model.getValue('hideAiFeatures');
-      return hideAiFeatures;
+      if (
+        organization.features.includes('seer-added') ||
+        organization.features.includes('code-review-beta')
+      ) {
+        // This looks flipped but it's just a weirdly named field
+        return model.getValue('hideAiFeatures');
+      }
+
+      return false;
     },
     disabled: ({access}) => isDisabled || !access.has('org:write'),
   };


### PR DESCRIPTION
Update legacy feature enablement switch so it does NOT show for new seat-based plan orgs. It still shows for legacy payg seer orgs and code-review-beta orgs (that are not on the new seat-based plan).