### PR TITLE
fix(dashboards): Only link to platformized frontend session health

### DIFF
--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -130,9 +130,10 @@ function ViewSpecificCharts({
 }
 
 function PageWithProviders() {
+  const {view = ''} = useDomainViewFilters();
   const hasDashboardsPlatformizedSessionHealth =
     useHasDashboardsPlatformizedSessionHealth();
-  if (hasDashboardsPlatformizedSessionHealth) {
+  if (hasDashboardsPlatformizedSessionHealth && view === FRONTEND_LANDING_SUB_PATH) {
     return <PlatformizedSessionsOverview />;
   }
   return (


### PR DESCRIPTION
Fixes an issue where the new platformized frontend session health was being used for the mobile session health page.