### PR TITLE
ref(layout): Use `Outlet` to render children in app body content route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -15,7 +15,6 @@ import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 import App from 'sentry/views/app';
 import {AppBodyContentRoute} from 'sentry/views/app/appBodyContent';
-import AuthLayout from 'sentry/views/auth/layout';
 import AuthLayoutRoute from 'sentry/views/auth/layout';
 import {authV2Routes} from 'sentry/views/authV2/routes';
 import {automationRoutes} from 'sentry/views/automations/routes';

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -14,7 +14,7 @@ import {translateSentryRoute} from 'sentry/utils/reactRouter6Compat/router';
 import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 import App from 'sentry/views/app';
-import {AppBodyContent} from 'sentry/views/app/appBodyContent';
+import {AppBodyContentRoute} from 'sentry/views/app/appBodyContent';
 import AuthLayout from 'sentry/views/auth/layout';
 import {authV2Routes} from 'sentry/views/authV2/routes';
 import {automationRoutes} from 'sentry/views/automations/routes';
@@ -329,9 +329,8 @@ function buildRoutes(): RouteObject[] {
     },
   ];
   const rootRoutes: SentryRouteObject = {
-    component: errorHandler(AppBodyContent),
+    component: errorHandler(AppBodyContentRoute),
     children: rootChildren,
-    deprecatedRouteProps: true,
   };
 
   const accountSettingsChildren: SentryRouteObject[] = [

--- a/static/app/views/app/appBodyContent.tsx
+++ b/static/app/views/app/appBodyContent.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {Outlet} from 'react-router-dom';
 
 import SystemAlerts from 'sentry/views/app/systemAlerts';
 
@@ -19,5 +20,16 @@ export function AppBodyContent({children}: AppContentProps) {
       <SystemAlerts className="messages-container" />
       {children}
     </Fragment>
+  );
+}
+
+/**
+ * Route component version that renders children via Outlet.
+ */
+export function AppBodyContentRoute() {
+  return (
+    <AppBodyContent>
+      <Outlet />
+    </AppBodyContent>
   );
 }


### PR DESCRIPTION
Migrates the `AppBodyContent` component route off of `deprecatedRouteProps`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7