### PR TITLE
ref(admin): Remove usage of `deprecatedRouteProps` for `AdminUsers`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2749,7 +2749,6 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/admin/adminUsers')),
-          deprecatedRouteProps: true,
         },
         {
           path: ':id',

--- a/static/app/views/admin/adminUsers.tsx
+++ b/static/app/views/admin/adminUsers.tsx
@@ -3,7 +3,6 @@ import moment from 'moment-timezone';
 import {Link} from 'sentry/components/core/link';
 import ResultGrid from 'sentry/components/resultGrid';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 
 type Row = {
   dateJoined: string;
@@ -12,8 +11,6 @@ type Row = {
   lastLogin: string;
   username: string;
 };
-
-type Props = RouteComponentProps;
 
 const getRow = (row: Row) => [
   <td key="username">
@@ -31,7 +28,7 @@ const getRow = (row: Row) => [
   </td>,
 ];
 
-function AdminUsers(props: Props) {
+export default function AdminUsers() {
   const columns = [
     <th key="username">User</th>,
     <th key="dateJoined" style={{textAlign: 'center', width: 150}}>
@@ -63,10 +60,7 @@ function AdminUsers(props: Props) {
         }}
         sortOptions={[['date', 'Date Joined']]}
         defaultSort="date"
-        {...props}
       />
     </div>
   );
 }
-
-export default AdminUsers;


### PR DESCRIPTION
Migrates the `AdminUsers` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7