### PR TITLE
fix(explore): Compare not wrapped in query param context

### DIFF
--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -65,6 +65,7 @@ interface UseTrackAnalyticsProps {
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
   visualizes: readonly Visualize[];
   attributeBreakdownsMode?: 'breakdowns' | 'cohort_comparison';
+  crossEventQueries?: ReturnType<typeof useCrossEventQueries>;
   title?: string;
   tracesTableResult?: TracesTableResult;
 }
@@ -84,9 +85,9 @@ function useTrackAnalytics({
   page_source,
   interval,
   isTopN,
+  crossEventQueries,
 }: UseTrackAnalyticsProps) {
   const organization = useOrganization();
-  const crossEventQueries = useCrossEventQueries();
 
   const {
     data: {hasExceededPerformanceUsageLimit},
@@ -506,6 +507,7 @@ export function useAnalytics({
   const topEvents = useTopEvents();
   const isTopN = topEvents ? topEvents > 0 : false;
   const {chartSelection} = useChartSelection();
+  const crossEventQueries = useCrossEventQueries();
 
   const attributeBreakdownsMode =
     queryType === 'attribute_breakdowns'
@@ -529,6 +531,7 @@ export function useAnalytics({
     page_source: 'explore',
     isTopN,
     attributeBreakdownsMode,
+    crossEventQueries,
   });
 }
 

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {type ReactNode} from 'react';
 import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
@@ -13,62 +13,21 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
-import {useResettableState} from 'sentry/utils/useResettableState';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
-import {
-  defaultAggregateFields,
-  defaultAggregateSortBys,
-  defaultFields,
-  defaultQuery,
-  defaultSortBys,
-} from 'sentry/views/explore/metrics/metricQuery';
 import {MultiQueryModeContent} from 'sentry/views/explore/multiQueryMode/content';
 import {useReadQueriesFromLocation} from 'sentry/views/explore/multiQueryMode/locationUtils';
-import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
-import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
-import {defaultCursor} from 'sentry/views/explore/queryParams/cursor';
-import {Mode} from 'sentry/views/explore/queryParams/mode';
-import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 jest.mock('sentry/components/lazyRender', () => ({
   LazyRender: ({children}: {children: React.ReactNode}) => children,
 }));
 
-function Wrapper(crossEvents?: CrossEvent[]) {
+function Wrapper() {
   return function ({children}: {children: ReactNode}) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [query] = useResettableState(defaultQuery);
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const readableQueryParams = useMemo(
-      () =>
-        new ReadableQueryParams({
-          aggregateCursor: defaultCursor(),
-          aggregateFields: defaultAggregateFields(),
-          aggregateSortBys: defaultAggregateSortBys(defaultAggregateFields()),
-          cursor: defaultCursor(),
-          extrapolate: true,
-          fields: defaultFields(),
-          mode: Mode.AGGREGATE,
-          query,
-          sortBys: defaultSortBys(defaultFields()),
-          crossEvents,
-        }),
-      [query]
-    );
-
     return (
-      <QueryParamsContextProvider
-        isUsingDefaultFields={false}
-        queryParams={readableQueryParams}
-        setQueryParams={jest.fn()}
-        shouldManageFields={false}
-      >
-        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
-          {children}
-        </TraceItemAttributeProvider>
-      </QueryParamsContextProvider>
+      <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+        {children}
+      </TraceItemAttributeProvider>
     );
   };
 }


### PR DESCRIPTION
The compare page doesn't use the readable query param context stuff, so needed to move things around to get context to be happy.

Fixes: JAVASCRIPT-35TB