### PR TITLE
ref(relocation): Remove usage of `deprecatedRouteProps` for relocation route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -272,7 +272,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/relocation/',
       component: make(() => import('sentry/views/relocation')),
-      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -281,7 +280,6 @@ function buildRoutes(): RouteObject[] {
         {
           path: ':step/',
           component: make(() => import('sentry/views/relocation')),
-          deprecatedRouteProps: true,
         },
       ],
     },

--- a/static/app/views/relocation/index.spec.tsx
+++ b/static/app/views/relocation/index.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -31,14 +30,8 @@ describe('Relocation Onboarding Container', () => {
   });
 
   it('should render if feature enabled', async () => {
-    const {routerProps, organization} = initializeOrg({
-      router: {
-        params: {step: 'get-started'},
-      },
-    });
     ConfigStore.set('features', new Set(['relocation:enabled']));
-    render(<RelocationOnboardingContainer {...routerProps} />, {
-      organization,
+    render(<RelocationOnboardingContainer />, {
       initialRouterConfig: {
         location: {
           pathname: '/relocation/get-started/',
@@ -55,14 +48,8 @@ describe('Relocation Onboarding Container', () => {
   });
 
   it('should not render if feature disabled', async () => {
-    const {routerProps, organization} = initializeOrg({
-      router: {
-        params: {step: 'get-started'},
-      },
-    });
     ConfigStore.set('features', new Set([]));
-    render(<RelocationOnboardingContainer {...routerProps} />, {
-      organization,
+    render(<RelocationOnboardingContainer />, {
       initialRouterConfig: {
         location: {
           pathname: '/relocation/get-started/',

--- a/static/app/views/relocation/index.tsx
+++ b/static/app/views/relocation/index.tsx
@@ -2,13 +2,10 @@ import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 
 import RelocationOnboarding from './relocation';
 
-type Props = RouteComponentProps<{step: string}>;
-
-export default function RelocationOnboardingContainer(props: Props) {
+export default function RelocationOnboardingContainer() {
   return (
     <Feature
       features={['relocation:enabled']}
@@ -23,7 +20,7 @@ export default function RelocationOnboardingContainer(props: Props) {
         </Layout.Page>
       )}
     >
-      <RelocationOnboarding {...props} />
+      <RelocationOnboarding />
     </Feature>
   );
 }

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -12,11 +12,10 @@ import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import testableTransition from 'sentry/utils/testableTransition';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import PageCorners from 'sentry/views/onboarding/components/pageCorners';
@@ -28,12 +27,6 @@ import {InProgress} from './inProgress';
 import {PublicKey} from './publicKey';
 import type {MaybeUpdateRelocationState, RelocationState, StepDescriptor} from './types';
 import {UploadBackup} from './uploadBackup';
-
-type RouteParams = {
-  step: string;
-};
-
-type Props = RouteComponentProps<RouteParams>;
 
 function getRelocationOnboardingSteps(): StepDescriptor[] {
   return [
@@ -76,7 +69,8 @@ enum LoadingState {
   ERROR = 2,
 }
 
-function RelocationOnboarding(props: Props) {
+export default function RelocationOnboarding() {
+  const navigate = useNavigate();
   const {step: stepId} = useParams<{step: string}>();
   const onboardingSteps = getRelocationOnboardingSteps();
   const stepObj = onboardingSteps.find(({id}) => stepId === id);
@@ -125,20 +119,20 @@ function RelocationOnboarding(props: Props) {
         // progress of that relocation instead, since they can only have one relocation in flight at
         // a time.
         if (existingRelocationUUID !== '' && stepId !== 'in-progress') {
-          browserHistory.push('/relocation/in-progress/');
+          navigate('/relocation/in-progress/');
         }
 
         // The user does not have a relocation in-flight, but tried to view the in progress screen.
         // Since we have nothing to show them, take them back to the start of the flow.
         if (existingRelocationUUID === '' && stepId === 'in-progress') {
-          browserHistory.push('/relocation/get-started/');
+          navigate('/relocation/get-started/');
         }
 
         // The user tried to view a later step, but at least one bit of required data was missing in
         // their local storage. Take them back to the first screen.
         const {orgSlugs, regionUrl} = relocationState;
         if (stepId !== 'get-started' && (!orgSlugs || !regionUrl)) {
-          browserHistory.push('/relocation/get-started/');
+          navigate('/relocation/get-started/');
         }
 
         setExistingRelocation(existingRelocationUUID);
@@ -148,7 +142,7 @@ function RelocationOnboarding(props: Props) {
         setExistingRelocation('');
         setExistingRelocationState(LoadingState.ERROR);
       });
-  }, [api, regions, relocationState, stepId]);
+  }, [api, navigate, regions, relocationState, stepId]);
   useEffect(() => {
     fetchExistingRelocation();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -193,7 +187,7 @@ function RelocationOnboarding(props: Props) {
     if (!stepObj) {
       return;
     }
-    props.router.push(normalizeUrl(`/relocation/${step.id}/`));
+    navigate(normalizeUrl(`/relocation/${step.id}/`));
   };
 
   const goNextStep = useCallback(
@@ -201,9 +195,9 @@ function RelocationOnboarding(props: Props) {
       const currentStepIndex = onboardingSteps.findIndex(s => s.id === step.id);
       const nextStep = onboardingSteps[currentStepIndex + 1]!;
 
-      props.router.push(normalizeUrl(`/relocation/${nextStep.id}/`));
+      navigate(normalizeUrl(`/relocation/${nextStep.id}/`));
     },
-    [onboardingSteps, props.router]
+    [onboardingSteps, navigate]
   );
 
   if (!stepObj || stepIndex === -1) {
@@ -291,9 +285,6 @@ function RelocationOnboarding(props: Props) {
             }}
             publicKeys={publicKeys}
             relocationState={relocationState}
-            route={props.route}
-            router={props.router}
-            location={props.location}
           />
         )}
       </OnboardingStep>
@@ -417,5 +408,3 @@ const OnboardingWrapper = styled('main')`
   display: flex;
   flex-direction: column;
 `;
-
-export default RelocationOnboarding;

--- a/static/app/views/relocation/types.ts
+++ b/static/app/views/relocation/types.ts
@@ -1,5 +1,3 @@
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-
 export type RelocationState = {
   orgSlugs: string;
   promoCode: string;
@@ -12,7 +10,7 @@ export type MaybeUpdateRelocationState = {
   regionUrl?: string;
 };
 
-export type StepProps = Pick<RouteComponentProps, 'router' | 'route' | 'location'> & {
+export type StepProps = {
   active: boolean;
   existingRelocationUUID: string;
   onComplete: (uuid?: string) => void;


### PR DESCRIPTION
Migrates the `RelocationOnboardingContainer` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7