### PR TITLE
ref(admin): Remove usage of `deprecatedRouteProps` for `AdminProjects`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2737,7 +2737,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'projects/',
       component: make(() => import('sentry/views/admin/adminProjects')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'settings/',

--- a/static/app/views/admin/adminProjects.tsx
+++ b/static/app/views/admin/adminProjects.tsx
@@ -2,7 +2,6 @@ import moment from 'moment-timezone';
 
 import ResultGrid from 'sentry/components/resultGrid';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 
 type Row = {
@@ -12,8 +11,6 @@ type Row = {
   slug: string;
   status: string;
 };
-
-type Props = RouteComponentProps;
 
 const getRow = (row: Row) => [
   <td key="name">
@@ -31,7 +28,7 @@ const getRow = (row: Row) => [
   </td>,
 ];
 
-function AdminProjects(props: Props) {
+export default function AdminProjects() {
   const columns = [
     <th key="name">Project</th>,
     <th key="status" style={{width: 150, textAlign: 'center'}}>
@@ -63,10 +60,7 @@ function AdminProjects(props: Props) {
         }}
         sortOptions={[['date', 'Date Created']]}
         defaultSort="date"
-        {...props}
       />
     </div>
   );
 }
-
-export default AdminProjects;


### PR DESCRIPTION
Migrates the `AdminProjects` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7