### PR TITLE
chore(router): Migrate `withSentryRouter` tests off of `deprecatedRouterMocks`

### DIFF
--- a/static/app/utils/withSentryRouter.spec.tsx
+++ b/static/app/utils/withSentryRouter.spec.tsx
@@ -1,6 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
@@ -15,11 +14,11 @@ jest.mock('sentry/constants', () => {
   return {
     ...sentryConstant,
 
-    get usingCustomerDomain() {
+    get USING_CUSTOMER_DOMAIN() {
       return mockUsingCustomerDomain();
     },
 
-    get customerDomain() {
+    get CUSTOMER_DOMAIN() {
       return mockCustomerDomain();
     },
   };
@@ -41,14 +40,14 @@ describe('withSentryRouter', () => {
       features: [],
     });
 
-    const {router} = initializeOrg({
-      organization,
-    });
-
     const WrappedComponent = withSentryRouter(MyComponent);
     render(<WrappedComponent />, {
-      router,
-      deprecatedRouterMocks: true,
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/issues/',
+        },
+      },
     });
 
     expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();
@@ -63,20 +62,15 @@ describe('withSentryRouter', () => {
       features: [],
     });
 
-    const params = {
-      orgId: 'something-else',
-    };
-    const {router} = initializeOrg({
-      organization,
-      router: {
-        params,
-      },
-    });
-
     const WrappedComponent = withSentryRouter(MyComponent);
     render(<WrappedComponent />, {
-      router,
-      deprecatedRouterMocks: true,
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/something-else/issues/',
+        },
+        route: '/organizations/:orgId/issues/',
+      },
     });
 
     expect(screen.getByText('Org slug: something-else')).toBeInTheDocument();


### PR DESCRIPTION
Updating these tests to use the modern routing pattern.