### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` for `SettingsWrapper` component

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1336,7 +1336,6 @@ function buildRoutes(): RouteObject[] {
         deprecatedRouteProps: true,
       },
     ],
-    deprecatedRouteProps: true,
   };
 
   const projectsChildren: SentryRouteObject[] = [

--- a/static/app/views/settings/components/settingsWrapper.tsx
+++ b/static/app/views/settings/components/settingsWrapper.tsx
@@ -1,29 +1,27 @@
+import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import {useLocation} from 'sentry/utils/useLocation';
 import useScrollToTop from 'sentry/utils/useScrollToTop';
 import {BreadcrumbProvider} from 'sentry/views/settings/components/settingsBreadcrumb/context';
-
-type Props = {
-  children: React.ReactNode;
-  location: Location;
-};
 
 function scrollDisable(newLocation: Location, prevLocation: Location) {
   return newLocation.pathname === prevLocation.pathname;
 }
 
-function SettingsWrapper({location, children}: Props) {
+export default function SettingsWrapper() {
+  const location = useLocation();
   useScrollToTop({location, disable: scrollDisable});
 
   return (
     <StyledSettingsWrapper>
-      <BreadcrumbProvider>{children}</BreadcrumbProvider>
+      <BreadcrumbProvider>
+        <Outlet />
+      </BreadcrumbProvider>
     </StyledSettingsWrapper>
   );
 }
-
-export default SettingsWrapper;
 
 const StyledSettingsWrapper = styled('div')`
   display: flex;


### PR DESCRIPTION
Migrates the `SettingsWrapper` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7