### PR TITLE
feat(autopilot): SDK update detector logging

### DIFF
--- a/src/sentry/autopilot/tasks.py
+++ b/src/sentry/autopilot/tasks.py
@@ -45,7 +45,7 @@ def run_sdk_update_detector_for_organization(organization: Organization):
     metrics.incr("autopilot.sdk_update_detector.projects_found", len(projects))
 
     with handle_query_errors():
-        data: Any = discover.query(
+        result: Any = discover.query(
             query="has:sdk.version",
             selected_columns=[
                 "project",
@@ -66,7 +66,7 @@ def run_sdk_update_detector_for_organization(organization: Organization):
 
     # filter out SDKs with empty sdk.name or sdk.version or invalid version
     nonempty_sdks = []
-    for sdk in data:
+    for sdk in result["data"]:
         if not sdk["sdk.name"] or not sdk["sdk.version"]:
             continue
 

--- a/src/sentry/autopilot/tasks.py
+++ b/src/sentry/autopilot/tasks.py
@@ -1,0 +1,122 @@
+import logging
+from datetime import timedelta
+from itertools import chain, groupby
+from typing import Any
+
+from django.utils import timezone
+from packaging import version
+
+from sentry import options
+from sentry.api.utils import handle_query_errors
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sdk_updates import SdkIndexState, SdkSetupState, get_suggested_updates
+from sentry.search.events.types import SnubaParams
+from sentry.snuba import discover
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import autopilot_tasks
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.autopilot.tasks.run_sdk_update_detector",
+    namespace=autopilot_tasks,
+    processing_deadline_duration=60,
+)
+def run_sdk_update_detector() -> None:
+    organization_allowlist = options.get("autopilot.organization-allowlist")
+    if not organization_allowlist:
+        return
+
+    organizations = Organization.objects.filter(slug__in=organization_allowlist).all()
+
+    for organization in organizations:
+        run_sdk_update_detector_for_organization(organization)
+
+
+def run_sdk_update_detector_for_organization(organization: Organization):
+    projects = Project.objects.filter(organization=organization).all()
+
+    if len(projects) == 0:
+        return
+
+    metrics.incr("autopilot.sdk_update_detector.projects_found", len(projects))
+
+    with handle_query_errors():
+        data: Any = discover.query(
+            query="has:sdk.version",
+            selected_columns=[
+                "project",
+                "project.id",
+                "sdk.name",
+                "sdk.version",
+                "last_seen()",
+            ],
+            orderby=["-project"],
+            snuba_params=SnubaParams(
+                start=timezone.now() - timedelta(days=1),
+                end=timezone.now(),
+                organization=organization,
+                projects=list(projects),
+            ),
+            referrer="api.organization-sdk-updates",
+        )
+
+    # filter out SDKs with empty sdk.name or sdk.version or invalid version
+    nonempty_sdks = []
+    for sdk in data:
+        if not sdk["sdk.name"] or not sdk["sdk.version"]:
+            continue
+
+        try:
+            version.parse(sdk["sdk.version"])
+        except version.InvalidVersion:
+            continue
+
+        nonempty_sdks.append(sdk)
+
+    # Build datastructure of the latest version of each SDK in use for each
+    # project we have events for.
+    latest_sdks = chain.from_iterable(
+        [
+            {
+                "projectId": str(project_id),
+                "sdkName": sdk_name,
+                "sdkVersion": max((s["sdk.version"] for s in sdks), key=version.parse),
+            }
+            for sdk_name, sdks in groupby(
+                sorted(sdks_used, key=lambda x: x["sdk.name"]), key=lambda x: x["sdk.name"]
+            )
+        ]
+        for project_id, sdks_used in groupby(nonempty_sdks, key=lambda x: x["project.id"])
+    )
+
+    # Determine suggested upgrades for each project
+    index_state = SdkIndexState()
+
+    updates_list = [
+        dict(
+            **latest,
+            suggestions=list(
+                get_suggested_updates(
+                    # TODO: In the future it would be nice to also add
+                    # the integrations and modules the SDK is using.
+                    # However this isn't currently available in the
+                    # discover dataset from snuba.
+                    SdkSetupState(latest["sdkName"], latest["sdkVersion"], (), ()),
+                    index_state,
+                    ignore_patch_version=True,
+                )
+            ),
+        )
+        for latest in latest_sdks
+    ]
+
+    updates_list = [update for update in updates_list if len(update["suggestions"]) > 0]
+
+    logger.warning("updates_list: %s", updates_list)
+    metrics.incr("autopilot.sdk_update_detector.updates_found", len(updates_list))
+
+    return updates_list

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -826,6 +826,7 @@ TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 # Taskworkers need to import task modules to make tasks
 # accessible to the worker.
 TASKWORKER_IMPORTS: tuple[str, ...] = (
+    "sentry.autopilot.tasks.run_sdk_update_detector",
     "sentry.conduit.tasks",
     "sentry.data_export.tasks",
     "sentry.debug_files.tasks",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -826,7 +826,7 @@ TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 # Taskworkers need to import task modules to make tasks
 # accessible to the worker.
 TASKWORKER_IMPORTS: tuple[str, ...] = (
-    "sentry.autopilot.tasks.run_sdk_update_detector",
+    "sentry.autopilot.tasks",
     "sentry.conduit.tasks",
     "sentry.data_export.tasks",
     "sentry.debug_files.tasks",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1058,6 +1058,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "telemetry-experience:sentry.dynamic_sampling.tasks.boost_low_volume_projects",
         "schedule": task_crontab("*/10", "*", "*", "*", "*"),
     },
+    "autopilot-run-sdk-update-detector": {
+        "task": "autopilot:sentry.autopilot.tasks.run_sdk_update_detector",
+        "schedule": task_crontab("*/5", "*", "*", "*", "*"),
+    },
     "dynamic-sampling-boost-low-volume-transactions": {
         "task": "telemetry-experience:sentry.dynamic_sampling.tasks.boost_low_volume_transactions",
         "schedule": task_crontab("*/10", "*", "*", "*", "*"),

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3827,3 +3827,11 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Organization slug allowlist to enable Autopilot for specific organizations.
+register(
+    "autopilot.organization-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -21,6 +21,11 @@ auth_control_tasks = app.taskregistry.create_namespace(
     app_feature="shared",
 )
 
+autopilot_tasks = app.taskregistry.create_namespace(
+    "autopilot",
+    app_feature="shared",
+)
+
 buffer_tasks = app.taskregistry.create_namespace(
     "buffer",
     app_feature="errors",

--- a/tests/sentry/autopilot/test_tasks.py
+++ b/tests/sentry/autopilot/test_tasks.py
@@ -1,0 +1,40 @@
+from unittest import mock
+
+from sentry.autopilot.tasks import run_sdk_update_detector_for_organization
+from sentry.sdk_updates import SdkIndexState
+from sentry.testutils.cases import SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class TestRunSdkUpdateDetector(SnubaTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project2 = self.create_project(organization=self.organization)
+
+    @mock.patch(
+        "sentry.api.endpoints.organization_sdk_updates.SdkIndexState",
+        return_value=SdkIndexState(sdk_versions={"example.sdk": "2.0.0"}),
+    )
+    def test_simple(self, mock_index_state: mock.MagicMock) -> None:
+        min_ago = before_now(minutes=1).isoformat()
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "oh no",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "sdk": {"name": "example.sdk", "version": "1.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        updates = run_sdk_update_detector_for_organization(self.organization)
+        assert len(updates) == 1
+        assert updates[0]["suggestions"][0] == {
+            "type": "updateSdk",
+            "sdkName": "example.sdk",
+            "newSdkVersion": "2.0.0",
+            "sdkUrl": None,
+            "enables": [],
+        }


### PR DESCRIPTION
Add first POC of a detector for Autopilot, that detects outdated SDKs.
This version simply emits metrics for checking the system's behavior.

- part of [TET-1687: Outdated SDK detector](https://linear.app/getsentry/issue/TET-1687/outdated-sdk-detector)