### PR TITLE
chore(breadcrumbs): Migrate tests off of `deprecatedRouterMocks`

### DIFF
--- a/static/app/components/breadcrumbs.spec.tsx
+++ b/static/app/components/breadcrumbs.spec.tsx
@@ -1,16 +1,8 @@
-import {RouterFixture} from 'sentry-fixture/routerFixture';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 
 describe('Breadcrumbs', () => {
-  const router = RouterFixture();
-
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
   function createWrapper() {
     return render(
       <Breadcrumbs
@@ -28,20 +20,14 @@ describe('Breadcrumbs', () => {
             to: null,
           },
         ]}
-      />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
   }
 
   it('returns null when 0 crumbs', () => {
-    const empty = render(<Breadcrumbs crumbs={[]} />, {
-      deprecatedRouterMocks: true,
-    });
+    const {container} = render(<Breadcrumbs crumbs={[]} />);
 
-    expect(empty.container).toBeEmptyDOMElement();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('renders crumbs with icon', () => {
@@ -49,16 +35,17 @@ describe('Breadcrumbs', () => {
   });
 
   it('generates correct links', async () => {
-    createWrapper();
+    const {router} = createWrapper();
     await userEvent.click(screen.getByText('Test 1'));
-    expect(router.push).toHaveBeenCalledWith('/test1');
+    expect(router.location.pathname).toBe('/test1');
     await userEvent.click(screen.getByText('Test 2'));
-    expect(router.push).toHaveBeenCalledWith('/test2');
+    expect(router.location.pathname).toBe('/test2');
   });
 
   it('does not make links where no `to` is provided', async () => {
-    createWrapper();
+    const {router} = createWrapper();
+    const initialPathname = router.location.pathname;
     await userEvent.click(screen.getByText('Test 3'));
-    expect(router.push).not.toHaveBeenCalled();
+    expect(router.location.pathname).toBe(initialPathname);
   });
 });


### PR DESCRIPTION
Updating these tests to use the modern routing pattern.