### PR TITLE
fix(ui): Fix removed `open` prop from SlideOverPanel

### DIFF
--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -108,9 +108,12 @@ function ManageReposPanel({
     .filter(r => orgConfig.repo_overrides?.hasOwnProperty(r.externalId))
     .map(r => getRepoNameWithoutOrg(r.name));
 
+  if (collapsed) {
+    return null;
+  }
+
   return (
     <SlideOverPanel
-      open={!collapsed}
       position="right"
       ariaLabel="Settings Panel"
       data-test-id="manage-repos-panel"


### PR DESCRIPTION
unbreaks master from reverting https://github.com/getsentry/sentry/pull/104539

`open` was removed in https://github.com/getsentry/sentry/pull/104627
