### PR TITLE
Master branch collapsed usage

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -119,12 +119,12 @@ export function GroupSummary({
   event,
   project,
   preview = false,
-  collapsed = false,
+  defaultExpanded = true,
 }: {
   event: Event | null | undefined;
   group: Group;
   project: Project;
-  collapsed?: boolean;
+  defaultExpanded?: boolean;
   preview?: boolean;
 }) {
   const queryClient = useQueryClient();
@@ -180,7 +180,7 @@ export function GroupSummary({
       isPending={isPending}
       isError={isError}
       setForceEvent={setForceEvent}
-      defaultCollapsed={collapsed}
+      defaultExpanded={defaultExpanded}
     />
   );
 }
@@ -254,7 +254,7 @@ function GroupSummaryCollapsed({
   isPending,
   setForceEvent,
   isError,
-  defaultCollapsed = false,
+  defaultExpanded = true,
 }: {
   data: GroupSummaryData | undefined;
   event: Event | null | undefined;
@@ -263,17 +263,17 @@ function GroupSummaryCollapsed({
   isPending: boolean;
   project: Project;
   setForceEvent: (v: boolean) => void;
-  defaultCollapsed?: boolean;
+  defaultExpanded?: boolean;
 }) {
-  const [isExpanded, setIsExpanded] = useState(!defaultCollapsed);
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   const handleToggle = () => {
     setIsExpanded(!isExpanded);
   };
 
   useLayoutEffect(() => {
-    setIsExpanded(!defaultCollapsed);
-  }, [defaultCollapsed]);
+    setIsExpanded(defaultExpanded);
+  }, [defaultExpanded]);
 
   return (
     <div data-testid="group-summary-collapsed">

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -468,7 +468,7 @@ function LegacySeerDrawer({group, project, event, aiConfig}: LegacySeerDrawerPro
               group={group}
               event={event}
               project={project}
-              collapsed={!!autofixData}
+              defaultExpanded={!autofixData}
             />
           </StyledCard>
         )}

--- a/static/app/views/prevent/preventAI/manageReposPage.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPage.tsx
@@ -131,7 +131,7 @@ function ManageReposPage({integratedOrgs}: {integratedOrgs: OrganizationIntegrat
       {selectedOrg && (
         <ManageReposPanel
           key={`${selectedOrgId || 'no-org'}-${selectedRepo?.externalId || 'all-repos'}`}
-          collapsed={!isPanelOpen}
+          open={isPanelOpen}
           onClose={() => setIsPanelOpen(false)}
           org={selectedOrg}
           repo={selectedRepo}

--- a/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
@@ -64,7 +64,7 @@ describe('ManageReposPanel', () => {
   ];
 
   const defaultProps: ManageReposPanelProps = {
-    collapsed: false,
+    open: true,
     onClose: jest.fn(),
     repo: mockRepo,
     org: mockOrg,

--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -24,9 +24,9 @@ import {useUpdatePreventAIFeature} from 'sentry/views/prevent/preventAI/hooks/us
 import {getRepoNameWithoutOrg} from 'sentry/views/prevent/preventAI/utils';
 
 export type ManageReposPanelProps = {
-  collapsed: boolean;
   isEditingOrgDefaults: boolean;
   onClose: () => void;
+  open: boolean;
   org: OrganizationIntegration;
   allRepos?: Repository[];
   onFocusRepoSelector?: () => void;
@@ -63,8 +63,8 @@ const sensitivityOptions: SensitivityOption[] = [
 ];
 
 function ManageReposPanel({
-  collapsed,
   onClose,
+  open,
   org,
   repo,
   allRepos = [],
@@ -108,9 +108,8 @@ function ManageReposPanel({
     .filter(r => orgConfig.repo_overrides?.hasOwnProperty(r.externalId))
     .map(r => getRepoNameWithoutOrg(r.name));
 
-  return (
+  return open ? (
     <SlideOverPanel
-      open={!collapsed}
       position="right"
       ariaLabel="Settings Panel"
       data-test-id="manage-repos-panel"
@@ -458,7 +457,7 @@ function ManageReposPanel({
         </Flex>
       </Flex>
     </SlideOverPanel>
-  );
+  ) : null;
 }
 
 interface GetRepoConfigResult {


### PR DESCRIPTION
Fixes a broken master branch by removing the incorrect `collapsed` prop usage for `SlideOverPanel` and similar components.

The `SlideOverPanel` component should be conditionally rendered using the pattern `{isOpen && <SlideOverPanel>...}` rather than being passed `open` or `collapsed` props. This PR updates all relevant usages to follow this established pattern, ensuring correct component behavior and consistency.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D090L9MST54/p1766164388944589?thread_ts=1766164388.944589&cid=D090L9MST54)

<a href="https://cursor.com/background-agent?bcId=bc-1c35382d-2b13-4df6-a01c-6f2457cdcfd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c35382d-2b13-4df6-a01c-6f2457cdcfd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

