### PR TITLE
feat(preprod): Add treemap diff UI

### DIFF
--- a/static/app/components/events/eventXrayDiff.tsx
+++ b/static/app/components/events/eventXrayDiff.tsx
@@ -1,5 +1,6 @@
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -33,10 +34,19 @@ function EventXrayDiffContent({baseMetricId, headMetricId, project}: ContentProp
     return <LoadingIndicator />;
   }
 
+  if (query.isError) {
+    return (
+      <LoadingError
+        message={t('Failed to load X-Ray diff data.')}
+        onRetry={query.refetch}
+      />
+    );
+  }
+
   const diffItems = query.data?.diff_items;
 
   if (!diffItems || diffItems.length === 0) {
-    return <EmptyStateWarning small>No diff found.</EmptyStateWarning>;
+    return <EmptyStateWarning small>{t('No diff found.')}</EmptyStateWarning>;
   }
 
   return <TreemapDiffSection diffItems={diffItems} />;

--- a/static/app/components/events/eventXrayDiff.tsx
+++ b/static/app/components/events/eventXrayDiff.tsx
@@ -1,0 +1,96 @@
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import type {Project} from 'sentry/types/project';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {TreemapDiffSection} from 'sentry/views/preprod/buildComparison/main/treemapDiffSection';
+import type {SizeAnalysisComparisonResults} from 'sentry/views/preprod/types/appSizeTypes';
+
+type ContentProps = {
+  baseMetricId: string;
+  headMetricId: string;
+  project: Project;
+};
+
+function EventXrayDiffContent({baseMetricId, headMetricId, project}: ContentProps) {
+  const organization = useOrganization();
+
+  const query = useApiQuery<SizeAnalysisComparisonResults>(
+    [
+      `/projects/${organization.slug}/${project.id}/preprodartifacts/size-analysis/compare/${headMetricId}/${baseMetricId}/download/`,
+    ],
+    {
+      staleTime: 0,
+    }
+  );
+
+  if (query.isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  const diffItems = query.data?.diff_items;
+
+  if (!diffItems || diffItems.length === 0) {
+    return <EmptyStateWarning small>No diff found.</EmptyStateWarning>;
+  }
+
+  return <TreemapDiffSection diffItems={diffItems} />;
+}
+
+type SectionProps = {
+  baseMetricId: string;
+  headMetricId: string;
+  project: Project;
+};
+
+function EventXrayDiffSection({baseMetricId, headMetricId, project}: SectionProps) {
+  return (
+    <InterimSection title={t('X-Ray diff')} type={SectionKey.XRAY_DIFF}>
+      <ErrorBoundary mini>
+        <EventXrayDiffContent
+          project={project}
+          headMetricId={headMetricId}
+          baseMetricId={baseMetricId}
+        />
+      </ErrorBoundary>
+    </InterimSection>
+  );
+}
+
+interface MetricIds {
+  baseMetricId: string;
+  headMetricId: string;
+}
+
+function getMetricIds(event: Event): MetricIds | undefined {
+  const headMetricId = event.occurrence?.evidenceData?.headSizeMetricId;
+  const baseMetricId = event.occurrence?.evidenceData?.baseSizeMetricId;
+
+  if (baseMetricId && headMetricId) {
+    return {
+      baseMetricId,
+      headMetricId,
+    };
+  }
+  return undefined;
+}
+
+type Props = {
+  event: Event;
+  project: Project;
+};
+
+function EventXrayDiff(props: Props) {
+  const ids = getMetricIds(props.event);
+  if (ids) {
+    return <EventXrayDiffSection {...props} {...ids} />;
+  }
+  return null;
+}
+
+export {EventXrayDiff};

--- a/static/app/components/events/eventXrayDiff.tsx
+++ b/static/app/components/events/eventXrayDiff.tsx
@@ -12,11 +12,8 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 import {TreemapDiffSection} from 'sentry/views/preprod/buildComparison/main/treemapDiffSection';
 import type {SizeAnalysisComparisonResults} from 'sentry/views/preprod/types/appSizeTypes';
 
-type ContentProps = {
-  baseMetricId: string;
-  headMetricId: string;
-  project: Project;
-};
+// Currently Content and Section props are identical.
+type ContentProps = SectionProps;
 
 function EventXrayDiffContent({baseMetricId, headMetricId, project}: ContentProps) {
   const organization = useOrganization();

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -29,6 +29,7 @@ import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScree
 import {ScreenshotDataSection} from 'sentry/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection';
 import {EventTagsDataSection} from 'sentry/components/events/eventTagsAndScreenshot/tags';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
+import {EventXrayDiff} from 'sentry/components/events/eventXrayDiff';
 import {EventFeatureFlagSection} from 'sentry/components/events/featureFlags/eventFeatureFlagSection';
 import {EventGroupingInfoSection} from 'sentry/components/events/groupingInfo/groupingInfoSection';
 import HighlightsDataSection from 'sentry/components/events/highlights/highlightsDataSection';
@@ -414,6 +415,7 @@ export function EventDetailsContent({
       </ErrorBoundary>
       <EventExtraData event={event} />
       <EventViewHierarchy event={event} project={project} />
+      <EventXrayDiff event={event} project={project} />
       <EventPackageData event={event} />
       <EventDevice event={event} />
       <EventAttachments event={event} project={project} group={group} />

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -94,6 +94,8 @@ export const enum SectionKey {
   MCP_OUTPUT = 'mcp-output',
 
   SPAN_LINKS = 'span-links',
+
+  XRAY_DIFF = 'xray-diff',
 }
 
 /**


### PR DESCRIPTION
This causes the x-ray to show up in the issues feed for size issues:

<img width="2186" height="1138" alt="CleanShot 2026-01-06 at 12 43 45@2x" src="https://github.com/user-attachments/assets/0b959b0e-5721-480c-9b1f-7b2b6d145eec" />
