### PR TITLE
feat(issues): Add stack trace, tags to top issues

### DIFF
--- a/static/app/views/issueList/pages/topIssues.tsx
+++ b/static/app/views/issueList/pages/topIssues.tsx
@@ -148,12 +148,8 @@ function useClusterStats(groupIds: number[]): ClusterStats {
   }, [groups, isPending]);
 }
 
-type StatsPeriod = '7d' | '30d';
-
-function useClusterEventsStats(groupIds: number[], statsPeriod: StatsPeriod) {
+function useClusterEventsStats(groupIds: number[]) {
   const organization = useOrganization();
-
-  const interval = statsPeriod === '7d' ? '1d' : '1d';
 
   return useApiQuery<EventsStats>(
     [
@@ -161,8 +157,8 @@ function useClusterEventsStats(groupIds: number[], statsPeriod: StatsPeriod) {
       {
         query: {
           query: `issue.id:[${groupIds.join(',')}]`,
-          statsPeriod,
-          interval,
+          statsPeriod: '30d',
+          interval: '1d',
           yAxis: 'count()',
           project: -1,
           referrer: 'top-issues.cluster-events-graph',
@@ -182,13 +178,12 @@ interface ClusterEventsGraphProps {
 
 interface SinglePeriodGraphProps {
   groupIds: number[];
-  statsPeriod: StatsPeriod;
   title: string;
 }
 
-function SinglePeriodGraph({groupIds, statsPeriod, title}: SinglePeriodGraphProps) {
+function SinglePeriodGraph({groupIds, title}: SinglePeriodGraphProps) {
   const theme = useTheme();
-  const {data: eventsStats, isPending} = useClusterEventsStats(groupIds, statsPeriod);
+  const {data: eventsStats, isPending} = useClusterEventsStats(groupIds);
 
   const series = useMemo((): Series[] => {
     if (!eventsStats?.data) {
@@ -247,11 +242,7 @@ function SinglePeriodGraph({groupIds, statsPeriod, title}: SinglePeriodGraphProp
 function ClusterEventsGraph({groupIds}: ClusterEventsGraphProps) {
   return (
     <EventsGraphContainer>
-      <SinglePeriodGraph
-        groupIds={groupIds}
-        statsPeriod="30d"
-        title={t('Last 30 Days')}
-      />
+      <SinglePeriodGraph groupIds={groupIds} title={t('Last 30 Days')} />
     </EventsGraphContainer>
   );
 }

--- a/static/app/views/issueList/pages/topIssues.tsx
+++ b/static/app/views/issueList/pages/topIssues.tsx
@@ -1,28 +1,46 @@
-import {useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
+import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import {Button} from 'sentry/components/core/button';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {InlineCode} from 'sentry/components/core/code/inlineCode';
+import {Disclosure} from 'sentry/components/core/disclosure/disclosure';
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import StackTraceContent from 'sentry/components/events/interfaces/crashContent/stackTrace/content';
+import {NativeContent} from 'sentry/components/events/interfaces/crashContent/stackTrace/nativeContent';
+import findBestThread from 'sentry/components/events/interfaces/threads/threadSelector/findBestThread';
+import getThreadStacktrace from 'sentry/components/events/interfaces/threads/threadSelector/getThreadStacktrace';
+import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import Placeholder from 'sentry/components/placeholder';
 import Redirect from 'sentry/components/redirect';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCalendar, IconClock, IconFire, IconLink, IconUser} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import type {Series} from 'sentry/types/echarts';
+import type {Event} from 'sentry/types/event';
+import {EntryType} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
+import type {EventsStats} from 'sentry/types/organization';
+import type {StacktraceType} from 'sentry/types/stacktrace';
+import {defined} from 'sentry/utils';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {isNativePlatform} from 'sentry/utils/platform';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
+import {type GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {useDefaultIssueEvent} from 'sentry/views/issueDetails/utils';
 
 interface AssignedEntity {
   email: string | null;
@@ -130,6 +148,440 @@ function useClusterStats(groupIds: number[]): ClusterStats {
   }, [groups, isPending]);
 }
 
+type StatsPeriod = '7d' | '30d';
+
+function useClusterEventsStats(groupIds: number[], statsPeriod: StatsPeriod) {
+  const organization = useOrganization();
+
+  const interval = statsPeriod === '7d' ? '1d' : '1d';
+
+  return useApiQuery<EventsStats>(
+    [
+      `/organizations/${organization.slug}/events-stats/`,
+      {
+        query: {
+          query: `issue.id:[${groupIds.join(',')}]`,
+          statsPeriod,
+          interval,
+          yAxis: 'count()',
+          project: -1,
+          referrer: 'top-issues.cluster-events-graph',
+        },
+      },
+    ],
+    {
+      staleTime: 60000,
+      enabled: groupIds.length > 0,
+    }
+  );
+}
+
+interface ClusterEventsGraphProps {
+  groupIds: number[];
+}
+
+interface SinglePeriodGraphProps {
+  groupIds: number[];
+  statsPeriod: StatsPeriod;
+  title: string;
+}
+
+function SinglePeriodGraph({groupIds, statsPeriod, title}: SinglePeriodGraphProps) {
+  const theme = useTheme();
+  const {data: eventsStats, isPending} = useClusterEventsStats(groupIds, statsPeriod);
+
+  const series = useMemo((): Series[] => {
+    if (!eventsStats?.data) {
+      return [];
+    }
+
+    const chartData = eventsStats.data.map(([timestamp, countData]) => ({
+      name: timestamp * 1000,
+      value: countData?.[0]?.count ?? 0,
+    }));
+
+    return [
+      {
+        seriesName: t('Events'),
+        data: chartData,
+      },
+    ];
+  }, [eventsStats]);
+
+  const totalCount = useMemo(() => {
+    if (!eventsStats?.data) {
+      return 0;
+    }
+    return eventsStats.data.reduce(
+      (sum, [, countData]) => sum + (countData?.[0]?.count ?? 0),
+      0
+    );
+  }, [eventsStats]);
+
+  return (
+    <SingleGraphContainer>
+      <Flex justify="between" align="center" style={{marginBottom: theme.space.xs}}>
+        <Text size="xs" bold>
+          {title}
+        </Text>
+        <Text size="xs" variant="muted">
+          {totalCount.toLocaleString()}
+        </Text>
+      </Flex>
+      {isPending ? (
+        <Placeholder height="50px" />
+      ) : (
+        <MiniBarChart
+          height={50}
+          isGroupedByDate
+          showTimeInTooltip
+          series={series}
+          colors={[theme.colors.gray300]}
+          emphasisColors={[theme.colors.gray400]}
+        />
+      )}
+    </SingleGraphContainer>
+  );
+}
+
+function ClusterEventsGraph({groupIds}: ClusterEventsGraphProps) {
+  return (
+    <EventsGraphContainer>
+      <SinglePeriodGraph
+        groupIds={groupIds}
+        statsPeriod="30d"
+        title={t('Last 30 Days')}
+      />
+    </EventsGraphContainer>
+  );
+}
+
+function getStacktraceFromEvent(event: Event): StacktraceType | null {
+  const exceptionsWithStacktrace =
+    event.entries
+      .find(e => e.type === EntryType.EXCEPTION)
+      ?.data?.values?.filter((exc: {stacktrace?: StacktraceType}) =>
+        defined(exc.stacktrace)
+      ) ?? [];
+
+  const exceptionStacktrace: StacktraceType | undefined = isStacktraceNewestFirst()
+    ? exceptionsWithStacktrace[exceptionsWithStacktrace.length - 1]?.stacktrace
+    : exceptionsWithStacktrace[0]?.stacktrace;
+
+  if (exceptionStacktrace) {
+    return exceptionStacktrace;
+  }
+
+  const threads =
+    event.entries.find(e => e.type === EntryType.THREADS)?.data?.values ?? [];
+  const bestThread = findBestThread(threads);
+
+  if (!bestThread) {
+    return null;
+  }
+
+  const bestThreadStacktrace = getThreadStacktrace(false, bestThread);
+
+  if (bestThreadStacktrace) {
+    return bestThreadStacktrace;
+  }
+
+  return null;
+}
+
+interface ClusterStackTraceProps {
+  groupId: number;
+}
+
+function ClusterStackTrace({groupId}: ClusterStackTraceProps) {
+  const organization = useOrganization();
+  const defaultIssueEvent = useDefaultIssueEvent();
+
+  const {data: event, isPending} = useApiQuery<Event>(
+    [
+      `/organizations/${organization.slug}/issues/${groupId}/events/${defaultIssueEvent}/`,
+      {
+        query: {
+          collapse: ['fullRelease'],
+        },
+      },
+    ],
+    {
+      staleTime: 30000,
+      enabled: groupId > 0,
+    }
+  );
+
+  const stacktrace = useMemo(
+    () => (event ? getStacktraceFromEvent(event) : null),
+    [event]
+  );
+
+  if (isPending) {
+    return <Placeholder height="200px" />;
+  }
+
+  if (!stacktrace || !event) {
+    return (
+      <Text size="sm" variant="muted">
+        {t('No stack trace available for this issue.')}
+      </Text>
+    );
+  }
+
+  const includeSystemFrames = stacktrace.frames?.every(frame => !frame.inApp) ?? false;
+  const framePlatform = stacktrace.frames?.find(frame => !!frame.platform)?.platform;
+  const platform = framePlatform ?? event.platform ?? 'other';
+  const newestFirst = isStacktraceNewestFirst();
+
+  const commonProps = {
+    data: stacktrace,
+    includeSystemFrames,
+    platform,
+    newestFirst,
+    event,
+    isHoverPreviewed: true,
+  };
+
+  if (isNativePlatform(platform)) {
+    return <NativeContent {...commonProps} hideIcon maxDepth={5} />;
+  }
+
+  return <StackTraceContent {...commonProps} expandFirstFrame hideIcon />;
+}
+
+interface DiscoverFacetTag {
+  key: string;
+  topValues: Array<{
+    count: number;
+    name: string | null;
+    value: string | number;
+  }>;
+}
+
+function useClusterTagFacets(groupIds: number[]) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const currentProjects = selection.projects ?? [];
+  const currentEnvironments = selection.environments ?? [];
+
+  const queryResult = useApiQuery<DiscoverFacetTag[]>(
+    [
+      `/organizations/${organization.slug}/events-facets/`,
+      {
+        query: {
+          dataset: DiscoverDatasets.ERRORS,
+          query: `issue.id:[${groupIds.join(',')}]`,
+          statsPeriod: '30d',
+          per_page: 50,
+          ...(currentProjects.length ? {project: currentProjects} : {}),
+          ...(currentEnvironments.length ? {environment: currentEnvironments} : {}),
+        },
+      },
+    ],
+    {
+      enabled: groupIds.length !== 0,
+      staleTime: 30000,
+    }
+  );
+
+  const data = useMemo<GroupTag[] | undefined>(() => {
+    if (!queryResult.data) {
+      return undefined;
+    }
+
+    return queryResult.data
+      .map(tag => {
+        const topValues = tag.topValues.map(value => ({
+          count: value.count,
+          name: value.name ?? String(value.value),
+          value: String(value.value),
+          firstSeen: '',
+          lastSeen: '',
+        }));
+        const totalValues = topValues.reduce((sum, value) => sum + value.count, 0);
+        return {
+          key: tag.key,
+          name: tag.key,
+          topValues,
+          totalValues,
+        };
+      })
+      .filter(tag => tag.topValues.length > 0);
+  }, [queryResult.data]);
+
+  return {
+    data,
+    isPending: queryResult.isPending,
+    isError: queryResult.isError,
+  };
+}
+
+interface DenseTagFacetsProps {
+  groupIds: number[];
+}
+
+function DenseTagFacets({groupIds}: DenseTagFacetsProps) {
+  const theme = useTheme();
+  const {data: tags, isPending} = useClusterTagFacets(groupIds);
+
+  if (isPending) {
+    return <Placeholder height="60px" />;
+  }
+
+  if (!tags || tags.length === 0) {
+    return (
+      <Text size="sm" variant="muted">
+        {t('No tags found')}
+      </Text>
+    );
+  }
+
+  return (
+    <TagsTable>
+      <TagsTableHeader>
+        <Text size="xs" uppercase variant="muted">
+          {t('Tag')}
+        </Text>
+        <Text size="xs" uppercase variant="muted">
+          {t('Top %')}
+        </Text>
+        <Text size="xs" uppercase variant="muted">
+          {t('Top Value')}
+        </Text>
+      </TagsTableHeader>
+      <DenseTagsGrid>
+        {tags.map((tag: GroupTag) => (
+          <DenseTagItem key={tag.key} tag={tag} colors={theme.chart.getColorPalette(4)} />
+        ))}
+      </DenseTagsGrid>
+    </TagsTable>
+  );
+}
+
+interface DenseTagItemProps {
+  colors: readonly string[];
+  tag: GroupTag;
+}
+
+interface TagDistributionPreviewProps {
+  colors: readonly string[];
+  tag: GroupTag;
+}
+
+function TagDistributionPreview({tag, colors}: TagDistributionPreviewProps) {
+  const theme = useTheme();
+  const topValues = tag.topValues.slice(0, 3);
+  const totalCount = tag.totalValues;
+  const hasValues = topValues.length > 0;
+
+  return (
+    <DenseTagCard>
+      <Text
+        as="div"
+        size="xs"
+        bold
+        uppercase
+        variant="muted"
+        ellipsis
+        style={{marginBottom: theme.space.xs}}
+      >
+        {tag.key}
+      </Text>
+      {hasValues ? (
+        <Fragment>
+          <DenseTagBar>
+            {topValues.map((value, index) => {
+              const pct = totalCount > 0 ? (value.count / totalCount) * 100 : 0;
+              return (
+                <DenseTagSegment
+                  key={value.value}
+                  style={{
+                    width: `${pct}%`,
+                    backgroundColor: colors[index] ?? theme.colors.gray300,
+                  }}
+                />
+              );
+            })}
+          </DenseTagBar>
+          <DenseTagValues>
+            {topValues.map((value, index) => {
+              const pct =
+                totalCount > 0 ? Math.round((value.count / totalCount) * 100) : 0;
+              return (
+                <Tooltip key={value.value} title={value.name} skipWrapper>
+                  <DenseTagChip>
+                    <DenseTagDot
+                      style={{backgroundColor: colors[index] ?? theme.colors.gray300}}
+                    />
+                    <Text size="xs" ellipsis align="left" style={{flex: 1}}>
+                      {value.name || t('(empty)')}
+                    </Text>
+                    <Text size="xs" variant="muted" style={{flexShrink: 0}}>
+                      {pct}%
+                    </Text>
+                  </DenseTagChip>
+                </Tooltip>
+              );
+            })}
+          </DenseTagValues>
+        </Fragment>
+      ) : (
+        <Text size="sm" variant="muted">
+          {t('No values available')}
+        </Text>
+      )}
+    </DenseTagCard>
+  );
+}
+
+function DenseTagItem({tag, colors}: DenseTagItemProps) {
+  const topValue = tag.topValues[0];
+  const totalCount = tag.totalValues;
+  const topValuePct =
+    topValue && totalCount > 0 ? Math.round((topValue.count / totalCount) * 100) : null;
+  const hasValues = Boolean(topValue);
+
+  return (
+    <Tooltip
+      title={<TagDistributionPreview tag={tag} colors={colors} />}
+      skipWrapper
+      maxWidth={360}
+    >
+      <TagRow>
+        <Text size="sm" bold ellipsis>
+          {tag.key}
+        </Text>
+        <TagPctCell>
+          {hasValues && topValuePct !== null ? (
+            <Text size="xs" variant="muted" style={{flexShrink: 0}}>
+              {topValuePct}%
+            </Text>
+          ) : (
+            <Text size="sm" variant="muted">
+              {t('—')}
+            </Text>
+          )}
+        </TagPctCell>
+        {hasValues ? (
+          <TagValueCell>
+            <Text size="sm" ellipsis>
+              {topValue?.name || t('(empty)')}
+            </Text>
+          </TagValueCell>
+        ) : (
+          <TagValueCell>
+            <Text size="sm" variant="muted">
+              {t('No values')}
+            </Text>
+          </TagValueCell>
+        )}
+      </TagRow>
+    </Tooltip>
+  );
+}
+
 function renderWithInlineCode(text: string): React.ReactNode {
   const parts = text.split(/(`[^`]+`)/g);
   if (parts.length === 1) {
@@ -144,6 +596,7 @@ function renderWithInlineCode(text: string): React.ReactNode {
 }
 
 function ClusterDetailCard({cluster}: {cluster: ClusterSummary}) {
+  const theme = useTheme();
   const organization = useOrganization();
   const clusterStats = useClusterStats(cluster.group_ids);
 
@@ -167,10 +620,15 @@ function ClusterDetailCard({cluster}: {cluster: ClusterSummary}) {
     <CardContainer>
       <CardMain>
         <CardHeader>
-          <Heading as="h2" size="xl" style={{marginBottom: space(2)}}>
+          <Heading as="h2" size="xl" style={{marginBottom: theme.space.xl}}>
             {renderWithInlineCode(cluster.title)}
           </Heading>
-          <Flex wrap="wrap" align="center" gap="md" style={{marginBottom: space(2)}}>
+          <Flex
+            wrap="wrap"
+            align="center"
+            gap="md"
+            style={{marginBottom: theme.space.xl}}
+          >
             {relevancePercent !== null && (
               <Flex align="center" gap="xs">
                 <IconLink size="xs" />
@@ -234,7 +692,7 @@ function ClusterDetailCard({cluster}: {cluster: ClusterSummary}) {
             )}
           </Flex>
 
-          <Flex wrap="wrap" gap="lg" style={{marginBottom: space(2)}}>
+          <Flex wrap="wrap" gap="lg" style={{marginBottom: theme.space.xl}}>
             {cluster.error_type && (
               <Flex gap="xs">
                 <Text size="sm" variant="muted">
@@ -263,20 +721,40 @@ function ClusterDetailCard({cluster}: {cluster: ClusterSummary}) {
           )}
         </CardHeader>
 
-        <ContentSection>
-          <Heading as="h3" size="md" style={{marginBottom: space(1.5)}}>
-            {t('What went wrong')}
-          </Heading>
-          <div style={{minHeight: 60}}>
-            {cluster.summary ? (
-              <Text size="sm">{renderWithInlineCode(cluster.summary)}</Text>
-            ) : (
-              <Text size="sm" variant="muted">
-                {t('No summary available')}
-              </Text>
-            )}
-          </div>
-        </ContentSection>
+        <Grid padding="sm" gap="sm">
+          <Disclosure size="sm" expanded>
+            <Disclosure.Title>{t('What went wrong')}</Disclosure.Title>
+            <Disclosure.Content>
+              <div style={{minHeight: 60}}>
+                {cluster.summary ? (
+                  <Text size="sm">{renderWithInlineCode(cluster.summary)}</Text>
+                ) : (
+                  <Text size="sm" variant="muted">
+                    {t('No summary available')}
+                  </Text>
+                )}
+              </div>
+            </Disclosure.Content>
+          </Disclosure>
+
+          {cluster.group_ids[0] && (
+            <Disclosure size="sm">
+              <Disclosure.Title>{t('Example Stack Trace')}</Disclosure.Title>
+              <Disclosure.Content>
+                <ClusterStackTrace groupId={cluster.group_ids[0]} />
+              </Disclosure.Content>
+            </Disclosure>
+          )}
+
+          {cluster.group_ids.length > 0 && (
+            <Disclosure size="sm">
+              <Disclosure.Title>{t('Aggregate Tags')}</Disclosure.Title>
+              <Disclosure.Content>
+                <DenseTagFacets groupIds={cluster.group_ids} />
+              </Disclosure.Content>
+            </Disclosure>
+          )}
+        </Grid>
 
         <CardFooter>
           <Link
@@ -290,50 +768,57 @@ function ClusterDetailCard({cluster}: {cluster: ClusterSummary}) {
       </CardMain>
 
       <CardSidebar>
-        <Heading as="h4" size="md" style={{marginBottom: space(1.5)}}>
-          {t('People')}
-        </Heading>
-        {totalAssigned > 0 ? (
-          <Tooltip
-            title={
-              <Flex direction="column" gap="xs">
-                {assignedUsers.map(user => (
-                  <Text key={user.id} size="xs">
-                    {user.name || user.email}
-                  </Text>
-                ))}
-                {assignedTeams.map(team => (
-                  <Text key={team.id} size="xs">
-                    #{team.name}
-                  </Text>
-                ))}
+        <SidebarSection>
+          <Heading as="h4" size="md" style={{marginBottom: theme.space.lg}}>
+            {t('People')}
+          </Heading>
+          {totalAssigned > 0 ? (
+            <Tooltip
+              title={
+                <Flex direction="column" gap="xs">
+                  {assignedUsers.map(user => (
+                    <Text key={user.id} size="xs">
+                      {user.name || user.email}
+                    </Text>
+                  ))}
+                  {assignedTeams.map(team => (
+                    <Text key={team.id} size="xs">
+                      #{team.name}
+                    </Text>
+                  ))}
+                </Flex>
+              }
+            >
+              <Flex align="center" gap="sm">
+                <AvatarStack>
+                  {cluster.assignedTo.slice(0, 3).map((entity, i) => (
+                    <AvatarPlaceholder key={entity.id} style={{zIndex: 3 - i}}>
+                      {entity.name?.charAt(0).toUpperCase() || '?'}
+                    </AvatarPlaceholder>
+                  ))}
+                </AvatarStack>
+                <Text size="sm" variant="muted">
+                  {tn('%s assignee', '%s assignees', totalAssigned)}
+                </Text>
               </Flex>
-            }
-          >
-            <Flex align="center" gap="sm">
-              <AvatarStack>
-                {cluster.assignedTo.slice(0, 3).map((entity, i) => (
-                  <AvatarPlaceholder key={entity.id} style={{zIndex: 3 - i}}>
-                    {entity.name?.charAt(0).toUpperCase() || '?'}
-                  </AvatarPlaceholder>
-                ))}
-              </AvatarStack>
-              <Text size="sm" variant="muted">
-                {tn('%s assignee', '%s assignees', totalAssigned)}
-              </Text>
-            </Flex>
-          </Tooltip>
-        ) : (
-          <Text size="sm" variant="muted">
-            {t('No assignees')}
-          </Text>
-        )}
+            </Tooltip>
+          ) : (
+            <Text size="sm" variant="muted">
+              {t('No assignees')}
+            </Text>
+          )}
+        </SidebarSection>
+
+        <SidebarSection>
+          <ClusterEventsGraph groupIds={cluster.group_ids} />
+        </SidebarSection>
       </CardSidebar>
     </CardContainer>
   );
 }
 
 function TopIssues() {
+  const theme = useTheme();
   const organization = useOrganization();
   const user = useUser();
   const {teams: userTeams} = useUserTeams();
@@ -403,7 +888,7 @@ function TopIssues() {
   return (
     <PageFiltersContainer>
       <PageWrapper>
-        <HeaderSection>
+        <Grid padding="2xl 3xl xl">
           <Flex justify="between" align="center">
             <Heading as="h1">{t('Top Issues')}</Heading>
             <Link to={`/organizations/${organization.slug}/issues/dynamic-groups/`}>
@@ -416,7 +901,7 @@ function TopIssues() {
             align="center"
             wrap="wrap"
             gap="md"
-            style={{marginTop: space(2)}}
+            style={{marginTop: theme.space.xl}}
           >
             <Flex gap="sm" align="center">
               <ProjectPageFilter />
@@ -436,7 +921,7 @@ function TopIssues() {
 
             {!isPending && totalClusters > 0 && (
               <Flex align="center" gap="sm">
-                <Text size="sm" variant="muted" style={{padding: `0 ${space(1)}`}}>
+                <Text size="sm" variant="muted" style={{padding: `0 ${theme.space.md}`}}>
                   {currentIndex + 1} {t('of')} {totalClusters} {t('top issues')}
                 </Text>
                 <Button size="sm" onClick={handlePrevious} disabled={currentIndex <= 0}>
@@ -452,7 +937,7 @@ function TopIssues() {
               </Flex>
             )}
           </Flex>
-        </HeaderSection>
+        </Grid>
 
         <ContentArea>
           {isPending ? (
@@ -477,27 +962,23 @@ const PageWrapper = styled('div')`
   background: ${p => p.theme.backgroundSecondary};
 `;
 
-const HeaderSection = styled('div')`
-  padding: ${space(3)} ${space(4)} ${space(2)};
-`;
-
 const CheckboxLabel = styled('label')`
   display: flex;
   align-items: center;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   cursor: pointer;
 `;
 
 const ContentArea = styled('div')`
   flex: 1;
-  padding: ${space(3)} ${space(4)};
+  padding: ${p => p.theme.space['2xl']} ${p => p.theme.space['3xl']};
 `;
 
 const EmptyState = styled('div')`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: ${space(4)};
+  padding: ${p => p.theme.space['3xl']};
   background: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.radius.md};
@@ -508,7 +989,6 @@ const CardContainer = styled('div')`
   background: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.radius.md};
-  overflow: hidden;
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
     flex-direction: column;
@@ -523,9 +1003,9 @@ const CardMain = styled('div')`
 `;
 
 const CardSidebar = styled('div')`
-  width: 200px;
+  width: 280px;
   flex-shrink: 0;
-  padding: ${space(3)};
+  padding: ${p => p.theme.space['2xl']};
   border-left: 1px solid ${p => p.theme.border};
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
@@ -535,14 +1015,22 @@ const CardSidebar = styled('div')`
   }
 `;
 
+const SidebarSection = styled('div')`
+  &:not(:last-child) {
+    margin-bottom: ${p => p.theme.space['2xl']};
+    padding-bottom: ${p => p.theme.space['2xl']};
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
+  }
+`;
+
 const CardHeader = styled('div')`
-  padding: ${space(3)};
+  padding: ${p => p.theme.space['2xl']};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
 `;
 
 const TagPill = styled('span')`
   display: inline-block;
-  padding: ${space(0.5)} ${space(1)};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
   font-size: ${p => p.theme.fontSize.xs};
   color: ${p => p.theme.tokens.content.primary};
   background: ${p => p.theme.backgroundSecondary};
@@ -550,12 +1038,8 @@ const TagPill = styled('span')`
   border-radius: 20px;
 `;
 
-const ContentSection = styled('div')`
-  padding: ${space(3)};
-`;
-
 const CardFooter = styled('div')`
-  padding: ${space(2)} ${space(3)};
+  padding: ${p => p.theme.space.xl} ${p => p.theme.space['2xl']};
   border-top: 1px solid ${p => p.theme.innerBorder};
 `;
 
@@ -581,6 +1065,113 @@ const AvatarPlaceholder = styled('div')`
   &:first-child {
     margin-left: 0;
   }
+`;
+
+const EventsGraphContainer = styled('div')`
+  padding: ${p => p.theme.space.md} 0;
+`;
+
+const SingleGraphContainer = styled('div')`
+  &:not(:last-child) {
+    padding-bottom: ${p => p.theme.space.md};
+  }
+`;
+
+const TagsTable = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 70px minmax(180px, 2fr);
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.radius.md};
+  overflow: hidden;
+`;
+
+const TagsTableHeader = styled('div')`
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  gap: ${p => p.theme.space.xl};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  background: ${p => p.theme.backgroundSecondary};
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const DenseTagsGrid = styled('div')`
+  display: contents;
+`;
+
+const DenseTagCard = styled('div')`
+  min-width: 250px;
+`;
+
+const DenseTagBar = styled('div')`
+  display: flex;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: ${p => p.theme.backgroundSecondary};
+  margin-bottom: ${p => p.theme.space.sm};
+`;
+
+const DenseTagValues = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const DenseTagSegment = styled('div')`
+  height: 100%;
+  min-width: 2px;
+`;
+
+const DenseTagChip = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  width: 100%;
+  cursor: default;
+`;
+
+const DenseTagDot = styled('span')`
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+`;
+
+const TagRow = styled('div')`
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  gap: ${p => p.theme.space.xl};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  align-items: baseline;
+  cursor: default;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
+  }
+
+  &:hover {
+    background: ${p => p.theme.backgroundSecondary};
+  }
+`;
+
+const TagValueCell = styled('div')`
+  display: flex;
+  align-items: baseline;
+  gap: ${p => p.theme.space.xs};
+  min-width: 0;
+`;
+
+const TagPctCell = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-width: 0;
 `;
 
 export default TopIssues;


### PR DESCRIPTION
adds tags and an example stack trace to the single card layout. Currently you would need to click view all issues -> pick issue to see a stack trace or tags. I think adding a bit of aggregate data helps someone other than seer decide what the fix looks like

<img width="990" height="704" alt="image" src="https://github.com/user-attachments/assets/6c7697f4-07cf-4629-a65d-3291982bd9f0" />
