### PR TITLE
feat(tracemetrics): Implement Add to Dashboard

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -1,8 +1,9 @@
+import type {ReactNode} from 'react';
 import pickBy from 'lodash/pickBy';
 
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {ApiResult, Client} from 'sentry/api';
-import type {PageFilters, SelectValue} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
@@ -154,12 +155,15 @@ function useTraceMetricsSearchBarDataProvider(
   };
 }
 
-function prettifySortOption(option: SelectValue<string>) {
-  const parsedFunction = parseFunction(option.value);
+export function formatTraceMetricsFunction(
+  valueToParse: string,
+  defaultValue: string | ReactNode = ''
+) {
+  const parsedFunction = parseFunction(valueToParse);
   if (parsedFunction) {
     return `${parsedFunction.name}(${parsedFunction.arguments[1] ?? '…'})`;
   }
-  return option.label;
+  return defaultValue;
 }
 
 export const TraceMetricsConfig: DatasetConfig<EventsTimeSeriesResponse, never> = {
@@ -176,7 +180,7 @@ export const TraceMetricsConfig: DatasetConfig<EventsTimeSeriesResponse, never> 
   // we only want to allow sorting by selected aggregates.
   getTableSortOptions: (organization, widgetQuery) =>
     getTableSortOptions(organization, widgetQuery).map(option => ({
-      label: prettifySortOption(option),
+      label: formatTraceMetricsFunction(option.value, option.label),
       value: option.value,
     })),
   getGroupByFieldOptions,

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -234,4 +234,5 @@ export enum DashboardWidgetSource {
   TRACE_EXPLORER = 'traceExplorer',
   LOGS = 'logs',
   INSIGHTS = 'insights',
+  TRACEMETRICS = 'traceMetrics',
 }

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -796,6 +796,7 @@ export function constructAddQueryToDashboardLink({
         fields: eventView.getFields(),
         columns:
           widgetType === WidgetType.SPANS ||
+          widgetType === WidgetType.TRACEMETRICS ||
           displayType === DisplayType.TOP_N ||
           eventView.display === DisplayModes.DAILYTOP5
             ? eventView

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -650,7 +650,7 @@ export function handleAddQueryToDashboard({
   yAxis?: string | string[];
 }) {
   const displayType =
-    widgetType === WidgetType.SPANS
+    widgetType === WidgetType.SPANS || widgetType === WidgetType.TRACEMETRICS
       ? (eventView.display as DisplayType)
       : displayModeToDisplayType(eventView.display as DisplayModes);
   const defaultWidgetQuery = eventViewToWidgetQuery({

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
@@ -1,0 +1,134 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useAddMetricToDashboard} from 'sentry/views/explore/metrics/hooks/useAddMetricToDashboard';
+import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+jest.mock('sentry/actionCreators/modal');
+
+describe('useAddMetricToDashboard', () => {
+  const project = ProjectFixture();
+  const organization = OrganizationFixture();
+  const context = initializeOrg({
+    organization,
+    projects: [project],
+    router: {
+      location: {
+        pathname: '/organizations/org-slug/explore/metrics/',
+        query: {project: project.id},
+      },
+      params: {},
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens the dashboard modal with the trace metrics widget configuration', () => {
+    const yAxis = 'avg(value,metric.a,counter,-)';
+    const visualize = new VisualizeFunction(yAxis, {chartType: ChartType.BAR});
+    const metricQuery: BaseMetricQuery = {
+      metric: {name: 'metric.a', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: 'release:1.2.3',
+        cursor: '',
+        fields: [],
+        sortBys: [],
+        aggregateCursor: '',
+        aggregateFields: [visualize, {groupBy: 'project'}],
+        aggregateSortBys: [{field: yAxis, kind: 'desc'}],
+      }),
+    };
+
+    const {result} = renderHookWithProviders(useAddMetricToDashboard, {
+      ...context,
+    });
+
+    act(() => {
+      result.current.addToDashboard(metricQuery);
+    });
+
+    expect(openAddToDashboardModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widget: {
+          title: 'Custom Widget',
+          displayType: DisplayType.BAR,
+          interval: undefined,
+          limit: undefined,
+          widgetType: WidgetType.TRACEMETRICS,
+          queries: [
+            {
+              aggregates: [yAxis],
+              columns: ['project'],
+              fields: ['project'],
+              conditions: 'release:1.2.3',
+              orderby: `-${yAxis}`,
+              name: '',
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it('does not pass an orderby if there are no group bys', () => {
+    const yAxis = 'avg(value,metric.a,counter,-)';
+    const visualize = new VisualizeFunction(yAxis, {chartType: ChartType.BAR});
+    const metricQuery: BaseMetricQuery = {
+      metric: {name: 'metric.a', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: 'release:1.2.3',
+        cursor: '',
+        fields: [],
+        sortBys: [],
+        aggregateCursor: '',
+        aggregateFields: [visualize],
+        aggregateSortBys: [{field: yAxis, kind: 'desc'}],
+      }),
+    };
+
+    const {result} = renderHookWithProviders(useAddMetricToDashboard, {
+      ...context,
+    });
+
+    act(() => {
+      result.current.addToDashboard(metricQuery);
+    });
+
+    expect(openAddToDashboardModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widget: {
+          title: 'Custom Widget',
+          displayType: DisplayType.BAR,
+          interval: undefined,
+          limit: undefined,
+          widgetType: WidgetType.TRACEMETRICS,
+          queries: [
+            {
+              aggregates: [yAxis],
+              columns: [],
+              fields: [],
+              conditions: 'release:1.2.3',
+              orderby: '',
+              name: '',
+            },
+          ],
+        },
+      })
+    );
+  });
+});

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
@@ -1,0 +1,85 @@
+import {useCallback} from 'react';
+
+import type {NewQuery} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  DashboardWidgetSource,
+  DEFAULT_WIDGET_NAME,
+  DisplayType,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
+import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+export const CHART_TYPE_TO_DISPLAY_TYPE = {
+  [ChartType.LINE]: DisplayType.LINE,
+  [ChartType.BAR]: DisplayType.BAR,
+  [ChartType.AREA]: DisplayType.AREA,
+};
+
+export function useAddMetricToDashboard() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const getEventView = useCallback(
+    (metricQuery: BaseMetricQuery) => {
+      const queryValues = metricQuery?.queryParams;
+      const visualize = queryValues?.aggregateFields?.find(isVisualize);
+      const yAxis = visualize?.yAxis;
+      const fields = queryValues?.groupBys ?? [];
+      const aggregateSortBys = queryValues?.aggregateSortBys ?? [];
+
+      const search = new MutableSearch(queryValues?.query ?? '');
+
+      const discoverQuery: NewQuery = {
+        name: DEFAULT_WIDGET_NAME,
+        fields,
+        query: search.formatString(),
+        version: 2,
+        dataset: DiscoverDatasets.TRACEMETRICS,
+        yAxis: [yAxis ?? ''],
+      };
+
+      const newEventView = EventView.fromNewQueryWithPageFilters(
+        discoverQuery,
+        selection
+      );
+      newEventView.display =
+        CHART_TYPE_TO_DISPLAY_TYPE[visualize?.chartType ?? ChartType.LINE];
+
+      if (fields.length > 0) {
+        newEventView.sorts = aggregateSortBys;
+      }
+      return newEventView;
+    },
+    [selection]
+  );
+
+  const addToDashboard = useCallback(
+    (metricQuery: BaseMetricQuery) => {
+      const eventView = getEventView(metricQuery);
+
+      handleAddQueryToDashboard({
+        organization,
+        location,
+        eventView,
+        yAxis: eventView.yAxis,
+        widgetType: WidgetType.TRACEMETRICS,
+        source: DashboardWidgetSource.TRACEMETRICS,
+      });
+    },
+    [organization, location, getEventView]
+  );
+
+  return {
+    addToDashboard,
+  };
+}

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
@@ -10,19 +10,13 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   DashboardWidgetSource,
   DEFAULT_WIDGET_NAME,
-  DisplayType,
   WidgetType,
 } from 'sentry/views/dashboards/types';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-
-export const CHART_TYPE_TO_DISPLAY_TYPE = {
-  [ChartType.LINE]: DisplayType.LINE,
-  [ChartType.BAR]: DisplayType.BAR,
-  [ChartType.AREA]: DisplayType.AREA,
-};
 
 export function useAddMetricToDashboard() {
   const location = useLocation();

--- a/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
@@ -15,7 +15,11 @@ export function MetricSaveAs() {
   if (items.length === 1) {
     const item = items[0]!;
     return (
-      <Button size="sm" onClick={item.onAction} aria-label={item.textValue}>
+      <Button
+        size="sm"
+        onClick={'onAction' in item ? item.onAction : undefined}
+        aria-label={item.textValue}
+      >
         {t('Save as')}…
       </Button>
     );

--- a/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
@@ -12,14 +12,10 @@ export function MetricSaveAs() {
     return null;
   }
 
-  if (items.length === 1) {
-    const item = items[0]!;
+  if (items.length === 1 && 'onAction' in items[0]! && !('children' in items[0])) {
+    const item = items[0];
     return (
-      <Button
-        size="sm"
-        onClick={'onAction' in item ? item.onAction : undefined}
-        aria-label={item.textValue}
-      >
+      <Button size="sm" onClick={item.onAction} aria-label={item.textValue}>
         {t('Save as')}…
       </Button>
     );


### PR DESCRIPTION
Implements Add to Dashboard. Each metric visualized gets rendered as a dropdown item and renders a prettified label as well as the row label in the case of duplicate metrics. In the future maybe we can differentiate them better with specific filters or groupings but for now this is okay.

<img width="1221" height="171" alt="Screenshot 2025-12-23 at 3 48 49 PM" src="https://github.com/user-attachments/assets/08e3d43d-dd23-47de-bce7-9a9dce7b06dc" />

Each menu item, when clicked, converts the metric into a widget format and calls `openAddToDashboardModal` where the user can follow with the normal flow we use for other widgets.