### PR TITLE
ci: upgrade to action-setup-venv 3.2.0

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -230,9 +230,8 @@ jobs:
         with:
           version: '0.8.2'
 
-      - uses: getsentry/action-setup-venv@3a832a9604b3e1a4202ae559248f26867b467cc7 # v2.1.1
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.1
           cache-dependency-path: uv.lock
           install-cmd: echo
 
@@ -378,9 +377,8 @@ jobs:
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 
-      - uses: getsentry/action-setup-venv@3a832a9604b3e1a4202ae559248f26867b467cc7 # v2.1.1
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.1
           cache-dependency-path: uv.lock
           install-cmd: uv sync --frozen --active
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -40,9 +40,8 @@ jobs:
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 
-      - uses: getsentry/action-setup-venv@3a832a9604b3e1a4202ae559248f26867b467cc7 # v2.1.1
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.1
           cache-dependency-path: uv.lock
           install-cmd: uv sync --only-dev --frozen --active
 
@@ -66,9 +65,8 @@ jobs:
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 
-      - uses: getsentry/action-setup-venv@3a832a9604b3e1a4202ae559248f26867b467cc7 # v2.1.1
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.1
           cache-dependency-path: uv.lock
           # technically we can just use --only-dev but more cache is nice
           install-cmd: uv sync --frozen --active

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -77,9 +77,8 @@ jobs:
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 
-      - uses: getsentry/action-setup-venv@3a832a9604b3e1a4202ae559248f26867b467cc7 # v2.1.1
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.1
           cache-dependency-path: uv.lock
           install-cmd: uv sync --only-dev --frozen --active
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/react-to-product-owners-yml-changes.yml
+++ b/.github/workflows/react-to-product-owners-yml-changes.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+        with:
+          version: '0.8.2'
+          # we just cache the venv-dir directly in action-setup-venv
+          enable-cache: false
+
       - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
           cache-dependency-path: uv.lock

--- a/.github/workflows/react-to-product-owners-yml-changes.yml
+++ b/.github/workflows/react-to-product-owners-yml-changes.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: getsentry/action-setup-venv@3a832a9604b3e1a4202ae559248f26867b467cc7 # v2.1.1
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.1
+          cache-dependency-path: uv.lock
+          install-cmd: echo
 
       - name: React to product-owners.yml changes
         shell: bash
@@ -21,4 +22,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
           COMMITTER_NAME: getsentry-bot
           COMMITTER_EMAIL: bot@sentry.io
-        run: ./bin/react-to-product-owners-yml-changes.sh
+        run: |
+          uv export --only-dev --no-hashes --no-annotate --no-header \
+          | grep '^pyyaml' | sed -E 's/ ;.*//' \
+          | xargs uv pip install --index-url 'https://pypi.devinfra.sentry.io/simple'
+
+          ./bin/react-to-product-owners-yml-changes.sh

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -45,9 +45,8 @@ jobs:
         with:
           version: '0.8.2'
 
-      - uses: getsentry/action-setup-venv@3a832a9604b3e1a4202ae559248f26867b467cc7 # v2.1.1
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.1
           cache-dependency-path: uv.lock
           # sentry.build.main has no external dependencies;
           # this is only to set up the venv with the correct


### PR DESCRIPTION
recently had to spend time debugging something silly in https://github.com/getsentry/sentry-kafka-schemas/pull/465 which wouldn't have been an issue if we were using a more modern version of this which infers the python version from `.python-version`

