### PR TITLE
insights draw doesn’t work on mobile (EME-518)

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeLegend.tsx
@@ -249,12 +249,14 @@ const MeasurementContainer = styled('div')`
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
   visibility: hidden;
   pointer-events: none;
   display: flex;
   gap: ${p => p.theme.space.xs};
   flex-wrap: nowrap;
   white-space: nowrap;
+  overflow: hidden;
 `;
 
 const LegendItem = styled('div')<{isActive: boolean}>`


### PR DESCRIPTION
### TL;DR

Added `overflow: hidden` to the `LegendContainer` styled component in the AppSizeLegend component.

### What changed?

Modified the `LegendContainer` styled component in the AppSizeLegend component by adding the CSS property `overflow: hidden` to prevent content from overflowing outside its boundaries. 

### Why make this change?

This change prevents content from spilling outside the legend container's boundaries which prevents potential layout issues with the SlideOverPane. 