### PR TITLE
ref(code-review): Update org default triggers copy

### DIFF
--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -97,9 +97,9 @@ export default function SeerAutomationSettings() {
                 },
                 {
                   name: 'defaultCodeReviewTriggers',
-                  label: t('Auto Run on Opened Pull Requests'),
+                  label: t('Code Review Triggers'),
                   help: t(
-                    'Run when a new pull request is published, ignoring subsequent pushes.'
+                    'Reviews can run on demand, whenever a PR is opened, or after each commit is pushed to a PR.'
                   ),
                   type: 'choice',
                   multiple: true,


### PR DESCRIPTION
Update the copy on the org default triggers to match that on the repo page ([here](https://github.com/getsentry/sentry/blob/c70b03196704d978972b590522ad50b568cac904/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx#L61))

NEW
<img width="1155" height="235" alt="Screenshot 2025-12-18 at 8 56 33 PM" src="https://github.com/user-attachments/assets/1df79390-525c-479f-a388-f92e58fa3c35" />


OLD
<img width="1140" height="209" alt="Screenshot 2025-12-18 at 8 55 25 PM" src="https://github.com/user-attachments/assets/059487eb-4ff0-4ed1-8a19-f55f788b1ac3" />


OTHER SPOT FOR REFERENCE
<img width="1135" height="333" alt="Screenshot 2025-12-18 at 8 55 55 PM" src="https://github.com/user-attachments/assets/4fa3ac5c-2bd8-47fc-a4ae-156a04bdd8cc" />
