### PR TITLE
feat(preprod): Add artifact and metric ids to issue evidence_data

### DIFF
--- a/src/sentry/preprod/size_analysis/issues.py
+++ b/src/sentry/preprod/size_analysis/issues.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 from uuid import uuid4
 
 from sentry.issues.grouptype import PreprodDeltaGroupType
-from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     platform_from_artifact_type,
 )
@@ -71,14 +71,17 @@ def diff_to_occurrence(
         "tags": tags,
     }
 
-    evidence_display = [
-        IssueEvidence("some_evidence_name", "some_evidence_data", False),
-    ]
+    evidence_data = {
+        "head_artifact_id": head_artifact.id,
+        "base_artifact_id": base_artifact.id,
+        "head_size_metric_id": head_metric.id,
+        "base_size_metric_id": base_metric.id,
+    }
+
     match size:
         case "download":
             delta = diff.head_download_size - diff.base_download_size
             issue_title = "Download size regression"
-
         case "install":
             delta = diff.head_install_size - diff.base_install_size
             issue_title = "Install size regression"
@@ -94,8 +97,8 @@ def diff_to_occurrence(
         fingerprint=fingerprint,
         type=PreprodDeltaGroupType,
         detection_time=current_timestamp,
-        evidence_data={},
-        evidence_display=evidence_display,
+        evidence_data=evidence_data,
+        evidence_display=[],
         level="info",
         resource_id=None,
         culprit="",

--- a/tests/sentry/preprod/size_analysis/test_issues.py
+++ b/tests/sentry/preprod/size_analysis/test_issues.py
@@ -13,18 +13,18 @@ class DiffToOccurrenceTest(TestCase):
         head_artifact = self.create_preprod_artifact(project=project, app_id="com.example.app")
         base_artifact = self.create_preprod_artifact(project=project, app_id="com.example.app")
 
-        head_metric = PreprodArtifactSizeMetrics.objects.create(
-            preprod_artifact=head_artifact,
-            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        head_metric = self.create_preprod_artifact_size_metrics(
+            head_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             identifier="main",
             max_install_size=150,
             max_download_size=400,
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
 
-        base_metric = PreprodArtifactSizeMetrics.objects.create(
-            preprod_artifact=base_artifact,
-            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        base_metric = self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             identifier="main",
             max_install_size=100,
             max_download_size=300,
@@ -53,10 +53,11 @@ class DiffToOccurrenceTest(TestCase):
         assert event["tags"]["regression_kind"] == "install"
         assert event["tags"]["head.app_id"] == "com.example.app"
         assert event["tags"]["base.app_id"] == "com.example.app"
-        assert len(occurrence.evidence_display) == 1
-        assert occurrence.evidence_display[0].name == "some_evidence_name"
-        assert occurrence.evidence_display[0].value == "some_evidence_data"
-        assert occurrence.evidence_display[0].important is False
+        assert len(occurrence.evidence_display) == 0
+        assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
+        assert occurrence.evidence_data["base_artifact_id"] == base_artifact.id
+        assert occurrence.evidence_data["head_size_metric_id"] == head_metric.id
+        assert occurrence.evidence_data["base_size_metric_id"] == base_metric.id
 
     def test_diff_to_occurrence_download(self):
 
@@ -65,18 +66,18 @@ class DiffToOccurrenceTest(TestCase):
         head_artifact = self.create_preprod_artifact(project=project, app_id="com.example.app")
         base_artifact = self.create_preprod_artifact(project=project, app_id="com.example.app")
 
-        head_metric = PreprodArtifactSizeMetrics.objects.create(
-            preprod_artifact=head_artifact,
-            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        head_metric = self.create_preprod_artifact_size_metrics(
+            head_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             identifier="main",
             max_install_size=150,
             max_download_size=500,
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
 
-        base_metric = PreprodArtifactSizeMetrics.objects.create(
-            preprod_artifact=base_artifact,
-            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        base_metric = self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             identifier="main",
             max_install_size=100,
             max_download_size=300,
@@ -105,10 +106,11 @@ class DiffToOccurrenceTest(TestCase):
         assert event["tags"]["regression_kind"] == "download"
         assert event["tags"]["head.app_id"] == "com.example.app"
         assert event["tags"]["base.app_id"] == "com.example.app"
-        assert len(occurrence.evidence_display) == 1
-        assert occurrence.evidence_display[0].name == "some_evidence_name"
-        assert occurrence.evidence_display[0].value == "some_evidence_data"
-        assert occurrence.evidence_display[0].important is False
+        assert len(occurrence.evidence_display) == 0
+        assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
+        assert occurrence.evidence_data["base_artifact_id"] == base_artifact.id
+        assert occurrence.evidence_data["head_size_metric_id"] == head_metric.id
+        assert occurrence.evidence_data["base_size_metric_id"] == base_metric.id
 
 
 class ArtifactToTagsTest(TestCase):


### PR DESCRIPTION
Populate evidence_data with `{head,base} x {metric,artifact}` ids.
Also remove unused `evidence_display`.

This will allow us to show the diff treemap:
<img width="2226" height="1472" alt="CleanShot 2025-12-19 at 14 55 35@2x" src="https://github.com/user-attachments/assets/8b8ae56d-7c9c-41f5-8a03-6098331afe54" />

In the issue group view (after a matching UI change).