### PR TITLE
tabs: remove hideborder

### DIFF
--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -159,7 +159,7 @@ function NoteInput({
   return (
     <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
       <Tabs>
-        <TabList variant="floating" hideBorder>
+        <TabList variant="floating">
           <TabList.Item key="edit">{existingItem ? t('Edit') : t('Write')}</TabList.Item>
           <TabList.Item key="preview">{t('Preview')}</TabList.Item>
         </TabList>

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -129,13 +129,6 @@ function OverflowMenu({state, overflowMenuItems, disabled}: any) {
 
 export interface TabListProps {
   children: TabListStateOptions<TabListItemProps>['children'];
-  /**
-   * @deprecated
-   * With chonk, tabs never have a border.
-   * Whether to hide the bottom border of the tab list.
-   * Defaults to `false`.
-   */
-  hideBorder?: boolean;
   outerWrapStyles?: React.CSSProperties;
   variant?: BaseTabProps['variant'];
 }
@@ -145,12 +138,7 @@ interface BaseTabListProps extends AriaTabListOptions<TabListItemProps>, TabList
   variant?: BaseTabProps['variant'];
 }
 
-function BaseTabList({
-  hideBorder = false,
-  outerWrapStyles,
-  variant = 'flat',
-  ...props
-}: BaseTabListProps) {
+function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListProps) {
   const navigate = useNavigate();
   const tabListRef = useRef<HTMLUListElement>(null);
   const {rootProps, setTabListState} = useContext(TabsContext);
@@ -231,7 +219,6 @@ function BaseTabList({
       <TabListWrap
         {...tabListProps}
         orientation={orientation}
-        hideBorder={hideBorder}
         ref={tabListRef}
         variant={variant}
       >
@@ -310,7 +297,6 @@ const TabListOuterWrap = styled('div')`
 
 const TabListWrap = withChonk(
   styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
-    hideBorder: boolean;
     orientation: Orientation;
     variant: BaseTabProps['variant'];
   }>`
@@ -327,7 +313,7 @@ const TabListWrap = withChonk(
             grid-auto-flow: column;
             justify-content: start;
             gap: ${p.variant === 'floating' ? 0 : space(2)};
-            ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
+            border-bottom: solid 1px ${p.theme.border};
           `
         : css`
             height: 100%;
@@ -335,8 +321,8 @@ const TabListWrap = withChonk(
             align-content: start;
             gap: 1px;
             padding-right: ${space(2)};
-            ${!p.hideBorder && `border-right: solid 1px ${p.theme.border};`}
-          `};
+            border-right: solid 1px ${p.theme.border};
+          `}
   `,
   ChonkStyledTabListWrap
 );

--- a/static/app/components/core/tabs/tabs.stories.tsx
+++ b/static/app/components/core/tabs/tabs.stories.tsx
@@ -185,7 +185,7 @@ export default Storybook.story('Tabs', story => {
         </p>
         <Storybook.SizingWindow>
           <Tabs>
-            <TabList variant="floating" hideBorder>
+            <TabList variant="floating">
               {TABS.map(tab => (
                 <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
               ))}

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -640,7 +640,7 @@ export function SourceMapsDebuggerModal({
             value={activeTab}
             onChange={setActiveTab}
           >
-            <TabList hideBorder={hideAllTabs}>
+            <TabList>
               <TabList.Item
                 key="debug-ids"
                 textValue={`${t('Debug IDs')} (${

--- a/static/app/stories/theme.tsx
+++ b/static/app/stories/theme.tsx
@@ -29,7 +29,7 @@ export function ThemeToggle({children}: ThemeToggleProps) {
           value={localThemeName}
           onChange={() => setLocalThemeName(localThemeName === 'dark' ? 'light' : 'dark')}
         >
-          <TabList hideBorder>
+          <TabList>
             <TabList.Item key="light">Light Theme</TabList.Item>
             <TabList.Item key="dark">Dark Theme</TabList.Item>
           </TabList>

--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -84,7 +84,7 @@ function AlertHeader({activeTab}: Props) {
         </ButtonBar>
       </Layout.HeaderActions>
       <Layout.HeaderTabs value={activeTab}>
-        <TabList hideBorder>
+        <TabList>
           {alertRulesLink}
           <TabList.Item
             key="stream"

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
@@ -168,7 +168,7 @@ export function DatasetSelectorTabs(props: Props) {
         });
       }}
     >
-      <TabList hideBorder>
+      <TabList>
         {options.map(option => (
           <TabList.Item key={option.value} tooltip={option.tooltip}>
             {option.label}

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -362,7 +362,7 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
           </LogsGraphContainer>
           <LogsTableActionsContainer>
             <Tabs value={tableTab} onChange={setTableTab} size="sm">
-              <TabList hideBorder variant="floating">
+              <TabList variant="floating">
                 <TabList.Item key="logs">{t('Logs')}</TabList.Item>
                 <TabList.Item key="aggregates">{t('Aggregates')}</TabList.Item>
               </TabList>

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -93,7 +93,7 @@ export function ExploreTables(props: ExploreTablesProps) {
     <Fragment>
       <SamplesTableHeader>
         <Tabs value={props.tab} onChange={props.setTab} size="sm">
-          <TabList hideBorder variant="floating">
+          <TabList variant="floating">
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
             <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
             <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
@@ -96,7 +96,7 @@ function ScreenDetailsPage() {
   }
 
   const tabList = (
-    <TabList hideBorder>
+    <TabList>
       {tabs.map(tab => {
         const visible =
           tab.feature === undefined || organization.features.includes(tab.feature);

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -139,7 +139,7 @@ export function DomainViewHeader({
         </Layout.HeaderActions>
         <Layout.HeaderTabs value={tabValue} onChange={tabs?.onTabChange}>
           {!hideDefaultTabs && (
-            <TabList hideBorder>
+            <TabList>
               {tabList.map(tab => (
                 <TabList.Item {...tab} key={tab.key} />
               ))}

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -92,7 +92,7 @@ function GroupHeaderTabs({
   }, [group.issueType, organization]);
 
   return (
-    <StyledTabList hideBorder>
+    <StyledTabList>
       <TabList.Item
         key={Tab.DETAILS}
         disabled={disabledTabs.includes(Tab.DETAILS)}

--- a/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
@@ -168,7 +168,7 @@ export function IssueDetailsEventNavigation({
         />
       </Navigation>
       <Tabs value={selectedOption} disableOverflow onChange={onTabChange} size="xs">
-        <TabList hideBorder variant="floating">
+        <TabList variant="floating">
           {EventNavOrder.map(label => {
             const eventPath =
               label === selectedOption

--- a/static/app/views/organizationStats/header.tsx
+++ b/static/app/views/organizationStats/header.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 function StatsHeaderTabs({organization}: Props) {
   return (
-    <TabList hideBorder>
+    <TabList>
       <TabList.Item
         key="stats"
         to={makeStatsPathname({

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -98,7 +98,7 @@ export function TraceTabsAndVitals({
   return (
     <Flex ref={setRef} justify="between" minHeight={`${CONTAINER_MIN_HEIGHT}px`}>
       <Tabs value={currentTab} onChange={onTabChange}>
-        <TabList hideBorder variant="floating">
+        <TabList variant="floating">
           {tabOptions.map(tab => (
             <TabList.Item key={tab.slug}>{tab.label}</TabList.Item>
           ))}

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -151,7 +151,6 @@ function TransactionHeader({
 
   const tabList = (
     <TabList
-      hideBorder
       outerWrapStyles={{
         gridColumn: '1 / -1',
       }}
@@ -317,7 +316,6 @@ function TransactionHeader({
         </ButtonBar>
       </Layout.HeaderActions>
       <TabList
-        hideBorder
         outerWrapStyles={{
           gridColumn: '1 / -1',
         }}

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -205,7 +205,7 @@ export default function ProfilingContent() {
                   )}
                   <div>
                     <Tabs value={tab} onChange={onTabChange}>
-                      <TabList hideBorder>
+                      <TabList>
                         <TabList.Item key="transactions">
                           {t('Transactions')}
                           <StyledQuestionTooltip

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -165,7 +165,7 @@ function ProfileSummaryHeader(props: ProfileSummaryHeaderProps) {
         </StyledHeaderActions>
       )}
       <Tabs onChange={props.onViewChange} value={props.view}>
-        <TabList hideBorder>
+        <TabList>
           <TabList.Item key="flamegraph">{t('Flamegraph')}</TabList.Item>
           <TabList.Item key="profiles">{t('Sampled Profiles')}</TabList.Item>
         </TabList>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -175,7 +175,7 @@ function ReleaseHeader({
       </Layout.HeaderActions>
 
       <Layout.HeaderTabs value={getActiveTabTo()}>
-        <TabList hideBorder>
+        <TabList>
           {tabs.map(tab => (
             <TabList.Item key={tab.to} to={getTabUrl(tab.to)} textValue={tab.textValue}>
               {tab.title}

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -127,7 +127,7 @@ export default function FocusTabs({isVideoReplay}: Props) {
           });
         }}
       >
-        <TabList hideBorder>
+        <TabList>
           {tabs.map(([tab, label]) => (
             <TabList.Item
               key={tab}

--- a/static/app/views/replays/detail/network/details/tabs.tsx
+++ b/static/app/views/replays/detail/network/details/tabs.tsx
@@ -25,7 +25,7 @@ function NetworkDetailsTabs() {
           setParamValue(tab);
         }}
       >
-        <TabList hideBorder>
+        <TabList>
           {Object.entries(TABS).map(([tab, label]) => (
             <TabList.Item key={tab}>{label}</TabList.Item>
           ))}


### PR DESCRIPTION
 Tabs no longer implement borders, making `hideBorder` a void prop in UI2.