### PR TITLE
feat(issues): GA empty tags subtraction query

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -200,8 +200,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Whether to allow issue only search on the issue list
     manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use 2-query subtraction approach for empty tag counts (avoids query-size limits)
-    manager.add("organizations:issue-tags-subtraction-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enabling this will remove the consent flow for free generative AI features such as issue feedback summaries
     manager.add("organizations:gen-ai-consent-flow-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:metric-issue-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/issues/endpoints/group_tags.py
+++ b/src/sentry/issues/endpoints/group_tags.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.helpers.environments import get_environments
@@ -62,19 +62,12 @@ class GroupTagsEndpoint(GroupEndpoint):
 
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
 
-        use_subtraction_query = features.has(
-            "organizations:issue-tags-subtraction-query",
-            group.project.organization,
-            actor=request.user,
-        )
-
         tag_keys = backend.get_group_tag_keys_and_top_values(
             group,
             environment_ids,
             keys=keys,
             value_limit=value_limit,
             tenant_ids={"organization_id": group.project.organization_id},
-            use_subtraction_query=use_subtraction_query,
         )
 
         data = serialize(tag_keys, request.user)

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -891,7 +891,6 @@ class SnubaTagStorage(TagStorage):
         keys: list[str] | None = None,
         value_limit: int = TOP_VALUES_DEFAULT_LIMIT,
         tenant_ids=None,
-        use_subtraction_query: bool = False,
         **kwargs,
     ):
         # Similar to __get_tag_key_and_top_values except we get the top values
@@ -945,7 +944,6 @@ class SnubaTagStorage(TagStorage):
             tenant_ids=tenant_ids,
             start=kwargs.get("start"),
             end=kwargs.get("end"),
-            use_subtraction_query=use_subtraction_query,
         )
         for k, stats in empty_stats_map.items():
             if not stats or stats.get("count", 0) <= 0:
@@ -992,85 +990,13 @@ class SnubaTagStorage(TagStorage):
         tenant_ids: dict[str, int | str] | None,
         start: datetime | None,
         end: datetime | None,
-        use_subtraction_query: bool = False,
     ) -> dict[str, dict[str, Any]]:
-        """Count events with empty/missing tag values for each key."""
+        """
+        Count events with empty/missing tag values for each key.
+        """
         if not keys_to_check:
             return {}
 
-        if use_subtraction_query:
-            return self.__get_empty_value_stats_map_subtraction(
-                dataset, filters, conditions, keys_to_check, tenant_ids, start, end
-            )
-        return self.__get_empty_value_stats_map_countif(
-            dataset, filters, conditions, keys_to_check, tenant_ids, start, end
-        )
-
-    def __get_empty_value_stats_map_countif(
-        self,
-        dataset: Dataset,
-        filters: MutableMapping[str, Sequence[Any]],
-        conditions: list,
-        keys_to_check: list[str],
-        tenant_ids: dict[str, int | str] | None,
-        start: datetime | None,
-        end: datetime | None,
-    ) -> dict[str, dict[str, Any]]:
-        stats_map: dict[str, dict[str, Any]] = {}
-        if not keys_to_check:
-            return stats_map
-
-        empty_alias_map: dict[str, dict[str, str]] = {}
-        selected_columns_empty: list[list] = []
-        for i, k in enumerate(keys_to_check):
-            cnt_alias = f"cnt_{i}"
-            empty_alias_map[k] = {"count": cnt_alias}
-            tag_expr = self.format_string.format(k)
-            empty_predicate = ["equals", [tag_expr, ""]]
-            selected_columns_empty.append(["countIf", [empty_predicate], cnt_alias])
-
-        empty_filters = dict(filters)
-        if self.key_column in empty_filters:
-            # For empty-value stats, do not restrict by tags_key; events that
-            # store an empty value may omit the key entirely. Removing this
-            # filter ensures those events are counted.
-            del empty_filters[self.key_column]
-
-        empty_results = snuba.query(
-            dataset=dataset,
-            start=start,
-            end=end,
-            groupby=None,
-            conditions=conditions,
-            filter_keys=empty_filters,
-            aggregations=[],
-            selected_columns=selected_columns_empty,
-            referrer=Referrer.TAGSTORE__GET_TAG_KEYS_AND_TOP_VALUES_EMPTY_COUNTS,
-            tenant_ids=tenant_ids,
-        )
-
-        for k in keys_to_check:
-            aliases = empty_alias_map[k]
-            stats_map[k] = {
-                "count": empty_results.get(aliases["count"], 0),
-            }
-        return stats_map
-
-    def __get_empty_value_stats_map_subtraction(
-        self,
-        dataset: Dataset,
-        filters: MutableMapping[str, Sequence[Any]],
-        conditions: list,
-        keys_to_check: list[str],
-        tenant_ids: dict[str, int | str] | None,
-        start: datetime | None,
-        end: datetime | None,
-    ) -> dict[str, dict[str, Any]]:
-        """
-        Two-query subtraction: empty_count(k) = total_events - non_empty_events(k).
-
-        Avoids per-key countIf that can exceed ClickHouse query-size limits.
-        """
         # Don't filter by tags_key so events missing the key count toward total.
         total_filters = dict(filters)
         total_filters.pop(self.key_column, None)


### PR DESCRIPTION
GA calculating empty tags by running two queries instead of a single query with a bunch of countif statements. Some issues have more tags than allowed in a single query

Remove the temporary test, we already have another test covering this case.