### PR TITLE
chore(auth): Clean up component definitions for auth layout

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -15,7 +15,7 @@ import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 import App from 'sentry/views/app';
 import {AppBodyContent} from 'sentry/views/app/appBodyContent';
-import AuthLayout from 'sentry/views/auth/layout';
+import AuthLayoutRoute from 'sentry/views/auth/layout';
 import {authV2Routes} from 'sentry/views/authV2/routes';
 import {automationRoutes} from 'sentry/views/automations/routes';
 import {detectorRoutes} from 'sentry/views/detectors/routes';
@@ -146,7 +146,7 @@ function buildRoutes(): RouteObject[] {
   const experimentalSpaRoutes: SentryRouteObject = EXPERIMENTAL_SPA
     ? {
         path: '/auth/login/',
-        component: errorHandler(AuthLayout),
+        component: errorHandler(AuthLayoutRoute),
         children: experimentalSpaChildRoutes,
       }
     : {};

--- a/static/app/views/auth/layout.tsx
+++ b/static/app/views/auth/layout.tsx
@@ -11,9 +11,9 @@ import {AppBodyContent} from 'sentry/views/app/appBodyContent';
 const BODY_CLASSES = ['narrow'];
 
 /**
- * Shared auth layout structure - includes all wrapper elements.
+ * Content component for auth-style layout.
  */
-function AuthLayoutContent({children}: {children: React.ReactNode}) {
+export function AuthLayoutContent({children}: {children: React.ReactNode}) {
   useEffect(() => {
     document.body.classList.add(...BODY_CLASSES);
     return () => document.body.classList.remove(...BODY_CLASSES);
@@ -37,22 +37,14 @@ function AuthLayoutContent({children}: {children: React.ReactNode}) {
 }
 
 /**
- * Route component for auth pages.
- * Uses <Outlet /> for child routes.
+ * Route component version that renders children via Outlet.
  */
-export default function AuthLayout() {
+export default function AuthLayoutRoute() {
   return (
     <AuthLayoutContent>
       <Outlet />
     </AuthLayoutContent>
   );
-}
-
-/**
- * Wrapper component for auth-style layout with children to render.
- */
-export function AuthLayoutWrapper({children}: {children: React.ReactNode}) {
-  return <AuthLayoutContent>{children}</AuthLayoutContent>;
 }
 
 const AuthContainer = styled('div')`

--- a/static/app/views/dataExport/dataDownload.tsx
+++ b/static/app/views/dataExport/dataDownload.tsx
@@ -15,7 +15,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
-import {AuthLayoutWrapper as Layout} from 'sentry/views/auth/layout';
+import {AuthLayoutContent as Layout} from 'sentry/views/auth/layout';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -69,7 +69,7 @@ type OtherDownload = BaseDownload & {
 
 type Download = ExploreDownload | OtherDownload;
 
-function DataDownload() {
+export default function DataDownload() {
   const {dataExportId, orgId: orgSlug} = useParams<{
     dataExportId: string;
     orgId: string;
@@ -390,5 +390,3 @@ const Body = styled('div')`
 const DownloadButton = styled(LinkButton)`
   margin-bottom: ${space(1.5)};
 `;
-
-export default DataDownload;


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/105313.

Removes an unnecessary auth layout component - we only need one for the route (which renders children via `Outlet`) and one for the layout content.