### PR TITLE
feat(api): Require verified email to create API applications

### DIFF
--- a/src/sentry/api/endpoints/api_applications.py
+++ b/src/sentry/api/endpoints/api_applications.py
@@ -33,7 +33,7 @@ class ApiApplicationsEndpoint(Endpoint):
         )
 
     def post(self, request: Request) -> Response:
-        if not request.user.has_verified_emails():
+        if not request.user.is_authenticated or not request.user.has_verified_emails():
             return Response(
                 {
                     "detail": "You must verify your email address before creating an API application."

--- a/src/sentry/api/endpoints/api_applications.py
+++ b/src/sentry/api/endpoints/api_applications.py
@@ -35,7 +35,9 @@ class ApiApplicationsEndpoint(Endpoint):
     def post(self, request: Request) -> Response:
         if not request.user.has_verified_emails():
             return Response(
-                {"detail": "You must verify your email address before creating an API application."},
+                {
+                    "detail": "You must verify your email address before creating an API application."
+                },
                 status=403,
             )
 

--- a/src/sentry/api/endpoints/api_applications.py
+++ b/src/sentry/api/endpoints/api_applications.py
@@ -33,6 +33,12 @@ class ApiApplicationsEndpoint(Endpoint):
         )
 
     def post(self, request: Request) -> Response:
+        if not request.user.has_verified_emails():
+            return Response(
+                {"detail": "You must verify your email address before creating an API application."},
+                status=403,
+            )
+
         app = ApiApplication.objects.create(owner_id=request.user.id)
 
         return Response(serialize(app, request.user), status=201)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
@@ -76,7 +76,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
         )
 
     def post(self, request: Request, organization) -> Response:
-        if not request.user.has_verified_emails():
+        if not request.user.is_authenticated or not request.user.has_verified_emails():
             return Response(
                 {"detail": "You must verify your email address before creating a Sentry App."},
                 status=403,

--- a/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
@@ -76,6 +76,12 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
         )
 
     def post(self, request: Request, organization) -> Response:
+        if not request.user.has_verified_emails():
+            return Response(
+                {"detail": "You must verify your email address before creating a Sentry App."},
+                status=403,
+            )
+
         data = {
             "name": request.data.get("name"),
             "user": request.user,


### PR DESCRIPTION
## Summary

Require users to have at least one verified email address before they can create:
- API applications via `POST /api/0/api-applications/`
- Sentry Apps (custom integrations) via `POST /api/0/sentry-apps/`

Previously, any authenticated user could create these without email verification.

## Changes

- Added `has_verified_emails()` check in `ApiApplicationsEndpoint.post()`
- Added `has_verified_emails()` check in `SentryAppsEndpoint.post()`
- Returns 403 with message if user has no verified emails

## Test plan

- Added tests for unverified users getting 403 on both endpoints
- Existing tests cover verified users creating apps successfully