### PR TITLE
feat(nav): Add feature flag logic to show/hide the Prevent nav item

### DIFF
--- a/static/app/utils/seer/showNewSeer.ts
+++ b/static/app/utils/seer/showNewSeer.ts
@@ -23,6 +23,11 @@ export default function showNewSeer(organization: Organization) {
     return false;
   }
 
+  // code-review-beta group
+  if (organization.features.includes('code-review-beta')) {
+    return false;
+  }
+
   // This is the launch flag
   if (
     organization.features.includes('seer-user-billing') &&

--- a/static/app/utils/seer/showNewSeer.ts
+++ b/static/app/utils/seer/showNewSeer.ts
@@ -23,11 +23,6 @@ export default function showNewSeer(organization: Organization) {
     return false;
   }
 
-  // code-review-beta group
-  if (organization.features.includes('code-review-beta')) {
-    return false;
-  }
-
   // This is the launch flag
   if (
     organization.features.includes('seer-user-billing') &&

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -15,6 +15,7 @@ import {
   IconSettings,
   IconSiren,
 } from 'sentry/icons';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDefaultExploreRoute} from 'sentry/views/explore/utils';
 import {useNavContext} from 'sentry/views/nav/context';
@@ -73,6 +74,10 @@ export function PrimaryNavigationItems() {
   const ref = useRef<HTMLUListElement>(null);
 
   const makeNavItemProps = useActivateNavGroupOnHover({ref});
+
+  const showPreventNav = organization.features.includes('prevent-test-analytics')
+    ? true // If you've got test analytics, then you can see the nav
+    : !showNewSeer(organization); // Old seer plan members will see the button to access the AI Code Review landing page.
 
   return (
     <Fragment>
@@ -145,18 +150,20 @@ export function PrimaryNavigationItems() {
         </Feature>
 
         <Feature features={['prevent-ai']}>
-          <Container position="relative" height="100%">
-            <SidebarLink
-              to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}
-              activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
-              analyticsKey="prevent"
-              group={PrimaryNavGroup.PREVENT}
-              {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
-            >
-              <IconPrevent />
-            </SidebarLink>
-            <BetaBadge type="beta" />
-          </Container>
+          {showPreventNav ? (
+            <Container position="relative" height="100%">
+              <SidebarLink
+                to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}
+                activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
+                analyticsKey="prevent"
+                group={PrimaryNavGroup.PREVENT}
+                {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
+              >
+                <IconPrevent />
+              </SidebarLink>
+              <BetaBadge type="beta" />
+            </Container>
+          ) : null}
         </Feature>
 
         <SeparatorItem />

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -15,6 +15,7 @@ import {
   IconSettings,
   IconSiren,
 } from 'sentry/icons';
+import type {Organization} from 'sentry/types/organization';
 import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDefaultExploreRoute} from 'sentry/views/explore/utils';
@@ -68,16 +69,22 @@ function SidebarFooter({children}: {children: React.ReactNode}) {
   );
 }
 
+function showPreventNav(organization: Organization) {
+  if (showNewSeer(organization)) {
+    // If you've got the new seer, then we won't show code-review sub-nav items.
+    // We will show the main prevent nav only if you have test analytics.
+    return organization.features.includes('prevent-test-analytics');
+  }
+  // If you've got the old seer, then we will show the sub-nav items, maybe the test items too
+  return true;
+}
+
 export function PrimaryNavigationItems() {
   const organization = useOrganization();
   const prefix = `organizations/${organization.slug}`;
   const ref = useRef<HTMLUListElement>(null);
 
   const makeNavItemProps = useActivateNavGroupOnHover({ref});
-
-  const showPreventNav = organization.features.includes('prevent-test-analytics')
-    ? true // If you've got test analytics, then you can see the nav
-    : !showNewSeer(organization); // Old seer plan members will see the button to access the AI Code Review landing page.
 
   return (
     <Fragment>
@@ -150,7 +157,7 @@ export function PrimaryNavigationItems() {
         </Feature>
 
         <Feature features={['prevent-ai']}>
-          {showPreventNav ? (
+          {showPreventNav(organization) ? (
             <Container position="relative" height="100%">
               <SidebarLink
                 to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import useOrganization from 'sentry/utils/useOrganization';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
@@ -28,6 +29,8 @@ function PreventSecondaryNav() {
     path: `/${PREVENT_AI_BASE_URL}/`,
   });
 
+  const hasOriginalSeerPlan = !showNewSeer(organization);
+
   return (
     <Fragment>
       <SecondaryNav.Header>
@@ -40,12 +43,14 @@ function PreventSecondaryNav() {
               {t('Tests')}
             </SecondaryNav.Item>
           </Feature>
-          <SecondaryNav.Item
-            to={`${preventAIPathName}new/`}
-            activeTo={`${preventAIPathName}new/`}
-          >
-            {t('AI Code Review')}
-          </SecondaryNav.Item>
+          {hasOriginalSeerPlan ? (
+            <SecondaryNav.Item
+              to={`${preventAIPathName}new/`}
+              activeTo={`${preventAIPathName}new/`}
+            >
+              {t('AI Code Review')}
+            </SecondaryNav.Item>
+          ) : null}
         </SecondaryNav.Section>
         <Feature features={['prevent-test-analytics']}>
           <SecondaryNav.Section id="prevent-configure" title={t('Configure')}>

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
@@ -29,8 +29,6 @@ function PreventSecondaryNav() {
     path: `/${PREVENT_AI_BASE_URL}/`,
   });
 
-  const hasOriginalSeerPlan = !showNewSeer(organization);
-
   return (
     <Fragment>
       <SecondaryNav.Header>
@@ -43,14 +41,14 @@ function PreventSecondaryNav() {
               {t('Tests')}
             </SecondaryNav.Item>
           </Feature>
-          {hasOriginalSeerPlan ? (
+          {showNewSeer(organization) ? null : (
             <SecondaryNav.Item
               to={`${preventAIPathName}new/`}
               activeTo={`${preventAIPathName}new/`}
             >
               {t('AI Code Review')}
             </SecondaryNav.Item>
-          ) : null}
+          )}
         </SecondaryNav.Section>
         <Feature features={['prevent-test-analytics']}>
           <SecondaryNav.Section id="prevent-configure" title={t('Configure')}>

--- a/static/app/views/prevent/preventAI/wrapper.tsx
+++ b/static/app/views/prevent/preventAI/wrapper.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {Outlet} from 'react-router-dom';
 
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
@@ -5,11 +6,21 @@ import {Flex} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import showNewSeer from 'sentry/utils/seer/showNewSeer';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {PREVENT_AI_PAGE_TITLE} from 'sentry/views/prevent/settings';
 
 export default function PreventAIPageWrapper() {
   const organization = useOrganization();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (showNewSeer(organization)) {
+      navigate(normalizeUrl(`/organizations/${organization.slug}/settings/seer/`));
+    }
+  }, [navigate, organization, organization.slug]);
 
   return (
     <SentryDocumentTitle title={PREVENT_AI_PAGE_TITLE} orgSlug={organization.slug}>

--- a/static/app/views/prevent/tests/testsWrapper.tsx
+++ b/static/app/views/prevent/tests/testsWrapper.tsx
@@ -3,6 +3,7 @@ import {Outlet} from 'react-router-dom';
 import {Flex} from '@sentry/scraps/layout';
 
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import NotFound from 'sentry/components/errors/notFound';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
@@ -12,6 +13,10 @@ import {TESTS_PAGE_TITLE} from 'sentry/views/prevent/settings';
 
 export default function TestAnalyticsPageWrapper() {
   const organization = useOrganization();
+
+  if (!organization.features.includes('prevent-test-analytics')) {
+    return <NotFound />;
+  }
 
   return (
     <SentryDocumentTitle title={TESTS_PAGE_TITLE} orgSlug={organization.slug}>

--- a/static/app/views/prevent/tokens/tokensWrapper.tsx
+++ b/static/app/views/prevent/tokens/tokensWrapper.tsx
@@ -1,6 +1,7 @@
 import {Outlet} from 'react-router-dom';
 
 import {Flex} from 'sentry/components/core/layout';
+import NotFound from 'sentry/components/errors/notFound';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -13,6 +14,10 @@ export default function TokensPageWrapper() {
   const organization = useOrganization();
 
   const tooltip = t('Manage your upload tokens that are created in Sentry Prevent.');
+
+  if (!organization.features.includes('prevent-test-analytics')) {
+    return <NotFound />;
+  }
 
   return (
     <SentryDocumentTitle title={TOKENS_PAGE_TITLE} orgSlug={organization.slug}>


### PR DESCRIPTION
The relevant flags/cases here
| Case | Img |
| --- | --- |
| showNewSeer()==true && prevent-test-analytics==false | <img width="998" height="758" alt="SCR-20260116-odvm" src="https://github.com/user-attachments/assets/49a20147-9c35-4968-971f-52bbdd4d6253" />
| showNewSeer()==true && prevent-test-analytics==true | <img width="998" height="758" alt="SCR-20260116-oenf" src="https://github.com/user-attachments/assets/3aec98c9-4f57-4d9d-b80e-06533799d2bc" />
| showNewSeer()==false && prevent-test-analytics==false | <img width="998" height="758" alt="SCR-20260116-ofhy" src="https://github.com/user-attachments/assets/557bbbf3-b5d7-46be-a55f-35a00fc2c108" />
| showNewSeer()==false && prevent-test-analytics==true | <img width="998" height="758" alt="SCR-20260116-ofdh" src="https://github.com/user-attachments/assets/6fff8e3a-fe42-446c-90f0-3b50f82aec8c" />

When `seer-user-billing-launch` is enabled, we'll fall back to looking at `seer-added || code-review-beta` which will be the same as the bottom two screenshots (showNewSeer() returning false).


Navigating to the old-code-review page when it's not in the nav will result in a redirect to the new settings page
Navigating to the old tests pages when they're not in the nav will result in a NotFound
