### PR TITLE
ref(layout): Migrate `OrganizationContainer` off of `deprecatedRouterProps`

### DIFF
--- a/static/app/debug/notifications/views/index.tsx
+++ b/static/app/debug/notifications/views/index.tsx
@@ -13,7 +13,7 @@ import {DiscordPreview} from 'sentry/debug/notifications/previews/discordPreview
 import {EmailPreview} from 'sentry/debug/notifications/previews/emailPreview';
 import {SlackPreview} from 'sentry/debug/notifications/previews/slackPreview';
 import {TeamsPreview} from 'sentry/debug/notifications/previews/teamsPreview';
-import OrganizationContainer from 'sentry/views/organizationContainer';
+import {OrganizationContainer} from 'sentry/views/organizationContainer';
 import RouteAnalyticsContextProvider from 'sentry/views/routeAnalyticsContextProvider';
 
 const HEADER_HEIGHT = 52;

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -34,7 +34,7 @@ import {GroupEventDetailsLoading} from 'sentry/views/issueDetails/groupEventDeta
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {OverviewWrapper} from 'sentry/views/issueList/overviewWrapper';
 import {IssueTaxonomy} from 'sentry/views/issueList/taxonomies';
-import OrganizationContainer from 'sentry/views/organizationContainer';
+import OrganizationContainerRoute from 'sentry/views/organizationContainer';
 import OrganizationLayout from 'sentry/views/organizationLayout';
 import {OrganizationStatsWrapper} from 'sentry/views/organizationStats/organizationStatsWrapper';
 import TransactionSummaryTab from 'sentry/views/performance/transactionSummary/tabs';
@@ -170,8 +170,7 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/acceptProjectTransfer')),
     },
     {
-      component: errorHandler(OrganizationContainer),
-      deprecatedRouteProps: true,
+      component: errorHandler(OrganizationContainerRoute),
       children: [
         {
           path: '/extensions/external-install/:integrationSlug/:installationId',
@@ -236,8 +235,7 @@ function buildRoutes(): RouteObject[] {
       withOrgPath: true,
     },
     {
-      component: errorHandler(OrganizationContainer),
-      deprecatedRouteProps: true,
+      component: errorHandler(OrganizationContainerRoute),
       children: [
         {
           path: '/disabled-member/',
@@ -292,9 +290,8 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: '/onboarding/:step/',
-      component: errorHandler(withDomainRequired(OrganizationContainer)),
+      component: errorHandler(withDomainRequired(OrganizationContainerRoute)),
       customerDomainOnlyRoute: true,
-      deprecatedRouteProps: true,
       children: [
         {
           index: true,
@@ -308,8 +305,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: '/onboarding/:orgId/:step/',
-      component: withDomainRedirect(errorHandler(OrganizationContainer)),
-      deprecatedRouteProps: true,
+      component: withDomainRedirect(errorHandler(OrganizationContainerRoute)),
       children: [
         {
           index: true,

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -10,7 +10,7 @@ import {
 } from 'sentry/stories/view/storySidebar';
 import {StoryTreeNode, type StoryCategory} from 'sentry/stories/view/storyTree';
 import {useLocation} from 'sentry/utils/useLocation';
-import OrganizationContainer from 'sentry/views/organizationContainer';
+import {OrganizationContainer} from 'sentry/views/organizationContainer';
 import RouteAnalyticsContextProvider from 'sentry/views/routeAnalyticsContextProvider';
 
 import {StoryLanding} from './landing';

--- a/static/app/views/organizationContainer.tsx
+++ b/static/app/views/organizationContainer.tsx
@@ -1,3 +1,4 @@
+import {Outlet} from 'react-router-dom';
 import {useProfiler} from '@sentry/react';
 
 import {Container} from '@sentry/scraps/layout';
@@ -40,7 +41,7 @@ interface Props {
  * Ensures the current organization is loaded. A loading indicator will be
  * rendered while loading the organization.
  */
-function OrganizationContainer({children}: Props) {
+export function OrganizationContainer({children}: Props) {
   const {loading, error, errorType} = useLegacyStore(OrganizationStore);
 
   if (loading) {
@@ -90,4 +91,13 @@ function OrganizationContainer({children}: Props) {
   return children;
 }
 
-export default OrganizationContainer;
+/**
+ * Route component version of OrganizationContainer that uses <Outlet />.
+ */
+export default function OrganizationContainerRoute() {
+  return (
+    <OrganizationContainer>
+      <Outlet />
+    </OrganizationContainer>
+  );
+}

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -19,7 +19,7 @@ import {AppBodyContent} from 'sentry/views/app/appBodyContent';
 import {useRegisterDomainViewUsage} from 'sentry/views/insights/common/utils/domainRedirect';
 import Nav from 'sentry/views/nav';
 import {NavContextProvider} from 'sentry/views/nav/context';
-import OrganizationContainer from 'sentry/views/organizationContainer';
+import {OrganizationContainer} from 'sentry/views/organizationContainer';
 import {useReleasesDrawer} from 'sentry/views/releases/drawer/useReleasesDrawer';
 
 import OrganizationDetailsBody from './body';

--- a/static/gsApp/components/organizationSubscriptionContext.tsx
+++ b/static/gsApp/components/organizationSubscriptionContext.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import OrganizationContainer from 'sentry/views/organizationContainer';
+import {OrganizationContainer} from 'sentry/views/organizationContainer';
 
 import SubscriptionContext from 'getsentry/components/subscriptionContext';
 


### PR DESCRIPTION
Migrates the `OrganizationContainer` component route off of `deprecatedRouteProps`. We now have one component providing the router view and another component providing the content layout (for the non-routing usages).

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7