### PR TITLE
ref(admin): Use `Outlet` to render children in admin layout route

### DIFF
--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -44,7 +44,6 @@ function buildRoutes() {
   const routes: SentryRouteObject = {
     path: '/_admin/',
     component: Layout,
-    deprecatedRouteProps: true,
     children: [
       {
         index: true,

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {Outlet} from 'react-router-dom';
 import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -37,11 +38,7 @@ const useToggleTheme = () => {
   return [themeName === 'darkTheme', themes[themeName], toggleTheme] as const;
 };
 
-type Props = {
-  children: React.ReactNode;
-};
-
-function Layout({children}: Props) {
+export default function Layout() {
   const [isDark, theme, toggleTheme] = useToggleTheme();
 
   return (
@@ -100,7 +97,9 @@ function Layout({children}: Props) {
               </ThemeToggle>
             </div>
           </Sidebar>
-          <Content>{children}</Content>
+          <Content>
+            <Outlet />
+          </Content>
         </AppContainer>
       </ScrapsProviders>
     </ThemeProvider>
@@ -196,5 +195,3 @@ const NavLink = styled(ListLink)`
     color: ${p => p.theme.active};
   }
 `;
-
-export default Layout;


### PR DESCRIPTION
Migrates the admin `Layout` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7