### PR TITLE
test(explore): Move explore tests off deprecatedRouterMocks

### DIFF
--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -1,6 +1,5 @@
 import {type ReactNode} from 'react';
 import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -1104,22 +1103,18 @@ describe('MultiQueryModeContent', () => {
   });
 
   it('sets interval correctly', async () => {
-    const router = RouterFixture({
-      location: {
-        pathname: '/traces/compare',
-        query: {
-          queries: [
-            '{"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["avg(span.duration)"]}',
-          ],
+    const {router} = render(<MultiQueryModeContent />, {
+      organization,
+      additionalWrapper: Wrapper(),
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/compare',
+          query: {
+            queries:
+              '{"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["avg(span.duration)"]}',
+          },
         },
       },
-    });
-
-    render(<MultiQueryModeContent />, {
-      router,
-      organization,
-      deprecatedRouterMocks: true,
-      additionalWrapper: Wrapper(),
     });
 
     const section = screen.getByTestId('section-visualization-0');
@@ -1128,21 +1123,19 @@ describe('MultiQueryModeContent', () => {
     ).toBeInTheDocument();
     await userEvent.click(within(section).getByRole('button', {name: '30 minutes'}));
     await userEvent.click(within(section).getByRole('option', {name: '3 hours'}));
-    expect(router.push).toHaveBeenCalledWith({
-      pathname: '/traces/compare',
-      query: expect.objectContaining({
+    expect(router.location.pathname).toBe('/traces/compare');
+    expect(router.location.query).toEqual(
+      expect.objectContaining({
         interval: '3h',
-        queries: [
+        queries:
           '{"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["avg(span.duration)"]}',
-        ],
-      }),
-    });
+      })
+    );
   });
 
   it('renders a save query button', async () => {
     render(<MultiQueryModeContent />, {
       organization,
-      deprecatedRouterMocks: true,
       additionalWrapper: Wrapper(),
     });
     expect(await screen.findByLabelText('Save')).toBeInTheDocument();
@@ -1180,23 +1173,20 @@ describe('MultiQueryModeContent', () => {
       url: `/organizations/${organization.slug}/explore/saved/123/visit/`,
       method: 'POST',
     });
-    const router = RouterFixture({
-      location: {
-        pathname: '/traces/compare',
-        query: {
-          queries: [
-            '{"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["avg(span.duration)"]}',
-          ],
-          id: '123',
-        },
-      },
-    });
 
     render(<MultiQueryModeContent />, {
-      router,
       organization,
-      deprecatedRouterMocks: true,
       additionalWrapper: Wrapper(),
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/compare',
+          query: {
+            queries:
+              '{"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["avg(span.duration)"]}',
+            id: '123',
+          },
+        },
+      },
     });
     // No good way to check for highlighted css, so we just check for the text
     expect(await screen.findByText('Save')).toBeInTheDocument();

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -62,9 +62,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('should render', async () => {
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Project')).toBeInTheDocument();
     expect(screen.getByText('Query')).toBeInTheDocument();
@@ -74,9 +72,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('should request for owned queries', async () => {
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     await waitFor(() =>
       expect(getQueriesMock).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/explore/saved/`,
@@ -92,9 +88,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('should request for shared queries', async () => {
-    render(<SavedQueriesTable mode="shared" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="shared" title="title" />);
     await waitFor(() =>
       expect(getQueriesMock).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/explore/saved/`,
@@ -110,9 +104,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('deletes a query', async () => {
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     renderGlobalModal();
     await screen.findByText('Query Name');
     await userEvent.click(screen.getByLabelText('More options'));
@@ -135,9 +127,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('should link to a single query view', async () => {
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     expect(await screen.findByText('Query Name')).toHaveAttribute(
       'href',
       '/organizations/org-slug/explore/traces/?environment=production&groupBy=&id=1&project=1&title=Query%20Name'
@@ -170,9 +160,7 @@ describe('SavedQueriesTable', () => {
         },
       ],
     });
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     expect(await screen.findByText('Query Name')).toHaveAttribute(
       'href',
       '/organizations/org-slug/explore/traces/compare/?environment=production&id=1&project=1&queries=%7B%22groupBys%22%3A%5B%5D%2C%22yAxes%22%3A%5B%5D%2C%22caseInsensitive%22%3A%221%22%7D&queries=%7B%22groupBys%22%3A%5B%5D%2C%22yAxes%22%3A%5B%5D%7D&title=Query%20Name'
@@ -208,9 +196,7 @@ describe('SavedQueriesTable', () => {
         },
       ],
     });
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     expect(await screen.findByText('Logs Query Name')).toHaveAttribute(
       'href',
       '/organizations/org-slug/explore/logs/?aggregateField=%7B%22groupBy%22%3A%22message%22%7D&caseInsensitive=1&environment=production&id=1&interval=5m&logsFields=timestamp&logsFields=message&logsFields=user.email&logsQuery=message%3A%22System%20time%20zone%20does%20not%20match%20user%20preferences%20time%20zone%22&logsSortBys=user.email&mode=samples&project=1&statsPeriod=1h&title=Logs%20Query%20Name'
@@ -245,9 +231,7 @@ describe('SavedQueriesTable', () => {
         },
       ],
     });
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     expect(await screen.findByText('ABC')).toHaveAttribute(
       'href',
       '/organizations/org-slug/explore/logs/?aggregateField=%7B%22groupBy%22%3A%22message%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22avg%28tags%5Bamount%2Cnumber%5D%29%22%5D%7D&environment=production&id=1&interval=5m&logsFields=timestamp&logsFields=tags%5Bamount%2Cnumber%5D&logsQuery=message%3Afoo&logsSortBys=user.email&mode=samples&project=1&statsPeriod=1h&title=ABC'
@@ -292,9 +276,7 @@ describe('SavedQueriesTable', () => {
         },
       ],
     });
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     await screen.findByText('Query Name');
     screen.getByText('Starred Query');
     expect(screen.getByLabelText('Unstar')).toBeInTheDocument();
@@ -326,9 +308,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('should sort by most popular', async () => {
-    render(<SavedQueriesTable mode="owned" sort="mostPopular" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" sort="mostPopular" title="title" />);
     await screen.findByText('Query Name');
     expect(getQueriesMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/explore/saved/`,
@@ -339,9 +319,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('should search for a query', async () => {
-    render(<SavedQueriesTable mode="owned" searchQuery="Query Name" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" searchQuery="Query Name" title="title" />);
     await screen.findByText('Query Name');
     expect(getQueriesMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/explore/saved/`,
@@ -352,9 +330,7 @@ describe('SavedQueriesTable', () => {
   });
 
   it('should duplicate a query', async () => {
-    render(<SavedQueriesTable mode="owned" title="title" />, {
-      deprecatedRouterMocks: true,
-    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
     await screen.findByText('Query Name');
     await userEvent.click(screen.getByLabelText('More options'));
     await userEvent.click(screen.getByText('Duplicate'));

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,7 +1,6 @@
 import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   act,
@@ -621,64 +620,64 @@ describe('ExploreToolbar', () => {
   });
 
   it('opens compare queries', async () => {
-    const router = RouterFixture({
-      location: {
-        pathname: '/traces/',
-        query: {
-          visualize: encodeURIComponent('{"chartType":1,"yAxes":["p95(span.duration)"]}'),
-        },
-      },
-    });
-
     function Component() {
       return <ExploreToolbar />;
     }
-    render(
+    const {router} = render(
       <Wrapper>
         <Component />
       </Wrapper>,
       {
-        router,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/traces/',
+            query: {
+              visualize: encodeURIComponent(
+                '{"chartType":1,"yAxes":["p95(span.duration)"]}'
+              ),
+            },
+          },
+        },
       }
     );
 
     const section = screen.getByTestId('section-save-as');
 
     await userEvent.click(within(section).getByText(/Compare/));
-    expect(router.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/explore/traces/compare/',
-      query: expect.objectContaining({
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/explore/traces/compare/'
+    );
+    expect(router.location.query).toEqual(
+      expect.objectContaining({
         queries: [
           '{"chartType":0,"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["count(span.duration)"]}',
           '{"fields":["id","span.duration","timestamp"],"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["count(span.duration)"]}',
         ],
-      }),
-    });
+      })
+    );
   });
 
   it('opens the right alert', async () => {
-    const router = RouterFixture({
-      location: {
-        pathname: '/traces/',
-        query: {
-          visualize: encodeURIComponent('{"chartType":1,"yAxes":["avg(span.duration)"]}'),
-        },
-      },
-    });
-
     function Component() {
       return <ExploreToolbar />;
     }
-    render(
+    const {router} = render(
       <Wrapper>
         <Component />
       </Wrapper>,
       {
-        router,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/traces/',
+            query: {
+              visualize: encodeURIComponent(
+                '{"chartType":1,"yAxes":["avg(span.duration)"]}'
+              ),
+            },
+          },
+        },
       }
     );
 
@@ -691,24 +690,21 @@ describe('ExploreToolbar', () => {
     await userEvent.click(
       await within(section).findByRole('menuitemradio', {name: 'count(spans)'})
     );
-    expect(router.push).toHaveBeenCalledWith({
-      pathname:
-        '/organizations/org-slug/issues/alerts/new/metric/?aggregate=count%28span.duration%29&dataset=events_analytics_platform&eventTypes=transaction&interval=1h&project=proj-slug&query=&statsPeriod=7d',
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/issues/alerts/new/metric/'
+    );
+    expect(router.location.query).toEqual({
+      aggregate: 'count(span.duration)',
+      dataset: 'events_analytics_platform',
+      eventTypes: 'transaction',
+      interval: '1h',
+      project: 'proj-slug',
+      query: '',
+      statsPeriod: '7d',
     });
   });
 
   it('add to dashboard options correctly', async () => {
-    const router = RouterFixture({
-      location: {
-        pathname: '/traces/',
-        query: {
-          visualize: encodeURIComponent(
-            '{"chartType":1,"yAxes":["count(span.duration)"]}'
-          ),
-        },
-      },
-    });
-
     function Component() {
       return <ExploreToolbar />;
     }
@@ -717,9 +713,17 @@ describe('ExploreToolbar', () => {
         <Component />
       </Wrapper>,
       {
-        router,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/traces/',
+            query: {
+              visualize: encodeURIComponent(
+                '{"chartType":1,"yAxes":["count(span.duration)"]}'
+              ),
+            },
+          },
+        },
       }
     );
 
@@ -776,61 +780,43 @@ describe('ExploreToolbar', () => {
       },
     });
 
-    const router = RouterFixture({
-      location: {
-        pathname: '/traces/',
-        query: {
-          query: '',
-          visualize: '{"chartType":1,"yAxes":["count(span.duration)"]}',
-          groupBy: ['span.op'],
-          sort: ['-count(span.duration)'],
-          field: ['count(span.duration)'],
-          id: '123',
-          mode: 'aggregate',
-        },
-      },
-    });
-
     function Component() {
       return <ExploreToolbar />;
     }
 
-    render(
+    const {router} = render(
       <Wrapper>
         <Component />
       </Wrapper>,
       {
-        router,
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/traces/',
+            query: {
+              query: '',
+              visualize: '{"chartType":1,"yAxes":["count(span.duration)"]}',
+              groupBy: 'span.op',
+              sort: '-count(span.duration)',
+              field: 'count(span.duration)',
+              id: '123',
+              mode: 'aggregate',
+            },
+          },
+        },
       }
     );
     screen.getByText('Save as\u2026');
     const section = screen.getByTestId('section-sort-by');
     await userEvent.click(within(section).getByRole('button', {name: 'Desc'}));
     await userEvent.click(within(section).getByRole('option', {name: 'Asc'}));
-    expect(router.push).toHaveBeenCalledWith(
+    expect(router.location.query).toEqual(
       expect.objectContaining({
-        query: expect.objectContaining({
-          aggregateSort: ['count(span.duration)'],
-        }),
+        aggregateSort: 'count(span.duration)',
       })
     );
 
-    // Simulate navigation from sort change
-    router.location.query.aggregateSort = ['count(span.duration)'];
-    router.push(router.location);
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>,
-      {
-        router,
-        organization,
-        deprecatedRouterMocks: true,
-      }
-    );
-
+    // After navigation, the UI should update to show "Save" instead of "Save as…"
     await waitFor(() => {
       expect(screen.getByText('Save')).toBeInTheDocument();
     });


### PR DESCRIPTION
switch to initialRouterConfig and the full in memory browser router
