### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` for `NoOp` component

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1,4 +1,5 @@
 import type {RouteObject} from 'react-router-dom';
+import {Outlet} from 'react-router-dom';
 import memoize from 'lodash/memoize';
 
 import {EXPERIMENTAL_SPA} from 'sentry/constants';
@@ -1321,7 +1322,6 @@ function buildRoutes(): RouteObject[] {
         component: withDomainRequired(NoOp),
         customerDomainOnlyRoute: true,
         children: [orgSettingsRoutes, projectSettingsRoutes, subscriptionSettingsRoutes],
-        deprecatedRouteProps: true,
       },
       {
         path: ':orgId/',
@@ -1333,7 +1333,6 @@ function buildRoutes(): RouteObject[] {
           subscriptionSettingsRoutes,
           legacySettingsRedirects,
         ],
-        deprecatedRouteProps: true,
       },
     ],
     deprecatedRouteProps: true,
@@ -3135,6 +3134,6 @@ export const routes = memoize(buildRoutes);
 // Exported for use in tests.
 export {buildRoutes};
 
-function NoOp({children}: {children: React.JSX.Element}) {
-  return children;
+function NoOp() {
+  return <Outlet />;
 }


### PR DESCRIPTION
Migrates the `NoOp` component off of `deprecatedRouteProps` — now uses `<Outlet />` in place of `children`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7