### PR TITLE
fix(preprocessing): bump redirect-preprocess threshold

### DIFF
--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -13,10 +13,10 @@ from sentry.models.groupredirect import GroupRedirect
 """
 Clickhouse can only handle a query of size 131072b. Our IDs are about 10b and there are
 commas & spaces, so each ID ends up ~12b in the query. That gives ~10k possible group
-IDs; we quarter that here both for breathing room and to ensure that we're still fine if
-a poorly-formatted query has the same list twice.
+IDs; we less-than-half that here both for breathing room and to ensure that we're still
+fine if a poorly-formatted query has the same list twice.
 """
-SIZE_THRESHOLD_FOR_CLICKHOUSE = 2500
+SIZE_THRESHOLD_FOR_CLICKHOUSE = 4000
 
 
 def _build_group_redirect_by_group_id_cache_key(group_id: str | int) -> str:


### PR DESCRIPTION
This was originally set to 2500 semi-arbitrarily to help avoid Clickhouse ingestion size limits. We're seeing folks hit the threshold; it seems like increasing to a threshold of 4000 would eliminate most of (though not all of) the problems.

See: [Widget](https://sentry.sentry.io/organizations/sentry/dashboard/167228/widget/5/?statsPeriod=14d)

Notably, we already gave ourselves a lot of breathing room below the Clickhouse limit and we now have the ability to up that limit if needed. Let's bump the threshold to avoid problems.

The ideal number might change after #105385; we should keep an eye on that.
