### PR TITLE
feat(dynamic-grouping): Implement Dismiss on Cluster cards

### DIFF
--- a/static/app/views/issueList/pages/dynamicGrouping.tsx
+++ b/static/app/views/issueList/pages/dynamicGrouping.tsx
@@ -767,7 +767,7 @@ function DynamicGrouping() {
   const [filterByRegressed, setFilterByRegressed] = useState(false);
   const [filterByEscalating, setFilterByEscalating] = useState(false);
   const [dismissedClusterIds, setDismissedClusterIds] = useLocalStorageState<number[]>(
-    'top-issues-dismissed-clusters',
+    `top-issues-dismissed-clusters:${organization.slug}`,
     []
   );
 


### PR DESCRIPTION
Allow users to hide clusters locally using the Dismiss button which was not implemented until now. Uses localStorage to hold the list of clusterIDs, with a confirmation after clicking to prevent accidental dismissing.

<img width="1512" height="660" alt="Screenshot 2025-12-22 at 2 14 08 PM" src="https://github.com/user-attachments/assets/405b04ac-779a-4bc2-9fd0-13a0cf202032" />