### PR TITLE
feat(dashboards): Adds positive polarity render support for Big Number widgets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -7,6 +7,7 @@ import type {NumberFieldProps} from 'sentry/components/forms/fields/numberField'
 import NumberField from 'sentry/components/forms/fields/numberField';
 import type {SelectFieldProps} from 'sentry/components/forms/fields/selectField';
 import SelectField from 'sentry/components/forms/fields/selectField';
+import type {Polarity} from 'sentry/components/percentChange';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getThresholdUnitSelectOptions} from 'sentry/views/dashboards/utils';
@@ -43,6 +44,7 @@ type ThresholdMaxValues = Partial<Record<ThresholdMaxKeys, number>>;
 export type ThresholdsConfig = {
   max_values: ThresholdMaxValues;
   unit: string | null;
+  preferredPolarity?: Polarity;
 };
 
 const WIDGET_INDICATOR_SIZE = 15;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper.tsx
@@ -15,6 +15,9 @@ type Props = {
   type?: string;
 };
 
+const NEGATIVE_POLARITY_COLOR_ORDER = ['green400', 'yellow400', 'red400'] as const;
+const POSITIVE_POLARITY_COLOR_ORDER = ['red400', 'yellow400', 'green400'] as const;
+
 export function ThresholdsHoverWrapper({children, thresholds, type}: Props) {
   const {
     unit,
@@ -29,6 +32,11 @@ export function ThresholdsHoverWrapper({children, thresholds, type}: Props) {
   const maxOneValue = max1 ?? notSetMsg;
   const maxTwoValue = max2 ?? notSetMsg;
 
+  const colorOrder =
+    thresholds.preferredPolarity === '+'
+      ? POSITIVE_POLARITY_COLOR_ORDER
+      : NEGATIVE_POLARITY_COLOR_ORDER;
+
   return (
     <StyledHoverCard
       skipWrapper
@@ -36,17 +44,17 @@ export function ThresholdsHoverWrapper({children, thresholds, type}: Props) {
         <BodyWrapper>
           <ContextTitle>{title}</ContextTitle>
           <Row>
-            <StyledIndicator color={theme.colors.green400} size={10} />
+            <StyledIndicator color={theme.colors[colorOrder[0]]} size={10} />
             <span>0 - {maxOneValue}</span>
           </Row>
           <Row>
-            <StyledIndicator color={theme.colors.yellow400} size={10} />
+            <StyledIndicator color={theme.colors[colorOrder[1]]} size={10} />
             <span>
               {maxOneValue} - {maxTwoValue}
             </span>
           </Row>
           <Row>
-            <StyledIndicator color={theme.colors.red400} size={10} />
+            <StyledIndicator color={theme.colors[colorOrder[2]]} size={10} />
             <span>
               {maxTwoValue} - {t('No max')}
             </span>

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -678,7 +678,9 @@ function BigNumberComponent({
         type={meta.fields?.[field] ?? null}
         unit={(meta.units?.[field] as DataUnit) ?? null}
         thresholds={widget.thresholds ?? undefined}
-        preferredPolarity="-"
+        // TODO: preferredPolarity has been added to ThresholdsConfig as a property,
+        // we should remove this prop fromBigNumberWidgetVisualization
+        preferredPolarity={widget.thresholds?.preferredPolarity ?? '-'}
       />
     );
   });

--- a/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
@@ -53,6 +53,7 @@ export function ThresholdsIndicator({
       max1: max1 ?? null,
       max2: max2 ?? null,
     },
+    preferredPolarity,
   };
 
   return (


### PR DESCRIPTION
Adds `preferredPolarity` as an attribute to `ThresholdsConfig` in the frontend, and adds support to render Big Number widget thresholds using reverse polarity.
- Does NOT add ui to enable choosing positive or negative polarity in the widget builder. (Can be a separate pr)
- Backend currently does not store `preferredPolarity` in the serializer for `ThresholdsConfig`. (Also separate pr)

To be used by web vital performance score big number widgets
<img width="173" height="205" alt="image" src="https://github.com/user-attachments/assets/517b1362-b7ee-405b-8f3b-e4f2eb4a4f7d" />

