### PR TITLE
fix(other-onboarding): Fallback for missing DSN

### DIFF
--- a/static/app/views/projectInstall/otherPlatformsInfo.spec.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.spec.tsx
@@ -1,0 +1,89 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {OtherPlatformsInfo} from 'sentry/views/projectInstall/otherPlatformsInfo';
+
+describe('OtherPlatformsInfo', () => {
+  const organization = OrganizationFixture();
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders loading state', () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/test-project/keys/`,
+      body: ProjectKeysFixture(),
+      statusCode: 200,
+    });
+
+    render(<OtherPlatformsInfo projectSlug="test-project" platform="custom-platform" />, {
+      organization,
+    });
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
+  it('renders error state and allows retry', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/test-project/keys/`,
+      statusCode: 500,
+    });
+
+    render(<OtherPlatformsInfo projectSlug="test-project" platform="custom-platform" />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByText('There was an error loading data.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+  });
+
+  it('renders DSN when available', async () => {
+    const projectKeys = ProjectKeysFixture();
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/test-project/keys/`,
+      body: projectKeys,
+    });
+
+    render(<OtherPlatformsInfo projectSlug="test-project" platform="custom-platform" />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByText(
+        /We cannot provide instructions for 'custom-platform' projects/
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/dsn:/)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(projectKeys[0]!.dsn.public))).toBeInTheDocument();
+  });
+
+  it('renders warning when no DSN is available', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/test-project/keys/`,
+      body: [],
+    });
+
+    render(<OtherPlatformsInfo projectSlug="test-project" platform="custom-platform" />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByText(
+        /We cannot provide instructions for 'custom-platform' projects/
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/No DSN found for this project/)).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'project settings'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/settings/projects/test-project/keys/`
+    );
+  });
+});

--- a/static/app/views/projectInstall/otherPlatformsInfo.tsx
+++ b/static/app/views/projectInstall/otherPlatformsInfo.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
+
 import {CodeBlock} from 'sentry/components/core/code';
-import {ExternalLink} from 'sentry/components/core/link';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import LoadingError from 'sentry/components/loadingError';
@@ -38,15 +40,32 @@ export function OtherPlatformsInfo({
     return <LoadingError onRetry={refetch} />;
   }
 
+  const dsn = data[0]?.dsn?.public;
+
   return (
     <Wrapper>
       {t(
         "We cannot provide instructions for '%s' projects. However, please find below the DSN key for this project, which is required to instrument Sentry.",
         platform
       )}
-      <CodeBlock dark language="properties">
-        {t('dsn: %s', data[0]!.dsn.public)}
-      </CodeBlock>
+      {dsn ? (
+        <CodeBlock dark language="properties">
+          {t('dsn: %s', data[0]!.dsn.public)}
+        </CodeBlock>
+      ) : (
+        <Alert type="warning">
+          {tct(
+            'No DSN found for this project. You an create a new one by visiting your [link:project settings].',
+            {
+              link: (
+                <Link
+                  to={`/organizations/${organization.slug}/settings/projects/${projectSlug}/keys/`}
+                />
+              ),
+            }
+          )}
+        </Alert>
+      )}
       <Suggestion>
         {t(
           'Since it can be a lot of work creating a Sentry SDK from scratch, we suggest you review the following SDKs which are applicable for a wide variety of applications:'


### PR DESCRIPTION
An incident resulted in projects being created without DSN, this was breaking the onboarding of the `other` platform.

- fixes JAVASCRIPT-35TR