### PR TITLE
ref(admin): Remove usage of `deprecatedRouteProps` for `AdminRelays`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2727,7 +2727,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'relays/',
       component: make(() => import('sentry/views/admin/adminRelays')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'organizations/',

--- a/static/app/views/admin/adminRelays.spec.tsx
+++ b/static/app/views/admin/adminRelays.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -30,20 +29,14 @@ describe('AdminRelays', () => {
     },
   ];
 
-  afterEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
   it('renders rows', async () => {
-    const {routerProps} = initializeOrg();
-
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'GET',
       body: rows,
     });
 
-    render(<AdminRelays {...routerProps} />);
+    render(<AdminRelays />);
 
     expect(await screen.findByText('relay-one')).toBeInTheDocument();
     expect(screen.getByText('relay-two')).toBeInTheDocument();
@@ -52,8 +45,6 @@ describe('AdminRelays', () => {
   });
 
   it('deletes a relay via confirmation modal', async () => {
-    const {routerProps} = initializeOrg();
-
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'GET',
@@ -65,7 +56,7 @@ describe('AdminRelays', () => {
       method: 'DELETE',
     });
 
-    render(<AdminRelays {...routerProps} />);
+    render(<AdminRelays />);
     renderGlobalModal();
 
     const firstRow = await screen.findByText('relay-one');

--- a/static/app/views/admin/adminRelays.tsx
+++ b/static/app/views/admin/adminRelays.tsx
@@ -1,18 +1,14 @@
 import {useCallback, useState} from 'react';
 import moment from 'moment-timezone';
 
-import type {Client} from 'sentry/api';
 import Confirm from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
 import ResultGrid from 'sentry/components/resultGrid';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import withApi from 'sentry/utils/withApi';
+import useApi from 'sentry/utils/useApi';
 
 const prettyDate = (x: string) => moment(x).format('ll LTS');
-
-type Props = RouteComponentProps & {api: Client};
 
 type RelayRow = {
   firstSeen: string;
@@ -22,20 +18,21 @@ type RelayRow = {
   relayId: string;
 };
 
-function AdminRelays(props: Props) {
+export default function AdminRelays() {
+  const api = useApi();
   // TODO: Loading not hooked up to anything?
   const [, setLoading] = useState(false);
 
   const onDelete = useCallback(
     (key: string) => {
       setLoading(true);
-      props.api.request(`/relays/${key}/`, {
+      api.request(`/relays/${key}/`, {
         method: 'DELETE',
         success: () => setLoading(false),
         error: () => setLoading(false),
       });
     },
-    [props.api]
+    [api]
   );
 
   const getRow = (row: RelayRow) => {
@@ -95,10 +92,7 @@ function AdminRelays(props: Props) {
           ['relayId', 'Relay ID'],
         ]}
         defaultSort="firstSeen"
-        {...props}
       />
     </div>
   );
 }
-
-export default withApi(AdminRelays);


### PR DESCRIPTION
Migrates the `AdminRelays` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7