### PR TITLE
ref(admin): Remove usage of `deprecateRouteProps` for `AdminOrganizations`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2732,7 +2732,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'organizations/',
       component: make(() => import('sentry/views/admin/adminOrganizations')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'projects/',

--- a/static/app/views/admin/adminOrganizations.tsx
+++ b/static/app/views/admin/adminOrganizations.tsx
@@ -1,9 +1,6 @@
 import {Link} from 'sentry/components/core/link';
 import ResultGrid from 'sentry/components/resultGrid';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-
-type Props = RouteComponentProps;
 
 const getRow = (row: any) => [
   <td key={row.id}>
@@ -15,7 +12,7 @@ const getRow = (row: any) => [
   </td>,
 ];
 
-function AdminOrganizations(props: Props) {
+export default function AdminOrganizations() {
   return (
     <div>
       <h3>{t('Organizations')}</h3>
@@ -34,10 +31,7 @@ function AdminOrganizations(props: Props) {
           ['employees', 'Employees'],
         ]}
         defaultSort="date"
-        {...props}
       />
     </div>
   );
 }
-
-export default AdminOrganizations;


### PR DESCRIPTION
Migrates the `AdminOrganizations` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7