### PR TITLE
fix(issues): Fix TypeError on save event with None in tags

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -90,7 +90,10 @@ def encode_attributes(
     tag_keys = set()
     tags = event_data.get("tags")
     if tags is not None:
-        for key, value in tags:
+        for tag in tags:
+            if tag is None:
+                continue
+            key, value = tag
             if value is None:
                 continue
             formatted_key = format_tag_key(key)


### PR DESCRIPTION
Fixes: SENTRY-5F52.

Following up on the PR we did with seer there #105306, turns out the `tags` themselves being none wasnt the problem, its none elements inside the array being broken into `value, key`. Tags being able to contain `None` is something that was introducted recently and this is another one its fallouts.
Fixed the iteration and added test.