### PR TITLE
User facing github spelling

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -619,7 +619,7 @@ class GitHubIntegration(
                     {
                         "name": self.inbound_assignee_key,
                         "type": "boolean",
-                        "label": _("Sync Github Assignment to Sentry"),
+                        "label": _("Sync GitHub Assignment to Sentry"),
                         "help": _(
                             "When an issue is assigned in GitHub, assign its linked Sentry issue to the same user."
                         ),
@@ -688,14 +688,14 @@ class GitHubIntegration(
                     {
                         "name": self.outbound_status_key,
                         "type": "choice_mapper",
-                        "label": _("Sync Sentry Status to Github"),
+                        "label": _("Sync Sentry Status to GitHub"),
                         "help": _(
-                            "When a Sentry issue changes status, change the status of the linked ticket in Github."
+                            "When a Sentry issue changes status, change the status of the linked ticket in GitHub."
                         ),
-                        "addButtonText": _("Add Github Project"),
+                        "addButtonText": _("Add GitHub Project"),
                         "addDropdown": {
                             "emptyMessage": _("All projects configured"),
-                            "noResultsMessage": _("Could not find Github project"),
+                            "noResultsMessage": _("Could not find GitHub project"),
                             "items": current_repo_items,
                             "url": reverse(
                                 "sentry-integration-github-search",
@@ -711,7 +711,7 @@ class GitHubIntegration(
                             "on_resolve": _("When resolved"),
                             "on_unresolve": _("When unresolved"),
                         },
-                        "mappedColumnLabel": _("Github Project"),
+                        "mappedColumnLabel": _("GitHub Project"),
                         "formatMessageValue": False,
                     },
                 )
@@ -721,14 +721,14 @@ class GitHubIntegration(
                     {
                         "name": self.outbound_status_key,
                         "type": "choice_mapper",
-                        "label": _("Sync Sentry Status to Github"),
+                        "label": _("Sync Sentry Status to GitHub"),
                         "help": _(
-                            "When a Sentry issue changes status, change the status of the linked ticket in Github."
+                            "When a Sentry issue changes status, change the status of the linked ticket in GitHub."
                         ),
-                        "addButtonText": _("Add Github Project"),
+                        "addButtonText": _("Add GitHub Project"),
                         "addDropdown": {
                             "emptyMessage": _("All projects configured"),
-                            "noResultsMessage": _("Could not find Github project"),
+                            "noResultsMessage": _("Could not find GitHub project"),
                             "items": [],  # Populated with projects
                         },
                         "mappedSelectors": {},
@@ -736,7 +736,7 @@ class GitHubIntegration(
                             "on_resolve": _("When resolved"),
                             "on_unresolve": _("When unresolved"),
                         },
-                        "mappedColumnLabel": _("Github Project"),
+                        "mappedColumnLabel": _("GitHub Project"),
                         "formatMessageValue": False,
                     },
                 )

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -245,8 +245,8 @@ class GitHubPlugin(CorePluginMixin, IssuePlugin2):
                 "help": (
                     "If you want to add a repository to integrate commit data with releases, please install the "
                     'new <a href="/settings/{}/integrations/github/">'
-                    "Github global integration</a>.  "
-                    "You cannot add repositories to the legacy Github integration."
+                    "GitHub global integration</a>.  "
+                    "You cannot add repositories to the legacy GitHub integration."
                 ).format(project.organization.slug),
                 "required": True,
             }

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -302,7 +302,7 @@ const SECTIONS: TSection[] = [
         id: 'github',
         groups: ['logo'],
         keywords: ['git', 'repository', 'code', 'microsoft'],
-        name: 'Github',
+        name: 'GitHub',
         defaultProps: {},
       },
       {

--- a/static/app/views/automations/components/actionNodes.tsx
+++ b/static/app/views/automations/components/actionNodes.tsx
@@ -123,7 +123,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
   [
     ActionType.GITHUB,
     {
-      label: t('Github'),
+      label: t('GitHub'),
       action: GithubNode,
       details: GithubDetails,
       ticketType: t('a GitHub issue'),
@@ -133,7 +133,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
   [
     ActionType.GITHUB_ENTERPRISE,
     {
-      label: t('Github Enterprise'),
+      label: t('GitHub Enterprise'),
       action: GithubEnterpriseNode,
       details: GithubEnterpriseDetails,
       ticketType: t('a GitHub Enterprise issue'),

--- a/static/app/views/integrationPipeline/pipelineView.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.tsx
@@ -32,7 +32,7 @@ const pipelineMapper: Record<string, [React.ComponentType<any>, string]> = {
   awsLambdaFunctionSelect: [AwsLambdaFunctionSelect, 'AWS Lambda Select Lambdas'],
   awsLambdaCloudformation: [AwsLambdaCloudformation, 'AWS Lambda Create Cloudformation'],
   awsLambdaFailureDetails: [AwsLambdaFailureDetails, 'AWS Lambda View Failures'],
-  githubInstallationSelect: [GithubInstallationSelect, 'Github Select Installation'],
+  githubInstallationSelect: [GithubInstallationSelect, 'GitHub Select Installation'],
 };
 
 type Props = {

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -153,7 +153,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           path: `${organizationSettingsPathPrefix}/integrations/`,
           title: t('Integrations'),
           description: t(
-            'Manage organization-level integrations, including: Slack, Github, Bitbucket, Jira, and Azure DevOps'
+            'Manage organization-level integrations, including: Slack, GitHub, Bitbucket, Jira, and Azure DevOps'
           ),
           id: 'integrations',
           recordAnalytics: true,

--- a/static/app/views/settings/organizationIntegrations/integrationRow.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRow.spec.tsx
@@ -95,7 +95,7 @@ describe('IntegrationRow', () => {
           organization={org}
           type="firstParty"
           slug="github"
-          displayName="Github"
+          displayName="GitHub"
           status="Not Installed"
           publishStatus="published"
           configurations={0}
@@ -103,7 +103,7 @@ describe('IntegrationRow', () => {
         />
       );
       expect(screen.getByText('Not Installed')).toBeInTheDocument();
-      expect(screen.getByText('Github')).toHaveAttribute(
+      expect(screen.getByText('GitHub')).toHaveAttribute(
         'href',
         `/settings/${org.slug}/integrations/github/`
       );

--- a/static/gsApp/components/partnerPlanEndingModal.tsx
+++ b/static/gsApp/components/partnerPlanEndingModal.tsx
@@ -86,7 +86,7 @@ function PartnerPlanEndingModal({organization, subscription, closeModal}: Props)
     ? [
         t('Unlimited users'),
         t('Event volume controls'),
-        t('SSO via Google and Github'),
+        t('SSO via Google and GitHub'),
         t('Third party integrations'),
         t('Extended data retention'),
         t('Custom alerts'),

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
@@ -371,7 +371,7 @@ function SetupCta({
       imageAlt=""
       title={t('Get started with Seer')}
       subtitle={t(
-        'Finish connecting to Github, configure your repositories and projects, and start getting the most out of Seer.'
+        'Finish connecting to GitHub, configure your repositories and projects, and start getting the most out of Seer.'
       )}
       heightOverride={`calc(100% - ${USAGE_OVERVIEW_PANEL_HEADER_HEIGHT})`}
       buttons={


### PR DESCRIPTION
<!-- Describe your PR here. -->
Corrects all instances of "Github" to "GitHub" in user-facing text, such as labels, buttons, and help messages, across both frontend and backend. This ensures consistent branding and adherence to the official capitalization, while carefully avoiding changes to internal code identifiers, file paths, or analytics event names.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D09151U0YN9/p1766156898784909?thread_ts=1766156898.784909&cid=D09151U0YN9)

<a href="https://cursor.com/background-agent?bcId=bc-29010a09-6a14-4186-a022-93a69174f30c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29010a09-6a14-4186-a022-93a69174f30c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

