### PR TITLE
feat(security): prepend API application client secrets with `sntrya_` prefix

### DIFF
--- a/src/sentry/api/endpoints/api_application_rotate_secret.py
+++ b/src/sentry/api/endpoints/api_application_rotate_secret.py
@@ -9,6 +9,7 @@ from sentry.api.endpoints.api_application_details import ApiApplicationEndpoint
 from sentry.api.permissions import SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.models.apiapplication import ApiApplication, generate_token
+from sentry.types.token import AuthTokenType
 
 
 @control_silo_endpoint
@@ -21,6 +22,6 @@ class ApiApplicationRotateSecretEndpoint(ApiApplicationEndpoint):
     permission_classes = (SentryIsAuthenticated,)
 
     def post(self, request: Request, application: ApiApplication) -> Response:
-        new_token = generate_token()
+        new_token = generate_token(token_type=AuthTokenType.USER_APP)
         application.update(client_secret=new_token)
         return Response(serialize({"clientSecret": new_token}))

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_rotate_secret.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_rotate_secret.py
@@ -17,6 +17,7 @@ from sentry.organizations.services.organization import organization_service
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppBaseEndpoint
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.utils.errors import SentryAppError
+from sentry.types.token import AuthTokenType
 from sentry.users.services.user.service import user_service
 
 logger = logging.getLogger(__name__)
@@ -84,7 +85,7 @@ class SentryAppRotateSecretEndpoint(SentryAppBaseEndpoint):
         if sentry_app.application is None:
             return Response({"detail": "Corresponding application was not found."}, status=404)
 
-        new_token = generate_token()
+        new_token = generate_token(token_type=AuthTokenType.USER_APP)
         sentry_app.application.update(client_secret=new_token)
         self.create_audit_entry(
             request=self.request,

--- a/tests/sentry/api/endpoints/test_api_application_rotate_secrets.py
+++ b/tests/sentry/api/endpoints/test_api_application_rotate_secrets.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from sentry.models.apiapplication import ApiApplication
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.types.token import AuthTokenType
 
 
 @control_silo_test
@@ -40,3 +41,4 @@ class ApiApplicationRotateSecretTest(APITestCase):
         new_secret = response.data["clientSecret"]
         assert len(new_secret) == len(old_secret)
         assert new_secret != old_secret
+        assert new_secret.startswith(AuthTokenType.USER_APP)

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -1,6 +1,7 @@
 from sentry.models.apiapplication import ApiApplication
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.types.token import AuthTokenType
 
 
 @control_silo_test
@@ -206,3 +207,11 @@ class ApiApplicationTest(TestCase):
         )
 
         assert f"{app} is cool" == f"{app.name} is cool"
+
+    def test_client_secret_has_prefix(self) -> None:
+        app = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com",
+        )
+
+        assert app.client_secret.startswith(AuthTokenType.USER_APP)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_rotate_secret.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_rotate_secret.py
@@ -4,6 +4,7 @@ from sentry.models.apiapplication import ApiApplication
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.types.token import AuthTokenType
 
 
 @control_silo_test
@@ -88,6 +89,7 @@ class SentryAppRotateSecretTest(APITestCase):
         new_secret = response.data["clientSecret"]
         assert len(new_secret) == len(old_secret)
         assert new_secret != old_secret
+        assert new_secret.startswith(AuthTokenType.USER_APP)
 
     def test_superuser_has_access(self) -> None:
         superuser = self.create_user(is_superuser=True)
@@ -98,6 +100,7 @@ class SentryAppRotateSecretTest(APITestCase):
         new_secret = response.data["clientSecret"]
         assert len(new_secret) == len(old_secret)
         assert new_secret != old_secret
+        assert new_secret.startswith(AuthTokenType.USER_APP)
 
     def test_no_corresponding_application_found(self) -> None:
         self.login_as(self.user)


### PR DESCRIPTION
Newly created client secrets for API applications (personal) and Custom Integrations (Internal + Public integrations) will receive `sntrya_` prefix on creation. This is to support leaked secret detection:
https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/secret_scanning/github.py#L89