### PR TITLE
feat(invites): Require verified email to invite members

### DIFF
--- a/src/sentry/core/endpoints/organization_member_invite/index.py
+++ b/src/sentry/core/endpoints/organization_member_invite/index.py
@@ -205,6 +205,12 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
         )
 
     def post(self, request: Request, organization) -> Response:
+        if not request.user.has_verified_emails():
+            return Response(
+                {"detail": "You must verify your email address before inviting members."},
+                status=403,
+            )
+
         if not features.has(
             "organizations:new-organization-member-invite", organization, actor=request.user
         ):


### PR DESCRIPTION
## Summary

Require users to have at least one verified email address before they can invite new members to an organization via `POST /api/0/organizations/{org}/invited-members/`.

This prevents abuse where unverified users with `member:invite` permission could spam arbitrary external email addresses with organization invitations.

## Changes

- Added `has_verified_emails()` check in `OrganizationMemberInviteIndexEndpoint.post()`
- Returns 403 with message if user has no verified emails

## Test plan

- Added test for unverified user getting 403 when inviting members