### PR TITLE
feat(rpc): Tag response logs with organization_id

### DIFF
--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -180,6 +180,7 @@ def _make_rpc_requests(
                 "Table RPC query response",
                 extra={
                     "rpc_rows": rpc_rows,
+                    "organization_id": request.meta.organization_id,
                     "page_token": table_response.page_token,
                     "meta": table_response.meta,
                 },
@@ -198,6 +199,7 @@ def _make_rpc_requests(
                 "Timeseries RPC query response",
                 extra={
                     "rpc_rows": rpc_rows,
+                    "organization_id": request.meta.organization_id,
                     "meta": timeseries_response.meta,
                 },
             )


### PR DESCRIPTION
It would have been useful to have organization_id on these to filter for requests that have particular response characteristics (e.g. empty responses)

My use case was to find logs where the timeseries response was empty for a particular org.