### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` for early features route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1172,7 +1172,6 @@ function buildRoutes(): RouteObject[] {
       path: 'early-features/',
       name: t('Early Features'),
       component: make(() => import('sentry/views/settings/earlyFeatures')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'dynamic-sampling/',

--- a/static/app/views/settings/earlyFeatures/index.tsx
+++ b/static/app/views/settings/earlyFeatures/index.tsx
@@ -4,13 +4,12 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import EarlyFeaturesSettingsForm from 'sentry/views/settings/earlyFeatures/settingsForm';
 import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
-export default function OrganizationGeneralSettings(props: RouteComponentProps) {
+export default function OrganizationGeneralSettings() {
   const {isSelfHosted} = useLegacyStore(ConfigStore);
   const organization = useOrganization();
 
@@ -25,7 +24,7 @@ export default function OrganizationGeneralSettings(props: RouteComponentProps) 
         <SettingsPageHeader title={t('Early Features')} />
         <OrganizationPermissionAlert />
 
-        <EarlyFeaturesSettingsForm {...props} access={access} />
+        <EarlyFeaturesSettingsForm access={access} />
       </div>
     </Fragment>
   );

--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import type {Location} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import Form from 'sentry/components/forms/form';
@@ -9,18 +8,18 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {OrganizationAuthProvider} from 'sentry/types/auth';
 import type {Scope} from 'sentry/types/core';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-interface Props extends RouteComponentProps {
+interface Props {
   access: Set<Scope>;
-  location: Location;
 }
 
 type FeatureFlags = Record<string, {description: string; value: boolean}>;
 
-export default function EarlyFeaturesSettingsForm({access, location}: Props) {
+export default function EarlyFeaturesSettingsForm({access}: Props) {
+  const location = useLocation();
   const organization = useOrganization();
 
   const {data: authProvider, isPending: authProviderIsLoading} =


### PR DESCRIPTION
Migrates the early features component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7