### PR TITLE
fix(logs): Only send timestamp filter if autorefresh enabled

### DIFF
--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -223,7 +223,7 @@ describe('LogsPage', () => {
             interval: '5m',
             partial: 1,
             project: [],
-            query: 'timestamp_precise:<=1508208040000000000',
+            query: '',
             referrer: 'api.explore.ourlogs-timeseries',
             sampling: 'NORMAL',
             sort: '-count_message',


### PR DESCRIPTION
There's a very subtle bug that occurs because of this `timestamp_precise` filter being applied at the wrong time. The reported behaviour is when the _chart_ displays as if it received an empty response, but the table has data.

The `events-timeseries` wasn't conditionally applying the `timestamp_precise` filter, and since it is stored in state it can become stale. This timestamp is updated when autorefresh occurs, or if a user presses the refresh button. It is _not_ updated when page filters change. It then becomes possible that the `timestamp_precise` filter can move out of the compatible window for the range filter and produce no results if the user is triggering data fetches that don't reset this `timestamp_precise` filter. i.e. we erroneously filter for `timestamp_precise < start < end`, which would result in nothing

The solution here is to only apply the filter conditionally when auto refresh is on. This more accurately mirrors the behaviour for tables as well (i.e. the precise filter is only provided conditionally) and keeps the requests in sync.