### PR TITLE
ref(github): Move more logic into base class

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -884,7 +884,7 @@ class PullRequestEventWebhook(GitHubWebhook):
         # XXX: Use the signature expected in the for loop below.
         handle_github_pr_webhook_for_autofix(organization, action, pull_request, user)
         for processor in self.WEBHOOK_EVENT_PROCESSORS:
-            processor(event_type=self.EVENT_TYPE, event=event, **kwargs)
+            processor(event_type=self.event_type.value, event=event, **kwargs)
 
 
 class CheckRunEventWebhook(GitHubWebhook):
@@ -903,7 +903,7 @@ class CheckRunEventWebhook(GitHubWebhook):
         **kwargs,
     ) -> None:
         for processor in PREPROCESSORS:
-            processor(event_type=self.EVENT_TYPE, event=event, **kwargs)
+            processor(event_type=self.event_type.value, event=event, **kwargs)
 
 
 @all_silo_endpoint

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -710,7 +710,7 @@ class PullRequestEventWebhook(GitHubWebhook):
     """https://developer.github.com/v3/activity/events/types/#pullrequestevent"""
 
     EVENT_TYPE = IntegrationWebhookEventType.PULL_REQUEST
-    WEBHOOK_EVENT_PROCESSORS = [handle_github_pr_webhook_for_autofix]
+    WEBHOOK_EVENT_PROCESSORS = []
 
     def _handle(
         self,

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -94,7 +94,7 @@ class GitHubWebhook(SCMWebhook, ABC):
 
     EVENT_TYPE: IntegrationWebhookEventType
     # When subclassing, add your webhook event processor here.
-    WEBHOOK_EVENT_PROCESSORS: list[Callable[[str, Mapping[str, Any], Any], None]] = []
+    WEBHOOK_EVENT_PROCESSORS: list[Callable[..., None]] = []
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -710,7 +710,7 @@ class PullRequestEventWebhook(GitHubWebhook):
     """https://developer.github.com/v3/activity/events/types/#pullrequestevent"""
 
     EVENT_TYPE = IntegrationWebhookEventType.PULL_REQUEST
-    WEBHOOK_EVENT_PROCESSORS = []
+    WEBHOOK_EVENT_PROCESSORS = [handle_github_pr_webhook_for_autofix]
 
     def _handle(
         self,
@@ -881,7 +881,7 @@ class PullRequestEventWebhook(GitHubWebhook):
 
         # Because we require that the sentry github integration be installed for autofix, we can piggyback
         # on this webhook for autofix for now. We may move to a separate autofix github integration in the future.
-        # XXX: Move to signature expected in the for loop below.
+        # XXX: Use the signature expected in the for loop below.
         handle_github_pr_webhook_for_autofix(organization, action, pull_request, user)
         for processor in self.WEBHOOK_EVENT_PROCESSORS:
             processor(event_type=self.EVENT_TYPE, event=event, **kwargs)

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 import inspect
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Callable, Mapping, MutableMapping
 from datetime import timezone
 from typing import Any
@@ -132,7 +132,6 @@ class GitHubWebhook(SCMWebhook, ABC):
     def provider(self) -> str:
         return IntegrationProviderSlug.GITHUB.value
 
-    @abstractmethod
     def _handle(
         self,
         integration: RpcIntegration,


### PR DESCRIPTION
Changes included:

* `_handle` to process registered webhook event processors
* Declare `EVENT_TYPE` when subclassing