### PR TITLE
feat(dashboards): Adds a feature flag to enable synchronizing all prebuilt dashboards

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -136,6 +136,10 @@ def sync_prebuilt_dashboards(organization: Organization) -> None:
             dashboard
             for dashboard in PREBUILT_DASHBOARDS
             if dashboard["prebuilt_id"] in enabled_prebuilt_dashboard_ids
+            or features.has(
+                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
+                organization,
+            )
         ]
 
         saved_prebuilt_dashboards = Dashboard.objects.filter(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -288,6 +288,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-http-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Mobile Vitals Insights module on dashboards platform
     manager.add("organizations:insights-mobile-vitals-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable all registered prebuilt dashboards to be synced to the database
+    manager.add("organizations:dashboards-sync-all-registered-prebuilt-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable sentry convention fields
     manager.add("organizations:performance-sentry-conventions-fields", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable querying spans fields stats from comparative workflows project


### PR DESCRIPTION
We already have an existing `dashboards.prebuilt-dashboard-ids` that controls which prebuilt dashboards are synced for all orgs across each region. However, we often want to test new prebuilt dashboards internally before releasing to all regions. Adds a `organizations:dashboards-sync-all-registered-prebuilt-dashboard` feature flag that enables syncing all registered prebuilt dashboards for this purpose.