### PR TITLE
chore(routes): Remove leftover usage of `deprecatedRouteProps` for the `DisabledMemberComponent`

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -243,7 +243,6 @@ function buildRoutes(): RouteObject[] {
           path: '/disabled-member/',
           component: make(() => import('sentry/views/disabledMember')),
           withOrgPath: true,
-          deprecatedRouteProps: true,
         },
       ],
     },


### PR DESCRIPTION
Removing a leftover usage of `deprecatedRouteProps` for the `DisabledMemberComponent`. This route was already updated in https://github.com/getsentry/sentry/pull/100265.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7