### PR TITLE
fix(seer): Empty state blurs input focus

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -161,27 +161,6 @@ export default function SeerProjectTable() {
     );
   }
 
-  if (filteredProjects.length === 0) {
-    return (
-      <ProjectTable
-        projects={filteredProjects}
-        onSortClick={setSort}
-        sort={sort}
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-        updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
-      >
-        <SimpleTable.Empty>
-          {searchTerm
-            ? tct('No projects found matching [searchTerm]', {
-                searchTerm: <code>{searchTerm}</code>,
-              })
-            : t('No projects found')}
-        </SimpleTable.Empty>
-      </ProjectTable>
-    );
-  }
-
   return (
     <ListItemCheckboxProvider
       hits={filteredProjects.length}
@@ -196,19 +175,29 @@ export default function SeerProjectTable() {
         setSearchTerm={setSearchTerm}
         updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
       >
-        {filteredProjects.map(project => (
-          <SeerProjectTableRow
-            key={project.id}
-            project={project}
-            isFetchingSettings={isFetchingSettings}
-            autofixSettings={{
-              ...getDefaultAutofixSettings(organization, project.id),
-              ...autofixSettingsByProjectId.get(project.id),
-              ...mutationData[project.id],
-            }}
-            updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
-          />
-        ))}
+        {filteredProjects.length === 0 ? (
+          <SimpleTable.Empty>
+            {searchTerm
+              ? tct('No projects found matching [searchTerm]', {
+                  searchTerm: <code>{searchTerm}</code>,
+                })
+              : t('No projects found')}
+          </SimpleTable.Empty>
+        ) : (
+          filteredProjects.map(project => (
+            <SeerProjectTableRow
+              key={project.id}
+              project={project}
+              isFetchingSettings={isFetchingSettings}
+              autofixSettings={{
+                ...getDefaultAutofixSettings(organization, project.id),
+                ...autofixSettingsByProjectId.get(project.id),
+                ...mutationData[project.id],
+              }}
+              updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
+            />
+          ))
+        )}
       </ProjectTable>
     </ListItemCheckboxProvider>
   );

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -142,27 +142,6 @@ export default function SeerRepoTable() {
     );
   }
 
-  if (filteredRepositories.length === 0) {
-    return (
-      <RepoTable
-        mutateRepositorySettings={mutateRepositorySettings}
-        onSortClick={setSort}
-        repositories={filteredRepositories}
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-        sort={sort}
-      >
-        <SimpleTable.Empty>
-          {searchTerm
-            ? tct('No repositories found matching [searchTerm]', {
-                searchTerm: <code>{searchTerm}</code>,
-              })
-            : t('No repositories found')}
-        </SimpleTable.Empty>
-      </RepoTable>
-    );
-  }
-
   return (
     <ListItemCheckboxProvider
       hits={filteredRepositories.length}
@@ -177,14 +156,24 @@ export default function SeerRepoTable() {
         setSearchTerm={setSearchTerm}
         sort={sort}
       >
-        {filteredRepositories.map(repository => (
-          <SeerRepoTableRow
-            key={repository.id}
-            mutateRepositorySettings={mutateRepositorySettings}
-            mutationData={mutationData}
-            repository={repository}
-          />
-        ))}
+        {filteredRepositories.length === 0 ? (
+          <SimpleTable.Empty>
+            {searchTerm
+              ? tct('No repositories found matching [searchTerm]', {
+                  searchTerm: <code>{searchTerm}</code>,
+                })
+              : t('No repositories found')}
+          </SimpleTable.Empty>
+        ) : (
+          filteredRepositories.map(repository => (
+            <SeerRepoTableRow
+              key={repository.id}
+              mutateRepositorySettings={mutateRepositorySettings}
+              mutationData={mutationData}
+              repository={repository}
+            />
+          ))
+        )}
       </RepoTable>
     </ListItemCheckboxProvider>
   );


### PR DESCRIPTION
This fixes a bug in seer project/repo settings where searching and causing empty state will cause input to blur. This happens because going from having results  to empty state (or vice versa) causes a re-render that changes the component tree. I believe this re-mounts the input due to tree change and causes the input blur,
